### PR TITLE
feat: make custom model keys (BYOK) generally available

### DIFF
--- a/.changeset/custom-model-keys-ga.md
+++ b/.changeset/custom-model-keys-ga.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Make custom model provider keys (BYOK) generally available. The `custom_model_keys` product feature is now always on for every organization: `IsFeatureEnabled` short-circuits it to true, `getProductFeatures` always reports it enabled, disable attempts are no-ops, and the Internal Admin toggle is removed. The feature name remains in the API for compatibility.

--- a/client/dashboard/src/pages/platform-admin/Features.tsx
+++ b/client/dashboard/src/pages/platform-admin/Features.tsx
@@ -60,7 +60,6 @@ const PRODUCT_FEATURES: {
   enabledKey:
     | "authzChallengeLoggingEnabled"
     | "customerManagedEncryptionKeysEnabled"
-    | "customModelKeysEnabled"
     | "remoteSessionAutoRefreshEnabled"
     | "ssoEnabled"
     | "scimEnabled";
@@ -78,13 +77,6 @@ const PRODUCT_FEATURES: {
     description:
       "Unlocks encryption key management for an organization, enabling external service credential, external encryption key, and asymmetric signing functionality.",
     enabledKey: "customerManagedEncryptionKeysEnabled",
-  },
-  {
-    featureName: FeatureName.CustomModelKeys,
-    label: "Custom Model Provider Keys",
-    description:
-      "Allows projects in this organization to store OpenRouter API keys for model completions.",
-    enabledKey: "customModelKeysEnabled",
   },
   {
     featureName: FeatureName.RemoteSessionAutoRefresh,

--- a/server/internal/modelkeys/deletekey_test.go
+++ b/server/internal/modelkeys/deletekey_test.go
@@ -19,7 +19,6 @@ func TestDeleteKey_RemovesKey(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	key, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
 	require.NoError(t, err)
@@ -59,7 +58,6 @@ func TestDeleteKey_RequiresProjectWriteScope(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	key, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
 	require.NoError(t, err)

--- a/server/internal/modelkeys/listkeys_test.go
+++ b/server/internal/modelkeys/listkeys_test.go
@@ -23,7 +23,6 @@ func TestListKeys_ReturnsConfiguredKeys(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
 	require.NoError(t, err)

--- a/server/internal/modelkeys/resolver_test.go
+++ b/server/internal/modelkeys/resolver_test.go
@@ -51,7 +51,6 @@ func TestResolveKey_DefaultSlotCoversEverySlot(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
@@ -68,7 +67,6 @@ func TestResolveKey_SlotOverrideBeatsDefault(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
@@ -88,7 +86,6 @@ func TestResolveKey_InternalKeyTypeStaysOnPlatform(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
@@ -105,7 +102,6 @@ func TestResolveKey_JudgeSlotsResolveIndependently(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
@@ -129,7 +125,6 @@ func TestResolveKey_JudgeSlotsWithoutKeysStayOnPlatform(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	resolved, err := resolver.ResolveKey(ctx, orgID, projectID, billing.ModelUsageSourcePromptInjection, openrouter.KeyTypeInternal)
@@ -142,7 +137,6 @@ func TestResolveKey_DisabledKeyIsIgnored(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(p *gen.UpsertKeyPayload) {
@@ -160,7 +154,6 @@ func TestResolveKey_DisabledSlotOverrideFallsBackToProjectDefault(t *testing.T) 
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
@@ -187,7 +180,6 @@ func TestResolveKey_DeletedKeyIsIgnored(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
 
 	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
@@ -205,7 +197,6 @@ func TestResolveKey_NoProjectFallsBackToPlatform(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 	resolver, orgID, _ := newResolverUnderTest(t, ctx, ti)
 
 	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")

--- a/server/internal/modelkeys/setkeyenabled_test.go
+++ b/server/internal/modelkeys/setkeyenabled_test.go
@@ -30,7 +30,6 @@ func TestSetKeyEnabled_DisablesKeyInPlaceAndAuditsChange(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
 	require.NoError(t, err)
@@ -67,7 +66,6 @@ func TestSetKeyEnabled_ReenablesKeyInPlace(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(payload *gen.UpsertKeyPayload) {
 		payload.Enabled = false
@@ -81,22 +79,23 @@ func TestSetKeyEnabled_ReenablesKeyInPlace(t *testing.T) {
 	require.Equal(t, 1, ti.provisioner.usageCalls)
 }
 
-func TestSetKeyEnabled_DisableAllowedWithoutProductFeature(t *testing.T) {
+func TestSetKeyEnabled_ToggleAllowedWithoutProductFeature(t *testing.T) {
 	t.Parallel()
 
+	// Custom model keys are generally available: keys toggle freely without an
+	// organization_features row.
 	ctx, ti := newTestServiceWithRedisDB(t, 2)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
 	require.NoError(t, err)
-	disableCustomModelKeys(t, ctx, ti)
 
 	updated, err := ti.service.SetKeyEnabled(ctx, newSetKeyEnabledPayload(created.ID, false))
 	require.NoError(t, err)
 	require.False(t, updated.Enabled)
 
-	_, err = ti.service.SetKeyEnabled(ctx, newSetKeyEnabledPayload(created.ID, true))
-	requireOopsCode(t, err, oops.CodeForbidden)
+	reenabled, err := ti.service.SetKeyEnabled(ctx, newSetKeyEnabledPayload(created.ID, true))
+	require.NoError(t, err)
+	require.True(t, reenabled.Enabled)
 }
 
 func TestSetKeyEnabled_UnknownKeyReturnsNotFound(t *testing.T) {
@@ -112,12 +111,10 @@ func TestSetKeyEnabled_DeletedKeyReturnsNotFound(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestServiceWithRedisDB(t, 4)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
 	require.NoError(t, err)
 	require.NoError(t, ti.service.DeleteKey(ctx, &gen.DeleteKeyPayload{ID: created.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil}))
-	disableCustomModelKeys(t, ctx, ti)
 
 	_, err = ti.service.SetKeyEnabled(ctx, newSetKeyEnabledPayload(created.ID, true))
 	requireOopsCode(t, err, oops.CodeNotFound)
@@ -127,7 +124,6 @@ func TestSetKeyEnabled_UnchangedStateIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(payload *gen.UpsertKeyPayload) {
 		payload.Enabled = false
@@ -158,7 +154,6 @@ func TestSetKeyEnabled_RequiresProjectWriteScope(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
 	require.NoError(t, err)

--- a/server/internal/modelkeys/setup_test.go
+++ b/server/internal/modelkeys/setup_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/modelkeys"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
-	pfrepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
@@ -150,35 +149,6 @@ func newTestServiceWithRedisDB(t *testing.T, redisDB int) (context.Context, *tes
 		provisioner: provisioner,
 		features:    features,
 	}
-}
-
-// enableCustomModelKeys turns on the product feature for the auth context's
-// organization, which gates the upsert endpoint.
-func enableCustomModelKeys(t *testing.T, ctx context.Context, conn *pgxpool.Pool) {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-
-	_, pfErr := pfrepo.New(conn).EnableFeature(ctx, pfrepo.EnableFeatureParams{
-		OrganizationID: authCtx.ActiveOrganizationID,
-		FeatureName:    string(productfeatures.FeatureCustomModelKeys),
-	})
-	require.NoError(t, pfErr)
-}
-
-func disableCustomModelKeys(t *testing.T, ctx context.Context, ti *testInstance) {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-
-	_, err := pfrepo.New(ti.conn).DeleteFeature(ctx, pfrepo.DeleteFeatureParams{
-		OrganizationID: authCtx.ActiveOrganizationID,
-		FeatureName:    string(productfeatures.FeatureCustomModelKeys),
-	})
-	require.NoError(t, err)
-	ti.features.UpdateFeatureCache(ctx, authCtx.ActiveOrganizationID, productfeatures.FeatureCustomModelKeys, false)
 }
 
 func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...authz.Grant) context.Context {

--- a/server/internal/modelkeys/upsertkey_test.go
+++ b/server/internal/modelkeys/upsertkey_test.go
@@ -38,7 +38,6 @@ func TestUpsertKey_CreatesKey(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionModelProviderKeyUpsert)
 	require.NoError(t, err)
@@ -63,7 +62,6 @@ func TestUpsertKey_ReplacesExistingSlotKey(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	first, err := ti.service.UpsertKey(ctx, newUpsertPayload("assistants", nil))
 	require.NoError(t, err)
@@ -90,7 +88,6 @@ func TestUpsertKey_RejectsUnknownSlot(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	_, err := ti.service.UpsertKey(ctx, newUpsertPayload("not-a-slot", nil))
 	requireOopsCode(t, err, oops.CodeInvalid)
@@ -100,7 +97,6 @@ func TestUpsertKey_RejectsRiskAnalysisSlot(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	// Risk-policy analysis stays on the platform's internal key until the
 	// dedicated risk/PI BYOK slots ship.
@@ -112,7 +108,6 @@ func TestUpsertKey_RejectsUnknownProvider(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(p *gen.UpsertKeyPayload) {
 		p.Provider = "anthropic"
@@ -124,7 +119,6 @@ func TestUpsertKey_RejectsKeyTheProviderRejects(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	ti.provisioner.usageErr = errors.New("401 unauthorized")
 
@@ -132,20 +126,22 @@ func TestUpsertKey_RejectsKeyTheProviderRejects(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }
 
-func TestUpsertKey_RequiresProductFeature(t *testing.T) {
+func TestUpsertKey_NoProductFeatureRowRequired(t *testing.T) {
 	t.Parallel()
 
+	// Custom model keys are generally available: upsert succeeds without an
+	// organization_features row.
 	ctx, ti := newTestServiceWithRedisDB(t, 1)
 
-	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
-	requireOopsCode(t, err, oops.CodeForbidden)
+	created, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, nil))
+	require.NoError(t, err)
+	require.NotEmpty(t, created.ID)
 }
 
 func TestUpsertKey_RequiresProjectWriteScope(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
-	enableCustomModelKeys(t, ctx, ti.conn)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -37,8 +37,9 @@ func NewClient(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgx
 }
 
 func (c *Client) IsFeatureEnabled(ctx context.Context, organizationID string, feature Feature) (bool, error) {
-	// Skills is generally available; the feature remains in the API for compatibility.
-	if feature == FeatureSkills {
+	// Skills and custom model keys are generally available; the features
+	// remain in the API for compatibility.
+	if feature == FeatureSkills || feature == FeatureCustomModelKeys {
 		return true, nil
 	}
 
@@ -151,11 +152,11 @@ func provisionSkillsSystemRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, orga
 // receives at signup. A trial gates only on the time window, so identity (SSO,
 // SCIM) is included rather than held back as a conversion lever.
 //
-// FeatureSkills is absent because Skills is generally available. The bundle
-// still calls EnableSkillsTx, which provisions the Skills role grants that the
-// entitlement cannot work without. FeatureHooksFailOpen and
-// FeatureSkillCaptureMetadataOnly are absent because they change how an
-// entitlement behaves rather than granting one.
+// FeatureSkills and FeatureCustomModelKeys are absent because both are
+// generally available. The bundle still calls EnableSkillsTx, which provisions
+// the Skills role grants that the entitlement cannot work without.
+// FeatureHooksFailOpen and FeatureSkillCaptureMetadataOnly are absent because
+// they change how an entitlement behaves rather than granting one.
 var EnterpriseTrialBundle = []Feature{
 	FeatureLogs,
 	FeatureToolIOLogs,
@@ -164,7 +165,6 @@ var EnterpriseTrialBundle = []Feature{
 	FeatureSSO,
 	FeatureSCIM,
 	FeatureHooksBrowserLogin,
-	FeatureCustomModelKeys,
 	FeatureAIPlatformPushIntegrations,
 	FeaturePlatformMCP,
 	FeatureCustomerManagedEncryptionKeys,

--- a/server/internal/productfeatures/custommodelkeys_test.go
+++ b/server/internal/productfeatures/custommodelkeys_test.go
@@ -1,0 +1,78 @@
+package productfeatures_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/features"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestProductFeaturesService_CustomModelKeysAlwaysEnabled(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestProductFeaturesService(t)
+	organizationID := activeOrganizationID(t, ctx)
+	seedOrganization(t, ctx, ti.conn, organizationID)
+
+	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{SessionToken: nil})
+	require.NoError(t, err)
+	require.True(t, result.CustomModelKeysEnabled)
+
+	// Disabling is a no-op: the call succeeds and the feature stays on.
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		FeatureName: string(productfeatures.FeatureCustomModelKeys),
+		Enabled:     false,
+	})
+	require.NoError(t, err)
+
+	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{SessionToken: nil})
+	require.NoError(t, err)
+	require.True(t, result.CustomModelKeysEnabled)
+
+	// An organization_features row left over from the entitlement era must
+	// survive a disable attempt rather than being soft-deleted.
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		FeatureName: string(productfeatures.FeatureCustomModelKeys),
+		Enabled:     true,
+	})
+	require.NoError(t, err)
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		FeatureName: string(productfeatures.FeatureCustomModelKeys),
+		Enabled:     false,
+	})
+	require.NoError(t, err)
+
+	rowEnabled, err := featurerepo.New(ti.conn).IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+		OrganizationID: organizationID,
+		FeatureName:    string(productfeatures.FeatureCustomModelKeys),
+	})
+	require.NoError(t, err)
+	require.True(t, rowEnabled)
+}
+
+func TestProductFeaturesClient_CustomModelKeysAlwaysEnabled(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	redisClient, err := infra.NewRedisClient(t, 1)
+	require.NoError(t, err)
+	client := productfeatures.NewClient(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		ti.conn,
+		redisClient,
+	)
+	client.UpdateFeatureCache(ctx, authCtx.ActiveOrganizationID, productfeatures.FeatureCustomModelKeys, false)
+
+	enabled, err := client.IsFeatureEnabled(ctx, authCtx.ActiveOrganizationID, productfeatures.FeatureCustomModelKeys)
+	require.NoError(t, err)
+	require.True(t, enabled)
+}

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -87,7 +87,9 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 	}
 
 	orgID := authCtx.ActiveOrganizationID
-	if payload.FeatureName == string(FeatureSkills) && !payload.Enabled {
+	// Skills and custom model keys are generally available; disabling them is
+	// a no-op, mirroring how IsFeatureEnabled short-circuits them to true.
+	if !payload.Enabled && (payload.FeatureName == string(FeatureSkills) || payload.FeatureName == string(FeatureCustomModelKeys)) {
 		return nil
 	}
 
@@ -335,7 +337,7 @@ func (s *Service) GetProductFeatures(ctx context.Context, payload *gen.GetProduc
 		ScimEnabled:                             isEnabled(FeatureSCIM),
 		HooksBrowserLoginEnabled:                isEnabled(FeatureHooksBrowserLogin),
 		HooksFailOpenEnabled:                    isEnabled(FeatureHooksFailOpen),
-		CustomModelKeysEnabled:                  isEnabled(FeatureCustomModelKeys),
+		CustomModelKeysEnabled:                  true,
 		SkillsEnabled:                           true,
 		SkillCaptureMetadataOnly:                isEnabled(FeatureSkillCaptureMetadataOnly),
 		AiPlatformPushIntegrationsEnabled:       isEnabled(FeatureAIPlatformPushIntegrations),


### PR DESCRIPTION
## Summary

Rolls the BYOK `custom_model_keys` product feature out to **every organization**, following the `FeatureSkills` GA precedent. Previously it was enabled only for enterprise-trial orgs (via `EnterpriseTrialBundle`) and orgs toggled manually through the Internal Admin panel.

## Changes

- **`productfeatures.Client.IsFeatureEnabled`** short-circuits `custom_model_keys` to `true` before cache and DB, which covers both enforcement points in the `modelkeys` service (`UpsertKey`, `SetKeyEnabled`).
- **`getProductFeatures`** always reports `custom_model_keys_enabled: true`, unlocking the dashboard Settings UI for all orgs.
- **`setProductFeature`** disable attempts are silent no-ops (mirroring Skills), so entitlement-era `organization_features` rows survive and a code revert restores the exact pre-GA state.
- Dropped from **`EnterpriseTrialBundle`** — seeding it is now pointless.
- Removed the **Internal Admin toggle** from the Platform Admin Features page (Skills has no toggle either).
- The feature name stays in the API enum for compatibility; no schema or codegen changes.

## Tests

- New `custommodelkeys_test.go`: service-level GA test (get/set round-trip, disable no-op leaves rows intact) and client-level test (poisoned cache still reports enabled).
- Repurposed the two obsolete "Forbidden when feature disabled" tests into "works without a feature row" tests.
- Deleted the now-inert `enableCustomModelKeys`/`disableCustomModelKeys` test helpers and all 26 call sites.

Verified: `go build ./server/...`, `go vet`, full `productfeatures` + `modelkeys` suites, `mise lint:server`, dashboard oxlint/oxfmt on the touched file.

## Notes for reviewers

- The runtime key **resolver never checked this flag** — only the management-plane endpoints did. Orgs with existing keys were already using them; this change only opens up who can add/enable keys.
- Takes effect on deploy; the GA short-circuit bypasses the 15-minute Redis feature cache entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZFXjGWngVT3j5gzvsWfnr


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes custom model provider keys (BYOK) generally available for every organization. Previously limited to enterprise trials or manual toggles; now the feature is always on across API and UI so any org can add and enable keys.

- `productfeatures.Client.IsFeatureEnabled` returns true for `FeatureCustomModelKeys`, and `getProductFeatures` always reports `customModelKeysEnabled: true`; disabling via `setProductFeature` is a no-op and preserves existing `organization_features` rows for reversibility.
- Removed from `EnterpriseTrialBundle` and deleted the Platform Admin toggle in the dashboard.
- No runtime resolver change; this only lifts management-plane gating and unlocks the Settings UI.
- No migration required; takes effect on deploy and bypasses the Redis feature cache.

<sup>Written for commit b856e7ed3b6e3b7e127660c8151d2149913af8e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

