### PR TITLE
feat(telemetry): add local agent telemetry capture tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ gram.code-workspace
 /server/cmd/local
 /server/custom-gcl
 /local/cmd
+# Local telemetry capture dumps (gram capture-agent-telemetry); may contain
+# raw provider data when anonymization is disabled — never commit.
+/local/agent-telemetry
 dist/
 **/.claude/settings.local.json
 **/.claude/.gram-install-prompted

--- a/.mise-tasks/capture/agent-telemetry.sh
+++ b/.mise-tasks/capture/agent-telemetry.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+#MISE description="Capture agent telemetry: poll provider admin APIs in parallel with an agent session (interactive or headless), then dump anonymized NDJSON fixtures"
+#MISE dir="{{ config_root }}"
+
+#USAGE flag "--agent <agent>" default="claude" help="Agent to drive and capture: claude"
+#USAGE flag "--project <slug>" default="default" help="Project slug rows are attributed to and dumped from"
+#USAGE flag "--api-key <key>" env="GRAM_CAPTURE_API_KEY" help="Provider admin API key for the poll leg (claude: Anthropic admin key); empty skips polling"
+#USAGE flag "--external-org-id <id>" env="GRAM_CAPTURE_EXTERNAL_ORG_ID" help="Provider-side organization ID, stamped on polled rows when set"
+#USAGE flag "--lookback <duration>" default="168h" help="Poll and dump window as a Go duration (168h = 7 days)"
+#USAGE flag "--out <dir>" default="local/agent-telemetry" help="Output directory for the NDJSON dump"
+#USAGE flag "--prompt <text>" help="Drive the session headless with this single prompt instead of interactively"
+#USAGE flag "--prompts-file <file>" help="Drive one headless session per non-empty line of this file"
+#USAGE flag "--no-session" help="Skip the agent session; poll (if keyed) and dump only"
+#USAGE flag "--raw" help="Disable anonymization in the dump"
+
+set -euo pipefail
+
+agent="${usage_agent:-claude}"
+project="${usage_project:-default}"
+api_key="${usage_api_key:-}"
+external_org_id="${usage_external_org_id:-}"
+lookback="${usage_lookback:-168h}"
+out_dir="${usage_out:-local/agent-telemetry}"
+
+if [ "$agent" != "claude" ]; then
+  echo "capture:agent-telemetry: --agent must be claude, got '${agent}'" >&2
+  exit 2
+fi
+
+# Headless prompts: --prompt gives one, --prompts-file one per non-empty line.
+prompts=()
+if [ -n "${usage_prompt:-}" ]; then
+  prompts+=("$usage_prompt")
+fi
+if [ -n "${usage_prompts_file:-}" ]; then
+  if [ ! -f "$usage_prompts_file" ]; then
+    echo "capture:agent-telemetry: prompts file not found: ${usage_prompts_file}" >&2
+    exit 2
+  fi
+  while IFS= read -r line; do
+    if [ -n "$line" ]; then
+      prompts+=("$line")
+    fi
+  done <"$usage_prompts_file"
+fi
+if [ "${#prompts[@]}" -gt 0 ] && [ "${usage_no_session:-false}" = "true" ]; then
+  echo "capture:agent-telemetry: --prompt/--prompts-file conflict with --no-session" >&2
+  exit 2
+fi
+
+capture_cmd=(go run ./server/cmd/capture-agent-telemetry --agent "$agent" --project "$project" --lookback "$lookback" --out "$out_dir")
+if [ -n "$external_org_id" ]; then
+  capture_cmd+=(--external-org-id "$external_org_id")
+fi
+
+# Leg 1: provider poll, in the background. Runs while the session is live so
+# the historical admin-API backfill and the fresh session telemetry land
+# together. --dump=false: the export happens once, after the session, so it
+# includes the session's rows.
+poll_pid=""
+poll_log=""
+if [ -n "$api_key" ]; then
+  poll_log="$(mktemp -t capture-agent-telemetry-poll)"
+  echo "Starting provider poll in background (log: ${poll_log})"
+  "${capture_cmd[@]}" --api-key "$api_key" --dump=false >"$poll_log" 2>&1 &
+  poll_pid=$!
+else
+  echo "No API key supplied — skipping the provider poll leg."
+fi
+
+# Don't leave the poller running if the session leg (or the user) aborts.
+cleanup() {
+  if [ -n "$poll_pid" ] && kill -0 "$poll_pid" 2>/dev/null; then
+    kill "$poll_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Leg 2: agent session(s) with dev hooks + OTel wired to the local server
+# (mise hooks:test). Sessions push OTLP live, so the server must be up.
+# Headless when prompts were given, interactive otherwise.
+if [ "${usage_no_session:-false}" != "true" ]; then
+  if ! curl -s -o /dev/null --max-time 3 "${GRAM_SERVER_URL}"; then
+    echo "capture:agent-telemetry: local server not reachable at ${GRAM_SERVER_URL} — run 'mise run start' first." >&2
+    exit 1
+  fi
+  if [ "${#prompts[@]}" -gt 0 ]; then
+    i=0
+    for prompt in "${prompts[@]}"; do
+      i=$((i + 1))
+      echo "Running headless ${agent} session ${i}/${#prompts[@]}..."
+      mise run hooks:test --agent "$agent" --project "$project" --print "$prompt"
+      echo ""
+    done
+  else
+    echo "Launching ${agent} session (exit the session to finish the capture)..."
+    echo ""
+    mise run hooks:test --agent "$agent" --project "$project"
+  fi
+fi
+
+# Join the poll leg before dumping so its rows are in ClickHouse.
+poll_failed=false
+if [ -n "$poll_pid" ]; then
+  if ! wait "$poll_pid"; then
+    poll_failed=true
+  fi
+  poll_pid=""
+  echo ""
+  echo "--- provider poll output ---"
+  cat "$poll_log"
+  echo "----------------------------"
+fi
+
+# Final phase: dump everything captured in the window. No API key: the poll
+# already ran (or was skipped), this pass only exports.
+dump_cmd=("${capture_cmd[@]}")
+if [ "${usage_raw:-false}" = "true" ]; then
+  dump_cmd+=(--anonymize=false)
+fi
+"${dump_cmd[@]}"
+
+echo ""
+echo "Capture written to ${out_dir} (see manifest.json for the row breakdown)."
+if [ "$poll_failed" = "true" ]; then
+  echo "WARNING: the provider poll leg failed — the dump only contains session/pre-existing rows. See the poll output above." >&2
+  exit 1
+fi

--- a/.mise-tasks/capture/agent-telemetry.sh
+++ b/.mise-tasks/capture/agent-telemetry.sh
@@ -6,7 +6,7 @@
 #USAGE flag "--agent <agent>" default="claude" help="Agent to drive and capture: claude"
 #USAGE flag "--project <slug>" default="default" help="Project slug rows are attributed to and dumped from"
 #USAGE flag "--api-key <key>" env="GRAM_CAPTURE_API_KEY" help="Provider admin API key for the poll leg (claude: Anthropic admin key); empty skips polling"
-#USAGE flag "--external-org-id <id>" env="GRAM_CAPTURE_EXTERNAL_ORG_ID" help="Provider-side organization ID, stamped on polled rows when set"
+#USAGE flag "--external-org-id <id>" env="GRAM_CAPTURE_EXTERNAL_ORG_ID" help="Provider-side organization ID; enables the Compliance API transcript import and is stamped on polled rows"
 #USAGE flag "--lookback <duration>" default="168h" help="Poll and dump window as a Go duration (168h = 7 days)"
 #USAGE flag "--out <dir>" default="local/agent-telemetry" help="Output directory for the NDJSON dump"
 #USAGE flag "--prompt <text>" help="Drive the session headless with this single prompt instead of interactively"

--- a/.mise-tasks/hooks/test.sh
+++ b/.mise-tasks/hooks/test.sh
@@ -6,6 +6,7 @@
 #USAGE flag "--local" help="Always use local plugin directory instead of published plugin"
 #USAGE flag "--project <slug>" help="Project slug for OTEL session validation (enables blocking)" default="default"
 #USAGE flag "--agent <agent>" help="Agent to launch with the dev hooks installed: claude or opencode" default="claude"
+#USAGE flag "--print <prompt>" help="Run one headless prompt instead of an interactive session (claude only)"
 
 set -euo pipefail
 
@@ -16,6 +17,32 @@ case "${usage_agent:-claude}" in
     exit 2
     ;;
 esac
+
+if [ -n "${usage_print:-}" ] && [ "${usage_agent:-claude}" = "opencode" ]; then
+  echo "hooks:test: --print is only supported with --agent=claude" >&2
+  exit 2
+fi
+
+# launch_claude starts the session: interactive with --debug by default, or a
+# single headless prompt when --print is set. Headless runs execute tools
+# without permission prompts, so they get a scratch working directory to keep
+# stray writes out of the repo. The OTel exporter env this task provisions
+# applies either way, so headless sessions stream telemetry identically.
+launch_claude() {
+  if [ -n "${usage_print:-}" ]; then
+    headless_dir="$(mktemp -d)"
+    session_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    echo "Running headless claude session ${session_id} in ${headless_dir}"
+    cd "$headless_dir"
+    exec claude "$@" \
+      --debug \
+      --permission-mode bypassPermissions \
+      --allowedTools "Read,Bash" \
+      --session-id "$session_id" \
+      -p "$usage_print"
+  fi
+  exec claude "$@" --debug
+}
 
 export GRAM_HOOKS_SERVER_URL=$GRAM_SERVER_URL
 # Local dev splits the API and dashboard across ports; the browser sign-in
@@ -189,15 +216,17 @@ elif [ "${usage_local:-}" = "true" ]; then
     --browser-login \
     --binary="$hooks_binary"
   echo ""
-  exec claude --setting-sources project,local --plugin-dir "${plugin_out}/plugin-claude" --debug
-elif ! git diff --quiet main -- server/internal/plugins/ server/cmd/export-hook-plugin/; then
+  launch_claude --setting-sources project,local --plugin-dir "${plugin_out}/plugin-claude"
+else
+  # Always render the plugin and load it explicitly with --plugin-dir. The
+  # published (marketplace) plugin is enabled through user-scope settings,
+  # which --setting-sources project,local excludes — claude would register
+  # zero hooks and the session would emit OTel telemetry only. The rendered
+  # tree comes from the same generators that publish the plugin, and its
+  # bootstrap downloads the same pinned binary.
   plugin_out="$(mktemp -d)"
   echo "Rendering local plugin into: ${plugin_out}"
   (cd server && go run ./cmd/export-hook-plugin -out "$plugin_out" >/dev/null)
   echo ""
-  exec claude --setting-sources project,local --plugin-dir "${plugin_out}/plugin-claude" --debug
-else
-  echo "No branch changes to the plugin generators vs main — using published plugin"
-  echo ""
-  exec claude --setting-sources project,local --debug
+  launch_claude --setting-sources project,local --plugin-dir "${plugin_out}/plugin-claude"
 fi

--- a/server/cmd/capture-agent-telemetry/main.go
+++ b/server/cmd/capture-agent-telemetry/main.go
@@ -1,0 +1,218 @@
+// Command capture-agent-telemetry is a local-dev tool that polls an agent
+// provider's admin APIs into the local telemetry_logs bronze table and dumps
+// the captured window as an anonymized NDJSON fixture. It is deliberately a
+// standalone binary, not a gram CLI subcommand: it exists for generating
+// local test data and never ships to production.
+//
+// The mise task `capture:agent-telemetry` wraps this command, running the
+// poll leg in parallel with an interactive agent session (mise hooks:test)
+// and dumping once the session ends.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/otel"
+
+	"github.com/speakeasy-api/gram/server/internal/agentcapture"
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+
+	app := &cli.App{
+		Name:  "capture-agent-telemetry",
+		Usage: "Poll an agent provider's admin APIs into local telemetry_logs and dump the window as an anonymized NDJSON fixture (local dev only)",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "agent",
+				Usage: "Agent provider to capture (supported: claude)",
+				Value: agentcapture.AgentClaude,
+			},
+			&cli.StringFlag{
+				Name:    "api-key",
+				Usage:   "Provider admin API key (for claude: an Anthropic admin key with Admin Analytics access); when empty the poll phase is skipped",
+				EnvVars: []string{"GRAM_CAPTURE_API_KEY"},
+			},
+			&cli.StringFlag{
+				Name:    "external-org-id",
+				Usage:   "Provider-side organization ID (for claude: the Anthropic organization UUID); optional for Admin Analytics, stamped on rows as gram.external_org_id when set",
+				EnvVars: []string{"GRAM_CAPTURE_EXTERNAL_ORG_ID"},
+			},
+			&cli.StringFlag{
+				Name:  "project",
+				Usage: "Local project slug that captured rows are attributed to",
+				Value: "default",
+			},
+			&cli.StringFlag{
+				Name:  "out",
+				Usage: "Directory for the NDJSON dump, manifest, and anonymization salt",
+				Value: "local/agent-telemetry",
+			},
+			&cli.DurationFlag{
+				Name:  "lookback",
+				Usage: "How far back to poll and dump (default 7 days)",
+				Value: 7 * 24 * time.Hour,
+			},
+			&cli.BoolFlag{
+				Name:  "anonymize",
+				Usage: "Pseudonymize provider identities and scrub free-text content in the dump (pass --anonymize=false for a raw dump)",
+				Value: true,
+			},
+			&cli.BoolFlag{
+				Name:  "dump",
+				Usage: "Export the captured window as NDJSON (pass --dump=false for a poll-only run, e.g. alongside a live agent session)",
+				Value: true,
+			},
+			&cli.StringFlag{
+				Name:     "database-url",
+				Usage:    "Database URL",
+				EnvVars:  []string{"GRAM_DATABASE_URL"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "encryption-key",
+				Usage:    "Key for App level AES encryption/decryption",
+				EnvVars:  []string{"GRAM_ENCRYPTION_KEY"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "clickhouse-host",
+				EnvVars: []string{"CLICKHOUSE_HOST"},
+				Value:   "localhost",
+			},
+			&cli.StringFlag{
+				Name:    "clickhouse-database",
+				EnvVars: []string{"CLICKHOUSE_DATABASE"},
+				Value:   "default",
+			},
+			&cli.StringFlag{
+				Name:    "clickhouse-username",
+				EnvVars: []string{"CLICKHOUSE_USERNAME"},
+				Value:   "gram",
+			},
+			&cli.StringFlag{
+				Name:    "clickhouse-password",
+				EnvVars: []string{"CLICKHOUSE_PASSWORD"},
+				Value:   "gram",
+			},
+			&cli.StringFlag{
+				Name:    "clickhouse-native-port",
+				EnvVars: []string{"CLICKHOUSE_NATIVE_PORT"},
+				Value:   "9440",
+			},
+			&cli.BoolFlag{
+				Name:    "clickhouse-insecure",
+				EnvVars: []string{"CLICKHOUSE_INSECURE"},
+				Value:   false,
+			},
+		},
+		Action: run,
+	}
+
+	err := app.RunContext(ctx, os.Args)
+	stop()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(c *cli.Context) error {
+	ctx := c.Context
+	logger := slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
+		RawLevel:    "info",
+		Pretty:      true,
+		DataDogAttr: false,
+	}))
+	tracerProvider := otel.GetTracerProvider()
+	meterProvider := otel.GetMeterProvider()
+
+	db, err := pgxpool.New(ctx, c.String("database-url"))
+	if err != nil {
+		return fmt.Errorf("connect to postgres: %w", err)
+	}
+	defer db.Close()
+
+	ch, err := clickhouse.Open(&clickhouse.Options{
+		Protocol: clickhouse.Native,
+		Addr:     []string{fmt.Sprintf("%s:%s", c.String("clickhouse-host"), c.String("clickhouse-native-port"))},
+		Auth: clickhouse.Auth{
+			Database: c.String("clickhouse-database"),
+			Username: c.String("clickhouse-username"),
+			Password: c.String("clickhouse-password"),
+		},
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+		TLS: &tls.Config{
+			// #nosec G402 -- local-dev tool; mirrors the server's flag-driven setting.
+			InsecureSkipVerify: c.Bool("clickhouse-insecure"),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("open clickhouse connection: %w", err)
+	}
+	defer o11y.NoLogDefer(ch.Close)
+	if err := ch.Ping(ctx); err != nil {
+		return fmt.Errorf("ping clickhouse: %w", err)
+	}
+
+	encryptionClient, err := encryption.New(c.String("encryption-key"))
+	if err != nil {
+		return fmt.Errorf("create encryption client: %w", err)
+	}
+
+	guardianPolicy := guardian.NewDefaultPolicy(tracerProvider)
+	store := aiintegrations.NewStore(logger, db, encryptionClient)
+
+	// A local capture must always land rows: feature gates are hard-wired to
+	// enabled instead of consulting per-org product features, and toolIOLogs
+	// enabled keeps tool IO content in bronze (the dump's anonymizer scrubs
+	// it on export).
+	alwaysEnabled := telemetry.FeatureChecker(func(context.Context, string) (bool, error) {
+		return true, nil
+	})
+	users := telemetry.NewUserInfoResolver(logger, db, cache.NoopCache)
+	telemetryLogger := telemetry.NewLogger(
+		ctx,
+		logger,
+		tracerProvider,
+		meterProvider,
+		ch,
+		alwaysEnabled,
+		alwaysEnabled,
+		users,
+		telemetry.NewNoopLogPublisher(logger),
+	)
+
+	svc := agentcapture.NewService(logger, db, ch, store, guardianPolicy, telemetryLogger)
+	if err := svc.Run(ctx, agentcapture.Options{
+		Agent:         c.String("agent"),
+		APIKey:        c.String("api-key"),
+		ExternalOrgID: c.String("external-org-id"),
+		ProjectSlug:   c.String("project"),
+		OutDir:        c.String("out"),
+		Lookback:      c.Duration("lookback"),
+		Anonymize:     c.Bool("anonymize"),
+		Dump:          c.Bool("dump"),
+	}); err != nil {
+		return fmt.Errorf("capture agent telemetry: %w", err)
+	}
+	return nil
+}

--- a/server/cmd/capture-agent-telemetry/main.go
+++ b/server/cmd/capture-agent-telemetry/main.go
@@ -1,8 +1,10 @@
 // Command capture-agent-telemetry is a local-dev tool that polls an agent
-// provider's admin APIs into the local telemetry_logs bronze table and dumps
-// the captured window as an anonymized NDJSON fixture. It is deliberately a
-// standalone binary, not a gram CLI subcommand: it exists for generating
-// local test data and never ships to production.
+// provider's admin APIs into the local dev stack — Admin Analytics reports
+// into the telemetry_logs bronze table, and Compliance API chat transcripts
+// into Postgres when an external org ID is supplied — and dumps the captured
+// window as an anonymized NDJSON fixture. It is deliberately a standalone
+// binary, not a gram CLI subcommand: it exists for generating local test
+// data and never ships to production.
 //
 // The mise task `capture:agent-telemetry` wraps this command, running the
 // poll leg in parallel with an interactive agent session (mise hooks:test)
@@ -46,12 +48,12 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:    "api-key",
-				Usage:   "Provider admin API key (for claude: an Anthropic admin key with Admin Analytics access); when empty the poll phase is skipped",
+				Usage:   "Provider admin API key (for claude: an Anthropic admin key with Admin Analytics access, plus Compliance API access when --external-org-id is set); when empty the poll phase is skipped",
 				EnvVars: []string{"GRAM_CAPTURE_API_KEY"},
 			},
 			&cli.StringFlag{
 				Name:    "external-org-id",
-				Usage:   "Provider-side organization ID (for claude: the Anthropic organization UUID); optional for Admin Analytics, stamped on rows as gram.external_org_id when set",
+				Usage:   "Provider-side organization ID (for claude: the Anthropic organization UUID); enables the Compliance API transcript import and is stamped on polled rows as gram.external_org_id",
 				EnvVars: []string{"GRAM_CAPTURE_EXTERNAL_ORG_ID"},
 			},
 			&cli.StringFlag{
@@ -201,7 +203,7 @@ func run(c *cli.Context) error {
 		telemetry.NewNoopLogPublisher(logger),
 	)
 
-	svc := agentcapture.NewService(logger, db, ch, store, guardianPolicy, telemetryLogger)
+	svc := agentcapture.NewService(logger, db, ch, store, guardianPolicy, telemetryLogger, encryptionClient)
 	if err := svc.Run(ctx, agentcapture.Options{
 		Agent:         c.String("agent"),
 		APIKey:        c.String("api-key"),

--- a/server/internal/agentcapture/agentcapture.go
+++ b/server/internal/agentcapture/agentcapture.go
@@ -1,0 +1,173 @@
+// Package agentcapture drives a local-dev capture of agent provider
+// telemetry. It polls a provider's admin APIs into the local telemetry_logs
+// bronze table — the same ingest path production uses — and then dumps the
+// captured window as an anonymized NDJSON fixture, so telemetry features can
+// be developed against realistic data without live credentials.
+//
+// The capture is one leg of local test-data generation: interactive or
+// scripted agent sessions (mise hooks:test / hooks:e2e) stream OTel and hook
+// events into telemetry_logs live, while this package backfills the
+// provider-settled reports that production pollers fetch on Temporal
+// schedules. The dump covers both.
+package agentcapture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+)
+
+// AgentClaude captures Anthropic Admin Analytics reports (Claude usage and
+// cost).
+const AgentClaude = "claude"
+
+type Options struct {
+	// Agent selects the provider integration to poll. Supported: claude.
+	Agent string
+
+	// APIKey authenticates against the provider's admin API. Empty skips the
+	// poll phase so only rows already in ClickHouse (e.g. from agent
+	// sessions) are dumped.
+	APIKey string
+
+	// ExternalOrgID is the provider-side organization ID (for claude: the
+	// Anthropic organization UUID from the Console). Optional for the Admin
+	// Analytics reports, whose org-scoped admin key already implies the
+	// organization; when set it is stamped on captured rows as
+	// gram.external_org_id, matching production configs.
+	ExternalOrgID string
+
+	// ProjectSlug names the local project that polled rows are attributed to
+	// and that the dump is scoped to.
+	ProjectSlug string
+
+	// OutDir receives the NDJSON dump, manifest, and anonymization salt.
+	OutDir string
+
+	// Lookback bounds the poll and dump window, ending now.
+	Lookback time.Duration
+
+	// Anonymize pseudonymizes provider identities and scrubs free-text
+	// content in the dump. It does not alter what lands in ClickHouse.
+	Anonymize bool
+
+	// Dump controls the export phase. The capture:agent-telemetry wrapper
+	// disables it on the poll leg it runs in parallel with an agent session,
+	// then runs a final dump-only pass once the session ends so the export
+	// includes the session's rows.
+	Dump bool
+}
+
+type Service struct {
+	logger          *slog.Logger
+	db              *pgxpool.Pool
+	ch              clickhouse.Conn
+	store           *aiintegrations.Store
+	guardianPolicy  *guardian.Policy
+	telemetryLogger *telemetry.Logger
+	written         *writeCounter
+}
+
+// NewService wires the capture service and registers its row counter as a
+// telemetry log observer, so call it before any rows flow through
+// telemetryLogger.
+func NewService(
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+	ch clickhouse.Conn,
+	store *aiintegrations.Store,
+	guardianPolicy *guardian.Policy,
+	telemetryLogger *telemetry.Logger,
+) *Service {
+	written := &writeCounter{mu: sync.Mutex{}, total: 0}
+	telemetryLogger.AddObserver(written)
+	return &Service{
+		logger:          logger.With(attr.SlogComponent("agentcapture")),
+		db:              db,
+		ch:              ch,
+		store:           store,
+		guardianPolicy:  guardianPolicy,
+		telemetryLogger: telemetryLogger,
+		written:         written,
+	}
+}
+
+// Run executes the capture: poll the provider's admin APIs for the lookback
+// window (when an API key is supplied), then dump the project's
+// telemetry_logs rows for that window into the output directory. A poll
+// failure does not stop the dump — whatever landed is still dumped and the
+// poll error is returned alongside.
+func (s *Service) Run(ctx context.Context, opts Options) error {
+	if opts.Agent != AgentClaude {
+		return fmt.Errorf("unsupported agent %q: supported agents: %s", opts.Agent, AgentClaude)
+	}
+	if opts.Lookback <= 0 {
+		return fmt.Errorf("lookback must be positive, got %s", opts.Lookback)
+	}
+	if !opts.Dump && opts.APIKey == "" {
+		return fmt.Errorf("nothing to do: dump disabled and no api key supplied for polling")
+	}
+
+	project, err := projectsrepo.New(s.db).GetProjectBySlugAcrossOrgs(ctx, opts.ProjectSlug)
+	if err != nil {
+		return fmt.Errorf("resolve project %q: %w", opts.ProjectSlug, err)
+	}
+
+	until := time.Now().UTC()
+	since := until.Add(-opts.Lookback)
+	s.logger.InfoContext(ctx, "capturing agent telemetry",
+		attr.SlogProjectSlug(project.Slug),
+		attr.SlogProjectID(project.ID.String()),
+		attr.SlogOrganizationID(project.OrganizationID),
+	)
+
+	var pollErr error
+	if opts.APIKey == "" {
+		s.logger.InfoContext(ctx, "no api key supplied: skipping provider poll phase")
+	} else {
+		pollErr = s.pollClaude(ctx, project.ID, project.OrganizationID, opts, since, until)
+	}
+
+	if !opts.Dump {
+		return pollErr
+	}
+	if err := s.dump(ctx, project, since, until, opts); err != nil {
+		return errors.Join(pollErr, fmt.Errorf("dump telemetry logs: %w", err))
+	}
+	return pollErr
+}
+
+// writeCounter counts rows submitted to the telemetry logger during the poll
+// phase. Observers see batches before per-org feature filtering, but the
+// capture command hard-wires those checks to enabled, so submitted equals
+// written in practice.
+type writeCounter struct {
+	mu    sync.Mutex
+	total int
+}
+
+var _ telemetry.LogObserver = (*writeCounter)(nil)
+
+func (w *writeCounter) OnTelemetryLogsWritten(_ context.Context, params []telemetry.LogParams) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.total += len(params)
+}
+
+func (w *writeCounter) count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.total
+}

