### PR TITLE
fix: prevent orphaned Slack assistant triggers

### DIFF
--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -1698,16 +1698,23 @@ function buildAssistantTools(deps: ToolDeps) {
                 t.name === name,
             );
             if (duplicate) {
+              const trigger =
+                duplicate.status === "paused"
+                  ? await sdk.triggers.resume({ id: duplicate.id })
+                  : duplicate;
+              if (duplicate.status === "paused") draft.invalidateAll();
               return okResult({
-                id: duplicate.id,
-                name: duplicate.name,
-                definition_slug: duplicate.definitionSlug,
-                status: duplicate.status,
-                webhook_url: duplicate.webhookUrl,
-                config: duplicate.config,
-                environment_id: duplicate.environmentId,
+                id: trigger.id,
+                name: trigger.name,
+                definition_slug: trigger.definitionSlug,
+                status: trigger.status,
+                webhook_url: trigger.webhookUrl,
+                config: trigger.config,
+                environment_id: trigger.environmentId,
                 notes: [
-                  "Trigger with this name already exists for this assistant; returning the existing one instead of creating a duplicate.",
+                  duplicate.status === "paused"
+                    ? "Trigger with this name already exists for this assistant; reactivated it instead of creating a duplicate."
+                    : "Trigger with this name already exists for this assistant; returning the existing one instead of creating a duplicate.",
                   ...notes,
                 ],
               });
@@ -2180,6 +2187,7 @@ function buildAssistantTools(deps: ToolDeps) {
                   updateTriggerInstanceForm: {
                     id: existingSlackTrigger.id,
                     config: mergedConfig,
+                    status: "active",
                   },
                 });
               } else {

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -2190,6 +2190,7 @@ function buildAssistantTools(deps: ToolDeps) {
                     status: "active",
                   },
                 });
