### PR TITLE
fix(dashboard): send Gram-Project on time range picker AI parsing

### DIFF
--- a/.changeset/time-range-picker-project-header.md
+++ b/.changeset/time-range-picker-project-header.md
@@ -6,6 +6,8 @@ Fix natural-language input in the dashboard time range picker. The picker's
 "type any date" parsing POSTs to `/chat/completions`, which requires both
 `Gram-Session` and `Gram-Project` headers, but most pages rendered the picker
 without a `projectSlug`, so the request 401ed and parsing silently did nothing.
-The `DashboardTimeRangePicker` wrapper now injects the route's project slug
-(callers can still override it), fixing the project home, MCP overview,
-security overview, watchdog, and risk overview pages in one place.
+The `DashboardTimeRangePicker` wrapper now injects the request project slug
+via `useProjectSlugForRequests()` (callers can still override it), fixing the
+project home, MCP overview, security overview, watchdog, and risk overview
+pages in one place — and org-scoped pages like Billing through the same
+default-project fallback every other SDK request uses.

--- a/.changeset/time-range-picker-project-header.md
+++ b/.changeset/time-range-picker-project-header.md
@@ -1,0 +1,11 @@
+---
+"dashboard": patch
+---
+
+Fix natural-language input in the dashboard time range picker. The picker's
+"type any date" parsing POSTs to `/chat/completions`, which requires both
+`Gram-Session` and `Gram-Project` headers, but most pages rendered the picker
+without a `projectSlug`, so the request 401ed and parsing silently did nothing.
+The `DashboardTimeRangePicker` wrapper now injects the route's project slug
+(callers can still override it), fixing the project home, MCP overview,
+security overview, watchdog, and risk overview pages in one place.

--- a/client/dashboard/src/components/DashboardTimeRangePicker.test.tsx
+++ b/client/dashboard/src/components/DashboardTimeRangePicker.test.tsx
@@ -1,11 +1,11 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Capture the props the wrapper forwards to the Elements picker. The
 // /chat/completions proxy requires BOTH Gram-Session and Gram-Project, so the
