### PR TITLE
fix(dashboard): soft-wrap revealed match in watchdog drawer

### DIFF
--- a/client/dashboard/src/pages/security/risk-ui.tsx
+++ b/client/dashboard/src/pages/security/risk-ui.tsx
@@ -175,6 +175,7 @@ export function MaskedMatch({
   resultId,
   matchRedacted,
   tone = "default",
+  wrap = false,
 }: {
   resultId: string | undefined;
   matchRedacted: string | undefined;
@@ -184,6 +185,12 @@ export function MaskedMatch({
    * revealed value flips to the backdrop's inverse text color.
    */
   tone?: "default" | "contrast";
+  /**
+   * Soft-wrap the revealed value instead of scrolling it horizontally. Use in
+   * detail surfaces (drawers) where the full value should stay visible; table
+   * cells keep the default single-line scroll so row heights stay stable.
+   */
+  wrap?: boolean;
 }): JSX.Element {
   const contrast = tone === "contrast";
   const { hasScope } = useRBAC();
@@ -257,11 +264,19 @@ export function MaskedMatch({
   }
 
   return (
-    <span className="inline-flex max-w-full min-w-0 items-center gap-1">
+    <span
+      className={cn(
+        "inline-flex max-w-full min-w-0 gap-1",
+        wrap ? "items-start" : "items-center",
+      )}
+    >
       <SimpleTooltip tooltip={value}>
         <span
           className={cn(
-            "min-w-0 overflow-x-auto font-mono text-xs whitespace-nowrap",
+            "min-w-0 font-mono text-xs",
+            wrap
+              ? "break-all whitespace-pre-wrap"
+              : "overflow-x-auto whitespace-nowrap",
             contrast && "text-background",
           )}
         >

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -116,6 +116,7 @@ function EvidenceRow({
       <div className="bg-foreground px-3 py-4">
         <MaskedMatch
           tone="contrast"
+          wrap
           resultId={result.id}
           matchRedacted={result.matchRedacted}
         />


### PR DESCRIPTION
## What

In the Watchdog signal detail drawer, a revealed match value now soft-wraps inside the evidence card instead of scrolling horizontally.

## Why

Long match strings (tokens, keys) overflowed the drawer's evidence card and forced a horizontal scrollbar, hiding most of the value.

## How

- `MaskedMatch` (`pages/security/risk-ui.tsx`) gains an opt-in `wrap` prop: the revealed value renders with `break-all whitespace-pre-wrap` (the existing `code.tsx` idiom) instead of `overflow-x-auto whitespace-nowrap`, and the hide toggle aligns to the top for multi-line values.
- The Watchdog drawer's evidence card (`SignalDrawer.tsx`) passes `wrap`.
- Table usages (`RiskEvents`, `RiskOverviewCategoryDetail`) are unchanged and keep the single-line scroll so row heights stay stable.

## Testing

- `pnpm -F dashboard type-check`, `pnpm -F dashboard lint` — clean
- `pnpm -F dashboard test` — 1718 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revealed match values in the Watchdog signal drawer now wrap to new lines instead of scrolling, so long tokens stay visible. Adds a `wrap` option to `MaskedMatch` and enables it in the drawer; table cells remain single-line to preserve row heights.

- **Bug Fixes**
  - Added `wrap` prop to `MaskedMatch` to render with soft wrap and top-align the toggle for multi-line values.
  - Enabled wrapping in the drawer’s evidence card; left table views unchanged to keep stable row heights.

<sup>Written for commit 2a770d09e0ec107862f3fe91818233e750fb3372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

