### PR TITLE
fix: block SSRF on OpenAPI URL import

### DIFF
--- a/.changeset/ssrf-openapi-fetch-url.md
+++ b/.changeset/ssrf-openapi-fetch-url.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Harden OpenAPI-from-URL (and in-process image-from-URL) fetches against SSRF. User-supplied URLs are rejected unless they are http(s) with a host that passes the guardian blocklist (loopback, RFC 1918, link-local/metadata, and other reserved ranges), and redirects are capped and re-checked so a hostile target cannot chain into private address space.

--- a/.changeset/ssrf-openapi-fetch-url.md
+++ b/.changeset/ssrf-openapi-fetch-url.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Harden OpenAPI-from-URL (and in-process image-from-URL) fetches against SSRF. User-supplied URLs are rejected unless they are http(s) with a host that passes the guardian blocklist (loopback, RFC 1918, link-local/metadata, and other reserved ranges), and redirects are capped and re-checked so a hostile target cannot chain into private address space.
+Harden OpenAPI-from-URL (and in-process image-from-URL) fetches against SSRF. User-supplied URLs are rejected unless they are https with a host that passes the guardian blocklist (loopback, RFC 1918, link-local/metadata, and other reserved ranges), and redirects are capped and re-checked so a hostile target cannot chain into private address space or downgrade to plaintext HTTP.

--- a/server/internal/assets/fetchopenapiv3fromurl_test.go
+++ b/server/internal/assets/fetchopenapiv3fromurl_test.go
@@ -2,6 +2,7 @@ package assets_test
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -43,17 +44,38 @@ func fetchOpenAPIForm(rawURL string) *gen.FetchOpenAPIv3FromURLForm {
 	}
 }
 
+func newTLSOpenAPIServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func unsafeFetchPolicy(t *testing.T, blocklist []string, resolver dns.Resolver, servers ...*httptest.Server) *guardian.Policy {
+	t.Helper()
+	pool := x509.NewCertPool()
+	for _, srv := range servers {
+		pool.AddCert(srv.Certificate())
+	}
+	opts := []func(*guardian.Policy){guardian.WithTLSRootCAs(pool)}
+	if resolver != nil {
+		opts = append(opts, guardian.WithResolver(resolver))
+	}
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), blocklist, opts...)
+	require.NoError(t, err)
+	return policy
+}
+
 func TestService_FetchOpenAPIv3FromURL_Success(t *testing.T) {
 	t.Parallel()
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := newTLSOpenAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set("Content-Type", "application/yaml")
 		_, _ = w.Write([]byte(fetchOpenAPIYAML))
-	}))
-	t.Cleanup(upstream.Close)
+	})
 
-	ctx, ti := newTestAssetsService(t)
+	ctx, ti := newTestAssetsServiceWithPolicy(t, unsafeFetchPolicy(t, []string{}, nil, upstream))
 	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionAssetCreate)
 	require.NoError(t, err)
 
@@ -83,12 +105,13 @@ func TestService_FetchOpenAPIv3FromURL_Unauthorized(t *testing.T) {
 	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
-func TestService_FetchOpenAPIv3FromURL_RejectsNonHTTPScheme(t *testing.T) {
+func TestService_FetchOpenAPIv3FromURL_RejectsNonHTTPSScheme(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAssetsService(t)
 
 	for _, rawURL := range []string{
+		"http://example.com/openapi.yaml",
 		"file:///etc/passwd",
 		"ftp://example.com/openapi.yaml",
 		"gopher://example.com/1",
@@ -121,12 +144,12 @@ func TestService_FetchOpenAPIv3FromURL_RejectsBlockedIPLiterals(t *testing.T) {
 	ctx, ti := newTestAssetsServiceWithPolicy(t, guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)))
 
 	for _, rawURL := range []string{
-		"http://127.0.0.1/openapi.yaml",
-		"http://10.0.0.1/openapi.yaml",
-		"http://172.16.0.1/openapi.yaml",
-		"http://192.168.1.1/openapi.yaml",
-		"http://169.254.169.254/latest/meta-data/",
-		"http://[::1]/openapi.yaml",
+		"https://127.0.0.1/openapi.yaml",
+		"https://10.0.0.1/openapi.yaml",
+		"https://172.16.0.1/openapi.yaml",
+		"https://192.168.1.1/openapi.yaml",
+		"https://169.254.169.254/latest/meta-data/",
+		"https://[::1]/openapi.yaml",
 	} {
 		_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(rawURL))
 		var oopsErr *oops.ShareableError
@@ -154,7 +177,7 @@ func TestService_FetchOpenAPIv3FromURL_RejectsBlockedHostname(t *testing.T) {
 
 	ctx, ti := newTestAssetsServiceWithPolicy(t, policy)
 
-	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm("http://"+blockedHost+"/openapi.yaml"))
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm("https://"+blockedHost+"/openapi.yaml"))
 
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
@@ -178,23 +201,16 @@ func TestService_FetchOpenAPIv3FromURL_RedirectToBlockedHost(t *testing.T) {
 	})
 
 	// Block TEST-NET-3 only; loopback stays reachable so the httptest
-	// server (which listens on 127.0.0.1) can serve the initial request.
-	policy, err := guardian.NewUnsafePolicy(
-		testenv.NewTracerProvider(t),
-		[]string{"203.0.113.0/24"},
-		guardian.WithResolver(mockResolver),
-	)
-	require.NoError(t, err)
-
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Location", "http://"+blockedHost+"/openapi.yaml")
+	// TLS server (which listens on 127.0.0.1) can serve the initial request.
+	upstream := newTLSOpenAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://"+blockedHost+"/openapi.yaml")
 		w.WriteHeader(http.StatusFound)
-	}))
-	t.Cleanup(upstream.Close)
+	})
+	policy := unsafeFetchPolicy(t, []string{"203.0.113.0/24"}, mockResolver, upstream)
 
 	ctx, ti := newTestAssetsServiceWithPolicy(t, policy)
 
