### PR TITLE
fix: fold account emails in cost analytics

### DIFF
--- a/.changeset/cost-email-filters-fold-identities.md
+++ b/.changeset/cost-email-filters-fold-identities.md
@@ -1,0 +1,8 @@
+---
+"server": patch
+---
+
+Expand user email filters in cost analytics and session lists to include the
+employee's directory email and linked AI account emails. User drill-down pages
+now report the same cost, token, tool-call, and session totals across work and
+personal account identities.

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -270,6 +270,16 @@ WHERE organization_id = @organization_id
   AND deleted_at IS NULL
 ORDER BY user_id, account_type DESC, provider, last_seen_at DESC;
 
+-- name: ListUserAccountsByEmails :many
+-- Resolves account emails back to their directory owner. This supports telemetry
+-- rows whose only identity is a linked personal/provider account email.
+SELECT id, user_id, provider, email, account_type, external_org_id, last_seen_at
+FROM user_accounts
+WHERE organization_id = @organization_id
+  AND lower(email) = ANY(ARRAY(SELECT lower(e) FROM unnest(@emails::text[]) AS e))
+  AND deleted_at IS NULL
+ORDER BY user_id, account_type DESC, provider, last_seen_at DESC;
+
 -- name: GetProviderOrgBillingMode :one
 -- Resolves the org-level admin-declared billing mode for a provider org from the
 -- org's AI integration config (the org-level tier of the billing-mode cascade).

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -586,6 +586,60 @@ func (q *Queries) ListSkillObservations(ctx context.Context, projectID uuid.UUID
 	return items, nil
 }
 
