### PR TITLE
feat: cache CIMD metadata documents

### DIFF
--- a/.changeset/cimd-metadata-document-cache.md
+++ b/.changeset/cimd-metadata-document-cache.md
@@ -1,0 +1,9 @@
+---
+"server": minor
+---
+
+Cache OAuth client ID metadata documents instead of refetching them on every
+authorization request, honoring upstream `Cache-Control` and `Expires` headers
+within a 5 minute to 24 hour bound and revalidating with `If-None-Match`. A
+fetch or validation failure leaves the cached document untouched and fails the
+request rather than serving a stale one.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1466,10 +1466,13 @@ CREATE TABLE IF NOT EXISTS user_session_clients (
   -- this URL, so storing it as a discriminator avoids parsing client_id at
   -- runtime to tell CIMD rows from DCR rows.
   client_id_metadata_uri TEXT,
-  -- Last successful fetch of the metadata document (observability and ops).
+  -- Last successful read of the metadata document, whether that was a fresh
+  -- body or a 304 confirming the stored one (observability and ops).
   client_id_metadata_fetched_at timestamptz,
   -- Cache TTL hint derived from upstream Cache-Control / Expires headers,
-  -- bounded by application-side min/max. NULL means no cached fetch yet.
+  -- bounded by application-side min/max. NULL means no cached fetch yet, and
+  -- setting it back to NULL is the purge lever that forces the next
+  -- authorization to re-read the document.
   client_id_metadata_cache_expires_at timestamptz,
   -- ETag from the last successful fetch, used for If-None-Match conditional
   -- refresh. Optional, since not all metadata hosts emit one.

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,11 +32,18 @@ import (
 )
 
 // cimdDocServer hosts a Client ID Metadata Document at
-// <TLS server>/oauth/client.json. Tests mutate doc before issuing requests.
+// <TLS server>/oauth/client.json. Tests reshape the served response through
+// set before issuing requests; mu covers every mutable field because the
+// handler runs on the server's own goroutine and a loopback round trip is
+// not a synchronization edge the race detector recognizes.
 type cimdDocServer struct {
 	srv      *httptest.Server
 	clientID string
-	doc      map[string]any
+
+	mu sync.Mutex
+
+	// doc is the document body, encoded on every 200.
+	doc map[string]any
 
 	// etag, when non-empty, is served as the document's ETag and matched
 	// against an incoming If-None-Match, which a match answers with 304.
@@ -60,12 +68,23 @@ type cimdDocServer struct {
 	conditionalRequests atomic.Int64
 }
 
+// set applies a mutation to the served response under the same lock the
+// handler reads with.
+func (ds *cimdDocServer) set(t *testing.T, mutate func(ds *cimdDocServer)) {
+	t.Helper()
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	mutate(ds)
+}
+
 func startCIMDDocServer(t *testing.T) *cimdDocServer {
 	t.Helper()
 
 	ds := &cimdDocServer{
 		srv:                 nil,
 		clientID:            "",
+		mu:                  sync.Mutex{},
 		doc:                 nil,
 		etag:                "",
 		cacheControl:        "",
@@ -80,6 +99,12 @@ func startCIMDDocServer(t *testing.T) *cimdDocServer {
 		if conditional != "" {
 			ds.conditionalRequests.Add(1)
 		}
+
+		// Held for the whole response so the doc map cannot change mid
+		// encode; requests in these tests are sequential, so contention is
+		// not a concern.
+		ds.mu.Lock()
+		defer ds.mu.Unlock()
 
 		// Failure injection wins over revalidation: a host that has started
 		// erroring does so whether or not the request was conditional.
@@ -311,7 +336,7 @@ func TestOAuthCIMD_ConfidentialAuthMethodRejected(t *testing.T) {
 
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.doc["token_endpoint_auth_method"] = "client_secret_basic"
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["token_endpoint_auth_method"] = "client_secret_basic" })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_client_metadata")
@@ -322,7 +347,7 @@ func TestOAuthCIMD_DocumentClientIDMismatchRejected(t *testing.T) {
 
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.doc["client_id"] = ds.srv.URL + "/oauth/other.json"
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_id"] = ds.srv.URL + "/oauth/other.json" })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_client_metadata")
@@ -333,7 +358,7 @@ func TestOAuthCIMD_CrossOriginRedirectURIRejected(t *testing.T) {
 
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.doc["redirect_uris"] = []any{"https://elsewhere.example.com/callback"}
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{"https://elsewhere.example.com/callback"} })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "https://elsewhere.example.com/callback", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_redirect_uri")
@@ -358,7 +383,7 @@ func TestOAuthCIMD_NonLoopbackPortVarianceRejected(t *testing.T) {
 
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.doc["redirect_uris"] = []any{ds.srv.URL + "/callback"}
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{ds.srv.URL + "/callback"} })
 
 	docURL, err := url.Parse(ds.srv.URL)
 	require.NoError(t, err)
@@ -373,9 +398,9 @@ func TestOAuthCIMD_UnknownExtensionFieldsAccepted(t *testing.T) {
 
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.doc["software_statement"] = "eyJhbGciOiJub25lIn0.e30."
-	ds.doc["client_id_expires_at"] = 4102444800
-	ds.doc["x_vendor_extension"] = map[string]any{"nested": true}
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["software_statement"] = "eyJhbGciOiJub25lIn0.e30." })
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_id_expires_at"] = 4102444800 })
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["x_vendor_extension"] = map[string]any{"nested": true} })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code, "documents with unrecognized extension fields must be accepted: %s", w.Body.String())
@@ -522,7 +547,7 @@ func TestOAuthCIMD_RepeatAuthorizeServesFromCache(t *testing.T) {
 	require.True(t, first.ClientIDMetadataCacheExpiresAt.Valid, "the first fetch must establish a cache expiry")
 	require.True(t, first.ClientIDMetadataCacheExpiresAt.Time.After(time.Now()), "a freshly written expiry must be in the future")
 
-	ds.doc["client_name"] = "Renamed CIMD Client"
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_name"] = "Renamed CIMD Client" })
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
@@ -553,8 +578,8 @@ func TestOAuthCIMD_RepeatAuthorizeRefreshesClient(t *testing.T) {
 	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
 
 	lapsed := lapseCIMDCache(t, ctx, ti, first)
-	ds.doc["client_name"] = "Renamed CIMD Client"
-	ds.doc["redirect_uris"] = []any{redirectURI, "http://localhost:3000/other"}
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_name"] = "Renamed CIMD Client" })
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{redirectURI, "http://localhost:3000/other"} })
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
@@ -578,7 +603,7 @@ func TestOAuthCIMD_LapsedCacheRevalidatesWithETag(t *testing.T) {
 
 	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.etag = `"v1"`
+	ds.set(t, func(ds *cimdDocServer) { ds.etag = `"v1"` })
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:33418/callback"
@@ -589,7 +614,7 @@ func TestOAuthCIMD_LapsedCacheRevalidatesWithETag(t *testing.T) {
 	require.Equal(t, `"v1"`, first.ClientIDMetadataEtag.String, "the host's validator must be persisted")
 
 	lapsed := lapseCIMDCache(t, ctx, ti, first)
-	ds.doc["client_name"] = "Never Served"
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_name"] = "Never Served" })
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
@@ -615,7 +640,7 @@ func TestOAuthCIMD_RevalidationPicksUpRotatedDocument(t *testing.T) {
 
 	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.etag = `"v1"`
+	ds.set(t, func(ds *cimdDocServer) { ds.etag = `"v1"` })
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:33418/callback"
@@ -625,9 +650,9 @@ func TestOAuthCIMD_RevalidationPicksUpRotatedDocument(t *testing.T) {
 	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
 
 	lapseCIMDCache(t, ctx, ti, first)
-	ds.etag = `"v2"`
-	ds.doc["client_name"] = "Rotated CIMD Client"
-	ds.doc["redirect_uris"] = []any{redirectURI, "http://localhost:3000/other"}
+	ds.set(t, func(ds *cimdDocServer) { ds.etag = `"v2"` })
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_name"] = "Rotated CIMD Client" })
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{redirectURI, "http://localhost:3000/other"} })
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
@@ -649,7 +674,7 @@ func TestOAuthCIMD_PurgeForcesUnconditionalReread(t *testing.T) {
 
 	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.etag = `"v1"`
+	ds.set(t, func(ds *cimdDocServer) { ds.etag = `"v1"` })
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:33418/callback"
@@ -664,7 +689,7 @@ func TestOAuthCIMD_PurgeForcesUnconditionalReread(t *testing.T) {
 	require.False(t, purged.ClientIDMetadataCacheExpiresAt.Valid)
 	require.False(t, purged.ClientIDMetadataEtag.Valid)
 
-	ds.doc["client_name"] = "Renamed After Purge"
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_name"] = "Renamed After Purge" })
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
@@ -684,7 +709,7 @@ func TestOAuthCIMD_UpstreamMaxAgeClampedToFloor(t *testing.T) {
 
 	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.cacheControl = "public, max-age=120"
+	ds.set(t, func(ds *cimdDocServer) { ds.cacheControl = "public, max-age=120" })
 
 	before := time.Now()
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
@@ -713,7 +738,7 @@ func TestOAuthCIMD_RefreshFailureDoesNotPoisonCache(t *testing.T) {
 	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
 
 	lapsed := lapseCIMDCache(t, ctx, ti, first)
-	ds.status = http.StatusInternalServerError
+	ds.set(t, func(ds *cimdDocServer) { ds.status = http.StatusInternalServerError })
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusServiceUnavailable, w.Code, "a failed refresh aborts rather than serving stale")
@@ -743,7 +768,7 @@ func TestOAuthCIMD_InvalidDocumentOnRefreshDoesNotPoisonCache(t *testing.T) {
 	lapsed := lapseCIMDCache(t, ctx, ti, first)
 	// A document that no longer satisfies the spec: -02 §4.1 forbids a
 	// client_secret in a document that is public by definition.
-	ds.doc["client_secret"] = "leaked"
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_secret"] = "leaked" })
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_client_metadata")
@@ -850,7 +875,7 @@ func TestOAuthCIMD_ConsentEscapesHostileClientName(t *testing.T) {
 
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.doc["client_name"] = `<img src=x onerror=alert(1)> Client`
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_name"] = `<img src=x onerror=alert(1)> Client` })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
@@ -872,7 +897,7 @@ func TestOAuthCIMD_ConsentNoLoopbackWarningForSameOriginRedirect(t *testing.T) {
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
 	redirectURI := ds.srv.URL + "/callback"
-	ds.doc["redirect_uris"] = []any{redirectURI}
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{redirectURI} })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
@@ -923,7 +948,7 @@ func TestOAuthCIMD_LoopbackEmptyFragmentRegistrationRejected(t *testing.T) {
 
 	_, ti, ds, toolset, orgID := newTestCIMDService(t)
 	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
-	ds.doc["redirect_uris"] = []any{"http://127.0.0.1:33418/callback#"}
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{"http://127.0.0.1:33418/callback#"} })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -35,19 +36,68 @@ type cimdDocServer struct {
 	srv      *httptest.Server
 	clientID string
 	doc      map[string]any
+
+	// etag, when non-empty, is served as the document's ETag and matched
+	// against an incoming If-None-Match, which a match answers with 304.
+	etag string
+
+	// cacheControl, when non-empty, is sent verbatim as the document's
+	// Cache-Control header on both 200 and 304 responses.
+	cacheControl string
+
+	// status, when non-zero, replaces every response with that error status,
+	// standing in for a document host that has started failing.
+	status int
+
 	// requests counts document fetches. Admission control's whole value is
-	// that a denial costs no outbound request, which is only observable by
-	// asserting this stays at zero.
+	// that a denial costs no outbound request, and the document cache's is
+	// that a warm client costs none either; both are only observable by
+	// asserting on this.
 	requests atomic.Int64
+
+	// conditionalRequests counts the subset of requests that carried an
+	// If-None-Match header.
+	conditionalRequests atomic.Int64
 }
 
 func startCIMDDocServer(t *testing.T) *cimdDocServer {
 	t.Helper()
 
-	ds := &cimdDocServer{srv: nil, clientID: "", doc: nil, requests: atomic.Int64{}}
+	ds := &cimdDocServer{
+		srv:                 nil,
+		clientID:            "",
+		doc:                 nil,
+		etag:                "",
+		cacheControl:        "",
+		status:              0,
+		requests:            atomic.Int64{},
+		conditionalRequests: atomic.Int64{},
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/oauth/client.json", func(w http.ResponseWriter, r *http.Request) {
 		ds.requests.Add(1)
+		conditional := r.Header.Get("If-None-Match")
+		if conditional != "" {
+			ds.conditionalRequests.Add(1)
+		}
+
+		// Failure injection wins over revalidation: a host that has started
+		// erroring does so whether or not the request was conditional.
+		if ds.status != 0 {
+			http.Error(w, "document host failure", ds.status)
+			return
+		}
+
+		if ds.cacheControl != "" {
+			w.Header().Set("Cache-Control", ds.cacheControl)
+		}
+		if ds.etag != "" && conditional == ds.etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if ds.etag != "" {
+			w.Header().Set("ETag", ds.etag)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(ds.doc); err != nil {
 			t.Errorf("encode cimd document: %v", err)
@@ -416,10 +466,79 @@ func doCIMDConsentGet(t *testing.T, ti *testInstance, mcpSlug, stateID string) *
 	return w
 }
 
+// getCIMDClientRow reads the persisted client row for the doc server's
+// client_id, which every cache assertion is made against.
+func getCIMDClientRow(t *testing.T, ctx context.Context, ti *testInstance, toolset toolsets_repo.Toolset, clientID string) usersessions_repo.UserSessionClient {
+	t.Helper()
+
+	row, err := usersessions_repo.New(ti.conn).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		ClientID:            clientID,
+	})
+	require.NoError(t, err)
+	return row
+}
+
+// lapseCIMDCache back-dates a client's cache expiry, leaving its stored
+// validator in place so the next authorize revalidates conditionally. Tests
+// need it because the floor on a cache lifetime is five minutes, which no
+// test can wait out.
+//
+// It drives the same writer the 304 path uses, with a negative lifetime the
+// [5m, 24h] clamp can never produce in production. Nothing in the query
+// treats a negative interval specially, so the only effect is landing the
+// expiry in the past. The returned row is the state the client is in when the
+// authorize under test runs, so assertions about what that authorize changed
+// should compare against it rather than against the pre-lapse row.
+func lapseCIMDCache(t *testing.T, ctx context.Context, ti *testInstance, client usersessions_repo.UserSessionClient) usersessions_repo.UserSessionClient {
+	t.Helper()
+
+	row, err := usersessions_repo.New(ti.conn).UpdateUserSessionClientCIMDCache(ctx, usersessions_repo.UpdateUserSessionClientCIMDCacheParams{
+		ID:                   client.ID,
+		CacheTtlSeconds:      -60,
+		ClientIDMetadataEtag: client.ClientIDMetadataEtag,
+	})
+	require.NoError(t, err)
+	require.True(t, row.ClientIDMetadataCacheExpiresAt.Time.Before(time.Now()), "the cache must actually be lapsed for the test to exercise a refresh")
+	return row
+}
+
+// TestOAuthCIMD_RepeatAuthorizeServesFromCache pins the headline behaviour: a
+// client connecting twice in quick succession costs exactly one upstream
+// fetch, and the second authorize answers from the stored row even though the
+// document behind it has since changed.
+func TestOAuthCIMD_RepeatAuthorizeServesFromCache(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:33418/callback"
+
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.True(t, first.ClientIDMetadataCacheExpiresAt.Valid, "the first fetch must establish a cache expiry")
+	require.True(t, first.ClientIDMetadataCacheExpiresAt.Time.After(time.Now()), "a freshly written expiry must be in the future")
+
+	ds.doc["client_name"] = "Renamed CIMD Client"
+
+	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	require.Equal(t, int64(1), ds.requests.Load(), "a warm cache must cost no upstream request")
+	second := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, first.ID, second.ID)
+	require.Equal(t, "CIMD Integration Client", second.ClientName, "a cache hit writes nothing")
+	require.Equal(t, first.ClientIDMetadataFetchedAt.Time, second.ClientIDMetadataFetchedAt.Time)
+	require.Equal(t, first.ClientIDMetadataCacheExpiresAt.Time, second.ClientIDMetadataCacheExpiresAt.Time)
+}
+
 // TestOAuthCIMD_RepeatAuthorizeRefreshesClient exercises the ON CONFLICT DO
-// UPDATE branch of the lazy upsert — the path every returning user hits: the
-// second authorize must reuse the same row (stable id for consent/session
-// FKs) while replacing the mutable metadata from the refetched document.
+// UPDATE branch of the lazy upsert — the path a returning user hits once the
+// cache has lapsed: the refetch must reuse the same row (stable id for
+// consent/session FKs) while replacing the mutable metadata.
 func TestOAuthCIMD_RepeatAuthorizeRefreshesClient(t *testing.T) {
 	t.Parallel()
 
@@ -431,28 +550,207 @@ func TestOAuthCIMD_RepeatAuthorizeRefreshesClient(t *testing.T) {
 
 	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
+	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
 
-	first, err := usersessions_repo.New(ti.conn).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
-		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ClientID:            ds.clientID,
-	})
-	require.NoError(t, err)
-
+	lapsed := lapseCIMDCache(t, ctx, ti, first)
 	ds.doc["client_name"] = "Renamed CIMD Client"
 	ds.doc["redirect_uris"] = []any{redirectURI, "http://localhost:3000/other"}
 
 	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
 
-	second, err := usersessions_repo.New(ti.conn).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
-		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ClientID:            ds.clientID,
-	})
-	require.NoError(t, err)
+	require.Equal(t, int64(2), ds.requests.Load(), "a lapsed cache must refetch")
+	second := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
 	require.Equal(t, first.ID, second.ID, "repeat authorize must update the existing row, not create a new one")
 	require.Equal(t, "Renamed CIMD Client", second.ClientName)
 	require.Equal(t, []string{redirectURI, "http://localhost:3000/other"}, second.RedirectUris)
-	require.True(t, second.ClientIDMetadataFetchedAt.Time.After(first.ClientIDMetadataFetchedAt.Time), "fetch stamp must be refreshed")
+	require.True(t, second.ClientIDMetadataFetchedAt.Time.After(lapsed.ClientIDMetadataFetchedAt.Time), "fetch stamp must be refreshed")
+	require.True(t, second.ClientIDMetadataCacheExpiresAt.Time.After(time.Now()), "the refetch must re-establish the expiry")
+}
+
+// TestOAuthCIMD_LapsedCacheRevalidatesWithETag drives the full validator
+// round trip: the first authorize stores the host's ETag, and the refresh
+// after the cache lapses is conditional. The 304 must leave the stored
+// document alone — including a client_name the host has since changed, which
+// it never gets to report because the body is not re-sent.
+func TestOAuthCIMD_LapsedCacheRevalidatesWithETag(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.etag = `"v1"`
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:33418/callback"
+
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, `"v1"`, first.ClientIDMetadataEtag.String, "the host's validator must be persisted")
+
+	lapsed := lapseCIMDCache(t, ctx, ti, first)
+	ds.doc["client_name"] = "Never Served"
+
+	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	require.Equal(t, int64(2), ds.requests.Load())
+	require.Equal(t, int64(1), ds.conditionalRequests.Load(), "the stored validator must be replayed")
+
+	second := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, first.ID, second.ID)
+	require.Equal(t, "CIMD Integration Client", second.ClientName, "a 304 must not blow away the cached document")
+	require.Equal(t, []string{redirectURI}, second.RedirectUris)
+	require.Equal(t, `"v1"`, second.ClientIDMetadataEtag.String)
+	require.True(t, second.ClientIDMetadataFetchedAt.Time.After(lapsed.ClientIDMetadataFetchedAt.Time), "a revalidation is a successful fetch")
+	require.True(t, second.ClientIDMetadataCacheExpiresAt.Time.After(time.Now()), "a 304 must re-establish the expiry")
+}
+
+// TestOAuthCIMD_RevalidationPicksUpRotatedDocument is the other half of the
+// conditional refresh: when the host's validator has moved on it answers the
+// conditional request with a body, and the rotated metadata must land in the
+// row. This is how a client that changes its redirect_uris keeps working.
+func TestOAuthCIMD_RevalidationPicksUpRotatedDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.etag = `"v1"`
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:33418/callback"
+
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+
+	lapseCIMDCache(t, ctx, ti, first)
+	ds.etag = `"v2"`
+	ds.doc["client_name"] = "Rotated CIMD Client"
+	ds.doc["redirect_uris"] = []any{redirectURI, "http://localhost:3000/other"}
+
+	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	require.Equal(t, int64(1), ds.conditionalRequests.Load(), "the stale validator is still offered")
+	second := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, first.ID, second.ID)
+	require.Equal(t, "Rotated CIMD Client", second.ClientName)
+	require.Equal(t, []string{redirectURI, "http://localhost:3000/other"}, second.RedirectUris)
+	require.Equal(t, `"v2"`, second.ClientIDMetadataEtag.String, "the superseding validator replaces the stored one")
+}
+
+// TestOAuthCIMD_PurgeForcesUnconditionalReread pins the ops lever: purging
+// clears the validator along with the expiry, so the next authorize re-reads
+// and re-validates a full body rather than accepting a 304 that would confirm
+// the very document being purged.
+func TestOAuthCIMD_PurgeForcesUnconditionalReread(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.etag = `"v1"`
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:33418/callback"
+
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, `"v1"`, first.ClientIDMetadataEtag.String)
+
+	purged, err := usersessions_repo.New(ti.conn).PurgeUserSessionClientCIMDCache(ctx, first.ID)
+	require.NoError(t, err)
+	require.False(t, purged.ClientIDMetadataCacheExpiresAt.Valid)
+	require.False(t, purged.ClientIDMetadataEtag.Valid)
+
+	ds.doc["client_name"] = "Renamed After Purge"
+
+	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	require.Equal(t, int64(2), ds.requests.Load())
+	require.Zero(t, ds.conditionalRequests.Load(), "a purge must leave nothing to revalidate against")
+	second := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, "Renamed After Purge", second.ClientName)
+	require.Equal(t, `"v1"`, second.ClientIDMetadataEtag.String, "the re-read stores the host's validator again")
+}
+
+// TestOAuthCIMD_UpstreamMaxAgeClampedToFloor pins the lower bound: a host
+// asking for two minutes gets the five minute floor, so an unauthenticated
+// endpoint cannot be pushed into fetching on every authorize.
+func TestOAuthCIMD_UpstreamMaxAgeClampedToFloor(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.cacheControl = "public, max-age=120"
+
+	before := time.Now()
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	row := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.True(t, row.ClientIDMetadataCacheExpiresAt.Time.After(before.Add(4*time.Minute)), "max-age below the floor must be raised to it")
+	require.True(t, row.ClientIDMetadataCacheExpiresAt.Time.Before(before.Add(6*time.Minute)), "the floor must not be exceeded either")
+}
+
+// TestOAuthCIMD_RefreshFailureDoesNotPoisonCache pins the fail-closed rule: a
+// failing document host aborts the authorize (-02 §5.1) and leaves every
+// cache column exactly as it was, so nothing stale is served and no expiry is
+// silently extended.
+func TestOAuthCIMD_RefreshFailureDoesNotPoisonCache(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:33418/callback"
+
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+
+	lapsed := lapseCIMDCache(t, ctx, ti, first)
+	ds.status = http.StatusInternalServerError
+
+	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, "a failed refresh aborts rather than serving stale")
+
+	second := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, "CIMD Integration Client", second.ClientName)
+	require.True(t, second.ClientIDMetadataCacheExpiresAt.Time.Equal(lapsed.ClientIDMetadataCacheExpiresAt.Time), "a failed refresh must not extend the expiry")
+	require.Equal(t, lapsed.ClientIDMetadataFetchedAt.Time, second.ClientIDMetadataFetchedAt.Time, "a failed refresh must not move the fetch stamp")
+}
+
+// TestOAuthCIMD_InvalidDocumentOnRefreshDoesNotPoisonCache is the same rule
+// for a host that answers 200 with something unparseable: an error response
+// and an invalid document are both uncacheable (-02 §5.2).
+func TestOAuthCIMD_InvalidDocumentOnRefreshDoesNotPoisonCache(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:33418/callback"
+
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	first := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+
+	lapsed := lapseCIMDCache(t, ctx, ti, first)
+	// A document that no longer satisfies the spec: -02 §4.1 forbids a
+	// client_secret in a document that is public by definition.
+	ds.doc["client_secret"] = "leaked"
+
+	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_client_metadata")
+
+	second := getCIMDClientRow(t, ctx, ti, toolset, ds.clientID)
+	require.Equal(t, "CIMD Integration Client", second.ClientName)
+	require.True(t, second.ClientIDMetadataCacheExpiresAt.Time.Equal(lapsed.ClientIDMetadataCacheExpiresAt.Time), "an invalid document must not refresh the expiry")
 }
 
 // TestOAuthCIMD_SecretBearingCollisionRejected pins the upsert guard: a

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -1,9 +1,9 @@
 // Client resolution seam for the issuer-gated OAuth surface. Every handler
 // that resolves a user_session_clients row from a presented client_id —
 // authorize, token, consent GET/POST — funnels through
