### PR TITLE
fix(ci): cache hk Pkl package

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -269,6 +269,25 @@ jobs:
           cache: true
           env: false
 
+      - name: Cache Pkl packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: pkl-${{ runner.os }}-${{ runner.arch }}-pkl0.32.1-${{ hashFiles('hk.pkl') }}
+          path: ~/.pkl/cache
+
+      - name: Prefetch hk Pkl package
+        run: |
+          for attempt in 1 2 3 4; do
+            if pkl download-package "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0"; then
+              exit 0
+            fi
+            if [[ "$attempt" == 4 ]]; then
+              exit 1
+            fi
+            echo "Pkl package download failed; retrying after backoff..."
+            sleep $((attempt * 5))
+          done
+
       - name: Prepare GitHub Actions environment
         run: mise run github
 


### PR DESCRIPTION
## Summary

- cache Pkl packages used by the formatting job
- prefetch the pinned `hk` Pkl package before `hk check --all`
- retry transient GitHub release download failures with bounded backoff

## Root cause

Merge queue formatting jobs repeatedly failed while evaluating `hk.pkl` because Pkl made a live request for `package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0` and GitHub returned `request not processed by peer`. The job cached pnpm and aube stores but not Pkl's package cache, so every fresh runner depended on a single successful release download at `hk` startup.

The prefetch makes failures retryable and the cache lets subsequent runs avoid the network request entirely.

## Validation

- `mise exec -- pkl download-package "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0"`
- `mise exec -- hk validate`
- `mise exec -- hk check .github/workflows/pr.yaml`
- `mise exec -- hk check --all`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches Pkl packages in the PR workflow and prefetches `hk@1.38.0` with bounded retries to stop flaky `hk.pkl` evaluations. Previously each run fetched `hk` from GitHub at startup; now we cache `~/.pkl/cache` and prefetch before `hk check --all`, reducing network dependence.

**Review notes**
- Cache key: `pkl-${{ runner.os }}-${{ runner.arch }}-pkl0.32.1-${{ hashFiles('hk.pkl') }}`; update the `pkl0.32.1` segment when upgrading Pkl. Changes to `hk` are captured via the `hk.pkl` hash.
- Prefetch uses `pkl download-package` with up to 4 attempts and increasing 5s backoff, then proceeds with validation and checks.

<sup>Written for commit b553b2b939d77a1dd52756ef5c6cc55719cc205a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

