### PR TITLE
chore(ci): allowlist the cubic review bot in the CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: "https://github.com/speakeasy-api/gram/blob/main/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: "cla-signatures"
-          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cursoragent,claude,linear-code,linear-code[bot]
+          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cubic-dev-ai[bot],cursoragent,claude,linear-code,linear-code[bot]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
Any PR that carries a Cubic-applied review suggestion can never pass `CLAAssistantCheck`, because a bot cannot sign the CLA.

## The problem

When Cubic applies one of its own review suggestions, it lands a commit authored **and** committed by `cubic-dev-ai[bot]`. The CLA Assistant counts every distinct committer on the PR and requires each one to post the signature comment. A bot never posts that comment, so the check sits below the threshold permanently.

Seen on #5118, where commit `9410a3e9` ("fix: require HTTPS for OAuth revocation endpoints") is attributed to `cubic-dev-ai[bot]`:

> **2** out of **3** committers have signed the CLA.
> :white_check_mark: aa-wong
> :white_check_mark: walker-tx
> :x: @cubic-dev-ai[bot]

## The fix

Add `cubic-dev-ai[bot]` to the `allowlist` input, alongside the bot entries already there.

In `contributor-assistant/github-action`, `src/checkAllowList.ts` compares an allowlist pattern that contains no `*` by exact string equality against the committer login. So this entry matches exactly the way `dependabot[bot]` already does.

## Rollout

This workflow triggers on `pull_request_target` and `issue_comment`. Both load the workflow file from the base branch, not from the PR branch. So the allowlist change only takes effect once it merges here. After it merges, comment `recheck` on an affected PR to re-run the check.

## Follow-up, not fixed here

The existing `speakeasy-api/*` entry is a no-op. A pattern containing `*` becomes the unanchored regex `speakeasy-api/.*`, which is then tested against a bare login such as `aa-wong`. It never matches, so org membership does not exempt anyone. That is why both humans on #5118 still had to sign. Worth a separate ticket if we want employees exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allowlisted `cubic-dev-ai[bot]` in the CLA Assistant workflow so PRs with Cubic-applied suggestions no longer get stuck on the CLA check.

- **Bug Fixes**
  - Added `cubic-dev-ai[bot]` to `allowlist` in `.github/workflows/cla.yml`.
  - Prevents CLA failures when the bot commits; matches by exact login like `dependabot[bot]`.

- **Migration**
  - Takes effect after merge (workflow runs from base). Comment `recheck` on affected PRs to rerun the check.

<sup>Written for commit 8efdffa8fcd09477678d1f6c5d8eeebaba26443e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

