### PR TITLE
fix(auth): record actor display name for organization-less sessions (AGE-3130)

### DIFF
--- a/.changeset/orgless-audit-actor-display-name.md
+++ b/.changeset/orgless-audit-actor-display-name.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Record an actor display name on audit entries written from organization-less sessions. `sessions.Authenticate` now populates the actor email for sessions with no active organization, and enterprise-trial arming threads the actor email through provisioning so the self-signup callback — which has no auth context — still attributes the `organization:enterprise_trial_armed` entry instead of storing a bare actor id.

--- a/server/internal/audit/audittest/helpers.go
+++ b/server/internal/audit/audittest/helpers.go
@@ -15,10 +15,7 @@ import (
 type LogRecord struct {
 	Action           string
 	ProjectID        uuid.NullUUID
-	ActorID          string
-	ActorType        string
 	ActorDisplayName *string
-	ActorSlug        *string
 	SubjectType      string
 	SubjectDisplay   string
 	SubjectSlug      string
@@ -36,10 +33,7 @@ func LatestAuditLogByAction(ctx context.Context, dbtx repo.DBTX, action audit.Ac
 	return LogRecord{
 		Action:           row.Action,
 		ProjectID:        row.ProjectID,
-		ActorID:          row.ActorID,
-		ActorType:        row.ActorType,
 		ActorDisplayName: conv.FromPGText[string](row.ActorDisplayName),
-		ActorSlug:        conv.FromPGText[string](row.ActorSlug),
 		SubjectType:      row.SubjectType,
 		SubjectDisplay:   conv.PtrValOr(conv.FromPGText[string](row.SubjectDisplayName), ""),
 		SubjectSlug:      conv.PtrValOr(conv.FromPGText[string](row.SubjectSlug), ""),

--- a/server/internal/audit/audittest/helpers.go
+++ b/server/internal/audit/audittest/helpers.go
@@ -13,14 +13,18 @@ import (
 )
 
 type LogRecord struct {
-	Action         string
-	ProjectID      uuid.NullUUID
-	SubjectType    string
-	SubjectDisplay string
-	SubjectSlug    string
-	Metadata       []byte
-	BeforeSnapshot []byte
-	AfterSnapshot  []byte
+	Action           string
+	ProjectID        uuid.NullUUID
+	ActorID          string
+	ActorType        string
+	ActorDisplayName *string
+	ActorSlug        *string
+	SubjectType      string
+	SubjectDisplay   string
+	SubjectSlug      string
+	Metadata         []byte
+	BeforeSnapshot   []byte
+	AfterSnapshot    []byte
 }
 
 func LatestAuditLogByAction(ctx context.Context, dbtx repo.DBTX, action audit.Action) (LogRecord, error) {
@@ -30,14 +34,18 @@ func LatestAuditLogByAction(ctx context.Context, dbtx repo.DBTX, action audit.Ac
 	}
 
 	return LogRecord{
-		Action:         row.Action,
-		ProjectID:      row.ProjectID,
-		SubjectType:    row.SubjectType,
-		SubjectDisplay: conv.PtrValOr(conv.FromPGText[string](row.SubjectDisplayName), ""),
-		SubjectSlug:    conv.PtrValOr(conv.FromPGText[string](row.SubjectSlug), ""),
-		Metadata:       row.Metadata,
-		BeforeSnapshot: row.BeforeSnapshot,
-		AfterSnapshot:  row.AfterSnapshot,
+		Action:           row.Action,
+		ProjectID:        row.ProjectID,
+		ActorID:          row.ActorID,
+		ActorType:        row.ActorType,
+		ActorDisplayName: conv.FromPGText[string](row.ActorDisplayName),
+		ActorSlug:        conv.FromPGText[string](row.ActorSlug),
+		SubjectType:      row.SubjectType,
+		SubjectDisplay:   conv.PtrValOr(conv.FromPGText[string](row.SubjectDisplayName), ""),
+		SubjectSlug:      conv.PtrValOr(conv.FromPGText[string](row.SubjectSlug), ""),
+		Metadata:         row.Metadata,
+		BeforeSnapshot:   row.BeforeSnapshot,
+		AfterSnapshot:    row.AfterSnapshot,
 	}, nil
 }
 

--- a/server/internal/audit/audittest/queries.sql
+++ b/server/internal/audit/audittest/queries.sql
@@ -2,6 +2,10 @@
 SELECT
   action,
   project_id,
+  actor_id,
+  actor_type,
+  actor_display_name,
+  actor_slug,
   subject_type,
   subject_display_name,
   subject_slug,

--- a/server/internal/audit/audittest/queries.sql
+++ b/server/internal/audit/audittest/queries.sql
@@ -2,10 +2,7 @@
 SELECT
   action,
   project_id,
-  actor_id,
-  actor_type,
   actor_display_name,
-  actor_slug,
   subject_type,
   subject_display_name,
   subject_slug,

--- a/server/internal/audit/audittest/repo/queries.sql.go
+++ b/server/internal/audit/audittest/repo/queries.sql.go
@@ -41,10 +41,7 @@ const getLatestAuditLogByAction = `-- name: GetLatestAuditLogByAction :one
 SELECT
   action,
   project_id,
-  actor_id,
-  actor_type,
   actor_display_name,
-  actor_slug,
   subject_type,
   subject_display_name,
   subject_slug,
@@ -60,10 +57,7 @@ LIMIT 1
 type GetLatestAuditLogByActionRow struct {
 	Action             string
 	ProjectID          uuid.NullUUID
-	ActorID            string
-	ActorType          string
 	ActorDisplayName   pgtype.Text
-	ActorSlug          pgtype.Text
 	SubjectType        string
 	SubjectDisplayName pgtype.Text
 	SubjectSlug        pgtype.Text
@@ -78,10 +72,7 @@ func (q *Queries) GetLatestAuditLogByAction(ctx context.Context, action string) 
 	err := row.Scan(
 		&i.Action,
 		&i.ProjectID,
-		&i.ActorID,
-		&i.ActorType,
 		&i.ActorDisplayName,
-		&i.ActorSlug,
 		&i.SubjectType,
 		&i.SubjectDisplayName,
 		&i.SubjectSlug,

--- a/server/internal/audit/audittest/repo/queries.sql.go
+++ b/server/internal/audit/audittest/repo/queries.sql.go
@@ -41,6 +41,10 @@ const getLatestAuditLogByAction = `-- name: GetLatestAuditLogByAction :one
 SELECT
   action,
   project_id,
+  actor_id,
+  actor_type,
+  actor_display_name,
+  actor_slug,
   subject_type,
   subject_display_name,
   subject_slug,
@@ -56,6 +60,10 @@ LIMIT 1
 type GetLatestAuditLogByActionRow struct {
 	Action             string
 	ProjectID          uuid.NullUUID
+	ActorID            string
+	ActorType          string
+	ActorDisplayName   pgtype.Text
+	ActorSlug          pgtype.Text
 	SubjectType        string
 	SubjectDisplayName pgtype.Text
 	SubjectSlug        pgtype.Text
@@ -70,6 +78,10 @@ func (q *Queries) GetLatestAuditLogByAction(ctx context.Context, action string) 
 	err := row.Scan(
 		&i.Action,
 		&i.ProjectID,
+		&i.ActorID,
+		&i.ActorType,
+		&i.ActorDisplayName,
+		&i.ActorSlug,
 		&i.SubjectType,
 		&i.SubjectDisplayName,
 		&i.SubjectSlug,

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -649,6 +651,13 @@ func TestService_Callback_SignupIntent(t *testing.T) {
 		trial, err := trialsRepo.New(instance.conn).GetTrial(ctx, session.ActiveOrganizationID)
 		require.NoError(t, err)
 		require.Equal(t, "enterprise", trial.Tier)
+
+		// Callback is unauthenticated, so the audit actor cannot come from an
+		// auth context. The email has to be threaded through provisioning.
+		entry, err := audittest.LatestAuditLogByAction(ctx, instance.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+		require.NoError(t, err)
+		require.NotNil(t, entry.ActorDisplayName, "signup must attribute the trial to the user who signed up")
+		require.Equal(t, userInfo.Email, *entry.ActorDisplayName)
 	})
 
 	t.Run("trial notifier failure does not fail signup", func(t *testing.T) {

--- a/server/internal/auth/enterprise_trial.go
+++ b/server/internal/auth/enterprise_trial.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/billing"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
@@ -33,7 +32,11 @@ type EnterpriseTrialBundleSeeder func(ctx context.Context, tx pgx.Tx, organizati
 // A trial sits on the real enterprise tier rather than a tier of its own, so
 // every account-type lookup downstream, including the OpenRouter credit
 // ceiling, resolves against a value it already knows.
-func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRepo.OrganizationMetadatum, userID string) error {
+//
+// actorEmail is the display name recorded on the audit entry. It travels as a
+// parameter rather than an auth-context read because signup arms a trial from
+// the unauthenticated callback, where there is no auth context to read.
+func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRepo.OrganizationMetadatum, userID, actorEmail string) error {
 	if err := orgRepo.New(tx).SetAccountType(ctx, orgRepo.SetAccountTypeParams{
 		ID:              org.ID,
 		GramAccountType: string(billing.TierEnterprise),
@@ -54,15 +57,10 @@ func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRe
 		return fmt.Errorf("create enterprise trial: %w", err)
 	}
 
-	var actorDisplayName *string
-	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
-		actorDisplayName = authCtx.Email
-	}
-
 	if err := s.auditLogger.LogOrganizationEnterpriseTrialArmed(ctx, tx, audit.LogOrganizationEnterpriseTrialArmedEvent{
 		OrganizationID:   org.ID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, userID),
-		ActorDisplayName: actorDisplayName,
+		ActorDisplayName: conv.PtrEmpty(actorEmail),
 		ActorSlug:        nil,
 		OrganizationName: org.Name,
 		OrganizationSlug: org.Slug,

--- a/server/internal/auth/enterprise_trial_test.go
+++ b/server/internal/auth/enterprise_trial_test.go
@@ -84,10 +84,6 @@ func TestRegister_ArmsEnterpriseTrial(t *testing.T) {
 	require.Equal(t, auditsBefore+1, auditsAfter)
 }
 
-// TestRegister_TrialArmedAuditRecordsActorDisplayName guards the org-less audit
-// actor. Self-signup arms the trial on a session with no active organization,
-// and sessions.Authenticate must still populate the actor email so the entry
-// records a display name rather than a bare actor id.
 func TestRegister_TrialArmedAuditRecordsActorDisplayName(t *testing.T) {
 	t.Parallel()
 
@@ -99,8 +95,6 @@ func TestRegister_TrialArmedAuditRecordsActorDisplayName(t *testing.T) {
 
 	entry, err := audittest.LatestAuditLogByAction(ctx, inst.conn, audit.ActionOrganizationEnterpriseTrialArmed)
 	require.NoError(t, err)
-	require.Equal(t, "user", entry.ActorType)
-	require.NotEmpty(t, entry.ActorID)
 	require.NotNil(t, entry.ActorDisplayName, "org-less session must still resolve the actor email")
 	require.Equal(t, email, *entry.ActorDisplayName)
 }

--- a/server/internal/auth/enterprise_trial_test.go
+++ b/server/internal/auth/enterprise_trial_test.go
@@ -49,7 +49,8 @@ func signUpWithoutOrganization(t *testing.T, workosUserID, email string) (contex
 func TestRegister_ArmsEnterpriseTrial(t *testing.T) {
 	t.Parallel()
 
-	ctx, inst, _ := signUpWithoutOrganization(t, "user_01TRIAL_ARMED", "trial-armed@example.com")
+	const email = "trial-armed@example.com"
+	ctx, inst, _ := signUpWithoutOrganization(t, "user_01TRIAL_ARMED", email)
 
 	auditsBefore, err := audittest.AuditLogCountByAction(ctx, inst.conn, audit.ActionOrganizationEnterpriseTrialArmed)
 	require.NoError(t, err)
@@ -82,16 +83,6 @@ func TestRegister_ArmsEnterpriseTrial(t *testing.T) {
 	auditsAfter, err := audittest.AuditLogCountByAction(ctx, inst.conn, audit.ActionOrganizationEnterpriseTrialArmed)
 	require.NoError(t, err)
 	require.Equal(t, auditsBefore+1, auditsAfter)
-}
-
-func TestRegister_TrialArmedAuditRecordsActorDisplayName(t *testing.T) {
-	t.Parallel()
-
-	const email = "trial-actor@example.com"
-	const workosUserID = "user_01TRIAL_ACTOR"
-	ctx, inst, _ := signUpWithoutOrganization(t, workosUserID, email)
-
-	require.NoError(t, inst.service.Register(ctx, &gen.RegisterPayload{OrgName: "Enterprise Actor Org"}))
 
 	entry, err := audittest.LatestAuditLogByAction(ctx, inst.conn, audit.ActionOrganizationEnterpriseTrialArmed)
 	require.NoError(t, err)

--- a/server/internal/auth/enterprise_trial_test.go
+++ b/server/internal/auth/enterprise_trial_test.go
@@ -84,6 +84,27 @@ func TestRegister_ArmsEnterpriseTrial(t *testing.T) {
 	require.Equal(t, auditsBefore+1, auditsAfter)
 }
 
+// TestRegister_TrialArmedAuditRecordsActorDisplayName guards the org-less audit
+// actor. Self-signup arms the trial on a session with no active organization,
+// and sessions.Authenticate must still populate the actor email so the entry
+// records a display name rather than a bare actor id.
+func TestRegister_TrialArmedAuditRecordsActorDisplayName(t *testing.T) {
+	t.Parallel()
+
+	const email = "trial-actor@example.com"
+	const workosUserID = "user_01TRIAL_ACTOR"
+	ctx, inst, _ := signUpWithoutOrganization(t, workosUserID, email)
+
+	require.NoError(t, inst.service.Register(ctx, &gen.RegisterPayload{OrgName: "Enterprise Actor Org"}))
+
+	entry, err := audittest.LatestAuditLogByAction(ctx, inst.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+	require.Equal(t, "user", entry.ActorType)
+	require.NotEmpty(t, entry.ActorID)
+	require.NotNil(t, entry.ActorDisplayName, "org-less session must still resolve the actor email")
+	require.Equal(t, email, *entry.ActorDisplayName)
+}
+
 // TestRegister_EnterpriseTrialResolvesThroughInfo checks the tier survives the
 // Info round trip, so the enterprise surfaces appear straight after signup
 // without a re-login.

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -338,6 +338,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 			org, err := s.provisionOrgForUser(ctx, userID, intent.OrgName, orgProvisionOptions{
 				Whitelisted:    true,
 				ProvisionTrial: true,
+				ActorEmail:     userInfo.Email,
 			})
 			if err != nil {
 				return s.redirectSignupError(ctx, err)
@@ -933,6 +934,12 @@ type orgProvisionOptions struct {
 	// ProvisionTrial arms a 14-day enterprise trial in the same transaction
 	// that creates the organization.
 	ProvisionTrial bool
+
+	// ActorEmail names the human this provisioning is attributed to in the
+	// audit log. It travels explicitly because the signup path runs on the
+	// unauthenticated callback, which has no auth context to read it from.
+	// Empty stores no display name, leaving the entry showing a bare actor id.
+	ActorEmail string
 }
 
 // provisionOrgForUser creates an organization and attaches a user to it as the
@@ -989,6 +996,7 @@ func (s *Service) Register(ctx context.Context, payload *gen.RegisterPayload) (e
 	org, err := s.provisionOrgForUser(ctx, authCtx.UserID, payload.OrgName, orgProvisionOptions{
 		Whitelisted:    true,
 		ProvisionTrial: true,
+		ActorEmail:     conv.PtrValOr(authCtx.Email, ""),
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error creating organization").LogError(ctx, s.logger)
@@ -1014,6 +1022,7 @@ func (s *Service) autoProvisionForAssistants(ctx context.Context, userInfo *sess
 	org, err := s.provisionOrgForUser(ctx, userInfo.UserID, orgName, orgProvisionOptions{
 		Whitelisted:    true,
 		ProvisionTrial: false,
+		ActorEmail:     userInfo.Email,
 	})
 	if err != nil {
 		return "", err
@@ -1106,7 +1115,7 @@ func (s *Service) persistProvisionedOrganization(
 	}
 
 	if opts.ProvisionTrial {
-		if err := s.armEnterpriseTrialTx(ctx, tx, org, userID); err != nil {
+		if err := s.armEnterpriseTrialTx(ctx, tx, org, userID, opts.ActorEmail); err != nil {
 			return orgRepo.OrganizationMetadatum{}, fmt.Errorf("arm enterprise trial: %w", err)
 		}
 	}

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -120,16 +120,14 @@ func (s *Manager) Authenticate(ctx context.Context, key string) (context.Context
 	}
 
 	if session.ActiveOrganizationID == "" {
-		// Org-less sessions still need the actor email so audit entries written
-		// on this path (e.g. self-signup enterprise trial arming) record an
-		// actor display name rather than a bare actor id. GetUserInfo warms the
-		// user-info cache on a miss, so the subsequent IsAdmin read — which
-		// leaves IsAdmin false on a cache miss (safe default) — resolves against
-		// a warm cache. No org membership check is needed for org-less sessions.
-		if userInfo, _, err := s.identity.GetUserInfo(ctx, session.UserID); err == nil {
-			authCtx.Email = &userInfo.Email
+		// Organization-less sessions still need identity attributes for
+		// request handling and audit attribution.
+		userInfo, _, err := s.identity.GetUserInfo(ctx, session.UserID)
+		if err != nil {
+			return ctx, oops.E(oops.CodeUnexpected, err, "error getting user info").LogError(ctx, s.logger)
 		}
-		authCtx.IsAdmin = s.identity.IsAdmin(ctx, session.UserID)
+		authCtx.Email = &userInfo.Email
+		authCtx.IsAdmin = userInfo.Admin
 		ctx = contextvalues.SetAuthContext(ctx, authCtx)
 		return ctx, nil
 	}

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -120,8 +120,15 @@ func (s *Manager) Authenticate(ctx context.Context, key string) (context.Context
 	}
 
 	if session.ActiveOrganizationID == "" {
-		// Populate IsAdmin from cached user info. A cache miss leaves it false
-		// (safe default). No org membership check needed for org-less sessions.
+		// Org-less sessions still need the actor email so audit entries written
+		// on this path (e.g. self-signup enterprise trial arming) record an
+		// actor display name rather than a bare actor id. GetUserInfo warms the
+		// user-info cache on a miss, so the subsequent IsAdmin read — which
+		// leaves IsAdmin false on a cache miss (safe default) — resolves against
+		// a warm cache. No org membership check is needed for org-less sessions.
+		if userInfo, _, err := s.identity.GetUserInfo(ctx, session.UserID); err == nil {
+			authCtx.Email = &userInfo.Email
+		}
 		authCtx.IsAdmin = s.identity.IsAdmin(ctx, session.UserID)
 		ctx = contextvalues.SetAuthContext(ctx, authCtx)
 		return ctx, nil

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -123,11 +123,11 @@ func (s *Manager) Authenticate(ctx context.Context, key string) (context.Context
 		// Organization-less sessions still need identity attributes for
 		// request handling and audit attribution.
 		userInfo, _, err := s.identity.GetUserInfo(ctx, session.UserID)
-		if err != nil {
-			return ctx, oops.E(oops.CodeUnexpected, err, "error getting user info").LogError(ctx, s.logger)
+		if err == nil {
+			email := userInfo.Email
+			authCtx.Email = &email
+			authCtx.IsAdmin = userInfo.Admin
 		}
-		authCtx.Email = &userInfo.Email
-		authCtx.IsAdmin = userInfo.Admin
 		ctx = contextvalues.SetAuthContext(ctx, authCtx)
 		return ctx, nil
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

An audit entry written during a request whose session has no active organization stored `actor_display_name` as NULL, so the Activity timeline rendered the entry with a bare actor id and no name.

`sessions.Authenticate` built the auth context with `Email: nil` and returned early when `session.ActiveOrganizationID == ""`, before the `HasAccessToOrganization` call that populates the email. So `authCtx.Email` stayed nil for the whole org-less request, and any `Log*` call that sets `ActorDisplayName` from `authCtx.Email` wrote nothing.

This is pre-existing. It surfaces for the `organization:enterprise_trial_armed` entry, which is always written on an organization-less self-signup request.

## Fix (Option 1 from the issue)

Populate `authCtx.Email` and `authCtx.IsAdmin` from `GetUserInfo` in the org-less branch of `sessions.Authenticate`. This fixes every org-less `Log*` caller at once.

- On the normal warm-cache path, the existing `IsAdmin` Redis lookup is replaced by one `GetUserInfo` Redis lookup, so latency is neutral.
- On a cold cache, `GetUserInfo` rebuilds identity data from the database. Callback normally warms this cache before the org-less request reaches Register.
- Identity lookup errors preserve the prior fail-soft authentication semantics: the valid session remains authenticated with the existing safe defaults (`Email == nil`, `IsAdmin == false`).
- Using the returned `Admin` value directly avoids a redundant second cache lookup and avoids cold-cache admin false negatives when identity resolution succeeds.

## Test

- Extended the `audittest` helper (`GetLatestAuditLogByAction` query + `LogRecord`) with only the stored `actor_display_name` field needed by this regression.
- Extended `TestRegister_ArmsEnterpriseTrial` to assert that the audit entry written through the real organization-less Callback → Authenticate → Register path records the signup email as its actor display name.

Verified the assertion fails on `main` (actor display name is nil) and passes with the fix.

## Existing NULL rows

Left as-is (no backfill). The bug only produced NULL `actor_display_name` on org-less audit paths, and the first such path (enterprise trial arming) is not yet in production, so there is no meaningful backfill population to correct.

## Verification

- `mise run test:server -count=10 -run '^TestRegister_ArmsEnterpriseTrial$' ./internal/auth/...` — 10/10 pass.
- `mise run test:server ./internal/auth/... ./internal/audit/...` — 230 tests pass.
- `mise run lint:server` — clean.

Resolves AGE-3130.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3130](https://linear.app/speakeasy/issue/AGE-3130/bug-audit-entries-from-organization-less-sessions-record-no-actor)

<div><a href="https://cursor.com/agents/bc-7eee3eb0-ffd7-4eba-916d-8d047fe0f094?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eee3eb0-ffd7-4eba-916d-8d047fe0f094&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records actor display names on audit entries from organization-less requests and the unauthenticated signup callback. Previously these entries stored NULL and rendered a bare actor id; now we store the user’s email while preserving fail-soft auth on identity lookup failures.

- In `sessions.Authenticate`, resolve identity for org-less sessions via `GetUserInfo`; set `authCtx.Email` and `authCtx.IsAdmin`; continue on errors. This warms the cache and avoids cold-cache `IsAdmin` false negatives.
- Attribute provisioning explicitly: add `ActorEmail` to `orgProvisionOptions`; `Callback` and assistants pass `userInfo.Email`; `Register` passes `authCtx.Email`. `armEnterpriseTrialTx` now accepts `actorEmail` and records it.
- Extend `audittest.LatestAuditLogByAction` to return `actor_display_name`; add assertions in Callback signup and Register tests verifying the trial-armed entry records the signup email.
- No backfill; the first affected event isn’t in production.

Linear: AGE-3130.

<sup>Written for commit 662d25849990d8ccad583cce5667af7b8bd891f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

