### PR TITLE
perf(access): speed up challenge logs

### DIFF
--- a/.changeset/fast-challenge-logs.md
+++ b/.changeset/fast-challenge-logs.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+---
+
+Serve challenge-log buckets from the pre-aggregated ClickHouse summary and
+paginate resolved and unresolved results in ClickHouse.

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -761,15 +761,17 @@ func (s *Service) ListChallenges(ctx context.Context, payload *gen.ListChallenge
 	}
 
 	filters := chrepo.ChallengeListFilters{
-		OrganizationID: authCtx.ActiveOrganizationID,
-		ProjectID:      payload.ProjectID,
-		Outcome:        payload.Outcome,
-		PrincipalURN:   payload.PrincipalUrn,
-		Scope:          payload.Scope,
-		Limit:          uint64(payload.Limit),  //nolint:gosec // Goa validates 1..200
-		Offset:         uint64(payload.Offset), //nolint:gosec // Goa validates >= 0
-		SkipPagination: skipPagination,
-		MemberUserIDs:  memberIDs,
+		OrganizationID:       authCtx.ActiveOrganizationID,
+		ProjectID:            payload.ProjectID,
+		Outcome:              payload.Outcome,
+		PrincipalURN:         payload.PrincipalUrn,
+		Scope:                payload.Scope,
+		Resolved:             nil,
+		ResolvedChallengeIDs: nil,
+		Limit:                uint64(payload.Limit),  //nolint:gosec // Goa validates 1..200
+		Offset:               uint64(payload.Offset), //nolint:gosec // Goa validates >= 0
+		SkipPagination:       skipPagination,
+		MemberUserIDs:        memberIDs,
 	}
 
 	var total uint64
@@ -962,47 +964,49 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 		attr.UserID(authCtx.UserID),
 	)
 
-	skipPagination := payload.Resolved != nil
-
 	// Suppress challenges from users outside the org (see activeOrgMemberUserIDs).
 	memberIDs, err := s.activeOrgMemberUserIDs(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, err
 	}
 
+	var resolvedChallengeIDs []string
+	if payload.Resolved != nil {
+		resolvedChallengeIDs, err = repo.New(s.db).ListResolvedChallengeIDs(ctx, authCtx.ActiveOrganizationID)
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "list resolved challenge ids").LogError(ctx, s.logger)
+		}
+		if *payload.Resolved && len(resolvedChallengeIDs) == 0 {
+			return &gen.ListChallengeBucketsResult{Buckets: []*gen.ChallengeBucket{}, Total: 0}, nil
+		}
+	}
+
 	filters := chrepo.ChallengeListFilters{
-		OrganizationID: authCtx.ActiveOrganizationID,
-		ProjectID:      payload.ProjectID,
-		Outcome:        payload.Outcome,
-		PrincipalURN:   payload.PrincipalUrn,
-		Scope:          payload.Scope,
-		Limit:          uint64(payload.Limit),  //nolint:gosec // Goa validates 1..200
-		Offset:         uint64(payload.Offset), //nolint:gosec // Goa validates >= 0
-		SkipPagination: skipPagination,
-		MemberUserIDs:  memberIDs,
+		OrganizationID:       authCtx.ActiveOrganizationID,
+		ProjectID:            payload.ProjectID,
+		Outcome:              payload.Outcome,
+		PrincipalURN:         payload.PrincipalUrn,
+		Scope:                payload.Scope,
+		Resolved:             payload.Resolved,
+		ResolvedChallengeIDs: resolvedChallengeIDs,
+		Limit:                uint64(payload.Limit),  //nolint:gosec // Goa validates 1..200
+		Offset:               uint64(payload.Offset), //nolint:gosec // Goa validates >= 0
+		SkipPagination:       false,
+		MemberUserIDs:        memberIDs,
 	}
 
 	chQueries := chrepo.New(s.chConn)
 