-// resolveUserSessionClient, so inbound CIMD resolution (and its future
-// layers: document caching, per-origin rate limits, admission control) has
-// exactly one home instead of per-handler branches.
+// resolveUserSessionClient, so inbound CIMD resolution and the layers around
+// it (admission control, document caching, and the per-origin rate limiting
+// AIS-215 adds) have exactly one home instead of per-handler branches.
 
 package mcp
 
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
@@ -40,10 +41,10 @@ const (
 
 	// resolveClientCIMD additionally treats a URL-shaped client_id as a
 	// Client ID Metadata Document reference when the issuer organization's
-	// gram-user-session-cimd flag is on: the document is fetched and
-	// validated on every call (no caching) and the row lazily
-	// upserted. Authorize-time only — the consent GET/POST re-resolve the
-	// client by client_id, so the row must exist before the flow leaves
+	// gram-user-session-cimd flag is on: the row is read, the document
+	// fetched and validated when that row's cache has lapsed, and the row
+	// lazily upserted. Authorize-time only — the consent GET/POST re-resolve
+	// the client by client_id, so the row must exist before the flow leaves
 	// /authorize.
 	resolveClientCIMD clientIDResolveMode = "resolve_cimd"
 )
@@ -102,30 +103,102 @@ func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Log
 			return nil, err
 		}
 
-		doc, err := s.cimdResolver.Resolve(ctx, clientID)
+		// The persisted row doubles as the document cache, so it is read
+		// before the fetch rather than only written after one. A miss is
+		// the ordinary first-contact case, not an error.
+		var cachedRow *usersessions_repo.UserSessionClient
+		existing, err := queries.GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			ClientID:            clientID,
+		})
+		switch {
+		case err == nil:
+			cachedRow = &existing
+		case errors.Is(err, pgx.ErrNoRows):
+		default:
+			return nil, fmt.Errorf("lookup cimd user session client: %w", err)
+		}
+
+		// Only a CIMD-resolved row is a cache. A secret-bearing DCR row
+		// that happens to share this client_id must still force a fetch:
+		// its metadata never came from a document, and the upsert's guard
+		// will refuse to rewrite it anyway.
+		//
+		// A row with no expiry still contributes its validator. The two
+		// columns are independent: a host may serve an ETag with no
+		// freshness directives at all, and clearing only the expiry is a
+		// request to revalidate now, not to discard what revalidation
+		// needs. Discarding both is what a purge is for.
+		var cache cimd.CacheState
+		if cachedRow != nil && cachedRow.ClientIDMetadataUri.Valid {
+			cache = cimd.CacheState{
+				ExpiresAt: cachedRow.ClientIDMetadataCacheExpiresAt.Time,
+				ETag:      cachedRow.ClientIDMetadataEtag.String,
+			}
+		}
+
+		result, err := s.cimdResolver.Resolve(ctx, clientID, cache)
 		if err != nil {
+			// Fail closed on every refresh failure, leaving the cached row
+			// as it was: -02 §5.1 says a fetch failure SHOULD abort the
+			// authorization request, so an expired document is never served
+			// stale to keep a flow alive.
 			if _, ok := errors.AsType[*oauthwire.Error](err); ok {
 				return nil, fmt.Errorf("resolve cimd client: %w", err)
 			}
 			return nil, fmt.Errorf("%w: %w", errCIMDFetchFailed, err)
 		}
 
-		row, err := queries.UpsertUserSessionClientFromCIMD(ctx, usersessions_repo.UpsertUserSessionClientFromCIMDParams{
-			UserSessionIssuerID: endpoint.UserSessionIssuerID,
-			ClientID:            clientID,
-			ClientName:          doc.ClientName,
-			RedirectUris:        doc.RedirectURIs,
-		})
-		if err != nil {
-			// No-rows here means the DO UPDATE guard refused to rewrite a
-			// secret-bearing row sharing this client_id; surface it as an
-			// unknown client rather than a 500.
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, pgx.ErrNoRows
-			}
-			return nil, fmt.Errorf("upsert cimd user session client: %w", err)
+		if result.Outcome != cimd.CacheOutcomeRefreshed && cachedRow == nil {
+			// Unreachable: the resolver reports a cache outcome only for
+			// cache state this function passed in, and it passes none
+			// without a row. Checked rather than dereferenced because the
+			// alternative is a panic on an unauthenticated endpoint.
+			return nil, fmt.Errorf("cimd resolver reported %q outcome with no cached client", result.Outcome)
 		}
