### PR TITLE
fix: correct LiteLLM-proxied Claude session transcripts and labels

### DIFF
--- a/.changeset/litellm-proxied-claude-turns.md
+++ b/.changeset/litellm-proxied-claude-turns.md
@@ -9,7 +9,8 @@ text when the turn ends; prompts already collapsed onto one row through the
 session's native marker, but assistant turns share no identity across the two
 observers, so both rows survived. A proxied assistant turn is now dropped for
 sessions a Claude hook stream already captured (cost and telemetry for the
-proxied call are unaffected). Separately, the bare `claude` adapter slug the
+proxied call are unaffected), so those sessions are attributed to the agent that
+ran them rather than to the proxy. Separately, the bare `claude` adapter slug the
 hooks binary sends now resolves to the `claude-code` surface even when a session
 has no OpenTelemetry stream, instead of colliding with the `claude` the Anthropic
 compliance import writes for Claude Chat Desktop and being displayed as that

--- a/.changeset/litellm-proxied-claude-turns.md
+++ b/.changeset/litellm-proxied-claude-turns.md
@@ -1,0 +1,16 @@
+---
+"server": patch
+---
+
+Stop LiteLLM-proxied agent sessions from persisting each assistant turn twice,
+and label Claude Code sessions as Claude Code. The proxy reports the completion
+the moment the model returns it and the agent's own hook stream reports the same
+text when the turn ends; prompts already collapsed onto one row through the
+session's native marker, but assistant turns share no identity across the two
+observers, so both rows survived. A proxied assistant turn is now dropped for
+sessions a Claude hook stream already captured (cost and telemetry for the
+proxied call are unaffected). Separately, the bare `claude` adapter slug the
+hooks binary sends now resolves to the `claude-code` surface even when a session
+has no OpenTelemetry stream, instead of colliding with the `claude` the Anthropic
+compliance import writes for Claude Chat Desktop and being displayed as that
+surface.

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -1432,7 +1432,7 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		if correlationID := agentPromptCorrelationID(payload); correlationID != "" {
 			msg.MessageID = conv.ToPGText(correlationID)
 		} else {
-			uncorrelatedPrompt = strings.EqualFold(strings.TrimSpace(hookSource), "litellm") || usesNativeTranscriptFallback(payload.Source.Adapter)
+			uncorrelatedPrompt = proxiedTranscriptSource(hookSource) || usesNativeTranscriptFallback(payload.Source.Adapter)
 			nativePrompt = usesNativeTranscriptFallback(payload.Source.Adapter)
 		}
 		titleContent = content
