### PR TITLE
fix(platform-mcp): tolerate milestone index migration

### DIFF
--- a/server/internal/platformmcp/lifecycle.go
+++ b/server/internal/platformmcp/lifecycle.go
@@ -506,7 +506,7 @@ func recordSetupMilestone(ctx context.Context, q *platformrepo.Queries, principa
 	if err != nil {
 		return err
 	}
-	if registration.ID == uuid.Nil || registration.ProjectID == uuid.Nil || registration.CatalogProvider == "" || registration.CatalogReference == "" || handoffID == uuid.Nil {
+	if registration.ID == uuid.Nil || registration.ProjectID == uuid.Nil || registration.CatalogProvider == "" || registration.CatalogReference == "" || handoffID == uuid.Nil || !isSetupMilestone(milestone) {
 		return ErrReadinessInvalid
 	}
 	if err := q.RecordPlatformMCPSetupMilestone(ctx, platformrepo.RecordPlatformMCPSetupMilestoneParams{
@@ -521,6 +521,15 @@ func recordSetupMilestone(ctx context.Context, q *platformrepo.Queries, principa
 		return fmt.Errorf("record platform mcp setup milestone: %w", err)
 	}
 	return nil
+}
+
+func isSetupMilestone(value string) bool {
+	switch value {
+	case "provider_setup_started", "provider_setup_failed", "provider_setup_succeeded", "platform_flow_ready":
+		return true
+	default:
+		return false
+	}
 }
 
 func lifecycleRegistration(ctx context.Context, q *platformrepo.Queries, principal Principal, projectID, registrationID uuid.UUID) (platformrepo.PlatformMcpCatalogRegistration, error) {

--- a/server/internal/platformmcp/lifecycle_test.go
+++ b/server/internal/platformmcp/lifecycle_test.go
@@ -40,6 +40,16 @@ func TestValidateSetupHandoffBinding(t *testing.T) {
 	require.ErrorIs(t, validateSetupHandoffBinding("organization", binding), ErrSetupHandoffInvalid)
 }
 
+func TestIsSetupMilestone(t *testing.T) {
+	t.Parallel()
+
+	for _, milestone := range []string{"provider_setup_started", "provider_setup_failed", "provider_setup_succeeded", "platform_flow_ready"} {
+		require.True(t, isSetupMilestone(milestone), milestone)
+	}
+	require.False(t, isSetupMilestone("registration_succeeded"))
+	require.False(t, isSetupMilestone(""))
+}
+
 func TestValidateReadinessAcceptsOnlyRFCStates(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -932,9 +932,7 @@ INSERT INTO platform_mcp_onboarding_milestones (
     @mcp_key,
     @attempt_id
 )
-ON CONFLICT (organization_id, milestone, project_id, mcp_key, attempt_id)
-WHERE attempt_id IS NOT NULL
-DO NOTHING;
+ON CONFLICT DO NOTHING;
 
 -- name: RecordPlatformMCPRegistrationSucceeded :exec
 INSERT INTO platform_mcp_onboarding_milestones (
@@ -954,6 +952,4 @@ INSERT INTO platform_mcp_onboarding_milestones (
     @mcp_key,
     @attempt_id
 )
-ON CONFLICT (organization_id, milestone, project_id, mcp_key, attempt_id)
-WHERE attempt_id IS NOT NULL
-DO NOTHING;
+ON CONFLICT DO NOTHING;

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -2208,9 +2208,7 @@ INSERT INTO platform_mcp_onboarding_milestones (
     $5,
     $6
 )
-ON CONFLICT (organization_id, milestone, project_id, mcp_key, attempt_id)
-WHERE attempt_id IS NOT NULL
-DO NOTHING
+ON CONFLICT DO NOTHING
 `
 
 type RecordPlatformMCPRegistrationSucceededParams struct {
@@ -2252,9 +2250,7 @@ INSERT INTO platform_mcp_onboarding_milestones (
     $6,
     $7
 )
-ON CONFLICT (organization_id, milestone, project_id, mcp_key, attempt_id)
-WHERE attempt_id IS NOT NULL
-DO NOTHING
+ON CONFLICT DO NOTHING
 `
 
 type RecordPlatformMCPSetupMilestoneParams struct {


### PR DESCRIPTION
## Why

The onboarding milestone migration changes the unique-index conflict grain to include `connection_generation`. Existing milestone writes named the old partial index target, causing a deploy-order SQL error while the migration is present but application code has not yet advanced.

## What changed

- Use index-agnostic `ON CONFLICT DO NOTHING` for the two attempt-scoped milestone inserts that must work before and after the index migration.
- Restrict setup milestone recording to the four supported lifecycle values before the generic conflict handler runs.
- Regenerate SQLc and add focused coverage for the setup milestone allowlist.

## Validation

- `mise run gen:sqlc-server`
- `go test -c -o /tmp/platformmcp-compatibility.test ./server/internal/platformmcp`
- `git diff --check`

Full package execution was attempted but blocked by local Testcontainers Postgres startup timing out before tests ran.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates the onboarding milestone unique-index migration by making attempt-scoped milestone inserts index-agnostic and validating setup milestone values. Previously, inserts targeted a partial unique index and failed during deploys when the DB migration changed the index; now they use `ON CONFLICT DO NOTHING`, and invalid setup milestones fail early with `ErrReadinessInvalid`.

- Inserts in `RecordPlatformMCPRegistrationSucceeded` and `RecordPlatformMCPSetupMilestone` now use `ON CONFLICT DO NOTHING`, compatible before and after the migration.
- `recordSetupMilestone` now accepts only: `provider_setup_started`, `provider_setup_failed`, `provider_setup_succeeded`, `platform_flow_ready`; other values return `ErrReadinessInvalid`.
- No schema changes. Generated code refreshed (`repo/queries.sql.go`). Focused tests added for the allowed setup milestone list.

<sup>Written for commit 4240ac81eadc35089f6d9cf4f80843830c6df1a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