-	_, err = ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL))
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL))
 
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
@@ -206,18 +222,15 @@ func TestService_FetchOpenAPIv3FromURL_RedirectToBlockedHost(t *testing.T) {
 func TestService_FetchOpenAPIv3FromURL_FollowsAllowedRedirect(t *testing.T) {
 	t.Parallel()
 
-	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	dest := newTLSOpenAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/yaml")
 		_, _ = w.Write([]byte(fetchOpenAPIYAML))
-	}))
-	t.Cleanup(dest.Close)
-
-	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	})
+	src := newTLSOpenAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, dest.URL+"/openapi.yaml", http.StatusFound)
-	}))
-	t.Cleanup(src.Close)
+	})
 
-	ctx, ti := newTestAssetsService(t)
+	ctx, ti := newTestAssetsServiceWithPolicy(t, unsafeFetchPolicy(t, []string{}, nil, src, dest))
 
 	result, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(src.URL))
 	require.NoError(t, err)
@@ -239,22 +252,15 @@ func TestService_FetchOpenAPIv3FromURL_RedirectToUnresolvableHost(t *testing.T) 
 		},
 	})
 
-	policy, err := guardian.NewUnsafePolicy(
-		testenv.NewTracerProvider(t),
-		[]string{},
-		guardian.WithResolver(mockResolver),
-	)
-	require.NoError(t, err)
-
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Location", "http://"+brokenHost+"/openapi.yaml")
+	upstream := newTLSOpenAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://"+brokenHost+"/openapi.yaml")
 		w.WriteHeader(http.StatusFound)
-	}))
-	t.Cleanup(upstream.Close)
+	})
+	policy := unsafeFetchPolicy(t, []string{}, mockResolver, upstream)
 
 	ctx, ti := newTestAssetsServiceWithPolicy(t, policy)
 
-	_, err = ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL))
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL))
 
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
@@ -267,13 +273,12 @@ func TestService_FetchOpenAPIv3FromURL_RedirectToUnresolvableHost(t *testing.T) 
 func TestService_FetchOpenAPIv3FromURL_RedirectsCapped(t *testing.T) {
 	t.Parallel()
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := newTLSOpenAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Location", r.URL.Path+"/next")
 		w.WriteHeader(http.StatusFound)
-	}))
-	t.Cleanup(upstream.Close)
+	})
 
-	ctx, ti := newTestAssetsService(t)
+	ctx, ti := newTestAssetsServiceWithPolicy(t, unsafeFetchPolicy(t, []string{}, nil, upstream))
 
 	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL+"/start"))
 
@@ -284,12 +289,44 @@ func TestService_FetchOpenAPIv3FromURL_RedirectsCapped(t *testing.T) {
 	require.Contains(t, oopsErr.String(), "stopped after 3 redirects")
 }
 
+func TestService_FetchOpenAPIv3FromURL_RejectsHTTPRedirect(t *testing.T) {
+	t.Parallel()
+
+	upstream := newTLSOpenAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "http://8.8.8.8/openapi.yaml")
+		w.WriteHeader(http.StatusFound)
+	})
+
+	ctx, ti := newTestAssetsServiceWithPolicy(t, unsafeFetchPolicy(t, []string{}, nil, upstream))
+
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL))
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "error fetching URL", oopsErr.Error())
+	require.NotErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestService_FetchImageFromURL_RejectsHTTPScheme(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAssetsService(t)
+
+	_, err := ti.service.FetchImageFromURL(ctx, "http://example.com/favicon.ico")
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "invalid URL", oopsErr.Error())
+}
+
 func TestService_FetchImageFromURL_RejectsBlockedIPLiteral(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAssetsServiceWithPolicy(t, guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)))
 
-	_, err := ti.service.FetchImageFromURL(ctx, "http://169.254.169.254/latest/meta-data/")
+	_, err := ti.service.FetchImageFromURL(ctx, "https://169.254.169.254/latest/meta-data/")
 
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)

--- a/server/internal/assets/fetchopenapiv3fromurl_test.go
+++ b/server/internal/assets/fetchopenapiv3fromurl_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/assets"
@@ -46,7 +47,7 @@ func TestService_FetchOpenAPIv3FromURL_Success(t *testing.T) {
 	t.Parallel()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
 		w.Header().Set("Content-Type", "application/yaml")
 		_, _ = w.Write([]byte(fetchOpenAPIYAML))
 	}))