-// wrapper must inject the route's project slug alongside the session header —
-// callers that omit projectSlug otherwise 401 and natural-language parsing
-// silently no-ops.
+// wrapper must inject the request project slug (useProjectSlugForRequests)
+// alongside the session header — callers that omit projectSlug otherwise 401
+// and natural-language parsing silently no-ops.
 const pickerProps = vi.fn();
 
 vi.mock("@/elements", () => ({
@@ -20,7 +20,7 @@ vi.mock("@/contexts/Auth", () => ({
 }));
 
 vi.mock("@/contexts/Sdk", () => ({
-  useSlugs: () => ({ orgSlug: "acme", projectSlug: "route-project" }),
+  useProjectSlugForRequests: () => "route-project",
 }));
 
 vi.mock("@/lib/utils", async (importOriginal) => ({
@@ -31,7 +31,11 @@ vi.mock("@/lib/utils", async (importOriginal) => ({
 import { TimeRangePicker } from "./DashboardTimeRangePicker";
 
 describe("DashboardTimeRangePicker", () => {
-  it("injects the route's project slug when the caller does not pass one", () => {
+  beforeEach(() => {
+    pickerProps.mockClear();
+  });
+
+  it("injects the request project slug when the caller does not pass one", () => {
     render(<TimeRangePicker />);
 
     expect(pickerProps).toHaveBeenCalledWith(
@@ -39,7 +43,7 @@ describe("DashboardTimeRangePicker", () => {
     );
   });
 
-  it("prefers an explicitly passed project slug over the route's", () => {
+  it("prefers an explicitly passed project slug over the request slug", () => {
     render(<TimeRangePicker projectSlug="explicit-project" />);
 
     expect(pickerProps).toHaveBeenCalledWith(

--- a/client/dashboard/src/components/DashboardTimeRangePicker.test.tsx
+++ b/client/dashboard/src/components/DashboardTimeRangePicker.test.tsx
@@ -1,0 +1,60 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Capture the props the wrapper forwards to the Elements picker. The
+// /chat/completions proxy requires BOTH Gram-Session and Gram-Project, so the
+// wrapper must inject the route's project slug alongside the session header —
+// callers that omit projectSlug otherwise 401 and natural-language parsing
+// silently no-ops.
+const pickerProps = vi.fn();
+
+vi.mock("@/elements", () => ({
+  TimeRangePicker: (props: Record<string, unknown>) => {
+    pickerProps(props);
+    return null;
+  },
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useSession: () => ({ session: "test-session-token" }),
+}));
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSlugs: () => ({ orgSlug: "acme", projectSlug: "route-project" }),
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getServerURL: () => "https://server.test",
+}));
+
+import { TimeRangePicker } from "./DashboardTimeRangePicker";
+
+describe("DashboardTimeRangePicker", () => {
+  it("injects the route's project slug when the caller does not pass one", () => {
+    render(<TimeRangePicker />);
+
+    expect(pickerProps).toHaveBeenCalledWith(
+      expect.objectContaining({ projectSlug: "route-project" }),
+    );
+  });
+
+  it("prefers an explicitly passed project slug over the route's", () => {
+    render(<TimeRangePicker projectSlug="explicit-project" />);
+
+    expect(pickerProps).toHaveBeenCalledWith(
+      expect.objectContaining({ projectSlug: "explicit-project" }),
+    );
+  });
+
+  it("injects the server URL and session auth header", () => {
+    render(<TimeRangePicker />);
+
+    expect(pickerProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiUrl: "https://server.test",
+        authHeaders: { "Gram-Session": "test-session-token" },
+      }),
+    );
+  });
+});

--- a/client/dashboard/src/components/DashboardTimeRangePicker.tsx
+++ b/client/dashboard/src/components/DashboardTimeRangePicker.tsx
@@ -3,26 +3,30 @@ import {
   type TimeRangePickerProps,
 } from "@/elements";
 import { useSession } from "@/contexts/Auth";
+import { useSlugs } from "@/contexts/Sdk";
 import { getServerURL } from "@/lib/utils";
 
 /**
  * Dashboard wrapper around the Elements `TimeRangePicker`.
  *
  * The picker's natural-language ("type any date") parsing POSTs to
- * `/chat/completions`, which authenticates from request headers — NOT cookies.
- * Every other dashboard caller of that endpoint (e.g. the playground's
- * `useModel`) sends the `Gram-Session` token explicitly; the bare Elements
- * component cannot reach dashboard auth context, so it must be injected here.
- * Without it the request 401s and parsing silently no-ops.
+ * `/chat/completions`, which authenticates from request headers — NOT cookies —
+ * and requires BOTH `Gram-Session` and `Gram-Project`. The bare Elements
+ * component cannot reach dashboard auth or route context, so both are injected
+ * here: the session token from `useSession()` and the project slug from the
+ * route (callers may still pass `projectSlug` explicitly to override). Missing
+ * either header 401s and parsing silently no-ops.
  *
  * Use this wrapper anywhere in the dashboard instead of importing
  * `TimeRangePicker` directly from `@/elements`.
  */
 export function TimeRangePicker(props: TimeRangePickerProps): JSX.Element {
   const { session } = useSession();
+  const { projectSlug } = useSlugs();
   return (
     <ElementsTimeRangePicker
       {...props}
+      projectSlug={props.projectSlug ?? projectSlug}
       apiUrl={getServerURL()}
       authHeaders={session ? { "Gram-Session": session } : undefined}
     />

--- a/client/dashboard/src/components/DashboardTimeRangePicker.tsx
+++ b/client/dashboard/src/components/DashboardTimeRangePicker.tsx
@@ -3,7 +3,7 @@ import {
   type TimeRangePickerProps,
 } from "@/elements";
 import { useSession } from "@/contexts/Auth";
-import { useSlugs } from "@/contexts/Sdk";
+import { useProjectSlugForRequests } from "@/contexts/Sdk";
 import { getServerURL } from "@/lib/utils";
 
 /**
@@ -13,20 +13,22 @@ import { getServerURL } from "@/lib/utils";
  * `/chat/completions`, which authenticates from request headers — NOT cookies —
  * and requires BOTH `Gram-Session` and `Gram-Project`. The bare Elements
  * component cannot reach dashboard auth or route context, so both are injected
- * here: the session token from `useSession()` and the project slug from the
- * route (callers may still pass `projectSlug` explicitly to override). Missing
- * either header 401s and parsing silently no-ops.
+ * here: the session token from `useSession()` and the request project slug
+ * from `useProjectSlugForRequests()` — which falls back to the default project
+ * on org-scoped pages like Billing, matching every other SDK request (callers
+ * may still pass `projectSlug` explicitly to override). Missing either header
+ * 401s and parsing silently no-ops.
  *
  * Use this wrapper anywhere in the dashboard instead of importing
  * `TimeRangePicker` directly from `@/elements`.
  */
 export function TimeRangePicker(props: TimeRangePickerProps): JSX.Element {
   const { session } = useSession();
-  const { projectSlug } = useSlugs();
+  const requestProjectSlug = useProjectSlugForRequests();
   return (
     <ElementsTimeRangePicker
       {...props}
-      projectSlug={props.projectSlug ?? projectSlug}
+      projectSlug={props.projectSlug ?? requestProjectSlug}
       apiUrl={getServerURL()}
       authHeaders={session ? { "Gram-Session": session } : undefined}
     />

--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -86,7 +86,8 @@ const createQueryClient = () =>
 export const queryClient: QueryClient =
   (import.meta.hot?.data?.queryClient as QueryClient) ?? createQueryClient();
 
-if (import.meta.hot) {
+// Vite always provides `hot.data`, but vitest's shim defines `hot` without it.
+if (import.meta.hot?.data) {
   import.meta.hot.data.queryClient = queryClient;
 }
 


### PR DESCRIPTION
## Summary

Typing a natural-language range ("4 days ago", "last week") into the dashboard time range picker silently did nothing on most pages. The picker's AI parsing POSTs to `/chat/completions`, whose `directAuthorize` requires **both** `Gram-Session` and `Gram-Project` request headers. The `DashboardTimeRangePicker` wrapper (added for the earlier session-header half of this same failure class) injected `Gram-Session` but left `projectSlug` as per-caller homework — and the project home, MCP overview, security overview, watchdog, and risk overview pages never passed it. The resulting 401 is swallowed by `parseWithAI`'s catch, so the UI just no-ops.

## Fix

- `DashboardTimeRangePicker` now injects the route's project slug via `useSlugs()`, with an explicitly passed `projectSlug` still taking precedence. All dashboard usages are covered in one place.
- Guard the `Sdk.tsx` HMR `queryClient` stash with `import.meta.hot?.data` — vitest's `import.meta.hot` shim lacks `data`, which the wrapper's new `Sdk` import surfaced in `ClientsAndSessionsTab.test.tsx`.
- New wrapper test locks in slug injection, explicit-prop precedence, and the existing session-header/apiUrl injection.

## Root cause verification

Reproduced live against the local stack: the picker's request went out with `gram-session` but **no** `gram-project` → 401 `unauthorized access` (`server/internal/chat/impl.go` requires project auth after session auth). Replaying the identical request with `Gram-Project` added moved it past auth. With this fix, the picker's request carries `gram-project` and passes auth end-to-end in the browser.

Note for local dev: after auth passes, local stacks without a valid OpenRouter platform key still get a 502 from upstream (`OpenRouter API error (status 401)` in server logs) — same as the playground. Production keys are unaffected.

## Test plan

- [x] `aube run -F dashboard test` — 200 files / 1779 tests pass (new wrapper test red before fix, green after)
- [x] `aube run -F dashboard lint` (format, no-barrels, oxlint, type-check)
- [x] Browser: picker request on a project page now sends `gram-project` and clears `/chat/completions` auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdQYkZveCPiSd5jX6QA7fT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes natural-language input in the dashboard time range picker by sending both required headers to `/chat/completions`. Previously only `Gram-Session` was sent; pages without a project context returned 401 and input like "4 days ago" did nothing.

- `DashboardTimeRangePicker` injects the request project slug via `useProjectSlugForRequests()`; an explicit `projectSlug` prop still takes precedence. This covers project pages and org-scoped pages via the default-project fallback.
- Requests now include both `Gram-Session` and `Gram-Project`; restores parsing on project home, MCP overview, security overview, watchdog, and risk overview.
- Guards `import.meta.hot?.data` in `client/dashboard/src/contexts/Sdk.tsx` for vitest’s HMR shim.
- Adds a wrapper test covering slug injection, override precedence, and `apiUrl`/auth header forwarding.

<sup>Written for commit c4d0fffbe77bde10d83eb4eb8d23f31289b004a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

