### PR TITLE
chore: remove the reserved CIMD per-origin rate limit vocabulary

### DIFF
--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -2,8 +2,8 @@
 // that resolves a user_session_clients row from a presented client_id —
 // authorize, token, consent GET/POST — funnels through
 // resolveUserSessionClient, so inbound CIMD resolution and the layers around
-// it (admission control, document caching, and the per-origin rate limiting
-// AIS-215 adds) have exactly one home instead of per-handler branches.
+// it (admission control and document caching) have exactly one home instead
+// of per-handler branches.
 
 package mcp
 
@@ -95,10 +95,9 @@ func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Log
 		}
 
 		// Admission runs before the resolver, so a denied client_id costs a
-		// map lookup — no outbound request, no fetch timeout, and (once
-		// AIS-215 lands) no rate-limiter token. It also runs before the
-		// length cap inside the resolver, which is why admission applies its
-		// own bound before a catalog miss can reach the database.
+		// map lookup — no outbound request, no fetch timeout. It also runs
+		// before the length cap inside the resolver, which is why admission
+		// applies its own bound before a catalog miss can reach the database.
 		if err := s.admitCIMDClient(ctx, logger, endpoint, clientID); err != nil {
 			return nil, err
 		}

--- a/server/internal/usersessions/cimd/admission/doc.go
+++ b/server/internal/usersessions/cimd/admission/doc.go
@@ -2,7 +2,7 @@
 // policy deciding WHICH Client ID Metadata Document URLs a Gram user-session
 // authorization server will accept, evaluated before any document is
 // fetched. A denied client_id costs a map lookup — no outbound request, no
-// rate-limiter token, no timeout.
+// timeout.
 //
 // It is deliberately a leaf: it imports nothing from usersessions and
 // touches no database. It has to be, because the dependency runs the other

--- a/server/internal/usersessions/cimd/metrics.go
+++ b/server/internal/usersessions/cimd/metrics.go
@@ -22,6 +22,13 @@ const (
 // metrics. Every Resolve call records exactly one cimd.fetch.attempts point;
 // cimd.fetch.duration_seconds is recorded only for results where an upstream
 // fetch actually ran, so short-circuit results never skew latency percentiles.
+//
+// An admission_denied result is deliberately absent from this vocabulary.
+// Admission control records to its own cimd.admission.decisions counter
+// (internal/usersessions/cimd/admission): a denial means no fetch ran at all,
+// so counting it under fetch.attempts would break this instrument's
+// one-point-per-Resolve invariant and quietly change the denominator of every
+// fetch-success chart.
 type fetchResult string
 
 const (
@@ -38,20 +45,6 @@ const (
 	// the fetch-bearing outcomes rather than against every attempt.
 	fetchResultCached                 fetchResult = "cached"
 	fetchResultConditionalNotModified fetchResult = "conditional_not_modified"
-
-	// rate_limited is PROVISIONAL: it labels the per-origin rate limiting
-	// AIS-215 adds inside this package. It is declared now so the label
-	// vocabulary is stable for dashboards, but nothing records it yet and
-	// its exact semantics may still shift when the emitting code lands — do
-	// not build monitors on it until then.
-	//
-	// An admission_denied result was formerly reserved here for AIS-371.
-	// Admission control instead records to its own cimd.admission.decisions
-	// counter (internal/usersessions/cimd/admission): a denial means no
-	// fetch ran at all, so counting it under fetch.attempts would break this
-	// instrument's one-point-per-Resolve invariant and quietly change the
-	// denominator of every fetch-success chart.
-	fetchResultRateLimited fetchResult = "rate_limited"
 )
 
 // validationReason is the machine-readable label recorded on

--- a/server/internal/usersessions/cimd/metrics_test.go
+++ b/server/internal/usersessions/cimd/metrics_test.go
@@ -356,28 +356,3 @@ func TestMetrics_CacheResultLabelsPinned(t *testing.T) {
 	require.Equal(t, "cached", string(fetchResultCached))
 	require.Equal(t, "conditional_not_modified", string(fetchResultConditionalNotModified))
 }
-
-// TestMetrics_ReservedResultLabels pins the provisional label spelling that a
-// follow-up issue will emit — rate_limited (AIS-215) — so dashboards built on
-// this vocabulary stay valid when the emitting code lands. AIS-371's
-// admission_denied is deliberately absent: admission records to its own
-// cimd.admission.decisions counter, since a denial means no fetch ran and so
-// has no place under fetch.attempts.
-func TestMetrics_ReservedResultLabels(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	reader := sdkmetric.NewManualReader()
-	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	m := newMetrics(meterProvider, testenv.NewLogger(t))
-
-	require.Equal(t, "rate_limited", string(fetchResultRateLimited))
-	m.RecordAttempt(ctx, "client.example.com", fetchResultRateLimited)
-
-	rm := collectMetrics(t, reader)
-
-	attempts := counterPoints(t, rm, meterFetchAttempts)
-	require.Len(t, attempts, 1)
-	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultRateLimited))
-	requireAttr(t, attempts[0].Attributes, attr.CIMDOriginKey, "client.example.com")
-}


### PR DESCRIPTION
The per-origin rate limiter on CIMD metadata fetches is not being built. It is not required by draft-ietf-oauth-client-id-metadata-document-02, and the fetch path already bounds outbound volume through document caching (with a 5 minute TTL floor), admission control, the response size cap, the special-use IP restriction, and the redirect ban.

Remove the reserved `rate_limited` label and the dead `fetchResultRateLimited` constant from the `cimd.fetch.attempts` vocabulary, delete the test that pinned the reserved spelling, and drop the comments anticipating the limiter in the MCP client resolver and the admission package doc. Nothing ever recorded the label, so no dashboard can depend on it (verified: no Datadog dashboard references any `cimd` metric).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the reserved `rate_limited` outcome and dead `fetchResultRateLimited` constant from `cimd.fetch.attempts` because the per‑origin rate limiter for CIMD fetches will not ship (AIS-215). This shrinks the metric vocabulary without changing runtime behavior; nothing emitted `rate_limited`, so dashboards are unaffected.

- Drops `fetchResultRateLimited` and the spelling‑pin test in `server/internal/usersessions/cimd/metrics*_test.go`; keeps the cached/conditional labels unchanged.
- Updates comments in `server/internal/mcp/client_resolver.go` and `server/internal/usersessions/cimd/admission/doc.go` to remove rate‑limiter references.
- Confirms `admission_denied` remains out of `cimd.fetch.attempts` and is counted under `cimd.admission.decisions`; fetch attempt denominators and latency percentiles are unchanged.

<sup>Written for commit 2e3b822e1bacbbd589f3e5fdd64570387e32981c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

