### PR TITLE
mig: scope onboarding milestones to connection generation

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -6425,8 +6425,11 @@ WHERE connection_id IS NOT NULL
     'read_only_cohort'
   );
 
+-- Lifecycle facts are current-connection evidence, so their idempotency grain
+-- includes connection_generation. A reauthorized connection must record its own
+-- registration, readiness, and distribution milestones.
 CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_onboarding_milestones_attempt_target_key
-ON platform_mcp_onboarding_milestones (organization_id, milestone, project_id, mcp_key, attempt_id) NULLS NOT DISTINCT
+ON platform_mcp_onboarding_milestones (organization_id, milestone, project_id, mcp_key, attempt_id, connection_generation) NULLS NOT DISTINCT
 WHERE attempt_id IS NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_onboarding_milestones_first_value_key

--- a/server/migrations/20260813230844_platform-mcp-onboarding-milestone-generation.sql
+++ b/server/migrations/20260813230844_platform-mcp-onboarding-milestone-generation.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Drop index "platform_mcp_onboarding_milestones_attempt_target_key" from table: "platform_mcp_onboarding_milestones"
+DROP INDEX CONCURRENTLY "platform_mcp_onboarding_milestones_attempt_target_key";
+-- Create index "platform_mcp_onboarding_milestones_attempt_target_key" to table: "platform_mcp_onboarding_milestones"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_onboarding_milestones_attempt_target_key" ON "platform_mcp_onboarding_milestones" ("organization_id", "milestone", "project_id", "mcp_key", "attempt_id", "connection_generation") NULLS NOT DISTINCT WHERE (attempt_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:CwwiHa4t2ZJQhlRi9iAlUpnjtlnFrHLTOgvXPCoMSd0=
+h1:apYXKwsBDd+VquEC87AF+rXYjCQGXtqSVbNBkad7hiE=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -339,3 +339,4 @@ h1:CwwiHa4t2ZJQhlRi9iAlUpnjtlnFrHLTOgvXPCoMSd0=
 20260813104734_assistant-thread-events-trigger-idx.sql h1:25W52A5j1pRb6MmqC970tKXtnSatjdMovordpgUn8Gs=
 20260813140026_assistant-thread-events-trigger-instance-fkey-idx.sql h1:HOy5z8JXCh3rl8qfgYX7YXepyH8o4vezsEDruYeIT98=
 20260813150000_user-sessions-tool-selection.sql h1:6l17RI8mPHjZDTtBoUDL+EDSTouOLhTEhgWK0COmOz0=
+20260813230844_platform-mcp-onboarding-milestone-generation.sql h1:N9818ntJknuX+hIp9KZ0RGzCich+h0H2nIFmaXsSfkk=


### PR DESCRIPTION
## Why

Reauthorizing a Platform MCP connection must allow the selected onboarding workflow to record fresh registration, readiness, and distribution evidence. The previous lifecycle unique-index grain omitted `connection_generation`, so an old-generation milestone could block the new generation while reads correctly required current-generation evidence.

## What changed

- Adds `connection_generation` to `platform_mcp_onboarding_milestones_attempt_target_key`.
- Atlas generated an online-safe `DROP INDEX CONCURRENTLY` / `CREATE UNIQUE INDEX CONCURRENTLY` migration with `-- atlas:txmode none`.
- Keeps the change migration-only: declarative schema, generated migration, and `atlas.sum` only.

## Validation

- `mise run db:diff platform-mcp-onboarding-milestone-generation`
- `git diff --cached --check`
- `mise lint:migrations`: migration ordering and concurrent-index directive passed.
- Full `atlas migrate lint` was blocked locally because the disposable local database is not clean (`agent_executions` predates its recorded migration state). No shared, development, or production database was touched.

[skip migration check]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Platform MCP onboarding milestone uniqueness to `connection_generation` so reauthorized connections can record fresh registration, readiness, and distribution evidence. Previously the unique index omitted `connection_generation`, letting old-generation milestones block writes; now milestones are unique per generation.

**Migration and rollout**
- Replace unique index `platform_mcp_onboarding_milestones_attempt_target_key` to include `connection_generation`.
- Run online: `DROP INDEX CONCURRENTLY` then `CREATE UNIQUE INDEX CONCURRENTLY` with `-- atlas:txmode none`; no table lock or downtime expected.
- Action: run the migration outside a transaction and monitor until the new index is valid.

<sup>Written for commit f3249fc470c18f1e9bce269b28795f131c7581dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