--- a/server/internal/assets/fetchopenapiv3fromurl_test.go
+++ b/server/internal/assets/fetchopenapiv3fromurl_test.go
@@ -1,0 +1,236 @@
+package assets_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/assets"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/dns"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+const fetchOpenAPIYAML = `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      summary: Test endpoint
+      responses:
+        '200':
+          description: Success
+`
+
+func fetchOpenAPIForm(rawURL string) *gen.FetchOpenAPIv3FromURLForm {
+	return &gen.FetchOpenAPIv3FromURLForm{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		URL:              rawURL,
+	}
+}
+
+func TestService_FetchOpenAPIv3FromURL_Success(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte(fetchOpenAPIYAML))
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctx, ti := newTestAssetsService(t)
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionAssetCreate)
+	require.NoError(t, err)
+
+	result, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL+"/openapi.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Asset)
+	require.NotEqual(t, uuid.Nil.String(), result.Asset.ID)
+	require.Equal(t, "openapiv3", result.Asset.Kind)
+	require.NotEmpty(t, result.Asset.Sha256)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionAssetCreate)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+}
+
+func TestService_FetchOpenAPIv3FromURL_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestAssetsService(t)
+	ctx := t.Context()
+
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm("https://example.com/openapi.yaml"))
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
+}
+
+func TestService_FetchOpenAPIv3FromURL_RejectsNonHTTPScheme(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAssetsService(t)
+
+	for _, rawURL := range []string{
+		"file:///etc/passwd",
+		"ftp://example.com/openapi.yaml",
+		"gopher://example.com/1",
+		"data:application/json,{}",
+	} {
+		_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(rawURL))
+		var oopsErr *oops.ShareableError
+		require.ErrorAs(t, err, &oopsErr, "url %s", rawURL)
+		require.Equal(t, oops.CodeBadRequest, oopsErr.Code, "url %s", rawURL)
+		require.Equal(t, "invalid URL", oopsErr.Error(), "url %s", rawURL)
+	}
+}
+
+func TestService_FetchOpenAPIv3FromURL_RejectsEmptyHost(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAssetsService(t)
+
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm("https:///openapi.yaml"))
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "invalid URL", oopsErr.Error())
+}
+
+func TestService_FetchOpenAPIv3FromURL_RejectsBlockedIPLiterals(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAssetsServiceWithPolicy(t, guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)))
+
+	for _, rawURL := range []string{
+		"http://127.0.0.1/openapi.yaml",
+		"http://10.0.0.1/openapi.yaml",
+		"http://172.16.0.1/openapi.yaml",
+		"http://192.168.1.1/openapi.yaml",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://[::1]/openapi.yaml",
+	} {
+		_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(rawURL))
+		var oopsErr *oops.ShareableError
+		require.ErrorAs(t, err, &oopsErr, "url %s", rawURL)
+		require.Equal(t, oops.CodeBadRequest, oopsErr.Code, "url %s", rawURL)
+		require.Equal(t, "invalid URL", oopsErr.Error(), "url %s", rawURL)
+	}
+}
+
+func TestService_FetchOpenAPIv3FromURL_RejectsBlockedHostname(t *testing.T) {
+	t.Parallel()
+
+	const blockedHost = "internal.test"
+	policy := guardian.NewDefaultPolicy(
+		testenv.NewTracerProvider(t),
+		guardian.WithResolver(dns.NewMockResolver(dns.MockResolverConfig{
+			LookupIPFunc: func(_ context.Context, _, host string) ([]net.IP, error) {
+				if host == blockedHost {
+					return []net.IP{net.ParseIP("10.0.0.1")}, nil
+				}
+				return nil, fmt.Errorf("unexpected host: %s", host)
+			},
+		})),
+	)
+
+	ctx, ti := newTestAssetsServiceWithPolicy(t, policy)
+
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm("http://"+blockedHost+"/openapi.yaml"))
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "invalid URL", oopsErr.Error())
+}
+
+func TestService_FetchOpenAPIv3FromURL_RedirectToBlockedHost(t *testing.T) {
+	t.Parallel()
+
+	const blockedHost = "blocked.test"
+	blockedIP := net.ParseIP("203.0.113.1") // RFC 5737 TEST-NET-3
+
+	mockResolver := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(_ context.Context, _, host string) ([]net.IP, error) {
+			if host == blockedHost {
+				return []net.IP{blockedIP}, nil
+			}
+			return nil, fmt.Errorf("unexpected host: %s", host)
+		},
+	})
+
+	// Block TEST-NET-3 only; loopback stays reachable so the httptest
+	// server (which listens on 127.0.0.1) can serve the initial request.
+	policy, err := guardian.NewUnsafePolicy(
+		testenv.NewTracerProvider(t),
+		[]string{"203.0.113.0/24"},
+		guardian.WithResolver(mockResolver),
+	)
+	require.NoError(t, err)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "http://"+blockedHost+"/openapi.yaml")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctx, ti := newTestAssetsServiceWithPolicy(t, policy)
+
+	_, err = ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL))
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "host is not allowed", oopsErr.Error())
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestService_FetchOpenAPIv3FromURL_RedirectsCapped(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", r.URL.Path+"/next")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctx, ti := newTestAssetsService(t)
+
+	_, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL+"/start"))
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "error fetching URL", oopsErr.Error())
+	require.Contains(t, oopsErr.String(), "stopped after 3 redirects")
+}
+
+func TestService_FetchImageFromURL_RejectsBlockedIPLiteral(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAssetsServiceWithPolicy(t, guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)))
+
+	_, err := ti.service.FetchImageFromURL(ctx, "http://169.254.169.254/latest/meta-data/")
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "invalid URL", oopsErr.Error())
+}

--- a/server/internal/assets/fetchopenapiv3fromurl_test.go
+++ b/server/internal/assets/fetchopenapiv3fromurl_test.go
@@ -203,6 +203,67 @@ func TestService_FetchOpenAPIv3FromURL_RedirectToBlockedHost(t *testing.T) {
 	require.ErrorIs(t, err, guardian.ErrBlockedIP)
 }
 
