### PR TITLE
fix(dashboard): stop nesting the shared assistant runtime on self-hosting pages (DNO-826)

### DIFF
--- a/client/dashboard/src/components/insights-dock-routes.test.ts
+++ b/client/dashboard/src/components/insights-dock-routes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { pageHostsOwnAssistantRuntime } from "./insights-dock-routes";
+
+const PREFIX = "/acme/projects/widgets";
+
+describe("pageHostsOwnAssistantRuntime", () => {
+  it("matches pages that host their own chat runtime", () => {
+    // Playground and Chat Elements bring their own RemoteThreadListRuntime.
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/playground`)).toBe(true);
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/elements`)).toBe(true);
+    // Assistant onboarding editor (create + edit) hosts its own runtime.
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/assistants/new`)).toBe(true);
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/assistants/asst_123`)).toBe(
+      true,
+    );
+  });
+
+  it("does not match the bare assistants list (needs the shared dock composer)", () => {
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/assistants`)).toBe(false);
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/assistants/`)).toBe(false);
+  });
+
+  it("does not match ordinary pages that show the docked composer", () => {
+    expect(pageHostsOwnAssistantRuntime(PREFIX)).toBe(false);
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/chat`)).toBe(false);
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/mcp`)).toBe(false);
+    expect(pageHostsOwnAssistantRuntime(`${PREFIX}/skills`)).toBe(false);
+  });
+});

