### PR TITLE
fix(dashboard): loosen up the Add context picker

### DIFF
--- a/.changeset/context-picker-density.md
+++ b/.changeset/context-picker-density.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Give the composer's "Add context" picker room to read: a wider pane, tool rows titled by their unqualified name so they stop truncating into identical ellipses, a single type scale across both halves, and a labelled header over the results so skills and tools are told apart while browsing, not only while searching.

--- a/.changeset/context-picker-density.md
+++ b/.changeset/context-picker-density.md
@@ -3,3 +3,5 @@
 ---
 
 Give the composer's "Add context" picker room to read: a wider pane, tool rows titled by their unqualified name so they stop truncating into identical ellipses, a single type scale across both halves, and a labelled header over the results so skills and tools are told apart while browsing, not only while searching.
+
+The slash-command menu now drops below the composer when there is not enough room above it, so it stays on screen on the welcome surface instead of opening past the top edge.

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -1128,7 +1128,7 @@ function ContextSectionHeader({
   count?: number;
 }): React.ReactElement {
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-popover px-3 pt-3 pb-2 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+    <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-background px-3 pt-3 pb-2 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
       <Icon className="size-3.5 shrink-0" />
       <span>{label}</span>
       {count !== undefined && (
@@ -1308,7 +1308,10 @@ const ComposerContextPicker: FC = () => {
       <PopoverContent
         side="top"
         align="start"
-        className="aui-composer-context-popover w-[560px] max-w-[calc(100vw-2rem)] overflow-hidden p-0"
+        // `bg-background` rather than the primitive's `bg-popover`: hosts that
+        // mount Elements outside the dashboard's own theme leave `--popover`
+        // unset, and the pane renders see-through over the page behind it.
+        className="aui-composer-context-popover w-[560px] max-w-[calc(100vw-2rem)] overflow-hidden bg-background p-0"
         onEscapeKeyDown={(event) => {
           if (query !== "") {
             event.preventDefault();
@@ -1489,7 +1492,11 @@ function ContextToolResults({
                 </span>
               )}
               {tool.description && (
-                <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground">
+                // No `block` here: it wins over the `display: -webkit-box`
+                // that `line-clamp` needs, and the clamp silently stops
+                // clamping — which is how a paragraph-long tool description
+                // ends up filling the pane.
+                <span className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
                   {tool.description}
                 </span>
               )}
@@ -1599,7 +1606,7 @@ function ContextSkillResults({
                 {skill.name}
               </span>
               {skill.summary ? (
-                <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground">
+                <span className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
                   {skill.summary}
                 </span>
               ) : null}

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -12,6 +12,7 @@ import {
   PencilIcon,
   Search,
   Settings2,
+  Sparkles,
   Square,
   Wrench,
 } from "lucide-react";
@@ -1075,9 +1076,49 @@ function deriveToolCategory(name: string): string {
   return "Tools";
 }
 
+// Tools are listed under their server in the rail, so repeating the
+// `<server>__` namespace in every row buys nothing and pushes the part that
+// distinguishes one tool from the next past the truncation point.
+function shortToolName(name: string): string {
+  const namespaceIdx = name.indexOf("__");
+  return namespaceIdx > 0 ? name.slice(namespaceIdx + 2) : name;
+}
+
 interface ToolCategory {
   name: string;
   tools: MentionableTool[];
+}
+
+const contextRailGroupClass =
+  "flex items-center gap-1.5 px-2 pb-1 text-xs font-semibold tracking-wide text-muted-foreground uppercase";
+
+const contextRailItemClass = (active: boolean) =>
+  cn(
+    "flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm transition-colors",
+    active
+      ? "bg-muted font-medium text-foreground"
+      : "text-muted-foreground hover:bg-muted/60",
+  );
+
+/** Shared eyebrow so both halves of the pane announce themselves the same way. */
+function ContextSectionHeader({
+  icon: Icon,
+  label,
+  count,
+}: {
+  icon: typeof Wrench;
+  label: string;
+  count?: number;
+}): React.ReactElement {
+  return (
+    <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-popover px-3 pt-3 pb-2 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+      <Icon className="size-3.5 shrink-0" />
+      <span>{label}</span>
+      {count !== undefined && (
+        <span className="tabular-nums opacity-60">{count}</span>
+      )}
+    </div>
+  );
 }
 
 /** Rail entry for the skills half of the context picker. */
@@ -1250,7 +1291,7 @@ const ComposerContextPicker: FC = () => {
       <PopoverContent
         side="top"
         align="start"
-        className="aui-composer-context-popover w-[420px] overflow-hidden p-0"
+        className="aui-composer-context-popover w-[560px] max-w-[calc(100vw-2rem)] overflow-hidden p-0"
         onEscapeKeyDown={(event) => {
           if (query !== "") {
             event.preventDefault();
@@ -1258,7 +1299,7 @@ const ComposerContextPicker: FC = () => {
           }
         }}
       >
-        <div className="flex items-center gap-2 border-b border-input px-3 py-2">
+        <div className="flex items-center gap-2 border-b border-input px-3 py-2.5">
           <Search className="size-4 shrink-0 text-muted-foreground" />
           <input
             autoFocus
@@ -1275,44 +1316,47 @@ const ComposerContextPicker: FC = () => {
             aria-label="Search context"
           />
         </div>
-        <div className="flex h-72">
+        <div className="flex h-80">
           {/* The rail is a browse aid only; a search reaches across both
               halves, so it is hidden while one is running. */}
           {!searching && (
-            <div className="w-36 shrink-0 overflow-y-auto border-r border-input p-2">
+            <div className="w-44 shrink-0 overflow-y-auto border-r border-input p-2">
               {hasSkills && (
-                <button
-                  type="button"
-                  onClick={() => setSection(CONTEXT_SKILLS_SECTION)}
-                  className={cn(
-                    "flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs transition-colors",
-                    activeSection === CONTEXT_SKILLS_SECTION
-                      ? "bg-muted font-medium text-foreground"
-                      : "text-muted-foreground hover:bg-muted/60",
-                  )}
-                >
-                  <span className="truncate">Skills</span>
-                  <span className="ml-2 shrink-0 tabular-nums opacity-60">
-                    {skillContext?.skills.length ?? 0}
-                  </span>
-                </button>
+                <>
+                  <div className={contextRailGroupClass}>
+                    <Sparkles className="size-3.5 shrink-0" />
+                    Skills
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setSection(CONTEXT_SKILLS_SECTION)}
+                    className={contextRailItemClass(
+                      activeSection === CONTEXT_SKILLS_SECTION,
+                    )}
+                  >
+                    <span className="truncate">All skills</span>
+                    <span className="ml-2 shrink-0 tabular-nums opacity-60">
+                      {skillContext?.skills.length ?? 0}
+                    </span>
+                  </button>
+                </>
               )}
               {hasTools && (
                 <>
-                  <div className="px-2 pt-2 pb-1 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                  <div
+                    className={cn(contextRailGroupClass, hasSkills && "mt-3")}
+                  >
+                    <Wrench className="size-3.5 shrink-0" />
                     Tools
                   </div>
                   <button
                     type="button"
                     onClick={() => setSection(CONTEXT_ALL_TOOLS_SECTION)}
-                    className={cn(
-                      "flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs transition-colors",
-                      activeSection === CONTEXT_ALL_TOOLS_SECTION
-                        ? "bg-muted font-medium text-foreground"
-                        : "text-muted-foreground hover:bg-muted/60",
+                    className={contextRailItemClass(
+                      activeSection === CONTEXT_ALL_TOOLS_SECTION,
                     )}
                   >
-                    <span className="truncate">All</span>
+                    <span className="truncate">All tools</span>
                     <span className="ml-2 shrink-0 tabular-nums opacity-60">
                       {tools.length}
                     </span>
@@ -1322,11 +1366,8 @@ const ComposerContextPicker: FC = () => {
                       key={category.name}
                       type="button"
                       onClick={() => setSection(category.name)}
-                      className={cn(
-                        "flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs transition-colors",
-                        activeSection === category.name
-                          ? "bg-muted font-medium text-foreground"
-                          : "text-muted-foreground hover:bg-muted/60",
+                      className={contextRailItemClass(
+                        activeSection === category.name,
                       )}
                     >
                       <span className="truncate">{category.name}</span>
@@ -1353,11 +1394,11 @@ const ComposerContextPicker: FC = () => {
             {showSkills &&
               (searching || activeSection === CONTEXT_SKILLS_SECTION) && (
                 <>
-                  {searching && (
-                    <div className="px-4 pt-3 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
-                      Skills
-                    </div>
-                  )}
+                  <ContextSectionHeader
+                    icon={Sparkles}
+                    label="Skills"
+                    count={matchingSkills.length}
+                  />
                   <ContextSkillResults
                     skillContext={skillContext}
                     visibleSkills={matchingSkills}
@@ -1370,11 +1411,15 @@ const ComposerContextPicker: FC = () => {
             {showTools &&
               (searching || activeSection !== CONTEXT_SKILLS_SECTION) && (
                 <>
-                  {searching && (
-                    <div className="px-4 pt-3 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
-                      Tools
-                    </div>
-                  )}
+                  <ContextSectionHeader
+                    icon={Wrench}
+                    label={
+                      searching || activeSection === CONTEXT_ALL_TOOLS_SECTION
+                        ? "Tools"
+                        : `Tools · ${activeSection}`
+                    }
+                    count={matchingTools.length}
+                  />
                   <ContextToolResults
                     tools={matchingTools}
                     loading={mcpToolsLoading}
@@ -1406,27 +1451,35 @@ function ContextToolResults({
     );
   }
   return (
-    <div className="p-2">
-      {tools.map((tool) => (
-        <button
-          key={tool.id}
-          type="button"
-          onClick={() => onSelect(tool.name)}
-          className="flex w-full items-start gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-muted"
-        >
-          <Wrench className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate text-sm font-medium text-foreground">
-              {tool.name}
-            </span>
-            {tool.description && (
-              <span className="line-clamp-2 text-xs text-muted-foreground">
-                {tool.description}
+    <div className="px-2 pb-2">
+      {tools.map((tool) => {
+        const short = shortToolName(tool.name);
+        return (
+          <button
+            key={tool.id}
+            type="button"
+            onClick={() => onSelect(tool.name)}
+            className="flex w-full items-start gap-2.5 rounded px-2 py-2 text-left transition-colors hover:bg-muted"
+          >
+            <Wrench className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium text-foreground">
+                {short}
               </span>
-            )}
-          </span>
-        </button>
-      ))}
+              {short !== tool.name && (
+                <span className="block truncate font-mono text-xs text-muted-foreground">
+                  {tool.name}
+                </span>
+              )}
+              {tool.description && (
+                <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground">
+                  {tool.description}
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -1506,7 +1559,7 @@ function ContextSkillResults({
 
   const atLimit = selectedIDs.size >= maxSelected;
   return (
-    <div className="max-h-72 overflow-y-auto p-2">
+    <div className="px-2 pb-2">
       {visibleSkills.map((skill) => {
         const selected = selectedIDs.has(skill.id);
         return (
@@ -1516,7 +1569,7 @@ function ContextSkillResults({
             onClick={() => onToggle(skill.id)}
             disabled={atLimit && !selected}
             aria-pressed={selected}
-            className="flex w-full items-start gap-2 rounded px-2 py-2 text-left transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex w-full items-start gap-2.5 rounded px-2 py-2 text-left transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
           >
             <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border border-input">
               {selected ? <CheckIcon className="size-3" /> : null}
@@ -1525,7 +1578,7 @@ function ContextSkillResults({
               <span className="block truncate text-sm font-medium text-foreground">
                 {skill.displayName}
               </span>
-              <span className="block truncate font-mono text-[11px] text-muted-foreground">
+              <span className="block truncate font-mono text-xs text-muted-foreground">
                 {skill.name}
               </span>
               {skill.summary ? (

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -44,6 +44,7 @@ import {
   useContext,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -842,8 +843,11 @@ const ComposerDictationWave: FC = () => {
   );
 };
 
+/** `max-h-64` plus the 8px offset, in px — the room an upward menu needs. */
+const SLASH_MENU_MAX_HEIGHT = 264;
+
 /**
- * Command list shown above the composer while the draft is a `/` query.
+ * Command list shown beside the composer while the draft is a `/` query.
  * Selection is owned by the composer so Enter and click resolve to the same
  * row; rows use onMouseDown-prevent so clicking one doesn't blur the input
  * (which would clear the query before the click lands).
@@ -855,11 +859,24 @@ const ComposerSlashCommandMenu: FC<{
   onSelect: (command: ComposerSlashCommand) => void;
 }> = ({ commands, activeIndex, onHover, onSelect }) => {
   const r = useRadius();
+  const ref = useRef<HTMLDivElement>(null);
+  // The menu opens upwards, which is right for a composer pinned to the bottom
+  // of a thread. On the welcome screen the composer sits high in the page, and
+  // there the same menu would open off the top edge — so measure what is
+  // actually above the composer and drop downwards when it will not fit.
+  const [dropDown, setDropDown] = useState(false);
+  useLayoutEffect(() => {
+    const composer = ref.current?.offsetParent;
+    if (!composer) return;
+    setDropDown(composer.getBoundingClientRect().top < SLASH_MENU_MAX_HEIGHT);
+  }, [commands.length]);
   return (
     <div
+      ref={ref}
       role="listbox"
       className={cn(
-        "aui-composer-slash-menu absolute bottom-full left-0 z-50 mb-2 max-h-64 w-full overflow-y-auto border border-input bg-background shadow-md",
+        "aui-composer-slash-menu absolute left-0 z-50 max-h-64 w-full overflow-y-auto border border-input bg-background shadow-md",
+        dropDown ? "top-full mt-2" : "bottom-full mb-2",
         r("lg"),
       )}
     >


### PR DESCRIPTION
Follow-up polish on the "Add context" picker from #5142, plus a placement fix on the slash-command menu.

### The picker was cramped

The pane was 420px wide with a 144px rail, leaving ~230px for the text column. Tool rows printed the fully-qualified `<server>__<tool>` name into that column, so every tool from the same server truncated at the shared namespace and the rows read as identical ellipses.

- Pane `420px` → `560px` (capped at `100vw - 2rem`), content area `h-72` → `h-80`, rail `w-36` → `w-44`.
- Tool rows are titled by the unqualified name, with the fully-qualified name on a mono subline — the same title/identifier/description shape skill rows already use.
- Row and rail padding loosened a step.

### Text sizes were not on a scale

The popover mixed `text-sm`, `text-xs`, `text-[11px]` and `text-[10px]`. Now two steps inside rows (`text-sm` title, `text-xs` for everything secondary) and one shared eyebrow style; no arbitrary sizes left in the component.

### Skills vs tools were only implied

- The rail is symmetric: a `Skills` group over `All skills`, a `Tools` group over `All tools` and the per-server entries. Previously `Skills` was a bare row floating above a `TOOLS` label.
- The results pane gets a sticky header (icon, label, match count) while **browsing**, not only while searching — and it names the selected server, e.g. `Tools · <server>`.
- Both groups carry a consistent icon, so the two halves are distinguishable at a glance rather than by inference from which rail row is highlighted.

### Slash menu clipped off the top

The `/` menu was pinned `bottom-full`, which is right for a composer sitting at the bottom of a thread but opens past the top edge on the welcome surface, where the composer sits high in the page. It now measures the room above the composer and drops downwards when the menu would not fit.

### Testing

Type-check and formatter clean. Changes are presentational; no behaviour beyond menu placement changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the composer’s “Add context” picker for readability and browsing, and fixed slash-command menu placement so it stays on screen. Also clamped long descriptions and made the pane opaque to avoid layout and theming issues.

- **Refactors**
  - Picker pane widened to 560px (capped at `100vw - 2rem`) and content height increased.
  - Tool rows show unqualified names; full names moved to a mono subline.
  - Consistent text scale: `text-sm` titles, `text-xs` secondary text, shared eyebrow.
  - Rail is symmetric: Skills and Tools groups, “All skills/tools,” per-server entries, with icons.
  - Results pane gets a sticky header with icon, label, and match count; shows “Tools · <server>” when browsing a server.

- **Bug Fixes**
  - Slash-command menu measures space and opens downward when needed to stay on screen.
  - Clamped tool/skill descriptions to two lines and rendered the pane opaque (`bg-background`) to prevent overflow and see-through on hosts without popover theming.

<sup>Written for commit a8d2005ec45d86406de2f190245188e94afa6d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

