### PR TITLE
chore(ci): retry uv sync when GitHub refuses the download

### DIFF
--- a/.mise-tasks/install/uv.sh
+++ b/.mise-tasks/install/uv.sh
@@ -3,4 +3,42 @@
 #MISE hide=true
 #MISE dir="{{ config_root }}"
 
-exec uv sync "$@"
+set -euo pipefail
+
+# pystreams pins the spaCy model (en-core-web-lg) to a GitHub release asset, so
+# every sync that misses the uv cache fetches it straight from github.com.
+# GitHub intermittently refuses those connections — HTTP/2 "refused stream", or
+# a reset mid-transfer — and uv gives up after 3 attempts inside ~8s, which is
+# too short to ride out a refusal that clears in seconds. The result is CI jobs
+# failing for reasons unrelated to the change under test, including in the merge
+# queue where this task runs for every PR.
+#
+# Retry the whole sync with exponential backoff, but only when the failure looks
+# like a transport problem: a genuine failure (a stale lockfile under --locked,
+# an unresolvable dependency) must still fail fast and loudly rather than
+# burning the backoff budget first.
+attempts="${UV_SYNC_ATTEMPTS:-4}"
+delay="${UV_SYNC_RETRY_DELAY:-5}"
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+for attempt in $(seq 1 "$attempts"); do
+  # pipefail makes this reflect uv's exit status, not tee's.
+  if uv sync "$@" 2>&1 | tee "$log"; then
+    exit 0
+  fi
+
+  if ! grep -qiE 'failed to fetch|error sending request|stream error|request failed after|connection (reset|closed)|operation timed out' "$log"; then
+    exit 1
+  fi
+
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "uv sync: giving up after ${attempts} attempts" >&2
+    exit 1
+  fi
+
+  echo "uv sync: transport failure on attempt ${attempt}/${attempts}, retrying in ${delay}s" >&2
+  sleep "$delay"
+  delay=$((delay * 2))
+done

--- a/.mise-tasks/install/uv.sh
+++ b/.mise-tasks/install/uv.sh
@@ -8,15 +8,23 @@ set -euo pipefail
 # pystreams pins the spaCy model (en-core-web-lg) to a GitHub release asset, so
 # every sync that misses the uv cache fetches it straight from github.com.
 # GitHub intermittently refuses those connections — HTTP/2 "refused stream", or
-# a reset mid-transfer — and uv gives up after 3 attempts inside ~8s, which is
-# too short to ride out a refusal that clears in seconds. The result is CI jobs
-# failing for reasons unrelated to the change under test, including in the merge
-# queue where this task runs for every PR.
+# a reset mid-transfer — and uv's default budget of 3 in-process retries spans
+# only ~8s, too short to ride out a refusal that clears in seconds. The result
+# is CI jobs failing for reasons unrelated to the change under test, including
+# in the merge queue where this task runs for every PR.
 #
-# Retry the whole sync with exponential backoff, but only when the failure looks
-# like a transport problem: a genuine failure (a stale lockfile under --locked,
-# an unresolvable dependency) must still fail fast and loudly rather than
-# burning the backoff budget first.
+# Two layers of defense:
+#
+# 1. Raise uv's own per-request retry budget. Its backoff is exponential, so 6
+#    retries spans roughly a minute in-process (measured: 4 retries ≈ 16s).
+# 2. Re-run the whole sync with exponential backoff on top. A fresh process gets
+#    fresh connections, which in-process retries don't guarantee when an HTTP/2
+#    connection has gone bad.
+#
+# The outer retry only fires when the failure looks like a transport problem: a
+# genuine failure (a stale lockfile under --locked, an unresolvable dependency)
+# must still fail fast and loudly rather than burning the backoff budget first.
+export UV_HTTP_RETRIES="${UV_HTTP_RETRIES:-6}"
 attempts="${UV_SYNC_ATTEMPTS:-4}"
 delay="${UV_SYNC_RETRY_DELAY:-5}"
 


### PR DESCRIPTION
## Problem

`pystreams` pins the spaCy model to a GitHub release asset:

```toml
en-core-web-lg = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl" }
```

so any `uv sync` that misses the cache fetches it straight from github.com. GitHub has been intermittently refusing those connections:

```
error: Failed to generate package metadata for `en-core-web-lg==3.8.0 @ direct+https://...`
  Caused by: Request failed after 3 retries in 8.3s
  Caused by: http2 error
  Caused by: stream error received: refused stream before processing any application logic
```

uv's default budget is **3 in-process retries spanning ~8.3s** — too short to ride out a refusal that clears seconds later.

## Why it matters

This fails `install:uv`, and with it **Lint and generate infra** and **Lint and test the pystreams package**, for reasons unrelated to the change under test. It bites hardest in the **merge queue**, where those jobs run for every PR even when the PR touches no Python at all — several PRs were ejected repeatedly today (5162 five times, 5199 three times, plus 5151 and 5194).

**Caching does not cover this.** The failing runs restored the uv cache successfully (`Cache hit for: uv-1-linux-x64-uv0.12.1-…`) and still went to the network for this wheel.

## Fix — two layers

1. **`UV_HTTP_RETRIES=6`** — raises uv's own per-request retry budget. Verified supported in uv 0.12.1 (an invalid value fails env parsing) and that its backoff is exponential: measured 0 retries → instant failure, 4 retries → `Request failed after 4 retries in 15.8s`. Six spans roughly a minute in-process.
2. **Whole-sync retry with exponential backoff** (4 attempts, 5s → 10s → 20s) on top. In-process retries reuse the client's connection pool, so a poisoned HTTP/2 connection can keep refusing streams across all of them; a fresh process is guaranteed fresh connections.

The outer retry only fires when the failure **looks like a transport problem**. A genuine failure — a stale lockfile under `--locked`, an unresolvable dependency — still exits on the first attempt, so real breakage stays fast and loud.

All knobs overridable: `UV_HTTP_RETRIES`, `UV_SYNC_ATTEMPTS`, `UV_SYNC_RETRY_DELAY`.

> Correction from the first revision: this PR originally claimed `UV_HTTP_RETRIES` was unsupported in uv 0.12.1. That was wrong — it was inferred from the variable being absent in `uv sync --help`, which doesn't list every env var. Re-verified empirically and layered it in.

## Verification

| case | result |
|---|---|
| Transport failure, recovers on attempt 3 | retries with backoff, exits 0, `UV_HTTP_RETRIES=6` visible to uv |
| Stale lockfile under `--locked` | **no retry, 0s, exits 1** — real errors stay fast |
| Persistent transport failure | exhausts attempts, exits 1, clear message |
| `UV_HTTP_RETRIES` efficacy | 0 → instant fail; 4 → 15.8s of exponential backoff |

Also ran the real task end to end (`mise run install:uv --all-packages --locked`) cold and warm — both succeed. `hk` (shellcheck) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)