### PR TITLE
ci: run buf breaking against the PR base branch

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1176,15 +1176,15 @@ jobs:
             ${{ env.GH_CACHE_UV_KEY_PARTIAL }}
           path: ${{ env.UV_CACHE_DIR }}
 
-      - name: Fetch main branch
-        run: git fetch --depth=1 origin main
+      - name: Fetch base branch
+        run: git fetch --depth=1 origin "${{ github.base_ref || 'main' }}"
 
-      # buf breaking against main is what catches a wire-incompatible proto
-      # change (field renumbering, type change) that would corrupt already
-      # published messages — including outbox rows, which store marshaled bytes
-      # and republish them verbatim after a deploy.
+      # buf breaking against the PR base is what catches a wire-incompatible
+      # proto change (field renumbering, type change) that would corrupt
+      # already published messages. Stacked PRs compare against their feature
+      # base; that base's own PR re-checks the full stack against main.
       - name: Lint proto files
-        run: mise run lint:infra --against ".git#ref=origin/main"
+        run: mise run lint:infra --against ".git#ref=origin/${{ github.base_ref || 'main' }}"
 
       - name: Install uv dependencies
         run: mise run install:uv --all-packages --locked


### PR DESCRIPTION
`infra-build-lint` hardcodes `buf breaking --against origin/main`, so stacked PRs see protos added to main after they diverged as false "deleted file" breakages (hit on #4807). Compare against `github.base_ref` instead, falling back to `main` for push/merge-queue events. Main still gets full coverage: the base branch's own PR checks the whole stack against main.