-		return &row, nil
+
+		switch result.Outcome {
+		case cimd.CacheOutcomeCached:
+			return cachedRow, nil
+		case cimd.CacheOutcomeNotModified:
+			row, err := queries.UpdateUserSessionClientCIMDCache(ctx, usersessions_repo.UpdateUserSessionClientCIMDCacheParams{
+				ID:                   cachedRow.ID,
+				CacheTtlSeconds:      result.TTL.Seconds(),
+				ClientIDMetadataEtag: conv.ToPGTextEmpty(result.ETag),
+			})
+			if err != nil {
+				// No-rows means the row stopped being an updatable CIMD row
+				// between the read and the write (revoked, or replaced by a
+				// secret-bearing registration); treat it as unknown rather
+				// than serving the row the 304 was about.
+				if errors.Is(err, pgx.ErrNoRows) {
+					return nil, pgx.ErrNoRows
+				}
+				return nil, fmt.Errorf("update cimd user session client cache: %w", err)
+			}
+			return &row, nil
+		case cimd.CacheOutcomeRefreshed:
+			row, err := queries.UpsertUserSessionClientFromCIMD(ctx, usersessions_repo.UpsertUserSessionClientFromCIMDParams{
+				UserSessionIssuerID:  endpoint.UserSessionIssuerID,
+				ClientID:             clientID,
+				ClientName:           result.Document.ClientName,
+				RedirectUris:         result.Document.RedirectURIs,
+				CacheTtlSeconds:      result.TTL.Seconds(),
+				ClientIDMetadataEtag: conv.ToPGTextEmpty(result.ETag),
+			})
+			if err != nil {
+				// No-rows here means the DO UPDATE guard refused to rewrite a
+				// secret-bearing row sharing this client_id; surface it as an
+				// unknown client rather than a 500.
+				if errors.Is(err, pgx.ErrNoRows) {
+					return nil, pgx.ErrNoRows
+				}
+				return nil, fmt.Errorf("upsert cimd user session client: %w", err)
+			}
+			return &row, nil
+		default:
+			return nil, fmt.Errorf("unknown cimd resolve outcome %q", result.Outcome)
+		}
 	}
 
 	row, err := queries.GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{

--- a/server/internal/usersessions/cimd/cache_outcome.go
+++ b/server/internal/usersessions/cimd/cache_outcome.go
@@ -1,0 +1,20 @@
+package cimd
+
+// CacheOutcome reports which branch of the cache policy a Resolve call took,
+// and therefore what the caller must persist.
+type CacheOutcome string
+
+const (
+	// CacheOutcomeCached means the stored document was still fresh: no request
+	// was made and the caller must write nothing.
+	CacheOutcomeCached CacheOutcome = "cached"
+
+	// CacheOutcomeNotModified means the upstream answered 304 to a conditional
+	// request: the caller's stored client_name and redirect_uris remain
+	// correct, and it must persist only the refreshed ETag and TTL.
+	CacheOutcomeNotModified CacheOutcome = "not_modified"
+
+	// CacheOutcomeRefreshed means a new document was fetched and validated: the
+	// caller must replace the stored metadata along with the ETag and TTL.
+	CacheOutcomeRefreshed CacheOutcome = "refreshed"
+)

--- a/server/internal/usersessions/cimd/cache_policy.go
+++ b/server/internal/usersessions/cimd/cache_policy.go
@@ -1,0 +1,168 @@
+package cimd
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultCacheTTL applies when the document response carries no usable
+	// freshness header. Draft -02 §5.2 lets the server pick; an hour keeps a
+	// rotated document from lingering while still collapsing the repeated
+	// authorize legs a single client makes in a session.
+	defaultCacheTTL = time.Hour
+
+	// minCacheTTL and maxCacheTTL bound whatever the upstream asks for. The
+	// floor stops a hostile or misconfigured host from forcing a fetch on
+	// every authorize (the request is unauthenticated, so the fetch is
+	// attacker-triggerable); the ceiling stops it from pinning a document —
+	// and therefore a redirect_uris set — indefinitely. -02 §5.2 explicitly
+	// permits both bounds, and the 24h ceiling matches the MCP
+	// specification's recommended maximum.
+	minCacheTTL = 5 * time.Minute
+	maxCacheTTL = 24 * time.Hour
+
+	// maxETagLength caps the validator persisted in
+	// client_id_metadata_etag and echoed back in If-None-Match. The value is
+	// chosen by the document host, and net/http accepts response headers up
+	// to MaxResponseHeaderBytes (1 MB by default), so an unbounded ETag is a
+	// write amplification primitive against a TEXT column. Real validators
+	// are a hash or a version stamp; anything longer is dropped and the next
+	// refresh is unconditional.
+	maxETagLength = 256
+)
+
+// cacheTTL derives the lifetime of a freshly fetched document from its
+// response headers, following RFC 9111 §4.2: the granted freshness lifetime
+// (s-maxage, then max-age, then Expires measured against Date) less the age
+// the response already carries, clamped to [minCacheTTL, maxCacheTTL].
+//
+// no-store / no-cache are deliberately NOT honoured. A Client ID Metadata
+// Document is public by definition — -02 §4.1 bans every secret from it — so
+// a directive that forbids caching carries no confidentiality meaning here
+// and would only let a host defeat the floor that keeps this endpoint from
+// being an amplifier. This is a conscious RFC 9111 deviation of the kind
+// -02 §5.2 permits.
+//
+// now is the reference instant the caller will also use to derive the
+// absolute expiry, so a slow header parse cannot shift the two apart.
+func cacheTTL(header http.Header, now time.Time) time.Duration {
+	lifetime, ok := freshnessLifetime(header, now)
+	if !ok {
+		return defaultCacheTTL
+	}
+
+	// RFC 9111 §4.2.3: what is left of a lifetime is that lifetime minus the
+	// age the response already carries. Skipping this would cache a
+	// CDN-served document far longer than its origin allowed — a document
+	// answered with max-age=86400 and Age: 86000 has minutes of freshness
+	// left, not a day — which is exactly how a rotated redirect_uris set
+	// would go unnoticed. An absent or malformed Age reads as zero.
+	age, _ := deltaSeconds(header.Get("Age"))
+	return clampCacheTTL(lifetime - age)
+}
+
+// freshnessLifetime is the lifetime the origin granted the response, before
+// its current age is deducted.
+func freshnessLifetime(header http.Header, now time.Time) (time.Duration, bool) {
+	// RFC 9111 §5.2.2.10: s-maxage overrides max-age for a shared cache, and
+	// this AS is one — a document fetched for one authorization is served to
+	// every tenant that presents the same client_id.
+	if sMaxAge, ok := cacheControlDelta(header, "s-maxage"); ok {
+		return sMaxAge, true
+	}
+	if maxAge, ok := cacheControlDelta(header, "max-age"); ok {
+		return maxAge, true
+	}
+
+	// http.ParseTime accepts the three formats RFC 9110 §5.6.7 requires.
+	// An unparseable Expires (including the common "Expires: 0" spelling
+	// meaning "already stale") falls through to the default rather than to
+	// zero: the floor would clamp a zero TTL back up anyway, and treating a
+	// malformed header as "no opinion" is the more predictable rule.
+	expires, err := http.ParseTime(header.Get("Expires"))
+	if err != nil {
+		return 0, false
+	}
+	// RFC 9111 §4.2.1 measures Expires against the response's own Date, which
+	// makes the result immune to a skewed origin clock. Falling back to the
+	// local clock when Date is absent or unparseable is the best available
+	// approximation.
+	reference := now
+	if date, err := http.ParseTime(header.Get("Date")); err == nil {
+		reference = date
+	}
+	return expires.Sub(reference), true
+}
+
+func clampCacheTTL(ttl time.Duration) time.Duration {
+	return min(max(ttl, minCacheTTL), maxCacheTTL)
+}
+
+// cacheControlDelta extracts a delta-seconds directive from every
+// Cache-Control header on the response. RFC 9110 §5.3 lets a field repeat
+// across lines, so Values is read rather than Get, which would see only the
+// first line.
+//
+// A malformed or overflowing value reports not-found rather than a zero
+// duration, so the caller falls through to the next source of freshness
+// instead of pinning the row at the floor.
+func cacheControlDelta(header http.Header, directive string) (time.Duration, bool) {
+	for _, value := range header.Values("Cache-Control") {
+		for candidate := range strings.SplitSeq(value, ",") {
+			name, arg, found := strings.Cut(strings.TrimSpace(candidate), "=")
+			if !found || !strings.EqualFold(strings.TrimSpace(name), directive) {
+				continue
+			}
+			if seconds, ok := deltaSeconds(arg); ok {
+				return seconds, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// deltaSeconds parses an RFC 9111 §1.2.2 delta-seconds value into a duration.
+// It reports not-found for anything negative, unparseable, or large enough to
+// overflow: the value is attacker-supplied and time.Duration is nanoseconds,
+// so an unguarded multiplication would wrap into a negative duration that the
+// clamp would silently read as "expire immediately".
+func deltaSeconds(raw string) (time.Duration, bool) {
+	// RFC 9110 §5.6.6 allows a directive argument to be sent as a
+	// quoted-string even when the grammar calls for a token.
+	seconds, err := strconv.ParseInt(strings.Trim(strings.TrimSpace(raw), `"`), 10, 64)
+	if err != nil || seconds < 0 || seconds > math.MaxInt64/int64(time.Second) {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
+// sanitizeETag returns the entity tag to persist and replay in If-None-Match,
+// or "" when the response carries nothing usable. The value is stored and
+// replayed verbatim (quotes and any W/ prefix included): If-None-Match is
+// compared with RFC 9110 §13.1.2 weak comparison, so a weak validator is
+// legitimate here and rewriting it would break revalidation against hosts
+// that emit one.
+//
+// Anything that could corrupt the outbound request is dropped instead of
+// escaped — a header value is not a place to be clever with attacker-chosen
+// bytes, and dropping it costs only an unconditional refresh.
+func sanitizeETag(raw string) string {
+	etag := strings.TrimSpace(raw)
+	if etag == "" || len(etag) > maxETagLength {
+		return ""
+	}
+	// Reject anything outside printable US-ASCII. This covers CR and LF
+	// (request splitting) and also keeps the stored value inside what
+	// net/http will agree to send: a header value it considers invalid makes
+	// every later conditional request fail outright.
+	for _, r := range etag {
+		if r < ' ' || r > '~' {
+			return ""
+		}
+	}
+	return etag
+}

--- a/server/internal/usersessions/cimd/cache_policy.go
+++ b/server/internal/usersessions/cimd/cache_policy.go
@@ -136,7 +136,7 @@ func clampCacheTTL(ttl time.Duration) time.Duration {
 // instead of pinning the row at the floor.
 func cacheControlDelta(header http.Header, directive string) (time.Duration, bool) {
 	for _, value := range header.Values("Cache-Control") {
-		for candidate := range strings.SplitSeq(value, ",") {
+		for _, candidate := range splitDirectives(value) {
 			name, arg, found := strings.Cut(strings.TrimSpace(candidate), "=")
 			if !found || !strings.EqualFold(strings.TrimSpace(name), directive) {
 				continue
@@ -149,15 +149,57 @@ func cacheControlDelta(header http.Header, directive string) (time.Duration, boo
 	return 0, false
 }
 
+// splitDirectives splits one Cache-Control field value on the commas that
+// separate directives, leaving commas inside a quoted-string alone.
+//
+// Splitting naively would let a quoted argument masquerade as a directive:
+// no-cache="Set-Cookie, max-age=99999" breaks into a fragment reading
+// `max-age=99999"`, which is a lifetime the host never granted. Directives
+// that take a quoted field-name list (no-cache, private) are exactly the ones
+// where this arises, and the field value is chosen by the document host.
+func splitDirectives(value string) []string {
+	directives := make([]string, 0, strings.Count(value, ",")+1)
+	quoted := false
+	start := 0
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '\\':
+			// RFC 9110 §5.6.4 quoted-pair: the next octet is literal, so it
+			// can neither open nor close the string.
+			if quoted {
+				i++
+			}
+		case '"':
+			quoted = !quoted
+		case ',':
+			if !quoted {
+				directives = append(directives, value[start:i])
+				start = i + 1
+			}
+		}
+	}
+	return append(directives, value[start:])
+}
+
 // deltaSeconds parses an RFC 9111 §1.2.2 delta-seconds value into a duration.
 // It reports not-found for anything negative, unparseable, or large enough to
 // overflow: the value is attacker-supplied and time.Duration is nanoseconds,
 // so an unguarded multiplication would wrap into a negative duration that the
 // clamp would silently read as "expire immediately".
 func deltaSeconds(raw string) (time.Duration, bool) {
+	value := strings.TrimSpace(raw)
+
 	// RFC 9110 §5.6.6 allows a directive argument to be sent as a
-	// quoted-string even when the grammar calls for a token.
-	seconds, err := strconv.ParseInt(strings.Trim(strings.TrimSpace(raw), `"`), 10, 64)
+	// quoted-string even when the grammar calls for a token, but only as a
+	// matched pair. Stripping stray quotes instead would honour a lifetime
+	// the upstream never expressed; anything still holding a quote after one
+	// matched pair comes off fails the parse below and falls through to the
+	// next source of freshness.
+	if len(value) >= 2 && strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+		value = value[1 : len(value)-1]
+	}
+
+	seconds, err := strconv.ParseInt(value, 10, 64)
 	if err != nil || seconds < 0 || seconds > math.MaxInt64/int64(time.Second) {
 		return 0, false
 	}

--- a/server/internal/usersessions/cimd/cache_policy.go
+++ b/server/internal/usersessions/cimd/cache_policy.go
@@ -71,6 +71,13 @@ func cacheTTL(header http.Header, now time.Time) time.Duration {
 // its own Date suggests — and trusting only Age would hand a full lifetime to
 // the first case.
 //
+// It approximates rather than reproduces the RFC's current_age, which also
+// adds the request delay and the time the response has since spent resident
+// in the cache. Resident time is zero by construction here (the absolute
+// expiry is derived from this the moment the fetch returns) and the request
+// delay is bounded by fetchTimeout, so both are far below the five minute
+// floor every result is clamped to.
+//
 // An absent or malformed Age reads as zero, and a Date in the future (a
 // skewed origin clock) yields a negative apparent age that never wins the
 // comparison, so the result is never negative.
@@ -195,9 +202,12 @@ func sanitizeETag(raw string) string {
 	if len(opaque) < 2 || !strings.HasPrefix(opaque, `"`) || !strings.HasSuffix(opaque, `"`) {
 		return ""
 	}
-	// etagc excludes DQUOTE, so an interior quote means the value is a list
-	// or is otherwise malformed.
-	if strings.Contains(opaque[1:len(opaque)-1], `"`) {
+	// etagc is %x21 / %x23-7E / obs-text, so within the printable ASCII this
+	// function already requires it admits everything except SP and DQUOTE. An
+	// interior quote means the value is a list or is otherwise malformed, and
+	// a space cannot appear in a well-formed tag at all. Dropping such a
+	// validator costs an unconditional refresh, which is the safe direction.
+	if strings.ContainsAny(opaque[1:len(opaque)-1], " \"") {
 		return ""
 	}
 	return etag

--- a/server/internal/usersessions/cimd/cache_policy.go
+++ b/server/internal/usersessions/cimd/cache_policy.go
@@ -47,8 +47,9 @@ const (
 // being an amplifier. This is a conscious RFC 9111 deviation of the kind
 // -02 §5.2 permits.
 //
-// now is the reference instant the caller will also use to derive the
-// absolute expiry, so a slow header parse cannot shift the two apart.
+// now is the local reference instant, read when the response carries no
+// usable Date: the Expires fallback and the apparent age are both measured
+// against it then.
 func cacheTTL(header http.Header, now time.Time) time.Duration {
 	lifetime, ok := freshnessLifetime(header, now)
 	if !ok {
@@ -61,7 +62,19 @@ func cacheTTL(header http.Header, now time.Time) time.Duration {
 	// answered with max-age=86400 and Age: 86000 has minutes of freshness
 	// left, not a day — which is exactly how a rotated redirect_uris set
 	// would go unnoticed.
-	return clampCacheTTL(lifetime - responseAge(header, now))
+	//
+	// The comparison stands in for a subtraction that could wrap: the
+	// lifetime may be hugely negative (an Expires far before Date) and the
+	// age saturates at MaxInt64, so lifetime-minus-age can fall past
+	// MinInt64 and come out large and positive — the clamp would then read
+	// two "this is ancient" signals as maximum freshness. Age is never
+	// negative, so age >= lifetime is exactly "no freshness left", and
+	// otherwise the difference is positive and cannot wrap.
+	age := responseAge(header, now)
+	if age >= lifetime {
+		return minCacheTTL
+	}
+	return clampCacheTTL(lifetime - age)
 }
 
 // responseAge is RFC 9111 §4.2.3's current_age: the larger of the Age header

--- a/server/internal/usersessions/cimd/cache_policy.go
+++ b/server/internal/usersessions/cimd/cache_policy.go
@@ -60,9 +60,26 @@ func cacheTTL(header http.Header, now time.Time) time.Duration {
 	// CDN-served document far longer than its origin allowed — a document
 	// answered with max-age=86400 and Age: 86000 has minutes of freshness
 	// left, not a day — which is exactly how a rotated redirect_uris set
-	// would go unnoticed. An absent or malformed Age reads as zero.
+	// would go unnoticed.
+	return clampCacheTTL(lifetime - responseAge(header, now))
+}
+
+// responseAge is RFC 9111 §4.2.3's current_age: the larger of the Age header
+// and the apparent age the Date header implies. Taking the larger of the two
+// matters because they fail in different ways — an intermediary can replay a
+// stale body without adding Age, and an origin can send an Age larger than
+// its own Date suggests — and trusting only Age would hand a full lifetime to
+// the first case.
+//
+// An absent or malformed Age reads as zero, and a Date in the future (a
+// skewed origin clock) yields a negative apparent age that never wins the
+// comparison, so the result is never negative.
+func responseAge(header http.Header, now time.Time) time.Duration {
 	age, _ := deltaSeconds(header.Get("Age"))
-	return clampCacheTTL(lifetime - age)
+	if date, err := http.ParseTime(header.Get("Date")); err == nil {
+		age = max(age, now.Sub(date))
+	}
+	return age
 }
 
 // freshnessLifetime is the lifetime the origin granted the response, before
@@ -163,6 +180,25 @@ func sanitizeETag(raw string) string {
 		if r < ' ' || r > '~' {
 			return ""
 		}
+	}
+
+	// RFC 9110 §8.8.3: entity-tag = [ "W/" ] DQUOTE *etagc DQUOTE. Enforcing
+	// the grammar rather than storing any printable string is what keeps the
+	// wildcard out. "ETag: *" is not a valid response header, but a host that
+	// sends one would have it replayed as "If-None-Match: *", which §13.1.2
+	// defines as matching whenever the origin has any representation at all:
+	// every revalidation would then answer 304 and extend the cache, so a
+	// rotated redirect_uris set could never propagate. A list of tags is
+	// rejected for the same reason — If-None-Match is a request for one
+	// specific stored document, not for whichever of several the host likes.
+	opaque, _ := strings.CutPrefix(etag, "W/")
+	if len(opaque) < 2 || !strings.HasPrefix(opaque, `"`) || !strings.HasSuffix(opaque, `"`) {
+		return ""
+	}
+	// etagc excludes DQUOTE, so an interior quote means the value is a list
+	// or is otherwise malformed.
+	if strings.Contains(opaque[1:len(opaque)-1], `"`) {
+		return ""
 	}
 	return etag
 }

--- a/server/internal/usersessions/cimd/cache_policy.go
+++ b/server/internal/usersessions/cimd/cache_policy.go
@@ -82,11 +82,33 @@ func cacheTTL(header http.Header, now time.Time) time.Duration {
 // skewed origin clock) yields a negative apparent age that never wins the
 // comparison, so the result is never negative.
 func responseAge(header http.Header, now time.Time) time.Duration {
-	age, _ := deltaSeconds(header.Get("Age"))
+	age := headerAge(header)
 	if date, err := http.ParseTime(header.Get("Date")); err == nil {
 		age = max(age, now.Sub(date))
 	}
 	return age
+}
+
+// headerAge reads the Age header.
+//
+// An age too large to represent is treated as the opposite of an unparseable
+// lifetime. A lifetime we cannot parse means the host expressed no opinion,
+// so the default applies; an age we cannot parse because it is astronomically
+// large is the host saying the response is ancient, so it saturates and the
+// subtraction drives the TTL to the floor. Reading it as zero instead would
+// grant a document the host called stale its full lifetime.
+func headerAge(header http.Header) time.Duration {
+	raw := header.Get("Age")
+	if raw == "" {
+		return 0
+	}
+	if age, ok := deltaSeconds(raw); ok {
+		return age
+	}
+	if _, wellFormed := deltaSecondsDigits(raw); wellFormed {
+		return time.Duration(math.MaxInt64)
+	}
+	return 0
 }
 
 // freshnessLifetime is the lifetime the origin granted the response, before
@@ -178,6 +200,13 @@ func splitDirectives(value string) []string {
 			}
 		}
 	}
+	// An unterminated quoted-string means the field value is malformed and
+	// its directive boundaries are guesswork. Discarding it entirely keeps
+	// the same rule the rest of this parser follows: what cannot be read as
+	// the host meant it is treated as no opinion, not as a partial one.
+	if quoted {
+		return nil
+	}
 	return append(directives, value[start:])
 }
 
@@ -187,23 +216,49 @@ func splitDirectives(value string) []string {
 // so an unguarded multiplication would wrap into a negative duration that the
 // clamp would silently read as "expire immediately".
 func deltaSeconds(raw string) (time.Duration, bool) {
+	digits, ok := deltaSecondsDigits(raw)
+	if !ok {
+		return 0, false
+	}
+
+	// Guard the multiplication rather than the result: time.Duration is
+	// nanoseconds, so a value past this bound overflows into a negative
+	// duration that the clamp would silently read as "expire immediately".
+	seconds, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil || seconds > math.MaxInt64/int64(time.Second) {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
+// deltaSecondsDigits returns the digits of a well-formed delta-seconds value,
+// reporting false for anything that is not one. The grammar is 1*DIGIT, so a
+// sign is not part of it: strconv would happily read "+7200" and "-0", and
+// honouring either would mean acting on a lifetime the host did not express.
+//
+// It reports true for digit strings too large to be a duration, which is why
+// it is separate from deltaSeconds — the two callers want opposite fallbacks
+// for an overflow.
+func deltaSecondsDigits(raw string) (string, bool) {
 	value := strings.TrimSpace(raw)
 
 	// RFC 9110 §5.6.6 allows a directive argument to be sent as a
 	// quoted-string even when the grammar calls for a token, but only as a
-	// matched pair. Stripping stray quotes instead would honour a lifetime
-	// the upstream never expressed; anything still holding a quote after one
-	// matched pair comes off fails the parse below and falls through to the
-	// next source of freshness.
+	// matched pair. Stripping stray quotes instead would accept a value the
+	// upstream never expressed.
 	if len(value) >= 2 && strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
 		value = value[1 : len(value)-1]
 	}
 
-	seconds, err := strconv.ParseInt(value, 10, 64)
-	if err != nil || seconds < 0 || seconds > math.MaxInt64/int64(time.Second) {
-		return 0, false
+	if value == "" {
+		return "", false
 	}
-	return time.Duration(seconds) * time.Second, true
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return "", false
+		}
+	}
+	return value, true
 }
 
 // sanitizeETag returns the entity tag to persist and replay in If-None-Match,

--- a/server/internal/usersessions/cimd/cache_policy_test.go
+++ b/server/internal/usersessions/cimd/cache_policy_test.go
@@ -155,6 +155,50 @@ func TestCacheTTL_AgeExceedingLifetimeClampedToFloor(t *testing.T) {
 	require.Equal(t, minCacheTTL, ttl)
 }
 
+func TestCacheTTL_ApparentAgeFromDateDeducted(t *testing.T) {
+	t.Parallel()
+
+	// An intermediary replaying a stale body without adding an Age header:
+	// the Date it kept is what reveals how much freshness is really left.
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=86400",
+		"Date", cacheTTLReference.Add(-22*time.Hour).Format(http.TimeFormat),
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_LargerOfAgeAndApparentAgeWins(t *testing.T) {
+	t.Parallel()
+
+	// Age says 22 hours while Date implies only one, so Age wins.
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=86400",
+		"Age", "79200",
+		"Date", cacheTTLReference.Add(-time.Hour).Format(http.TimeFormat),
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+
+	// Reversed: Date implies 22 hours while Age claims one.
+	ttl = cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=86400",
+		"Age", "3600",
+		"Date", cacheTTLReference.Add(-22*time.Hour).Format(http.TimeFormat),
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_FutureDateDoesNotExtendLifetime(t *testing.T) {
+	t.Parallel()
+
+	// A skewed origin clock implies a negative apparent age, which must not
+	// be added back onto the lifetime.
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=7200",
+		"Date", cacheTTLReference.Add(time.Hour).Format(http.TimeFormat),
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
 func TestCacheTTL_MalformedAgeIgnored(t *testing.T) {
 	t.Parallel()
 
@@ -241,8 +285,47 @@ func TestSanitizeETag_EmptyDropped(t *testing.T) {
 func TestSanitizeETag_OversizedDropped(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, strings.Repeat("a", maxETagLength), sanitizeETag(strings.Repeat("a", maxETagLength)))
-	require.Empty(t, sanitizeETag(strings.Repeat("a", maxETagLength+1)))
+	atLimit := `"` + strings.Repeat("a", maxETagLength-2) + `"`
+	require.Len(t, atLimit, maxETagLength)
+	require.Equal(t, atLimit, sanitizeETag(atLimit))
+	require.Empty(t, sanitizeETag(`"`+strings.Repeat("a", maxETagLength-1)+`"`))
+}
+
+func TestSanitizeETag_WildcardDropped(t *testing.T) {
+	t.Parallel()
+
+	// "ETag: *" is not a valid response header, and replaying it as
+	// "If-None-Match: *" would match whenever the host has any
+	// representation at all, so every revalidation would answer 304 and the
+	// cached document could never be superseded.
+	require.Empty(t, sanitizeETag("*"))
+	require.Empty(t, sanitizeETag("W/*"))
+}
+
+func TestSanitizeETag_UnquotedDropped(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, sanitizeETag("abc123"))
+	require.Empty(t, sanitizeETag(`"abc123`))
+	require.Empty(t, sanitizeETag(`abc123"`))
+	require.Empty(t, sanitizeETag(`"`))
+}
+
+func TestSanitizeETag_ListDropped(t *testing.T) {
+	t.Parallel()
+
+	// If-None-Match here asks about one specific stored document, so a list
+	// of candidates is not usable.
+	require.Empty(t, sanitizeETag(`"abc", "def"`))
+	require.Empty(t, sanitizeETag(`W/"abc", W/"def"`))
+}
+
+func TestSanitizeETag_EmptyQuotedAccepted(t *testing.T) {
+	t.Parallel()
+
+	// *etagc permits zero characters, so `""` is a well-formed if unusual
+	// validator and replays harmlessly.
+	require.Equal(t, `""`, sanitizeETag(`""`))
 }
 
 func TestSanitizeETag_ControlAndNonASCIIDropped(t *testing.T) {

--- a/server/internal/usersessions/cimd/cache_policy_test.go
+++ b/server/internal/usersessions/cimd/cache_policy_test.go
@@ -134,6 +134,36 @@ func TestCacheTTL_MaxAgeNegativeFallsBackToDefault(t *testing.T) {
 	require.Equal(t, defaultCacheTTL, ttl)
 }
 
+func TestCacheTTL_MaxAgeSignedFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	// delta-seconds is 1*DIGIT, so a sign is not part of the grammar even
+	// where strconv would accept it.
+	require.Equal(t, defaultCacheTTL, cacheTTL(headerWith(t, "Cache-Control", "max-age=+7200"), cacheTTLReference))
+	require.Equal(t, defaultCacheTTL, cacheTTL(headerWith(t, "Cache-Control", "max-age=-0"), cacheTTLReference))
+}
+
+func TestCacheTTL_UnterminatedQuoteDiscardsWholeField(t *testing.T) {
+	t.Parallel()
+
+	// The directive boundaries after an unterminated quote are guesswork, so
+	// the field is treated as no opinion rather than as a partial one.
+	ttl := cacheTTL(headerWith(t, "Cache-Control", `max-age=7200, no-cache="unterminated`), cacheTTLReference)
+	require.Equal(t, defaultCacheTTL, ttl)
+}
+
+func TestCacheTTL_OverflowingAgeReadsAsAncient(t *testing.T) {
+	t.Parallel()
+
+	// An Age too large to represent means the host is calling the response
+	// ancient. Reading it as zero would hand a stale document a full day.
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=86400",
+		"Age", "99999999999999999999",
+	), cacheTTLReference)
+	require.Equal(t, minCacheTTL, ttl)
+}
+
 func TestCacheTTL_MaxAgeMalformedFallsBackToDefault(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/cimd/cache_policy_test.go
+++ b/server/internal/usersessions/cimd/cache_policy_test.go
@@ -164,6 +164,38 @@ func TestCacheTTL_OverflowingAgeReadsAsAncient(t *testing.T) {
 	require.Equal(t, minCacheTTL, ttl)
 }
 
+func TestCacheTTL_AncientExpiresWithOverflowingAgeStaysAtFloor(t *testing.T) {
+	t.Parallel()
+
+	// Two "this is ancient" signals at once: an Expires decades before Date
+	// makes the lifetime hugely negative, and the Age saturates. A plain
+	// subtraction would wrap past MinInt64 into a large positive value the
+	// clamp reads as maximum freshness — the floor is the only correct
+	// answer.
+	ttl := cacheTTL(headerWith(t,
+		"Date", cacheTTLReference.Format(http.TimeFormat),
+		"Expires", cacheTTLReference.AddDate(-32, 0, 0).Format(http.TimeFormat),
+		"Age", "99999999999999999999",
+	), cacheTTLReference)
+	require.Equal(t, minCacheTTL, ttl)
+
+	// The merely-huge spelling wraps the same subtraction without saturating
+	// anything first.
+	ttl = cacheTTL(headerWith(t,
+		"Date", cacheTTLReference.Format(http.TimeFormat),
+		"Expires", cacheTTLReference.AddDate(-32, 0, 0).Format(http.TimeFormat),
+		"Age", "8300000000",
+	), cacheTTLReference)
+	require.Equal(t, minCacheTTL, ttl)
+}
+
+func TestCacheTTL_MalformedSharedMaxAgeFallsThroughToMaxAge(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "s-maxage=abc, max-age=7200"), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
 func TestCacheTTL_MaxAgeMalformedFallsBackToDefault(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/cimd/cache_policy_test.go
+++ b/server/internal/usersessions/cimd/cache_policy_test.go
@@ -311,6 +311,15 @@ func TestSanitizeETag_UnquotedDropped(t *testing.T) {
 	require.Empty(t, sanitizeETag(`"`))
 }
 
+func TestSanitizeETag_InteriorSpaceDropped(t *testing.T) {
+	t.Parallel()
+
+	// etagc admits neither SP nor DQUOTE, so a spaced tag is malformed even
+	// though a space is legal elsewhere in a header value.
+	require.Empty(t, sanitizeETag(`"abc def"`))
+	require.Empty(t, sanitizeETag(`W/"abc def"`))
+}
+
 func TestSanitizeETag_ListDropped(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/cimd/cache_policy_test.go
+++ b/server/internal/usersessions/cimd/cache_policy_test.go
@@ -1,0 +1,254 @@
+package cimd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// cacheTTLReference is the fixed instant Expires-based cases are measured
+// against, so the arithmetic in the test is exact rather than racing the
+// clock.
+var cacheTTLReference = time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+
+func headerWith(t *testing.T, pairs ...string) http.Header {
+	t.Helper()
+
+	require.Zero(t, len(pairs)%2, "pairs must be key/value")
+	header := http.Header{}
+	for i := 0; i < len(pairs); i += 2 {
+		header.Add(pairs[i], pairs[i+1])
+	}
+	return header
+}
+
+func TestCacheTTL_MaxAgeHonoured(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "public, max-age=7200"), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_MaxAgeBelowFloorClamped(t *testing.T) {
+	t.Parallel()
+
+	// The acceptance case from the issue: an upstream asking for 2 minutes
+	// reads as the 5 minute floor, so an attacker-triggerable endpoint can
+	// never be pushed into fetching on every authorize.
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "max-age=120"), cacheTTLReference)
+	require.Equal(t, minCacheTTL, ttl)
+}
+
+func TestCacheTTL_MaxAgeAboveCeilingClamped(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "max-age=31536000"), cacheTTLReference)
+	require.Equal(t, maxCacheTTL, ttl)
+}
+
+func TestCacheTTL_MaxAgeZeroClampedToFloor(t *testing.T) {
+	t.Parallel()
+
+	// max-age=0 is a well-formed request to never cache. The floor applies
+	// anyway: caching a public document is the point of this package, and
+	// -02 §5.2 permits a lower bound.
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "max-age=0"), cacheTTLReference)
+	require.Equal(t, minCacheTTL, ttl)
+}
+
+func TestCacheTTL_MaxAgeQuoted(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", `max-age="7200"`), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_MaxAgeAcrossRepeatedHeaders(t *testing.T) {
+	t.Parallel()
+
+	// RFC 9110 §5.3 lets a field repeat across lines; reading only the first
+	// would miss this directive entirely.
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "public",
+		"Cache-Control", "max-age=7200",
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_MaxAgeCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "Max-Age=7200"), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_MaxAgeOverflowFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	// A value past the int64 nanosecond range must not wrap into a negative
+	// duration, which the clamp would silently read as "expire immediately".
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "max-age=99999999999999999999"), cacheTTLReference)
+	require.Equal(t, defaultCacheTTL, ttl)
+}
+
+func TestCacheTTL_MaxAgeNegativeFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "max-age=-30"), cacheTTLReference)
+	require.Equal(t, defaultCacheTTL, ttl)
+}
+
+func TestCacheTTL_MaxAgeMalformedFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "max-age=soon"), cacheTTLReference)
+	require.Equal(t, defaultCacheTTL, ttl)
+}
+
+func TestCacheTTL_NoStoreIgnored(t *testing.T) {
+	t.Parallel()
+
+	// A deliberate RFC 9111 deviation: the document is public by definition,
+	// so no-store carries no confidentiality meaning here and honouring it
+	// would only defeat the floor.
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "no-store, no-cache, must-revalidate"), cacheTTLReference)
+	require.Equal(t, defaultCacheTTL, ttl)
+}
+
+func TestCacheTTL_NoStoreDoesNotOverrideMaxAge(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "no-cache, max-age=7200"), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_SharedMaxAgePreferredOverMaxAge(t *testing.T) {
+	t.Parallel()
+
+	// RFC 9111 §5.2.2.10: this AS is a shared cache, so s-maxage wins.
+	ttl := cacheTTL(headerWith(t, "Cache-Control", "s-maxage=7200, max-age=86400"), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_AgeDeductedFromMaxAge(t *testing.T) {
+	t.Parallel()
+
+	// The CDN case: a day of granted freshness that has already been sitting
+	// in an intermediary for 22 hours leaves 2 hours, not 24.
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=86400",
+		"Age", "79200",
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_AgeExceedingLifetimeClampedToFloor(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=86400",
+		"Age", "90000",
+	), cacheTTLReference)
+	require.Equal(t, minCacheTTL, ttl)
+}
+
+func TestCacheTTL_MalformedAgeIgnored(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=7200",
+		"Age", "ancient",
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_ExpiresMeasuredAgainstDate(t *testing.T) {
+	t.Parallel()
+
+	// An origin whose clock runs two hours fast still grants exactly the two
+	// hours it meant to, because Expires is read relative to its own Date.
+	originNow := cacheTTLReference.Add(2 * time.Hour)
+	ttl := cacheTTL(headerWith(t,
+		"Date", originNow.Format(http.TimeFormat),
+		"Expires", originNow.Add(2*time.Hour).Format(http.TimeFormat),
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_ExpiresHonouredWhenNoMaxAge(t *testing.T) {
+	t.Parallel()
+
+	expires := cacheTTLReference.Add(2 * time.Hour).Format(http.TimeFormat)
+	ttl := cacheTTL(headerWith(t, "Expires", expires), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_MaxAgePreferredOverExpires(t *testing.T) {
+	t.Parallel()
+
+	expires := cacheTTLReference.Add(20 * time.Hour).Format(http.TimeFormat)
+	ttl := cacheTTL(headerWith(t,
+		"Cache-Control", "max-age=7200",
+		"Expires", expires,
+	), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_ExpiresInPastClampedToFloor(t *testing.T) {
+	t.Parallel()
+
+	expires := cacheTTLReference.Add(-time.Hour).Format(http.TimeFormat)
+	ttl := cacheTTL(headerWith(t, "Expires", expires), cacheTTLReference)
+	require.Equal(t, minCacheTTL, ttl)
+}
+
+func TestCacheTTL_ExpiresZeroFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	// "Expires: 0" is the common spelling of "already stale" and is not a
+	// valid HTTP-date, so it reads as no opinion rather than as the floor.
+	ttl := cacheTTL(headerWith(t, "Expires", "0"), cacheTTLReference)
+	require.Equal(t, defaultCacheTTL, ttl)
+}
+
+func TestCacheTTL_NoHeadersUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, defaultCacheTTL, cacheTTL(http.Header{}, cacheTTLReference))
+}
+
+func TestSanitizeETag_StrongAndWeakPreservedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	// The validator is replayed byte for byte: If-None-Match uses weak
+	// comparison, so rewriting a W/ prefix would break revalidation against
+	// hosts that emit one.
+	require.Equal(t, `"abc123"`, sanitizeETag(`"abc123"`))
+	require.Equal(t, `W/"abc123"`, sanitizeETag(`W/"abc123"`))
+	require.Equal(t, `"abc123"`, sanitizeETag(`  "abc123"  `))
+}
+
+func TestSanitizeETag_EmptyDropped(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, sanitizeETag(""))
+	require.Empty(t, sanitizeETag("   "))
+}
+
+func TestSanitizeETag_OversizedDropped(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, strings.Repeat("a", maxETagLength), sanitizeETag(strings.Repeat("a", maxETagLength)))
+	require.Empty(t, sanitizeETag(strings.Repeat("a", maxETagLength+1)))
+}
+
+func TestSanitizeETag_ControlAndNonASCIIDropped(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, sanitizeETag("\"abc\r\nX-Injected: 1\""))
+	require.Empty(t, sanitizeETag("\"abc\tdef\""))
+	require.Empty(t, sanitizeETag(`"caf é"`))
+}

--- a/server/internal/usersessions/cimd/cache_policy_test.go
+++ b/server/internal/usersessions/cimd/cache_policy_test.go
@@ -85,6 +85,39 @@ func TestCacheTTL_MaxAgeCaseInsensitive(t *testing.T) {
 	require.Equal(t, 2*time.Hour, ttl)
 }
 
+func TestCacheTTL_CommaInsideQuotedDirectiveIsNotADirective(t *testing.T) {
+	t.Parallel()
+
+	// The quoted argument of no-cache must not be split into a fragment that
+	// reads as a max-age the host never granted.
+	ttl := cacheTTL(headerWith(t, "Cache-Control", `no-cache="Set-Cookie, max-age=99999"`), cacheTTLReference)
+	require.Equal(t, defaultCacheTTL, ttl)
+}
+
+func TestCacheTTL_QuotedDirectiveDoesNotHideRealMaxAge(t *testing.T) {
+	t.Parallel()
+
+	ttl := cacheTTL(headerWith(t, "Cache-Control", `private="Set-Cookie, Authorization", max-age=7200`), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_EscapedQuoteInsideDirectiveHandled(t *testing.T) {
+	t.Parallel()
+
+	// A quoted-pair escaping a quote must not be read as closing the string,
+	// which would put the rest of the value back in directive position.
+	ttl := cacheTTL(headerWith(t, "Cache-Control", `no-cache="a\", max-age=99999", max-age=7200`), cacheTTLReference)
+	require.Equal(t, 2*time.Hour, ttl)
+}
+
+func TestCacheTTL_UnmatchedQuoteFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, defaultCacheTTL, cacheTTL(headerWith(t, "Cache-Control", `max-age="7200`), cacheTTLReference))
+	require.Equal(t, defaultCacheTTL, cacheTTL(headerWith(t, "Cache-Control", `max-age=7200"`), cacheTTLReference))
+	require.Equal(t, defaultCacheTTL, cacheTTL(headerWith(t, "Cache-Control", `max-age=""7200""`), cacheTTLReference))
+}
+
 func TestCacheTTL_MaxAgeOverflowFallsBackToDefault(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/cimd/cache_result.go
+++ b/server/internal/usersessions/cimd/cache_result.go
@@ -1,0 +1,26 @@
+package cimd
+
+import "time"
+
+// CacheResult carries the effect of one Resolve call.
+type CacheResult struct {
+	// Outcome selects which of the remaining fields are meaningful; callers
+	// must switch on it rather than testing fields for emptiness.
+	Outcome CacheOutcome
+
+	// Document is the freshly fetched and validated document. It is non-nil
+	// if and only if Outcome is CacheOutcomeRefreshed — on the other two
+	// outcomes the caller's own stored row is the authoritative copy and
+	// nothing was parsed.
+	Document *Document
+
+	// ETag is the validator to persist. Empty means the upstream offers no
+	// validator and the next refresh must be unconditional; the caller
+	// should store NULL rather than an empty string.
+	ETag string
+
+	// TTL is the lifetime to add to the stored expiry, already clamped to
+	// the resolver's bounds. It is zero on CacheOutcomeCached, where the
+	// existing expiry stands.
+	TTL time.Duration
+}

--- a/server/internal/usersessions/cimd/cache_state.go
+++ b/server/internal/usersessions/cimd/cache_state.go
@@ -1,0 +1,16 @@
+package cimd
+
+import "time"
+
+// CacheState is the cached metadata the caller has persisted for a client_id.
+// The zero value means "nothing cached" and forces an unconditional fetch.
+type CacheState struct {
+	// ExpiresAt is the stored client_id_metadata_cache_expires_at. While it
+	// is in the future the document is served from the caller's row with no
+	// upstream request at all.
+	ExpiresAt time.Time
+
+	// ETag is the stored client_id_metadata_etag, replayed verbatim in
+	// If-None-Match. Empty means the refresh is unconditional.
+	ETag string
+}

--- a/server/internal/usersessions/cimd/cache_test.go
+++ b/server/internal/usersessions/cimd/cache_test.go
@@ -161,7 +161,9 @@ func TestResolve_NotModifiedKeepsCachedDocument(t *testing.T) {
 	require.Equal(t, CacheOutcomeNotModified, result.Outcome)
 	require.Nil(t, result.Document, "a 304 has no body to parse; the caller's row stands")
 	require.Equal(t, `"v1"`, result.ETag)
-	require.Equal(t, 2*time.Hour, result.TTL, "the 304's own freshness headers set the new expiry")
+	// Not exactly two hours: the server stamps a Date, HTTP-date has
+	// one-second granularity, and the apparent age that implies is deducted.
+	require.InDelta(t, (2 * time.Hour).Seconds(), result.TTL.Seconds(), 2, "the 304's own freshness headers set the new expiry")
 
 	total, conditional := ds.counts(t)
 	require.Equal(t, 1, total)
@@ -261,7 +263,7 @@ func TestResolve_RefreshCarriesETagAndTTL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
 	require.Equal(t, `"v1"`, result.ETag)
-	require.Equal(t, 2*time.Hour, result.TTL)
+	require.InDelta(t, (2 * time.Hour).Seconds(), result.TTL.Seconds(), 2)
 }
 
 func TestResolve_RefreshDropsOversizedETag(t *testing.T) {

--- a/server/internal/usersessions/cimd/cache_test.go
+++ b/server/internal/usersessions/cimd/cache_test.go
@@ -1,0 +1,327 @@
+// Tests for the document cache layered over the fetch lifecycle: the
+// short-circuit on a fresh cache, the conditional refresh when it has
+// lapsed, and the outcomes each produces for the caller to persist.
+
+package cimd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// conditionalDocServer hosts a document that carries an ETag and answers a
+// matching If-None-Match with 304, so a test can drive a full revalidation
+// round trip. Its counters and mutable response settings are guarded because
+// the handler runs on the server's own goroutine.
+type conditionalDocServer struct {
+	srv      *httptest.Server
+	resolver *Resolver
+	clientID string
+
+	mu sync.Mutex
+	// etag is served on 200 responses and matched against If-None-Match.
+	// Empty means the host offers no validator at all.
+	etag string
+	// notModifiedETag is served on 304 responses when non-empty, standing
+	// in for a host that supersedes its validator on revalidation.
+	notModifiedETag string
+	// cacheControl is sent verbatim as the Cache-Control header when
+	// non-empty.
+	cacheControl string
+	// requests counts every request the host received, and
+	// conditionalRequests only those carrying If-None-Match.
+	requests            int
+	conditionalRequests int
+}
+
+func newConditionalDocServer(t *testing.T, etag string) *conditionalDocServer {
+	t.Helper()
+
+	ds := &conditionalDocServer{
+		srv:                 nil,
+		resolver:            nil,
+		clientID:            "",
+		mu:                  sync.Mutex{},
+		etag:                etag,
+		notModifiedETag:     "",
+		cacheControl:        "",
+		requests:            0,
+		conditionalRequests: 0,
+	}
+
+	ds.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ds.mu.Lock()
+		ds.requests++
+		conditional := r.Header.Get("If-None-Match")
+		if conditional != "" {
+			ds.conditionalRequests++
+		}
+		etag, notModifiedETag, cacheControl := ds.etag, ds.notModifiedETag, ds.cacheControl
+		clientID := ds.clientID
+		ds.mu.Unlock()
+
+		if cacheControl != "" {
+			w.Header().Set("Cache-Control", cacheControl)
+		}
+		if conditional != "" && conditional == etag {
+			if notModifiedETag != "" {
+				w.Header().Set("ETag", notModifiedETag)
+			}
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if etag != "" {
+			w.Header().Set("ETag", etag)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(validDocumentJSON(clientID)); err != nil {
+			t.Errorf("encode document: %v", err)
+		}
+	}))
+	t.Cleanup(ds.srv.Close)
+
+	ds.resolver = newResolver(newFetchClientFrom(ds.srv.Client()), testenv.NewMeterProvider(t), testenv.NewLogger(t))
+	ds.clientID = ds.srv.URL + "/client.json"
+	return ds
+}
+
+func (ds *conditionalDocServer) counts(t *testing.T) (total int, conditional int) {
+	t.Helper()
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	return ds.requests, ds.conditionalRequests
+}
+
+func (ds *conditionalDocServer) set(t *testing.T, mutate func(ds *conditionalDocServer)) {
+	t.Helper()
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	mutate(ds)
+}
+
+func TestResolve_FreshCacheSkipsFetch(t *testing.T) {
+	t.Parallel()
+
+	ds := newConditionalDocServer(t, `"v1"`)
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(time.Hour),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeCached, result.Outcome)
+	require.Nil(t, result.Document, "a cache hit parses nothing; the caller's row is the document")
+	require.Equal(t, `"v1"`, result.ETag, "the stored validator survives a cache hit")
+	require.Zero(t, result.TTL, "a cache hit leaves the stored expiry alone")
+
+	total, _ := ds.counts(t)
+	require.Zero(t, total, "a fresh cache must not reach the document host at all")
+}
+
+func TestResolve_ExpiredCacheRefetches(t *testing.T) {
+	t.Parallel()
+
+	ds := newConditionalDocServer(t, "")
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      "",
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
+	require.NotNil(t, result.Document)
+
+	total, conditional := ds.counts(t)
+	require.Equal(t, 1, total)
+	require.Zero(t, conditional, "no stored validator means an unconditional refresh")
+}
+
+func TestResolve_NotModifiedKeepsCachedDocument(t *testing.T) {
+	t.Parallel()
+
+	ds := newConditionalDocServer(t, `"v1"`)
+	ds.set(t, func(ds *conditionalDocServer) { ds.cacheControl = "max-age=7200" })
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeNotModified, result.Outcome)
+	require.Nil(t, result.Document, "a 304 has no body to parse; the caller's row stands")
+	require.Equal(t, `"v1"`, result.ETag)
+	require.Equal(t, 2*time.Hour, result.TTL, "the 304's own freshness headers set the new expiry")
+
+	total, conditional := ds.counts(t)
+	require.Equal(t, 1, total)
+	require.Equal(t, 1, conditional, "a stored validator must be replayed in If-None-Match")
+}
+
+func TestResolve_NotModifiedAdoptsSupersedingETag(t *testing.T) {
+	t.Parallel()
+
+	// RFC 9110 §15.4.5 lets a 304 carry a new validator. Ignoring it would
+	// revalidate against the superseded one forever.
+	ds := newConditionalDocServer(t, `"v1"`)
+	ds.set(t, func(ds *conditionalDocServer) { ds.notModifiedETag = `"v2"` })
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeNotModified, result.Outcome)
+	require.Equal(t, `"v2"`, result.ETag)
+}
+
+func TestResolve_NotModifiedKeepsStoredETagWhenUnusable(t *testing.T) {
+	t.Parallel()
+
+	ds := newConditionalDocServer(t, `"v1"`)
+	ds.set(t, func(ds *conditionalDocServer) { ds.notModifiedETag = `"` + strings.Repeat("a", maxETagLength) + `"` })
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeNotModified, result.Outcome)
+	require.Equal(t, `"v1"`, result.ETag, "an unusable replacement leaves the working validator in place")
+}
+
+func TestResolve_ConditionalRequestAnsweredWith200Replaces(t *testing.T) {
+	t.Parallel()
+
+	// The rotation path: the stored validator no longer matches, so the host
+	// sends a body instead of a 304 and the new validator replaces the old.
+	ds := newConditionalDocServer(t, `"v2"`)
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
+	require.NotNil(t, result.Document)
+	require.Equal(t, `"v2"`, result.ETag)
+
+	_, conditional := ds.counts(t)
+	require.Equal(t, 1, conditional, "the stale validator is still offered; the host decides")
+}
+
+func TestResolve_RefreshClearsStoredETagWhenHostStopsSendingOne(t *testing.T) {
+	t.Parallel()
+
+	// A host that drops its ETag must not leave the old one stored: the next
+	// refresh would revalidate against a validator the host no longer knows,
+	// and a buggy host answering 304 to it would pin the old document.
+	ds := newConditionalDocServer(t, "")
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
+	require.Empty(t, result.ETag, "the refreshed document carries no validator, so none is kept")
+}
+
+func TestResolve_UnconditionalRequestRejectsNotModified(t *testing.T) {
+	t.Parallel()
+
+	// A host that answers 304 to a request carrying no If-None-Match is
+	// broken or intermediary-fronted. Treating it as a cache confirmation
+	// would confirm a document this resolver has never seen.
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	})
+
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
+	require.ErrorContains(t, err, "status 304")
+}
+
+func TestResolve_RefreshCarriesETagAndTTL(t *testing.T) {
+	t.Parallel()
+
+	ds := newConditionalDocServer(t, `"v1"`)
+	ds.set(t, func(ds *conditionalDocServer) { ds.cacheControl = "public, max-age=7200" })
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, noCache)
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
+	require.Equal(t, `"v1"`, result.ETag)
+	require.Equal(t, 2*time.Hour, result.TTL)
+}
+
+func TestResolve_RefreshDropsOversizedETag(t *testing.T) {
+	t.Parallel()
+
+	// The validator is chosen by the document host and lands in a TEXT
+	// column, so an oversized one is dropped and the next refresh is
+	// unconditional rather than replaying megabytes.
+	ds := newConditionalDocServer(t, `"`+strings.Repeat("a", maxETagLength)+`"`)
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, noCache)
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
+	require.Empty(t, result.ETag)
+}
+
+func TestResolve_RefreshWithoutETagReportsNoValidator(t *testing.T) {
+	t.Parallel()
+
+	ds := newConditionalDocServer(t, "")
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, noCache)
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
+	require.Empty(t, result.ETag)
+	require.Equal(t, defaultCacheTTL, result.TTL)
+}
+
+func TestResolve_RefreshFailureReturnsNoResult(t *testing.T) {
+	t.Parallel()
+
+	// Fail-closed: a lapsed cache whose refresh fails yields an error and
+	// nothing to persist, so the caller's stored row is left exactly as it
+	// was rather than being extended or served stale (-02 §5.1).
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream is down", http.StatusInternalServerError)
+	})
+
+	result, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      `"v1"`,
+	})
+	require.ErrorContains(t, err, "status 500")
+	require.Nil(t, result)
+}
+
+func TestResolve_FreshCacheStillRejectsInvalidClientIDURL(t *testing.T) {
+	t.Parallel()
+
+	// Freshness is consulted only after §3 syntax has passed, so a stored
+	// row can never keep a client_id alive that current rules reject.
+	requests := 0
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+	})
+
+	_, err := resolver.Resolve(t.Context(), srv.URL, CacheState{
+		ExpiresAt: time.Now().Add(time.Hour),
+		ETag:      `"v1"`,
+	})
+	requireOAuthError(t, err, "invalid_request")
+	require.Zero(t, requests)
+}