@@ -1441,6 +1441,20 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		outputToolCalls := authenticatedIngestOptions(ctx).OutputToolCalls
 		if strings.TrimSpace(content) == "" && len(outputToolCalls) == 0 {
 			return false, nil
+		}
+		// The proxy observes the same completion the session's own hook stream
+		// reports as its assistant turn. Prompts carry a turn identity that
+		// collapses the two observations into one row; assistant turns carry
+		// none, so a proxied row for a natively captured session is dropped
+		// instead of persisted alongside the native one.
+		if proxiedTranscriptSource(hookSource) {
+			duplicate, err := s.proxiedTurnDuplicatesNativeStream(ctx, metadata, sessionIDToUUID(sessionID), *authCtx.ProjectID)
+			if err != nil {
+				return false, err
+			}
+			if duplicate {
+				return false, nil
+			}
 		}
 		msg = baseMsg("assistant", content)
 		if len(outputToolCalls) > 0 {
@@ -1496,6 +1510,31 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 func usesNativeTranscriptFallback(adapter string) bool {
 	switch strings.ToLower(strings.TrimSpace(adapter)) {
 	case "claude", "claude-code", "claude-code-desktop", "cowork", "cursor":
+		return true
+	default:
+		return false
+	}
+}
+
+// proxiedTranscriptSource reports whether a conversation row's source is the
+// LiteLLM proxy rather than an agent's own hook stream. The proxy sees every
+// turn it routes, so its transcript rows are only authoritative for sessions
+// no native stream captured.
+func proxiedTranscriptSource(source string) bool {
+	return strings.EqualFold(strings.TrimSpace(source), "litellm")
+}
+
+// nativeAssistantTurnSource reports whether a source identifies a hook stream
+// that reports an assistant turn of its own for every turn it captures, which
+// is what makes a proxied row for the same turn a duplicate. Claude's Stop hook
+// always carries the turn's final assistant message. Cursor is excluded because
+// its afterAgentResponse hook does not fire reliably outside interactive
+// sessions, and Codex and OpenCode because their final-message hooks depend on a
+// transcript read that can come back empty; dropping the proxy's copy for those
+// would leave turns with no assistant text at all.
+func nativeAssistantTurnSource(source string) bool {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "claude", "claude-code", "claude-code-desktop", "cowork":
 		return true
 	default:
 		return false

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -51,11 +51,11 @@ func isConversationEvent(eventName string) bool {
 }
 
 // defaultChatTitleForSession picks the default chat title based on the
-// session's resolved product surface. If the surface is unknown (no OTEL
-// service.name or SessionStart variant on file yet) we fall back to the
-// ambiguous "Claude Session" title rather than assuming claude-code — the
-// title generator will replace it with a real one once enough conversation
-// is on file.
+// session's resolved product surface. If the surface is unknown (nothing
+// identifying a Claude sender on file yet) we fall back to the ambiguous
+// "Claude Session" title rather than assuming claude-code — the title
+// generator will replace it with a real one once enough conversation is on
+// file.
 func (s *Service) defaultChatTitleForSession(ctx context.Context, metadata *SessionMetadata) string {
 	switch s.claudeSessionSurface(ctx, metadata) {
 	case agentVariantCowork:
@@ -102,10 +102,18 @@ func claudeServiceNameSpecificity(name string) int {
 	case agentVariantClaudeCode:
 		return 2
 	}
-	if strings.ToLower(strings.TrimSpace(name)) == "claude" {
+	if bareClaudeAdapterSlug(name) {
 		return 1
 	}
 	return 0
+}
+
+// bareClaudeAdapterSlug reports whether a reported service name is the legacy
+// "claude" slug the hooks binary sends for Claude Code. It names the sender
+// family without naming a surface, and it collides with the "claude" the
+// Anthropic compliance import writes for Claude Chat Desktop.
+func bareClaudeAdapterSlug(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(name), "claude")
 }
 
 // preferClaudeServiceName merges a freshly reported service name (or adapter
@@ -154,6 +162,16 @@ func (s *Service) claudeSessionSurface(ctx context.Context, metadata *SessionMet
 	}
 	if variant != "" {
 		return variant
+	}
+	// Only the Claude Code runtimes send the bare slug — the desktop clients
+	// send "claude-code-desktop" and cowork self-identifies on the OTEL
+	// service.name — so with nothing more specific on file the sender is Claude
+	// Code. Resolving it here keeps the slug off chat rows and telemetry, where
+	// it reads back as Claude Chat Desktop. Sessions whose OTEL stream never
+	// arrives (Claude Code telemetry disabled, or traffic routed through a proxy
+	// instead) would otherwise carry the colliding slug for their whole lifetime.
+	if bareClaudeAdapterSlug(metadata.ServiceName) {
+		return agentVariantClaudeCode
 	}
 	return metadata.ServiceName
 }
@@ -424,6 +442,35 @@ func (s *Service) sessionCaptureEnabled(ctx context.Context, metadata *SessionMe
 		return false, nil
 	}
 	return true, nil
+}
+
+// proxiedTurnDuplicatesNativeStream reports whether the session's transcript is
+// already owned by a hook stream that reports its own assistant turns, which
+// makes a proxied row for the same turn a duplicate. The marker written when a
+// native prompt lands answers this without a query; the latest user prompt's
+// source is the durable fallback for sessions whose marker expired or was
+// written before this instance saw them. Unlike the prompt path this does not
+// repair the marker: the marker also gates prompt suppression, and only the
+// prompt path's own writes decide what belongs there.
+func (s *Service) proxiedTurnDuplicatesNativeStream(ctx context.Context, metadata *SessionMetadata, chatID, projectID uuid.UUID) (bool, error) {
+	if metadata.SessionID == "" {
+		return false, nil
+	}
+	var nativeSource string
+	if err := s.cache.Get(ctx, sessionNativeHooksCacheKey(projectID.String(), metadata.SessionID), &nativeSource); err == nil && nativeAssistantTurnSource(nativeSource) {
+		return true, nil
+	}
+	latestSource, err := chatRepo.New(s.db).GetLatestChatUserPromptSource(ctx, chatRepo.GetLatestChatUserPromptSourceParams{
+		ChatID:    chatID,
+		ProjectID: projectID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("get latest chat user prompt source: %w", err)
+	}
+	return latestSource.Valid && nativeAssistantTurnSource(latestSource.String), nil
 }
 
 func (s *Service) insertUncorrelatedAgentPrompt(

--- a/server/internal/hooks/session_capture_test.go
+++ b/server/internal/hooks/session_capture_test.go
@@ -255,6 +255,41 @@ func TestPreferClaudeServiceName(t *testing.T) {
 	assert.Equal(t, "claude-code", preferClaudeServiceName("claude-code", "claude"))
 }
 
+// The bare "claude" adapter slug names no surface, but only the Claude Code
+// runtimes send it, so a session carrying nothing more specific resolves to
+// claude-code. Leaving the slug in place would stamp chat rows and telemetry
+// with the value the Anthropic compliance import uses for Claude Chat Desktop,
+// and sessions with no OTEL stream (telemetry off, or traffic routed through a
+// proxy) never get a second chance to correct it. Every more specific signal
+// still wins.
+func TestClaudeSessionSurface_ResolvesBareClaudeAdapterToClaudeCode(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	bare := &SessionMetadata{SessionID: uuid.NewString(), ServiceName: "claude"}
+	assert.Equal(t, agentVariantClaudeCode, ti.service.claudeSessionSurface(ctx, bare))
+
+	// A cached SessionStart variant still overrides the slug.
+	coworkSession := uuid.NewString()
+	require.NoError(t, ti.service.cache.Set(ctx, sessionAgentVariantCacheKey(coworkSession), agentVariantCowork, sessionMCPListTTL))
+	assert.Equal(t, agentVariantCowork, ti.service.claudeSessionSurface(ctx, &SessionMetadata{
+		SessionID:   coworkSession,
+		ServiceName: "claude",
+	}))
+
+	// Concrete surfaces and non-Claude senders are untouched, and a session
+	// with no reported name at all stays unresolved.
+	assert.Equal(t, surfaceClaudeCodeDesktop, ti.service.claudeSessionSurface(ctx, &SessionMetadata{
+		SessionID:   uuid.NewString(),
+		ServiceName: surfaceClaudeCodeDesktop,
+	}))
+	assert.Equal(t, "cursor", ti.service.claudeSessionSurface(ctx, &SessionMetadata{
+		SessionID:   uuid.NewString(),
+		ServiceName: "cursor",
+	}))
+	assert.Empty(t, ti.service.claudeSessionSurface(ctx, &SessionMetadata{SessionID: uuid.NewString()}))
+}
+
 // A session whose OTEL stream reports service.name "cowork" must persist its
 // chat messages with source "cowork" — no SessionStart inventory variant
 // needed. This is the current cowork identification path: the canonical

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -456,10 +456,12 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 		ChatID:    chat.SessionIDToChatID(claudeSession),
 		ProjectID: *authCtx.ProjectID,
 	}, 1)
-	require.Equal(t, "claude", messages[0].Source.String)
+	// The bare "claude" adapter slug resolves to the claude-code surface, so
+	// that — not the slug — is what the row and the repaired marker carry.
+	require.Equal(t, "claude-code", messages[0].Source.String)
 	var repairedMarker string
 	require.NoError(t, ti.cache.Get(ctx, fmt.Sprintf("session:native-prompt:v1:%s:%s", authCtx.ProjectID.String(), claudeSession), &repairedMarker))
-	require.Equal(t, "claude", repairedMarker)
+	require.Equal(t, "claude-code", repairedMarker)
 
 	cursorSession := uuid.NewString()
 	ingestNativePrompt("cursor", cursorSession, "generation_"+uuid.NewString())
@@ -481,8 +483,8 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 	// Claude has no turn ID shared with LiteLLM. LiteLLM-first therefore keeps
 	// both observations, and repeated identical native prompts remain distinct.
 	require.Equal(t, "litellm", messages[0].Source.String)
-	require.Equal(t, "claude", messages[1].Source.String)
-	require.Equal(t, "claude", messages[2].Source.String)
+	require.Equal(t, "claude-code", messages[1].Source.String)
+	require.Equal(t, "claude-code", messages[2].Source.String)
 
 	startedOnlySession := uuid.NewString()
 	_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
@@ -509,6 +511,107 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 		ChatID:    chat.SessionIDToChatID(startedOnlySession),
 		ProjectID: *authCtx.ProjectID,
 	}, 1)
