### PR TITLE
mig: add openrouter_api_keys.key_encrypted and relax key to nullable

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1978,7 +1978,15 @@ CREATE TABLE IF NOT EXISTS openrouter_api_keys (
   -- and 402 the customer's chat surface.
   key_type TEXT NOT NULL DEFAULT 'chat',
 
-  key TEXT NOT NULL,
+  -- Plaintext upstream OpenRouter key. Deprecated in favor of key_encrypted:
+  -- new rows dual-write both columns during the expand phase, and the
+  -- platform-admin encrypt action clears this column once the encrypted copy
+  -- is verified. Kept nullable until a later contract migration drops it.
+  key TEXT,
+  -- AES-256-GCM encrypted upstream OpenRouter key, encrypted at rest and
+  -- never returned by the API. Nullable while pre-encryption rows are
+  -- migrated; reads prefer this column and fall back to key.
+  key_encrypted TEXT,
   key_hash TEXT NOT NULL,
   monthly_credits BIGINT NOT NULL DEFAULT 0,
   disabled BOOLEAN NOT NULL DEFAULT FALSE,

--- a/server/internal/background/activities/openrouter_credits_metrics.go
+++ b/server/internal/background/activities/openrouter_credits_metrics.go
@@ -74,7 +74,7 @@ func (c *CollectOpenRouterCreditsMetrics) Do(ctx context.Context, args CollectOp
 	g.SetLimit(openRouterCreditsPollConcurrency)
 	for i, row := range rows {
 		g.Go(func() error {
-			used, upstreamLimit, err := c.openRouter.GetKeyUsage(gctx, row.ApiKey)
+			used, upstreamLimit, err := c.openRouter.GetKeyUsage(gctx, row.ApiKey.String)
 			if err != nil {
 				// Skip on a per-org failure so one bad key does not blank the
 				// whole batch. The error is logged for diagnosis and swallowed

--- a/server/internal/background/activities/openrouter_credits_targets_test.go
+++ b/server/internal/background/activities/openrouter_credits_targets_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	repo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 )
@@ -37,7 +38,7 @@ func TestGetOpenRouterCreditsMonitoringTargets_OneRowPerKeyType(t *testing.T) {
 	_, err = orKeys.CreateOpenRouterAPIKey(ctx, openrouterrepo.CreateOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        "chat",
-		Key:            "sk-chat",
+		Key:            conv.ToPGText("sk-chat"),
 		KeyHash:        "hash-chat",
 		MonthlyCredits: 100,
 	})
@@ -45,7 +46,7 @@ func TestGetOpenRouterCreditsMonitoringTargets_OneRowPerKeyType(t *testing.T) {
 	_, err = orKeys.CreateOpenRouterAPIKey(ctx, openrouterrepo.CreateOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        "internal",
-		Key:            "sk-internal",
+		Key:            conv.ToPGText("sk-internal"),
 		KeyHash:        "hash-internal",
 		MonthlyCredits: 100,
 	})
@@ -59,7 +60,7 @@ func TestGetOpenRouterCreditsMonitoringTargets_OneRowPerKeyType(t *testing.T) {
 		if row.OrganizationID != orgID {
 			continue
 		}
-		byKeyType[row.KeyType] = row.ApiKey
+		byKeyType[row.KeyType] = row.ApiKey.String
 	}
 	require.Equal(t, map[string]string{
 		"chat":     "sk-chat",
@@ -73,12 +74,12 @@ func TestGetOpenRouterCreditsMonitoringTargets_OneRowPerKeyType(t *testing.T) {
 		KeyType:        "chat",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "sk-chat", chatKey.Key)
+	require.Equal(t, "sk-chat", chatKey.Key.String)
 
 	internalKey, err := orKeys.GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        "internal",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "sk-internal", internalKey.Key)
+	require.Equal(t, "sk-internal", internalKey.Key.String)
 }

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -493,7 +493,7 @@ type GetOpenRouterCreditsMonitoringTargetsRow struct {
 	GramAccountType  string
 	KeyType          string
 	MonthlyCredits   int64
-	ApiKey           string
+	ApiKey           pgtype.Text
 }
 
 // Targets for periodic OpenRouter credit usage polling. Filters out disabled

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1317,7 +1317,8 @@ type OauthProxyServer struct {
 type OpenrouterApiKey struct {
 	OrganizationID string
 	KeyType        string
-	Key            string
+	Key            pgtype.Text
+	KeyEncrypted   pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
 	Disabled       bool

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -302,7 +303,7 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string, keyType 
 	case err != nil && !errors.Is(err, pgx.ErrNoRows):
 		return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").LogError(ctx, o.logger)
 
-	case errors.Is(err, pgx.ErrNoRows), key.Key == "":
+	case errors.Is(err, pgx.ErrNoRows), key.Key.String == "":
 		openrouterKey, err = o.createAndStoreAPIKey(ctx, orgID, keyType)
 		if err != nil {
 			return "", err
@@ -315,7 +316,7 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string, keyType 
 		if key.Disabled {
 			return "", fmt.Errorf("resolve %s key: %w", keyType, ErrPlatformKeyDisabled)
 		}
-		openrouterKey = key.Key
+		openrouterKey = key.Key.String
 	}
 
 	if err := inv.Check("openrouter provisioning", "key is set", openrouterKey != ""); err != nil {
@@ -360,9 +361,9 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 	// ProvisionAPIKey.
 	case err != nil && !errors.Is(err, pgx.ErrNoRows):
 		return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").LogError(ctx, o.logger)
-	case errors.Is(err, pgx.ErrNoRows), key.Key == "":
+	case errors.Is(err, pgx.ErrNoRows), key.Key.String == "":
 	default:
-		return key.Key, nil
+		return key.Key.String, nil
 	}
 
 	// Read through the transaction: this goroutine already holds a pool
@@ -389,7 +390,7 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 	_, err = txRepo.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        string(keyType),
-		Key:            *keyResponse.Key,
+		Key:            conv.ToPGText(*keyResponse.Key),
 		KeyHash:        keyResponse.Data.Hash,
 		MonthlyCredits: int64(creditAmount),
 	})
@@ -548,7 +549,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 		return 0, limit, nil // the key doesn't exist yet
 	}
 
-	used, _, err := o.GetKeyUsage(ctx, key.Key)
+	used, _, err := o.GetKeyUsage(ctx, key.Key.String)
 	if err != nil {
 		return 0, limit, err
 	}
@@ -844,7 +845,7 @@ func (o *OpenRouter) getGenerationDetails(ctx context.Context, generationID stri
 	q.Set("id", generationID)
 	req.URL.RawQuery = q.Encode()
 
-	req.Header.Set("Authorization", "Bearer "+key.Key)
+	req.Header.Set("Authorization", "Bearer "+key.Key.String)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := o.orClient.Do(req)

--- a/server/internal/thirdparty/openrouter/provision_test.go
+++ b/server/internal/thirdparty/openrouter/provision_test.go
@@ -92,6 +92,6 @@ func TestProvisionAPIKey_ConcurrentFirstProvision(t *testing.T) {
 		KeyType:        string(KeyTypeInternal),
 	})
 	require.NoError(t, err)
-	require.Equal(t, "sk-or-race-1", row.Key)
+	require.Equal(t, "sk-or-race-1", row.Key.String)
 	require.Equal(t, "hash-1", row.KeyHash)
 }

--- a/server/internal/thirdparty/openrouter/repo/models.go
+++ b/server/internal/thirdparty/openrouter/repo/models.go
@@ -11,7 +11,8 @@ import (
 type OpenrouterApiKey struct {
 	OrganizationID string
 	KeyType        string
-	Key            string
+	Key            pgtype.Text
+	KeyEncrypted   pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
 	Disabled       bool

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -7,6 +7,8 @@ package repo
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const createOpenRouterAPIKey = `-- name: CreateOpenRouterAPIKey :one
@@ -23,13 +25,13 @@ INSERT INTO openrouter_api_keys (
   , $4
   , $5
 )
-RETURNING organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateOpenRouterAPIKeyParams struct {
 	OrganizationID string
 	KeyType        string
-	Key            string
+	Key            pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
 }
@@ -47,6 +49,7 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 		&i.OrganizationID,
 		&i.KeyType,
 		&i.Key,
+		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
 		&i.Disabled,
@@ -81,7 +84,7 @@ func (q *Queries) DisableOpenRouterAPIKey(ctx context.Context, arg DisableOpenRo
 }
 
 const getOpenRouterAPIKey = `-- name: GetOpenRouterAPIKey :one
-SELECT organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+SELECT organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 FROM openrouter_api_keys
 WHERE organization_id = $1
   AND key_type = $2
@@ -100,6 +103,7 @@ func (q *Queries) GetOpenRouterAPIKey(ctx context.Context, arg GetOpenRouterAPIK
 		&i.OrganizationID,
 		&i.KeyType,
 		&i.Key,
+		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
 		&i.Disabled,
@@ -134,13 +138,13 @@ SET monthly_credits = $1, key_hash = $2, key = $3,
 WHERE organization_id = $5
   AND key_type = $6
   AND deleted IS FALSE
-RETURNING organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateOpenRouterKeyParams struct {
 	MonthlyCredits int64
 	KeyHash        string
-	Key            string
+	Key            pgtype.Text
 	Reinstate      bool
 	OrganizationID string
 	KeyType        string
@@ -160,6 +164,7 @@ func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterK
 		&i.OrganizationID,
 		&i.KeyType,
 		&i.Key,
+		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
 		&i.Disabled,

--- a/server/internal/thirdparty/openrouter/trial_credits_test.go
+++ b/server/internal/thirdparty/openrouter/trial_credits_test.go
@@ -279,7 +279,7 @@ func TestGetCreditsUsed_ZeroKeyLimitFallsBackToPolicy(t *testing.T) {
 	_, err := repo.New(fixture.conn).CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
 		OrganizationID: fixture.orgID,
 		KeyType:        string(KeyTypeChat),
-		Key:            "sk-or-legacy-zero",
+		Key:            conv.ToPGText("sk-or-legacy-zero"),
 		KeyHash:        "hash-legacy",
 		MonthlyCredits: 0,
 	})

--- a/server/migrations/20260812151548_openrouter-api-key-encrypted.sql
+++ b/server/migrations/20260812151548_openrouter-api-key-encrypted.sql
@@ -1,0 +1,2 @@
+-- Modify "openrouter_api_keys" table
+ALTER TABLE "openrouter_api_keys" ALTER COLUMN "key" DROP NOT NULL, ADD COLUMN "key_encrypted" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:rTaQ3oLZdRCNIEvcCRLDYowm8yl7Pei4AhJEGqNLA/w=
+h1:UNRlworOFUYKInkpSS+ZmTsmylWtU5GbLmI/89zKws8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -332,3 +332,4 @@ h1:rTaQ3oLZdRCNIEvcCRLDYowm8yl7Pei4AhJEGqNLA/w=
 20260811225530_expand-assets-tiers.sql h1:K5IvMnYVFRA8qmUXXPvH5S0HtFWPUNYWbd7KCGlUFC4=
 20260811225943_assets-tier-dedupe-indexes.sql h1:thYfONo6SYry2Aew/GXLvIn/9WZtmZv82BfL7c5jp4A=
 20260812140226_jwks-index-external-key-tenant.sql h1:uuAVtFJtvI9Fh8P1g0lZCvFFIlUUoUraHM+HvBKT1dY=
+20260812151548_openrouter-api-key-encrypted.sql h1:D24ETMrCq2AY9UZCCd8kL9D9heB6vPaPMxghWFz5/uM=


### PR DESCRIPTION
Linear Issue: [AIS-450](https://linear.app/speakeasy/issue/AIS-450/triage-platform-openrouter-api-keys-are-stored-unencrypted-in-postgres)

## Summary

Expand-phase migration for encrypting platform OpenRouter API keys at rest (`openrouter_api_keys.key` currently holds the live upstream key in plaintext, the only credential of its class in the codebase not going through `server/internal/encryption`).

- Adds a nullable `key_encrypted` column for the AES-256-GCM ciphertext, following the existing `*_encrypted` column conventions (e.g. `model_provider_keys.api_key_encrypted`).
- Drops `NOT NULL` on the plaintext `key` column so a later platform admin encryption action can clear it after verifying the encrypted copy, ahead of a future contract migration that drops the column entirely.

Both operations are metadata-only (no table scan, no long lock, no PG305/PG306).

## Rollout

This is PR 1 of 4 for AIS-450 and must deploy before the application changes:

1. This migration (expand).
2. Application changes: dual-write on create, encrypted-preferred reads with lazy read-repair, and a platform admin OpenRouter Keys page with a per-key encrypt (scrub) action.
3. Remove all remaining plaintext `key` usage (encrypted-only create).
4. Contract migration dropping `key`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `openrouter_api_keys.key_encrypted` and makes `key` nullable to prepare at-rest encryption of platform OpenRouter API keys (AIS-450). Regenerates `sqlc` and updates call sites for the nullable `key`; behavior is unchanged.

- Migration: add nullable `key_encrypted`, drop NOT NULL on `key`; metadata-only and no backfill.
- Codegen: `sqlc` retypes `key`/`api_key` to `pgtype.Text`; update reads to `.String` and inserts to `conv.ToPGText`; NULL and empty string both trigger key provisioning.
- Deploy this before the app changes that dual-write and prefer `key_encrypted` (AIS-450). No operator action; current reads/writes continue to use `key`.

<sup>Written for commit 593afc26e5a3346e768d1399a49819eb59359634. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

[skip migration check] — dropping `NOT NULL` on `key` retypes the sqlc-generated `Key`/`ApiKey` fields from `string` to `pgtype.Text`, and CI's dirty-files check requires the regenerated code in the same PR. The accompanying Go edits are mechanical type adaptations only (`.String` access, `conv.ToPGText` on insert) with no behavior change; the actual encryption logic ships separately in #5201.
