### PR TITLE
mig(clickhouse): pre-aggregate challenge buckets

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create "authz_challenge_bucket_summaries_mv" view
+DROP VIEW `authz_challenge_bucket_summaries_mv`;
+-- reverse: create "authz_challenge_bucket_summaries" table
+DROP TABLE `authz_challenge_bucket_summaries`;

--- a/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.up.sql
@@ -22,34 +22,6 @@ CREATE TABLE `authz_challenge_bucket_summaries` (
   `first_seen` SimpleAggregateFunction(min, DateTime64(9)),
   `last_seen` SimpleAggregateFunction(max, DateTime64(9))
 ) ENGINE = AggregatingMergeTree
-PRIMARY KEY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
+PRIMARY KEY (`organization_id`, `project_id`, `outcome`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `project_id`, `outcome`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
 -- create "authz_challenge_bucket_summaries_mv" view
 CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
--- Backfill rows that predate the materialized view. Exact aggregate states make
--- overlap with concurrent view inserts idempotent when the states merge.
-INSERT INTO authz_challenge_bucket_summaries
-SELECT
-    toDate(timestamp, 'UTC') AS challenge_date,
-    organization_id,
-    project_id,
-    outcome,
-    scope,
-    principal_urn,
-    ifNull(authz_challenges.user_id, '') AS user_id_filter,
-    resource_kind,
-    resource_id,
-    argMaxState(id, timestamp) AS representative_id,
-    argMaxState(toString(principal_type), timestamp) AS principal_type,
-    argMaxState(authz_challenges.user_id, timestamp) AS user_id,
-    argMaxState(authz_challenges.user_email, timestamp) AS user_email,
-    argMaxState(toString(operation), timestamp) AS operation,
-    argMaxState(toString(reason), timestamp) AS reason,
-    argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
-    argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
-    max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
-    groupUniqArrayState(id) AS challenge_ids,
-    min(timestamp) AS first_seen,
-    max(timestamp) AS last_seen
-FROM authz_challenges
-WHERE scope != '' AND resource_kind != '' AND resource_id != ''
-GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;

--- a/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.up.sql
@@ -18,14 +18,13 @@ CREATE TABLE `authz_challenge_bucket_summaries` (
   `role_slugs` AggregateFunction(argMax, Array(String), DateTime64(9)),
   `evaluated_grant_count` AggregateFunction(argMax, UInt32, DateTime64(9)),
   `matched_grant_count` SimpleAggregateFunction(max, UInt64),
-  `challenge_count` AggregateFunction(uniqExact, UUID),
   `challenge_ids` AggregateFunction(groupUniqArray, UUID),
   `first_seen` SimpleAggregateFunction(min, DateTime64(9)),
   `last_seen` SimpleAggregateFunction(max, DateTime64(9))
 ) ENGINE = AggregatingMergeTree
 PRIMARY KEY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
 -- create "authz_challenge_bucket_summaries_mv" view
-CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, uniqExactState(id) AS challenge_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
+CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
 -- Backfill rows that predate the materialized view. Exact aggregate states make
 -- overlap with concurrent view inserts idempotent when the states merge.
 INSERT INTO authz_challenge_bucket_summaries
@@ -48,7 +47,6 @@ SELECT
     argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
     argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
     max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
-    uniqExactState(id) AS challenge_count,
     groupUniqArrayState(id) AS challenge_ids,
     min(timestamp) AS first_seen,
     max(timestamp) AS last_seen

--- a/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260811155533_challenge-bucket-summaries.up.sql
@@ -1,0 +1,57 @@
+-- create "authz_challenge_bucket_summaries" table
+CREATE TABLE `authz_challenge_bucket_summaries` (
+  `challenge_date` Date COMMENT 'UTC date of the summarized challenge rows.',
+  `organization_id` String COMMENT 'Organization the principal was acting in.' CODEC(ZSTD(1)),
+  `project_id` String COMMENT 'Project the check was scoped to.' CODEC(ZSTD(1)),
+  `outcome` LowCardinality(String) COMMENT 'Decision outcome.',
+  `scope` LowCardinality(String) COMMENT 'Scope of the focus check.',
+  `principal_urn` String COMMENT 'Primary principal URN.' CODEC(ZSTD(1)),
+  `user_id_filter` String COMMENT 'User ID used to suppress principals outside the organization.' CODEC(ZSTD(1)),
+  `resource_kind` LowCardinality(String) COMMENT 'Resource kind of the focus check.',
+  `resource_id` String COMMENT 'Resource ID of the focus check.' CODEC(ZSTD(1)),
+  `representative_id` AggregateFunction(argMax, UUID, DateTime64(9)),
+  `principal_type` AggregateFunction(argMax, String, DateTime64(9)),
+  `user_id` AggregateFunction(argMax, Nullable(String), DateTime64(9)),
+  `user_email` AggregateFunction(argMax, Nullable(String), DateTime64(9)),
+  `operation` AggregateFunction(argMax, String, DateTime64(9)),
+  `reason` AggregateFunction(argMax, String, DateTime64(9)),
+  `role_slugs` AggregateFunction(argMax, Array(String), DateTime64(9)),
+  `evaluated_grant_count` AggregateFunction(argMax, UInt32, DateTime64(9)),
+  `matched_grant_count` SimpleAggregateFunction(max, UInt64),
+  `challenge_count` AggregateFunction(uniqExact, UUID),
+  `challenge_ids` AggregateFunction(groupUniqArray, UUID),
+  `first_seen` SimpleAggregateFunction(min, DateTime64(9)),
+  `last_seen` SimpleAggregateFunction(max, DateTime64(9))
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
+-- create "authz_challenge_bucket_summaries_mv" view
+CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, uniqExactState(id) AS challenge_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
+-- Backfill rows that predate the materialized view. Exact aggregate states make
+-- overlap with concurrent view inserts idempotent when the states merge.
+INSERT INTO authz_challenge_bucket_summaries
+SELECT
+    toDate(timestamp, 'UTC') AS challenge_date,
+    organization_id,
+    project_id,
+    outcome,
+    scope,
+    principal_urn,
+    ifNull(authz_challenges.user_id, '') AS user_id_filter,
+    resource_kind,
+    resource_id,
+    argMaxState(id, timestamp) AS representative_id,
+    argMaxState(toString(principal_type), timestamp) AS principal_type,
+    argMaxState(authz_challenges.user_id, timestamp) AS user_id,
+    argMaxState(authz_challenges.user_email, timestamp) AS user_email,
+    argMaxState(toString(operation), timestamp) AS operation,
+    argMaxState(toString(reason), timestamp) AS reason,
+    argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
+    argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
+    max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
+    uniqExactState(id) AS challenge_count,
+    groupUniqArrayState(id) AS challenge_ids,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+FROM authz_challenges
+WHERE scope != '' AND resource_kind != '' AND resource_id != ''
+GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:80P0K0IywDt/4BvQc5I8qvbzXSf3zOIEmTYZIkshm3E=
+h1:nhOWGyyDv98QNWCsyGgXP8YZEKsJsfe0f0Iim/TEUK8=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -86,4 +86,4 @@ h1:80P0K0IywDt/4BvQc5I8qvbzXSf3zOIEmTYZIkshm3E=
 20260803192750_litellm-usage-in-summaries.up.sql h1:7L9bzpMEUz/JyjSe0uh+tQ3fvOhH3Ahm9Xavtl3xgZo=
 20260805105902_risk-findings-app-team-attribution.up.sql h1:UmQaEOmnP7ormKmGnaolNXAq2ogrRNVqxGj7EhfkGQ4=
 20260805161427_risk-findings-user-email.up.sql h1:2m9vZDNhLAZ2w5mVIS4vNtJtbTULtrHn+qZUU6ww3dE=
-20260811155533_challenge-bucket-summaries.up.sql h1:6XXOVJELIuDxKPJy2/6kHO0Ts1bpAXS6jVX1XvLBuIA=
+20260811155533_challenge-bucket-summaries.up.sql h1:wlr0qU+22lW55Px5NMcQRBIuozkNjnU3zlNVnvYQ5Ys=

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:nhOWGyyDv98QNWCsyGgXP8YZEKsJsfe0f0Iim/TEUK8=
+h1:0rR+UJolRapPBUsrFodmHjWjQ8oyTew2r2IOIZKy6lA=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -86,4 +86,4 @@ h1:nhOWGyyDv98QNWCsyGgXP8YZEKsJsfe0f0Iim/TEUK8=
 20260803192750_litellm-usage-in-summaries.up.sql h1:7L9bzpMEUz/JyjSe0uh+tQ3fvOhH3Ahm9Xavtl3xgZo=
 20260805105902_risk-findings-app-team-attribution.up.sql h1:UmQaEOmnP7ormKmGnaolNXAq2ogrRNVqxGj7EhfkGQ4=
 20260805161427_risk-findings-user-email.up.sql h1:2m9vZDNhLAZ2w5mVIS4vNtJtbTULtrHn+qZUU6ww3dE=
-20260811155533_challenge-bucket-summaries.up.sql h1:wlr0qU+22lW55Px5NMcQRBIuozkNjnU3zlNVnvYQ5Ys=
+20260811155533_challenge-bucket-summaries.up.sql h1:4+W+EYUk8z5tcrifQZAKKkecKy527L9MkVN/cWbPKhQ=

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:hj82rT4GwY/8s91jOfOT+KS9d4CQmkCJz41dnsp/Nb8=
+h1:80P0K0IywDt/4BvQc5I8qvbzXSf3zOIEmTYZIkshm3E=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -86,3 +86,4 @@ h1:hj82rT4GwY/8s91jOfOT+KS9d4CQmkCJz41dnsp/Nb8=
 20260803192750_litellm-usage-in-summaries.up.sql h1:7L9bzpMEUz/JyjSe0uh+tQ3fvOhH3Ahm9Xavtl3xgZo=
 20260805105902_risk-findings-app-team-attribution.up.sql h1:UmQaEOmnP7ormKmGnaolNXAq2ogrRNVqxGj7EhfkGQ4=
 20260805161427_risk-findings-user-email.up.sql h1:2m9vZDNhLAZ2w5mVIS4vNtJtbTULtrHn+qZUU6ww3dE=
+20260811155533_challenge-bucket-summaries.up.sql h1:6XXOVJELIuDxKPJy2/6kHO0Ts1bpAXS6jVX1XvLBuIA=

--- a/server/clickhouse/migrations/20260811155529_challenge-bucket-summaries.sql
+++ b/server/clickhouse/migrations/20260811155529_challenge-bucket-summaries.sql
@@ -1,0 +1,57 @@
+-- Create "authz_challenge_bucket_summaries" table
+CREATE TABLE `authz_challenge_bucket_summaries` (
+  `challenge_date` Date COMMENT 'UTC date of the summarized challenge rows.',
+  `organization_id` String COMMENT 'Organization the principal was acting in.' CODEC(ZSTD(1)),
+  `project_id` String COMMENT 'Project the check was scoped to.' CODEC(ZSTD(1)),
+  `outcome` LowCardinality(String) COMMENT 'Decision outcome.',
+  `scope` LowCardinality(String) COMMENT 'Scope of the focus check.',
+  `principal_urn` String COMMENT 'Primary principal URN.' CODEC(ZSTD(1)),
+  `user_id_filter` String COMMENT 'User ID used to suppress principals outside the organization.' CODEC(ZSTD(1)),
+  `resource_kind` LowCardinality(String) COMMENT 'Resource kind of the focus check.',
+  `resource_id` String COMMENT 'Resource ID of the focus check.' CODEC(ZSTD(1)),
+  `representative_id` AggregateFunction(argMax, UUID, DateTime64(9)),
+  `principal_type` AggregateFunction(argMax, String, DateTime64(9)),
+  `user_id` AggregateFunction(argMax, Nullable(String), DateTime64(9)),
+  `user_email` AggregateFunction(argMax, Nullable(String), DateTime64(9)),
+  `operation` AggregateFunction(argMax, String, DateTime64(9)),
+  `reason` AggregateFunction(argMax, String, DateTime64(9)),
+  `role_slugs` AggregateFunction(argMax, Array(String), DateTime64(9)),
+  `evaluated_grant_count` AggregateFunction(argMax, UInt32, DateTime64(9)),
+  `matched_grant_count` SimpleAggregateFunction(max, UInt64),
+  `challenge_count` AggregateFunction(uniqExact, UUID),
+  `challenge_ids` AggregateFunction(groupUniqArray, UUID),
+  `first_seen` SimpleAggregateFunction(min, DateTime64(9)),
+  `last_seen` SimpleAggregateFunction(max, DateTime64(9))
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
+-- Create "authz_challenge_bucket_summaries_mv" view
+CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, uniqExactState(id) AS challenge_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
+-- Backfill rows that predate the materialized view. Exact aggregate states make
+-- overlap with concurrent view inserts idempotent when the states merge.
+INSERT INTO authz_challenge_bucket_summaries
+SELECT
+    toDate(timestamp, 'UTC') AS challenge_date,
+    organization_id,
+    project_id,
+    outcome,
+    scope,
+    principal_urn,
+    ifNull(authz_challenges.user_id, '') AS user_id_filter,
+    resource_kind,
+    resource_id,
+    argMaxState(id, timestamp) AS representative_id,
+    argMaxState(toString(principal_type), timestamp) AS principal_type,
+    argMaxState(authz_challenges.user_id, timestamp) AS user_id,
+    argMaxState(authz_challenges.user_email, timestamp) AS user_email,
+    argMaxState(toString(operation), timestamp) AS operation,
+    argMaxState(toString(reason), timestamp) AS reason,
+    argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
+    argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
+    max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
+    uniqExactState(id) AS challenge_count,
+    groupUniqArrayState(id) AS challenge_ids,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+FROM authz_challenges
+WHERE scope != '' AND resource_kind != '' AND resource_id != ''
+GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;

--- a/server/clickhouse/migrations/20260811155529_challenge-bucket-summaries.sql
+++ b/server/clickhouse/migrations/20260811155529_challenge-bucket-summaries.sql
@@ -18,14 +18,13 @@ CREATE TABLE `authz_challenge_bucket_summaries` (
   `role_slugs` AggregateFunction(argMax, Array(String), DateTime64(9)),
   `evaluated_grant_count` AggregateFunction(argMax, UInt32, DateTime64(9)),
   `matched_grant_count` SimpleAggregateFunction(max, UInt64),
-  `challenge_count` AggregateFunction(uniqExact, UUID),
   `challenge_ids` AggregateFunction(groupUniqArray, UUID),
   `first_seen` SimpleAggregateFunction(min, DateTime64(9)),
   `last_seen` SimpleAggregateFunction(max, DateTime64(9))
 ) ENGINE = AggregatingMergeTree
 PRIMARY KEY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
 -- Create "authz_challenge_bucket_summaries_mv" view
-CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, uniqExactState(id) AS challenge_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
+CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
 -- Backfill rows that predate the materialized view. Exact aggregate states make
 -- overlap with concurrent view inserts idempotent when the states merge.
 INSERT INTO authz_challenge_bucket_summaries
@@ -48,7 +47,6 @@ SELECT
     argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
     argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
     max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
-    uniqExactState(id) AS challenge_count,
     groupUniqArrayState(id) AS challenge_ids,
     min(timestamp) AS first_seen,
     max(timestamp) AS last_seen

--- a/server/clickhouse/migrations/20260811155529_challenge-bucket-summaries.sql
+++ b/server/clickhouse/migrations/20260811155529_challenge-bucket-summaries.sql
@@ -22,34 +22,6 @@ CREATE TABLE `authz_challenge_bucket_summaries` (
   `first_seen` SimpleAggregateFunction(min, DateTime64(9)),
   `last_seen` SimpleAggregateFunction(max, DateTime64(9))
 ) ENGINE = AggregatingMergeTree
-PRIMARY KEY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `outcome`, `project_id`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
+PRIMARY KEY (`organization_id`, `project_id`, `outcome`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) ORDER BY (`organization_id`, `project_id`, `outcome`, `scope`, `challenge_date`, `principal_urn`, `user_id_filter`, `resource_kind`, `resource_id`) PARTITION BY (toYYYYMM(challenge_date)) TTL challenge_date + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
 -- Create "authz_challenge_bucket_summaries_mv" view
 CREATE MATERIALIZED VIEW `authz_challenge_bucket_summaries_mv` TO `authz_challenge_bucket_summaries` AS SELECT toDate(timestamp, 'UTC') AS challenge_date, organization_id, project_id, outcome, scope, principal_urn, ifNull(authz_challenges.user_id, '') AS user_id_filter, resource_kind, resource_id, argMaxState(id, timestamp) AS representative_id, argMaxState(toString(principal_type), timestamp) AS principal_type, argMaxState(authz_challenges.user_id, timestamp) AS user_id, argMaxState(authz_challenges.user_email, timestamp) AS user_email, argMaxState(toString(operation), timestamp) AS operation, argMaxState(toString(reason), timestamp) AS reason, argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs, argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count, max(toUInt64(length(matched_grants.scope))) AS matched_grant_count, groupUniqArrayState(id) AS challenge_ids, min(timestamp) AS first_seen, max(timestamp) AS last_seen FROM authz_challenges WHERE (scope != '') AND (resource_kind != '') AND (resource_id != '') GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
--- Backfill rows that predate the materialized view. Exact aggregate states make
--- overlap with concurrent view inserts idempotent when the states merge.
-INSERT INTO authz_challenge_bucket_summaries
-SELECT
-    toDate(timestamp, 'UTC') AS challenge_date,
-    organization_id,
-    project_id,
-    outcome,
-    scope,
-    principal_urn,
-    ifNull(authz_challenges.user_id, '') AS user_id_filter,
-    resource_kind,
-    resource_id,
-    argMaxState(id, timestamp) AS representative_id,
-    argMaxState(toString(principal_type), timestamp) AS principal_type,
-    argMaxState(authz_challenges.user_id, timestamp) AS user_id,
-    argMaxState(authz_challenges.user_email, timestamp) AS user_email,
-    argMaxState(toString(operation), timestamp) AS operation,
-    argMaxState(toString(reason), timestamp) AS reason,
-    argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
-    argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
-    max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
-    groupUniqArrayState(id) AS challenge_ids,
-    min(timestamp) AS first_seen,
-    max(timestamp) AS last_seen
-FROM authz_challenges
-WHERE scope != '' AND resource_kind != '' AND resource_id != ''
-GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Mq76XAULFPC58+uB8wBu3kO3XpxMHdIqhHv/CX1zADg=
+h1:cYEp4U9oK4H77sqsWvI4fv6SUaliqk3qAsjyfWTDabM=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -91,3 +91,4 @@ h1:Mq76XAULFPC58+uB8wBu3kO3XpxMHdIqhHv/CX1zADg=
 20260803192745_litellm-usage-in-summaries.sql h1:dMsZ2uPJxHOq8HL/Y0Eb0acbiPscYc9DMRdBZgKVYTo=
 20260805105857_risk-findings-app-team-attribution.sql h1:vfAJnjNr6OCXRxKCft2zjU02TZ6MjdfSMGqcLWchAos=
 20260805161421_risk-findings-user-email.sql h1:vIbFrSbYl1wNZ+j1o3GKTsE7s5yIFAQEcHhnqB2yW9Q=
+20260811155529_challenge-bucket-summaries.sql h1:tQGa7la3/+nILl/I3QTTlUXaQ+lz4HoY5ap9CaOOrf4=

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:s94lHHbE7sUCJ2QV2DOzuDnrlip1viMQ/BXFkLsB8T0=
+h1:wqRCuiA4X/gRsCVatiyVFLaAAH+f1X9AHjcJoFb65TA=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -91,4 +91,4 @@ h1:s94lHHbE7sUCJ2QV2DOzuDnrlip1viMQ/BXFkLsB8T0=
 20260803192745_litellm-usage-in-summaries.sql h1:dMsZ2uPJxHOq8HL/Y0Eb0acbiPscYc9DMRdBZgKVYTo=
 20260805105857_risk-findings-app-team-attribution.sql h1:vfAJnjNr6OCXRxKCft2zjU02TZ6MjdfSMGqcLWchAos=
 20260805161421_risk-findings-user-email.sql h1:vIbFrSbYl1wNZ+j1o3GKTsE7s5yIFAQEcHhnqB2yW9Q=
-20260811155529_challenge-bucket-summaries.sql h1:WzxDiv2NJE7E8FVlPYcBqEJDWIR84sOS1lJPJYQpSnM=
+20260811155529_challenge-bucket-summaries.sql h1:9p9pNlNAgWvl6qsKuExCMP80qVONmNRxeThkJbBmkiE=

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:cYEp4U9oK4H77sqsWvI4fv6SUaliqk3qAsjyfWTDabM=
+h1:s94lHHbE7sUCJ2QV2DOzuDnrlip1viMQ/BXFkLsB8T0=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -91,4 +91,4 @@ h1:cYEp4U9oK4H77sqsWvI4fv6SUaliqk3qAsjyfWTDabM=
 20260803192745_litellm-usage-in-summaries.sql h1:dMsZ2uPJxHOq8HL/Y0Eb0acbiPscYc9DMRdBZgKVYTo=
 20260805105857_risk-findings-app-team-attribution.sql h1:vfAJnjNr6OCXRxKCft2zjU02TZ6MjdfSMGqcLWchAos=
 20260805161421_risk-findings-user-email.sql h1:vIbFrSbYl1wNZ+j1o3GKTsE7s5yIFAQEcHhnqB2yW9Q=
-20260811155529_challenge-bucket-summaries.sql h1:tQGa7la3/+nILl/I3QTTlUXaQ+lz4HoY5ap9CaOOrf4=
+20260811155529_challenge-bucket-summaries.sql h1:WzxDiv2NJE7E8FVlPYcBqEJDWIR84sOS1lJPJYQpSnM=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1274,7 +1274,6 @@ CREATE TABLE IF NOT EXISTS authz_challenge_bucket_summaries (
     role_slugs AggregateFunction(argMax, Array(String), DateTime64(9)),
     evaluated_grant_count AggregateFunction(argMax, UInt32, DateTime64(9)),
     matched_grant_count SimpleAggregateFunction(max, UInt64),
-    challenge_count AggregateFunction(uniqExact, UUID),
     challenge_ids AggregateFunction(groupUniqArray, UUID),
     first_seen SimpleAggregateFunction(min, DateTime64(9)),
     last_seen SimpleAggregateFunction(max, DateTime64(9))
@@ -1305,7 +1304,6 @@ SELECT
     argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
     argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
     max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
-    uniqExactState(id) AS challenge_count,
     groupUniqArrayState(id) AS challenge_ids,
     min(timestamp) AS first_seen,
     max(timestamp) AS last_seen

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1279,7 +1279,7 @@ CREATE TABLE IF NOT EXISTS authz_challenge_bucket_summaries (
     last_seen SimpleAggregateFunction(max, DateTime64(9))
 ) ENGINE = AggregatingMergeTree
 PARTITION BY toYYYYMM(challenge_date)
-ORDER BY (organization_id, outcome, project_id, scope, challenge_date, principal_urn, user_id_filter, resource_kind, resource_id)
+ORDER BY (organization_id, project_id, outcome, scope, challenge_date, principal_urn, user_id_filter, resource_kind, resource_id)
 TTL challenge_date + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1253,6 +1253,66 @@ CREATE INDEX IF NOT EXISTS idx_authz_challenges_api_key_id ON authz_challenges (
 CREATE INDEX IF NOT EXISTS idx_authz_challenges_scope ON authz_challenges (scope) TYPE set(0) GRANULARITY 4;
 CREATE INDEX IF NOT EXISTS idx_authz_challenges_reason ON authz_challenges (reason) TYPE set(0) GRANULARITY 4;
 
+CREATE TABLE IF NOT EXISTS authz_challenge_bucket_summaries (
+    challenge_date Date COMMENT 'UTC date of the summarized challenge rows.',
+
+    organization_id String COMMENT 'Organization the principal was acting in.' CODEC(ZSTD),
+    project_id String COMMENT 'Project the check was scoped to.' CODEC(ZSTD),
+    outcome LowCardinality(String) COMMENT 'Decision outcome.',
+    scope LowCardinality(String) COMMENT 'Scope of the focus check.',
+    principal_urn String COMMENT 'Primary principal URN.' CODEC(ZSTD),
+    user_id_filter String COMMENT 'User ID used to suppress principals outside the organization.' CODEC(ZSTD),
+    resource_kind LowCardinality(String) COMMENT 'Resource kind of the focus check.',
+    resource_id String COMMENT 'Resource ID of the focus check.' CODEC(ZSTD),
+
+    representative_id AggregateFunction(argMax, UUID, DateTime64(9)),
+    principal_type AggregateFunction(argMax, String, DateTime64(9)),
+    user_id AggregateFunction(argMax, Nullable(String), DateTime64(9)),
+    user_email AggregateFunction(argMax, Nullable(String), DateTime64(9)),
+    operation AggregateFunction(argMax, String, DateTime64(9)),
+    reason AggregateFunction(argMax, String, DateTime64(9)),
+    role_slugs AggregateFunction(argMax, Array(String), DateTime64(9)),
+    evaluated_grant_count AggregateFunction(argMax, UInt32, DateTime64(9)),
+    matched_grant_count SimpleAggregateFunction(max, UInt64),
+    challenge_count AggregateFunction(uniqExact, UUID),
+    challenge_ids AggregateFunction(groupUniqArray, UUID),
+    first_seen SimpleAggregateFunction(min, DateTime64(9)),
+    last_seen SimpleAggregateFunction(max, DateTime64(9))
+) ENGINE = AggregatingMergeTree
+PARTITION BY toYYYYMM(challenge_date)
+ORDER BY (organization_id, outcome, project_id, scope, challenge_date, principal_urn, user_id_filter, resource_kind, resource_id)
+TTL challenge_date + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192
+COMMENT 'Daily pre-aggregated authz challenge buckets for the Challenge UI';
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS authz_challenge_bucket_summaries_mv TO authz_challenge_bucket_summaries AS
+SELECT
+    toDate(timestamp, 'UTC') AS challenge_date,
+    organization_id,
+    project_id,
+    outcome,
+    scope,
+    principal_urn,
+    ifNull(authz_challenges.user_id, '') AS user_id_filter,
+    resource_kind,
+    resource_id,
+    argMaxState(id, timestamp) AS representative_id,
+    argMaxState(toString(principal_type), timestamp) AS principal_type,
+    argMaxState(authz_challenges.user_id, timestamp) AS user_id,
+    argMaxState(authz_challenges.user_email, timestamp) AS user_email,
+    argMaxState(toString(operation), timestamp) AS operation,
+    argMaxState(toString(reason), timestamp) AS reason,
+    argMaxState(arrayMap(x -> toString(x), role_slugs), timestamp) AS role_slugs,
+    argMaxState(evaluated_grant_count, timestamp) AS evaluated_grant_count,
+    max(toUInt64(length(matched_grants.scope))) AS matched_grant_count,
+    uniqExactState(id) AS challenge_count,
+    groupUniqArrayState(id) AS challenge_ids,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+FROM authz_challenges
+WHERE scope != '' AND resource_kind != '' AND resource_id != ''
+GROUP BY challenge_date, organization_id, project_id, outcome, scope, principal_urn, user_id_filter, resource_kind, resource_id;
+
 CREATE TABLE IF NOT EXISTS risk_findings (
     -- Identity
     id UUID COMMENT 'Finding UUIDv7, supplied by the scanner that produced it.',


### PR DESCRIPTION
## Summary

- add a daily AggregatingMergeTree summary and incremental materialized view for authorization challenge buckets
- order the summary key for organization- and project-scoped pruning
- ship synchronized Atlas and golang-migrate schema migrations

## Why

The Challenges page currently rebuilds bucket aggregates from the raw 90-day authorization event log on every request. This migration creates the summary read model needed to move that repeated work to ingestion time.

This PR intentionally contains only schema and migration changes. Historical population will be delivered and run as a separate operational backfill after this migration is applied. The application read-path change remains draft until that backfill is confirmed complete.

## Validation

- `mise run clickhouse:hash`
- `mise lint:migrations`
- `mise run clickhouse:migrate`
- `mise exec -- go test ./server/internal/access -run '^TestListChallengeBuckets_' -count=1`
- `git diff --check`