### PR TITLE
chore: switch the assistant platform toolset gate to a flag variant

### DIFF
--- a/server/internal/assistants/platform_slugs_test.go
+++ b/server/internal/assistants/platform_slugs_test.go
@@ -50,13 +50,32 @@ func platformSlugsFixture(t *testing.T) (*Service, assistantRecord, assistantRec
 	return svc, managedRecord, otherRecord
 }
 
-func TestAssistantPlatformSlugsManagedWithFlagOnGetsPlatformToolset(t *testing.T) {
+// The platformmcp variant REPLACES the legacy managed toolset rather than
+// adding to it: an org on one variant must never see the other's tools.
+func TestAssistantPlatformSlugsManagedPlatformMCPVariantReplacesLegacy(t *testing.T) {
 	t.Parallel()
 
 	svc, managedRecord, _ := platformSlugsFixture(t)
 
 	flags := &feature.InMemory{}
-	flags.SetFlag(feature.FlagAssistantPlatformMCP, "org-test", true)
+	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.VariantAssistantToolsPlatformMCP)
+	svc.core.SetFeatureProvider(flags)
+
+	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		platformtools.AssistantsPlatformToolsetSlug,
+		platformtools.PlatformMCPReadToolsetSlug,
+	}, slugs)
+}
+
+func TestAssistantPlatformSlugsManagedLegacyVariantUnchanged(t *testing.T) {
+	t.Parallel()
+
+	svc, managedRecord, _ := platformSlugsFixture(t)
+
+	flags := &feature.InMemory{}
+	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.VariantAssistantToolsLegacy)
 	svc.core.SetFeatureProvider(flags)
 
 	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
@@ -64,11 +83,29 @@ func TestAssistantPlatformSlugsManagedWithFlagOnGetsPlatformToolset(t *testing.T
 	require.Equal(t, []string{
 		platformtools.AssistantsPlatformToolsetSlug,
 		platformtools.ManagedAssistantPlatformToolsetSlug,
-		platformtools.PlatformMCPReadToolsetSlug,
 	}, slugs)
 }
 
-func TestAssistantPlatformSlugsManagedWithFlagOffUnchanged(t *testing.T) {
+// An unrecognized variant key (e.g. a PostHog variant renamed out from under
+// the server) must land on legacy, not on no toolset at all.
+func TestAssistantPlatformSlugsUnknownVariantFallsBackToLegacy(t *testing.T) {
+	t.Parallel()
+
+	svc, managedRecord, _ := platformSlugsFixture(t)
+
+	flags := &feature.InMemory{}
+	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.Variant("control"))
+	svc.core.SetFeatureProvider(flags)
+
+	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		platformtools.AssistantsPlatformToolsetSlug,
+		platformtools.ManagedAssistantPlatformToolsetSlug,
+	}, slugs)
+}
+
+func TestAssistantPlatformSlugsNoVariantUnchanged(t *testing.T) {
 	t.Parallel()
 
 	svc, managedRecord, _ := platformSlugsFixture(t)
@@ -82,7 +119,7 @@ func TestAssistantPlatformSlugsManagedWithFlagOffUnchanged(t *testing.T) {
 	}, slugs)
 }
 
