### PR TITLE
fix(dashboard): prevent nested assistant runtimes

### DIFF
--- a/client/dashboard/src/components/insights-dock.test.tsx
+++ b/client/dashboard/src/components/insights-dock.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, render } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useHideInsightsDock } from "./insights-context";
+import { InsightsProvider } from "./insights-dock";
+import { GramElementsProvider } from "@/elements";
+
+const mocks = vi.hoisted(() => ({
+  activeRoute: "detail" as "detail" | "new",
+}));
+
+vi.mock("@/elements", async () => {
+  const { createContext, createElement, useContext } = await import("react");
+  const RuntimeContext = createContext(false);
+
+  return {
+    ActiveChatTitle: () => null,
+    Chat: () => null,
+    ChatComposer: () => null,
+    ChatHistory: () => null,
+    focusChatComposer: vi.fn(),
+    GramElementsProvider: ({ children }: { children: ReactNode }) => {
+      if (useContext(RuntimeContext)) {
+        throw new Error(
+          "useRemoteThreadListRuntime cannot be nested inside another RemoteThreadListRuntime",
+        );
+      }
+      return createElement(RuntimeContext.Provider, { value: true }, children);
+    },
+    useThreadId: () => ({ threadId: null }),
+  };
+});
+
+vi.mock("@assistant-ui/react", () => ({
+  useAui: () => ({
+    composer: () => ({ stopDictation: vi.fn() }),
+    thread: () => ({ append: vi.fn() }),
+  }),
+  useAuiState: () => false,
+}));
+
+vi.mock("@/hooks/useObservabilityMcpConfig", () => ({
+  useNoToolsetsConfigured: () => false,
+}));
+vi.mock("@/hooks/useServerAssistantTransport", () => ({
+  useServerAssistantTransport: () => ({
+    transport: undefined,
+    assistantId: "managed-assistant",
+    ready: true,
+    error: undefined,
+    needsAdmin: false,
+  }),
+}));
+vi.mock("@/hooks/useDrainInfiniteQuery", () => ({
+  useDrainInfiniteQuery: vi.fn(),
+}));
+vi.mock("@gram/client/react-query/listChats.js", () => ({
+  useListChats: () => ({ data: undefined }),
+}));
+vi.mock("@gram/client/react-query/members.js", () => ({
+  useMembers: () => ({ data: undefined }),
+}));
+vi.mock("@gram/client/react-query/skills.js", () => ({
+  useSkillsInfinite: () => ({
+    data: undefined,
+    isPending: false,
+    isFetchingNextPage: false,
+    error: undefined,
+  }),
+}));
+vi.mock("@/contexts/Auth", () => ({
+  useSession: () => ({ user: { id: "user", email: "user@example.com" } }),
+}));
+vi.mock("@/lib/assistantEntityLinks", () => ({
+  useAssistantLinkResolver: () => undefined,
+}));
+vi.mock("@/hooks/useInsightsDockCta", () => ({
+  INSIGHTS_DOCK_CONTENT_VT_CLASS: "",
+  INSIGHTS_DOCK_VT_CLASS: "",
+  useInsightsDockCta: () => ({ dismissed: false, dismiss: vi.fn() }),
+}));
+vi.mock("@/components/ui/hooks/useConfig", () => ({
+  useConfig: () => ({ theme: "light" }),
+}));
+vi.mock("./command-palette/askAiBridge", () => ({
+  useAskAiListener: vi.fn(),
+}));
+vi.mock("react-router", () => ({
+  useLocation: () => ({
+    pathname:
+      mocks.activeRoute === "new"
+        ? "/org/projects/project/assistants/new"
+        : "/org/projects/project/assistants/assistant-id",
+  }),
+}));
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({
+    playground: { active: false },
+    elements: { active: false },
+    assistants: {
+      newAssistant: { active: mocks.activeRoute === "new" },
+      detail: { active: mocks.activeRoute === "detail" },
+    },
+    chat: { conversation: { goTo: vi.fn() } },
+  }),
+}));
+
+afterEach(cleanup);
+
+function AssistantEditor(): JSX.Element {
+  useHideInsightsDock();
+  return (
+    <GramElementsProvider config={{} as never}>Editor</GramElementsProvider>
+  );
+}
+
+describe("InsightsProvider", () => {
+  it.each(["new", "detail"] as const)(
+    "does not wrap the assistant %s route in the shared runtime",
+    (activeRoute) => {
+      mocks.activeRoute = activeRoute;
+
+      expect(() =>
+        render(
+          <InsightsProvider
+            mcpConfig={{ projectSlug: "project" } as never}
+            title="Assistant"
+            subtitle=""
+          >
+            <AssistantEditor />
+          </InsightsProvider>,
+        ),
+      ).not.toThrow();
+    },
+  );
+});

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -1027,26 +1027,17 @@ export function InsightsProvider({
     [user.id, user.email],
   );
 
-  // Mount the shared runtime only where it's actually used: a chat route (the
-  // page owns the chat) or the open dock — and only where the dock is shown.
-  // Pages with their own chat runtime (Playground, Elements, assistant
-  // onboarding) hide the dock, so `!hideTrigger` keeps the shared provider out
-  // of their tree and the two RemoteThreadListRuntimes never nest. Maximize
-  // stays seamless because the expand handler navigates WITHOUT collapsing, so
-  // `onChatRoute` takes over before `isExpanded` flips (no unmount gap).
-  // Everything runtime-dependent — the dock panel's chat view, the provider
-  // mount, and (via context) the chat pages — gates on this single flag.
-  // Mounted wherever a composer can appear — every surface now renders the
-  // same AUI composer, and that needs the runtime present, not just when the
-  // chat panel happens to be open. MCP discovery is a react-query on a
-  // module-level client, so the extra mounts reuse one cached result.
-  // Mounted as soon as the assistant resolves, not only where chat is visible:
-  // every entry point (dock pill, /chat landing, project home widget, full
-  // page) now renders the same AUI composer, and that needs the runtime in the
-  // tree. Pages that hide the dock still embed the landing widget, so gating on
-  // dock visibility left those surfaces on the legacy input. MCP discovery is a
-  // react-query on a module-level client, so the extra mounts share one result.
-  const runtimeMounted = assistantReady;
+  // The shared composer needs its runtime as soon as the assistant resolves,
+  // including on Home where the floating dock is hidden in favor of the
+  // landing widget. Routes that mount their own GramElementsProvider are the
+  // exception: wrapping them would nest RemoteThreadListRuntimes before their
+  // useHideInsightsDock layout effect can register with this parent.
+  const pageOwnsRuntime =
+    routes.playground.active ||
+    routes.elements.active ||
+    routes.assistants.newAssistant.active ||
+    routes.assistants.detail.active;
+  const runtimeMounted = assistantReady && !pageOwnsRuntime;
 
   // Read inside the transport wrapper via ref so override churn doesn't
   // re-create the transport identity on every parent re-render.


### PR DESCRIPTION
## Summary

- keep the shared Project Assistant runtime out of routes that mount their own `GramElementsProvider`
- preserve eager runtime mounting for the shared dock and Home landing composer
- add regression coverage for assistant create and edit routes

## Root cause

The shared Insights runtime was changed to mount as soon as the managed assistant resolved. On assistant onboarding routes, that global provider wrapped the page-owned provider before `useHideInsightsDock` could register its layout effect, causing `useRemoteThreadListRuntime` to reject the nested runtime and preventing assistants from loading.

Using `allowNesting` would make the inner page-owned runtime a no-op, so this instead makes runtime ownership explicit by route.

## Testing

- `pnpm -F dashboard test src/components/insights-dock.test.tsx`
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:oxlint`
- `mise exec -- pnpm -F dashboard lint:format`
- `mise exec -- pnpm -F dashboard build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents nested assistant runtimes that broke assistant create/edit pages. Previously the shared runtime mounted as soon as the managed assistant resolved, wrapping routes that mounted their own `GramElementsProvider` and triggering the runtime nesting rejection. Now the shared runtime skips routes that own their runtime, while staying eager for the dock and Home landing composer.

- Route gating: `runtimeMounted` now evaluates to `assistantReady && !pageOwnsRuntime`; `pageOwnsRuntime` is true on Playground, Elements, and Assistants `new` and `detail` routes.
- Behavior: Dock and Home composer continue to mount eagerly; maximize behavior is unchanged; no nested runtime errors on onboarding routes.
- Tests: Adds `insights-dock.test.tsx` to assert the shared runtime does not wrap `GramElementsProvider` on assistant create/edit routes.

<sup>Written for commit 724186c059977c67361220d9fbcc0aeb6f4b72f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

