### PR TITLE
feat(dashboard): recall past prompts from the chat composer

### DIFF
--- a/.changeset/composer-prompt-history.md
+++ b/.changeset/composer-prompt-history.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The chat composer recalls past prompts terminal-style: Up walks back through prompts sent from this browser, Down walks forward, and the walk wraps around through the empty draft. History is kept in localStorage, scoped per project.

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -83,6 +83,7 @@ import { useDensity } from "@/elements/hooks/useDensity";
 import { useDictationLevels } from "@/elements/hooks/useDictationLevels";
 import { useElements } from "@/elements/hooks/useElements";
 import { isLocalThreadId } from "@/elements/hooks/useGramThreadListAdapter";
+import { usePromptHistory } from "@/elements/hooks/usePromptHistory";
 import { useRadius } from "@/elements/hooks/useRadius";
 import { useRecordCassette } from "@/elements/hooks/useRecordCassette";
 import { useThemeProps } from "@/elements/hooks/useThemeProps";
@@ -673,6 +674,46 @@ export const Composer: FC<ComposerProps> = ({
     composer.send();
   };
 
+  // Terminal-style prompt recall. The draft text lives on the runtime, so the
+  // ref is what the submit handler reads: the runtime clears the composer as
+  // part of sending, and refs still hold the pre-send render's value there.
+  const promptHistory = usePromptHistory(config.projectSlug);
+  const composerTextRef = useRef(composerText);
+  composerTextRef.current = composerText;
+
+  const recallPrompt = (
+    textarea: HTMLTextAreaElement,
+    direction: "up" | "down",
+  ) => {
+    const recalled = promptHistory.navigate(direction, textarea.value);
+    if (recalled === null) return false;
+    aui.composer().setText(recalled);
+    // The composer is controlled, so the caret can only be placed once the
+    // recalled text has actually been painted.
+    requestAnimationFrame(() => {
+      textarea.setSelectionRange(recalled.length, recalled.length);
+    });
+    return true;
+  };
+
+  /**
+   * Arrow keys belong to the textarea first: recall only takes over when the
+   * caret has nowhere left to go in that direction (first line for Up, last
+   * line for Down), or when the text on screen is one we just recalled — that
+   * keeps a multi-line prompt from trapping the walk after one step.
+   */
+  const canRecall = (
+    textarea: HTMLTextAreaElement,
+    direction: "up" | "down",
+  ) => {
+    if (promptHistory.isShowingRecalled(textarea.value)) return true;
+    const { value, selectionStart, selectionEnd } = textarea;
+    if (selectionStart !== selectionEnd) return false;
+    return direction === "up"
+      ? !value.slice(0, selectionStart).includes("\n")
+      : !value.slice(selectionEnd).includes("\n");
+  };
+
   if (components.Composer) {
     return <components.Composer />;
   }
@@ -719,6 +760,9 @@ export const Composer: FC<ComposerProps> = ({
           ref={composerRootRef}
           // Capture: the menu owns Up/Down/Enter while it is open, before the
           // textarea inserts a newline or the composer sends the raw query.
+          onSubmit={() => {
+            promptHistory.record(composerTextRef.current);
+          }}
           onKeyDownCapture={(event) => {
             if (!slashOpen) return;
             if (event.key === "ArrowDown") {
@@ -786,6 +830,18 @@ export const Composer: FC<ComposerProps> = ({
           )}
           <ComposerPrimitive.Input
             placeholder={composerConfig.placeholder}
+            // Bubble phase, on the textarea itself: the slash menu (form,
+            // capture) and the @-mention menu (textarea, capture + stopPropagation)
+            // both get the arrow keys first, so recall only sees the ones nobody
+            // else claimed.
+            onKeyDown={(event) => {
+              if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+              if (isDictating || isReplay) return;
+              const textarea = event.currentTarget;
+              const direction = event.key === "ArrowUp" ? "up" : "down";
+              if (!canRecall(textarea, direction)) return;
+              if (recallPrompt(textarea, direction)) event.preventDefault();
+            }}
             className={cn(
               "aui-composer-input mb-1 max-h-32 w-full resize-none bg-transparent px-4 pt-0.5 pb-3 text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-0",
               d("h-input"),

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -668,18 +668,21 @@ export const Composer: FC<ComposerProps> = ({
     setActiveSlashIndex(0);
   }, [slashQuery]);
 
-  const runSlashCommand = (command: ComposerSlashCommand) => {
-    const composer = aui.composer();
-    composer.setText(command.prompt);
-    composer.send();
-  };
-
   // Terminal-style prompt recall. The draft text lives on the runtime, so the
   // ref is what the submit handler reads: the runtime clears the composer as
   // part of sending, and refs still hold the pre-send render's value there.
   const promptHistory = usePromptHistory(config.projectSlug);
   const composerTextRef = useRef(composerText);
   composerTextRef.current = composerText;
+
+  const runSlashCommand = (command: ComposerSlashCommand) => {
+    const composer = aui.composer();
+    composer.setText(command.prompt);
+    composer.send();
+    // Sends straight through the runtime, so the form never submits and the
+    // prompt would otherwise be missing from recall.
+    promptHistory.record(command.prompt);
+  };
 
   const recallPrompt = (
     textarea: HTMLTextAreaElement,
@@ -706,9 +709,10 @@ export const Composer: FC<ComposerProps> = ({
     textarea: HTMLTextAreaElement,
     direction: "up" | "down",
   ) => {
-    if (promptHistory.isShowingRecalled(textarea.value)) return true;
     const { value, selectionStart, selectionEnd } = textarea;
+    // A live selection is the user placing their cursor, never a recall.
     if (selectionStart !== selectionEnd) return false;
+    if (promptHistory.isShowingRecalled(value)) return true;
     return direction === "up"
       ? !value.slice(0, selectionStart).includes("\n")
       : !value.slice(selectionEnd).includes("\n");
@@ -836,7 +840,20 @@ export const Composer: FC<ComposerProps> = ({
             // else claimed.
             onKeyDown={(event) => {
               if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
-              if (isDictating || isReplay) return;
+              // Modified arrows select, jump by word, or move the caret to the
+              // ends of the field — all of them the textarea's to handle.
+              if (
+                event.shiftKey ||
+                event.altKey ||
+                event.metaKey ||
+                event.ctrlKey
+              ) {
+                return;
+              }
+              // The slash menu owns the arrows while it is open. It runs in
+              // capture on the form and calls preventDefault, but the event
+              // still reaches this handler.
+              if (slashOpen || isDictating || isReplay) return;
               const textarea = event.currentTarget;
               const direction = event.key === "ArrowUp" ? "up" : "down";
               if (!canRecall(textarea, direction)) return;

--- a/client/dashboard/src/elements/hooks/usePromptHistory.ts
+++ b/client/dashboard/src/elements/hooks/usePromptHistory.ts
@@ -16,8 +16,6 @@ export interface PromptHistory {
   navigate: (direction: "up" | "down", draft: string) => string | null;
   /** True while the composer still shows the text this hook last recalled. */
   isShowingRecalled: (text: string) => boolean;
-  /** Forget the cursor, e.g. after the user edits the recalled text. */
-  reset: () => void;
 }
 
 function readEntries(key: string): string[] {
@@ -55,14 +53,24 @@ export function usePromptHistory(projectSlug: string): PromptHistory {
   const slotRef = useRef(DRAFT_SLOT);
   const draftRef = useRef("");
   // The text we last handed the composer. Anything else on screen means the
-  // user has typed since, so the next Up starts a fresh walk from the draft.
+  // user has typed since, so the next step starts a fresh walk from the draft.
   const appliedRef = useRef<string | null>(null);
+  const keyRef = useRef(key);
 
   const reset = useCallback(() => {
     slotRef.current = DRAFT_SLOT;
     draftRef.current = "";
     appliedRef.current = null;
   }, []);
+
+  // A composer that outlives a project switch must not carry the old project's
+  // cursor into the new project's entries.
+  if (keyRef.current !== key) {
+    keyRef.current = key;
+    slotRef.current = DRAFT_SLOT;
+    draftRef.current = "";
+    appliedRef.current = null;
+  }
 
   const record = useCallback(
     (text: string) => {
@@ -81,6 +89,10 @@ export function usePromptHistory(projectSlug: string): PromptHistory {
       const entries = readEntries(key);
       if (entries.length === 0) return null;
 
+      // Text the user has typed or edited since the last step ends the walk it
+      // came from: it becomes the new draft, so the step starts over from there
+      // and the edit is waiting at the draft slot on the way back.
+      if (appliedRef.current !== draft) slotRef.current = DRAFT_SLOT;
       if (slotRef.current === DRAFT_SLOT) draftRef.current = draft;
 
       const slots = entries.length + 1;
@@ -103,7 +115,7 @@ export function usePromptHistory(projectSlug: string): PromptHistory {
   );
 
   return useMemo(
-    () => ({ record, navigate, isShowingRecalled, reset }),
-    [record, navigate, isShowingRecalled, reset],
+    () => ({ record, navigate, isShowingRecalled }),
+    [record, navigate, isShowingRecalled],
   );
 }

--- a/client/dashboard/src/elements/hooks/usePromptHistory.ts
+++ b/client/dashboard/src/elements/hooks/usePromptHistory.ts
@@ -1,0 +1,109 @@
+import { useCallback, useMemo, useRef } from "react";
+
+const STORAGE_PREFIX = "gram.elements.prompt-history";
+const MAX_ENTRIES = 50;
+
+/** Slot 0 is the live draft; slots 1..n are entries[slot - 1], newest first. */
+const DRAFT_SLOT = 0;
+
+export interface PromptHistory {
+  /** Persist a sent prompt at the head of the history. */
+  record: (text: string) => void;
+  /**
+   * Move one step through the history and return the text the composer should
+   * show, or null when there is nothing recorded yet.
+   */
+  navigate: (direction: "up" | "down", draft: string) => string | null;
+  /** True while the composer still shows the text this hook last recalled. */
+  isShowingRecalled: (text: string) => boolean;
+  /** Forget the cursor, e.g. after the user edits the recalled text. */
+  reset: () => void;
+}
+
+function readEntries(key: string): string[] {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    // Private-mode denials and hand-edited values both mean "no history".
+    return [];
+  }
+}
+
+function writeEntries(key: string, entries: string[]): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(entries));
+  } catch {
+    // History is a convenience; a full or blocked store must not break sending.
+  }
+}
+
+/**
+ * Terminal-style recall for the composer: Up walks back through prompts sent
+ * from this browser, Down walks forward, and both wrap around through the
+ * draft slot so the empty composer is always one step past the oldest entry.
+ *
+ * Entries live in localStorage, scoped per project, so history survives a
+ * reload and does not leak between projects on the same origin.
+ */
+export function usePromptHistory(projectSlug: string): PromptHistory {
+  const key = `${STORAGE_PREFIX}:${projectSlug}`;
+
+  const slotRef = useRef(DRAFT_SLOT);
+  const draftRef = useRef("");
+  // The text we last handed the composer. Anything else on screen means the
+  // user has typed since, so the next Up starts a fresh walk from the draft.
+  const appliedRef = useRef<string | null>(null);
+
+  const reset = useCallback(() => {
+    slotRef.current = DRAFT_SLOT;
+    draftRef.current = "";
+    appliedRef.current = null;
+  }, []);
+
+  const record = useCallback(
+    (text: string) => {
+      reset();
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const entries = readEntries(key);
+      if (entries[0] === trimmed) return;
+      writeEntries(key, [trimmed, ...entries].slice(0, MAX_ENTRIES));
+    },
+    [key, reset],
+  );
+
+  const navigate = useCallback(
+    (direction: "up" | "down", draft: string): string | null => {
+      const entries = readEntries(key);
+      if (entries.length === 0) return null;
+
+      if (slotRef.current === DRAFT_SLOT) draftRef.current = draft;
+
+      const slots = entries.length + 1;
+      const step = direction === "up" ? 1 : slots - 1;
+      const slot = (slotRef.current + step) % slots;
+      slotRef.current = slot;
+
+      const text =
+        slot === DRAFT_SLOT ? draftRef.current : (entries[slot - 1] ?? "");
+      appliedRef.current = text;
+      return text;
+    },
+    [key],
+  );
+
+  const isShowingRecalled = useCallback(
+    (text: string) =>
+      appliedRef.current !== null && appliedRef.current === text,
+    [],
+  );
+
+  return useMemo(
+    () => ({ record, navigate, isShowingRecalled, reset }),
+    [record, navigate, isShowingRecalled, reset],
+  );
+}


### PR DESCRIPTION
Terminal-style prompt recall in the chat composer: **Up** walks back through prompts you have sent, **Down** walks forward, and both wrap around through the empty draft, so the empty composer is always one step past the oldest entry.

### How it works

- `usePromptHistory` keeps the entries in `localStorage` under `gram.elements.prompt-history:<projectSlug>` — 50 max, newest first, consecutive duplicates and blanks skipped. Every access is try/caught: a blocked or full store must never break sending.
- Slot `0` is the live draft, slots `1..n` are the entries, and stepping is modulo `n + 1` — that is what makes the wrap pass through the empty prompt in both directions. A draft typed before the walk starts is stashed and handed back at slot 0.
- Recording hangs off the composer form's `onSubmit`, which both send paths reach (Enter calls `form.requestSubmit()`, the send button is a submit). It reads the text from a ref, because the runtime clears the composer as part of sending.
- Recall is a bubble-phase `onKeyDown` on the textarea, deliberately last in line: the slash-command menu claims arrows in capture on the form, and the @-mention menu claims them in capture on the textarea with `stopPropagation`. Both therefore win without needing a shared "is a menu open" flag.
- Arrows still belong to the textarea first — recall only takes over with no selection and the caret on the first line (Up) or last line (Down), or when the text on screen is exactly what recall last inserted, which keeps a multi-line recalled prompt from trapping the walk after one step. Skipped while dictating or replaying.

### Scope

This lives in `elements/`, so every surface built on that composer picks it up: the Project Assistant dock, `/chat`, and embedded Gram Elements.

### Testing

`pnpm -F dashboard type-check` and `hk fix` are clean. Not yet exercised in a browser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add terminal-style prompt recall to the chat composer. Up/Down cycle through your sent prompts and the empty draft; history is per project and arrows respect menus, selections, and edits.

- **New Features**
  - `usePromptHistory` stores up to 50 prompts in `localStorage` under `gram.elements.prompt-history:<projectSlug>`, skipping blanks and consecutive duplicates; safe if storage is blocked.
  - Works across all `elements` surfaces: Project Assistant dock, `/chat`, and embedded composers.
  - History is recorded on form submit and when slash commands send; reads the pre-clear text from a ref.
  - Recall only takes over at the top/bottom line or when showing recalled text; ignored during dictation/replay.

- **Bug Fixes**
  - Arrow keys now yield to the slash and @ menus, active selections, and modifier keys; recall only runs on unmodified Up/Down.

<sup>Written for commit 11e4eef675613209b778b64ccaae40cda904d20b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