--- a/server/internal/agentcapture/agentcapture.go
+++ b/server/internal/agentcapture/agentcapture.go
@@ -1,14 +1,17 @@
 // Package agentcapture drives a local-dev capture of agent provider
-// telemetry. It polls a provider's admin APIs into the local telemetry_logs
-// bronze table — the same ingest path production uses — and then dumps the
-// captured window as an anonymized NDJSON fixture, so telemetry features can
-// be developed against realistic data without live credentials.
+// telemetry. It polls a provider's admin APIs through the same ingest paths
+// production uses — Admin Analytics reports into the ClickHouse
+// telemetry_logs bronze table, and (when an external org ID is supplied)
+// Compliance API chat transcripts into Postgres chats/chat_messages — and
+// then dumps the captured window as an anonymized NDJSON fixture, so
+// telemetry features can be developed against realistic data without live
+// credentials.
 //
 // The capture is one leg of local test-data generation: interactive or
 // scripted agent sessions (mise hooks:test / hooks:e2e) stream OTel and hook
 // events into telemetry_logs live, while this package backfills the
-// provider-settled reports that production pollers fetch on Temporal
-// schedules. The dump covers both.
+// provider-settled reports and transcripts that production pollers fetch on
+// Temporal schedules. The dump covers all of it.
 package agentcapture
 
 import (
@@ -24,6 +27,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/aiintegrations"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -43,10 +47,12 @@ type Options struct {
 	APIKey string
 
 	// ExternalOrgID is the provider-side organization ID (for claude: the
-	// Anthropic organization UUID from the Console). Optional for the Admin
-	// Analytics reports, whose org-scoped admin key already implies the
-	// organization; when set it is stamped on captured rows as
-	// gram.external_org_id, matching production configs.
+	// Anthropic organization UUID from the Console). The Admin Analytics
+	// reports work without it — their org-scoped admin key already implies
+	// the organization — but the Compliance API transcript import requires
+	// it, so setting it is what enables that leg. When set it is also
+	// stamped on captured rows as gram.external_org_id, matching production
+	// configs.
 	ExternalOrgID string
 
 	// ProjectSlug names the local project that polled rows are attributed to
@@ -77,6 +83,7 @@ type Service struct {
 	store           *aiintegrations.Store
 	guardianPolicy  *guardian.Policy
 	telemetryLogger *telemetry.Logger
+	enc             *encryption.Client
 	written         *writeCounter
 }
 
@@ -90,6 +97,7 @@ func NewService(
 	store *aiintegrations.Store,
 	guardianPolicy *guardian.Policy,
 	telemetryLogger *telemetry.Logger,
+	enc *encryption.Client,
 ) *Service {
 	written := &writeCounter{mu: sync.Mutex{}, total: 0}
 	telemetryLogger.AddObserver(written)
@@ -100,6 +108,7 @@ func NewService(
 		store:           store,
 		guardianPolicy:  guardianPolicy,
 		telemetryLogger: telemetryLogger,
+		enc:             enc,
 		written:         written,
 	}
 }
@@ -138,6 +147,15 @@ func (s *Service) Run(ctx context.Context, opts Options) error {
 		s.logger.InfoContext(ctx, "no api key supplied: skipping provider poll phase")
 	} else {
 		pollErr = s.pollClaude(ctx, project.ID, project.OrganizationID, opts, since, until)
+		// The Compliance API needs the explicit org UUID (the admin key
+		// alone is not enough to scope its activities feed), so the
+		// transcript leg runs only when the flag is supplied.
+		if opts.ExternalOrgID == "" {
+			s.logger.InfoContext(ctx, "no external org id supplied: skipping claude.ai transcript import (compliance api)")
+		} else if err := s.pollClaudeCompliance(ctx, project, opts, since); err != nil {
+			s.logger.ErrorContext(ctx, "compliance transcript import failed", attr.SlogError(err))
+			pollErr = errors.Join(pollErr, fmt.Errorf("sync anthropic_compliance: %w", err))
+		}
 	}
 
 	if !opts.Dump {

--- a/server/internal/agentcapture/anonymize.go
+++ b/server/internal/agentcapture/anonymize.go
@@ -1,0 +1,216 @@
+package agentcapture
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const saltSize = 32
+
+// loadOrCreateSalt returns the hex-encoded salt stored at path, creating a
+// fresh random one on first use. Reusing the salt keeps pseudonyms stable
+// across repeated captures into the same directory, so identities keep their
+// join structure between dump files.
+func loadOrCreateSalt(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- the salt lives inside the operator-chosen output directory
+	if err == nil {
+		salt, decErr := hex.DecodeString(strings.TrimSpace(string(raw)))
+		if decErr != nil {
+			return nil, fmt.Errorf("decode anonymization salt %s: %w", path, decErr)
+		}
+		return salt, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("read anonymization salt: %w", err)
+	}
+
+	salt := make([]byte, saltSize)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("generate anonymization salt: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(hex.EncodeToString(salt)+"\n"), 0o600); err != nil {
+		return nil, fmt.Errorf("write anonymization salt: %w", err)
+	}
+	return salt, nil
+}
+
+// Anonymizer deterministically pseudonymizes provider-side identities and
+// scrubs free-text content in dumped telemetry rows. The same salt maps the
+// same input to the same output, preserving per-user grouping and natural
+// keys without exposing the original values.
+//
+// Gram-internal identifiers (local user, project, session, chat IDs) are
+// deliberately left intact: they are opaque UUIDs minted by the local dev
+// stack and are needed to join the dump against local Postgres fixtures.
+type Anonymizer struct {
+	salt []byte
+}
+
+func NewAnonymizer(salt []byte) *Anonymizer {
+	return &Anonymizer{salt: salt}
+}
+
+// identityPaths are dotted attribute paths whose string values name a person
+// or organization on the provider's side. Values are replaced with a
+// deterministic pseudonym; UUID-shaped values stay UUID-shaped so downstream
+// parsers keep working. Email-bearing keys are matched by shape instead (see
+// isEmailKey).
+var identityPaths = map[string]struct{}{
+	"user.account_uuid":     {},
+	"organization.id":       {},
+	"gram.external_user.id": {},
+	"gram.external_org_id":  {},
+}
+
+// contentPaths are dotted attribute paths that carry free text: prompts,
+// completions, and tool IO. Values are replaced with a length-stamped
+// placeholder so row shape and rough payload size survive.
+var contentPaths = map[string]struct{}{
+	"prompt":                     {},
+	"gen_ai.prompt":              {},
+	"gen_ai.completion":          {},
+	"gen_ai.tool.call.arguments": {},
+	"gen_ai.tool.call.result":    {},
+}
+
+// maxClearBodyLen bounds how long a body may be before it is scrubbed. Real
+// telemetry bodies are short event descriptors ("Claude Chat cost metrics",
+// "user_prompt"); anything longer is almost certainly free text that leaked
+// into the body.
+const maxClearBodyLen = 200
+
+// ScrubRow anonymizes one dumped row in place: both JSON attribute blobs are
+// walked with the path rules and an over-long body is replaced with a
+// placeholder.
+func (a *Anonymizer) ScrubRow(row *logRow) error {
+	attrs, err := a.ScrubJSON(string(row.Attributes))
+	if err != nil {
+		return fmt.Errorf("scrub attributes: %w", err)
+	}
+	row.Attributes = json.RawMessage(attrs)
+
+	res, err := a.ScrubJSON(string(row.ResourceAttributes))
+	if err != nil {
+		return fmt.Errorf("scrub resource attributes: %w", err)
+	}
+	row.ResourceAttributes = json.RawMessage(res)
+
+	if len(row.Body) > maxClearBodyLen {
+		row.Body = scrubPlaceholder(row.Body)
+	}
+	return nil
+}
+
+// ScrubJSON walks a JSON object and applies the anonymization rules to every
+// string leaf, keyed by the leaf's dotted path. ClickHouse's JSON type stores
+// dotted attribute keys as nested objects, so "user.email" arrives as
+// {"user":{"email":...}} and the walk reassembles the dotted path.
+func (a *Anonymizer) ScrubJSON(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return raw, nil
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(raw), &root); err != nil {
+		return "", fmt.Errorf("parse attribute json: %w", err)
+	}
+	a.walkMap(root, "")
+	out, err := json.Marshal(root)
+	if err != nil {
+		return "", fmt.Errorf("serialize scrubbed json: %w", err)
+	}
+	return string(out), nil
+}
+
+func (a *Anonymizer) walkMap(node map[string]any, prefix string) {
+	for key, value := range node {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		node[key] = a.walkValue(path, key, value)
+	}
+}
+
+func (a *Anonymizer) walkValue(path, key string, value any) any {
+	switch val := value.(type) {
+	case map[string]any:
+		a.walkMap(val, path)
+		return val
+	case []any:
+		for i, item := range val {
+			val[i] = a.walkValue(path, key, item)
+		}
+		return val
+	case string:
+		return a.scrubString(path, key, val)
+	default:
+		return value
+	}
+}
+
+func (a *Anonymizer) scrubString(path, key, value string) string {
+	if value == "" {
+		return value
+	}
+	if _, ok := contentPaths[path]; ok {
+		return scrubPlaceholder(value)
+	}
+	if isEmailKey(key) {
+		return a.pseudonymEmail(value)
+	}
+	if _, ok := identityPaths[path]; ok {
+		return a.pseudonymID(value)
+	}
+	return value
+}
+
+// isEmailKey reports whether a leaf key names an email address, whatever its
+// path — every email in a telemetry row is a person and must be
+// pseudonymized.
+func isEmailKey(key string) bool {
+	return key == "email" || strings.HasSuffix(key, "_email") || strings.HasSuffix(key, ".email")
+}
+
+func scrubPlaceholder(value string) string {
+	return fmt.Sprintf("[scrubbed %d bytes]", len(value))
+}
+
+func (a *Anonymizer) pseudonymEmail(value string) string {
+	return fmt.Sprintf("user-%s@anon.invalid", hex.EncodeToString(a.mac("email", value)[:6]))
+}
+
+// pseudonymID maps an identifier to a stable pseudonym. UUID-shaped inputs
+// produce a derived (version 4, RFC 4122 variant) UUID so consumers that
+// parse the field keep working; everything else gets an anon-<hex> handle.
+func (a *Anonymizer) pseudonymID(value string) string {
+	sum := a.mac("id", value)
+	if _, err := uuid.Parse(value); err == nil {
+		var out uuid.UUID
+		copy(out[:], sum[:16])
+		out[6] = (out[6] & 0x0f) | 0x40
+		out[8] = (out[8] & 0x3f) | 0x80
+		return out.String()
+	}
+	return "anon-" + hex.EncodeToString(sum[:8])
+}
+
+// mac derives the pseudonym bytes for one value. The kind prefix domain-
+// separates rule families so an email and an ID with the same raw value do
+// not share a pseudonym.
+func (a *Anonymizer) mac(kind, value string) []byte {
+	h := hmac.New(sha256.New, a.salt)
+	h.Write([]byte(kind))
+	h.Write([]byte{0})
+	h.Write([]byte(value))
+	return h.Sum(nil)
+}

--- a/server/internal/agentcapture/anonymize.go
+++ b/server/internal/agentcapture/anonymize.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
 )
 
 const saltSize = 32
