### PR TITLE
fix(dashboard): watchdog badge label clipping and within-window trend

### DIFF
--- a/.changeset/watchdog-sparkline-context.md
+++ b/.changeset/watchdog-sparkline-context.md
@@ -1,0 +1,7 @@
+---
+"dashboard": patch
+---
+
+Watchdog trend percentages now measure change within the current window so
+they move with the sparkline. Fix category badge labels rendering with
+clipped glyphs.

--- a/client/dashboard/src/pages/security/risk-ui.tsx
+++ b/client/dashboard/src/pages/security/risk-ui.tsx
@@ -51,7 +51,14 @@ export function CategoryLabel({
       title={`${meta.label}: ${meta.description}`}
     >
       <Badge variant="neutral" className="max-w-full">
-        <Badge.Text className="min-w-0 truncate">{meta.label}</Badge.Text>
+        {/* The ellipsis needs overflow:hidden, but Badge.Text's default box
+            hugs the glyph ink (leading-none plus cap/alphabetic
+            text-box-trim), so clipping there shaves the letters themselves.
+            Disable the trim and open up the line box on this truncating
+            instance so the ink never crosses the clip edge. */}
+        <Badge.Text className="min-w-0 truncate leading-normal [text-box-trim:none]">
+          {meta.label}
+        </Badge.Text>
       </Badge>
     </span>
   );

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -310,10 +310,7 @@ export function SignalDrawer({
                           {signal.teams > 0 ? signal.teams : "-"}
                         </StatCell>
                         <StatCell label="Trend">
-                          <SignalTrend
-                            findings={signal.findings}
-                            previousFindings={signal.previousFindings}
-                          />
+                          <SignalTrend sparkline={signal.sparkline} />
                         </StatCell>
                       </div>
 

--- a/client/dashboard/src/pages/security/watchdog/SignalsList.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalsList.tsx
@@ -21,18 +21,16 @@ import {
 } from "./signals-helpers";
 
 /**
- * Finding-count trend for a signal row: green/red arrow with the
- * window-over-window percentage, or a "new" badge when the previous window had
- * nothing to compare against.
+ * Finding-count trend for a signal row: the within-window percentage (end of
+ * the sparkline against its start, so the number moves with the drawn line),
+ * or a "new" badge when the window opened with nothing to compare against.
  */
 export function SignalTrend({
-  findings,
-  previousFindings,
+  sparkline,
 }: {
-  findings: number;
-  previousFindings: number;
+  sparkline: number[];
 }): JSX.Element {
-  const trend = trendPercent(findings, previousFindings);
+  const trend = trendPercent(sparkline);
   if (trend === null) {
     return (
       <Badge variant="information" size="sm">
@@ -175,10 +173,7 @@ function SignalRow({
             <span className="text-lg font-normal tabular-nums">
               {signal.findings.toLocaleString()}
             </span>
-            <SignalTrend
-              findings={signal.findings}
-              previousFindings={signal.previousFindings}
-            />
+            <SignalTrend sparkline={signal.sparkline} />
           </div>
           <Sparkline values={signal.sparkline} width={184} height={28} />
           <span className="text-muted-foreground font-mono text-xs">

--- a/client/dashboard/src/pages/security/watchdog/signals-helpers.test.ts
+++ b/client/dashboard/src/pages/security/watchdog/signals-helpers.test.ts
@@ -31,14 +31,22 @@ function signal(overrides: Partial<RiskSignal>): RiskSignal {
 }
 
 describe("trendPercent", () => {
-  it("computes window-over-window growth", () => {
-    expect(trendPercent(3, 1)).toBeCloseTo(200);
-    expect(trendPercent(1, 4)).toBeCloseTo(-75);
-    expect(trendPercent(5, 5)).toBeCloseTo(0);
+  it("computes within-window growth from segment means", () => {
+    // 9 buckets -> 3-bucket segments: first mean 1, last mean 3 -> +200%.
+    expect(trendPercent([1, 1, 1, 2, 2, 2, 3, 3, 3])).toBeCloseTo(200);
+    // First mean 4, last mean 1 -> -75%.
+    expect(trendPercent([4, 4, 4, 2, 2, 2, 1, 1, 1])).toBeCloseTo(-75);
+    // Flat series -> 0%.
+    expect(trendPercent([5, 5, 5, 5, 5, 5])).toBeCloseTo(0);
   });
 
-  it("returns null without a previous baseline", () => {
-    expect(trendPercent(10, 0)).toBeNull();
+  it("returns null when the window opens with no findings", () => {
+    expect(trendPercent([0, 0, 0, 4, 6, 8])).toBeNull();
+  });
+
+  it("returns null for series too short to compare", () => {
+    expect(trendPercent([7])).toBeNull();
+    expect(trendPercent([])).toBeNull();
   });
 });
 

--- a/client/dashboard/src/pages/security/watchdog/signals-helpers.ts
+++ b/client/dashboard/src/pages/security/watchdog/signals-helpers.ts
@@ -52,13 +52,27 @@ export const SEVERITY_GROUP_LABEL: Record<SignalSeverity, string> = {
   low: "Low",
 };
 
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
 /**
- * Window-over-window growth in percent, or null when there is no previous
- * baseline (the UI renders "new" instead of a misleading +100%).
+ * Within-window growth in percent: the last third of the window's sparkline
+ * buckets against the first third, so the number moves with the drawn line
+ * rather than with a previous window the chart never shows. Segment means
+ * (mirroring sparkline-math's trendOf) rather than single endpoint buckets,
+ * which are too noisy to anchor a percentage. Null when the window opens with
+ * no findings — the UI renders "new" instead of a misleading percentage.
  */
-export function trendPercent(current: number, previous: number): number | null {
-  if (previous <= 0) return null;
-  return ((current - previous) / previous) * 100;
+export function trendPercent(sparkline: number[]): number | null {
+  const n = sparkline.length;
+  if (n < 2) return null;
+  const seg = Math.max(1, Math.round(n / 3));
+  const first = mean(sparkline.slice(0, seg));
+  if (first <= 0) return null;
+  const last = mean(sparkline.slice(n - seg));
+  return ((last - first) / first) * 100;
 }
 
 export type SignalGroup = {


### PR DESCRIPTION
Two Watchdog list fixes.

## Badge labels rendered with clipped glyphs

`CategoryLabel` put `truncate` (overflow hidden) directly on `Badge.Text`, whose box hugs the glyph ink: badge size classes set `leading-none`, and `Badge.Text` applies cap/alphabetic `text-box-trim`. The clip edge ran through the letters themselves — most visible on retina displays. The truncating instance now disables the trim and opens the line box (`leading-normal [text-box-trim:none]`), so the ellipsis keeps working and the ink never crosses the clip edge. Note `text-box-trim` reaches into descendant line boxes, so nesting an inner truncating span does not dodge it.

## Trend percentage moved against the sparkline

The row percentage compared window-over-window totals while the sparkline draws only the current window, so a signal could show `+45%` next to a falling line. The percentage is now computed from the sparkline itself — mean of the last third of buckets vs the first third, mirroring `sparkline-math`'s segmentation — so number, line, and color move together. `null` (the "new" badge) now means the window opened with no findings.

## Testing

- Unit tests for the new trend math (growth, decline, flat, opens-at-zero, short series)
- Verified in the browser: glyph clip box now exceeds the text ink; badges ellipsize with borders intact at narrow widths
- `pnpm -F dashboard lint` and full dashboard test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Watchdog trend percentages with the sparkline and fixes clipped glyphs in category badge labels. Previously, the trend compared window-over-window totals and could disagree with the sparkline; now it computes within the current window. Ellipsized badge text no longer clips letter shapes.

**Review notes**
- `trendPercent` now takes a `sparkline: number[]` and returns percent as mean(last third) vs mean(first third); returns null when the window opens at 0 or the series is too short (mirrors `sparkline-math` segmentation).
- `SignalTrend` now accepts `sparkline` instead of `findings`/`previousFindings`; callers updated in `SignalsList` and `SignalDrawer`.
- `CategoryLabel` applies `leading-normal [text-box-trim:none]` on truncated `Badge.Text` to preserve the ellipsis without shaving glyphs.
- Tests cover growth/decline/flat, opens-at-zero, and short series; changeset added for `dashboard`.

**Rollout/QA**
- In Watchdog list and drawer, confirm the trend arrow/color and percentage move with the sparkline; “new” appears when the sparkline starts at zero.
- Narrow the category column to verify badges ellipsize cleanly with intact borders and no clipped glyphs.

<sup>Written for commit bba4931ccbcc17e4cc154c55efade9db89ba104b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