--- a/server/internal/usersessions/cimd/cache_test.go
+++ b/server/internal/usersessions/cimd/cache_test.go
@@ -239,6 +239,28 @@ func TestResolve_RefreshClearsStoredETagWhenHostStopsSendingOne(t *testing.T) {
 	require.Empty(t, result.ETag, "the refreshed document carries no validator, so none is kept")
 }
 
+func TestResolve_MalformedStoredETagNotReplayed(t *testing.T) {
+	t.Parallel()
+
+	// Stored validators are sanitized on the way in, but that invariant
+	// spans a process and a database: a row written under laxer rules, or by
+	// hand, must not be replayed. A wildcard is the case that matters, since
+	// "If-None-Match: *" matches whenever the host has any representation at
+	// all and would pin the cached document forever.
+	ds := newConditionalDocServer(t, `"v1"`)
+
+	result, err := ds.resolver.Resolve(t.Context(), ds.clientID, CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      "*",
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome, "a full document must be re-read, not confirmed")
+	require.Equal(t, `"v1"`, result.ETag, "the refresh stores the host's own validator")
+
+	_, conditional := ds.counts(t)
+	require.Zero(t, conditional, "a malformed stored validator must not reach the wire")
+}
+
 func TestResolve_UnconditionalRequestRejectsNotModified(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/cimd/cimd.go
+++ b/server/internal/usersessions/cimd/cimd.go
@@ -329,8 +329,12 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 			safeDescription: "",
 			tooLarge:        false,
 			cacheOutcome:    CacheOutcomeCached,
-			etag:            cache.ETag,
-			ttl:             0,
+			// Sanitized even though the caller persists nothing on a cache
+			// hit: every etag this package hands back must be safe to
+			// store, or a future caller trusting the field would launder a
+			// malformed stored validator back into the database.
+			etag: sanitizeETag(cache.ETag),
+			ttl:  0,
 		}
 	}
 