+func TestService_FetchOpenAPIv3FromURL_FollowsAllowedRedirect(t *testing.T) {
+	t.Parallel()
+
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte(fetchOpenAPIYAML))
+	}))
+	t.Cleanup(dest.Close)
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dest.URL+"/openapi.yaml", http.StatusFound)
+	}))
+	t.Cleanup(src.Close)
+
+	ctx, ti := newTestAssetsService(t)
+
+	result, err := ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(src.URL))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Asset)
+	require.Equal(t, "openapiv3", result.Asset.Kind)
+}
+
+func TestService_FetchOpenAPIv3FromURL_RedirectToUnresolvableHost(t *testing.T) {
+	t.Parallel()
+
+	const brokenHost = "broken.test"
+	mockResolver := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(_ context.Context, _, host string) ([]net.IP, error) {
+			if host == brokenHost {
+				return nil, fmt.Errorf("mock resolver: nxdomain")
+			}
+			return nil, fmt.Errorf("unexpected host: %s", host)
+		},
+	})
+
+	policy, err := guardian.NewUnsafePolicy(
+		testenv.NewTracerProvider(t),
+		[]string{},
+		guardian.WithResolver(mockResolver),
+	)
+	require.NoError(t, err)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "http://"+brokenHost+"/openapi.yaml")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	ctx, ti := newTestAssetsServiceWithPolicy(t, policy)
+
+	_, err = ti.service.FetchOpenAPIv3FromURL(ctx, fetchOpenAPIForm(upstream.URL))
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.Equal(t, "error fetching URL", oopsErr.Error())
+	require.ErrorIs(t, err, guardian.ErrBadHost)
+	require.NotErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
 func TestService_FetchOpenAPIv3FromURL_RedirectsCapped(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assets/fetchurl.go
+++ b/server/internal/assets/fetchurl.go
@@ -49,7 +49,7 @@ func validateFetchURL(ctx context.Context, policy *guardian.Policy, rawURL strin
 // the SSRF policy before the next request is issued. The dialer remains the
 // last line of defense: even if validation is skipped, ControlContext rejects
 // connections into blocked ranges after DNS resolution.
-func outboundFetchClient(policy *guardian.Policy, timeout time.Duration) *http.Client {
+func outboundFetchClient(policy *guardian.Policy, timeout time.Duration) *guardian.HTTPClient {
 	client := policy.Client()
 	client.Timeout = timeout
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {

--- a/server/internal/assets/fetchurl.go
+++ b/server/internal/assets/fetchurl.go
@@ -1,11 +1,9 @@
 package assets
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -19,31 +17,6 @@ const (
 	fetchURLMaxRedirects = 3
 )
 
-// validateFetchURL checks that rawURL is an absolute http(s) URL whose host
-// isn't blocked by the guardian SSRF policy. It validates the URL string and
-// resolves the host; it does not connect. Runtime enforcement still happens
-// via the policy dialer on the subsequent request, including each redirect.
-func validateFetchURL(ctx context.Context, policy *guardian.Policy, rawURL string) (*url.URL, error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, fmt.Errorf("parse url: %w", err)
-	}
-
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return nil, fmt.Errorf("url scheme must be http or https")
-	}
-
-	if u.Host == "" {
-		return nil, fmt.Errorf("url must include a host")
-	}
-
-	if err := policy.ValidateHost(ctx, u.Hostname()); err != nil {
-		return nil, fmt.Errorf("validate host: %w", err)
-	}
-
-	return u, nil
-}
-
 // outboundFetchClient returns a guardian client that follows at most
 // [fetchURLMaxRedirects] hops and re-validates each redirect target against
 // the SSRF policy before the next request is issued. The dialer remains the
@@ -56,7 +29,7 @@ func outboundFetchClient(policy *guardian.Policy, timeout time.Duration) *guardi
 		if len(via) >= fetchURLMaxRedirects {
 			return fmt.Errorf("stopped after %d redirects", fetchURLMaxRedirects)
 		}
-		if _, err := validateFetchURL(req.Context(), policy, req.URL.String()); err != nil {
+		if _, err := policy.ValidateHTTPURL(req.Context(), req.URL.String()); err != nil {
 			return fmt.Errorf("redirect url: %w", err)
 		}
 		return nil
@@ -65,12 +38,13 @@ func outboundFetchClient(policy *guardian.Policy, timeout time.Duration) *guardi
 }
 
 // fetchURLRequestError maps an outbound GET failure onto a client-facing
-// bad-request. Blocked and unresolvable hosts are distinguished from generic
-// transport faults so an operator who pointed at localhost sees "host is not
-// allowed" rather than a generic fetch error; the underlying cause is not
-// interpolated into the public message.
+// bad-request. A blocked IP is distinguished from generic transport faults so
+// an operator who pointed at localhost sees "host is not allowed" rather than
+// a generic fetch error. Unresolvable hosts fall through to the generic
+// message: [guardian.ErrBadHost] is a DNS/address failure, not an SSRF deny.
+// The underlying cause is not interpolated into the public message.
 func fetchURLRequestError(err error) error {
-	if errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
+	if errors.Is(err, guardian.ErrBlockedIP) {
 		return oops.E(oops.CodeBadRequest, err, "host is not allowed")
 	}
 	return oops.E(oops.CodeBadRequest, fmt.Errorf("fetch url: %w", err), "error fetching URL")

--- a/server/internal/assets/fetchurl.go
+++ b/server/internal/assets/fetchurl.go
@@ -1,0 +1,77 @@
+package assets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+const (
+	// fetchURLMaxRedirects caps how many HTTP redirects a user-supplied OpenAPI
+	// or image URL fetch will follow. Bounding this keeps the fetch from chasing
+	// arbitrary redirect chains supplied by a hostile target.
+	fetchURLMaxRedirects = 3
+)
+
+// validateFetchURL checks that rawURL is an absolute http(s) URL whose host
+// isn't blocked by the guardian SSRF policy. It validates the URL string and
+// resolves the host; it does not connect. Runtime enforcement still happens
+// via the policy dialer on the subsequent request, including each redirect.
+func validateFetchURL(ctx context.Context, policy *guardian.Policy, rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse url: %w", err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("url scheme must be http or https")
+	}
+
+	if u.Host == "" {
+		return nil, fmt.Errorf("url must include a host")
+	}
+
+	if err := policy.ValidateHost(ctx, u.Hostname()); err != nil {
+		return nil, fmt.Errorf("validate host: %w", err)
+	}
+
+	return u, nil
+}
+
+// outboundFetchClient returns a guardian client that follows at most
+// [fetchURLMaxRedirects] hops and re-validates each redirect target against
+// the SSRF policy before the next request is issued. The dialer remains the
+// last line of defense: even if validation is skipped, ControlContext rejects
+// connections into blocked ranges after DNS resolution.
+func outboundFetchClient(policy *guardian.Policy, timeout time.Duration) *http.Client {
+	client := policy.Client()
+	client.Timeout = timeout
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= fetchURLMaxRedirects {
+			return fmt.Errorf("stopped after %d redirects", fetchURLMaxRedirects)
+		}
+		if _, err := validateFetchURL(req.Context(), policy, req.URL.String()); err != nil {
+			return fmt.Errorf("redirect url: %w", err)
+		}
+		return nil
+	}
+	return client
+}
+
+// fetchURLRequestError maps an outbound GET failure onto a client-facing
+// bad-request. Blocked and unresolvable hosts are distinguished from generic
+// transport faults so an operator who pointed at localhost sees "host is not
+// allowed" rather than a generic fetch error; the underlying cause is not
+// interpolated into the public message.
+func fetchURLRequestError(err error) error {
+	if errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
+		return oops.E(oops.CodeBadRequest, err, "host is not allowed")
+	}
+	return oops.E(oops.CodeBadRequest, fmt.Errorf("fetch url: %w", err), "error fetching URL")
+}

--- a/server/internal/assets/fetchurl.go
+++ b/server/internal/assets/fetchurl.go
@@ -29,7 +29,7 @@ func outboundFetchClient(policy *guardian.Policy, timeout time.Duration) *guardi
 		if len(via) >= fetchURLMaxRedirects {
 			return fmt.Errorf("stopped after %d redirects", fetchURLMaxRedirects)
 		}
-		if _, err := policy.ValidateHTTPURL(req.Context(), req.URL.String()); err != nil {
+		if _, err := policy.ValidateHTTPSURL(req.Context(), req.URL.String()); err != nil {
 			return fmt.Errorf("redirect url: %w", err)
 		}
 		return nil

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -812,7 +812,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 
 	logger := s.logger
 
-	parsedURL, err := s.guardianPolicy.ValidateHTTPURL(ctx, payload.URL)
+	parsedURL, err := s.guardianPolicy.ValidateHTTPSURL(ctx, payload.URL)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid URL")
 	}
@@ -1006,7 +1006,7 @@ func (s *Service) FetchImageFromURL(ctx context.Context, imageURL string) (*gen.
 
 	logger := s.logger
 
-	if _, err := s.guardianPolicy.ValidateHTTPURL(ctx, imageURL); err != nil {
+	if _, err := s.guardianPolicy.ValidateHTTPSURL(ctx, imageURL); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid URL")
 	}
 

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -812,7 +812,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 
 	logger := s.logger
 
-	parsedURL, err := validateFetchURL(ctx, s.guardianPolicy, payload.URL)
+	parsedURL, err := s.guardianPolicy.ValidateHTTPURL(ctx, payload.URL)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid URL")
 	}
@@ -1006,7 +1006,7 @@ func (s *Service) FetchImageFromURL(ctx context.Context, imageURL string) (*gen.
 
 	logger := s.logger
 
-	if _, err := validateFetchURL(ctx, s.guardianPolicy, imageURL); err != nil {
+	if _, err := s.guardianPolicy.ValidateHTTPURL(ctx, imageURL); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid URL")
 	}
 

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -812,26 +812,19 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 
 	logger := s.logger
 
-	// Validate URL
-	parsedURL, err := url.Parse(payload.URL)
+	parsedURL, err := validateFetchURL(ctx, s.guardianPolicy, payload.URL)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("parse url: %w", err), "invalid URL")
-	}
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "URL must use http or https scheme")
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid URL")
 	}
 