+	require.Equal(t, "litellm", messages[0].Source.String)
+}
+
+// A Claude Code session routed through LiteLLM reports every turn twice: the
+// proxy sees the completion the moment the model returns it, and Claude's Stop
+// hook reports the same text when the turn ends. Prompts collapse onto a single
+// row through the session's native marker, but assistant turns share no
+// identity across the two observers, so the proxied row has to be dropped or
+// the transcript shows every answer twice.
+func TestRealHooksProxiedAssistantTurnDoesNotDuplicateNativeClaudeStop(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	prompt := "hey again"
+	answer := "Hey! What are you working on today?"
+	role := "assistant"
+	ingestNativeEvent := func(sessionID, eventType string, data *hooksgen.HookIngestData) {
+		t.Helper()
+		_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
+			ApikeyToken:      nil,
+			ProjectSlugInput: nil,
+			Replayed:         nil,
+			SchemaVersion:    "hook.ingest.v1",
+			IdempotencyKey:   new("native-" + uuid.NewString()),
+			Source: &hooksgen.HookIngestSource{
+				Adapter:        "claude",
+				AdapterVersion: nil,
+				RawEventName:   nil,
+				Hostname:       nil,
+				UserEmail:      nil,
+			},
+			Session: &hooksgen.HookIngestSession{ID: &sessionID, TurnID: nil, Cwd: nil, Model: nil},
+			Event:   &hooksgen.HookIngestEvent{Type: eventType, OccurredAt: nil},
+			Data:    data,
+			Raw:     nil,
+		})
+		require.NoError(t, err)
+	}
+	ingestLiteLLMResponse := func(sessionID string) {
+		t.Helper()
+		response := testPayload()
+		response.InputType = "response"
+		response.LitellmCallID = new("call-" + uuid.NewString())
+		response.Texts = []string{answer}
+		response.RequestHeaders = map[string]string{"x-session-id": sessionID}
+		result, err := ti.service.Ingest(ctx, response)
+		require.NoError(t, err)
+		require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+	}
+
+	sessionID := "claude-litellm-" + uuid.NewString()
+	ingestNativeEvent(sessionID, "prompt.submitted", &hooksgen.HookIngestData{Prompt: &hooksgen.HookPromptData{Text: &prompt}})
+	ingestLiteLLMResponse(sessionID)
+	ingestNativeEvent(sessionID, "assistant.responded", &hooksgen.HookIngestData{
+		Message: &hooksgen.HookMessageData{Text: &answer, Role: &role, DurationMs: nil},
+	})
+
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(sessionID),
+		ProjectID: *authCtx.ProjectID,
+	}, 2)
+	require.Equal(t, "user", messages[0].Role)
+	require.Equal(t, prompt, messages[0].Content)
+	require.Equal(t, "assistant", messages[1].Role)
+	require.Equal(t, answer, messages[1].Content)
+	for _, message := range messages {
+		require.Equal(t, "claude-code", message.Source.String,
+			"the native hook stream owns a proxied Claude session's transcript")
+	}
+
+	// The marker the native prompt wrote is a cache, not the contract: a
+	// session whose marker is gone must still resolve ownership from the
+	// transcript rather than duplicating the turn.
+	expiredMarkerSession := "claude-litellm-expired-" + uuid.NewString()
+	ingestNativeEvent(expiredMarkerSession, "prompt.submitted", &hooksgen.HookIngestData{Prompt: &hooksgen.HookPromptData{Text: &prompt}})
+	require.NoError(t, ti.cache.Delete(ctx, fmt.Sprintf("session:native-prompt:v1:%s:%s", authCtx.ProjectID.String(), expiredMarkerSession)))
+	ingestLiteLLMResponse(expiredMarkerSession)
+	ingestNativeEvent(expiredMarkerSession, "assistant.responded", &hooksgen.HookIngestData{
+		Message: &hooksgen.HookMessageData{Text: &answer, Role: &role, DurationMs: nil},
+	})
+
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(expiredMarkerSession),
+		ProjectID: *authCtx.ProjectID,
+	}, 2)
+	require.Equal(t, "user", messages[0].Role)
+	require.Equal(t, "assistant", messages[1].Role)
+
+	// A session no native stream captured keeps the proxy's assistant turn:
+	// dropping it there would leave the transcript with no answer at all.
+	proxyOnlySession := "litellm-only-" + uuid.NewString()
+	ingestLiteLLMResponse(proxyOnlySession)
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(proxyOnlySession),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "assistant", messages[0].Role)
+	require.Equal(t, answer, messages[0].Content)
 	require.Equal(t, "litellm", messages[0].Source.String)
 }
 
