### PR TITLE
chore: stop worktree boots hanging and colliding on ports

### DIFF
--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -122,14 +122,43 @@ else
 fi
 
 # run_bounded <seconds> <command...>
-# Runs the command via `gum spin` (gum is provided by mise), which aborts it
-# after <seconds> and propagates its exit code (124 on timeout). This bounds
-# each probe so a hung `docker compose exec` or Docker Engine call cannot block
-# past the deadline.
+# Runs the command, aborting it after <seconds> and returning 124 in that case.
+# This bounds each probe so a hung `docker compose exec` or Docker Engine call
+# cannot block past the deadline.
+#
+# Deliberately implemented without `gum spin` (or anything else that draws to
+# the terminal). `git:workboot` runs as a BACKGROUND process group under wt's
+# post-start hook, and a background process that reads the controlling terminal
+# is stopped with SIGTTIN. `gum spin` is a TUI, so it was suspended on its first
+# probe -- and with it its own `--timeout` timer -- leaving the boot hung in
+# "booting" with healthy containers and no further output. macOS ships no
+# `timeout(1)`, hence the hand-rolled poll.
 run_bounded() {
     local secs="$1"
     shift
-    gum spin --timeout "${secs}s" --show-output -- "$@"
+
+    "$@" &
+    local pid=$!
+
+    # Poll at 200ms so a probe that answers immediately still returns
+    # immediately. bash reaps exited background jobs, so `kill -0` failing is a
+    # reliable "it finished" signal here.
+    local ticks=$((secs * 5))
+    local i=0
+    while [ "$i" -lt "$ticks" ] && kill -0 "$pid" 2>/dev/null; do
+        sleep 0.2
+        i=$((i + 1))
+    done
+
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -TERM "$pid" 2>/dev/null
+        sleep 1
+        kill -KILL "$pid" 2>/dev/null
+        wait "$pid" 2>/dev/null
+        return 124
+    fi
+
+    wait "$pid"
 }
 
 # wait_for <display-name> <compose-service> <check command...>

--- a/.mise-tasks/zero/remap-ports.mts
+++ b/.mise-tasks/zero/remap-ports.mts
@@ -25,9 +25,11 @@
  * manual edits the user may have made to dependent values.
  */
 
+import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { parseTOML } from "confbox";
-import { getPort } from "get-port-please";
+import { checkPort } from "get-port-please";
 
 /**
  * Ports of services that are shared across ALL worktrees (see
@@ -37,6 +39,80 @@ import { getPort } from "get-port-please";
  * keep their mise.toml defaults too.
  */
 const SHARED_PORT_ENV_VARS = new Set(["PRESIDIO_PORT"]);
