### PR TITLE
fix(dashboard): stop page avatars painting over Elements overlays

### DIFF
--- a/client/dashboard/src/elements/components/ChatComposer/index.tsx
+++ b/client/dashboard/src/elements/components/ChatComposer/index.tsx
@@ -48,7 +48,15 @@ export const ChatComposer = ({
   <ErrorBoundary>
     <ShadowRoot
       hostClassName={COMPOSER_HOST_CLASS}
-      hostStyle={{ width: "100%" }}
+      // The host's `isolation: isolate` makes a stacking context but leaves
+      // the box static, so the whole shadow subtree paints with in-flow
+      // content — beneath any `position: relative` page chrome sharing the
+      // ancestor stacking context, avatars included. The context popover
+      // can't win that from inside (it is portalled into the shadow root so
+      // the scoped styles apply), so the host itself has to sit in the
+      // positioned paint layer. `z-index: 1` clears bare `z-auto` chrome
+      // while staying under the insights dock (z-30) and dialogs (z-50).
+      hostStyle={{ width: "100%", position: "relative", zIndex: 1 }}
     >
       <AttachmentDropZone className={className}>
         <ClearDraftOnUnmount />

--- a/client/dashboard/src/elements/components/ShadowRoot.tsx
+++ b/client/dashboard/src/elements/components/ShadowRoot.tsx
@@ -98,7 +98,18 @@ export const ShadowRoot = ({
     <div
       ref={hostRef}
       className={hostClassName}
-      style={{ isolation: "isolate", ...hostStyle }}
+      // `isolation` alone makes a stacking context on a STATIC box, which
+      // paints with in-flow content — below every positioned sibling, however
+      // low its z-index. Overlays inside the shadow root (the composer's
+      // context popover) then lose to plain `position: relative` page chrome
+      // such as avatars. Positioning the host lifts the whole subtree into the
+      // positioned paint layer so those overlays sit above the page again.
+      style={{
+        isolation: "isolate",
+        position: "relative",
+        zIndex: 1,
+        ...hostStyle,
+      }}
     >
       {shadowRoot
         ? createPortal(

--- a/client/dashboard/src/elements/components/ShadowRoot.tsx
+++ b/client/dashboard/src/elements/components/ShadowRoot.tsx
@@ -100,16 +100,11 @@ export const ShadowRoot = ({
       className={hostClassName}
       // `isolation` alone makes a stacking context on a STATIC box, which
       // paints with in-flow content — below every positioned sibling, however
-      // low its z-index. Overlays inside the shadow root (the composer's
-      // context popover) then lose to plain `position: relative` page chrome
-      // such as avatars. Positioning the host lifts the whole subtree into the
-      // positioned paint layer so those overlays sit above the page again.
-      style={{
-        isolation: "isolate",
-        position: "relative",
-        zIndex: 1,
-        ...hostStyle,
-      }}
+      // low its z-index. A surface whose overlays have to clear surrounding
+      // page chrome therefore has to position its own host (see
+      // ChatComposer); doing it here would re-anchor absolute descendants and
+      // re-stack every embed, including ones meant to sit behind page chrome.
+      style={{ isolation: "isolate", ...hostStyle }}
     >
       {shadowRoot
         ? createPortal(


### PR DESCRIPTION
Page avatars painted over the composer's "Add context" popover on project home and the `/chat` landing.

## Cause

`ShadowRoot`'s host div carried `isolation: isolate` on a `position: static` box. `isolation` creates a stacking context, but a _non-positioned_ one paints with in-flow content (CSS painting step 4/5), while positioned `z-auto` elements paint later (step 8). So the entire Elements shadow subtree — including a `z-[70]` popover inside it — lost to any plain `position: relative` page chrome sharing the same ancestor stacking context. `Avatar`'s Radix root ships `relative`, so recent-chat avatars landed on top.

z-index inside the shadow root can't fix this: overlays are deliberately portalled into the `.gram-elements` container _inside_ the root so the scoped Tailwind still applies, which caps them at the host's paint position.

## Fix

Position the host so its subtree lifts into the positioned paint layer:

```
style={{ isolation: "isolate", position: "relative", zIndex: 1, ...hostStyle }}
```

`relative` causes no layout shift. `zIndex: 1` clears bare `z-auto` page chrome while staying below the insights dock (`z-30`) and dialogs (`z-50`). `hostStyle` still spreads last, so callers keep the final word.

## Verification

Reproduced against the live DOM and confirmed the host chain was `[pos=static, z=auto, iso=isolate]` with overlapping avatars at `[pos=relative, z=auto]` in the same z-10 card stacking context. Applying exactly this style to the host and reopening the picker put the popover above the avatars. `pnpm -F dashboard type-check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Elements overlays (e.g., the composer “Add context” popover) being hidden under page avatars on project home and `/chat`. The stacking fix is now scoped to the `ChatComposer` host so its overlays render above page chrome without restacking other embeds.

- **Bug Fixes**
  - Root cause: `isolation: isolate` on a non-positioned host created a stacking context that painted below positioned siblings.
  - Change: Apply `position: "relative"` and `zIndex: 1` to the `ChatComposer` host via `hostStyle`; keep `isolation: "isolate"` on the shared `ShadowRoot`.
  - Result: Overlays appear above avatars with no layout shift and stay below the insights dock and dialogs; other embeds are unaffected.

<sup>Written for commit bf894ad677caa565a65cd64298672dd05e9c6d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

