### PR TITLE
fix(admin): end organization list paging on the last full page

### DIFF
--- a/.changeset/admin-org-list-final-page-cursor.md
+++ b/.changeset/admin-org-list-final-page-cursor.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Stop the admin organizations list from returning a next-page cursor on the last full page. When the number of matching organizations was an exact multiple of the page size, the final page still carried a cursor, so the next page came back empty. The endpoint now reads one row past the page to decide whether a next page exists.

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -331,26 +331,28 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 		limit = int32(l)
 	}
 
+	// Over-fetch one row to learn whether a next page exists.
 	rows, err := queries.AdminListOrganizations(ctx, repo.AdminListOrganizationsParams{
 		Q:               conv.PtrToPGText(payload.Q),
 		AccountType:     conv.PtrToPGText(payload.AccountType),
 		IncludeDisabled: conv.PtrValOr(payload.IncludeDisabled, false),
 		AfterID:         conv.PtrToPGText(payload.Cursor),
-		PageLimit:       limit,
+		PageLimit:       limit + 1,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list organizations").LogError(ctx, s.logger)
 	}
 
+	var nextCursor *string
+	if len(rows) > int(limit) {
+		rows = rows[:limit]
+		id := rows[limit-1].ID
+		nextCursor = &id
+	}
+
 	orgs := make([]*gen.AdminOrganization, len(rows))
 	for i := range rows {
 		orgs[i] = adminOrganizationFromRow(rows[i])
-	}
-
-	var nextCursor *string
-	if len(rows) == int(limit) && len(rows) > 0 {
-		id := rows[len(rows)-1].ID
-		nextCursor = &id
 	}
 
 	return &gen.AdminListOrganizationsResult{

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -283,12 +283,25 @@ func TestListOrganizations_CursorPagination(t *testing.T) {
 	require.Len(t, page2.Organizations, 2)
 	require.Equal(t, "org_c", page2.Organizations[0].ID)
 	require.Equal(t, "org_d", page2.Organizations[1].ID)
-	// Final page is full but exhausts, so next call returns empty + nil cursor.
-	require.NotNil(t, page2.NextCursor)
-	require.Equal(t, "org_d", *page2.NextCursor)
+	// The last page is full and exhausts the table, so it ends the walk.
+	require.Nil(t, page2.NextCursor)
+}
 
-	page3, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Limit: &limit, Cursor: page2.NextCursor})
+func TestListOrganizations_FullPageWithFilterEndsTheWalk(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_a", name: "Alpha", slug: "alpha", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_b", name: "Bravo", slug: "bravo", whitelisted: true})
+	// Sorts after the page but the filter drops it, so it is not a next page.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_c", name: "Charlie", slug: "charlie", accountType: "pro", whitelisted: true})
+
+	limit := 2
+	at := "free"
+
+	page, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Limit: &limit, AccountType: &at})
 	require.NoError(t, err)
-	require.Empty(t, page3.Organizations)
-	require.Nil(t, page3.NextCursor)
+	require.Len(t, page.Organizations, 2)
+	require.Nil(t, page.NextCursor)
 }


### PR DESCRIPTION
The admin organizations list showed an empty page at the end of the walk, so the list looked like it stopped loading.

## Root cause

`ListOrganizations` emitted a `next_cursor` whenever a page came back full. A full page does not say whether another row follows. When the number of matching organizations was an exact multiple of the page size, the last page still carried a cursor. The Next button stays enabled while `next_cursor` is present, so the operator clicked Next and landed on "No organizations found".

The design already declares the intended contract at `server/design/admin/design.go`: `next_cursor` is "Cursor for the next page; empty when exhausted." The old code broke that promise on every exact page boundary.

## Fix

Read one row past the page. Emit a cursor only when that row exists. This matches the pattern already used in `server/internal/auditapi`.

The extra row costs one more row per page. The query reads one table and gets `member_count` from a scalar subquery, so no join can fan out and `LIMIT limit+1` returns exactly one extra row.

## Evidence

I reproduced the fault against a local stack with the admin API and the admin dashboard, driven through the browser.

Before the fix, with exactly 50 active organizations:

```json
{
  "before": 50,
  "nextDisabled": false,
  "after": 1,
  "text": "No organizations found"
}
```

After the fix, same case:

```json
{ "before": 50, "nextDisabled": true }
```

I also walked 203 organizations and 200 organizations through the UI, with and without a search filter. Paging is complete in both cases and no trailing empty page appears.

## Tests

`TestListOrganizations_CursorPagination` previously asserted the defect: it required a cursor on the last full page and then an empty page 3. It now asserts that the last full page ends the walk.

`TestListOrganizations_FullPageWithFilterEndsTheWalk` is new. It proves the probe row passes the same `WHERE` clause, so a filtered list also ends cleanly.

Both tests fail without the fix.

## Follow-up, not in this PR

The same trait exists at 16 other paging sites. None of them over-fetch, so each one sends clients to a phantom empty page:

- `server/internal/assistantmemories/impl.go`
- `server/internal/spendrules/impl.go`
- `server/internal/usersessions/` (5 handlers)
- `server/internal/remotesessions/` (8 handlers)
- `server/internal/platformtools/usersessions/tools.go`

Only `server/internal/auditapi` and `server/internal/deployments` get it right today. The generated SDKs make this worse, because `x-speakeasy-pagination` tells the SDK to loop until `next_cursor` is empty, so every full walk costs one wasted request. A shared paging helper would end the class of fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