@@ -582,7 +685,7 @@ func TestRealHooksConcurrentUncorrelatedPromptsPreserveNative(t *testing.T) {
 		liteLLMCount := 0
 		for _, message := range messages {
 			switch message.Source.String {
-			case "claude":
+			case "claude-code":
 				nativeCount++
 			case "litellm":
 				liteLLMCount++


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes both defects in DNO-825, where a Claude Code session routed through LiteLLM appeared as a **Claude Chat Desktop** session with **every answer listed twice**.

**Duplicate assistant turns.** The proxy reports a completion the moment the model returns it, and Claude's `Stop` hook reports the same text when the turn ends. Prompts already collapse onto one row through the session's native-prompt marker, but assistant turns share no identity across the two observers, so both rows landed in the transcript. A proxied assistant turn is now dropped when a Claude hook stream already owns the session's transcript — resolved from the native-prompt marker, with the latest user prompt's source as the durable fallback for sessions whose marker expired. Sessions no native stream captured keep the proxy's row (dropping it there would leave a transcript with no answer at all), and cost/telemetry for the proxied call are untouched.

Suppression is limited to Claude-family native sources. Cursor's `afterAgentResponse` hook does not fire reliably outside interactive sessions, and Codex/OpenCode final-message hooks depend on a transcript read that can come back empty, so for those the proxy's copy is still the safer transcript row.

**Surface label.** The bare `claude` adapter slug the hooks binary sends for Claude Code now resolves to the `claude-code` surface even when a session has no OpenTelemetry `service.name` on file. Previously the slug reached chat rows and telemetry unchanged, where it collides with the `claude` the Anthropic compliance import writes for Claude Chat Desktop and renders as that surface. Sessions that never produce an OTEL stream — telemetry disabled, or traffic routed through a proxy — carried the colliding slug for their whole lifetime. Every more specific signal (cowork, `claude-code-desktop`, a cached `SessionStart` variant) still wins.

## Verification

Replayed a LiteLLM-proxied Claude Code turn against a local server — `SessionStart`, the native prompt hook, the proxy's post-call response hook, and the native `Stop` hook — first on the pre-fix build, then on the fixed build.

| | source rows | Agent Sessions label | messages |
|---|---|---|---|
| before | `claude`, `litellm`, `claude` | Claude Chat Desktop | 3 |
| after | `claude-code`, `claude-code` | Claude Code | 2 |

![Agent Sessions list showing the pre-fix session as Claude Chat Desktop with 3 messages and the post-fix session as Claude Code with 2 messages](https://cursor.com/artifacts/c/art-5ec39a06-009c-4c59-ac76-6cded887df1d)

Pre-fix transcript (reproduces the issue's screenshot) and the same replay after the fix:

![Pre-fix transcript with the assistant answer duplicated](https://cursor.com/artifacts/c/art-c7e402d1-7892-45fa-8f81-aed9102cbf80)

![Post-fix transcript with a single assistant answer](https://cursor.com/artifacts/c/art-83ebbfcc-0b6a-4fd3-bb53-6486897e572d)

Tests: `mise run test:server ./internal/hooks/...` (483) and `./internal/litellm/...` (94) pass, plus `mise run lint:server`. New coverage: `TestRealHooksProxiedAssistantTurnDoesNotDuplicateNativeClaudeStop` (native + proxied turn, expired marker, and proxy-only session) and `TestClaudeSessionSurface_ResolvesBareClaudeAdapterToClaudeCode`. Two existing LiteLLM integration assertions moved from `claude` to `claude-code` to match the resolved surface.

## Note for reviewers

These sessions are now attributed to the agent that ran them, so a proxied Claude Code session reads "Claude Code" and no longer carries a `litellm`-sourced message row — it will not match a LiteLLM platform filter. Annotating such a session as "\<Client\> via LiteLLM" is DNO-821's surface (#5140); because that work keys off the `litellm` message source, it will need a proxied-session marker rather than the row source to cover natively captured sessions. Left out of this fix to avoid conflicting with that PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-825](https://linear.app/speakeasy/issue/DNO-825/bug-litellm-integration-issues)

<div><a href="https://cursor.com/agents/bc-24a75b6a-c926-43b1-b087-65d1ace42d33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24a75b6a-c926-43b1-b087-65d1ace42d33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate assistant turns and wrong surface attribution for Claude Code sessions routed through `LiteLLM`. Previously these sessions appeared as Claude Chat Desktop with each assistant answer persisted twice; now each turn has a single assistant message and sessions/messages are labeled Claude Code, addressing DNO-825.

- Drops proxied assistant rows when a native Claude hook stream owns the transcript (resolved from the native-prompt marker, falling back to the latest user prompt’s source); keeps the proxy’s row when no native stream exists; cost/telemetry unaffected.
- Limits suppression to Claude-family native sources; `Cursor`, `Codex`, and `OpenCode` behavior is unchanged.
- Resolves the bare `claude` adapter slug to `claude-code` for session surface and message sources even without OTEL; more specific signals still override; no backfill.

<sup>Written for commit ef4384df200ac2307370cc8572edb6d9545c663b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