--- a/client/dashboard/src/components/insights-dock-routes.ts
+++ b/client/dashboard/src/components/insights-dock-routes.ts
@@ -1,0 +1,22 @@
+/**
+ * True for routes whose page mounts its OWN RemoteThreadListRuntime — the
+ * Playground, Chat Elements, and the assistant onboarding editor
+ * (/assistants/new and /assistants/:id). The shared Project Assistant runtime
+ * must NOT be mounted above these pages: assistant-ui throws when one
+ * RemoteThreadListRuntime is nested inside another. This is a synchronous,
+ * render-time signal (keyed off the route) rather than the ref-counted
+ * dock-hide, which flips in a layout effect — too late, since the nested inner
+ * runtime already threw during the child's render. The bare `/assistants` list
+ * has no runtime of its own and still wants the docked composer, so only its
+ * sub-routes match.
+ *
+ * Lives in its own module (not `insights-dock.tsx`) so it can be unit-tested
+ * without pulling in that component's heavy import graph.
+ */
+export function pageHostsOwnAssistantRuntime(pathname: string): boolean {
+  return (
+    /\/playground(\/|$)/.test(pathname) ||
+    /\/elements(\/|$)/.test(pathname) ||
+    /\/assistants\/[^/]/.test(pathname)
+  );
+}

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -60,6 +60,7 @@ import {
 import type { InsightsConfigOptions } from "./insights-context";
 import { InsightsContext, useInsightsState } from "./insights-context";
 import { InsightsShortcutKeys } from "./insights-dock-shortcut-hint";
+import { pageHostsOwnAssistantRuntime } from "./insights-dock-routes";
 import { useAskAiListener } from "./command-palette/askAiBridge";
 
 // Types-only re-export (erased at compile time, won't break Fast Refresh)
@@ -1027,26 +1028,17 @@ export function InsightsProvider({
     [user.id, user.email],
   );
 
-  // Mount the shared runtime only where it's actually used: a chat route (the
-  // page owns the chat) or the open dock — and only where the dock is shown.
-  // Pages with their own chat runtime (Playground, Elements, assistant
-  // onboarding) hide the dock, so `!hideTrigger` keeps the shared provider out
-  // of their tree and the two RemoteThreadListRuntimes never nest. Maximize
-  // stays seamless because the expand handler navigates WITHOUT collapsing, so
-  // `onChatRoute` takes over before `isExpanded` flips (no unmount gap).
-  // Everything runtime-dependent — the dock panel's chat view, the provider
-  // mount, and (via context) the chat pages — gates on this single flag.
-  // Mounted wherever a composer can appear — every surface now renders the
-  // same AUI composer, and that needs the runtime present, not just when the
-  // chat panel happens to be open. MCP discovery is a react-query on a
-  // module-level client, so the extra mounts reuse one cached result.
-  // Mounted as soon as the assistant resolves, not only where chat is visible:
-  // every entry point (dock pill, /chat landing, project home widget, full
-  // page) now renders the same AUI composer, and that needs the runtime in the
-  // tree. Pages that hide the dock still embed the landing widget, so gating on
-  // dock visibility left those surfaces on the legacy input. MCP discovery is a
-  // react-query on a module-level client, so the extra mounts share one result.
-  const runtimeMounted = assistantReady;
+  // Mount the shared runtime as soon as the assistant resolves, wherever a
+  // composer can appear: every entry point (dock pill, /chat landing, project
+  // home widget, full page) now renders the same AUI composer, and that needs
+  // the runtime in the tree. Pages that hide the dock still embed the landing
+  // widget, so gating on dock visibility would leave those surfaces on the
+  // legacy input. MCP discovery is a react-query on a module-level client, so
+  // the extra mounts share one cached result. Pages that host their own chat
+  // runtime are excluded (see pageHostsOwnAssistantRuntime) so the two
+  // RemoteThreadListRuntimes never nest — assistant-ui throws when they do.
+  const runtimeMounted =
+    assistantReady && !pageHostsOwnAssistantRuntime(pathname);
 
   // Read inside the transport wrapper via ref so override churn doesn't
   // re-create the transport identity on every parent re-render.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes the "Assistants UI totally broken" crash (DNO-826). Opening or creating an assistant (and visiting the Playground or Chat Elements) threw:

> `useRemoteThreadListRuntime cannot be nested inside another RemoteThreadListRuntime. Set allowNesting: true to allow nesting (the inner runtime will become a no-op).`

## Why

PR #5138 changed the shared Project Assistant runtime to mount on **every** page as soon as the assistant resolves (`runtimeMounted = assistantReady`). That was intentional — every entry point now renders the same AUI composer, which needs the runtime in the tree.

But three pages host their **own** `RemoteThreadListRuntime`: the **Playground**, **Chat Elements**, and the **assistant onboarding editor** (`/assistants/new`, `/assistants/:id`). With the shared runtime mounted above them, the inner runtime detects the nesting and throws during render — crashing the whole page.

These pages call `useHideInsightsDock()`, but that hides the dock via a ref-counted **layout effect**, which is too late: assistant-ui throws while the child renders, before any effect runs. So the gate has to be a synchronous, render-time signal.

## Changes

- **`insights-dock.tsx`** — gate the shared runtime with `assistantReady && !pageHostsOwnAssistantRuntime(pathname)`.
- **`insights-dock-routes.ts`** (new) — `pageHostsOwnAssistantRuntime(pathname)`, a pure route predicate matching `/playground`, `/elements`, and `/assistants/<sub>` (the bare `/assistants` list is excluded so it keeps the shared dock composer). Split into its own module so it's unit-testable without the component's heavy import graph.
- **`insights-dock-routes.test.ts`** (new) — unit tests for the predicate.

The composer-everywhere behavior from #5138 is preserved: the shared "Ask anything" dock composer still mounts on ordinary pages, the `/chat` landing/full page, and the project home widget.

## Testing

- `pnpm -F dashboard type-check`, `hk fix`, and the new vitest suite pass.
- Reproduced live against the local stack: `/assistants/new` crashed with the exact error before the fix and renders the onboarding UI after. Playground, Chat Elements, the assistants list, and `/mcp` (with the shared dock composer) all load without the nesting error.

### Before (crash)
![Assistant onboarding crash before fix](https://cursor.com/artifacts/c/art-a68dfb51-9ce2-4ddf-9b47-f17b7eb0e8f8)

### After (fixed)
![Assistant onboarding renders after fix](https://cursor.com/artifacts/c/art-20556db3-6c39-48d5-a01a-4c643f46b548)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-826](https://linear.app/speakeasy/issue/DNO-826/bug-assistants-ui-totally-broken)

<div><a href="https://cursor.com/agents/bc-e35801bf-1742-4c0d-b272-c491b2dbf9fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e35801bf-1742-4c0d-b272-c491b2dbf9fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the crash in DNO-826 by preventing the shared Project Assistant runtime from mounting on pages that host their own `RemoteThreadListRuntime` (Playground, Chat Elements, and assistant onboarding). Assistants UI loads reliably again without nesting errors.

- **Bug Fixes**
  - Gate the shared runtime with `assistantReady && !pageHostsOwnAssistantRuntime(pathname)`.
  - Add `insights-dock-routes.ts` with a route predicate for `/playground`, `/elements`, and `/assistants/<sub>` (excluding the bare `/assistants` list).
  - Add unit tests for the predicate.

<sup>Written for commit 732c4af5667d90b2c256df0244936b69f15ad331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

