### PR TITLE
fix(admin): hold the admin dashboard's first paint until the session resolves

### DIFF
--- a/client/admin/src/components/auth-gate.tsx
+++ b/client/admin/src/components/auth-gate.tsx
@@ -12,9 +12,12 @@ import { adminSessionQuery, isRedirectingToLogin } from "@/lib/gramAdminApi";
 export function AuthGate({ children }: { children: ReactNode }): JSX.Element {
   const session = useQuery(adminSessionQuery);
 
-  // Only a login redirect holds the placeholder. Other failures render the
-  // app, because each page reports its own errors.
-  if (session.isPending || isRedirectingToLogin(session.error)) {
+  // isFetched, not isPending: a query that failed with no data returns to
+  // pending on every refetch, so isPending would unmount the router again
+  // later. isFetched asks only whether the first check answered.
+  //
+  // Other failures render the app, because each page reports its own errors.
+  if (!session.isFetched || isRedirectingToLogin()) {
     return <Placeholder />;
   }
 

--- a/client/admin/src/components/auth-gate.tsx
+++ b/client/admin/src/components/auth-gate.tsx
@@ -1,0 +1,35 @@
+import type { JSX, ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { SpeakeasyMark } from "@/components/speakeasy-mark";
+import { adminSessionQuery, isRedirectingToLogin } from "@/lib/gramAdminApi";
+
+// Holds the first paint until the session check answers.
+//
+// Every page fetches with credentials on mount, and gramAdminFetch redirects to
+// /admin/auth.login on a 401. Without this gate an operator with no session
+// sees the whole admin shell paint before the redirect.
+export function AuthGate({ children }: { children: ReactNode }): JSX.Element {
+  const session = useQuery(adminSessionQuery);
+
+  // Only a login redirect holds the placeholder. Other failures render the
+  // app, because each page reports its own errors.
+  if (session.isPending || isRedirectingToLogin(session.error)) {
+    return <Placeholder />;
+  }
+
+  return <>{children}</>;
+}
+
+// A session check that answers inside 500ms shows nothing at all. delay-500 is
+// the tw-animate-css utility, so it delays the animation rather than a
+// transition, and fill-mode-both holds the opening frame through the delay.
+function Placeholder(): JSX.Element {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="animate-in fade-in fill-mode-both delay-500 duration-300">
+        <SpeakeasyMark className="size-10 animate-pulse text-muted-foreground" />
+      </div>
+    </div>
+  );
+}

--- a/client/admin/src/components/nav-user.tsx
+++ b/client/admin/src/components/nav-user.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-import { getSession, logout } from "@/lib/gramAdminApi";
+import { adminSessionQuery, logout } from "@/lib/gramAdminApi";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -39,11 +39,7 @@ function initials(name: string): string {
 export function NavUser(): JSX.Element {
   const { isMobile } = useSidebar();
 
-  const session = useQuery({
-    queryKey: ["adminSession"],
-    queryFn: getSession,
-    staleTime: Infinity,
-  });
+  const session = useQuery(adminSessionQuery);
 
   const logoutMutation = useMutation({ mutationFn: logout });
 

--- a/client/admin/src/components/nav-user.tsx
+++ b/client/admin/src/components/nav-user.tsx
@@ -21,7 +21,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSkeleton,
   useSidebar,
 } from "@/components/ui/sidebar";
 
@@ -43,18 +42,9 @@ export function NavUser(): JSX.Element {
 
   const logoutMutation = useMutation({ mutationFn: logout });
 
-  if (session.isPending) {
-    return (
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuSkeleton showIcon />
-        </SidebarMenuItem>
-      </SidebarMenu>
-    );
-  }
-
-  // A failed background refetch keeps the last session, so the menu only gives
-  // up when it holds nothing to render.
+  // AuthGate settles the session before the router mounts, so there is no
+  // loading state to render here. A failed background refetch keeps the last
+  // session, so the menu only gives up when it holds nothing to render.
   if (!session.data) {
     return (
       <SidebarMenu>

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -11,6 +11,8 @@
 // SameSite=None permits a cross-site cookie; it does not defeat third-party
 // cookie blocking. Same-origin is the fix.
 
+import { queryOptions } from "@tanstack/react-query";
+
 export class GramAdminError extends Error {
   status: number;
   body: unknown;
@@ -54,7 +56,8 @@ export async function gramAdminFetch<T>(
       window.location.pathname + window.location.search,
     );
     window.location.href = `/admin/auth.login?return_to=${returnTo}&prompt=none`;
-    // Caller never sees a resolved value; throw to unwind the in-flight call.
+    // Setting window.location starts the navigation but does not stop the code
+    // that follows it. Throw to unwind the in-flight call.
     throw new GramAdminError(401, null, "redirecting to admin login");
   }
 
@@ -75,6 +78,13 @@ export async function gramAdminFetch<T>(
   return (await res.json()) as T;
 }
 
+// True when gramAdminFetch has already sent the browser to the login page. The
+// request failed, but no caller should report it, because a top-level
+// navigation has started.
+export function isRedirectingToLogin(error: unknown): boolean {
+  return error instanceof GramAdminError && error.status === 401;
+}
+
 // Identity of the admin operator that owns the current session. The backend
 // reads it from the OIDC session record, so it names the identity-provider
 // account that signed in to this app, not any Gram customer account.
@@ -83,9 +93,14 @@ export type AdminSessionInfo = {
   name?: string;
 };
 
-export function getSession(): Promise<AdminSessionInfo> {
-  return gramAdminFetch<AdminSessionInfo>("/admin/session.get");
-}
+// The only way to read the session, so no caller can bypass the shared cache
+// entry or drift on staleTime. The backend ends the session, never the client,
+// so a refetch would find nothing new.
+export const adminSessionQuery = queryOptions({
+  queryKey: ["adminSession"],
+  queryFn: () => gramAdminFetch<AdminSessionInfo>("/admin/session.get"),
+  staleTime: Infinity,
+});
 
 // Ends the admin session, then sends the browser into the OIDC flow.
 //

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -55,6 +55,7 @@ export async function gramAdminFetch<T>(
     const returnTo = encodeURIComponent(
       window.location.pathname + window.location.search,
     );
+    redirectingToLogin = true;
     window.location.href = `/admin/auth.login?return_to=${returnTo}&prompt=none`;
     // Setting window.location starts the navigation but does not stop the code
     // that follows it. Throw to unwind the in-flight call.
@@ -78,11 +79,17 @@ export async function gramAdminFetch<T>(
   return (await res.json()) as T;
 }
 
-// True when gramAdminFetch has already sent the browser to the login page. The
-// request failed, but no caller should report it, because a top-level
-// navigation has started.
-export function isRedirectingToLogin(error: unknown): boolean {
-  return error instanceof GramAdminError && error.status === 401;
+// True once gramAdminFetch has sent the browser to the login page. The document
+// is on its way out, so no caller should report the failure that caused it.
+//
+// The module records the navigation instead of reading it back off the failed
+// query, because React Query clears the error of a query that holds no data on
+// the next refetch, and a refetch on window focus would then reopen the gate
+// while the browser is still leaving.
+let redirectingToLogin = false;
+
+export function isRedirectingToLogin(): boolean {
+  return redirectingToLogin;
 }
 
 // Identity of the admin operator that owns the current session. The backend
@@ -93,9 +100,9 @@ export type AdminSessionInfo = {
   name?: string;
 };
 
-// The only way to read the session, so no caller can bypass the shared cache
-// entry or drift on staleTime. The backend ends the session, never the client,
-// so a refetch would find nothing new.
+// The backend ends the session, never the client, so staleTime keeps a good
+// session from refetching. A failed check holds no data, which React Query
+// always treats as stale, so it still retries on focus and on reconnect.
 export const adminSessionQuery = queryOptions({
   queryKey: ["adminSession"],
   queryFn: () => gramAdminFetch<AdminSessionInfo>("/admin/session.get"),

--- a/client/admin/src/main.tsx
+++ b/client/admin/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthGate } from "@/components/auth-gate";
 import { routeTree } from "./routeTree.gen";
 import "./index.css";
 
@@ -29,7 +30,9 @@ declare module "@tanstack/react-router" {
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <AuthGate>
+        <RouterProvider router={router} />
+      </AuthGate>
     </QueryClientProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
An operator without an admin session sees the whole admin dashboard paint and then vanish on the way to the Google login flow.

`main.tsx` mounted the router immediately, so the shell rendered while the credentialed page fetches were still in flight. Those fetches answered 401, `gramAdminFetch` set `window.location` to `/admin/auth.login`, and the app flashed by in between.

## What changed

- **`auth-gate.tsx` (new)** — `AuthGate` wraps `RouterProvider` and renders the router only once the admin session resolves. On a 401 it holds a placeholder, because the browser is already navigating away. On any other error it renders the app, so each page keeps reporting its own errors and the `Session unavailable` retry in `NavUser` still works.
- **The placeholder** stays blank for 500ms, then fades in a muted pulsing mark. A fast session check therefore shows nothing at all.
- **`gramAdminApi.ts`** now owns both halves of the session contract: `adminSessionQuery` is the only way to read the session, and `isRedirectingToLogin` keeps the "a 401 means we already navigated" rule next to the code that navigates.
- **`nav-user.tsx`** reads the shared cache entry instead of defining its own copy of the query.

## Trade-off

The session check now runs before the page data requests instead of beside them, which adds one same-origin round trip on first load. A router-level gate would let the two overlap, but it needs a router context, a regenerated route tree, and a second data-loading paradigm for one query, and a rejecting `beforeLoad` would replace the app with the router error screen instead of letting each page report itself. Not worth it for one cheap endpoint on an internal tool.

## Testing

- `tsc -b --noEmit`, `oxlint --type-aware`, and `oxfmt` are clean.
- A `vite build` against a stub backend confirmed a blank page at 250ms, the mark at 1000ms, no shell at any point, and a correct redirect to the login flow.
- The authenticated path renders the organization list and the user menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the unauthenticated flash by deferring the admin dashboard’s first paint until the admin session resolves. Previously the router mounted and the shell flashed before a 401 redirected to login; now `AuthGate` waits for the first session check to settle and holds a minimal placeholder while a login redirect is in flight.

**Key changes**
- Adds `AuthGate` around `RouterProvider`; gates on `isFetched` so the router mounts after the first session check only. Placeholder stays blank for 500ms, then shows a subtle pulsing mark.
- Centralizes session in `gramAdminApi.ts` via `adminSessionQuery` (`queryOptions`, `staleTime: Infinity`) and `isRedirectingToLogin()`.
- `gramAdminFetch` sets `window.location`, records a redirect flag, then throws to unwind; the gate reads the flag to keep holding during navigation.
- `nav-user.tsx` consumes `adminSessionQuery` and drops its loading branch; the retry remains visible.
- Trade-off: adds one same-origin round trip before page data loads on first load.

**Migration**
- Read the admin session with `useQuery(adminSessionQuery)` and remove custom session queries or stale times.
- Use `isRedirectingToLogin()` to suppress error UX when a 401 triggers login navigation.

<sup>Written for commit 1303f975ebd1aaedaec9d1afcf65638aa0e6b907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