--- a/server/internal/usersessions/cimd/cimd.go
+++ b/server/internal/usersessions/cimd/cimd.go
@@ -379,7 +379,14 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 		// A response that offers none — or an unusable one — leaves the
 		// stored validator in place: it still identifies content the
 		// upstream just confirmed is unchanged.
-		etag := cache.ETag
+		//
+		// The stored value is re-sanitized so what gets persisted is what
+		// went on the wire. Reaching here at all means it survived
+		// sanitizing (an empty result suppresses the conditional request and
+		// with it this branch), so this only ever normalizes surrounding
+		// whitespace, but persisting a value the request did not use would
+		// be a quiet inconsistency.
+		etag := sanitizeETag(cache.ETag)
 		if refreshed := sanitizeETag(fetched.header.Get("ETag")); refreshed != "" {
 			etag = refreshed
 		}

--- a/server/internal/usersessions/cimd/cimd.go
+++ b/server/internal/usersessions/cimd/cimd.go
@@ -587,6 +587,16 @@ func (r *Resolver) fetchDocument(ctx context.Context, origin string, clientID st
 		return fetchedDocument{body: nil, status: 0, notModified: false, header: nil}, fmt.Errorf("build document request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+
+	// Re-sanitize rather than trusting the stored value. Everything written
+	// to client_id_metadata_etag passes sanitizeETag today, but that is a
+	// caller-side invariant across a process and a database: a row written
+	// under laxer rules than the ones now compiled in, or by hand during an
+	// incident, would otherwise be replayed forever. Dropping a validator
+	// here also correctly suppresses the 304 branch below, so a malformed
+	// stored tag cannot make this AS accept a revalidation it never asked
+	// for.
+	etag = sanitizeETag(etag)
 	if etag != "" {
 		req.Header.Set("If-None-Match", etag)
 	}

--- a/server/internal/usersessions/cimd/cimd.go
+++ b/server/internal/usersessions/cimd/cimd.go
@@ -4,10 +4,11 @@
 // fetching the document it names, parsing it, and validating it against the
 // spec's rules plus Gram's own origin-binding policy.
 //
-// The Resolver owns the fetch lifecycle and its telemetry (metrics + logs) but
-// deliberately nothing else: no caching (until AIS-216) and no persistence.
-// Callers own the upsert of the resolved client and the mapping of returned
-// errors onto their wire format.
+// The Resolver owns the fetch lifecycle, its cache policy, and its telemetry
+// (metrics + logs) but deliberately not persistence: the caller passes in the
+// cache state it has stored and applies the returned outcome to its own
+// tables. Callers own the upsert of the resolved client and the mapping of
+// returned errors onto their wire format.
 //
 // # Two entry points, two disclosure levels
 //
@@ -222,29 +223,57 @@ func newFetchClientFrom(base *guardian.HTTPClient) *guardian.HTTPClient {
 	return &client
 }
 
-// Resolve fetches, parses, and validates the Client ID Metadata Document
-// named by clientID. The returned Document has passed every check this AS
-// imposes: -02 §3 URL syntax, §4 triple client_id equality (the fetch never
+// Resolve returns the Client ID Metadata Document state for clientID,
+// fetching it only when the caller's cache says it must.
+//
+// The cache policy, in order: a cache whose expiry is still in the future
+// short-circuits with CacheOutcomeCached and no upstream request; otherwise a
+// conditional GET runs, carrying If-None-Match when cache.ETag is set, and
+// yields CacheOutcomeNotModified on 304 or CacheOutcomeRefreshed on 200.
+// Every failure — transport, status, parse, or validation — returns an error
+// and leaves the caller's cached row untouched. Serving a stale document when
+// a refresh fails is deliberately not offered: -02 §5.1 says a fetch failure
+// SHOULD abort the authorization request.
+//
+// A document returned with CacheOutcomeRefreshed has passed every check this
+// AS imposes: -02 §3 URL syntax, §4 triple client_id equality (the fetch never
 // follows redirects, so the fetched URL is the presented URL by
 // construction), required client_name + redirect_uris, public-client-only
 // auth method, secret/private-key bans, and Gram's same-origin redirect-URI
-// binding.
-func (r *Resolver) Resolve(ctx context.Context, clientID string) (*Document, error) {
-	// The OAuth path takes only the document and the error, discarding the
-	// outcome taxonomy. That discard is the disclosure boundary described in
-	// the package doc: everything Inspect would reveal is computed here too,
-	// and deliberately dropped before it can reach an unauthenticated caller.
-	result := r.inspect(ctx, clientID)
+// binding. Those checks run against the document as fetched, so a cached row
+// carries the verdict of the validation code that was deployed when it was
+// last refreshed: tightening a rule in validate.go does not re-reject a
+// cached client until its TTL lapses, up to maxCacheTTL later. Callers that
+// need a rule applied sooner must purge their stored cache state, which
+// forces the next resolve to fetch and re-validate a full document.
+func (r *Resolver) Resolve(ctx context.Context, clientID string, cache CacheState) (*CacheResult, error) {
+	// The OAuth path takes only the cache effect and the error, discarding
+	// the outcome taxonomy. That discard is the disclosure boundary described
+	// in the package doc: everything Inspect would reveal is computed here
+	// too, and deliberately dropped before it can reach an unauthenticated
+	// caller.
+	result := r.inspect(ctx, clientID, cache)
 	if result.err != nil {
 		return nil, result.err
 	}
-	return result.Document, nil
+	return &CacheResult{
+		Outcome:  result.cacheOutcome,
+		Document: result.Document,
+		ETag:     result.etag,
+		TTL:      result.ttl,
+	}, nil
 }
 
 // inspect runs the full resolution and records the telemetry. It is the sole
 // implementation behind both Resolve and Inspect, so the two can never drift
 // in what they fetch, what they accept, or what they report to o11y.
-func (r *Resolver) inspect(ctx context.Context, clientID string) inspection {
+//
+// cache is always the zero value on the Inspect path: an operator asking what
+// a URL serves right now must not be answered from a copy the authorize path
+// stored earlier. The two short-circuit outcomes below are therefore
+// unreachable from Inspect, which is what lets Inspection keep its invariant
+// that a valid outcome carries a document.
+func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheState) inspection {
 	clientIDURL, err := ValidateClientIDURL(clientID)
 	if err != nil {
 		// Pre-fetch rejection: no origin has been established (the URL did
@@ -269,19 +298,51 @@ func (r *Resolver) inspect(ctx context.Context, clientID string) inspection {
 			err:             err,
 			safeDescription: safeDescriptionOf(err),
 			tooLarge:        false,
+			cacheOutcome:    CacheOutcomeRefreshed,
+			etag:            "",
+			ttl:             0,
 		}
 	}
 	origin := clientIDURL.Host
 
+	// Freshness is consulted only after the URL itself has passed §3, so a
+	// cached row can never keep a client_id alive that current syntax rules
+	// reject.
+	if !cache.ExpiresAt.IsZero() && cache.ExpiresAt.After(time.Now()) {
+		r.observe(ctx, resolveObservation{
+			clientID:      clientID,
+			origin:        origin,
+			result:        fetchResultCached,
+			reason:        "",
+			status:        0,
+			duration:      0,
+			fetched:       false,
+			responseBytes: 0,
+			err:           nil,
+		})
+		return inspection{
+			Document:        nil,
+			outcome:         OutcomeValid,
+			status:          0,
+			reason:          "",
+			err:             nil,
+			safeDescription: "",
+			tooLarge:        false,
+			cacheOutcome:    CacheOutcomeCached,
+			etag:            cache.ETag,
+			ttl:             0,
+		}
+	}
+
 	start := time.Now()
-	body, status, err := r.fetchDocument(ctx, origin, clientID)
+	fetched, err := r.fetchDocument(ctx, origin, clientID, cache.ETag)
 	if err != nil {
 		r.observe(ctx, resolveObservation{
 			clientID:      clientID,
 			origin:        origin,
 			result:        fetchResultFetchError,
 			reason:        "",
-			status:        status,
+			status:        fetched.status,
 			duration:      time.Since(start),
 			fetched:       true,
 			responseBytes: 0,
@@ -290,13 +351,52 @@ func (r *Resolver) inspect(ctx context.Context, clientID string) inspection {
 		return inspection{
 			Document:        nil,
 			outcome:         OutcomeUnreachable,
-			status:          status,
+			status:          fetched.status,
 			reason:          "",
 			err:             fmt.Errorf("fetch client metadata document: %w", err),
 			safeDescription: "",
 			tooLarge:        errors.Is(err, ErrDocumentTooLarge),
+			cacheOutcome:    CacheOutcomeRefreshed,
+			etag:            "",
+			ttl:             0,
 		}
 	}
+
+	if fetched.notModified {
+		r.observe(ctx, resolveObservation{
+			clientID:      clientID,
+			origin:        origin,
+			result:        fetchResultConditionalNotModified,
+			reason:        "",
+			status:        fetched.status,
+			duration:      time.Since(start),
+			fetched:       true,
+			responseBytes: 0,
+			err:           nil,
+		})
+		// RFC 9110 §15.4.5 lets a 304 carry a new validator, and a cache
+		// that ignores one revalidates against a superseded ETag forever.
+		// A response that offers none — or an unusable one — leaves the
+		// stored validator in place: it still identifies content the
+		// upstream just confirmed is unchanged.
+		etag := cache.ETag
+		if refreshed := sanitizeETag(fetched.header.Get("ETag")); refreshed != "" {
+			etag = refreshed
+		}
+		return inspection{
+			Document:        nil,
+			outcome:         OutcomeValid,
+			status:          fetched.status,
+			reason:          "",
+			err:             nil,
+			safeDescription: "",
+			tooLarge:        false,
+			cacheOutcome:    CacheOutcomeNotModified,
+			etag:            etag,
+			ttl:             cacheTTL(fetched.header, time.Now()),
+		}
+	}
+	body, status := fetched.body, fetched.status
 
 	// On the OAuth path a malformed body is reported like any other fetch
 	// failure (plain wrapped error, generic wire response) rather than as a
@@ -325,6 +425,9 @@ func (r *Resolver) inspect(ctx context.Context, clientID string) inspection {
 			err:             fmt.Errorf("parse client metadata document: %w", err),
 			safeDescription: "",
 			tooLarge:        false,
+			cacheOutcome:    CacheOutcomeRefreshed,
+			etag:            "",
+			ttl:             0,
 		}
 	}
 
@@ -348,6 +451,9 @@ func (r *Resolver) inspect(ctx context.Context, clientID string) inspection {
 			err:             err,
 			safeDescription: safeDescriptionOf(err),
 			tooLarge:        false,
+			cacheOutcome:    CacheOutcomeRefreshed,
+			etag:            "",
+			ttl:             0,
 		}
 	}
 
@@ -370,6 +476,9 @@ func (r *Resolver) inspect(ctx context.Context, clientID string) inspection {
 		err:             nil,
 		safeDescription: "",
 		tooLarge:        false,
+		cacheOutcome:    CacheOutcomeRefreshed,
+		etag:            sanitizeETag(fetched.header.Get("ETag")),
+		ttl:             cacheTTL(fetched.header, time.Now()),
 	}
 }
 
@@ -434,14 +543,39 @@ func (r *Resolver) observe(ctx context.Context, o resolveObservation) {
 	r.logger.InfoContext(ctx, "cimd document resolved", logAttrs...)
 }
 
-// fetchDocument retrieves the metadata document. Only HTTP 200 is accepted
-// (-02 §5 MUST; other statuses — including the unfollowed redirects — are
-// fetch failures and are never cached per §5.2), and the body read is capped
-// at maxDocumentBytes. The returned status is 0 when no response was
-// received. Response size is recorded here because the byte count only
-// exists inside the read: the full body length on success, or the cap itself
-// when the read tripped it.
-func (r *Resolver) fetchDocument(ctx context.Context, origin string, clientID string) ([]byte, int, error) {
+// fetchedDocument is one HTTP exchange with a document host.
+type fetchedDocument struct {
+	// body is the document bytes, empty unless the response was a 200.
+	body []byte
+
+	// status is the HTTP status, 0 when no response was received.
+	status int
+
+	// notModified reports a 304 answer to a conditional request, meaning
+	// body is empty and the caller's cached document still stands.
+	notModified bool
+
+	// header is the response header, read for the freshness directives and
+	// the ETag. Nil when no response was received.
+	header http.Header
+}
+
+// fetchDocument retrieves the metadata document, conditionally when etag is
+// non-empty. HTTP 200 is the only status that yields a body (-02 §5 MUST;
+// other statuses — including the unfollowed redirects — are fetch failures
+// and are never cached per §5.2), and the body read is capped at
+// maxDocumentBytes.
+//
+// A 304 is accepted only in answer to a conditional request. An
+// unconditional GET that draws one is a broken or intermediary-fronted host
+// rather than a revalidation, and treating it as a cache confirmation would
+// mean confirming a document this AS has never seen, so it falls through to
+// the same fetch failure as any other unexpected status.
+//
+// Response size is recorded here because the byte count only exists inside
+// the read: the full body length on success, or the cap itself when the read
+// tripped it. A 304 records none, having read no body.
+func (r *Resolver) fetchDocument(ctx context.Context, origin string, clientID string, etag string) (fetchedDocument, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
@@ -450,29 +584,36 @@ func (r *Resolver) fetchDocument(ctx context.Context, origin string, clientID st
 	// accepted despite no request having been sent.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientID, nil)
 	if err != nil {
-		return nil, 0, fmt.Errorf("build document request: %w", err)
+		return fetchedDocument{body: nil, status: 0, notModified: false, header: nil}, fmt.Errorf("build document request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
 
 	resp, err := r.client.Do(req)
 	if err != nil {
-		return nil, 0, fmt.Errorf("request document: %w", err)
+		return fetchedDocument{body: nil, status: 0, notModified: false, header: nil}, fmt.Errorf("request document: %w", err)
 	}
 	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
+	if etag != "" && resp.StatusCode == http.StatusNotModified {
+		return fetchedDocument{body: nil, status: resp.StatusCode, notModified: true, header: resp.Header}, nil
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return nil, resp.StatusCode, fmt.Errorf("document endpoint returned status %d", resp.StatusCode)
+		return fetchedDocument{body: nil, status: resp.StatusCode, notModified: false, header: resp.Header}, fmt.Errorf("document endpoint returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, maxDocumentBytes))
 	if err != nil {
 		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			r.metrics.RecordResponseSize(ctx, origin, maxDocumentBytes)
-			return nil, resp.StatusCode, fmt.Errorf("document exceeds %d byte limit: %w", maxDocumentBytes, ErrDocumentTooLarge)
+			return fetchedDocument{body: nil, status: resp.StatusCode, notModified: false, header: resp.Header}, fmt.Errorf("document exceeds %d byte limit: %w", maxDocumentBytes, ErrDocumentTooLarge)
 		}
-		return nil, resp.StatusCode, fmt.Errorf("read document body: %w", err)
+		return fetchedDocument{body: nil, status: resp.StatusCode, notModified: false, header: resp.Header}, fmt.Errorf("read document body: %w", err)
 	}
 	r.metrics.RecordResponseSize(ctx, origin, int64(len(body)))
 
-	return body, resp.StatusCode, nil
+	return fetchedDocument{body: body, status: resp.StatusCode, notModified: false, header: resp.Header}, nil
 }

--- a/server/internal/usersessions/cimd/cimd_test.go
+++ b/server/internal/usersessions/cimd/cimd_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -62,16 +63,22 @@ func validDocumentJSON(clientID string) map[string]any {
 	}
 }
 
+// noCache is the cache state of a client_id nothing has been stored for. It
+// forces an unconditional fetch, which is what every test that is not about
+// the cache policy wants.
+var noCache = CacheState{ExpiresAt: time.Time{}, ETag: ""}
+
 func TestResolve_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	_, resolver, clientID := serveDocumentJSON(t, validDocumentJSON)
 
-	doc, err := resolver.Resolve(t.Context(), clientID)
+	result, err := resolver.Resolve(t.Context(), clientID, noCache)
 	require.NoError(t, err)
-	require.Equal(t, clientID, doc.ClientID)
-	require.Equal(t, "CIMD Test Client", doc.ClientName)
-	require.Equal(t, []string{"http://127.0.0.1:3000/callback"}, doc.RedirectURIs)
+	require.Equal(t, CacheOutcomeRefreshed, result.Outcome)
+	require.Equal(t, clientID, result.Document.ClientID)
+	require.Equal(t, "CIMD Test Client", result.Document.ClientName)
+	require.Equal(t, []string{"http://127.0.0.1:3000/callback"}, result.Document.RedirectURIs)
 }
 
 func TestResolve_Non200Rejected(t *testing.T) {
@@ -81,7 +88,7 @@ func TestResolve_Non200Rejected(t *testing.T) {
 		http.NotFound(w, r)
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 	require.ErrorContains(t, err, "status 404")
 }
 
@@ -103,7 +110,7 @@ func TestResolve_RedirectNotFollowed(t *testing.T) {
 	})
 	clientID = srv.URL + "/client.json"
 
-	_, err := resolver.Resolve(t.Context(), clientID)
+	_, err := resolver.Resolve(t.Context(), clientID, noCache)
 	require.ErrorContains(t, err, "status 302")
 }
 
@@ -117,7 +124,7 @@ func TestResolve_OversizedDocumentRejected(t *testing.T) {
 		}
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 	require.ErrorContains(t, err, "byte limit")
 }
 
@@ -134,7 +141,7 @@ func TestResolve_InvalidJSONRejected(t *testing.T) {
 	// Deliberately NOT an OAuthError: a distinguishable "reachable but not
 	// JSON" outcome would let unauthenticated callers probe external hosts
 	// through Gram, so it reports like any other fetch failure.
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 	require.ErrorContains(t, err, "parse client metadata document")
 	var oauthErr *oauthwire.Error
 	require.NotErrorAs(t, err, &oauthErr)
@@ -149,7 +156,7 @@ func TestResolve_DocumentClientIDMismatchRejected(t *testing.T) {
 		return doc
 	})
 
-	_, err := resolver.Resolve(t.Context(), clientID)
+	_, err := resolver.Resolve(t.Context(), clientID, noCache)
 	requireOAuthError(t, err, "invalid_client_metadata")
 }
 
@@ -161,7 +168,7 @@ func TestResolve_InvalidClientIDURLNoFetch(t *testing.T) {
 		requests++
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL) // no path component
+	_, err := resolver.Resolve(t.Context(), srv.URL, noCache) // no path component
 	requireOAuthError(t, err, "invalid_request")
 	require.Zero(t, requests, "syntactically invalid client_id must never be fetched")
 }
@@ -177,6 +184,6 @@ func TestResolve_ProductionPolicyBlocksLoopback(t *testing.T) {
 	})
 
 	resolver := NewResolver(guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)), testenv.NewMeterProvider(t), testenv.NewLogger(t))
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 	require.ErrorContains(t, err, "request document")
 }

