### PR TITLE
chore: cut cold worktree boot from 137s to 82s

### DIFF
--- a/.mise-tasks/build/server-cache.sh
+++ b/.mise-tasks/build/server-cache.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#MISE dir="{{ config_root }}/server"
+#MISE description="Warm the Go build cache for the server/worker/streams daemons"
+#MISE hide=true
+
+set -e
+
+# `start:server`, `start:worker` and `start:streams` are the SAME Go program --
+# `main.go` with a different subcommand -- and pitchfork launches all three at
+# once. On a cold cache that means three concurrent copies of one compile+link,
+# each racing the others for cores: ~75s before any of them serves a request,
+# and the boot cannot proceed to seeding until they do.
+#
+# Running the identical build once up front collapses that to a single compile,
+# after which each `go run` is a cache hit. `zero` backgrounds this so it
+# overlaps the Docker infra start and the migrations, which are IO-bound and
+# leave the CPU idle -- so it is close to free in wall-clock terms.
+#
+# The ldflags MUST stay byte-identical to the three start tasks: they feed the
+# link step's cache key, so any drift silently reintroduces the cold link.
+# -o /dev/null because only the cache entry is wanted, not the binary.
+GIT_SHA=$(git rev-parse HEAD)
+
+go build \
+    -ldflags="-X github.com/speakeasy-api/gram/server/cmd/gram.GitSHA=${GIT_SHA} -X goa.design/clue/health.Version=${GIT_SHA}" \
+    -o /dev/null \
+    ./main.go

--- a/.mise-tasks/git/workboot.sh
+++ b/.mise-tasks/git/workboot.sh
@@ -40,7 +40,13 @@ mise run stop || true
 # accepts queries, and several worktree stacks may be booting at once. At 30s
 # infra:start gives up mid-initdb and zero aborts before migrations run,
 # leaving the daemons pointed at an empty database.
-if INFRA_READINESS_TIMEOUT=300 ./zero --agent; then
+#
+# PRESIDIO_READINESS_TIMEOUT=0 skips the shared analyzer's health wait, which
+# is up to 90s of pure latency here: nothing in the boot path consumes Presidio
+# synchronously (only background Temporal risk activities do, and they already
+# retry), and infra:start treats the wait as advisory anyway. An interactive
+# `./zero` keeps the wait so its success message stays honest.
+if INFRA_READINESS_TIMEOUT=300 PRESIDIO_READINESS_TIMEOUT=0 ./zero --agent; then
     exit 0
 fi
 

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -30,8 +30,14 @@ if [ -n "$host_arch" ]; then
             *@sha256:*)
                 # `repo:tag@sha256:...` and `repo@sha256:...` both reduce to the
                 # `repo@sha256:...` form that `docker image ls --digests` prints.
+                # Only the final path component can carry a tag, so look for the
+                # separating colon there — stripping from the whole reference
+                # would eat a registry port instead (`host:5000/img@sha256:...`).
                 repo="${img%@*}"
-                key="${repo%:*}@${img#*@}"
+                case "${repo##*/}" in
+                    *:*) repo="${repo%:*}" ;;
+                esac
+                key="${repo}@${img#*@}"
                 ;;
             *:*) key="$img" ;;
             *) key="$img:latest" ;;
@@ -55,9 +61,17 @@ if [ -n "$host_arch" ]; then
             if [ -n "$img_arch" ] && [ "$img_arch" != "$host_arch" ]; then
                 # A digest-pinned ref cannot simply be re-pulled: the daemon
                 # refuses to rebind a digest it already has ("cannot overwrite
-                # digest"), so the local copy has to be evicted first.
+                # digest"), so the local copy has to be evicted first — and
+                # `docker rmi` refuses while ANY container still references it,
+                # including sibling worktrees'. Scoping the eviction to this
+                # compose project would therefore just make the remedy fail, so
+                # it stays repo-wide and the caveat is stated instead. The
+                # containers it removes come back with the next `infra:start`.
                 case "$img" in
-                    *@sha256:*) fix="${fix_prefix}docker rm -f \$(docker ps -aq --filter ancestor=$img) 2>/dev/null; docker rmi $img && docker pull --platform linux/$host_arch $img" ;;
+                    *@sha256:*)
+                        fix="${fix_prefix}docker rm -f \$(docker ps -aq --filter ancestor=$img) 2>/dev/null; docker rmi $img && docker pull --platform linux/$host_arch $img"
+                        fix="$fix (removes this image's containers in every worktree stack; each is recreated by its next \`mise infra:start\`)"
+                        ;;
                     *) fix="${fix_prefix}docker pull --platform linux/$host_arch $img" ;;
                 esac
                 echo "⚠️  Cached image $img is $img_arch but this Docker host is $host_arch — it runs emulated and can crash under load. Fix: $fix" >&2

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -7,21 +7,36 @@
 # under emulation on every stack — on Apple Silicon an emulated Postgres
 # backend segfaults under load (exit code 2 → crash recovery → every daemon
 # fails its DB ping mid-boot). Warn-only: emulation mostly works, and a hard
