### PR TITLE
fix(access): show loading skeleton while challenges load

### DIFF
--- a/client/dashboard/src/pages/access/ChallengesTab.test.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Controllable return value for the main data hook. Set per test before render.
+let bucketsResult: {
+  data: unknown;
+  isLoading: boolean;
+  isFetching: boolean;
+};
+
+vi.mock("react-router", () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock("@gram/client/react-query/challengeBuckets.js", () => ({
+  useChallengeBuckets: () => bucketsResult,
+}));
+
+vi.mock("@gram/client/react-query/challenges.js", () => ({
+  useChallenges: () => ({ data: undefined }),
+}));
+
+vi.mock("./useGrantFlow", () => ({
+  useGrantFlow: () => ({
+    actionsColumn: { key: "actions", header: "", render: () => null },
+    grantFlowPortals: null,
+    recentlyResolvedIds: new Set<string>(),
+    animatingOutIds: new Set<string>(),
+  }),
+}));
+
+vi.mock("./useChallengeRowColumns", () => ({
+  useChallengeRowColumns: () => [],
+}));
+
+vi.mock("@/components/ui/Skeleton", () => ({
+  SkeletonTable: () => <div data-testid="skeleton-table" />,
+}));
+
+import { ChallengesTab } from "./ChallengesTab";
+
+afterEach(cleanup);
+
+describe("ChallengesTab loading state", () => {
+  it("shows the loading skeleton (not the empty state) while a slow first-page fetch is in flight", () => {
+    // Mimics `keepPreviousData`: the query is fetching but `isLoading` is false
+    // because placeholder data keeps it out of the pending state. This is the
+    // exact condition that used to flash the "no challenges" empty state.
+    bucketsResult = { data: undefined, isLoading: false, isFetching: true };
+
+    render(<ChallengesTab />);
+
+    expect(screen.getByTestId("skeleton-table")).toBeTruthy();
+    expect(screen.queryByText("No denied access attempts")).toBeNull();
+  });
+
+  it("shows the empty state once the fetch settles with no results", () => {
+    bucketsResult = {
+      data: { buckets: [], total: 0 },
+      isLoading: false,
+      isFetching: false,
+    };
+
+    render(<ChallengesTab />);
+
+    expect(screen.getByText("No denied access attempts")).toBeTruthy();
+    expect(screen.queryByTestId("skeleton-table")).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/access/ChallengesTab.test.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.test.tsx
@@ -1,11 +1,17 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import type { ChallengeBucket } from "@gram/client/models/components/challengebucket.js";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Controllable return value for the main data hook. Set per test before render.
+// A stable object reference matters: the component's accumulate effect keys on
+// the `data` reference, so reusing the same object across renders mirrors how
+// `keepPreviousData` hands back the previous page while a new request is in
+// flight (the effect does not re-run, and `accumulated` stays reset to []).
 let bucketsResult: {
-  data: unknown;
+  data: { buckets: ChallengeBucket[]; total: number } | undefined;
   isLoading: boolean;
   isFetching: boolean;
+  isPlaceholderData: boolean;
 };
 
 vi.mock("react-router", () => ({
@@ -41,12 +47,37 @@ import { ChallengesTab } from "./ChallengesTab";
 
 afterEach(cleanup);
 
+/** A bucket that passes `isDisplayableBucket` (scope + resource present). */
+function bucket(id: string): ChallengeBucket {
+  return {
+    id,
+    challengeCount: 1,
+    challengeIds: [id],
+    evaluatedGrantCount: 0,
+    matchedGrantCount: 0,
+    firstSeen: new Date(),
+    lastSeen: new Date(),
+    operation: "require",
+    organizationId: "org",
+    outcome: "deny",
+    principalType: "user",
+    principalUrn: "user:1",
+    reason: "no_grants",
+    scope: "toolset:read",
+    resourceKind: "toolset",
+    resourceId: "resource-1",
+    roleSlugs: [],
+  };
+}
+
 describe("ChallengesTab loading state", () => {
-  it("shows the loading skeleton (not the empty state) while a slow first-page fetch is in flight", () => {
-    // Mimics `keepPreviousData`: the query is fetching but `isLoading` is false
-    // because placeholder data keeps it out of the pending state. This is the
-    // exact condition that used to flash the "no challenges" empty state.
-    bucketsResult = { data: undefined, isLoading: false, isFetching: true };
+  it("shows the loading skeleton on the initial load (no data yet)", () => {
+    bucketsResult = {
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isPlaceholderData: false,
+    };
 
     render(<ChallengesTab />);
 
@@ -54,11 +85,39 @@ describe("ChallengesTab loading state", () => {
     expect(screen.queryByText("No denied access attempts")).toBeNull();
   });
 
-  it("shows the empty state once the fetch settles with no results", () => {
+  it("shows a skeleton (not the empty state) while switching filters under keepPreviousData", () => {
+    // Mirrors keepPreviousData: the previous filter's rows linger in `data`
+    // (so `isLoading` is false) while the new filter's request is in flight
+    // (`isPlaceholderData` is true). The stable reference keeps the accumulate
+    // effect from repopulating after the filter switch resets `accumulated`.
+    bucketsResult = {
+      data: { buckets: [bucket("b1")], total: 39 },
+      isLoading: false,
+      isFetching: true,
+      isPlaceholderData: true,
+    };
+
+    render(<ChallengesTab />);
+
+    // The lingering (placeholder) rows render for the current filter — no skeleton yet.
+    expect(screen.queryByTestId("skeleton-table")).toBeNull();
+
+    // Switch to the "All" filter: `accumulated` resets and, because the data is
+    // still placeholder, the skeleton must show instead of the empty state.
+    fireEvent.click(screen.getByRole("button", { name: /^All/ }));
+
+    expect(screen.getByTestId("skeleton-table")).toBeTruthy();
+    expect(screen.queryByText("No challenges found")).toBeNull();
+  });
+
+  it("keeps the empty state (no skeleton) during a background refetch of a filter with no results", () => {
+    // Real, settled data for the current filter (not placeholder) with a refetch
+    // in flight. This must NOT flash a skeleton over the stable empty state.
     bucketsResult = {
       data: { buckets: [], total: 0 },
       isLoading: false,
-      isFetching: false,
+      isFetching: true,
+      isPlaceholderData: false,
     };
 
     render(<ChallengesTab />);

--- a/client/dashboard/src/pages/access/ChallengesTab.test.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.test.tsx
@@ -85,11 +85,11 @@ describe("ChallengesTab loading state", () => {
     expect(screen.queryByText("No denied access attempts")).toBeNull();
   });
 
-  it("shows a skeleton (not the empty state) while switching filters under keepPreviousData", () => {
-    // Mirrors keepPreviousData: the previous filter's rows linger in `data`
-    // (so `isLoading` is false) while the new filter's request is in flight
-    // (`isPlaceholderData` is true). The stable reference keeps the accumulate
-    // effect from repopulating after the filter switch resets `accumulated`.
+  it("shows a skeleton (not the empty state) while a filter switch is in flight under keepPreviousData", () => {
+    // Mirrors keepPreviousData mid-switch: the previous filter's rows linger in
+    // `data` (so `isLoading` is false) while the new filter's request is still
+    // in flight. Those rows belong to the old filter, so there is nothing to
+    // show for the new one yet — the skeleton must render, not the empty state.
     bucketsResult = {
       data: { buckets: [bucket("b1")], total: 39 },
       isLoading: false,
@@ -99,15 +99,29 @@ describe("ChallengesTab loading state", () => {
 
     render(<ChallengesTab />);
 
-    // The lingering (placeholder) rows render for the current filter — no skeleton yet.
-    expect(screen.queryByTestId("skeleton-table")).toBeNull();
+    expect(screen.getByTestId("skeleton-table")).toBeTruthy();
+    expect(screen.queryByText("No denied access attempts")).toBeNull();
+  });
 
-    // Switch to the "All" filter: `accumulated` resets and, because the data is
-    // still placeholder, the skeleton must show instead of the empty state.
+  it("does not flash the empty state when switching to a filter whose rows are already cached", () => {
+    // Rows served straight from the query cache: real data (not placeholder) and
+    // not loading, with a background refetch in flight. The filter switch resets
+    // `accumulated` during render and the accumulate effect only refills it after
+    // paint, so the rows must be derived during render to avoid an empty frame.
+    bucketsResult = {
+      data: { buckets: [bucket("b1")], total: 39 },
+      isLoading: false,
+      isFetching: true,
+      isPlaceholderData: false,
+    };
+
+    render(<ChallengesTab />);
+    expect(screen.queryByText("No denied access attempts")).toBeNull();
+
     fireEvent.click(screen.getByRole("button", { name: /^All/ }));
 
-    expect(screen.getByTestId("skeleton-table")).toBeTruthy();
     expect(screen.queryByText("No challenges found")).toBeNull();
+    expect(screen.queryByTestId("skeleton-table")).toBeNull();
   });
 
   it("keeps the empty state (no skeleton) during a background refetch of a filter with no results", () => {

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -299,9 +299,17 @@ export function ChallengesTab(): JSX.Element {
     setPageCount(1);
   }
 
-  // Accumulate results as pages load, excluding buckets with no scope.
+  // Buckets from the page the query currently holds, excluding those with no
+  // scope. Placeholder data still belongs to the previous filter, so it is
+  // ignored until the new filter's page arrives.
+  const currentPageBuckets = useMemo(() => {
+    if (isPlaceholderData || !data?.buckets) return [];
+    return data.buckets.filter(isDisplayableBucket);
+  }, [data, isPlaceholderData]);
+
+  // Accumulate results as pages load.
   useEffect(() => {
-    if (!data?.buckets) return;
+    if (isPlaceholderData || !data?.buckets) return;
     const withScope = data.buckets.filter(isDisplayableBucket);
     if (pageCount === 1) {
       setAccumulated(withScope);
@@ -312,10 +320,23 @@ export function ChallengesTab(): JSX.Element {
         return [...prev, ...newItems];
       });
     }
-  }, [data, pageCount]);
+  }, [data, pageCount, isPlaceholderData]);
+
+  // Derive the visible rows during render rather than reading `accumulated`
+  // directly. A filter switch resets `accumulated` during render while the
+  // effect above only refills it after paint, so switching to a filter already
+  // in the query cache would otherwise commit one frame of the empty state.
+  const rows = useMemo(() => {
+    if (accumulated.length === 0) return currentPageBuckets;
+    const seen = new Set(accumulated.map((b) => b.id));
+    return [
+      ...accumulated,
+      ...currentPageBuckets.filter((b) => !seen.has(b.id)),
+    ];
+  }, [accumulated, currentPageBuckets]);
 
   const totalBuckets = data?.total ?? 0;
-  const hasMore = accumulated.length < totalBuckets;
+  const hasMore = rows.length < totalBuckets;
   const isLoadingMore = isFetching && pageCount > 1;
 
   // Pill counts: fetch totals for each tab (lightweight, limit=1).
@@ -339,7 +360,7 @@ export function ChallengesTab(): JSX.Element {
   // Unique values for filter dropdowns (from loaded data).
   const uniquePrincipals = useMemo(() => {
     const principals = new Map<string, string>();
-    for (const bucket of accumulated) {
+    for (const bucket of rows) {
       const value = bucket.userEmail ?? bucket.principalUrn;
       if (!value) continue;
       principals.set(
@@ -348,12 +369,12 @@ export function ChallengesTab(): JSX.Element {
       );
     }
     return [...principals.entries()].sort((a, b) => a[1].localeCompare(b[1]));
-  }, [accumulated]);
+  }, [rows]);
 
   const uniqueScopes = useMemo(() => {
-    const set = new Set(accumulated.map((b) => b.scope));
+    const set = new Set(rows.map((b) => b.scope));
     return [...set].filter(Boolean).sort();
-  }, [accumulated]);
+  }, [rows]);
 
   // Expansion state.
   const [expandedBucketIds, setExpandedBucketIds] = useState<Set<string>>(
@@ -368,24 +389,24 @@ export function ChallengesTab(): JSX.Element {
     });
   }, []);
 
-  const expandedMap = useExpandedChallenges(expandedBucketIds, accumulated);
+  const expandedMap = useExpandedChallenges(expandedBucketIds, rows);
   const flatData = useMemo(
-    () => flattenWithExpanded(accumulated, expandedMap),
-    [accumulated, expandedMap],
+    () => flattenWithExpanded(rows, expandedMap),
+    [rows, expandedMap],
   );
 
   // IDs of individual challenge rows (expanded children) for styling and column hiding.
   // Exclude bucket trigger row IDs so they keep their avatar/identity/outcome.
   const expandedChildIds = useMemo(() => {
-    const bucketIds = new Set(accumulated.map((b) => b.id));
+    const bucketIds = new Set(rows.map((b) => b.id));
     const ids = new Set<string>();
-    for (const rows of expandedMap.values()) {
-      for (const r of rows) {
+    for (const childRows of expandedMap.values()) {
+      for (const r of childRows) {
         if (!bucketIds.has(r.id)) ids.add(r.id);
       }
     }
     return ids;
-  }, [expandedMap, accumulated]);
+  }, [expandedMap, rows]);
 
   const challengeRowColumns = useChallengeRowColumns(
     animatingOutIds,
@@ -414,10 +435,10 @@ export function ChallengesTab(): JSX.Element {
   //   - initial load: `isLoading` is true (no data yet); and
   //   - a filter switch under `keepPreviousData`: `isLoading` stays false because
   //     the previous filter's data lingers, but `isPlaceholderData` is true while
-  //     the new filter's request is in flight (and `accumulated` was reset to []).
+  //     the new filter's request is in flight (so there is nothing to show yet).
   // Gating on these (rather than the raw `isFetching`) keeps the empty state
   // stable during background refetches of a filter that genuinely has no results.
-  const hasRows = accumulated.length > 0;
+  const hasRows = rows.length > 0;
   const showInitialLoading = !hasRows && (isLoading || isPlaceholderData);
 
   return (
@@ -515,10 +536,10 @@ export function ChallengesTab(): JSX.Element {
               })}
             </Table.Body>
           </Table>
-          {(accumulated.length > 0 || isLoadingMore) && (
+          {(hasRows || isLoadingMore) && (
             <div className="bg-muted/20 flex items-center justify-between border-t px-4 py-3">
               <Text muted small>
-                Showing {accumulated.length.toLocaleString()} of{" "}
+                Showing {rows.length.toLocaleString()} of{" "}
                 {totalBuckets.toLocaleString()}
               </Text>
               {hasMore ? (

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -277,7 +277,7 @@ export function ChallengesTab(): JSX.Element {
   const outcomeParam = useOutcomeApiParam(outcomeFilter);
   const offset = (pageCount - 1) * PAGE_SIZE;
 
-  const { data, isLoading, isFetching } = useChallengeBuckets(
+  const { data, isFetching } = useChallengeBuckets(
     {
       ...outcomeParam,
       principalUrn: principalFilter !== "all" ? principalFilter : undefined,
@@ -408,6 +408,14 @@ export function ChallengesTab(): JSX.Element {
     wrappedActionsColumn,
   ];
 
+  // Show the skeleton whenever a first-page fetch is in flight with nothing to
+  // display yet. `isLoading` alone is insufficient: with `keepPreviousData`,
+  // switching filters resets `accumulated` to [] while `isLoading` stays false
+  // (placeholder data keeps the query out of the pending state), which would
+  // otherwise flash the "no challenges" empty state during a slow load.
+  const hasRows = accumulated.length > 0;
+  const showInitialLoading = !hasRows && isFetching;
+
   return (
     <div>
       <div className="mb-4 flex flex-wrap items-center gap-2">
@@ -467,9 +475,9 @@ export function ChallengesTab(): JSX.Element {
         </Select>
       </div>
 
-      {isLoading && accumulated.length === 0 ? (
+      {showInitialLoading ? (
         <SkeletonTable />
-      ) : accumulated.length === 0 ? (
+      ) : !hasRows ? (
         <ChallengesEmptyState outcomeFilter={outcomeFilter} />
       ) : (
         <>

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -277,17 +277,18 @@ export function ChallengesTab(): JSX.Element {
   const outcomeParam = useOutcomeApiParam(outcomeFilter);
   const offset = (pageCount - 1) * PAGE_SIZE;
 
-  const { data, isFetching } = useChallengeBuckets(
-    {
-      ...outcomeParam,
-      principalUrn: principalFilter !== "all" ? principalFilter : undefined,
-      scope: scopeFilter !== "all" ? scopeFilter : undefined,
-      limit: PAGE_SIZE,
-      offset,
-    },
-    undefined,
-    { placeholderData: keepPreviousData },
-  );
+  const { data, isLoading, isFetching, isPlaceholderData } =
+    useChallengeBuckets(
+      {
+        ...outcomeParam,
+        principalUrn: principalFilter !== "all" ? principalFilter : undefined,
+        scope: scopeFilter !== "all" ? scopeFilter : undefined,
+        limit: PAGE_SIZE,
+        offset,
+      },
+      undefined,
+      { placeholderData: keepPreviousData },
+    );
 
   // Reset accumulated data when filters change.
   const filterKey = `${outcomeFilter}|${principalFilter}|${scopeFilter}`;
@@ -408,13 +409,16 @@ export function ChallengesTab(): JSX.Element {
     wrappedActionsColumn,
   ];
 
-  // Show the skeleton whenever a first-page fetch is in flight with nothing to
-  // display yet. `isLoading` alone is insufficient: with `keepPreviousData`,
-  // switching filters resets `accumulated` to [] while `isLoading` stays false
-  // (placeholder data keeps the query out of the pending state), which would
-  // otherwise flash the "no challenges" empty state during a slow load.
+  // Show the skeleton for the first/active load of the current filter, so a slow
+  // load never flashes the "no challenges" empty state. Two cases need it:
+  //   - initial load: `isLoading` is true (no data yet); and
+  //   - a filter switch under `keepPreviousData`: `isLoading` stays false because
+  //     the previous filter's data lingers, but `isPlaceholderData` is true while
+  //     the new filter's request is in flight (and `accumulated` was reset to []).
+  // Gating on these (rather than the raw `isFetching`) keeps the empty state
+  // stable during background refetches of a filter that genuinely has no results.
   const hasRows = accumulated.length > 0;
-  const showInitialLoading = !hasRows && isFetching;
+  const showInitialLoading = !hasRows && (isLoading || isPlaceholderData);
 
   return (
     <div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the Authorization Challenges tab, the empty state ("No challenges found" / "No denied access attempts") flashed immediately instead of a loading indicator while data was still loading. This was most visible on the "All" view, which can take >10s to load.

Fixes [AGE-3174](https://linear.app/speakeasy/issue/AGE-3174).

## Demo

Clicking the "All" tab now shows a loading skeleton while the (slow) request is in flight, instead of flashing the "no challenges" empty state, before the table populates. (Recorded locally with the challenge-buckets request artificially delayed and served synthetic, non-customer data.)

![Challenges tab shows a loading skeleton while All challenges load, then the table populates](https://cursor.com/artifacts/c/art-61f58e3d-2697-45d2-a215-18bdbcfbcdd4)

## Root cause

`ChallengesTab` fetches with `useChallengeBuckets(..., { placeholderData: keepPreviousData })` and accumulates results into local state. The render branch was keyed on `isLoading`:

```tsx
{isLoading && accumulated.length === 0 ? <SkeletonTable /> : accumulated.length === 0 ? <ChallengesEmptyState .../> : ...}
```

With `keepPreviousData`, switching filters (e.g. to "All") resets `accumulated` to `[]` during render, but `isLoading` stays `false` because the placeholder data keeps the query out of the pending state. The condition therefore fell through to the empty state during the multi-second fetch.

There is a second, one-frame variant of the same bug: `accumulated` is reset during render but only refilled by an effect after paint, so switching to a filter already in the query cache committed a frame of the empty state even though rows were available immediately.

## Fix

1. Derive the visible rows during render, from the accumulated pages plus the page the query currently holds. Placeholder data is ignored because it still belongs to the previous filter. This removes the post-paint gap that caused the one-frame flash. The accumulate effect is kept for "Load more" pagination and now also skips placeholder pages so rows can't mix across filters.

2. Gate the skeleton on the first/active load of the current filter:

```tsx
const hasRows = rows.length > 0;
const showInitialLoading = !hasRows && (isLoading || isPlaceholderData);
```

Resulting behavior:

- Initial load → `isLoading` is true → skeleton (was: empty state).
- Filter switch under `keepPreviousData` → `isPlaceholderData` is true while the new request is in flight → skeleton (was: empty state).
- Switch to a filter already cached → rows render immediately, no empty-state frame.
- Background refetch of a filter that genuinely has no results → neither flag is set, so the empty state stays put (this is why we gate on `isLoading || isPlaceholderData` rather than the raw `isFetching`).
- "Load more" (page > 1) → keeps existing rows, uses the existing `isLoadingMore` button (unchanged).

## Tests

`ChallengesTab.test.tsx` covers the four states: initial load, an in-flight `keepPreviousData` filter switch, a switch to a cached filter (must not flash the empty state), and a background refetch of an empty filter (must keep the empty state). Each was verified to fail against the corresponding pre-fix implementation.

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

`aube run -F dashboard type-check` and `aube run -F dashboard lint` both pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3174](https://linear.app/speakeasy/issue/AGE-3174/bug-dashboard-shows-no-challenges-while-all-challenges-are-loading)

<div><a href="https://cursor.com/agents/bc-b768518a-b56a-4af8-87c2-a2951227eaa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b768518a-b56a-4af8-87c2-a2951227eaa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a loading skeleton on the Challenges tab during initial/active loads and filter switches to eliminate empty-state flashes, including when switching to cached filters. Previously we keyed on isLoading and flashed “No challenges”; now we gate on isLoading || isPlaceholderData and derive visible rows during render so background refetches keep a stable empty state. Fixes AGE-3174.

- Gate with showInitialLoading = !hasRows && (isLoading || isPlaceholderData); render the empty state only after a settled no-results response.
- Derive rows from accumulated pages plus the current page during render, ignoring placeholder data from `keepPreviousData`; skip placeholder pages in the accumulate effect.
- Keep pagination and “Load more” behavior unchanged; update counts and expansion logic to read from the derived rows.
- Tests: cover initial load, a `keepPreviousData` filter switch, switching to a cached filter (no empty-state flash), and a background refetch of an empty filter (empty state remains).

<sup>Written for commit 3d39baf3623bc26f315f8a59e4b7ea6609d0f6dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

