### PR TITLE
ci: run PR workflow and build preview images for stacked PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,6 @@
 name: Pull Request
 on:
   pull_request:
-    branches:
-      - main
     types: [opened, synchronize, reopened]
   push:
     branches:
@@ -56,19 +54,50 @@ jobs:
         id: filter
         with:
           filters: .github/filters.yaml
+      - id: stacked
+        name: Compare preview image components against main
+        if: github.event_name == 'pull_request' && github.base_ref != 'main' && !github.event.pull_request.head.repo.fork
+        run: |
+          set -euo pipefail
+          git fetch --quiet --depth=1 origin main
+          check() {
+            local name=$1
+            local pathspecs=()
+            local path
+            while IFS= read -r path; do
+              pathspecs+=(":(glob)${path}")
+            done < <(python3 -c 'import sys, yaml; print("\n".join(yaml.safe_load(open(".github/filters.yaml"))[sys.argv[1]]))' "$name")
+            if [ "${#pathspecs[@]}" -eq 0 ]; then
+              echo "::error::No watched paths resolved from .github/filters.yaml for ${name}"
+              exit 1
+            fi
+            if git diff --quiet origin/main HEAD -- "${pathspecs[@]}"; then
+              echo "${name}=false" >> "$GITHUB_OUTPUT"
+              echo "${name} matches main; the preview retag fallback can cover it."
+            else
+              echo "${name}=true" >> "$GITHUB_OUTPUT"
+              echo "${name} differs from main; its jobs will run."
+            fi
+          }
+          check server
+          check client
+          check pystreams
       - id: gates
         name: Set outputs
         env:
           HAS_FULL_CI_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
+          STACKED_SERVER: ${{ steps.stacked.outputs.server }}
+          STACKED_CLIENT: ${{ steps.stacked.outputs.client }}
+          STACKED_PYSTREAMS: ${{ steps.stacked.outputs.pystreams }}
         run: |
-          if [[ "${{ steps.filter.outputs.server }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.server }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" || "$STACKED_SERVER" == "true" ]]; then
             echo "server=true" >> $GITHUB_OUTPUT
             echo "Server jobs will run."
           else
             echo "Server jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.client }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.client }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" || "$STACKED_CLIENT" == "true" ]]; then
             echo "client=true" >> $GITHUB_OUTPUT
             echo "Client jobs will run."
           else
@@ -124,7 +153,7 @@ jobs:
             echo "Infra jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.pystreams }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.pystreams }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" || "$STACKED_PYSTREAMS" == "true" ]]; then
             echo "pystreams=true" >> $GITHUB_OUTPUT
             echo "Pystreams jobs will run."
           else


### PR DESCRIPTION
## Summary

Previews only worked for PRs targeting `main` (e.g. #4807 targets a feature branch and got no preview). Two changes:

- Remove the `branches: [main]` filter from the `pull_request` trigger so CI (and preview image builds / atlas tags) run for PRs targeting any branch.
- For stacked PRs (base != main, non-fork), a new `stacked` step in the `changes` job tree-diffs the PR merge ref against `origin/main` over each preview component's `filters.yaml` globs (`server`, `client`, `pystreams`). Only components that differ from main get their gates forced on; components identical to main keep using the existing retag fallback, which aliases a matching main image. The retag fallback can only alias images built from main, so anything the base branch changed over main must be built here — but nothing more.

Path-based gating vs the PR base (dorny) is unchanged, so tests still reflect the PR's own delta plus whatever the base carries over main for those components.

Pairs with speakeasy-api/gram-infra#2584, which drops the `targetBranchMatch: ^main$` filter from the `gram-app-previews` ApplicationSet.

## Notes

- Existing stacked PRs only pick up the new trigger once this lands on `main` **and** their merge ref contains it (update base branch from main or rebase the head).
- A stacked PR does not rebuild when its base branch moves (no `synchronize` fires); push to the head or update the branch to refresh the preview. Same staleness semantics previews already have vs `main`.