-# fail would strand hosts that have no native variant. Digest-pinned images are
-# skipped because a re-pull cannot change what a digest points at.
+# fail would strand hosts that have no native variant.
+#
+# Digest-pinned images are checked too. A pin is usually the digest of a
+# multi-arch INDEX, not of one platform's manifest, so the cached copy behind it
+# can still be the wrong architecture -- which is exactly how the pubsub
+# emulator ended up running under emulation on every worktree stack while this
+# check stayed silent.
 host_arch="$(docker version --format '{{.Server.Arch}}' 2>/dev/null)"
 if [ -n "$host_arch" ]; then
-    # Keep this advisory check to two daemon round-trips no matter how many
-    # images the stack declares: list local tags once, intersect with the
-    # compose images, then inspect the cached subset in a single call (its
-    # output lines map back to the input by position). A per-image inspect
-    # would add a slow serial round-trip per image on Docker Desktop.
+    # Keep this advisory check to a constant number of daemon round-trips no
+    # matter how many images the stack declares: list local tags and digests
+    # once, intersect with the compose images, then inspect the cached subset in
+    # a single call (its output lines map back to the input by position). A
+    # per-image inspect would add a slow serial round-trip per image on Docker
+    # Desktop.
     local_tags="$(docker image ls --format '{{.Repository}}:{{.Tag}}' 2>/dev/null)"
+    local_digests="$(docker image ls --digests --format '{{.Repository}}@{{.Digest}}' 2>/dev/null)"
     cached_imgs=()
     while IFS= read -r img; do
-        case "$img" in *@sha256:*) continue ;; esac
-        case "$img" in *:*) tag="$img" ;; *) tag="$img:latest" ;; esac
-        if grep -qxF "$tag" <<< "$local_tags"; then
+        case "$img" in
+            *@sha256:*)
+                # `repo:tag@sha256:...` and `repo@sha256:...` both reduce to the
+                # `repo@sha256:...` form that `docker image ls --digests` prints.
+                repo="${img%@*}"
+                key="${repo%:*}@${img#*@}"
+                ;;
+            *:*) key="$img" ;;
+            *) key="$img:latest" ;;
+        esac
+        if grep -qxF "$key" <<< "$local_tags"$'\n'"$local_digests"; then
             cached_imgs+=("$img")
         fi
     done < <(docker compose config --images 2>/dev/null | sort -u)
@@ -38,7 +53,14 @@ if [ -n "$host_arch" ]; then
             img="${cached_imgs[$i]}"
             i=$((i + 1))
             if [ -n "$img_arch" ] && [ "$img_arch" != "$host_arch" ]; then
-                echo "⚠️  Cached image $img is $img_arch but this Docker host is $host_arch — it runs emulated and can crash under load. Fix: ${fix_prefix}docker pull $img" >&2
+                # A digest-pinned ref cannot simply be re-pulled: the daemon
+                # refuses to rebind a digest it already has ("cannot overwrite
+                # digest"), so the local copy has to be evicted first.
+                case "$img" in
+                    *@sha256:*) fix="${fix_prefix}docker rm -f \$(docker ps -aq --filter ancestor=$img) 2>/dev/null; docker rmi $img && docker pull --platform linux/$host_arch $img" ;;
+                    *) fix="${fix_prefix}docker pull --platform linux/$host_arch $img" ;;
+                esac
+                echo "⚠️  Cached image $img is $img_arch but this Docker host is $host_arch — it runs emulated and can crash under load. Fix: $fix" >&2
             fi
         done < <(docker image inspect "${cached_imgs[@]}" --format '{{.Architecture}}' 2>/dev/null)
     fi

--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -36,10 +36,16 @@ ready_cmd = "mise run check:daemon --name {{name}}"
 run = "mise run start:pystreams-multi"
 ready_cmd = "mise run check:daemon --name {{name}}"
 
+# Deliberately does NOT depend on `server`. Vite's dev proxy dials the server
+# per request, not at startup, so gating the dashboard on server readiness
+# bought nothing and cost the whole cold Go compile: on a fresh worktree vite
+# only launched ~80s into a ~137s boot, which is most of the wait before the
+# dashboard is reachable. Starting it immediately means the page is up while
+# the server is still building; requests made in that window fail until the
+# server is ready, which is the normal dev experience after any server restart.
 [daemons.dashboard]
 run = "mise run start:dashboard"
 ready_cmd = "mise run check:daemon --name {{name}}"
-depends = ["server"]
 
 [daemons.assistant-runtime]
 run = "mise run start:assistant-runtime"

--- a/zero
+++ b/zero
@@ -231,6 +231,12 @@ if $started; then
 
     mise run "$start_task"
     mise run seed
+else
+    # Nothing will consume the cache, so stop paying for it: without this the
+    # build runs to completion in the background of a `./zero` the user
+    # declined to start, and is never reaped.
+    kill "$server_cache_pid" 2>/dev/null || true
+    wait "$server_cache_pid" 2>/dev/null || true
 fi
 
 mise run zero:summary

--- a/zero
+++ b/zero
@@ -182,6 +182,15 @@ echo -e "\n⏳ Cleaning up stale processes and Temporal state"
 interactive_only mise run zero:cleanup
 echo "✅ Cleaned up stale state"
 