@@ -109,6 +111,39 @@ func (a *Anonymizer) ScrubRow(row *logRow) error {
 		row.Body = scrubPlaceholder(row.Body)
 	}
 	return nil
+}
+
+// ScrubChat anonymizes one exported external chat in place: the title is
+// user-authored free text and the external user ID is a provider-side
+// identity. Gram-internal IDs (chat, project, connected user) stay intact
+// for local joins, and the external chat ID is a content natural key, not a
+// person, so it survives too.
+func (a *Anonymizer) ScrubChat(row *chatExportRow) {
+	if row.Title != nil && *row.Title != "" {
+		row.Title = conv.PtrEmpty(scrubPlaceholder(*row.Title))
+	}
+	if row.ExternalUserID != nil && *row.ExternalUserID != "" {
+		row.ExternalUserID = conv.PtrEmpty(a.pseudonymID(*row.ExternalUserID))
+	}
+}
+
+// ScrubChatMessage anonymizes one exported external chat message in place:
+// content is the transcript text, the user agent and IP address describe a
+// person's device, and the external user ID is a provider-side identity. The
+// external message ID is the row's natural key and stays.
+func (a *Anonymizer) ScrubChatMessage(row *chatMessageExportRow) {
+	if row.Content != "" {
+		row.Content = scrubPlaceholder(row.Content)
+	}
+	if row.ExternalUserID != nil && *row.ExternalUserID != "" {
+		row.ExternalUserID = conv.PtrEmpty(a.pseudonymID(*row.ExternalUserID))
+	}
+	if row.UserAgent != nil && *row.UserAgent != "" {
+		row.UserAgent = conv.PtrEmpty(scrubPlaceholder(*row.UserAgent))
+	}
+	if row.IPAddress != nil && *row.IPAddress != "" {
+		row.IPAddress = conv.PtrEmpty(a.pseudonymID(*row.IPAddress))
+	}
 }
 
 // ScrubJSON walks a JSON object and applies the anonymization rules to every