+                draft.invalidateAll();
               } else {
                 const created = await sdk.triggers.create({
                   createTriggerInstanceForm: {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1462,21 +1462,14 @@ func (s *ServiceCore) DeleteAssistant(ctx context.Context, projectID uuid.UUID, 
 	if err := s.revokeAssistantSkillDistributions(ctx, tx, projectID, assistantID, actor, actorDisplayName); err != nil {
 		return err
 	}
-	triggerQueries := triggerrepo.New(tx)
-	instances, err := triggerQueries.ListTriggerInstances(ctx, projectID)
+	err = triggerrepo.New(tx).DeleteTriggerInstancesByTargetExceptDefinition(ctx, triggerrepo.DeleteTriggerInstancesByTargetExceptDefinitionParams{
+		ProjectID:              projectID,
+		TargetKind:             bgtriggers.TargetKindAssistant,
+		TargetRef:              assistantID.String(),
+		ExcludedDefinitionSlug: bgtriggers.DefinitionSlugWake,
+	})
 	if err != nil {
-		return fmt.Errorf("list assistant trigger instances: %w", err)
-	}
-	for _, instance := range instances {
-		if instance.TargetKind != bgtriggers.TargetKindAssistant || instance.TargetRef != assistantID.String() {
-			continue
-		}
-		if _, err := triggerQueries.DeleteTriggerInstance(ctx, triggerrepo.DeleteTriggerInstanceParams{
-			ID:        instance.ID,
-			ProjectID: projectID,
-		}); err != nil {
-			return fmt.Errorf("delete assistant trigger instance: %w", err)
-		}
+		return fmt.Errorf("delete assistant trigger instances: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit delete assistant tx: %w", err)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -45,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	slackclient "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -1460,6 +1461,22 @@ func (s *ServiceCore) DeleteAssistant(ctx context.Context, projectID uuid.UUID, 
 	}
 	if err := s.revokeAssistantSkillDistributions(ctx, tx, projectID, assistantID, actor, actorDisplayName); err != nil {
 		return err
+	}
+	triggerQueries := triggerrepo.New(tx)
+	instances, err := triggerQueries.ListTriggerInstances(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("list assistant trigger instances: %w", err)
+	}
+	for _, instance := range instances {
+		if instance.TargetKind != bgtriggers.TargetKindAssistant || instance.TargetRef != assistantID.String() {
+			continue
+		}
+		if _, err := triggerQueries.DeleteTriggerInstance(ctx, triggerrepo.DeleteTriggerInstanceParams{
+			ID:        instance.ID,
+			ProjectID: projectID,
+		}); err != nil {
+			return fmt.Errorf("delete assistant trigger instance: %w", err)
+		}
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit delete assistant tx: %w", err)

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -28,6 +28,7 @@ import (
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -1569,6 +1570,37 @@ func TestServiceCoreDeleteAssistantReapsRuntimes(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, assistant.DeletedAt.Valid)
+}
+
+func TestServiceCoreDeleteAssistantDeletesActiveSlackTriggers(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "delete_assistant_triggers")
+	require.NoError(t, err)
+
+	projectID, assistantID, _, _ := insertAssistantFixture(t, conn)
+	trigger, err := triggerrepo.New(conn).CreateTriggerInstance(t.Context(), triggerrepo.CreateTriggerInstanceParams{
+		OrganizationID: "org-test",
+		ProjectID:      projectID,
+		DefinitionSlug: bgtriggers.DefinitionSlugSlack,
+		Name:           "Slack",
+		EnvironmentID:  uuid.NullUUID{},
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      assistantID.String(),
+		TargetDisplay:  "Assistant",
+		ConfigJson:     []byte(`{"event_types":["message"]}`),
+		Status:         bgtriggers.StatusActive,
+	})
+	require.NoError(t, err)
+
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil, newTestAuditLogger())
+	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID, urn.NewPrincipal(urn.PrincipalTypeUser, "test-user"), nil))
+
+	_, err = triggerrepo.New(conn).GetTriggerInstanceByID(t.Context(), triggerrepo.GetTriggerInstanceByIDParams{
+		ID:        trigger.ID,
+		ProjectID: projectID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 func TestServiceCoreDeleteAssistantSucceedsEvenWhenReapErrors(t *testing.T) {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -36,6 +36,12 @@ var assistantsInfra *testenv.Environment
 
 func newTestAuditLogger() *audit.Logger { return audit.NewLogger() }
 
+type wakeCancellerFunc func(ctx context.Context, projectID, assistantID uuid.UUID) error
+
+func (f wakeCancellerFunc) CancelAssistantWakes(ctx context.Context, projectID, assistantID uuid.UUID) error {
+	return f(ctx, projectID, assistantID)
+}
+
 func TestMain(m *testing.M) {
 	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, ClickHouse: true})
 	if err != nil {
@@ -1572,7 +1578,7 @@ func TestServiceCoreDeleteAssistantReapsRuntimes(t *testing.T) {
 	require.True(t, assistant.DeletedAt.Valid)
 }
 
-func TestServiceCoreDeleteAssistantDeletesActiveSlackTriggers(t *testing.T) {
+func TestServiceCoreDeleteAssistantDeletesTriggersWithoutDeletingWakes(t *testing.T) {
 	t.Parallel()
 
 	conn, err := assistantsInfra.CloneTestDatabase(t, "delete_assistant_triggers")
@@ -1592,15 +1598,54 @@ func TestServiceCoreDeleteAssistantDeletesActiveSlackTriggers(t *testing.T) {
 		Status:         bgtriggers.StatusActive,
 	})
 	require.NoError(t, err)
+	wake, err := triggerrepo.New(conn).CreateTriggerInstance(t.Context(), triggerrepo.CreateTriggerInstanceParams{
+		OrganizationID: "org-test",
+		ProjectID:      projectID,
+		DefinitionSlug: bgtriggers.DefinitionSlugWake,
+		Name:           "Wake",
+		EnvironmentID:  uuid.NullUUID{},
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      assistantID.String(),
+		TargetDisplay:  "Assistant",
+		ConfigJson:     []byte(`{"fire_at":"2099-01-01T00:00:00Z","correlation_id":"test"}`),
+		Status:         bgtriggers.StatusActive,
+	})
+	require.NoError(t, err)
 
 	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil, newTestAuditLogger())
+	wakeCancellationCalled := false
+	core.SetWakeCanceller(wakeCancellerFunc(func(ctx context.Context, gotProjectID, gotAssistantID uuid.UUID) error {
+		wakeCancellationCalled = true
+		if gotProjectID != projectID || gotAssistantID != assistantID {
+			return fmt.Errorf("unexpected wake cancellation target")
+		}
+		preservedWake, err := triggerrepo.New(conn).GetTriggerInstanceByID(ctx, triggerrepo.GetTriggerInstanceByIDParams{
+			ID:        wake.ID,
+			ProjectID: projectID,
+		})
+		if err != nil {
+			return fmt.Errorf("get wake during cancellation: %w", err)
+		}
+		if preservedWake.Status != bgtriggers.StatusActive {
+			return fmt.Errorf("wake status during cancellation: %s", preservedWake.Status)
+		}
+		return nil
+	}))
 	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID, urn.NewPrincipal(urn.PrincipalTypeUser, "test-user"), nil))
+	require.True(t, wakeCancellationCalled)
 
 	_, err = triggerrepo.New(conn).GetTriggerInstanceByID(t.Context(), triggerrepo.GetTriggerInstanceByIDParams{
 		ID:        trigger.ID,
 		ProjectID: projectID,
 	})
 	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	preservedWake, err := triggerrepo.New(conn).GetTriggerInstanceByID(t.Context(), triggerrepo.GetTriggerInstanceByIDParams{
+		ID:        wake.ID,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, bgtriggers.StatusActive, preservedWake.Status)
 }
 
 func TestServiceCoreDeleteAssistantSucceedsEvenWhenReapErrors(t *testing.T) {

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -764,16 +764,19 @@ func (a *App) ProcessWebhook(ctx context.Context, instanceID uuid.UUID, body []b
 
 	task, err := a.ProcessEvent(ctx, instance, *result.Event)
 	if err != nil {
+		a.clearSlackThreadStatus(ctx, instance, envMap, *result.Event)
 		return nil, fmt.Errorf("process event: %w", err)
 	}
 	result.Task = task
 	if task == nil {
+		a.clearSlackThreadStatus(ctx, instance, envMap, *result.Event)
 		return result, nil
 	}
 
 	a.ackSlackThreadStatus(ctx, instance, envMap, *result.Event)
 
 	if err := ExecuteTriggerDispatchWorkflow(ctx, a.temporalEnv, TriggerDispatchWorkflowInput{Task: *task}); err != nil {
+		a.clearSlackThreadStatus(ctx, instance, envMap, *result.Event)
 		return nil, fmt.Errorf("execute trigger dispatch workflow: %w", err)
 	}
 
@@ -789,6 +792,16 @@ func (a *App) ProcessWebhook(ctx context.Context, instanceID uuid.UUID, body []b
 // the indicator until Slack's two-minute timeout.
 // Best-effort: a failure here only costs the indicator.
 func (a *App) ackSlackThreadStatus(ctx context.Context, instance triggerrepo.TriggerInstance, env map[string]string, event EventEnvelope) {
+	a.setSlackThreadStatus(ctx, instance, env, event, slackThinkingStatus, slackInitialLoadingMessages)
+}
+
+// clearSlackThreadStatus removes a stale loading indicator when ingress cannot
+// dispatch an event that Slack expects the assistant to answer.
+func (a *App) clearSlackThreadStatus(ctx context.Context, instance triggerrepo.TriggerInstance, env map[string]string, event EventEnvelope) {
+	a.setSlackThreadStatus(ctx, instance, env, event, "", nil)
+}
+
+func (a *App) setSlackThreadStatus(ctx context.Context, instance triggerrepo.TriggerInstance, env map[string]string, event EventEnvelope, status string, loadingMessages []string) {
 	if a.slackClient == nil || instance.DefinitionSlug != DefinitionSlugSlack {
 		return
 	}
@@ -806,8 +819,8 @@ func (a *App) ackSlackThreadStatus(ctx context.Context, instance triggerrepo.Tri
 	if err := a.slackClient.SetThreadStatus(ctx, token, slackclient.SlackSetThreadStatusInput{
 		ChannelID:       channelID,
 		ThreadTS:        threadTS,
-		Status:          slackThinkingStatus,
-		LoadingMessages: slackInitialLoadingMessages,
+		Status:          status,
+		LoadingMessages: loadingMessages,
 	}); err != nil {
 		a.logger.WarnContext(ctx, "set slack thread status", attr.SlogError(err))
 	}

--- a/server/internal/background/triggers/app_test.go
+++ b/server/internal/background/triggers/app_test.go
@@ -2,6 +2,10 @@ package triggers
 
 import (
 	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -11,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	slackclient "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
 	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 )
 
@@ -148,4 +153,65 @@ func TestLogTriggerDeliveryOmitsTraceContextWhenAbsent(t *testing.T) {
 
 	require.NotContains(t, captured.Attributes, attr.TraceIDKey)
 	require.NotContains(t, captured.Attributes, attr.SpanIDKey)
+}
+
+func TestClearSlackThreadStatusForDM(t *testing.T) {
+	t.Parallel()
+
+	var form url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		form = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	app := &App{
+		logger:      slog.New(slog.DiscardHandler), //nolint:forbidigo // GG006: testenv imports this package
+		slackClient: slackclient.NewSlackClientWithBaseURL(server.URL, server.Client()),
+	}
+	app.clearSlackThreadStatus(
+		t.Context(),
+		triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack},
+		map[string]string{"SLACK_BOT_TOKEN": "xoxb-test-token"},
+		EventEnvelope{Event: slackTriggerEvent{ChannelID: "D123", Timestamp: "123.456"}},
+	)
+
+	require.Equal(t, "D123", form.Get("channel_id"))
+	require.Equal(t, "123.456", form.Get("thread_ts"))
+	require.Contains(t, form, "status")
+	require.Empty(t, form.Get("status"))
+	require.NotContains(t, form, "loading_messages")
+}
+
+func TestClearSlackThreadStatusSkipsAmbientChannelMessage(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	app := &App{
+		logger:      slog.New(slog.DiscardHandler), //nolint:forbidigo // GG006: testenv imports this package
+		slackClient: slackclient.NewSlackClientWithBaseURL(server.URL, server.Client()),
+	}
+	app.clearSlackThreadStatus(
+		t.Context(),
+		triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack},
+		map[string]string{"SLACK_BOT_TOKEN": "xoxb-test-token"},
+		EventEnvelope{Event: slackTriggerEvent{EventType: "message", ChannelID: "C123", Timestamp: "123.456"}},
+	)
+
+	require.False(t, called)
 }

--- a/server/internal/triggers/repo/queries.sql
+++ b/server/internal/triggers/repo/queries.sql
@@ -130,3 +130,14 @@ WHERE id = @id
   AND project_id = @project_id
   AND deleted IS FALSE
 RETURNING *;
+
+-- name: DeleteTriggerInstancesByTargetExceptDefinition :exec
+UPDATE trigger_instances
+SET
+    deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE project_id = @project_id
+  AND target_kind = @target_kind
+  AND target_ref = @target_ref
+  AND definition_slug <> @excluded_definition_slug
+  AND deleted IS FALSE;

--- a/server/internal/triggers/repo/queries.sql.go
+++ b/server/internal/triggers/repo/queries.sql.go
@@ -201,6 +201,35 @@ func (q *Queries) DeleteTriggerInstance(ctx context.Context, arg DeleteTriggerIn
 	return i, err
 }
 
+const deleteTriggerInstancesByTargetExceptDefinition = `-- name: DeleteTriggerInstancesByTargetExceptDefinition :exec
+UPDATE trigger_instances
+SET
+    deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE project_id = $1
+  AND target_kind = $2
+  AND target_ref = $3
+  AND definition_slug <> $4
+  AND deleted IS FALSE
+`
+
+type DeleteTriggerInstancesByTargetExceptDefinitionParams struct {
+	ProjectID              uuid.UUID
+	TargetKind             string
+	TargetRef              string
+	ExcludedDefinitionSlug string
+}
+
+func (q *Queries) DeleteTriggerInstancesByTargetExceptDefinition(ctx context.Context, arg DeleteTriggerInstancesByTargetExceptDefinitionParams) error {
+	_, err := q.db.Exec(ctx, deleteTriggerInstancesByTargetExceptDefinition,
+		arg.ProjectID,
+		arg.TargetKind,
+		arg.TargetRef,
+		arg.ExcludedDefinitionSlug,
+	)
+	return err
+}
+
 const getTriggerInstanceByID = `-- name: GetTriggerInstanceByID :one
 SELECT id, organization_id, project_id, definition_slug, name, environment_id, target_kind, target_ref, target_display, config_json, status, created_at, updated_at, deleted_at, deleted
 FROM trigger_instances ti


### PR DESCRIPTION
## Summary
- reactivate paused assistant triggers when onboarding reuses or reconfigures them
- delete assistant-targeted triggers transactionally when an assistant is deleted
- clear Slack's loading status when ingress skips or fails to dispatch an event

## Testing
- `mise exec -- go test ./server/internal/background/triggers`
- `mise exec -- go test ./server/internal/assistants -run 'TestServiceCoreDeleteAssistantDeletesActiveSlackTriggers'`
- `mise lint:server`
- `mise exec -- pnpm -F dashboard lint`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents orphaned Slack assistant triggers and clears stale Slack loading indicators. Fixes trigger lifecycle in onboarding, assistant deletion, and Slack ingress to avoid duplicates and stuck UIs.

- Onboarding: when a duplicate trigger exists and is paused, resume and return it; when reconfiguring an existing Slack trigger, set status to active.
- Assistant deletion: delete all non-Wake triggers targeted at that assistant in the same transaction; preserve Wake triggers and cancel pending wakes to avoid orphans.
- Slack ingress: clear the thread’s loading status when event processing errors, produces no task, or dispatch fails; skip ambient channel messages.

<sup>Written for commit 78222ff9849072c05e780bec2c643b2f506b6d41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