-	var total uint64
-	if !skipPagination {
-		count, err := chQueries.CountChallengeBuckets(ctx, filters)
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "count challenge buckets from clickhouse").LogError(ctx, s.logger)
-		}
-		if count == 0 {
-			return &gen.ListChallengeBucketsResult{Buckets: []*gen.ChallengeBucket{}, Total: 0}, nil
-		}
-		total = count
-	}
-
-	buckets, err := chQueries.ListChallengeBuckets(ctx, filters)
+	buckets, total, err := chQueries.ListChallengeBuckets(ctx, filters)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list challenge buckets from clickhouse").LogError(ctx, s.logger)
 	}
 
 	if len(buckets) == 0 {
-		return &gen.ListChallengeBucketsResult{Buckets: []*gen.ChallengeBucket{}, Total: int(total)}, nil
+		return &gen.ListChallengeBucketsResult{
+			Buckets: []*gen.ChallengeBucket{},
+			Total:   int(total), //nolint:gosec // Goa models totals as int; retained challenge rows cannot approach MaxInt.
+		}, nil
 	}
 
 	// Batch-lookup resolutions from PG using all challenge IDs across buckets.
@@ -1021,28 +1025,6 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 	resolutionMap := make(map[string]repo.AuthzChallengeResolution, len(resolutions))
 	for _, r := range resolutions {
 		resolutionMap[r.ChallengeID] = r
-	}
-
-	// Apply resolved filter post-join if requested, then paginate in Go.
-	if payload.Resolved != nil {
-		wantResolved := *payload.Resolved
-		filtered := buckets[:0]
-		for _, b := range buckets {
-			_, hasResolution := resolutionMap[b.ID]
-			if hasResolution == wantResolved {
-				filtered = append(filtered, b)
-			}
-		}
-		buckets = filtered
-		total = uint64(len(buckets))
-		offset := uint64(payload.Offset) //nolint:gosec // Goa validates >= 0
-		limit := uint64(payload.Limit)   //nolint:gosec // Goa validates 1..200
-		if offset >= total {
-			buckets = nil
-		} else {
-			end := min(offset+limit, total)
-			buckets = buckets[offset:end]
-		}
 	}
 
 	// Batch-lookup user photos from PG.
@@ -1142,7 +1124,7 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 
 	return &gen.ListChallengeBucketsResult{
 		Buckets: result,
-		Total:   int(total),
+		Total:   int(total), //nolint:gosec // Goa models totals as int; retained challenge rows cannot approach MaxInt.
 	}, nil
 }
 

--- a/server/internal/access/list_challenge_buckets_test.go
+++ b/server/internal/access/list_challenge_buckets_test.go
@@ -187,9 +187,11 @@ func TestListChallengeBuckets_FilterByResolved(t *testing.T) {
 
 	resolvedID := uuid.NewString()
 	unresolvedID := uuid.NewString()
+	unresolvedID2 := uuid.NewString()
 	// Different principals so they land in different buckets.
 	insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, resolvedID, "deny", "user:resolved-user", "org:read")
 	insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, unresolvedID, "deny", "user:unresolved-user", "org:read")
+	insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, unresolvedID2, "deny", "user:unresolved-user-2", "org:read")
 
 	// Resolve only the first.
 	_, err := accessrepo.New(ti.conn).InsertChallengeResolutions(ctx, accessrepo.InsertChallengeResolutionsParams{
@@ -228,6 +230,7 @@ func TestListChallengeBuckets_FilterByResolved(t *testing.T) {
 		if !assert.Len(c, result.Buckets, 1) {
 			return
 		}
+		assert.Equal(c, 1, result.Total)
 		assert.NotNil(c, result.Buckets[0].ResolvedAt)
 	}, 10*time.Second, 100*time.Millisecond)
 
@@ -239,14 +242,15 @@ func TestListChallengeBuckets_FilterByResolved(t *testing.T) {
 		Scope:        nil,
 		ProjectID:    nil,
 		Resolved:     &resolvedFalse,
-		Limit:        20,
+		Limit:        1,
 		Offset:       0,
 		ApikeyToken:  nil,
 		SessionToken: nil,
 	})
 	require.NoError(t, err)
 	require.Len(t, result.Buckets, 1)