--- a/server/internal/agentcapture/anonymize_test.go
+++ b/server/internal/agentcapture/anonymize_test.go
@@ -1,0 +1,205 @@
+package agentcapture
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func testAnonymizer(t *testing.T, seed byte) *Anonymizer {
+	t.Helper()
+	salt := make([]byte, saltSize)
+	for i := range salt {
+		salt[i] = seed
+	}
+	return NewAnonymizer(salt)
+}
+
+func scrubToMap(t *testing.T, a *Anonymizer, raw string) map[string]any {
+	t.Helper()
+	out, err := a.ScrubJSON(raw)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &m))
+	return m
+}
+
+// nested walks a decoded JSON object down the given keys and returns the
+// value at the end of the path.
+func nested(t *testing.T, m map[string]any, path ...string) any {
+	t.Helper()
+	var current any = m
+	for _, key := range path {
+		node, ok := current.(map[string]any)
+		require.True(t, ok, "expected object at %q in path %v", key, path)
+		current = node[key]
+	}
+	return current
+}
+
+func nestedString(t *testing.T, m map[string]any, path ...string) string {
+	t.Helper()
+	s, ok := nested(t, m, path...).(string)
+	require.True(t, ok, "expected string at path %v", path)
+	return s
+}
+
+func TestAnonymizerScrubJSONPseudonymizesEmails(t *testing.T) {
+	t.Parallel()
+	a := testAnonymizer(t, 1)
+
+	raw := `{"user":{"email":"alice@example.com"},"gram":{"auth":{"user_email":"bob@example.com"}}}`
+	first := scrubToMap(t, a, raw)
+
+	userEmail := nestedString(t, first, "user", "email")
+	authEmail := nestedString(t, first, "gram", "auth", "user_email")
+
+	require.NotEqual(t, "alice@example.com", userEmail)
+	require.NotEqual(t, "bob@example.com", authEmail)
+	require.True(t, strings.HasSuffix(userEmail, "@anon.invalid"))
+	require.True(t, strings.HasSuffix(authEmail, "@anon.invalid"))
+	require.NotEqual(t, userEmail, authEmail)
+
+	// Deterministic: the same input under the same salt maps to the same
+	// pseudonym.
+	second := scrubToMap(t, a, raw)
+	require.Equal(t, userEmail, nestedString(t, second, "user", "email"))
+}
+
+func TestAnonymizerScrubJSONPseudonymizesProviderIdentity(t *testing.T) {
+	t.Parallel()
+	a := testAnonymizer(t, 1)
+
+	accountUUID := "0d5c9bbc-1b13-4d54-8e2c-9f3c1a2b3c4d"
+	raw := `{"user":{"account_uuid":"` + accountUUID + `"},"gram":{"external_user":{"id":"user_abc123"},"external_org_id":"org_xyz789"}}`
+	out := scrubToMap(t, a, raw)
+
+	scrubbedUUID := nestedString(t, out, "user", "account_uuid")
+	require.NotEqual(t, accountUUID, scrubbedUUID)
+	// UUID-shaped inputs stay UUID-shaped so downstream parsers keep working.
+	_, err := uuid.Parse(scrubbedUUID)
+	require.NoError(t, err)
+
+	externalUser := nestedString(t, out, "gram", "external_user", "id")
+	require.NotEqual(t, "user_abc123", externalUser)
+	require.True(t, strings.HasPrefix(externalUser, "anon-"))
+
+	externalOrg := nestedString(t, out, "gram", "external_org_id")
+	require.NotEqual(t, "org_xyz789", externalOrg)
+	require.True(t, strings.HasPrefix(externalOrg, "anon-"))
+}
+
+func TestAnonymizerDifferentSaltsDiverge(t *testing.T) {
+	t.Parallel()
+	raw := `{"user":{"email":"alice@example.com"}}`
+
+	one := scrubToMap(t, testAnonymizer(t, 1), raw)
+	two := scrubToMap(t, testAnonymizer(t, 2), raw)
+
+	require.NotEqual(t,
+		nestedString(t, one, "user", "email"),
+		nestedString(t, two, "user", "email"),
+	)
+}
+
+func TestAnonymizerScrubJSONScrubsContent(t *testing.T) {
+	t.Parallel()
+	a := testAnonymizer(t, 1)
+
+	raw := `{"gen_ai":{"tool":{"call":{"arguments":"{\"path\":\"/etc/passwd\"}"}},"usage":{"input_tokens":42}},"prompt":"tell me a secret","gram":{"tool":{"name":"Read"}}}`
+	out := scrubToMap(t, a, raw)
+
+	args := nestedString(t, out, "gen_ai", "tool", "call", "arguments")
+	require.True(t, strings.HasPrefix(args, "[scrubbed "))
+
+	require.Equal(t, "[scrubbed 16 bytes]", nestedString(t, out, "prompt"))
+
+	// Non-content values survive untouched: numbers, and strings under
+	// unmatched paths.
+	tokens, ok := nested(t, out, "gen_ai", "usage", "input_tokens").(float64)
+	require.True(t, ok)
+	require.InEpsilon(t, 42.0, tokens, 0.0001)
+	require.Equal(t, "Read", nestedString(t, out, "gram", "tool", "name"))
+}
+
+func TestAnonymizerScrubJSONWalksArrays(t *testing.T) {
+	t.Parallel()
+	a := testAnonymizer(t, 1)
+
+	raw := `{"user":{"email":["a@example.com","b@example.com"]}}`
+	out := scrubToMap(t, a, raw)
+
+	emails, ok := nested(t, out, "user", "email").([]any)
+	require.True(t, ok)
+	require.Len(t, emails, 2)
+	for _, e := range emails {
+		s, ok := e.(string)
+		require.True(t, ok)
+		require.True(t, strings.HasSuffix(s, "@anon.invalid"))
+	}
+	require.NotEqual(t, emails[0], emails[1])
+}
+
+func TestAnonymizerScrubRowScrubsLongBody(t *testing.T) {
+	t.Parallel()
+	a := testAnonymizer(t, 1)
+
+	longBody := strings.Repeat("x", maxClearBodyLen+1)
+	row := logRow{
+		ID:                   "0198c3e4-0000-7000-8000-000000000000",
+		TimeUnixNano:         0,
+		ObservedTimeUnixNano: 0,
+		SeverityText:         nil,
+		Body:                 longBody,
+		TraceID:              nil,
+		SpanID:               nil,
+		Attributes:           json.RawMessage(`{}`),
+		ResourceAttributes:   json.RawMessage(`{}`),
+		GramProjectID:        "",
+		GramDeploymentID:     nil,
+		GramFunctionID:       nil,
+		GramURN:              "",
+		ServiceName:          "",
+		ServiceVersion:       nil,
+		GramChatID:           nil,
+		EventURN:             "",
+	}
+	require.NoError(t, a.ScrubRow(&row))
+	require.Equal(t, "[scrubbed 201 bytes]", row.Body)
+
+	row.Body = "Claude Chat cost metrics"
+	require.NoError(t, a.ScrubRow(&row))
+	require.Equal(t, "Claude Chat cost metrics", row.Body)
+}
+
+func TestLoadOrCreateSaltRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "anonymization-salt")
+
+	created, err := loadOrCreateSalt(path)
+	require.NoError(t, err)
+	require.Len(t, created, saltSize)
+
+	reloaded, err := loadOrCreateSalt(path)
+	require.NoError(t, err)
+	require.Equal(t, created, reloaded)
+
+	// The salt file is hex text so it can be inspected and copied around.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, strings.TrimSpace(string(raw)), strings.ToLower(strings.TrimSpace(string(raw))))
+}
+
+func TestOriginFromEventURN(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "provider_api", originFromEventURN("urn:telemetry:provider_api:metric:user_cost_report"))
+	require.Equal(t, "agent_hook", originFromEventURN("urn:telemetry:agent_hook:log:pretooluse"))
+	require.Equal(t, "unknown", originFromEventURN(""))
+	require.Equal(t, "unknown", originFromEventURN("garbage"))
+	require.Equal(t, "unknown", originFromEventURN("urn:telemetry:../escape:log:x"))
+}