-func TestAssistantPlatformSlugsNilProviderFailsClosed(t *testing.T) {
+func TestAssistantPlatformSlugsNilProviderFallsBackToLegacy(t *testing.T) {
 	t.Parallel()
 
 	svc, managedRecord, _ := platformSlugsFixture(t)
@@ -101,7 +138,7 @@ func TestAssistantPlatformSlugsNonManagedNeverGetsPlatformToolset(t *testing.T) 
 	svc, _, otherRecord := platformSlugsFixture(t)
 
 	flags := &feature.InMemory{}
-	flags.SetFlag(feature.FlagAssistantPlatformMCP, "org-test", true)
+	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.VariantAssistantToolsPlatformMCP)
 	svc.core.SetFeatureProvider(flags)
 
 	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), otherRecord)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -2806,16 +2806,18 @@ func (s *ServiceCore) currentRuntimeMCPServers(ctx context.Context, assistant as
 
 // assistantPlatformSlugs returns the platform toolset slugs granted to this
 // assistant's runtime. Every assistant gets the base assistants toolset; the
-// project's managed assistant additionally gets the managed-only toolset,
-// which must never be reachable by any other assistant.
+// project's managed assistant additionally gets exactly one managed-only
+// toolset — legacy or Platform MCP, per the rollout variant — which must never
+// be reachable by any other assistant.
 func (s *ServiceCore) assistantPlatformSlugs(ctx context.Context, assistant assistantRecord) ([]string, error) {
 	platformSlugs := []string{platformtools.AssistantsPlatformToolsetSlug}
 	switch managed, mErr := assistantrepo.New(s.db).GetManagedAssistantByProject(ctx, assistant.ProjectID); {
 	case mErr == nil:
 		if managed.ID == assistant.ID {
-			platformSlugs = append(platformSlugs, platformtools.ManagedAssistantPlatformToolsetSlug)
-			if s.platformMCPReadEnabled(ctx, assistant.ProjectID) {
+			if s.assistantToolsVariant(ctx, assistant.ProjectID) == feature.VariantAssistantToolsPlatformMCP {
 				platformSlugs = append(platformSlugs, platformtools.PlatformMCPReadToolsetSlug)
+			} else {
+				platformSlugs = append(platformSlugs, platformtools.ManagedAssistantPlatformToolsetSlug)
 			}
 		}
 	case errors.Is(mErr, pgx.ErrNoRows):
@@ -2826,27 +2828,27 @@ func (s *ServiceCore) assistantPlatformSlugs(ctx context.Context, assistant assi
 	return platformSlugs, nil
 }
 
-// platformMCPReadEnabled reports whether the organization owning projectID is
-// cleared for the Platform MCP read toolset rollout. Evaluation mirrors the
-// Platform MCP organization gate: distinct ID is the org ID with the org-slug
-// PostHog group. Errors fail closed but never abort the turn — a flag-provider
-// outage must not take down bootstrap or reconcile, so the toolset is simply
-// withheld until evaluation recovers.
-func (s *ServiceCore) platformMCPReadEnabled(ctx context.Context, projectID uuid.UUID) bool {
+// assistantToolsVariant reports which managed-assistant platform toolset the
+// organization owning projectID is on. Evaluation mirrors the Platform MCP
+// organization gate: distinct ID is the org ID with the org-slug PostHog
+// group. Every failure path returns the legacy variant but never aborts the
+// turn — a flag-provider outage must not take down bootstrap or reconcile, nor
+// silently strip the managed assistant's tools.
+func (s *ServiceCore) assistantToolsVariant(ctx context.Context, projectID uuid.UUID) feature.Variant {
 	if s.featureFlags == nil {
-		return false
+		return feature.VariantAssistantToolsLegacy
 	}
 	project, err := projectsrepo.New(s.db).GetProjectWithOrganizationMetadata(ctx, projectID)
 	if err != nil {
-		s.logger.WarnContext(ctx, "resolve organization for platform mcp read toolset", attr.SlogError(err))
-		return false
+		s.logger.WarnContext(ctx, "resolve organization for assistant tools variant", attr.SlogError(err))
+		return feature.VariantAssistantToolsLegacy
 	}
-	enabled, err := s.featureFlags.IsFlagEnabled(ctx, feature.FlagAssistantPlatformMCP, project.ID, feature.OrgProjectGroups(project.Slug, ""))
+	variant, err := feature.FlagVariant(ctx, s.featureFlags, feature.FlagAssistantPlatformMCP, project.ID, feature.OrgProjectGroups(project.Slug, ""))
 	if err != nil {
-		s.logger.WarnContext(ctx, "evaluate assistant platform mcp flag", attr.SlogError(err))
-		return false
+		s.logger.WarnContext(ctx, "resolve assistant platform mcp variant", attr.SlogError(err))
+		return feature.VariantAssistantToolsLegacy
 	}
-	return enabled
+	return feature.AssistantToolsVariant(variant)
 }
 
 // turnUserID returns the Gram user whose identity a turn should act under.

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -92,8 +92,8 @@ const (
 // PostHog outage can never strip the managed assistant's tools.
 const (
 	// VariantAssistantToolsLegacy serves the managed assistant the
-	// "managed-assistant" platform toolset (insights, chats, risk, skills,
-	// plugins, docs).
+	// "managed-assistant" platform toolset (logs, chats, users, risk,
+	// deployments, skills, plugins, docs, changelog).
 	VariantAssistantToolsLegacy Variant = "legacy"
 	// VariantAssistantToolsPlatformMCP serves the managed assistant the
 	// "platform" toolset — the Platform MCP read tools — INSTEAD of the

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -50,12 +50,13 @@ const (
 	// registration and provider-setup handoffs. It is evaluated after the main
 	// Platform MCP gate and is default-off during the mutation rollout.
 	FlagPlatformMCPCatalogRegistration Flag = "platform-mcp-catalog-registration"
-	// FlagAssistantPlatformMCP grants a project's managed (dashboard)
-	// assistant the Platform MCP read toolset — the "platform" platform
-	// toolset re-serving the Platform MCP read tools over the assistant
-	// runtime channel. Targeted by PostHog organization group (org slug),
-	// like FlagBudgets. Evaluated server-side only; removed once the toolset
-	// is GA.
+	// FlagAssistantPlatformMCP selects which platform toolset a project's
+	// managed (dashboard) assistant is served. It is MULTIVARIATE, not
+	// boolean: the matched variant names the toolset, and the two variants are
+	// mutually exclusive — an org on one never sees the other's tools. See
+	// VariantAssistantToolsLegacy / VariantAssistantToolsPlatformMCP. Targeted
+	// by PostHog organization group (org slug), like FlagBudgets. Evaluated
+	// server-side only; removed once one variant wins.
 	FlagAssistantPlatformMCP Flag = "assistant-platform-mcp"
 	// FlagRiskOverviewFromClickHouse serves the risk overview endpoint from
 	// ClickHouse risk_findings instead of Postgres risk_results. Per-org
@@ -84,3 +85,29 @@ const (
 	// can't strand it on stale hooks.
 	FlagHooksRollout Flag = "hooks-rollout"
 )
+
+// Variants of FlagAssistantPlatformMCP. Anything else — no variant, an
+// unrecognized key, an unavailable provider, or an evaluation error — resolves
+// to VariantAssistantToolsLegacy, which is the pre-rollout behaviour, so a
+// PostHog outage can never strip the managed assistant's tools.
+const (
+	// VariantAssistantToolsLegacy serves the managed assistant the
+	// "managed-assistant" platform toolset (insights, chats, risk, skills,
+	// plugins, docs).
+	VariantAssistantToolsLegacy Variant = "legacy"
+	// VariantAssistantToolsPlatformMCP serves the managed assistant the
+	// "platform" toolset — the Platform MCP read tools — INSTEAD of the
+	// legacy toolset, not in addition to it.
+	VariantAssistantToolsPlatformMCP Variant = "platformmcp"
+)
+
+// AssistantToolsVariant normalizes a resolved variant to one of the two known
+// keys, collapsing everything unrecognized onto the legacy default. Both the
+// attach path (assistants service) and the serve path (mcp service) must agree
+// on this mapping or a toolset would be attached and then 404 at request time.
+func AssistantToolsVariant(variant Variant) Variant {
+	if variant == VariantAssistantToolsPlatformMCP {
+		return VariantAssistantToolsPlatformMCP
+	}
+	return VariantAssistantToolsLegacy
+}

--- a/server/internal/feature/provider.go
+++ b/server/internal/feature/provider.go
@@ -79,6 +79,60 @@ func (imp *InMemory) SetFlagPayload(flag Flag, distinctID string, payload []byte
 	(*sync.Map)(imp).Store(payloadKey(flag, distinctID), payload)
 }
 
+// variantKey namespaces variant entries so they never collide with the boolean
+// or payload entries stored for the same flag.
+func variantKey(flag Flag, distinctID string) string {
+	return "variant:" + distinctID + ":" + string(flag)
+}
+
+func (imp *InMemory) FlagVariant(ctx context.Context, flag Flag, distinctID string, groups map[string]string) (Variant, error) {
+	val, ok := (*sync.Map)(imp).Load(variantKey(flag, distinctID))
+	if !ok {
+		return "", nil
+	}
+
+	variant, ok := val.(Variant)
+	if !ok {
+		return "", nil
+	}
+
+	return variant, nil
+}
+
+func (imp *InMemory) SetFlagVariant(flag Flag, distinctID string, variant Variant) {
+	(*sync.Map)(imp).Store(variantKey(flag, distinctID), variant)
+}
+
+// Variant is the release key a multivariate flag resolves to. An empty Variant
+// means the flag is off, boolean-only, missing, or the provider could not
+// decide — callers must map it to their own fail-safe default rather than
+// treating it as a distinct behaviour.
+type Variant string
+
+// VariantProvider is implemented by providers that can resolve a multivariate
+// flag's variant key. Kept separate from Provider so bool-only implementations
+// (test fakes included) keep compiling.
+type VariantProvider interface {
+	FlagVariant(ctx context.Context, flag Flag, distinctID string, groups map[string]string) (Variant, error)
+}
+
+// FlagVariant resolves a multivariate flag's variant, returning "" for
+// providers that only expose the bool contract or when no variant matched.
+func FlagVariant(ctx context.Context, provider Provider, flag Flag, distinctID string, groups map[string]string) (Variant, error) {
+	if provider == nil {
+		return "", nil
+	}
+	resolver, ok := provider.(VariantProvider)
+	if !ok {
+		return "", nil
+	}
+	variant, err := resolver.FlagVariant(ctx, flag, distinctID, groups)
+	if err != nil {
+		return "", fmt.Errorf("resolve feature flag variant %q: %w", flag, err)
+	}
+	return variant, nil
+}
+
 // Evaluation reports whether a flag provider reached an authoritative decision.
 // It is intentionally separate from Provider so existing feature checks can keep
 // their bool-only contract while safety-sensitive callers can distinguish an

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -156,27 +156,40 @@ func (s *Service) authorizePlatformToolset(ctx context.Context, slug string, aut
 		return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
 	}
 
-	// The Platform MCP read toolset is rollout-gated per organization. The
-	// attachment decision in the assistants service uses the same flag, but
-	// the assistant token lives inside the runner VM, so the serve path
-	// re-checks rather than trusting attachment. Fail closed on evaluation
-	// errors.
-	if slug == platformtools.PlatformMCPReadToolsetSlug {
-		if s.features == nil {
-			return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
-		}
-		enabled, err := s.features.IsFlagEnabled(ctx, feature.FlagAssistantPlatformMCP,
+	// The two managed-only toolsets are rollout variants of each other: an org
+	// reaches exactly one, never both. The attachment decision in the
+	// assistants service resolves the same variant, but the assistant token
+	// lives inside the runner VM, so the serve path re-resolves rather than
+	// trusting attachment. A variant that cannot be resolved falls back to
+	// legacy, matching attachment, so an outage never leaves the managed
+	// assistant with no toolset at all.
+	variant := feature.VariantAssistantToolsLegacy
+	if s.features != nil {
+		resolved, err := feature.FlagVariant(ctx, s.features, feature.FlagAssistantPlatformMCP,
 			authCtx.ActiveOrganizationID, feature.OrgProjectGroups(authCtx.OrganizationSlug, ""))
 		if err != nil {
-			s.logger.WarnContext(ctx, "evaluate assistant platform mcp flag", attr.SlogError(err))
-			return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
-		}
-		if !enabled {
-			return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
+			s.logger.WarnContext(ctx, "resolve assistant platform mcp variant", attr.SlogError(err))
+		} else {
+			variant = feature.AssistantToolsVariant(resolved)
 		}
 	}
 
+	if slug != wantedToolsetSlug(variant) {
+		return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
+	}
+
 	return nil
+}
+
+// wantedToolsetSlug maps a resolved rollout variant to the single managed-only
+// platform toolset that variant serves. Keep in lockstep with
+// assistantPlatformSlugs in the assistants service — the two must agree or a
+// toolset is attached at bootstrap and then 404s on every request.
+func wantedToolsetSlug(variant feature.Variant) string {
+	if variant == feature.VariantAssistantToolsPlatformMCP {
+		return platformtools.PlatformMCPReadToolsetSlug
+	}
+	return platformtools.ManagedAssistantPlatformToolsetSlug
 }
 
 func (s *Service) handlePlatformToolsetRequest(

--- a/server/internal/mcp/serve_platform_test.go
+++ b/server/internal/mcp/serve_platform_test.go
@@ -52,6 +52,32 @@ func TestServePlatformToolset_ManagedAssistantReachesManagedToolset(t *testing.T
 	require.Contains(t, w.Body.String(), platformtools.ToolNameSearchLogs)
 }
 
+// The swap cuts both ways: an org on the platformmcp variant must lose the
+// legacy toolset, not merely gain the platform one.
+func TestServePlatformToolset_ManagedToolsetRejectedOnPlatformMCPVariant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	managedID := createAssistant(t, ti, authCtx, "Managed")
+	err := assistantsrepo.New(ti.conn).CreateProjectManagedAssistant(t.Context(), assistantsrepo.CreateProjectManagedAssistantParams{
+		ProjectID:   *authCtx.ProjectID,
+		AssistantID: managedID,
+	})
+	require.NoError(t, err)
+
+	ti.features.SetFlagVariant(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, feature.VariantAssistantToolsPlatformMCP)
+
+	token := mintAssistantToken(t, ti, authCtx, managedID)
+	_, err = servePlatformHTTP(t, ti, platformtools.ManagedAssistantPlatformToolsetSlug, toolsListBody(), token)
+	require.Error(t, err, "the legacy toolset must stay hidden on the platformmcp variant")
+	require.Contains(t, err.Error(), "not found")
+}
+
 func TestServePlatformToolset_NonManagedAssistantRejected(t *testing.T) {
 	t.Parallel()
 
@@ -260,8 +286,9 @@ func servePlatformHTTP(t *testing.T, ti *testInstance, slug string, body []byte,
 }
 
 // The Platform MCP read toolset is rollout-gated: the managed assistant
-// reaches it only when the assistant-platform-mcp flag is on for the org.
-func TestServePlatformToolset_PlatformMCPReadFlagOnListsTools(t *testing.T) {
+// reaches it only when the assistant-platform-mcp flag resolves to the
+// platformmcp variant for the org.
+func TestServePlatformToolset_PlatformMCPReadVariantListsTools(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -277,7 +304,7 @@ func TestServePlatformToolset_PlatformMCPReadFlagOnListsTools(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ti.features.SetFlag(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, true)
+	ti.features.SetFlagVariant(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, feature.VariantAssistantToolsPlatformMCP)
 
 	token := mintAssistantToken(t, ti, authCtx, managedID)
 	w, err := servePlatformHTTP(t, ti, platformtools.PlatformMCPReadToolsetSlug, toolsListBody(), token)
@@ -290,7 +317,7 @@ func TestServePlatformToolset_PlatformMCPReadFlagOnListsTools(t *testing.T) {
 	require.Contains(t, body, platformtools.ToolNameGetMCP)
 }
 
-func TestServePlatformToolset_PlatformMCPReadFlagOffRejected(t *testing.T) {
+func TestServePlatformToolset_PlatformMCPReadLegacyVariantRejected(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -308,7 +335,7 @@ func TestServePlatformToolset_PlatformMCPReadFlagOffRejected(t *testing.T) {
 
 	token := mintAssistantToken(t, ti, authCtx, managedID)
 	_, err = servePlatformHTTP(t, ti, platformtools.PlatformMCPReadToolsetSlug, toolsListBody(), token)
-	require.Error(t, err, "the platform toolset must stay hidden while the flag is off")
+	require.Error(t, err, "the platform toolset must stay hidden on the legacy variant")
 	require.Contains(t, err.Error(), "not found")
 }
 
@@ -328,13 +355,13 @@ func TestServePlatformToolset_PlatformMCPReadNonManagedAssistantRejected(t *test
 	})
 	require.NoError(t, err)
 
-	ti.features.SetFlag(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, true)
+	ti.features.SetFlagVariant(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, feature.VariantAssistantToolsPlatformMCP)
 
 	otherID := createAssistant(t, ti, authCtx, "Other")
 	token := mintAssistantToken(t, ti, authCtx, otherID)
 
 	_, err = servePlatformHTTP(t, ti, platformtools.PlatformMCPReadToolsetSlug, toolsListBody(), token)
-	require.Error(t, err, "a non-managed assistant must not reach the platform toolset even with the flag on")
+	require.Error(t, err, "a non-managed assistant must not reach the platform toolset even on the platformmcp variant")
 	require.Contains(t, err.Error(), "not found")
 }
 
@@ -356,7 +383,7 @@ func TestServePlatformToolset_PlatformMCPReadListProjectsCall(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ti.features.SetFlag(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, true)
+	ti.features.SetFlagVariant(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, feature.VariantAssistantToolsPlatformMCP)
 
 	token := mintAssistantToken(t, ti, authCtx, managedID)
 

--- a/server/internal/thirdparty/posthog/posthog.go
+++ b/server/internal/thirdparty/posthog/posthog.go
@@ -143,6 +143,34 @@ func (p *Posthog) EvaluateFlag(ctx context.Context, flag feature.Flag, distinctI
 	return feature.EvaluationDisabled, nil
 }
 
+// FlagVariant returns the variant key a multivariate flag resolves to for
+// distinctID, or "" when posthog is disabled, the flag is off, the flag does
+// not exist, or it is a boolean flag (no variant). Callers map "" to their own
+// fail-safe default.
+func (p *Posthog) FlagVariant(ctx context.Context, flag feature.Flag, distinctID string, groups map[string]string) (feature.Variant, error) {
+	if p == nil || p.disabled || p.client == nil {
+		p.logger.InfoContext(ctx, "posthog is disabled, returning no variant")
+		return "", nil
+	}
+
+	result, err := p.client.GetFeatureFlagResult(posthog.FeatureFlagPayload{
+		Key:        string(flag),
+		DistinctId: distinctID,
+		Groups:     posthogGroups(groups),
+	})
+	if errors.Is(err, posthog.ErrFlagNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get feature flag variant: %w", err)
+	}
+	if result == nil || !result.Enabled || result.Variant == nil {
+		return "", nil
+	}
+
+	return feature.Variant(*result.Variant), nil
+}
+
 func (p *Posthog) evaluateLocalFlag(flag feature.Flag, distinctID string, groups map[string]string) (feature.Evaluation, error) {
 	sendFeatureFlagEvents := false
 	flags, err := p.client.GetAllFlags(posthog.FeatureFlagPayloadNoKey{

--- a/server/internal/thirdparty/posthog/posthog.go
+++ b/server/internal/thirdparty/posthog/posthog.go
@@ -148,7 +148,10 @@ func (p *Posthog) EvaluateFlag(ctx context.Context, flag feature.Flag, distinctI
 // not exist, or it is a boolean flag (no variant). Callers map "" to their own
 // fail-safe default.
 func (p *Posthog) FlagVariant(ctx context.Context, flag feature.Flag, distinctID string, groups map[string]string) (feature.Variant, error) {
-	if p == nil || p.disabled || p.client == nil {
+	if p == nil || p.client == nil {
+		return "", nil
+	}
+	if p.disabled {
 		p.logger.InfoContext(ctx, "posthog is disabled, returning no variant")
 		return "", nil
 	}

--- a/server/internal/thirdparty/posthog/posthog.go
+++ b/server/internal/thirdparty/posthog/posthog.go
@@ -148,11 +148,10 @@ func (p *Posthog) EvaluateFlag(ctx context.Context, flag feature.Flag, distinctI
 // not exist, or it is a boolean flag (no variant). Callers map "" to their own
 // fail-safe default.
 func (p *Posthog) FlagVariant(ctx context.Context, flag feature.Flag, distinctID string, groups map[string]string) (feature.Variant, error) {
-	if p == nil || p.client == nil {
-		return "", nil
-	}
-	if p.disabled {
-		p.logger.InfoContext(ctx, "posthog is disabled, returning no variant")
+	// No disabled-log here, unlike IsFlagEnabled: New already logs the reason
+	// once at startup, and this sits on the managed assistant's per-request
+	// path, where a line per call is noise rather than a diagnostic.
+	if p == nil || p.disabled || p.client == nil {
 		return "", nil
 	}
 

--- a/server/internal/thirdparty/posthog/posthog_test.go
+++ b/server/internal/thirdparty/posthog/posthog_test.go
@@ -90,3 +90,14 @@ func TestPosthogEvaluateFlag(t *testing.T) {
 		})
 	}
 }
+
+// A nil provider is the shape callers hold before wiring completes; resolving a
+// variant on it must yield "no variant", not a nil-pointer panic on the logger.
+func TestPosthogFlagVariantNilProvider(t *testing.T) {
+	t.Parallel()
+
+	var p *Posthog
+	variant, err := p.FlagVariant(t.Context(), feature.FlagAssistantPlatformMCP, "org-test", nil)
+	require.NoError(t, err)
+	require.Empty(t, variant)
+}


### PR DESCRIPTION
The managed (dashboard) assistant's Platform MCP rollout was an additive boolean: flag on meant the `platform` toolset was served _alongside_ the legacy `managed-assistant` one. That can't answer "does the Platform MCP tool surface work better than the legacy one" — both are in context at once.

This turns `assistant-platform-mcp` into a multivariate flag whose variant names the toolset, and makes the two mutually exclusive.

## Variants

| Variant            | Managed assistant is served                                                                       |
| ------------------ | ------------------------------------------------------------------------------------------------- |
| `legacy` (default) | `managed-assistant` — insights, chats, users, risk, deployments, skills, plugins, docs, changelog |
| `platformmcp`      | `platform` — the re-served Platform MCP read tools                                                |

Every other assistant keeps the base `assistants` toolset and nothing else, unchanged.

## Changes

- **`feature`** — new `Variant` type, optional `VariantProvider` side-interface, and a package-level `feature.FlagVariant` helper, following the existing `EvaluationProvider`/`EvaluateFlag` pattern so bool-only providers and test fakes keep compiling. `InMemory` gains `SetFlagVariant`/`FlagVariant`.
- **`thirdparty/posthog`** — `FlagVariant` via `GetFeatureFlagResult`; returns `""` when disabled, missing, off, or boolean.
- **`assistants`** — `platformMCPReadEnabled` becomes `assistantToolsVariant`; the managed assistant appends exactly one managed-only slug.
- **`mcp`** — the serve-time recheck resolves the variant and requires the requested slug to be the one that variant serves, so the legacy toolset now 404s on `platformmcp` too, not just the reverse.

## Fail-safe direction

Nil provider, evaluation error, missing flag, or an unrecognized variant key all resolve to `legacy`. Fail-_closed_ here would mean a PostHog outage silently stripping ~30 tools from the dashboard assistant, so the fallback is the pre-rollout behaviour instead. Attach-time and serve-time share the same mapping (`AssistantToolsVariant`) — if they disagreed, a toolset would be attached at bootstrap and then 404 on every call.

## Rollout note

The flag is evaluated **server-side only**, with `distinct_id` = the organization id and the `organization` group set to the org slug. Release conditions must target the organization group (as `gram-budgets` and `device-level-coverage` do); a condition matching a _user_ cohort cannot match and will fall through to the `legacy` default.

## Tests

- `platform_slugs_test.go` — `platformmcp` replaces rather than adds; `legacy`; unknown variant → legacy; nil provider → legacy; non-managed assistant unaffected.
- `serve_platform_test.go` — variant gates both directions, including the new "legacy toolset rejected on `platformmcp`" case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the managed assistant’s Platform MCP gate from a boolean additive flag to a multivariate flag. Previously, turning the flag on added the Platform MCP toolset alongside legacy; now `assistant-platform-mcp` resolves to `legacy` or `platformmcp`, and the managed assistant gets exactly one. Serve-time checks reject the wrong toolset; unknown variants, evaluation errors, or a nil provider fall back to legacy. Non-managed assistants are unchanged.

- Update tests and local providers to set variants using `SetFlagVariant` (not `SetFlag`).

**Review notes**
- `server/internal/feature`: adds `Variant`, `VariantProvider`, and `FlagVariant`; `InMemory` gains `SetFlagVariant`/`FlagVariant`; defines `VariantAssistantToolsLegacy`, `VariantAssistantToolsPlatformMCP`, and `AssistantToolsVariant` normalizer.
- `server/internal/thirdparty/posthog`: implements `FlagVariant` via `GetFeatureFlagResult`; returns empty variant when disabled/off/boolean/missing; safe on a nil provider; drops the per-request disabled-log branch from variant lookup.
- `server/internal/assistants`: replaces the boolean gate with `assistantToolsVariant`; the managed assistant attaches exactly one of the legacy or Platform MCP toolsets.
- `server/internal/mcp`: re-resolves the variant per request and requires the requested slug to match; legacy hides on `platformmcp` and vice versa. Tests cover swap, fallbacks, and non-managed behavior.

**Rollout**
- Evaluate `assistant-platform-mcp` server-side with `distinct_id` = org ID and `organization` group = org slug; target the organization group in PostHog.
- Define multivariate `assistant-platform-mcp` with variants `legacy` (default) and `platformmcp`.
- Fail-safe: nil provider, evaluation errors, missing flag, or unknown variant all resolve to legacy so the managed assistant never loses its tools.

<sup>Written for commit d47dd3003d410f84ae66eed0f65aac7d38e72643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