--- a/server/internal/usersessions/cimd/inspect_test.go
+++ b/server/internal/usersessions/cimd/inspect_test.go
@@ -206,7 +206,7 @@ func TestResolve_StaysOpaqueAfterInspectRefactor(t *testing.T) {
 		}
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 
 	require.Error(t, err)
 	// A parse failure is still reported as an opaque wrapped error carrying

--- a/server/internal/usersessions/cimd/inspection.go
+++ b/server/internal/usersessions/cimd/inspection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/usersessions/oauthwire"
 )
@@ -40,7 +41,10 @@ type Inspection struct {
 // surfaces only — never the OAuth endpoints, whose callers must not be able
 // to use Gram as a probe oracle for external hosts.
 func (r *Resolver) Inspect(ctx context.Context, clientID string) Inspection {
-	result := r.inspect(ctx, clientID)
+	// Always uncached. An operator asking what a URL serves is asking about
+	// right now, so answering from the copy the authorize path stored would
+	// defeat the point of the question.
+	result := r.inspect(ctx, clientID, CacheState{ExpiresAt: time.Time{}, ETag: ""})
 	return Inspection{
 		Outcome:    result.outcome,
 		Document:   result.Document,
@@ -71,6 +75,19 @@ type inspection struct {
 	// 200: the body ran past the size cap. Without it, every 200 that failed
 	// to read would be blamed on size.
 	tooLarge bool
+
+	// cacheOutcome is what the caller must persist, read only by Resolve.
+	// It is CacheOutcomeRefreshed on every path that ran a full fetch,
+	// including the failures, where Resolve discards it along with the rest
+	// of the result.
+	cacheOutcome CacheOutcome
+
+	// etag is the validator to persist, empty when the upstream offers none.
+	etag string
+
+	// ttl is the lifetime to add to the stored expiry, already clamped. Zero
+	// on CacheOutcomeCached, where the existing expiry stands.
+	ttl time.Duration
 }
 
 // detail renders the operator-facing explanation. Validation rejections reuse

--- a/server/internal/usersessions/cimd/metrics.go
+++ b/server/internal/usersessions/cimd/metrics.go
@@ -15,7 +15,6 @@ const (
 	meterFetchAttempts        = "cimd.fetch.attempts"
 	meterFetchDurationSeconds = "cimd.fetch.duration_seconds"
 	meterFetchResponseSize    = "cimd.fetch.response_size"
-	meterCacheHits            = "cimd.cache.hits"
 	meterValidationFailures   = "cimd.validation.failures"
 )
 
@@ -31,13 +30,20 @@ const (
 	fetchResultParseError      fetchResult = "parse_error"
 	fetchResultValidationError fetchResult = "validation_error"
 
-	// The remaining results are PROVISIONAL: they label lifecycle stages that
-	// follow-up issues add inside this package — document caching (AIS-216:
-	// cached, conditional_not_modified) and per-origin rate limiting
-	// (AIS-215: rate_limited). They are declared now so the label vocabulary
-	// is stable for dashboards, but nothing records them yet and their exact
-	// semantics may still shift when the emitting code lands — do not build
-	// monitors on them until then.
+	// The cache results describe resolutions that did not fetch a fresh
+	// document: cached served the caller's stored row without any upstream
+	// request, conditional_not_modified made a conditional request the
+	// upstream answered 304. Most points on this instrument are cached
+	// once a client is warm, so a fetch-failure ratio must be taken against
+	// the fetch-bearing outcomes rather than against every attempt.
+	fetchResultCached                 fetchResult = "cached"
+	fetchResultConditionalNotModified fetchResult = "conditional_not_modified"
+
+	// rate_limited is PROVISIONAL: it labels the per-origin rate limiting
+	// AIS-215 adds inside this package. It is declared now so the label
+	// vocabulary is stable for dashboards, but nothing records it yet and
+	// its exact semantics may still shift when the emitting code lands — do
+	// not build monitors on it until then.
 	//
 	// An admission_denied result was formerly reserved here for AIS-371.
 	// Admission control instead records to its own cimd.admission.decisions
@@ -45,9 +51,7 @@ const (
 	// fetch ran at all, so counting it under fetch.attempts would break this
 	// instrument's one-point-per-Resolve invariant and quietly change the
 	// denominator of every fetch-success chart.
-	fetchResultCached                 fetchResult = "cached"
-	fetchResultConditionalNotModified fetchResult = "conditional_not_modified"
-	fetchResultRateLimited            fetchResult = "rate_limited"
+	fetchResultRateLimited fetchResult = "rate_limited"
 )
 
 // validationReason is the machine-readable label recorded on
@@ -82,7 +86,6 @@ type metrics struct {
 	fetchAttempts      metric.Int64Counter
 	fetchDuration      metric.Float64Histogram
 	fetchResponseSize  metric.Int64Histogram
-	cacheHits          metric.Int64Counter
 	validationFailures metric.Int64Counter
 }
 
@@ -119,15 +122,6 @@ func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metric
 		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterFetchResponseSize), attr.SlogError(err))
 	}
 
-	cacheHits, err := meter.Int64Counter(
-		meterCacheHits,
-		metric.WithDescription("Count of CIMD metadata document cache hits by origin"),
-		metric.WithUnit("{hit}"),
-	)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterCacheHits), attr.SlogError(err))
-	}
-
 	validationFailures, err := meter.Int64Counter(
 		meterValidationFailures,
 		metric.WithDescription("Count of CIMD metadata document validation failures by reason"),
@@ -141,7 +135,6 @@ func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metric
 		fetchAttempts:      fetchAttempts,
 		fetchDuration:      fetchDuration,
 		fetchResponseSize:  fetchResponseSize,
-		cacheHits:          cacheHits,
 		validationFailures: validationFailures,
 	}
 }