--- a/server/internal/agentcapture/compliance.go
+++ b/server/internal/agentcapture/compliance.go
@@ -1,0 +1,124 @@
+package agentcapture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations"
+	airepo "github.com/speakeasy-api/gram/server/internal/aiintegrations/repo"
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations/timewindowpoller"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+)
+
+// pollClaudeCompliance imports Claude Chat (claude.ai web/desktop)
+// transcripts through the production compliance import pipeline. Unlike the
+// Admin Analytics pollers, whose rows land in ClickHouse telemetry_logs, the
+// compliance import writes chats and messages to Postgres (chats /
+// chat_messages) and persists per-chat pagination cursors keyed by a real
+// ai_integration_configs row — ai_integration_config_chats has a foreign key
+// on it — so the uuid.Nil stateless-config trick the analytics leg uses
+// cannot work here; the capture ensures a local config row instead.
+//
+// The run stays stateless at the feed level: LastCursor is always empty, so
+// every run walks the import's bounded backfill window (the watermark minus
+// its 24h margin) instead of resuming a stored feed position. Chat upserts
+// and message inserts are idempotent and per-chat message cursors persist,
+// so re-running over the same window is cheap.
+func (s *Service) pollClaudeCompliance(ctx context.Context, project projectsrepo.Project, opts Options, since time.Time) error {
+	configID, err := s.ensureComplianceConfig(ctx, project, opts)
+	if err != nil {
+		return err
+	}
+
+	// External message imports never upload assets, so no blob store is
+	// needed.
+	writer, shutdown := chat.NewChatMessageWriter(s.logger, s.db, nil)
+	defer o11y.NoLogDefer(func() error { return shutdown(ctx) })
+
+	// The heartbeat exists for Temporal activity liveness; a one-shot CLI
+	// run has nothing to keep alive.
+	heartbeat := func(context.Context, string, int) {}
+	importer := aiintegrations.NewComplianceImportService(s.logger, s.db, s.guardianPolicy, writer, heartbeat)
+
+	cfg := aiintegrations.Config{
+		ID:                     configID,
+		SyncID:                 uuid.Nil,
+		OrganizationID:         project.OrganizationID,
+		Provider:               aiintegrations.ProviderAnthropicCompliance,
+		ProjectID:              project.ID,
+		ExternalOrganizationID: conv.PtrEmpty(opts.ExternalOrgID),
+		BillingMode:            "",
+		APIKey:                 opts.APIKey,
+		Enabled:                true,
+		PollWatermarkAt:        since,
+		PollCheckpoint:         timewindowpoller.CompletedCheckpoint(since),
+		NextPollAfter:          time.Time{},
+		LastPollError:          "",
+		LastPollFailedAt:       time.Time{},
+		LastPollSuccessAt:      time.Time{},
+		ConsecutiveFailures:    0,
+		LastCursor:             "",
+		CreatedAt:              time.Time{},
+		UpdatedAt:              time.Time{},
+	}
+
+	// The returned feed cursor is deliberately dropped: persisting it would
+	// make the next run walk forward from this one's position instead of
+	// re-covering the requested lookback window.
+	if _, err := importer.SyncAnthropicCompliance(ctx, cfg); err != nil {
+		return fmt.Errorf("sync anthropic compliance: %w", err)
+	}
+	return nil
+}
+
+// ensureComplianceConfig returns the id of the organization's
+// anthropic_compliance integration config, creating a local one when none
+// exists. An existing config — e.g. one configured through the dashboard —
+// is reused as-is; the capture's api-key and external-org-id flags shape
+// only the in-memory Config for this run, never the stored row.
+func (s *Service) ensureComplianceConfig(ctx context.Context, project projectsrepo.Project, opts Options) (uuid.UUID, error) {
+	q := airepo.New(s.db)
+	id, err := q.GetConfigIDByOrgAndProvider(ctx, airepo.GetConfigIDByOrgAndProviderParams{
+		OrganizationID: project.OrganizationID,
+		Provider:       aiintegrations.ProviderAnthropicCompliance,
+	})
+	switch {
+	case err == nil:
+		return id, nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return uuid.Nil, fmt.Errorf("load anthropic compliance config: %w", err)
+	}
+
+	// The key is encrypted properly (not a placeholder) so the local
+	// dashboard's integrations views can still decrypt the row.
+	encrypted, err := s.enc.Encrypt([]byte(opts.APIKey))
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("encrypt capture api key: %w", err)
+	}
+	// Enabled is false and no sync schedule rows are created, so the local
+	// Temporal worker never starts polling with the stored key behind the
+	// operator's back; the import runs against the in-memory Config, which
+	// consults neither.
+	inserted, err := q.InsertConfig(ctx, airepo.InsertConfigParams{
+		OrganizationID:         project.OrganizationID,
+		Provider:               aiintegrations.ProviderAnthropicCompliance,
+		ProjectID:              project.ID,
+		ExternalOrganizationID: conv.ToPGText(opts.ExternalOrgID),
+		ApiKeyEncrypted:        encrypted,
+		Enabled:                false,
+		BillingMode:            pgtype.Text{String: "", Valid: false},
+	})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("insert anthropic compliance config: %w", err)
+	}
+	return inserted.ID, nil
+}

