### PR TITLE
mig: daniel/dno-821-litellm-proxied-session-marker

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2019,6 +2019,13 @@ CREATE TABLE IF NOT EXISTS chats (
   -- referenced without a FK; integrity is maintained by ingest.
   user_account_id uuid,
 
+  -- True when any event for this session was observed by the LiteLLM proxy,
+  -- set by hooks ingest independently of whether the proxied transcript row
+  -- itself was persisted. Sessions natively captured by an agent's own hook
+  -- stream suppress their proxied rows as duplicates, so message sources
+  -- alone cannot tell that the session was routed through LiteLLM.
+  litellm_proxied boolean NOT NULL DEFAULT false,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   deleted_at timestamptz,

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -636,7 +636,7 @@ func (q *Queries) GetAssistantThreadAssistantIDByChatID(ctx context.Context, arg
 }
 
 const getChat = `-- name: GetChat :one
-SELECT c.id, c.project_id, c.organization_id, c.user_id, c.external_user_id, c.external_chat_id, c.title, c.title_manually_set, c.pinned_at, c.summary, c.summary_generated_at, c.user_account_id, c.created_at, c.updated_at, c.deleted_at, c.deleted, COALESCE(ua.account_type, '')::text AS account_type, COALESCE(ua.email, '')::text AS account_email,
+SELECT c.id, c.project_id, c.organization_id, c.user_id, c.external_user_id, c.external_chat_id, c.title, c.title_manually_set, c.pinned_at, c.summary, c.summary_generated_at, c.user_account_id, c.litellm_proxied, c.created_at, c.updated_at, c.deleted_at, c.deleted, COALESCE(ua.account_type, '')::text AS account_type, COALESCE(ua.email, '')::text AS account_email,
   at.assistant_id, a.name AS assistant_name
 FROM chats c
 LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
@@ -663,6 +663,7 @@ type GetChatRow struct {
 	Summary            pgtype.Text
 	SummaryGeneratedAt pgtype.Timestamptz
 	UserAccountID      uuid.NullUUID
+	LitellmProxied     bool
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz
@@ -693,6 +694,7 @@ func (q *Queries) GetChat(ctx context.Context, arg GetChatParams) (GetChatRow, e
 		&i.Summary,
 		&i.SummaryGeneratedAt,
 		&i.UserAccountID,
+		&i.LitellmProxied,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -361,6 +361,7 @@ type Chat struct {
 	Summary            pgtype.Text
 	SummaryGeneratedAt pgtype.Timestamptz
 	UserAccountID      uuid.NullUUID
+	LitellmProxied     bool
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz

--- a/server/migrations/20260812120422_chats-add-litellm-proxied.sql
+++ b/server/migrations/20260812120422_chats-add-litellm-proxied.sql
@@ -1,0 +1,2 @@
+-- Modify "chats" table
+ALTER TABLE "chats" ADD COLUMN "litellm_proxied" boolean NOT NULL DEFAULT false;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Bs0pT+vnoPML6h15n8czWE8J3jHtihvAmPMIhtTW1TQ=
+h1:B+6DfK//sCjGu8rZlfmrkbsnkJl78qz5J4OD3BiwvLk=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -331,3 +331,4 @@ h1:Bs0pT+vnoPML6h15n8czWE8J3jHtihvAmPMIhtTW1TQ=
 20260811183332_mcp-approval-workflow.sql h1:UwCSdC5Xh39xdlv47ACNaCw9VkOa/S1Gxsp0pIeFzeM=
 20260811225530_expand-assets-tiers.sql h1:K5IvMnYVFRA8qmUXXPvH5S0HtFWPUNYWbd7KCGlUFC4=
 20260811225943_assets-tier-dedupe-indexes.sql h1:thYfONo6SYry2Aew/GXLvIn/9WZtmZv82BfL7c5jp4A=
+20260812120422_chats-add-litellm-proxied.sql h1:eE5UXEZcLJgKltBNow/Uwpeympq7Vk5Nldbt/1I1xt4=


### PR DESCRIPTION
Schema and migrations split off `daniel/dno-821-litellm-proxied-session-marker` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `litellm_proxied` to `chats` to mark sessions routed through LiteLLM, and expose it in `GetChat` and models. This unblocks DNO-821 by enabling the UI to show “<Client> via LiteLLM” when the originating client is known.

- **Migration**
  - Add `chats.litellm_proxied boolean NOT NULL DEFAULT false`.
  - Additive change; no backfill or downtime required.

<sup>Written for commit 7fb0f2cd69fc974947b44e2b2b7290f10e5bb768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