-	// Fetch the OpenAPI spec from the URL
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, payload.URL, nil)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create request: %w", err), "error fetching URL")
 	}
 
-	client := s.guardianPolicy.Client()
-	client.Timeout = 30 * time.Second
-	resp, err := client.Do(req)
+	resp, err := outboundFetchClient(s.guardianPolicy, 30*time.Second).Do(req)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("fetch url: %w", err), "error fetching URL")
+		return nil, fetchURLRequestError(err)
 	}
 	defer o11y.LogDefer(ctx, s.logger, func() error {
 		return resp.Body.Close()
@@ -1013,12 +1006,8 @@ func (s *Service) FetchImageFromURL(ctx context.Context, imageURL string) (*gen.
 
 	logger := s.logger
 
-	parsedURL, err := url.Parse(imageURL)
-	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("parse url: %w", err), "invalid URL")
-	}
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "URL must use http or https scheme")
+	if _, err := validateFetchURL(ctx, s.guardianPolicy, imageURL); err != nil {
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid URL")
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
@@ -1026,11 +1015,9 @@ func (s *Service) FetchImageFromURL(ctx context.Context, imageURL string) (*gen.
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create request: %w", err), "error fetching URL")
 	}
 
-	client := s.guardianPolicy.Client()
-	client.Timeout = 10 * time.Second
-	resp, err := client.Do(req)
+	resp, err := outboundFetchClient(s.guardianPolicy, 10*time.Second).Do(req)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("fetch url: %w", err), "error fetching URL")
+		return nil, fetchURLRequestError(err)
 	}
 	defer o11y.LogDefer(ctx, s.logger, func() error {
 		return resp.Body.Close()

--- a/server/internal/assets/setup_test.go
+++ b/server/internal/assets/setup_test.go
@@ -60,8 +60,8 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
 	tracerProvider := testenv.NewTracerProvider(t)
-	// UnsafePolicy with an empty blocklist lets httptest.NewServer (loopback)
-	// succeed. SSRF tests that need the production CIDR set use
+	// UnsafePolicy with an empty blocklist lets httptest loopback succeed.
+	// SSRF tests that need the production CIDR set use
 	// [newTestAssetsServiceWithPolicy] with [guardian.NewDefaultPolicy].
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)

--- a/server/internal/assets/setup_test.go
+++ b/server/internal/assets/setup_test.go
@@ -59,12 +59,22 @@ type testInstance struct {
 func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	// UnsafePolicy with an empty blocklist lets httptest.NewServer (loopback)
+	// succeed. SSRF tests that need the production CIDR set use
+	// [newTestAssetsServiceWithPolicy] with [guardian.NewDefaultPolicy].
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	return newTestAssetsServiceWithPolicy(t, guardianPolicy)
+}
+
+func newTestAssetsServiceWithPolicy(t *testing.T, guardianPolicy *guardian.Policy) (context.Context, *testInstance) {
+	t.Helper()
+
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
-	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
-	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -35,6 +35,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"syscall"
 	"time"
 
@@ -505,17 +506,33 @@ func (p *Policy) ValidateHost(ctx context.Context, host string) error {
 	return nil
 }
 
-// ValidateHTTPURL checks that rawURL is an absolute http(s) URL whose host is
-// permitted by the policy's CIDR blocklist. It validates the URL string and
-// resolves the host; it does not connect. Runtime enforcement still happens
-// via [Policy.Dialer] on the subsequent request, including each redirect.
+// ValidateHTTPURL checks that rawURL is an absolute http or https URL whose
+// host is permitted by the policy's CIDR blocklist. It validates the URL
+// string and resolves the host; it does not connect. Runtime enforcement still
+// happens via [Policy.Dialer] on the subsequent request, including each
+// redirect. Callers that fetch user-supplied content (OpenAPI specs, images)
+// should use [Policy.ValidateHTTPSURL] instead so the body cannot travel in
+// the clear.
 func (p *Policy) ValidateHTTPURL(ctx context.Context, rawURL string) (*url.URL, error) {
+	return p.validateAbsoluteURL(ctx, rawURL, []string{"http", "https"})
+}
+
+// ValidateHTTPSURL is [Policy.ValidateHTTPURL] restricted to https. Use it for
+// user-supplied fetch URLs so the request cannot be MITM'd in transit.
+func (p *Policy) ValidateHTTPSURL(ctx context.Context, rawURL string) (*url.URL, error) {
+	return p.validateAbsoluteURL(ctx, rawURL, []string{"https"})
+}
+
+func (p *Policy) validateAbsoluteURL(ctx context.Context, rawURL string, schemes []string) (*url.URL, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse url: %w", err)
 	}
 
-	if u.Scheme != "http" && u.Scheme != "https" {
+	if !slices.Contains(schemes, u.Scheme) {
+		if len(schemes) == 1 {
+			return nil, fmt.Errorf("url scheme must be %s", schemes[0])
+		}
 		return nil, fmt.Errorf("url scheme must be http or https")
 	}
 

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -34,6 +34,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"syscall"
 	"time"
 
@@ -502,6 +503,31 @@ func (p *Policy) ValidateHost(ctx context.Context, host string) error {
 	}
 
 	return nil
+}
+
+// ValidateHTTPURL checks that rawURL is an absolute http(s) URL whose host is
+// permitted by the policy's CIDR blocklist. It validates the URL string and
+// resolves the host; it does not connect. Runtime enforcement still happens
+// via [Policy.Dialer] on the subsequent request, including each redirect.
+func (p *Policy) ValidateHTTPURL(ctx context.Context, rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse url: %w", err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("url scheme must be http or https")
+	}
+
+	if u.Host == "" {
+		return nil, fmt.Errorf("url must include a host")
+	}
+
+	if err := p.ValidateHost(ctx, u.Hostname()); err != nil {
+		return nil, fmt.Errorf("validate host: %w", err)
+	}
+
+	return u, nil
 }
 
 // checkIP returns [ErrBlockedIP] if ip falls within any of the policy's

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -674,6 +674,29 @@ func TestPolicy_ValidateHTTPURL_AllowsPublicIPLiteral(t *testing.T) {
 	require.Equal(t, "8.8.8.8", u.Hostname())
 }
 
+func TestPolicy_ValidateHTTPURL_AllowsHTTPPublicIPLiteral(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	u, err := policy.ValidateHTTPURL(t.Context(), "http://8.8.8.8/openapi.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8.8", u.Hostname())
+}
+
+func TestPolicy_ValidateHTTPSURL_RejectsHTTPScheme(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	_, err := policy.ValidateHTTPSURL(t.Context(), "http://8.8.8.8/openapi.yaml")
+	require.Error(t, err)
+}
+
+func TestPolicy_ValidateHTTPSURL_AllowsPublicIPLiteral(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	u, err := policy.ValidateHTTPSURL(t.Context(), "https://8.8.8.8/openapi.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8.8", u.Hostname())
+}
+
 func TestPolicy_ValidateHTTPURL_AllowsPublicHostname(t *testing.T) {
 	t.Parallel()
 	policy := guardian.NewDefaultPolicy(

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -643,3 +643,51 @@ func TestPolicy_ValidateHost_UnsafePolicyPermitsBlockedLiteral(t *testing.T) {
 	require.NoError(t, policy.ValidateHost(t.Context(), "127.0.0.1"))
 	require.NoError(t, policy.ValidateHost(t.Context(), "10.0.0.1"))
 }
+
+func TestPolicy_ValidateHTTPURL_RejectsNonHTTPScheme(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	_, err := policy.ValidateHTTPURL(t.Context(), "ftp://example.com/spec.yaml")
+	require.Error(t, err)
+}
+
+func TestPolicy_ValidateHTTPURL_RejectsEmptyHost(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	_, err := policy.ValidateHTTPURL(t.Context(), "https:///spec.yaml")
+	require.Error(t, err)
+}
+
+func TestPolicy_ValidateHTTPURL_RejectsBlockedIPLiteral(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	_, err := policy.ValidateHTTPURL(t.Context(), "http://169.254.169.254/latest/meta-data/")
+	require.Error(t, err)
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestPolicy_ValidateHTTPURL_AllowsPublicIPLiteral(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	u, err := policy.ValidateHTTPURL(t.Context(), "https://8.8.8.8/openapi.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "8.8.8.8", u.Hostname())
+}
+
+func TestPolicy_ValidateHTTPURL_AllowsPublicHostname(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(
+		testenv.NewTracerProvider(t),
+		guardian.WithResolver(dns.NewMockResolver(dns.MockResolverConfig{
+			LookupIPFunc: func(_ context.Context, _, host string) ([]net.IP, error) {
+				if host == "cdn.example.com" {
+					return []net.IP{net.ParseIP("8.8.8.8")}, nil
+				}
+				return nil, fmt.Errorf("unexpected host: %s", host)
+			},
+		})),
+	)
+	u, err := policy.ValidateHTTPURL(t.Context(), "https://cdn.example.com/openapi.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "cdn.example.com", u.Hostname())
+}

--- a/server/internal/remotemcp/impl.go
+++ b/server/internal/remotemcp/impl.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -98,7 +97,7 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
-	if err := validateURL(ctx, s.policy, payload.URL); err != nil {
+	if _, err := s.policy.ValidateHTTPURL(ctx, payload.URL); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid url").LogError(ctx, logger)
 	}
 
@@ -254,7 +253,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 	}
 
 	if payload.URL != nil {
-		if err := validateURL(ctx, s.policy, *payload.URL); err != nil {
+		if _, err := s.policy.ValidateHTTPURL(ctx, *payload.URL); err != nil {
 			return nil, oops.E(oops.CodeBadRequest, err, "invalid url").LogError(ctx, logger)
 		}
 	}
@@ -348,7 +347,7 @@ func (s *Service) VerifyURL(ctx context.Context, payload *gen.VerifyURLPayload) 
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
-	if err := validateURL(ctx, s.policy, payload.URL); err != nil {
+	if _, err := s.policy.ValidateHTTPURL(ctx, payload.URL); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid url").LogError(ctx, logger)
 	}
 
@@ -754,29 +753,6 @@ func (s *Service) DeleteServerHeader(ctx context.Context, payload *gen.DeleteSer
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {
 	return s.auth.Authorize(ctx, key, schema)
-}
-
-// validateURL checks that the given URL string is a valid absolute HTTP(S) URL
-// whose host is permitted by the supplied [guardian.Policy].
-func validateURL(ctx context.Context, policy *guardian.Policy, rawURL string) error {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("parse url: %w", err)
-	}
-
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("url scheme must be http or https")
-	}
-
-	if u.Host == "" {
-		return fmt.Errorf("url must include a host")
-	}
-
-	if err := policy.ValidateHost(ctx, u.Hostname()); err != nil {
-		return fmt.Errorf("validate host: %w", err)
-	}
-
-	return nil
 }
 
 // validateHeaderValueSource checks that exactly one of value or

--- a/server/internal/remotemcp/setup_test.go
+++ b/server/internal/remotemcp/setup_test.go
@@ -76,7 +76,7 @@ type testInstance struct {
 func newTestService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
-	// servicePolicy blocks loopback / private ranges so validateURL exercises
+	// servicePolicy blocks loopback / private ranges so ValidateHTTPURL exercises
 	// the real production CIDR set, and uses a mock resolver so hostname-based
 	// test cases are deterministic.
 	servicePolicy := guardian.NewDefaultPolicy(

--- a/server/internal/remotemcp/verifyurl.go
+++ b/server/internal/remotemcp/verifyurl.go
@@ -46,8 +46,9 @@ const (
 
 // VerifyRemoteMcpURL issues an MCP initialize request against rawURL and
 // reports a verification outcome. The supplied [guardian.Policy] enforces the
-// SSRF blocklist; rawURL must already have passed [validateURL]. The caller
-// is responsible for bounding the overall deadline via ctx.
+// SSRF blocklist; rawURL must already have passed
+// [guardian.Policy.ValidateHTTPURL]. The caller is responsible for bounding
+// the overall deadline via ctx.
 func VerifyRemoteMcpURL(ctx context.Context, policy *guardian.Policy, rawURL string) (verified bool, httpStatus *int, message string) {
 	client := policy.Client()
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {

--- a/server/internal/unproxiedmcp/impl.go
+++ b/server/internal/unproxiedmcp/impl.go
@@ -3,9 +3,7 @@ package unproxiedmcp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
-	"net/url"
 	"strings"
 	"time"
 
@@ -106,7 +104,7 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 		return nil, err
 	}
 
-	if err := validateServerURL(ctx, s.policy, payload.URL); err != nil {
+	if _, err := s.policy.ValidateHTTPURL(ctx, payload.URL); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid server url").LogWarn(ctx, logger)
 	}
 
@@ -433,32 +431,6 @@ func (s *Service) DeleteServer(ctx context.Context, payload *gen.DeleteServerPay
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
-	}
-
-	return nil
-}
-
-// validateServerURL checks that rawURL is an absolute http(s) URL whose host
-// isn't blocked by the guardian SSRF policy. Mirrors remotemcp.validateURL:
-// this only validates the URL string and resolves its host, it doesn't
-// connect to it. ListTools does later connect to this same host for live
-// tool discovery, so the same SSRF guard applies here at creation time too.
-func validateServerURL(ctx context.Context, policy *guardian.Policy, rawURL string) error {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("parse url: %w", err)
-	}
-
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("url scheme must be http or https")
-	}
-
-	if u.Host == "" {
-		return fmt.Errorf("url must include a host")
-	}
-
-	if err := policy.ValidateHost(ctx, u.Hostname()); err != nil {
-		return fmt.Errorf("validate host: %w", err)
 	}
 
 	return nil

--- a/server/internal/unproxiedmcp/setup_test.go
+++ b/server/internal/unproxiedmcp/setup_test.go
@@ -80,7 +80,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	auditLogger := audit.NewLogger()
 
-	// servicePolicy blocks loopback / private ranges so validateServerURL
+	// servicePolicy blocks loopback / private ranges so ValidateHTTPURL
 	// exercises the real production CIDR set, and uses a mock resolver so
 	// hostname-based test cases are deterministic.
 	servicePolicy := guardian.NewDefaultPolicy(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes AIS-429.

`assets.fetchOpenAPIv3FromURL` already fetched user-supplied URLs through the guardian HTTP client, which blocks private/reserved ranges at dial time. This change adds the same management-time checks used by remote MCP URL validation so a hostile URL is rejected before any connection, and so redirects cannot hop into blocked space.

**What changed**
- `guardian.Policy.ValidateHTTPSURL` is used for OpenAPI and image fetches (and each redirect hop): scheme must be `https`, host must pass the guardian blocklist.
- `guardian.Policy.ValidateHTTPURL` remains the shared http-or-https+host+blocklist check for remote MCP and unproxied MCP, which still accept `http://` server URLs.
- Reject non-`https` schemes on OpenAPI/image fetches, URLs without a host, and hosts that fail the guardian blocklist (loopback, RFC 1918, link-local/metadata, other reserved ranges).
- Cap redirects at 3 and re-validate each hop (including rejecting an https→http downgrade); the dialer remains the last line of defense against DNS rebinding.
- Dial-time `ErrBlockedIP` surfaces as "host is not allowed"; unresolvable hosts stay a generic fetch error.
- Tests cover the pentest classes (`http://`/`file://`/`ftp://`/`gopher://`, empty host, private/metadata IP literals, hostname → private IP), redirect-into-blocked-range, redirect-to-NXDOMAIN, https→http redirect, an allowed TLS redirect hop, and the redirect cap.

A domain allowlist would break importing specs from arbitrary customer APIs; that is the intended product behavior. Internal destinations, plaintext HTTP, and dangerous schemes are what this finding requires us to deny.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-429](https://linear.app/speakeasy/issue/AIS-429/security-server-side-request-forgery-ssrf)

<div><a href="https://cursor.com/agents/bc-03fed919-4ddc-475f-816d-fee05e112588?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03fed919-4ddc-475f-816d-fee05e112588&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks SSRF on OpenAPI URL import and image fetch by requiring HTTPS, rejecting blocked hosts before dialing, and capping/re-validating redirects. Previously only the dialer blocked private ranges; now we pre-validate schemes/hosts and refuse HTTPS→HTTP downgrades (AIS-429).

**Details**
- Assets: `FetchOpenAPIv3FromURL` and `FetchImageFromURL` now use `guardian.Policy.ValidateHTTPSURL`; outbound client caps redirects at 3 and re-validates each hop; the dialer still guards DNS rebinding.
- Errors: invalid scheme/host or blocked host → "invalid URL"; blocked IP at request time → "host is not allowed"; other transport faults (including unresolvable host) → "error fetching URL".
- Guardian/MCP: adds `ValidateHTTPURL` and `ValidateHTTPSURL` on `guardian.Policy`; `remotemcp` and `unproxiedmcp` now use `ValidateHTTPURL`, removing duplicate validators.

**Rollout**
- No migrations. For OpenAPI/image imports, use HTTPS and public hosts; HTTP, private/internal/metadata targets, HTTPS→HTTP redirects, or >3 redirects return BadRequest. MCP server URLs continue to allow HTTP(S).

<sup>Written for commit 2c166e26eff497db6189e7d22b79b3d69ba651f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