@@ -168,15 +161,6 @@ func (m *metrics) RecordResponseSize(ctx context.Context, origin string, bytes i
 		return
 	}
 	m.fetchResponseSize.Record(ctx, bytes, metric.WithAttributes(attr.CIMDOrigin(origin)))
-}
-
-// RecordCacheHit is reserved for the document cache added by AIS-216; nothing
-// calls it in the fetch-every-time lifecycle shipped by AIS-217.
-func (m *metrics) RecordCacheHit(ctx context.Context, origin string) {
-	if m == nil || m.cacheHits == nil {
-		return
-	}
-	m.cacheHits.Add(ctx, 1, metric.WithAttributes(attr.CIMDOrigin(origin)))
 }
 
 func (m *metrics) RecordValidationFailure(ctx context.Context, reason validationReason) {

--- a/server/internal/usersessions/cimd/metrics_test.go
+++ b/server/internal/usersessions/cimd/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
@@ -90,7 +91,7 @@ func TestResolverMetrics_Success(t *testing.T) {
 	require.NoError(t, err)
 	origin := srvURL.Host
 
-	_, err = resolver.Resolve(t.Context(), clientID)
+	_, err = resolver.Resolve(t.Context(), clientID, noCache)
 	require.NoError(t, err)
 
 	rm := collectMetrics(t, reader)
@@ -127,7 +128,7 @@ func TestResolverMetrics_FetchError(t *testing.T) {
 		http.NotFound(w, r)
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 	require.Error(t, err)
 
 	rm := collectMetrics(t, reader)
@@ -158,7 +159,7 @@ func TestResolverMetrics_ParseError(t *testing.T) {
 		}
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 	require.Error(t, err)
 
 	rm := collectMetrics(t, reader)
@@ -186,7 +187,7 @@ func TestResolverMetrics_OversizedDocumentRecordsCap(t *testing.T) {
 		}
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", noCache)
 	require.Error(t, err)
 
 	rm := collectMetrics(t, reader)
@@ -217,7 +218,7 @@ func TestResolverMetrics_ValidationErrorWithReason(t *testing.T) {
 	})
 	clientID = srv.URL + "/client.json"
 
-	_, err := resolver.Resolve(t.Context(), clientID)
+	_, err := resolver.Resolve(t.Context(), clientID, noCache)
 	require.Error(t, err)
 
 	rm := collectMetrics(t, reader)
@@ -243,7 +244,7 @@ func TestResolverMetrics_URLSyntaxFailure(t *testing.T) {
 		t.Error("syntactically invalid client_id must never be fetched")
 	})
 
-	_, err := resolver.Resolve(t.Context(), srv.URL) // no path component
+	_, err := resolver.Resolve(t.Context(), srv.URL, noCache) // no path component
 	require.Error(t, err)
 
 	rm := collectMetrics(t, reader)
@@ -261,6 +262,80 @@ func TestResolverMetrics_URLSyntaxFailure(t *testing.T) {
 	requireAttr(t, failures[0].Attributes, attr.CIMDValidationReasonKey, string(reasonClientIDMissingPath))
 }
 
+// TestResolverMetrics_CacheHit pins the short-circuit shape: the attempt is
+// counted with its origin, but no duration point exists, so cache hits never
+// skew the latency percentiles of the requests that actually left the
+// process.
+func TestResolverMetrics_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("a fresh cache must not reach the document host")
+	})
+	srvURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	_, err = resolver.Resolve(t.Context(), srv.URL+"/client.json", CacheState{
+		ExpiresAt: time.Now().Add(time.Hour),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	require.Equal(t, int64(1), attempts[0].Value)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultCached))
+	requireAttr(t, attempts[0].Attributes, attr.CIMDOriginKey, srvURL.Host)
+
+	_, ok := findMetric(rm, meterFetchDurationSeconds)
+	require.False(t, ok, "no upstream request ran, so no duration is recorded")
+
+	_, ok = findMetric(rm, meterFetchResponseSize)
+	require.False(t, ok)
+}
+
+// TestResolverMetrics_ConditionalNotModified pins the revalidation shape: an
+// upstream request ran, so it is timed, but no body was read, so no size is
+// recorded.
+func TestResolverMetrics_ConditionalNotModified(t *testing.T) {
+	t.Parallel()
+
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") != `"v1"` {
+			t.Errorf("expected a conditional request, got If-None-Match %q", r.Header.Get("If-None-Match"))
+		}
+		w.WriteHeader(http.StatusNotModified)
+	})
+	srvURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	result, err := resolver.Resolve(t.Context(), srv.URL+"/client.json", CacheState{
+		ExpiresAt: time.Now().Add(-time.Minute),
+		ETag:      `"v1"`,
+	})
+	require.NoError(t, err)
+	require.Equal(t, CacheOutcomeNotModified, result.Outcome)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultConditionalNotModified))
+	requireAttr(t, attempts[0].Attributes, attr.CIMDOriginKey, srvURL.Host)
+
+	durationMetric, ok := findMetric(rm, meterFetchDurationSeconds)
+	require.True(t, ok, "a request left the process, so it is timed")
+	durationHistogram, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, durationHistogram.DataPoints, 1)
+	requireAttr(t, durationHistogram.DataPoints[0].Attributes, attr.OutcomeKey, string(fetchResultConditionalNotModified))
+
+	_, ok = findMetric(rm, meterFetchResponseSize)
+	require.False(t, ok, "a 304 reads no body, so no size is recorded")
+}
+
 // TestMetrics_NamesPinned pins the wire spellings of the metric names so a
 // const rename cannot silently break dashboards built on them.
 func TestMetrics_NamesPinned(t *testing.T) {
@@ -269,17 +344,25 @@ func TestMetrics_NamesPinned(t *testing.T) {
 	require.Equal(t, "cimd.fetch.attempts", meterFetchAttempts)
 	require.Equal(t, "cimd.fetch.duration_seconds", meterFetchDurationSeconds)
 	require.Equal(t, "cimd.fetch.response_size", meterFetchResponseSize)
-	require.Equal(t, "cimd.cache.hits", meterCacheHits)
 	require.Equal(t, "cimd.validation.failures", meterValidationFailures)
 }
 
-// TestMetrics_ReservedResultLabels pins the provisional label spellings that
-// follow-up issues will emit — cached / conditional_not_modified (AIS-216),
-// rate_limited (AIS-215) — plus the reserved cimd.cache.hits instrument, so
-// dashboards built on this vocabulary stay valid when the emitting code
-// lands. AIS-371's admission_denied is deliberately absent: admission
-// records to its own cimd.admission.decisions counter, since a denial means
-// no fetch ran and so has no place under fetch.attempts.
+// TestMetrics_CacheResultLabelsPinned pins the wire spellings of the two
+// cache outcomes, which dashboards use both to read cache effectiveness and
+// to restrict fetch-failure ratios to the attempts that actually fetched.
+func TestMetrics_CacheResultLabelsPinned(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "cached", string(fetchResultCached))
+	require.Equal(t, "conditional_not_modified", string(fetchResultConditionalNotModified))
+}
+
+// TestMetrics_ReservedResultLabels pins the provisional label spelling that a
+// follow-up issue will emit — rate_limited (AIS-215) — so dashboards built on
+// this vocabulary stay valid when the emitting code lands. AIS-371's
+// admission_denied is deliberately absent: admission records to its own
+// cimd.admission.decisions counter, since a denial means no fetch ran and so
+// has no place under fetch.attempts.
 func TestMetrics_ReservedResultLabels(t *testing.T) {
 	t.Parallel()
 
@@ -288,27 +371,13 @@ func TestMetrics_ReservedResultLabels(t *testing.T) {
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	m := newMetrics(meterProvider, testenv.NewLogger(t))
 
-	reserved := []struct {
-		result fetchResult
-		want   string
-	}{
-		{result: fetchResultCached, want: "cached"},
-		{result: fetchResultConditionalNotModified, want: "conditional_not_modified"},
-		{result: fetchResultRateLimited, want: "rate_limited"},
-	}
-	for _, r := range reserved {
-		require.Equal(t, r.want, string(r.result))
-		m.RecordAttempt(ctx, "client.example.com", r.result)
-	}
-	m.RecordCacheHit(ctx, "client.example.com")
+	require.Equal(t, "rate_limited", string(fetchResultRateLimited))
+	m.RecordAttempt(ctx, "client.example.com", fetchResultRateLimited)
 
 	rm := collectMetrics(t, reader)
 
 	attempts := counterPoints(t, rm, meterFetchAttempts)
-	require.Len(t, attempts, len(reserved))
-
-	hits := counterPoints(t, rm, meterCacheHits)
-	require.Len(t, hits, 1)
-	require.Equal(t, int64(1), hits[0].Value)
-	requireAttr(t, hits[0].Attributes, attr.CIMDOriginKey, "client.example.com")
+	require.Len(t, attempts, 1)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultRateLimited))
+	requireAttr(t, attempts[0].Attributes, attr.CIMDOriginKey, "client.example.com")
 }

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -441,9 +441,14 @@ RETURNING *;
 -- Lazy upsert for a client resolved from a Client ID Metadata Document at
 -- authorize time. For CIMD rows the document URL IS the client_id, so the
 -- conflict target is the same partial unique index that serves DCR lookups.