+# Compile the server/worker/streams binary while the steps below wait on
+# Docker and the database. Those steps are IO-bound, so the build is nearly
+# free in wall-clock terms, and it saves `mise run start` from doing three
+# concurrent copies of the same cold compile. Backgrounded rather than
+# depended on: a build failure must surface from the daemon that needs it, not
+# abort the stack before infra is even up.
+mise run build:server-cache &
+server_cache_pid=$!
+
 echo -e "\n⏳ Starting infra"
 mise infra:start
 
@@ -215,6 +224,11 @@ else
 fi
 
 if $started; then
+    # Let the build cache finish before the daemons race for it. `|| true`
+    # because a failed build must not abort the boot here -- the daemon that
+    # needs it rebuilds and reports the error where it is actionable.
+    wait "$server_cache_pid" || true
+
     mise run "$start_task"
     mise run seed
 fi


### PR DESCRIPTION
Follow-up to #5179. That PR stopped worktree boots from hanging; this one makes the boot that now completes actually fast.

Measured on a fresh worktree, `mise run nuke` then a full `./zero --agent` before and after:

|                     | before | after   |
| ------------------- | ------ | ------- |
| total cold boot     | 137s   | **82s** |
| dashboard reachable | 106s   | **53s** |

## What was slow

Reconstructed from pitchfork's timestamped daemon logs — `mise run start`'s own output is a TUI that batches every "started" line to the final flush, so it is useless for timing.

**The dashboard waited on the server for nothing (~80s).** `pitchfork.toml` had `[daemons.dashboard] depends = ["server"]`. Vite's dev proxy dials the server per request, not at startup, so the gate bought nothing while costing the entire cold Go compile: on a fresh worktree vite only launched at t+106s of a 137s boot. Removed.

**Three concurrent copies of one compile.** `start:server`, `start:worker` and `start:streams` are the _same_ program — `main.go` plus a different subcommand — and pitchfork launches all three at once, so a cold cache means three racing compile+link passes. New hidden `build:server-cache` task runs that build once; `zero` backgrounds it so it overlaps the Docker infra start and the migrations, which are IO-bound and leave the CPU idle. Each `go run` is then a cache hit.

The ldflags in that task must stay byte-identical to the three start tasks — they key the link cache. `build:server` cannot serve as the prewarm: its `-trimpath` / `CGO_ENABLED=0` change every package's build ID. Measured on this tree: matching ldflags 8.9s, novel ldflags 36.6s.

**Presidio health wait (up to 90s).** `workboot.sh` now passes `PRESIDIO_READINESS_TIMEOUT=0`. Nothing in the boot path consumes Presidio synchronously — only background Temporal risk activities, which already retry — and `infra:start` treats the wait as advisory anyway. An interactive `./zero` keeps the wait so its success message stays honest.

## Also: an arch-preflight blind spot

`infra:start`'s foreign-architecture warning skipped digest-pinned images, on the reasoning that "a re-pull cannot change what a digest points at". A pin is normally the digest of a multi-arch **index**, not of one platform's manifest, so the cached copy behind it can still be the wrong arch. That is exactly how the pubsub emulator ended up running under emulation on every worktree stack while the check stayed silent.

Digest-pinned refs are now checked too, matched against `docker image ls --digests`. The remedy text differs for them because a plain `docker pull` fails with `cannot overwrite digest` — the local copy has to be evicted first.

## Verification

Two full nuke-and-boot cycles, before and after. After the change: all daemons `RUNNING`, server `/healthz` 200, dashboard 200, seed completed in 18.4s with no errors. Confirmed the preflight now inspects the digest-pinned image, and that its warning and fix text render correctly by forcing a host/image arch mismatch.

## Reviewer notes

- The dashboard now serves while the server is still building, so requests in that window fail until it is up — the same behaviour as any server restart during development.
- Two larger items were deliberately left out: sharing Postgres/ClickHouse across worktrees (migrations are only 14s from cold, so the complexity is not yet worth it) and moving jaeger/prometheus/otel-collector behind a compose profile (would not speed up a boot, but would cut steady-state container load when many worktrees are live).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut cold worktree boot from 137s to 82s (dashboard reachable at 53s vs 106s). Also hardens Docker arch preflight to catch digest-pinned images and suggest the right fix.

- **Performance**
  - Launch dashboard immediately; Vite proxies per request.
  - Add `build:server-cache` to compile `main.go` once with identical ldflags; `zero` runs it in the background, waits for it before starting daemons, and cancels it if the boot is aborted.
  - Skip Presidio readiness in automated boots by setting `PRESIDIO_READINESS_TIMEOUT=0` in `workboot.sh` (interactive `./zero` still waits).

- **Bug Fixes**
  - `infra:start` now checks digest-pinned images against host arch using `docker image ls --digests` and shows the correct fix: for pins, evict then `docker pull --platform linux/$host_arch` (notes this removes containers across worktrees).

<sup>Written for commit 4a79280d2aed1dede2738b1feba18ad81e636a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