+const listUserAccountsByEmails = `-- name: ListUserAccountsByEmails :many
+SELECT id, user_id, provider, email, account_type, external_org_id, last_seen_at
+FROM user_accounts
+WHERE organization_id = $1
+  AND lower(email) = ANY(ARRAY(SELECT lower(e) FROM unnest($2::text[]) AS e))
+  AND deleted_at IS NULL
+ORDER BY user_id, account_type DESC, provider, last_seen_at DESC
+`
+
+type ListUserAccountsByEmailsParams struct {
+	OrganizationID string
+	Emails         []string
+}
+
+type ListUserAccountsByEmailsRow struct {
+	ID            uuid.UUID
+	UserID        pgtype.Text
+	Provider      string
+	Email         pgtype.Text
+	AccountType   pgtype.Text
+	ExternalOrgID pgtype.Text
+	LastSeenAt    pgtype.Timestamptz
+}
+
+// Resolves account emails back to their directory owner. This supports telemetry
+// rows whose only identity is a linked personal/provider account email.
+func (q *Queries) ListUserAccountsByEmails(ctx context.Context, arg ListUserAccountsByEmailsParams) ([]ListUserAccountsByEmailsRow, error) {
+	rows, err := q.db.Query(ctx, listUserAccountsByEmails, arg.OrganizationID, arg.Emails)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUserAccountsByEmailsRow
+	for rows.Next() {
+		var i ListUserAccountsByEmailsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Provider,
+			&i.Email,
+			&i.AccountType,
+			&i.ExternalOrgID,
+			&i.LastSeenAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUserAccountsByUsers = `-- name: ListUserAccountsByUsers :many
 SELECT id, user_id, provider, email, account_type, external_org_id, last_seen_at
 FROM user_accounts

--- a/server/internal/telemetry/employee_identity_test.go
+++ b/server/internal/telemetry/employee_identity_test.go
@@ -2,11 +2,14 @@ package telemetry_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	hooksRepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
@@ -147,6 +150,106 @@ func TestGetUserMetricsSummary_IgnoresEmailRowsOwnedByAnotherUser(t *testing.T) 
 
 	require.Equal(t, int64(100), m.TotalInputTokens)
 	require.InDelta(t, 2.5, m.TotalCost, 0.001)
+}
+
+func TestCostAnalytics_FoldsLinkedAccountEmailFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	projectID := authCtx.ProjectID.String()
+	employeeID, employeeEmail := seedConnectedOrgUser(t, ctx, ti, "employee")
+	personalEmail := "personal-" + uuid.New().String() + "@example.com"
+	linkUserAccount(t, ctx, ti, employeeID, personalEmail, "personal")
+
+	now := time.Now().UTC()
+	workChatID := uuid.NewString()
+	personalChatID := uuid.NewString()
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), workChatID, 1, 100, 50, 0, 0, "opus", employeeEmail, "Engineering", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-9*time.Minute), personalChatID, 2, 200, 100, 0, 0, "opus", strings.ToUpper(personalEmail), "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-8*time.Minute), uuid.NewString(), 9, 900, 900, 0, 0, "opus", "stranger@example.com", "Engineering", nil, "main", "", "", "", "")
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+	for _, email := range []string{employeeEmail, personalEmail} {
+		result, err := ti.service.Query(ctx, &gen.QueryPayload{
+			From:    from,
+			To:      to,
+			Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{email}}},
+			TopN:    10,
+			SortBy:  "total_cost",
+		})
+		require.NoError(t, err)
+		require.Len(t, result.Table, 1)
+		require.InDelta(t, 3, result.Table[0].Measures.TotalCost, 0.001)
+		require.Equal(t, int64(2), result.Table[0].Measures.TotalChats)
+
+		sessions, err := ti.service.ListSessions(ctx, &gen.ListSessionsPayload{
+			From:    from,
+			To:      to,
+			Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{email}}},
+			SortBy:  "total_cost",
+			Limit:   10,
+		})
+		require.NoError(t, err)
+		require.Len(t, sessions.Sessions, 2)
+		require.Equal(t, personalChatID, sessions.Sessions[0].GramChatID)
+		require.Equal(t, workChatID, sessions.Sessions[1].GramChatID)
+
+		wideFrom, wideTo := summaryWindow(now)
+		wideSessions := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+			From:    wideFrom,
+			To:      wideTo,
+			Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{email}}},
+			SortBy:  "total_cost",
+			Limit:   10,
+		}, func(result *gen.ListSessionsResult) bool {
+			return len(result.Sessions) == 2
+		})
+		require.Equal(t, personalChatID, wideSessions.Sessions[0].GramChatID)
+		require.Equal(t, workChatID, wideSessions.Sessions[1].GramChatID)
+	}
+}
+
+func TestCostAnalytics_DoesNotExpandAmbiguousAccountEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	firstID, firstEmail := seedConnectedOrgUser(t, ctx, ti, "first")
+	secondID, secondEmail := seedConnectedOrgUser(t, ctx, ti, "second")
+	sharedEmail := "shared-" + uuid.NewString() + "@example.com"
+	linkUserAccount(t, ctx, ti, firstID, sharedEmail, "personal")
+	linkUserAccount(t, ctx, ti, secondID, sharedEmail, "personal")
+
+	now := time.Now().UTC()
+	projectID := authCtx.ProjectID.String()
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), uuid.NewString(), 1, 100, 0, 0, 0, "opus", sharedEmail, "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-9*time.Minute), uuid.NewString(), 2, 200, 0, 0, 0, "opus", firstEmail, "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-8*time.Minute), uuid.NewString(), 4, 400, 0, 0, 0, "opus", secondEmail, "", nil, "main", "", "", "", "")
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	result, err := ti.service.Query(ctx, &gen.QueryPayload{
+		From:    now.Add(-time.Hour).Format(time.RFC3339),
+		To:      now.Add(time.Hour).Format(time.RFC3339),
+		Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{sharedEmail}}},
+		TopN:    10,
+		SortBy:  "total_cost",
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Table, 1)
+	require.InDelta(t, 1, result.Table[0].Measures.TotalCost, 0.001)
 }
 
 // userMetrics fetches one employee's metrics summary over a window wide enough

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -733,21 +733,57 @@ func (s *Service) resolveEmployeeIdentity(ctx context.Context, orgID, identifier
 
 	users := usersRepo.New(s.db)
 	if strings.Contains(identifier, "@") {
-		identity.Emails = append(identity.Emails, conv.NormalizeEmail(identifier))
+		identity.Emails = append(identity.Emails, identifier, conv.NormalizeEmail(identifier))
 
 		// Usage from someone with no directory row still aggregates by email, so
 		// an email that resolves to nobody is not an error.
-		rows, err := users.GetConnectedUsersByEmails(ctx, usersRepo.GetConnectedUsersByEmailsParams{
+		rows, err := users.GetConnectedUsersMatchingEmails(ctx, usersRepo.GetConnectedUsersMatchingEmailsParams{
 			Emails:         identity.Emails,
 			OrganizationID: orgID,
 		})
 		if err != nil {
 			s.logger.WarnContext(ctx, "failed to resolve employee email to org user", attr.SlogError(err))
 		}
-		for _, row := range rows {
+		if len(rows) == 1 {
+			row := rows[0]
 			// These rows already carry the directory email, so no lookup by id.
 			identity.UserIDs = append(identity.UserIDs, row.ID)
-			identity.Emails = append(identity.Emails, conv.NormalizeEmail(row.Email))
+			identity.Emails = append(identity.Emails, row.Email, conv.NormalizeEmail(row.Email))
+		}
+
+		// Directory ownership wins. Only reverse-resolve a provider account when
+		// the email has no directory row, and only when one owner claims it.
+		if len(rows) == 0 {
+			accounts, err := s.hooksRepo.ListUserAccountsByEmails(ctx, hooksRepo.ListUserAccountsByEmailsParams{
+				OrganizationID: orgID,
+				Emails:         identity.Emails,
+			})
+			if err != nil {
+				s.logger.WarnContext(ctx, "failed to resolve employee account email to org user", attr.SlogError(err))
+			}
+			owners := make([]string, 0, len(accounts))
+			for _, account := range accounts {
+				owners = append(owners, conv.FromPGTextOrEmpty[string](account.UserID))
+			}
+			owners = dedupeNonEmpty(owners)
+			if len(owners) == 1 {
+				identity.UserIDs = append(identity.UserIDs, owners[0])
+			}
+		}
+
+		// A linked account email resolves through user_accounts rather than users;
+		// add its owner's directory email before loading the rest of the accounts.
+		if len(identity.UserIDs) > 0 {
+			rows, err = users.GetConnectedUsersByIDs(ctx, usersRepo.GetConnectedUsersByIDsParams{
+				Ids:            identity.UserIDs,
+				OrganizationID: orgID,
+			})
+			if err != nil {
+				s.logger.WarnContext(ctx, "failed to resolve employee account owner", attr.SlogError(err))
+			}
+			for _, row := range rows {
+				identity.Emails = append(identity.Emails, row.Email, conv.NormalizeEmail(row.Email))
+			}
 		}
 	} else {
 		identity.UserIDs = append(identity.UserIDs, identifier)
@@ -760,7 +796,7 @@ func (s *Service) resolveEmployeeIdentity(ctx context.Context, orgID, identifier
 			s.logger.WarnContext(ctx, "failed to resolve employee user id to org user", attr.SlogError(err))
 		}
 		for _, row := range rows {
-			identity.Emails = append(identity.Emails, conv.NormalizeEmail(row.Email))
+			identity.Emails = append(identity.Emails, row.Email, conv.NormalizeEmail(row.Email))
 		}
 	}
 
@@ -773,7 +809,8 @@ func (s *Service) resolveEmployeeIdentity(ctx context.Context, orgID, identifier
 			s.logger.WarnContext(ctx, "failed to load linked accounts for employee identity", attr.SlogError(err))
 		}
 		for _, account := range accounts {
-			identity.Emails = append(identity.Emails, conv.NormalizeEmail(conv.FromPGTextOrEmpty[string](account.Email)))
+			email := conv.FromPGTextOrEmpty[string](account.Email)
+			identity.Emails = append(identity.Emails, email, conv.NormalizeEmail(email))
 		}
 	}
 
@@ -781,6 +818,49 @@ func (s *Service) resolveEmployeeIdentity(ctx context.Context, orgID, identifier
 	identity.UserIDs = dedupeNonEmpty(identity.UserIDs)
 
 	return identity
+}
+
+// expandEmployeeEmailFilters makes the generic cost analytics endpoints apply
+// the same employee identity fold as the dedicated employee endpoints. Values
+// without an @ are device-hostname buckets and retain literal filter semantics.
+func (s *Service) expandEmployeeEmailFilters(ctx context.Context, orgID string, filters []repo.AttributeMetricsFilter) []repo.AttributeMetricsFilter {
+	resolved := make(map[string][]string)
+	for i := range filters {
+		if filters[i].Dimension != "email" {
+			continue
+		}
+
+		values := make([]string, 0, len(filters[i].Values))
+		for _, value := range filters[i].Values {
+			if !strings.Contains(value, "@") {
+				values = append(values, value)
+				continue
+			}
+			key := conv.NormalizeEmail(value)
+			emails, ok := resolved[key]
+			if !ok {
+				emails = s.resolveEmployeeIdentity(ctx, orgID, value).Emails
+				resolved[key] = emails
+			}
+			values = append(values, emails...)
+		}
+		filters[i].Values = dedupe(values)
+	}
+
+	return filters
+}
+
+func dedupe(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 // dedupeNonEmpty drops blanks and repeats while keeping first-seen order.

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -753,7 +753,7 @@ func (s *Service) resolveEmployeeIdentity(ctx context.Context, orgID, identifier
 
 		// Directory ownership wins. Only reverse-resolve a provider account when
 		// the email has no directory row, and only when one owner claims it.
-		if len(rows) == 0 {
+		if err == nil && len(rows) == 0 {
 			accounts, err := s.hooksRepo.ListUserAccountsByEmails(ctx, hooksRepo.ListUserAccountsByEmailsParams{
 				OrganizationID: orgID,
 				Emails:         identity.Emails,

--- a/server/internal/telemetry/query.go
+++ b/server/internal/telemetry/query.go
@@ -150,6 +150,8 @@ func (s *Service) Query(ctx context.Context, payload *telem_gen.QueryPayload) (*
 		}
 		filters = append(filters, repo.AttributeMetricsFilter{Dimension: f.Dimension, Values: f.Values})
 	}
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	filters = s.expandEmployeeEmailFilters(ctx, authCtx.ActiveOrganizationID, filters)
 
 	params := repo.AttributeMetricsQueryParams{
 		ProjectIDs:      scope.projectIDs,
@@ -472,6 +474,7 @@ func (s *Service) ListSessions(ctx context.Context, payload *telem_gen.ListSessi
 		}
 		filters = append(filters, repo.AttributeMetricsFilter{Dimension: f.Dimension, Values: f.Values})
 	}
+	filters = s.expandEmployeeEmailFilters(ctx, authCtx.ActiveOrganizationID, filters)
 
 	params := repo.ListSessionsParams{
 		ProjectIDs:       projectIDs,

--- a/server/internal/telemetry/repo/attribute_metrics.go
+++ b/server/internal/telemetry/repo/attribute_metrics.go
@@ -321,7 +321,11 @@ func applyAttributeFilters(sb squirrel.SelectBuilder, filters []AttributeMetrics
 		case attributeDimArray:
 			sb = sb.Where(arrayDimFilter(dim.column, f.Values))
 		case attributeDimScalar, attributeDimProject:
-			sb = sb.Where(squirrel.Eq{dim.column: f.Values})
+			if f.Dimension == "email" {
+				sb = sb.Where(squirrel.Eq{"lower(" + dim.column + ")": normalizedEmailDimensionValues(f.Values)})
+			} else {
+				sb = sb.Where(squirrel.Eq{dim.column: f.Values})
+			}
 		default:
 			return sb, fmt.Errorf("unhandled dimension kind for filter %q", f.Dimension)
 		}

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -264,11 +264,17 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 		case attributeDimProject:
 			sb = sb.Where(squirrel.Eq{dim.column: f.Values})
 		case attributeDimScalar:
+			values := f.Values
+			column := dim.column
+			if f.Dimension == "email" {
+				values = normalizedEmailDimensionValues(values)
+				column = "lower(" + column + ")"
+			}
 			if dim.coLocateSessionFilters {
-				coLocatedPredicates = append(coLocatedPredicates, sessionScalarRowPredicate(dim.column, f.Values))
+				coLocatedPredicates = append(coLocatedPredicates, sessionScalarRowPredicate(column, values))
 				continue
 			}
-			sb = sb.Having(sessionScalarHaving(dim.column, f.Values))
+			sb = sb.Having(sessionScalarHaving(column, values))
 		case attributeDimArray:
 			sb = sb.Having(sessionArrayHaving(dim.column, f.Values))
 		default:
@@ -598,7 +604,13 @@ func applySessionSummaryFilters(sb squirrel.SelectBuilder, filters []AttributeMe
 			tuplePredicates = append(tuplePredicates, pred)
 			tupleArgs = append(tupleArgs, args...)
 		default:
-			sb = sb.Having(sessionSummaryValuesHaving("s."+dim.column, f.Values))
+			column := "s." + dim.column
+			values := f.Values
+			if f.Dimension == "email" {
+				column = "arrayMap(x -> lower(x), " + column + ")"
+				values = normalizedEmailDimensionValues(values)
+			}
+			sb = sb.Having(sessionSummaryValuesHaving(column, values))
 		}
 	}
 
@@ -640,6 +652,14 @@ func sessionSummaryValuesHaving(colExpr string, values []string) squirrel.Sqlize
 		return nonEmptyPred
 	}
 	return squirrel.Or{nonEmptyPred, emptyPred}
+}
+
+func normalizedEmailDimensionValues(values []string) []string {
+	out := make([]string, len(values))
+	for i, value := range values {
+		out[i] = strings.ToLower(value)
+	}
+	return out
 }
 
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -89,6 +89,7 @@ ORDER BY lower(u.email), (u.email = lower(u.email)) DESC, u.created_at, u.id;
 SELECT u.* FROM users u
 JOIN organization_user_relationships our ON our.user_id = u.id
 WHERE lower(u.email) = ANY(ARRAY(SELECT lower(e) FROM unnest(@emails::text[]) AS e))
+  AND u.deleted_at IS NULL
   AND our.organization_id = @organization_id
   AND our.deleted_at IS NULL
 ORDER BY lower(u.email), u.created_at, u.id;

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -83,6 +83,16 @@ WHERE lower(u.email) = ANY(ARRAY(SELECT lower(e) FROM unnest(@emails::text[]) AS
   AND our.deleted_at IS NULL
 ORDER BY lower(u.email), (u.email = lower(u.email)) DESC, u.created_at, u.id;
 
+-- name: GetConnectedUsersMatchingEmails :many
+-- Returns every connected row matching the emails case-insensitively. Callers
+-- that assign ownership use this to reject ambiguous case-variant identities.
+SELECT u.* FROM users u
+JOIN organization_user_relationships our ON our.user_id = u.id
+WHERE lower(u.email) = ANY(ARRAY(SELECT lower(e) FROM unnest(@emails::text[]) AS e))
+  AND our.organization_id = @organization_id
+  AND our.deleted_at IS NULL
+ORDER BY lower(u.email), u.created_at, u.id;
+
 -- name: GetUsersByIDs :many
 SELECT * FROM users
 WHERE id = ANY(@ids::text[]);

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -222,6 +222,56 @@ func (q *Queries) GetConnectedUsersByWorkosIDs(ctx context.Context, arg GetConne
 	return items, nil
 }
 
+const getConnectedUsersMatchingEmails = `-- name: GetConnectedUsersMatchingEmails :many
+SELECT u.id, u.email, u.display_name, u.photo_url, u.admin, u.last_login, u.workos_id, u.workos_created_at, u.workos_updated_at, u.workos_deleted_at, u.deleted_at, u.created_at, u.updated_at FROM users u
+JOIN organization_user_relationships our ON our.user_id = u.id
+WHERE lower(u.email) = ANY(ARRAY(SELECT lower(e) FROM unnest($1::text[]) AS e))
+  AND our.organization_id = $2
+  AND our.deleted_at IS NULL
+ORDER BY lower(u.email), u.created_at, u.id
+`
+
+type GetConnectedUsersMatchingEmailsParams struct {
+	Emails         []string
+	OrganizationID string
+}
+
+// Returns every connected row matching the emails case-insensitively. Callers
+// that assign ownership use this to reject ambiguous case-variant identities.
+func (q *Queries) GetConnectedUsersMatchingEmails(ctx context.Context, arg GetConnectedUsersMatchingEmailsParams) ([]User, error) {
+	rows, err := q.db.Query(ctx, getConnectedUsersMatchingEmails, arg.Emails, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []User
+	for rows.Next() {
+		var i User
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.DisplayName,
+			&i.PhotoUrl,
+			&i.Admin,
+			&i.LastLogin,
+			&i.WorkosID,
+			&i.WorkosCreatedAt,
+			&i.WorkosUpdatedAt,
+			&i.WorkosDeletedAt,
+			&i.DeletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getUser = `-- name: GetUser :one
 SELECT id, email, display_name, photo_url, admin, last_login, workos_id, workos_created_at, workos_updated_at, workos_deleted_at, deleted_at, created_at, updated_at FROM users
 WHERE id = $1

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -226,6 +226,7 @@ const getConnectedUsersMatchingEmails = `-- name: GetConnectedUsersMatchingEmail
 SELECT u.id, u.email, u.display_name, u.photo_url, u.admin, u.last_login, u.workos_id, u.workos_created_at, u.workos_updated_at, u.workos_deleted_at, u.deleted_at, u.created_at, u.updated_at FROM users u
 JOIN organization_user_relationships our ON our.user_id = u.id
 WHERE lower(u.email) = ANY(ARRAY(SELECT lower(e) FROM unnest($1::text[]) AS e))
+  AND u.deleted_at IS NULL
   AND our.organization_id = $2
   AND our.deleted_at IS NULL
 ORDER BY lower(u.email), u.created_at, u.id


### PR DESCRIPTION
Fixes DNO-827.

## Root cause

PR #5199 fixed the legacy employee-detail endpoints and `InsightsEmployeeDetail`, but the reported screen is the newer Costs Explorer. That surface reads `telemetry.query` and `telemetry.listSessions`, whose `email` filters still matched one literal telemetry email. A work-email drill therefore omitted sessions and usage attributed to a linked personal/provider account email.

## Fix

- Expand Costs Explorer email filters through the employee directory and linked AI accounts before querying ClickHouse.
- Resolve either a directory email or a uniquely owned provider-account email to the same employee identity set.
- Match email dimensions case-insensitively on aggregate, raw-session, and summary-session query paths.
- Preserve device-hostname and empty Team-wide API Usage buckets.
- Refuse to widen ambiguous shared account emails or case-variant directory identities.

## Verification

- `mise run test:server ./internal/telemetry -count=1` (305 tests)
- `mise run lint:server`
- Regression coverage checks work-email and personal-email entry points, mixed-case telemetry, aggregate totals, raw session lists, 30-day summary-backed session lists, and ambiguous shared account emails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Costs Explorer folds email filters into a single employee identity so costs, tokens, tool calls, and session totals match the Employee view (DNO-827). Previously filters matched one literal email; now they expand to the directory email plus linked AI account emails and match case-insensitively. Ambiguous shared-account emails or identity lookup errors do not widen filters.

**Review notes**
- Expands email filters in `telemetry.Query` and `telemetry.ListSessions` via an identity resolver; preserves device-hostname buckets and empty Team-wide API Usage buckets.
- Applies case-insensitive email matching across aggregate metrics, raw session lists, and summary-backed session lists.
- Resolves provider/personal account emails to their owner only when exactly one connected user claims them; otherwise keeps the literal filter and fails closed on lookup errors.
- Adds `hooks/repo.ListUserAccountsByEmails` and `users/repo.GetConnectedUsersMatchingEmails` to support ownership resolution.
- Adds regression tests for work/personal entry points, mixed-case telemetry, raw and summary session listing, and shared-account ambiguity.

<sup>Written for commit e62a020ec86eabd6fd6c7429440c7d6d938b52e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