--- a/server/internal/agentcapture/dump.go
+++ b/server/internal/agentcapture/dump.go
@@ -1,0 +1,262 @@
+package agentcapture
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+)
+
+// logRow is one dumped telemetry_logs row. It carries the table's physical
+// columns (materialized columns are recomputed by ClickHouse when a fixture
+// is re-inserted) plus event_urn, which is derived but included so consumers
+// can route rows without re-parsing attributes; drop it when re-inserting.
+type logRow struct {
+	ID                   string          `json:"id"`
+	TimeUnixNano         int64           `json:"time_unix_nano"`
+	ObservedTimeUnixNano int64           `json:"observed_time_unix_nano"`
+	SeverityText         *string         `json:"severity_text"`
+	Body                 string          `json:"body"`
+	TraceID              *string         `json:"trace_id"`
+	SpanID               *string         `json:"span_id"`
+	Attributes           json.RawMessage `json:"attributes"`
+	ResourceAttributes   json.RawMessage `json:"resource_attributes"`
+	GramProjectID        string          `json:"gram_project_id"`
+	GramDeploymentID     *string         `json:"gram_deployment_id"`
+	GramFunctionID       *string         `json:"gram_function_id"`
+	GramURN              string          `json:"gram_urn"`
+	ServiceName          string          `json:"service_name"`
+	ServiceVersion       *string         `json:"service_version"`
+	GramChatID           *string         `json:"gram_chat_id"`
+	EventURN             string          `json:"event_urn"`
+}
+
+const dumpQuery = `
+SELECT
+    toString(id) AS id,
+    time_unix_nano,
+    observed_time_unix_nano,
+    severity_text,
+    body,
+    toString(trace_id) AS trace_id,
+    toString(span_id) AS span_id,
+    toJSONString(attributes) AS attributes,
+    toJSONString(resource_attributes) AS resource_attributes,
+    -- Aliased away from the column name: ClickHouse resolves identifiers in
+    -- WHERE to SELECT aliases first, and a same-named String alias would
+    -- shadow the UUID column in the project filter.
+    toString(gram_project_id) AS project_id_str,
+    toString(gram_deployment_id) AS gram_deployment_id,
+    toString(gram_function_id) AS gram_function_id,
+    gram_urn,
+    service_name,
+    service_version,
+    gram_chat_id,
+    event_urn
+FROM telemetry_logs
+WHERE gram_project_id = toUUID(?)
+  AND time_unix_nano >= ?
+  AND time_unix_nano < ?
+ORDER BY time_unix_nano, id
+`
+
+// manifest describes one capture dump so consumers know the window, scope,
+// and file layout without inspecting rows.
+type manifest struct {
+	GeneratedAt    time.Time      `json:"generated_at"`
+	ProjectID      string         `json:"project_id"`
+	ProjectSlug    string         `json:"project_slug"`
+	OrganizationID string         `json:"organization_id"`
+	WindowSince    time.Time      `json:"window_since"`
+	WindowUntil    time.Time      `json:"window_until"`
+	Anonymized     bool           `json:"anonymized"`
+	RowsTotal      int            `json:"rows_total"`
+	RowsByEventURN map[string]int `json:"rows_by_event_urn"`
+	Files          map[string]int `json:"files"`
+}
+
+// dump exports the project's telemetry_logs rows for the capture window as
+// NDJSON, one file per event origin (provider_api, provider_otel, agent_hook,
+// gram_service, unknown), with a manifest.json describing the capture.
+func (s *Service) dump(ctx context.Context, project projectsrepo.Project, since, until time.Time, opts Options) error {
+	// The telemetry logger writes with async_insert=1 / wait_for_async_insert=0,
+	// so rows from the poll phase may still sit in ClickHouse's async insert
+	// buffer. Flush it so the dump sees everything; failure is non-fatal
+	// because the default buffer timeout drains within about a second anyway.
+	if err := s.ch.Exec(ctx, "SYSTEM FLUSH ASYNC INSERT QUEUE"); err != nil {
+		s.logger.WarnContext(ctx, "failed to flush clickhouse async insert queue", attr.SlogError(err))
+	}
+
+	logsDir := filepath.Join(opts.OutDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o750); err != nil {
+		return fmt.Errorf("create dump directory: %w", err)
+	}
+	// Each dump fully replaces the export: leftover files from a previous
+	// capture whose origins do not occur in this window would otherwise
+	// linger next to a manifest that no longer lists them.
+	stale, err := filepath.Glob(filepath.Join(logsDir, "*.ndjson"))
+	if err != nil {
+		return fmt.Errorf("list previous dump files: %w", err)
+	}
+	for _, path := range stale {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove previous dump file: %w", err)
+		}
+	}
+
+	var anonymizer *Anonymizer
+	if opts.Anonymize {
+		salt, err := loadOrCreateSalt(filepath.Join(opts.OutDir, "anonymization-salt"))
+		if err != nil {
+			return err
+		}
+		anonymizer = NewAnonymizer(salt)
+	}
+
+	rows, err := s.ch.Query(ctx, dumpQuery, project.ID.String(), since.UnixNano(), until.UnixNano())
+	if err != nil {
+		return fmt.Errorf("query telemetry logs: %w", err)
+	}
+	defer o11y.NoLogDefer(rows.Close)
+
+	writers := map[string]*dumpWriter{}
+	defer func() {
+		for _, w := range writers {
+			o11y.NoLogDefer(w.file.Close)
+		}
+	}()
+
+	total := 0
+	byURN := map[string]int{}
+	for rows.Next() {
+		var (
+			row              logRow
+			attrsJSON        string
+			resourceAttrsRaw string
+		)
+		if err := rows.Scan(
+			&row.ID,
+			&row.TimeUnixNano,
+			&row.ObservedTimeUnixNano,
+			&row.SeverityText,
+			&row.Body,
+			&row.TraceID,
+			&row.SpanID,
+			&attrsJSON,
+			&resourceAttrsRaw,
+			&row.GramProjectID,
+			&row.GramDeploymentID,
+			&row.GramFunctionID,
+			&row.GramURN,
+			&row.ServiceName,
+			&row.ServiceVersion,
+			&row.GramChatID,
+			&row.EventURN,
+		); err != nil {
+			return fmt.Errorf("scan telemetry log row: %w", err)
+		}
+		row.Attributes = json.RawMessage(attrsJSON)
+		row.ResourceAttributes = json.RawMessage(resourceAttrsRaw)
+
+		if anonymizer != nil {
+			if err := anonymizer.ScrubRow(&row); err != nil {
+				return fmt.Errorf("anonymize telemetry log row %s: %w", row.ID, err)
+			}
+		}
+
+		writer, err := writerFor(writers, logsDir, originFromEventURN(row.EventURN))
+		if err != nil {
+			return err
+		}
+		line, err := json.Marshal(row)
+		if err != nil {
+			return fmt.Errorf("serialize telemetry log row %s: %w", row.ID, err)
+		}
+		if _, err := writer.buf.Write(append(line, '\n')); err != nil {
+			return fmt.Errorf("write dump row: %w", err)
+		}
+		writer.rows++
+		total++
+		byURN[row.EventURN]++
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate telemetry log rows: %w", err)
+	}
+
+	files := map[string]int{}
+	for origin, w := range writers {
+		if err := w.buf.Flush(); err != nil {
+			return fmt.Errorf("flush dump file for %s: %w", origin, err)
+		}
+		files[filepath.Join("logs", origin+".ndjson")] = w.rows
+	}
+
+	m := manifest{
+		GeneratedAt:    time.Now().UTC(),
+		ProjectID:      project.ID.String(),
+		ProjectSlug:    project.Slug,
+		OrganizationID: project.OrganizationID,
+		WindowSince:    since,
+		WindowUntil:    until,
+		Anonymized:     opts.Anonymize,
+		RowsTotal:      total,
+		RowsByEventURN: byURN,
+		Files:          files,
+	}
+	encoded, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("serialize dump manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(opts.OutDir, "manifest.json"), append(encoded, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write dump manifest: %w", err)
+	}
+
+	s.logger.InfoContext(ctx, "telemetry dump complete",
+		attr.SlogTelemetryCHRowCount(total),
+		attr.SlogFilePath(opts.OutDir),
+	)
+	return nil
+}
+
+type dumpWriter struct {
+	file *os.File
+	buf  *bufio.Writer
+	rows int
+}
+
+func writerFor(writers map[string]*dumpWriter, dir string, origin string) (*dumpWriter, error) {
+	if w, ok := writers[origin]; ok {
+		return w, nil
+	}
+	// #nosec G304 -- dump files are created inside the operator-chosen output
+	// directory and origin is validated against safeOriginPattern.
+	file, err := os.OpenFile(filepath.Join(dir, origin+".ndjson"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create dump file for %s: %w", origin, err)
+	}
+	w := &dumpWriter{file: file, buf: bufio.NewWriter(file), rows: 0}
+	writers[origin] = w
+	return w, nil
+}
+
+var safeOriginPattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+// originFromEventURN extracts the observation channel from a canonical event
+// URN (urn:telemetry:<origin>:<kind>:<type>). Rows written before URN
+// stamping existed, and any malformed value, land in "unknown".
+func originFromEventURN(eventURN string) string {
+	parts := strings.Split(eventURN, ":")
+	if len(parts) >= 5 && parts[0] == "urn" && parts[1] == "telemetry" && safeOriginPattern.MatchString(parts[2]) {
+		return parts[2]
+	}
+	return "unknown"
+}

--- a/server/internal/agentcapture/dump.go
+++ b/server/internal/agentcapture/dump.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -70,23 +71,28 @@ ORDER BY time_unix_nano, id
 `
 
 // manifest describes one capture dump so consumers know the window, scope,
-// and file layout without inspecting rows.
+// and file layout without inspecting rows. rows_total counts telemetry_logs
+// rows; the external chat export (Compliance API transcripts, which land in
+// Postgres rather than bronze) is counted separately.
 type manifest struct {
-	GeneratedAt    time.Time      `json:"generated_at"`
-	ProjectID      string         `json:"project_id"`
-	ProjectSlug    string         `json:"project_slug"`
-	OrganizationID string         `json:"organization_id"`
-	WindowSince    time.Time      `json:"window_since"`
-	WindowUntil    time.Time      `json:"window_until"`
-	Anonymized     bool           `json:"anonymized"`
-	RowsTotal      int            `json:"rows_total"`
-	RowsByEventURN map[string]int `json:"rows_by_event_urn"`
-	Files          map[string]int `json:"files"`
+	GeneratedAt       time.Time      `json:"generated_at"`
+	ProjectID         string         `json:"project_id"`
+	ProjectSlug       string         `json:"project_slug"`
+	OrganizationID    string         `json:"organization_id"`
+	WindowSince       time.Time      `json:"window_since"`
+	WindowUntil       time.Time      `json:"window_until"`
+	Anonymized        bool           `json:"anonymized"`
+	RowsTotal         int            `json:"rows_total"`
+	RowsByEventURN    map[string]int `json:"rows_by_event_urn"`
+	ChatsTotal        int            `json:"chats_total"`
+	ChatMessagesTotal int            `json:"chat_messages_total"`
+	Files             map[string]int `json:"files"`
 }
 
 // dump exports the project's telemetry_logs rows for the capture window as
 // NDJSON, one file per event origin (provider_api, provider_otel, agent_hook,
-// gram_service, unknown), with a manifest.json describing the capture.
+// gram_service, unknown), plus the external chat transcripts under chats/,
+// with a manifest.json describing the capture.
 func (s *Service) dump(ctx context.Context, project projectsrepo.Project, since, until time.Time, opts Options) error {
 	// The telemetry logger writes with async_insert=1 / wait_for_async_insert=0,
 	// so rows from the poll phase may still sit in ClickHouse's async insert
@@ -200,17 +206,25 @@ func (s *Service) dump(ctx context.Context, project projectsrepo.Project, since,
 		files[filepath.Join("logs", origin+".ndjson")] = w.rows
 	}
 
+	chatFiles, err := s.dumpExternalChats(ctx, project, since, until, opts, anonymizer)
+	if err != nil {
+		return fmt.Errorf("dump external chats: %w", err)
+	}
+	maps.Copy(files, chatFiles)
+
 	m := manifest{
-		GeneratedAt:    time.Now().UTC(),
-		ProjectID:      project.ID.String(),
-		ProjectSlug:    project.Slug,
-		OrganizationID: project.OrganizationID,
-		WindowSince:    since,
-		WindowUntil:    until,
-		Anonymized:     opts.Anonymize,
-		RowsTotal:      total,
-		RowsByEventURN: byURN,
-		Files:          files,
+		GeneratedAt:       time.Now().UTC(),
+		ProjectID:         project.ID.String(),
+		ProjectSlug:       project.Slug,
+		OrganizationID:    project.OrganizationID,
+		WindowSince:       since,
+		WindowUntil:       until,
+		Anonymized:        opts.Anonymize,
+		RowsTotal:         total,
+		RowsByEventURN:    byURN,
+		ChatsTotal:        chatFiles[filepath.Join("chats", "chats.ndjson")],
+		ChatMessagesTotal: chatFiles[filepath.Join("chats", "messages.ndjson")],
+		Files:             files,
 	}
 	encoded, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {

--- a/server/internal/agentcapture/dump_chats.go
+++ b/server/internal/agentcapture/dump_chats.go
@@ -1,0 +1,172 @@
+package agentcapture
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+)
+
+// chatExportRow is one dumped external chat. The compliance import lands
+// claude.ai transcripts in Postgres (chats / chat_messages), not
+// telemetry_logs, so the dump exports them as their own NDJSON files under
+// chats/.
+type chatExportRow struct {
+	ID             string    `json:"id"`
+	ProjectID      string    `json:"project_id"`
+	OrganizationID string    `json:"organization_id"`
+	UserID         *string   `json:"user_id"`
+	ExternalUserID *string   `json:"external_user_id"`
+	ExternalChatID *string   `json:"external_chat_id"`
+	Title          *string   `json:"title"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// chatMessageExportRow is one dumped external chat message. content_raw is
+// deliberately not exported: the rendered content column is enough for
+// fixtures and the raw blocks would need their own deep scrub.
+type chatMessageExportRow struct {
+	ID                string    `json:"id"`
+	ChatID            string    `json:"chat_id"`
+	Role              string    `json:"role"`
+	Content           string    `json:"content"`
+	Model             *string   `json:"model"`
+	UserID            *string   `json:"user_id"`
+	ExternalUserID    *string   `json:"external_user_id"`
+	ExternalMessageID *string   `json:"external_message_id"`
+	Origin            *string   `json:"origin"`
+	UserAgent         *string   `json:"user_agent"`
+	IPAddress         *string   `json:"ip_address"`
+	Source            *string   `json:"source"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+// dumpExternalChats exports the project's provider-imported chats and
+// messages for the capture window as chats/chats.ndjson and
+// chats/messages.ndjson. Files are only created when the window has rows,
+// but stale files from a previous capture are always cleared so the export
+// never disagrees with the manifest.
+func (s *Service) dumpExternalChats(ctx context.Context, project projectsrepo.Project, since, until time.Time, opts Options, anonymizer *Anonymizer) (map[string]int, error) {
+	chatsDir := filepath.Join(opts.OutDir, "chats")
+	stale, err := filepath.Glob(filepath.Join(chatsDir, "*.ndjson"))
+	if err != nil {
+		return nil, fmt.Errorf("list previous chat dump files: %w", err)
+	}
+	for _, path := range stale {
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("remove previous chat dump file: %w", err)
+		}
+	}
+
+	q := chatrepo.New(s.db)
+	chats, err := q.ListExternalChatsForExport(ctx, chatrepo.ListExternalChatsForExportParams{
+		ProjectID: project.ID,
+		Since:     conv.ToPGTimestamptz(since),
+		Until:     conv.ToPGTimestamptz(until),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list external chats: %w", err)
+	}
+	messages, err := q.ListExternalChatMessagesForExport(ctx, chatrepo.ListExternalChatMessagesForExportParams{
+		ProjectID: project.ID,
+		Since:     conv.ToPGTimestamptz(since),
+		Until:     conv.ToPGTimestamptz(until),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list external chat messages: %w", err)
+	}
+	if len(chats) == 0 && len(messages) == 0 {
+		return map[string]int{}, nil
+	}
+
+	if err := os.MkdirAll(chatsDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create chat dump directory: %w", err)
+	}
+
+	chatRows := make([]any, 0, len(chats))
+	for _, c := range chats {
+		row := chatExportRow{
+			ID:             c.ID.String(),
+			ProjectID:      c.ProjectID.String(),
+			OrganizationID: c.OrganizationID,
+			UserID:         conv.FromPGText[string](c.UserID),
+			ExternalUserID: conv.FromPGText[string](c.ExternalUserID),
+			ExternalChatID: conv.FromPGText[string](c.ExternalChatID),
+			Title:          conv.FromPGText[string](c.Title),
+			CreatedAt:      c.CreatedAt.Time.UTC(),
+			UpdatedAt:      c.UpdatedAt.Time.UTC(),
+		}
+		if anonymizer != nil {
+			anonymizer.ScrubChat(&row)
+		}
+		chatRows = append(chatRows, row)
+	}
+
+	messageRows := make([]any, 0, len(messages))
+	for _, m := range messages {
+		row := chatMessageExportRow{
+			ID:                m.ID.String(),
+			ChatID:            m.ChatID.String(),
+			Role:              m.Role,
+			Content:           m.Content,
+			Model:             conv.FromPGText[string](m.Model),
+			UserID:            conv.FromPGText[string](m.UserID),
+			ExternalUserID:    conv.FromPGText[string](m.ExternalUserID),
+			ExternalMessageID: conv.FromPGText[string](m.ExternalMessageID),
+			Origin:            conv.FromPGText[string](m.Origin),
+			UserAgent:         conv.FromPGText[string](m.UserAgent),
+			IPAddress:         conv.FromPGText[string](m.IpAddress),
+			Source:            conv.FromPGText[string](m.Source),
+			CreatedAt:         m.CreatedAt.Time.UTC(),
+		}
+		if anonymizer != nil {
+			anonymizer.ScrubChatMessage(&row)
+		}
+		messageRows = append(messageRows, row)
+	}
+
+	files := map[string]int{}
+	for name, rows := range map[string][]any{"chats": chatRows, "messages": messageRows} {
+		if len(rows) == 0 {
+			continue
+		}
+		if err := writeNDJSON(filepath.Join(chatsDir, name+".ndjson"), rows); err != nil {
+			return nil, err
+		}
+		files[filepath.Join("chats", name+".ndjson")] = len(rows)
+	}
+	return files, nil
+}
+
+// writeNDJSON writes rows as newline-delimited JSON, one object per line.
+func writeNDJSON(path string, rows []any) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) // #nosec G304 -- dump files live inside the operator-chosen output directory
+	if err != nil {
+		return fmt.Errorf("create chat dump file %s: %w", path, err)
+	}
+	defer o11y.NoLogDefer(file.Close)
+
+	buf := bufio.NewWriter(file)
+	for _, row := range rows {
+		line, err := json.Marshal(row)
+		if err != nil {
+			return fmt.Errorf("serialize chat dump row: %w", err)
+		}
+		if _, err := buf.Write(append(line, '\n')); err != nil {
+			return fmt.Errorf("write chat dump row: %w", err)
+		}
+	}
+	if err := buf.Flush(); err != nil {
+		return fmt.Errorf("flush chat dump file %s: %w", path, err)
+	}
+	return nil
+}

--- a/server/internal/agentcapture/poll.go
+++ b/server/internal/agentcapture/poll.go
@@ -29,8 +29,9 @@ func (s *Service) pollClaude(ctx context.Context, projectID uuid.UUID, organizat
 		SyncID: uuid.Nil,
 		// The Anthropic Admin Analytics endpoints infer the organization from
 		// the org-scoped admin key, so the external org ID is optional here;
-		// when supplied it is stamped on rows as gram.external_org_id, and
-		// org-scoped feeds added later (the Compliance API) require it.
+		// when supplied it is stamped on rows as gram.external_org_id. The
+		// Compliance API transcript import requires it and runs as its own
+		// leg (pollClaudeCompliance).
 		OrganizationID:         organizationID,
 		Provider:               aiintegrations.ProviderAnthropicCompliance,
 		ProjectID:              projectID,

--- a/server/internal/agentcapture/poll.go
+++ b/server/internal/agentcapture/poll.go
@@ -1,0 +1,78 @@
+package agentcapture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations"
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations/timewindowpoller"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+// pollClaude runs the Anthropic Admin Analytics pollers (usage tokens and
+// cost) in-process against an ephemeral config, exactly as the Temporal
+// worker runs them, so rows land in telemetry_logs through the production
+// ingest path. The config's SyncID is uuid.Nil: watermark advances update no
+// ai_integration_syncs row, which makes the run stateless — the window is
+// bounded purely by the checkpoint seeded from since.
+//
+// One schedule failing (e.g. the key lacks analytics access) does not stop
+// the other; failures are joined and returned after both ran.
+func (s *Service) pollClaude(ctx context.Context, projectID uuid.UUID, organizationID string, opts Options, since, until time.Time) error {
+	cfg := aiintegrations.Config{
+		ID:     uuid.Nil,
+		SyncID: uuid.Nil,
+		// The Anthropic Admin Analytics endpoints infer the organization from
+		// the org-scoped admin key, so the external org ID is optional here;
+		// when supplied it is stamped on rows as gram.external_org_id, and
+		// org-scoped feeds added later (the Compliance API) require it.
+		OrganizationID:         organizationID,
+		Provider:               aiintegrations.ProviderAnthropicCompliance,
+		ProjectID:              projectID,
+		ExternalOrganizationID: conv.PtrEmpty(opts.ExternalOrgID),
+		BillingMode:            "",
+		APIKey:                 opts.APIKey,
+		Enabled:                true,
+		PollWatermarkAt:        since,
+		PollCheckpoint:         timewindowpoller.CompletedCheckpoint(since),
+		NextPollAfter:          time.Time{},
+		LastPollError:          "",
+		LastPollFailedAt:       time.Time{},
+		LastPollSuccessAt:      time.Time{},
+		ConsecutiveFailures:    0,
+		LastCursor:             "",
+		CreatedAt:              time.Time{},
+		UpdatedAt:              time.Time{},
+	}
+
+	// The heartbeat exists for Temporal activity liveness; a one-shot CLI
+	// run has nothing to keep alive.
+	heartbeat := func(context.Context, string, int) {}
+
+	pollers := []struct {
+		name   string
+		poller *aiintegrations.AnthropicAnalyticsPoller
+	}{
+		{"anthropic_analytics_usage", aiintegrations.NewAnthropicUsageAnalyticsPoller(s.store, s.guardianPolicy, s.telemetryLogger, heartbeat)},
+		{"anthropic_analytics_cost", aiintegrations.NewAnthropicCostAnalyticsPoller(s.store, s.guardianPolicy, s.telemetryLogger, heartbeat)},
+	}
+
+	var errs []error
+	for _, p := range pollers {
+		before := s.written.count()
+		if err := p.poller.Sync(ctx, cfg, until); err != nil {
+			s.logger.ErrorContext(ctx, "provider poll failed", attr.SlogError(err))
+			errs = append(errs, fmt.Errorf("sync %s: %w", p.name, err))
+			continue
+		}
+		s.logger.InfoContext(ctx, "provider poll complete",
+			attr.SlogTelemetryCHRowCount(s.written.count()-before),
+		)
+	}
+	return errors.Join(errs...)
+}

--- a/server/internal/aiintegrations/queries.sql
+++ b/server/internal/aiintegrations/queries.sql
@@ -24,6 +24,17 @@ WHERE c.organization_id = @organization_id
   AND c.provider = @provider
   AND c.deleted IS FALSE;
 
+-- name: GetConfigIDByOrgAndProvider :one
+-- Resolves a config row id without requiring its provider-named sync
+-- schedule row to exist, unlike GetConfigByOrgAndProvider which joins on it.
+-- Backs the local agent-telemetry capture, whose config rows deliberately
+-- carry no sync schedules.
+SELECT id
+FROM ai_integration_configs
+WHERE organization_id = @organization_id
+  AND provider = @provider
+  AND deleted IS FALSE;
+
 -- name: CountConfigsByOrganization :one
 SELECT count(*)
 FROM ai_integration_configs

--- a/server/internal/aiintegrations/repo/queries.sql.go
+++ b/server/internal/aiintegrations/repo/queries.sql.go
@@ -312,6 +312,30 @@ func (q *Queries) GetConfigByOrgAndProvider(ctx context.Context, arg GetConfigBy
 	return i, err
 }
 
+const getConfigIDByOrgAndProvider = `-- name: GetConfigIDByOrgAndProvider :one
+SELECT id
+FROM ai_integration_configs
+WHERE organization_id = $1
+  AND provider = $2
+  AND deleted IS FALSE
+`
+
+type GetConfigIDByOrgAndProviderParams struct {
+	OrganizationID string
+	Provider       string
+}
+
+// Resolves a config row id without requiring its provider-named sync
+// schedule row to exist, unlike GetConfigByOrgAndProvider which joins on it.
+// Backs the local agent-telemetry capture, whose config rows deliberately
+// carry no sync schedules.
+func (q *Queries) GetConfigIDByOrgAndProvider(ctx context.Context, arg GetConfigIDByOrgAndProviderParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, getConfigIDByOrgAndProvider, arg.OrganizationID, arg.Provider)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getFirstProjectByOrganization = `-- name: GetFirstProjectByOrganization :one
 SELECT id
 FROM projects

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -454,6 +454,58 @@ VALUES (
 ON CONFLICT (chat_id, external_message_id) WHERE external_message_id IS NOT NULL
 DO NOTHING;
 
+-- name: ListExternalChatsForExport :many
+-- Backs the local agent-telemetry capture dump: external (provider-imported)
+-- chats for a project whose activity falls inside the export window. The
+-- lower bound is on updated_at so a chat created before the window but still
+-- receiving messages inside it is exported alongside those messages.
+SELECT
+    id
+  , project_id
+  , organization_id
+  , user_id
+  , external_user_id
+  , external_chat_id
+  , title
+  , created_at
+  , updated_at
+FROM chats
+WHERE project_id = @project_id
+  AND external_chat_id IS NOT NULL
+  AND deleted IS FALSE
+  AND updated_at >= @since
+  AND created_at < @until
+ORDER BY created_at, id;
+
+-- name: ListExternalChatMessagesForExport :many
+-- Backs the local agent-telemetry capture dump: provider-imported messages
+-- of external chats in the export window. created_at is the provider-side
+-- message timestamp, so the window filter matches the telemetry dump's.
+-- content_raw is deliberately not exported: the rendered content column is
+-- enough for fixtures and the raw blocks would need their own deep scrub.
+SELECT
+    m.id
+  , m.chat_id
+  , m.role
+  , m.content
+  , m.model
+  , m.user_id
+  , m.external_user_id
+  , m.external_message_id
+  , m.origin
+  , m.user_agent
+  , m.ip_address
+  , m.source
+  , m.created_at
+FROM chat_messages m
+INNER JOIN chats c ON c.id = m.chat_id
+WHERE c.project_id = @project_id
+  AND c.external_chat_id IS NOT NULL
+  AND m.external_message_id IS NOT NULL
+  AND m.created_at >= @since
+  AND m.created_at < @until
+ORDER BY m.chat_id, m.created_at, m.seq;
+
 -- name: CountChats :one
 -- Fallback for chats.list pagination: ListChats returns the total alongside
 -- each page via a window count, so this only runs when a requested page is

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -2267,6 +2267,164 @@ func (q *Queries) ListClaudeUserMessagesForPromptAttachmentParent(ctx context.Co
 	return items, nil
 }
 
+const listExternalChatMessagesForExport = `-- name: ListExternalChatMessagesForExport :many
+SELECT
+    m.id
+  , m.chat_id
+  , m.role
+  , m.content
+  , m.model
+  , m.user_id
+  , m.external_user_id
+  , m.external_message_id
+  , m.origin
+  , m.user_agent
+  , m.ip_address
+  , m.source
+  , m.created_at
+FROM chat_messages m
+INNER JOIN chats c ON c.id = m.chat_id
+WHERE c.project_id = $1
+  AND c.external_chat_id IS NOT NULL
+  AND m.external_message_id IS NOT NULL
+  AND m.created_at >= $2
+  AND m.created_at < $3
+ORDER BY m.chat_id, m.created_at, m.seq
+`
+
+type ListExternalChatMessagesForExportParams struct {
+	ProjectID uuid.UUID
+	Since     pgtype.Timestamptz
+	Until     pgtype.Timestamptz
+}
+
+type ListExternalChatMessagesForExportRow struct {
+	ID                uuid.UUID
+	ChatID            uuid.UUID
+	Role              string
+	Content           string
+	Model             pgtype.Text
+	UserID            pgtype.Text
+	ExternalUserID    pgtype.Text
+	ExternalMessageID pgtype.Text
+	Origin            pgtype.Text
+	UserAgent         pgtype.Text
+	IpAddress         pgtype.Text
+	Source            pgtype.Text
+	CreatedAt         pgtype.Timestamptz
+}
+
+// Backs the local agent-telemetry capture dump: provider-imported messages
+// of external chats in the export window. created_at is the provider-side
+// message timestamp, so the window filter matches the telemetry dump's.
+// content_raw is deliberately not exported: the rendered content column is
+// enough for fixtures and the raw blocks would need their own deep scrub.
+func (q *Queries) ListExternalChatMessagesForExport(ctx context.Context, arg ListExternalChatMessagesForExportParams) ([]ListExternalChatMessagesForExportRow, error) {
+	rows, err := q.db.Query(ctx, listExternalChatMessagesForExport, arg.ProjectID, arg.Since, arg.Until)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListExternalChatMessagesForExportRow
+	for rows.Next() {
+		var i ListExternalChatMessagesForExportRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChatID,
+			&i.Role,
+			&i.Content,
+			&i.Model,
+			&i.UserID,
+			&i.ExternalUserID,
+			&i.ExternalMessageID,
+			&i.Origin,
+			&i.UserAgent,
+			&i.IpAddress,
+			&i.Source,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listExternalChatsForExport = `-- name: ListExternalChatsForExport :many
+SELECT
+    id
+  , project_id
+  , organization_id
+  , user_id
+  , external_user_id
+  , external_chat_id
+  , title
+  , created_at
+  , updated_at
+FROM chats
+WHERE project_id = $1
+  AND external_chat_id IS NOT NULL
+  AND deleted IS FALSE
+  AND updated_at >= $2
+  AND created_at < $3
+ORDER BY created_at, id
+`
+
+type ListExternalChatsForExportParams struct {
+	ProjectID uuid.UUID
+	Since     pgtype.Timestamptz
+	Until     pgtype.Timestamptz
+}
+
+type ListExternalChatsForExportRow struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	UserID         pgtype.Text
+	ExternalUserID pgtype.Text
+	ExternalChatID pgtype.Text
+	Title          pgtype.Text
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
+// Backs the local agent-telemetry capture dump: external (provider-imported)
+// chats for a project whose activity falls inside the export window. The
+// lower bound is on updated_at so a chat created before the window but still
+// receiving messages inside it is exported alongside those messages.
+func (q *Queries) ListExternalChatsForExport(ctx context.Context, arg ListExternalChatsForExportParams) ([]ListExternalChatsForExportRow, error) {
+	rows, err := q.db.Query(ctx, listExternalChatsForExport, arg.ProjectID, arg.Since, arg.Until)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListExternalChatsForExportRow
+	for rows.Next() {
+		var i ListExternalChatsForExportRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.OrganizationID,
+			&i.UserID,
+			&i.ExternalUserID,
+			&i.ExternalChatID,
+			&i.Title,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listLatestGenerationChatMessages = `-- name: ListLatestGenerationChatMessages :many
 SELECT cm.id, cm.seq, cm.chat_id, cm.project_id, cm.role, cm.content, cm.content_raw, cm.content_asset_url, cm.model, cm.message_id, cm.finish_reason, cm.tool_calls, cm.prompt_tokens, cm.completion_tokens, cm.total_tokens, cm.storage_error, cm.user_id, cm.external_user_id, cm.external_message_id, cm.origin, cm.user_agent, cm.ip_address, cm.source, cm.tool_call_id, cm.tool_urn, cm.tool_outcome, cm.tool_outcome_notes, cm.content_hash, cm.generation, cm.replayed, cm.created_at, cm.risk_analyzed_at FROM chat_messages cm
 WHERE cm.chat_id = $1

--- a/server/internal/projects/queries.sql
+++ b/server/internal/projects/queries.sql
@@ -42,6 +42,18 @@ WHERE slug = @slug
   AND organization_id = @organization_id
   AND deleted IS FALSE;
 
+-- GetProjectBySlugAcrossOrgs resolves a project by slug alone, without an
+-- organization scope. Seeded local databases can hold several orgs with
+-- identically-slugged projects, so order by creation time to keep every run
+-- landing on the same org. Local-dev only.
+-- name: GetProjectBySlugAcrossOrgs :one
+SELECT *
+FROM projects
+WHERE slug = @slug
+  AND deleted IS FALSE
+ORDER BY created_at ASC
+LIMIT 1;
+
 -- name: GetProjectByID :one
 SELECT *
 FROM projects

--- a/server/internal/projects/repo/queries.sql.go
+++ b/server/internal/projects/repo/queries.sql.go
@@ -180,6 +180,37 @@ func (q *Queries) GetProjectBySlug(ctx context.Context, arg GetProjectBySlugPara
 	return i, err
 }
 
+const getProjectBySlugAcrossOrgs = `-- name: GetProjectBySlugAcrossOrgs :one
+SELECT id, name, slug, organization_id, logo_asset_id, functions_runner_version, created_at, updated_at, deleted_at, deleted
+FROM projects
+WHERE slug = $1
+  AND deleted IS FALSE
+ORDER BY created_at ASC
+LIMIT 1
+`
+
+// GetProjectBySlugAcrossOrgs resolves a project by slug alone, without an
+// organization scope. Seeded local databases can hold several orgs with
+// identically-slugged projects, so order by creation time to keep every run
+// landing on the same org. Local-dev only.
+func (q *Queries) GetProjectBySlugAcrossOrgs(ctx context.Context, slug string) (Project, error) {
+	row := q.db.QueryRow(ctx, getProjectBySlugAcrossOrgs, slug)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.OrganizationID,
+		&i.LogoAssetID,
+		&i.FunctionsRunnerVersion,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getProjectWithOrganizationMetadata = `-- name: GetProjectWithOrganizationMetadata :one
 SELECT 
     -- Project fields


### PR DESCRIPTION
## Summary

- **`gram capture-agent-telemetry`** (standalone dev binary at `server/cmd/capture-agent-telemetry`, never ships in the `gram` CLI): polls a provider's admin APIs (claude: Anthropic Admin Analytics usage + cost) into local `telemetry_logs` through the production poller/ingest path, then dumps the window (`--lookback`, default 7d) as NDJSON fixtures split by event origin, with a manifest.
- **Deterministic anonymization** on export (raw data stays local-only in ClickHouse): salt-keyed HMAC pseudonyms for provider identities (emails, external user/org IDs — UUID-shaped stays UUID-shaped), length-stamped scrubbing for prompts/tool IO. Salt persists in the output dir so pseudonyms are stable across captures.
- **`mise run capture:agent-telemetry`** wrapper: runs the poll leg in parallel with an agent session — interactive by default, headless via `--prompt` / `--prompts-file` — then dumps once, so the export includes both provider reports and live session telemetry.
- **`hooks:test` fix**: always render the plugin and load it with `--plugin-dir`. The published plugin is enabled via user-scope settings, which `--setting-sources project,local` excludes — sessions silently registered zero hooks (OTel only, no `agent_hook` events). Also adds a `--print <prompt>` headless mode.

## Test plan

- [x] `go test ./server/internal/agentcapture/` (anonymizer determinism, salt round-trip, URN routing)
- [x] `mise lint:server`
- [x] Live smoke on the dev stack: poll with a real admin key (2,110 usage rows), headless session via the wrapper — dump contains `provider_api`, `provider_otel`, and the full `agent_hook` lifecycle (sessionstart → sessionend); pseudonyms verified stable across runs
- [x] Poll failure path: invalid key → per-schedule 401s logged, dump still written, exit 1

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev-only telemetry capture tool that polls Anthropic Admin Analytics and imports Claude Chat compliance transcripts, then dumps a bounded window as anonymized NDJSON so you can develop telemetry with realistic data and no live credentials. Fixes dev hooks so sessions emit `agent_hook` events instead of OTel-only.

- New binary `server/cmd/capture-agent-telemetry` (run with `mise run capture:agent-telemetry`) that runs the provider poll in parallel with an interactive or headless session and then dumps once; outputs include provider reports, provider OTel, `agent_hook`, and gram service rows split by origin.
- Compliance transcripts: when `--external-org-id` is set, imports claude.ai chats via the production pipeline using a disabled, schedule-less local config; exports `chats/chats.ndjson` and `chats/messages.ndjson`.
- Deterministic anonymization on export: HMAC pseudonyms for provider identities and scrubbed free text in logs and chats; stable salt persisted in the output dir; opt out with `--raw`.
- Dev hooks: `mise run hooks:test` always renders and loads the plugin with `--plugin-dir` and adds `--print` for a single headless prompt, ensuring consistent `agent_hook` emissions.
- `.gitignore` excludes `/local/agent-telemetry` to avoid committing local dumps.

<sup>Written for commit 4c18f479b52cf9c3bf826527896b3a71266b40f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