-	require.Equal(t, "user:unresolved-user", result.Buckets[0].PrincipalUrn)
+	require.Equal(t, 2, result.Total)
+	require.Contains(t, []string{"user:unresolved-user", "user:unresolved-user-2"}, result.Buckets[0].PrincipalUrn)
 }
 
 func TestListChallengeBuckets_Pagination(t *testing.T) {

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -118,6 +118,11 @@ SELECT * FROM authz_challenge_resolutions
 WHERE organization_id = @organization_id
   AND challenge_id = ANY(@challenge_ids::text[]);
 
+-- name: ListResolvedChallengeIDs :many
+-- Returns the resolved challenge IDs used to filter ClickHouse bucket aggregates.
+SELECT challenge_id FROM authz_challenge_resolutions
+WHERE organization_id = @organization_id;
+
 -- name: InsertChallengeResolutions :many
 -- Creates resolution records for one or more denied challenges.
 -- Silently skips challenges that are already resolved (ON CONFLICT DO NOTHING).

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -1547,6 +1547,32 @@ func (q *Queries) ListPrincipalGrantsByResourceIDs(ctx context.Context, arg List
 	return items, nil
 }
 
+const listResolvedChallengeIDs = `-- name: ListResolvedChallengeIDs :many
+SELECT challenge_id FROM authz_challenge_resolutions
+WHERE organization_id = $1
+`
+
+// Returns the resolved challenge IDs used to filter ClickHouse bucket aggregates.
+func (q *Queries) ListResolvedChallengeIDs(ctx context.Context, organizationID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listResolvedChallengeIDs, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var challenge_id string
+		if err := rows.Scan(&challenge_id); err != nil {
+			return nil, err
+		}
+		items = append(items, challenge_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markGlobalRoleDeleted = `-- name: MarkGlobalRoleDeleted :execrows
 UPDATE global_roles
 SET workos_deleted_at = $1,

--- a/server/internal/authz/repo/queries.go
+++ b/server/internal/authz/repo/queries.go
@@ -135,6 +135,12 @@ type ChallengeListFilters struct {
 	Outcome        *string
 	PrincipalURN   *string
 	Scope          *string
+	Resolved       *bool
+
+	// ResolvedChallengeIDs identifies challenge rows with a resolution record.
+	// Bucket queries compare these IDs with each bucket's representative row.
+	ResolvedChallengeIDs []string
+
 	Limit          uint64
 	Offset         uint64
 	SkipPagination bool // when true, omit LIMIT/OFFSET (used when resolved filter requires post-join pagination)
@@ -178,18 +184,49 @@ func challengeWhere(sb squirrel.SelectBuilder, f ChallengeListFilters) squirrel.
 	return sb
 }
 
-// challengeAttributed keeps only rows that name what was checked.
-//
-// Batch Filter and FindMatched calls log a single row for the whole batch with
-// a nil focus check, so scope, resource_kind and resource_id are all written
-// empty. Those rows carry nothing to display and nothing to grant against, and
-// they are produced on the hottest paths (project and toolset listing, MCP
-// tools/list), which makes them the most recent buckets in almost every
-// organization. Dropping them here rather than in the caller keeps LIMIT/OFFSET
-// and the bucket total consistent with what is actually returned — filtering
-// after pagination lets them fill a page and starve it of real buckets.
-func challengeAttributed(sb squirrel.SelectBuilder) squirrel.SelectBuilder {
-	return sb.Where("scope != '' AND resource_kind != '' AND resource_id != ''")
+// challengeBucketWhere applies filters to the pre-aggregated challenge bucket
+// summary. Unattributed challenge rows are excluded when the summary is built.
+func challengeBucketWhere(sb squirrel.SelectBuilder, f ChallengeListFilters) squirrel.SelectBuilder {
+	sb = sb.Where("organization_id = ?", f.OrganizationID)
+	if f.ProjectID != nil {
+		sb = sb.Where("project_id = ?", *f.ProjectID)
+	}
+	if f.Outcome != nil {
+		sb = sb.Where("outcome = ?", *f.Outcome)
+	}
+	if f.PrincipalURN != nil {
+		sb = sb.Where("principal_urn = ?", *f.PrincipalURN)
+	}
+	if f.Scope != nil {
+		sb = sb.Where("scope = ?", *f.Scope)
+	}
+	if f.MemberUserIDs != nil {
+		sb = sb.Where(squirrel.Or{
+			squirrel.Eq{"user_id_filter": ""},
+			squirrel.Eq{"user_id_filter": f.MemberUserIDs},
+		})
+	}
+	return sb
+}
+
+// challengeBucketResolution filters grouped buckets by whether their most
+// recent challenge has a resolution record in PostgreSQL.
+func challengeBucketResolution(sb squirrel.SelectBuilder, f ChallengeListFilters, representativeID string) squirrel.SelectBuilder {
+	if f.Resolved == nil {
+		return sb
+	}
+
+	if len(f.ResolvedChallengeIDs) == 0 {
+		if *f.Resolved {
+			return sb.Having("0")
+		}
+		return sb
+	}
+
+	if *f.Resolved {
+		return sb.Having(squirrel.Eq{representativeID: f.ResolvedChallengeIDs})
+	}
+	return sb.Having(squirrel.NotEq{representativeID: f.ResolvedChallengeIDs})
 }
 
 // challengePagination applies LIMIT/OFFSET to a squirrel SelectBuilder when not skipped.
@@ -393,52 +430,54 @@ type ChallengeBucket struct {
 }
 
 var challengeBucketColumns = []string{
-	"argMax(id, timestamp) AS rep_id",
-	"formatDateTime(max(timestamp), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') AS last_seen",
+	"argMaxMerge(representative_id) AS bucket_id",
+	"formatDateTime(max(last_seen), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') AS bucket_last_seen",
 	"organization_id",
 	"project_id",
 	"principal_urn",
-	"argMax(principal_type, timestamp) AS principal_type",
-	"argMax(user_id, timestamp) AS user_id",
-	"argMax(user_email, timestamp) AS user_email",
-	"argMax(operation, timestamp) AS operation",
+	"argMaxMerge(principal_type) AS bucket_principal_type",
+	"argMaxMerge(user_id) AS bucket_user_id",
+	"argMaxMerge(user_email) AS bucket_user_email",
+	"argMaxMerge(operation) AS bucket_operation",
 	"outcome",
-	"argMax(reason, timestamp) AS reason",
+	"argMaxMerge(reason) AS bucket_reason",
 	"scope",
 	"resource_kind",
 	"resource_id",
-	"argMax(role_slugs, timestamp) AS role_slugs",
-	"argMax(evaluated_grant_count, timestamp) AS evaluated_grant_count",
-	"max(length(matched_grants.scope)) AS matched_grant_count",
-	"uniqExact(id) AS challenge_count",
-	"arrayMap(x -> toString(x), groupUniqArray(id)) AS challenge_ids",
-	"formatDateTime(min(timestamp), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') AS first_seen",
+	"argMaxMerge(role_slugs) AS bucket_role_slugs",
+	"argMaxMerge(evaluated_grant_count) AS bucket_evaluated_grant_count",
+	"max(matched_grant_count) AS bucket_matched_grant_count",
+	"uniqExactMerge(challenge_count) AS bucket_challenge_count",
+	"arrayMap(x -> toString(x), groupUniqArrayMerge(challenge_ids)) AS bucket_challenge_ids",
+	"formatDateTime(min(first_seen), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') AS bucket_first_seen",
+	"count() OVER () AS total_count",
 }
 
 const challengeBucketGroupBy = "organization_id, project_id, principal_urn, scope, outcome, resource_kind, resource_id"
 
 // ListChallengeBuckets returns challenges grouped by dimensions, paginated.
-func (q *Queries) ListChallengeBuckets(ctx context.Context, f ChallengeListFilters) ([]ChallengeBucket, error) {
+func (q *Queries) ListChallengeBuckets(ctx context.Context, f ChallengeListFilters) ([]ChallengeBucket, uint64, error) {
 	sb := sq.Select(challengeBucketColumns...).
-		From("authz_challenges").
+		From("authz_challenge_bucket_summaries").
 		GroupBy(challengeBucketGroupBy).
-		OrderBy("max(timestamp) DESC")
-	sb = challengeWhere(sb, f)
-	sb = challengeAttributed(sb)
+		OrderBy("bucket_last_seen DESC")
+	sb = challengeBucketWhere(sb, f)
+	sb = challengeBucketResolution(sb, f, "argMaxMerge(representative_id)")
 	sb = challengePagination(sb, f)
 
 	query, args, err := sb.ToSql()
 	if err != nil {
-		return nil, fmt.Errorf("build list challenge buckets query: %w", err)
+		return nil, 0, fmt.Errorf("build list challenge buckets query: %w", err)
 	}
 
 	rows, err := q.conn.Query(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("exec list challenge buckets: %w", err)
+		return nil, 0, fmt.Errorf("exec list challenge buckets: %w", err)
 	}
 	defer rows.Close() //nolint:errcheck // best-effort close
 
 	var results []ChallengeBucket
+	var total uint64
 	for rows.Next() {
 		var r ChallengeBucket
 		if err := rows.Scan(
@@ -462,24 +501,35 @@ func (q *Queries) ListChallengeBuckets(ctx context.Context, f ChallengeListFilte
 			&r.ChallengeCount,
 			&r.ChallengeIDs,
 			&r.FirstSeen,
+			&total,
 		); err != nil {
-			return nil, fmt.Errorf("scan challenge bucket row: %w", err)
+			return nil, 0, fmt.Errorf("scan challenge bucket row: %w", err)
 		}
 		results = append(results, r)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate challenge bucket rows: %w", err)
+		return nil, 0, fmt.Errorf("iterate challenge bucket rows: %w", err)
 	}
-	return results, nil
+
+	// A nonzero offset can become stale if buckets disappear between pages. The
+	// window total is unavailable when LIMIT/OFFSET returns no rows, so retain a
+	// count-only fallback for that uncommon case.
+	if total == 0 && f.Offset > 0 {
+		total, err = q.CountChallengeBuckets(ctx, f)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	return results, total, nil
 }
 
 // CountChallengeBuckets returns the total number of dimension groups for pagination.
 func (q *Queries) CountChallengeBuckets(ctx context.Context, f ChallengeListFilters) (uint64, error) {
 	inner := sq.Select("1").
-		From("authz_challenges").
+		From("authz_challenge_bucket_summaries").
 		GroupBy(challengeBucketGroupBy)
-	inner = challengeWhere(inner, f)
-	inner = challengeAttributed(inner)
+	inner = challengeBucketWhere(inner, f)
+	inner = challengeBucketResolution(inner, f, "argMaxMerge(representative_id)")
 
 	innerQuery, args, err := inner.ToSql()
 	if err != nil {


### PR DESCRIPTION
## Summary

- read challenge buckets from the pre-aggregated summary
- apply resolved and unresolved filtering in ClickHouse before pagination
- return the exact total from the same query while retaining the stale-offset fallback
- add an organization-scoped resolved challenge ID lookup and pagination coverage

## Why

The endpoint previously grouped raw challenge events, ran a separate grouped count, and—when filtering by resolution state—loaded every matching bucket before joining and slicing in Go. Page-load cost therefore grew with retained history instead of page size.

This PR is stacked on #5182. Merge the migration PR first.

## Validation

- `mise run gen:sqlc-server`
- `mise exec -- go test ./server/internal/access -count=1`
- `mise lint:server`
- changeset formatting check
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up challenge log buckets by reading from a pre-aggregated ClickHouse summary and moving resolved/unresolved filtering and pagination into ClickHouse. Returns exact totals from the same query, with a safe fallback when offsets go stale.

- **Refactors**
  - Switch bucket queries to `authz_challenge_bucket_summaries`; order by `bucket_last_seen`; include a windowed total and fallback to a count-only query if the paged window is empty.
  - Add an org-scoped resolved challenge ID lookup in Postgres and pass IDs to ClickHouse for `Resolved` filtering; remove Go-side post-join filtering and pagination.
  - Extend filters (`Resolved`, `ResolvedChallengeIDs`) and update tests to cover resolved-state pagination.

<sup>Written for commit 058005511c5aa1e5fb2e7c2a26f441f9e25a8015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