--- On refresh the mutable metadata (client_name, redirect_uris) and the fetch
--- stamp are replaced wholesale — the document is refetched on every
--- authorize.
+-- On refresh the mutable metadata (client_name, redirect_uris) and every
+-- cache column are replaced wholesale, including the ETag, which is set to
+-- NULL when the response carried no usable validator so the next refresh is
+-- unconditional rather than replaying a stale one.
+--
+-- The cache expiry is derived from the database clock rather than the
+-- application's, so it can never land before the client_id_metadata_fetched_at
+-- written in the same statement.
 --
 -- Two deliberate behaviors:
 --   - A soft-deleted row does not conflict (partial index), so revoking a
@@ -464,7 +469,9 @@ INSERT INTO user_session_clients (
     redirect_uris,
     client_secret_expires_at,
     client_id_metadata_uri,
-    client_id_metadata_fetched_at
+    client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at,
+    client_id_metadata_etag
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
@@ -475,7 +482,9 @@ VALUES (
     @redirect_uris,
     NULL,
     @client_id,
-    clock_timestamp()
+    clock_timestamp(),
+    clock_timestamp() + make_interval(secs => @cache_ttl_seconds::double precision),
+    sqlc.narg('client_id_metadata_etag')
 )
 ON CONFLICT (user_session_issuer_id, client_id) WHERE deleted IS FALSE
 DO UPDATE SET
@@ -483,8 +492,61 @@ DO UPDATE SET
     redirect_uris = EXCLUDED.redirect_uris,
     client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,
     client_id_metadata_fetched_at = EXCLUDED.client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at = EXCLUDED.client_id_metadata_cache_expires_at,
+    client_id_metadata_etag = EXCLUDED.client_id_metadata_etag,
     updated_at = clock_timestamp()
 WHERE user_session_clients.client_secret_hash IS NULL
+RETURNING *;
+
+-- name: UpdateUserSessionClientCIMDCache :one
+-- Refreshes the cache bookkeeping on a CIMD-resolved client whose document
+-- host answered 304 Not Modified. The stored client_name and redirect_uris
+-- are current by definition of the 304, so they are deliberately untouched;
+-- only the fetch stamp, the expiry, and the validator move.
+--
+-- The guards mirror UpsertUserSessionClientFromCIMD's. A secret-bearing DCR
+-- row, or a row that is not CIMD-resolved at all, is never written, so this
+-- statement cannot push a row into violating the client_id_metadata_uri
+-- CHECK constraints; such a collision surfaces as no-rows, which handlers
+-- already map to invalid_client. Project scoping is intentionally absent for
+-- the same reason as GetUserSessionClientByClientID: the OAuth surface is
+-- public, and the id comes from a row the caller already resolved through
+-- the issuer.
+UPDATE user_session_clients
+SET client_id_metadata_fetched_at = clock_timestamp(),
+    client_id_metadata_cache_expires_at = clock_timestamp() + make_interval(secs => @cache_ttl_seconds::double precision),
+    client_id_metadata_etag = sqlc.narg('client_id_metadata_etag'),
+    updated_at = clock_timestamp()
+WHERE id = @id
+  AND client_id_metadata_uri IS NOT NULL
+  AND client_secret_hash IS NULL
+  AND deleted IS FALSE
+RETURNING *;
+
+-- name: PurgeUserSessionClientCIMDCache :one
+-- Forces the next authorize to re-read, re-parse, and re-validate a CIMD
+-- client's metadata document instead of serving the stored copy.
+--
+-- This is the purge lever for the cache: a document whose contents must stop
+-- being honoured before its TTL lapses — a compromised or mistakenly
+-- published redirect_uris set, a validation rule tightened after the row was
+-- written — is dealt with by running this and letting the next authorize
+-- refetch. The validator is cleared along with the expiry on purpose: leaving
+-- it would make the refresh conditional, and a 304 would confirm the very
+-- document being purged without the body ever being re-validated.
+--
+-- Revoking the client purges its cache as a side effect, since the lookup
+-- behind every authorize filters on deleted IS FALSE and a miss forces an
+-- unconditional fetch. This query exists for the case where the client should
+-- keep working and only its stored document is suspect. It has no endpoint
+-- yet and is run by hand; AIS-211 wires it to a per-client refresh action.
+UPDATE user_session_clients
+SET client_id_metadata_cache_expires_at = NULL,
+    client_id_metadata_etag = NULL,
+    updated_at = clock_timestamp()
+WHERE id = @id
+  AND client_id_metadata_uri IS NOT NULL
+  AND deleted IS FALSE
 RETURNING *;
 
 -- name: CreateUserSession :one

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -1295,6 +1295,58 @@ func (q *Queries) ListUserSessionsByProjectID(ctx context.Context, arg ListUserS
 	return items, nil
 }
 
+const purgeUserSessionClientCIMDCache = `-- name: PurgeUserSessionClientCIMDCache :one
+UPDATE user_session_clients
+SET client_id_metadata_cache_expires_at = NULL,
+    client_id_metadata_etag = NULL,
+    updated_at = clock_timestamp()
+WHERE id = $1
+  AND client_id_metadata_uri IS NOT NULL
+  AND deleted IS FALSE
+RETURNING id, project_id, user_session_issuer_id, client_id, client_secret_hash, client_name, redirect_uris, client_id_issued_at, client_secret_expires_at, client_id_metadata_uri, client_id_metadata_fetched_at, client_id_metadata_cache_expires_at, client_id_metadata_etag, created_at, updated_at, deleted_at, deleted
+`
+
+// Forces the next authorize to re-read, re-parse, and re-validate a CIMD
+// client's metadata document instead of serving the stored copy.
+//
+// This is the purge lever for the cache: a document whose contents must stop
+// being honoured before its TTL lapses — a compromised or mistakenly
+// published redirect_uris set, a validation rule tightened after the row was
+// written — is dealt with by running this and letting the next authorize
+// refetch. The validator is cleared along with the expiry on purpose: leaving
+// it would make the refresh conditional, and a 304 would confirm the very
+// document being purged without the body ever being re-validated.
+//
+// Revoking the client purges its cache as a side effect, since the lookup
+// behind every authorize filters on deleted IS FALSE and a miss forces an
+// unconditional fetch. This query exists for the case where the client should
+// keep working and only its stored document is suspect. It has no endpoint
+// yet and is run by hand; AIS-211 wires it to a per-client refresh action.
+func (q *Queries) PurgeUserSessionClientCIMDCache(ctx context.Context, id uuid.UUID) (UserSessionClient, error) {
+	row := q.db.QueryRow(ctx, purgeUserSessionClientCIMDCache, id)
+	var i UserSessionClient
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.UserSessionIssuerID,
+		&i.ClientID,
+		&i.ClientSecretHash,
+		&i.ClientName,
+		&i.RedirectUris,
+		&i.ClientIDIssuedAt,
+		&i.ClientSecretExpiresAt,
+		&i.ClientIDMetadataUri,
+		&i.ClientIDMetadataFetchedAt,
+		&i.ClientIDMetadataCacheExpiresAt,
+		&i.ClientIDMetadataEtag,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const revokeUserSession = `-- name: RevokeUserSession :one
 UPDATE user_sessions AS s
 SET deleted_at = clock_timestamp()
@@ -1597,6 +1649,63 @@ func (q *Queries) SoftDeleteUserSessionsByIssuerID(ctx context.Context, userSess
 	return items, nil
 }
 
+const updateUserSessionClientCIMDCache = `-- name: UpdateUserSessionClientCIMDCache :one
+UPDATE user_session_clients
+SET client_id_metadata_fetched_at = clock_timestamp(),
+    client_id_metadata_cache_expires_at = clock_timestamp() + make_interval(secs => $1::double precision),
+    client_id_metadata_etag = $2,
+    updated_at = clock_timestamp()
+WHERE id = $3
+  AND client_id_metadata_uri IS NOT NULL
+  AND client_secret_hash IS NULL
+  AND deleted IS FALSE
+RETURNING id, project_id, user_session_issuer_id, client_id, client_secret_hash, client_name, redirect_uris, client_id_issued_at, client_secret_expires_at, client_id_metadata_uri, client_id_metadata_fetched_at, client_id_metadata_cache_expires_at, client_id_metadata_etag, created_at, updated_at, deleted_at, deleted
+`
+
+type UpdateUserSessionClientCIMDCacheParams struct {
+	CacheTtlSeconds      float64
+	ClientIDMetadataEtag pgtype.Text
+	ID                   uuid.UUID
+}
+
+// Refreshes the cache bookkeeping on a CIMD-resolved client whose document
+// host answered 304 Not Modified. The stored client_name and redirect_uris
+// are current by definition of the 304, so they are deliberately untouched;
+// only the fetch stamp, the expiry, and the validator move.
+//
+// The guards mirror UpsertUserSessionClientFromCIMD's. A secret-bearing DCR
+// row, or a row that is not CIMD-resolved at all, is never written, so this
+// statement cannot push a row into violating the client_id_metadata_uri
+// CHECK constraints; such a collision surfaces as no-rows, which handlers
+// already map to invalid_client. Project scoping is intentionally absent for
+// the same reason as GetUserSessionClientByClientID: the OAuth surface is
+// public, and the id comes from a row the caller already resolved through
+// the issuer.
+func (q *Queries) UpdateUserSessionClientCIMDCache(ctx context.Context, arg UpdateUserSessionClientCIMDCacheParams) (UserSessionClient, error) {
+	row := q.db.QueryRow(ctx, updateUserSessionClientCIMDCache, arg.CacheTtlSeconds, arg.ClientIDMetadataEtag, arg.ID)
+	var i UserSessionClient
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.UserSessionIssuerID,
+		&i.ClientID,
+		&i.ClientSecretHash,
+		&i.ClientName,
+		&i.RedirectUris,
+		&i.ClientIDIssuedAt,
+		&i.ClientSecretExpiresAt,
+		&i.ClientIDMetadataUri,
+		&i.ClientIDMetadataFetchedAt,
+		&i.ClientIDMetadataCacheExpiresAt,
+		&i.ClientIDMetadataEtag,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const updateUserSessionIssuer = `-- name: UpdateUserSessionIssuer :one
 UPDATE user_session_issuers
 SET
@@ -1658,7 +1767,9 @@ INSERT INTO user_session_clients (
     redirect_uris,
     client_secret_expires_at,
     client_id_metadata_uri,
-    client_id_metadata_fetched_at
+    client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at,
+    client_id_metadata_etag
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = $1),
@@ -1669,7 +1780,9 @@ VALUES (
     $4,
     NULL,
     $2,
-    clock_timestamp()
+    clock_timestamp(),
+    clock_timestamp() + make_interval(secs => $5::double precision),
+    $6
 )
 ON CONFLICT (user_session_issuer_id, client_id) WHERE deleted IS FALSE
 DO UPDATE SET
@@ -1677,24 +1790,33 @@ DO UPDATE SET
     redirect_uris = EXCLUDED.redirect_uris,
     client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,
     client_id_metadata_fetched_at = EXCLUDED.client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at = EXCLUDED.client_id_metadata_cache_expires_at,
+    client_id_metadata_etag = EXCLUDED.client_id_metadata_etag,
     updated_at = clock_timestamp()
 WHERE user_session_clients.client_secret_hash IS NULL
 RETURNING id, project_id, user_session_issuer_id, client_id, client_secret_hash, client_name, redirect_uris, client_id_issued_at, client_secret_expires_at, client_id_metadata_uri, client_id_metadata_fetched_at, client_id_metadata_cache_expires_at, client_id_metadata_etag, created_at, updated_at, deleted_at, deleted
 `
 
 type UpsertUserSessionClientFromCIMDParams struct {
-	UserSessionIssuerID uuid.UUID
-	ClientID            string
-	ClientName          string
-	RedirectUris        []string
+	UserSessionIssuerID  uuid.UUID
+	ClientID             string
+	ClientName           string
+	RedirectUris         []string
+	CacheTtlSeconds      float64
+	ClientIDMetadataEtag pgtype.Text
 }
 
 // Lazy upsert for a client resolved from a Client ID Metadata Document at
 // authorize time. For CIMD rows the document URL IS the client_id, so the
 // conflict target is the same partial unique index that serves DCR lookups.
-// On refresh the mutable metadata (client_name, redirect_uris) and the fetch
-// stamp are replaced wholesale — the document is refetched on every
-// authorize.
+// On refresh the mutable metadata (client_name, redirect_uris) and every
+// cache column are replaced wholesale, including the ETag, which is set to
+// NULL when the response carried no usable validator so the next refresh is
+// unconditional rather than replaying a stale one.
+//
+// The cache expiry is derived from the database clock rather than the
+// application's, so it can never land before the client_id_metadata_fetched_at
+// written in the same statement.
 //
 // Two deliberate behaviors:
 //   - A soft-deleted row does not conflict (partial index), so revoking a
@@ -1712,6 +1834,8 @@ func (q *Queries) UpsertUserSessionClientFromCIMD(ctx context.Context, arg Upser
 		arg.ClientID,
 		arg.ClientName,
 		arg.RedirectUris,
+		arg.CacheTtlSeconds,
+		arg.ClientIDMetadataEtag,
 	)
 	var i UserSessionClient
 	err := row.Scan(


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-216/feat-cache-cimd-metadata-documents-etag-cache-control

The user session authorization server refetched a client ID metadata document on every authorize request. The persisted `user_session_clients` row now doubles as the cache: while `client_id_metadata_cache_expires_at` is in the future the row is served with no upstream request, and once it lapses the refresh is a conditional GET carrying the stored `ETag`.

Cache lifetime comes from the response headers (`s-maxage`, then `max-age`, then `Expires` measured against `Date`) less the age the response already carries, clamped to a 5-minute floor and a 24-hour ceiling. The floor keeps this unauthenticated endpoint from being pushed into fetching on every request; the ceiling stops a host from pinning a `redirect_uris` set indefinitely. `no-store` and `no-cache` are ignored, which `draft-ietf-oauth-client-id-metadata-document-02` §5.2 permits, because the document is public by definition.

Every failure leaves the cached row untouched and aborts the request rather than serving stale, per §5.1.

The `cached` and `conditional_not_modified` outcomes reserved by AIS-214 are now emitted, and the `cimd.cache.hits` counter is deleted: it would count exactly the same events as attempts with outcome `cached`. **Most points on `cimd.fetch.attempts` are now `cached`, so any fetch-failure ratio needs restricting to the fetch-bearing outcomes.**

No migration. AIS-218 added the columns and left them unused; existing rows have a null expiry, which reads as not fresh and takes the cold path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache CIMD client metadata documents and revalidate with ETag instead of refetching on every authorize/token request. TTL honors `Cache-Control`/`Expires` (5m–24h), subtracts response age, clamps edge cases, enforces valid ETags, and never serves stale.

- Implements AIS-216 using the cache columns from AIS-218.

- **New Features**
  - Use `user_session_clients` as the cache; serve when `client_id_metadata_cache_expires_at` is in the future, otherwise do a conditional GET with `If-None-Match` and handle 304 vs 200.
  - Persist refreshed ETag/expiry on 304; add a purge that NULLs expiry/etag; update `server/internal/usersessions/cimd` and the `server/internal/mcp` seam accordingly.
  - Telemetry: emit `cimd.fetch.attempts` outcomes `cached` and `not_modified`; remove `cimd.cache.hits`.

- **Bug Fixes**
  - Parse `Cache-Control` strictly: correct directive splitting, handle quoted args, reject unterminated/malformed strings, and require digit-only delta-seconds.
  - TTL math: subtract current age using `Age` or `Date`; saturate huge `Age`; when age ≥ granted lifetime, floor the TTL to avoid wrap; clamp to 5m–24h.
  - ETag handling: enforce RFC 9110 grammar; drop wildcard/malformed tags; re-sanitize before `If-None-Match`; persist the sanitized tag on 304; also sanitize on cache-hit so returned validators are always safe to store.

<sup>Written for commit 694c3fe6b999e7abe4bb0cd232ddcd44970ec59b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