+
+/**
+ * Range to draw worktree ports from. Deliberately BELOW the ephemeral range
+ * (49152-65535 on macOS and Linux): a port picked there is one the kernel also
+ * hands out to outbound sockets, and nothing holds the assignment between
+ * `git:workinit` picking it and Docker binding it minutes later during the
+ * boot. When that race is lost the whole stack dies at `infra:start` with
+ * `failed to bind host port ...: address already in use`, and the worktree
+ * never seeds. Stay above 20000 to clear the fixed ports in `mise.toml`.
+ */
+const PORT_RANGE_START = 20_000;
+const PORT_RANGE_END = 49_151;
+
+/** Attempts per port before giving up; the range holds ~29k candidates. */
+const MAX_PORT_ATTEMPTS = 100;
+
+/**
+ * Ports already spoken for by another worktree. A sibling's ports are recorded
+ * in its `mise.local.toml` as soon as `git:workinit` runs, but are not bound
+ * until its stack boots, so probing the host alone cannot see them: creating
+ * two worktrees back to back would otherwise hand both the same ports and the
+ * second stack would fail to bind. Best-effort — a worktree we cannot read
+ * just does not contribute reservations.
+ */
+function reservedByOtherWorktrees(): Set<number> {
+  const reserved = new Set<number>();
+
+  let porcelain: string;
+  try {
+    porcelain = execFileSync("git", ["worktree", "list", "--porcelain"], {
+      encoding: "utf-8",
+    });
+  } catch {
+    return reserved;
+  }
+
+  for (const line of porcelain.split("\n")) {
+    if (!line.startsWith("worktree ")) continue;
+    const dir = line.slice("worktree ".length).trim();
+    let local: { env?: Record<string, string> };
+    try {
+      local = parseTOML(readFileSync(join(dir, "mise.local.toml"), "utf-8"));
+    } catch {
+      continue;
+    }
+    for (const [key, value] of Object.entries(local.env ?? {})) {
+      if (!key.endsWith("_PORT")) continue;
+      const port = Number(value);
+      if (Number.isInteger(port)) reserved.add(port);
+    }
+  }
+
+  return reserved;
+}
+
+/**
+ * Picks a free port in the non-ephemeral range that no other worktree has
+ * claimed, recording it in `reserved` so the rest of this run skips it too.
+ */
+async function allocatePort(reserved: Set<number>): Promise<number> {
+  const span = PORT_RANGE_END - PORT_RANGE_START + 1;
+  for (let attempt = 0; attempt < MAX_PORT_ATTEMPTS; attempt++) {
+    const candidate = PORT_RANGE_START + Math.floor(Math.random() * span);
+    if (reserved.has(candidate)) continue;
+    // checkPort with no host tries every local address plus 0.0.0.0, which is
+    // what Docker publishes on.
+    if ((await checkPort(candidate)) === false) continue;
+    reserved.add(candidate);
+    return candidate;
+  }
+  throw new Error(
+    `Unable to find a free port in ${PORT_RANGE_START}-${PORT_RANGE_END} after ${MAX_PORT_ATTEMPTS} attempts`,
+  );
+}
 
 async function main() {
   const config = parseTOML(await readFileSync("mise.toml", "utf-8")) as {
@@ -61,6 +137,15 @@ async function main() {
     (key) => key.endsWith("_PORT") && !SHARED_PORT_ENV_VARS.has(key),
   );
 
+  // Ports this worktree keeps (--preserve) are reserved too, so a newly-added
+  // _PORT var cannot be handed a port this worktree already uses.
+  const reserved = reservedByOtherWorktrees();
+  for (const [key, value] of Object.entries(existing)) {
+    if (!key.endsWith("_PORT")) continue;
+    const port = Number(value);
+    if (Number.isInteger(port)) reserved.add(port);
+  }
+
   const emitted = new Map<string, string>();
   const emit = (key: string, value: string) => {
     // delete-then-set moves the key to the end of insertion order, matching
@@ -74,11 +159,7 @@ async function main() {
     if (preserve && portEnvVar in existing) {
       // Port is already assigned in mise.local.toml — keep it.
     } else {
-      const port = await getPort({
-        name: portEnvVar,
-        random: true,
-      });
-      emit(portEnvVar, `${port}`);
+      emit(portEnvVar, `${await allocatePort(reserved)}`);
     }
 
     for (const [key, value] of findDependentEnvVars(config.env, portEnvVar)) {


### PR DESCRIPTION
New worktrees frequently never reached a steady state: some sat in `wt status` as `booting` indefinitely, others went straight to `failed`. Two independent causes, both in the `post-start` boot path.

## 1. Boots hang forever in `infra:start`

`run_bounded` in `.mise-tasks/infra/start.sh` used `gum spin --timeout <n>s` to bound each readiness probe. `gum spin` is a TUI, and `git:workboot` runs as a **background process group** under wt's `post-start` hook — so gum's first terminal access earned it a SIGTTIN and the process was _stopped_, freezing its own `--timeout` timer along with it.

The result was the exact opposite of what the bound was for: the boot parked on its very first probe (`docker compose exec … psql`) and never moved again, with every container healthy and no further log output. Observed on three worktrees simultaneously, one of them stopped for over 15 hours:

```
PID  ELAPSED     STAT
50223 15:33:55   T     gum spin --timeout 5s --show-output -- docker compose exec -T gram-db psql …
```

Replaced with a TTY-free bounded runner: background the command, poll at 200 ms, then TERM → KILL and return 124 on timeout. macOS ships no `timeout(1)`, hence the hand-rolled poll.

## 2. Boots fail on port collisions

`zero:remap-ports` allocated each `*_PORT` with `getPort({ random: true })`, which binds port 0 — so the kernel returns an **ephemeral** port (≥ 49152 on macOS and Linux) and releases it immediately. Nothing holds that assignment between `git:workinit` picking it and Docker binding it minutes later, and a sibling worktree's already-claimed-but-not-yet-bound ports are invisible to a host probe. Creating several worktrees in quick succession therefore produced:

```
failed to bind host port 0.0.0.0:<port>/tcp: address already in use
```

which kills `infra:start`, so `zero` never reaches `mise run seed`, the daemons never come up, and the seed retries burn out against a dead server → `failed`.

Ports are now drawn from **20000–49151** (below the ephemeral range, above the fixed ports in `mise.toml`), and candidates are checked against the `*_PORT` values recorded in **every worktree's `mise.local.toml`** as well as against the host. `--preserve` behaviour is unchanged: existing assignments are kept, and now also reserved so a newly-added `_PORT` var cannot land on one.

## Testing

- `run_bounded` exercised directly: exit-code passthrough, `124` on timeout, and `124` for a child that ignores SIGTERM (SIGKILL fallback).
- Narrowing `PORT_RANGE_*` to a three-port window where all three are claimed by sibling worktrees makes the allocator refuse (`Unable to find a free port …`) instead of handing out a colliding port — cross-worktree reservation confirmed.
- A full run outputs 25 distinct ports, all within 20000–49151.
- Re-booted a worktree that had been wedged for 20+ minutes: `infra:start` now exits 0 and the boot proceeds through migrations to daemon startup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes worktree boots that hung or failed by removing the TTY-based timeout and preventing port collisions. Boots now complete reliably and stacks bind to unique ports.

- **Bug Fixes**
  - Replaced `gum spin --timeout` in `.mise-tasks/infra/start.sh` with a TTY-free bounded runner that backgrounds the command, polls, and returns 124 on timeout (TERM→KILL), so readiness probes can’t freeze when running in the background.
  - Updated `zero:remap-ports` to allocate ports from 20000–49151, check availability with `checkPort` from `get-port-please`, and reserve ports seen in every worktree’s `mise.local.toml`; existing `--preserve` assignments are kept and now reserved.

<sup>Written for commit 12ec8380f496ed842afe2157c8808d36c4f2f7bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

