### PR TITLE
fix(dashboard): hide cycling composer prompts once a file is attached

### DIFF
--- a/.changeset/composer-placeholder-attachments.md
+++ b/.changeset/composer-placeholder-attachments.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Hide the composer's cycling example prompts once a file is attached.

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -626,7 +626,11 @@ export const Composer: FC<ComposerProps> = ({
 
   const isReplay = replayCtx?.isReplay ?? false;
   const isDictating = useAuiState(({ composer }) => composer.dictation != null);
-  const isComposerEmpty = useAuiState(({ composer }) => composer.text === "");
+  // A dropped file is a draft even with no text yet — the landing's cycling
+  // example prompts would otherwise keep running above the attachment chip.
+  const isComposerEmpty = useAuiState(
+    ({ composer }) => composer.text === "" && composer.attachments.length === 0,
+  );
   const composerConfig = config.composer ?? {
     placeholder: "Send a message...",
     attachments: true,


### PR DESCRIPTION
## Problem

Dropping a file onto the standalone composer (the `/chat` landing) left the cycling example prompts painted over the input. The composer had text content pending — an attachment — but still advertised itself as empty.

## Cause

The landing renders its example prompts as a CSS `::before` on `.aui-composer-root[data-empty="true"]`, driven by a custom property so the examples can crossfade without re-rendering the chat tree. That `data-empty` attribute was derived from composer text alone, so an attachment-only draft still matched.

## Fix

Count attachments as draft content when computing `data-empty`. The existing rules that clear the placeholder on focus and during dictation already covered the other two cases; attachments were the missed third.

## Testing

- `pnpm -F dashboard type-check`
- Manually: drop a file on the `/chat` composer — the example prompt disappears and returns if the attachment is removed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the cycling example prompts in the `/chat` composer once a file is attached, so the placeholder no longer overlays the attachment chip. Counts attachments as draft content when computing the `data-empty` state.

<sup>Written for commit c64bde1e7d548f9e750e98a03927e684422d4010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

