### PR TITLE
feat: add generic error logging helpers

### DIFF
--- a/server/internal/middleware/trace.go
+++ b/server/internal/middleware/trace.go
@@ -26,6 +26,7 @@ func TraceMethods(tracer trace.Tracer) func(goa.Endpoint) goa.Endpoint {
 			}
 
 			ctx, span := tracer.Start(ctx, fmt.Sprintf("%s.%s", svc, method))
+			ctx = oops.WithSpanErrorHandling(ctx)
 			defer span.End()
 
 			val, err := next(ctx, req)
@@ -35,14 +36,16 @@ func TraceMethods(tracer trace.Tracer) func(goa.Endpoint) goa.Endpoint {
 				// client-fault-noise suppression. Re-recording here would duplicate
 				// the exception event and undo that suppression, so only act as a
 				// fallback for errors that never passed through such a helper.
-				if se, ok := errors.AsType[*oops.ShareableError](err); ok {
-					if !se.SpanHandled() {
-						span.SetStatus(codes.Error, se.String())
-						span.RecordError(se, trace.WithStackTrace(true))
+				if !oops.SpanErrorHandled(ctx, err) {
+					if se, ok := errors.AsType[*oops.ShareableError](err); ok {
+						if !se.SpanHandled() {
+							span.SetStatus(codes.Error, se.String())
+							span.RecordError(se, trace.WithStackTrace(true))
+						}
+					} else {
+						span.SetStatus(codes.Error, err.Error())
+						span.RecordError(err, trace.WithStackTrace(true))
 					}
-				} else {
-					span.SetStatus(codes.Error, err.Error())
-					span.RecordError(err, trace.WithStackTrace(true))
 				}
 				return nil, err
 			}

--- a/server/internal/middleware/trace_test.go
+++ b/server/internal/middleware/trace_test.go
@@ -1,0 +1,79 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	goa "goa.design/goa/v3/pkg"
+
+	"github.com/speakeasy-api/gram/server/internal/middleware"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func recordTraceMethodSpan(t *testing.T, endpoint goa.Endpoint) (sdktrace.ReadOnlySpan, error) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	ctx := context.WithValue(t.Context(), goa.ServiceKey, "test-service")
+	ctx = context.WithValue(ctx, goa.MethodKey, "test-method")
+	_, err := middleware.TraceMethods(provider.Tracer("test"))(endpoint)(ctx, nil)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	return spans[0], err
+}
+
+func TestTraceMethods_LogWarnPlainErrorSuppressesSpanError(t *testing.T) {
+	t.Parallel()
+	logger := testenv.NewLogger(t)
+	err := errors.New("invalid credentials")
+
+	span, got := recordTraceMethodSpan(t, func(ctx context.Context, _ any) (any, error) {
+		return nil, oops.LogWarn(ctx, logger, err)
+	})
+
+	require.ErrorIs(t, got, err)
+	require.Equal(t, codes.Unset, span.Status().Code)
+	require.Empty(t, span.Events())
+}
+
+func TestTraceMethods_LogErrorPlainErrorRecordsOnce(t *testing.T) {
+	t.Parallel()
+	logger := testenv.NewLogger(t)
+	err := errors.New("database unavailable")
+
+	span, got := recordTraceMethodSpan(t, func(ctx context.Context, _ any) (any, error) {
+		return nil, oops.LogError(ctx, logger, err)
+	})
+
+	require.ErrorIs(t, got, err)
+	require.Equal(t, codes.Error, span.Status().Code)
+	require.Equal(t, err.Error(), span.Status().Description)
+	require.Len(t, span.Events(), 1)
+}
+
+func TestTraceMethods_LoggedWarningDoesNotSuppressDifferentError(t *testing.T) {
+	t.Parallel()
+	logger := testenv.NewLogger(t)
+	warning := errors.New("invalid credentials")
+	err := errors.New("database unavailable")
+
+	span, got := recordTraceMethodSpan(t, func(ctx context.Context, _ any) (any, error) {
+		_ = oops.LogWarn(ctx, logger, warning)
+		return nil, err
+	})
+
+	require.ErrorIs(t, got, err)
+	require.Equal(t, codes.Error, span.Status().Code)
+	require.Equal(t, err.Error(), span.Status().Description)
+	require.Len(t, span.Events(), 1)
+}

--- a/server/internal/oops/log.go
+++ b/server/internal/oops/log.go
@@ -1,0 +1,80 @@
+package oops
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"runtime"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// LogError logs any error at error level and records it on the current span. A
+// client-initiated cancellation is demoted to info level and left off the span.
+// It returns err unchanged for use in a return statement.
+func LogError(ctx context.Context, logger *slog.Logger, err error, args ...slog.Attr) error {
+	logErr(ctx, logger, err, slog.LevelError, true, args)
+	return err
+}
+
+// LogWarn logs any error at warn level and never touches the span, keeping
+// client-fault errors out of the errored-span population that error-rate
+// monitors are keyed on. A client-initiated cancellation is demoted to info
+// level. It returns err unchanged for use in a return statement.
+func LogWarn(ctx context.Context, logger *slog.Logger, err error, args ...slog.Attr) error {
+	logErr(ctx, logger, err, slog.LevelWarn, false, args)
+	return err
+}
+
+// recordSpan controls whether a non-canceled error is recorded on the span.
+//
+//go:noinline
+func logErr(ctx context.Context, logger *slog.Logger, err error, level slog.Level, recordSpan bool, args []slog.Attr) {
+	if err == nil {
+		return
+	}
+
+	msg := err.Error()
+	detail := err.Error()
+	canceled := errors.Is(err, context.Canceled) && errors.Is(ctx.Err(), context.Canceled)
+
+	attrs := make([]slog.Attr, 0, len(args)+2)
+	attrs = append(attrs, args...)
+
+	var shareable *ShareableError
+	if errors.As(err, &shareable) {
+		shareable.spanHandled = true
+		canceled = shareable.effectiveCode(ctx) == CodeCanceled
+		attrs = append(attrs, attr.SlogErrorID(shareable.id))
+
+		// A wrapper's Error() already carries the public message plus whatever
+		// context the wrapping added. The exact type check distinguishes that
+		// wrapper from the ShareableError found above.
+		if direct, ok := err.(*ShareableError); ok && direct == shareable { //nolint:errorlint // The outer error must be matched without unwrapping.
+			msg = shareable.public
+			detail = shareable.String()
+		}
+	}
+
+	if canceled {
+		level = slog.LevelInfo
+	}
+
+	if recordSpan && !canceled {
+		span := trace.SpanFromContext(ctx)
+		span.SetStatus(codes.Error, detail)
+		span.RecordError(err, trace.WithStackTrace(true))
+	}
+
+	attrs = append(attrs, attr.SlogErrorMessage(detail))
+
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip [Callers, logErr, LogError|LogWarn]
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.AddAttrs(attrs...)
+
+	_ = logger.Handler().Handle(ctx, r)
+}

--- a/server/internal/oops/log.go
+++ b/server/internal/oops/log.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -29,6 +30,55 @@ func LogWarn(ctx context.Context, logger *slog.Logger, err error, args ...slog.A
 	return err
 }
 
+type spanErrorHandlingKey struct{}
+
+type spanErrorHandling struct {
+	mu      sync.Mutex
+	handled []error
+}
+
+// WithSpanErrorHandling returns a context that tracks errors whose span
+// treatment has already been applied by LogError or LogWarn. Error boundaries
+// use this to avoid recording the same returned error again.
+func WithSpanErrorHandling(ctx context.Context) context.Context {
+	return context.WithValue(ctx, spanErrorHandlingKey{}, &spanErrorHandling{mu: sync.Mutex{}, handled: nil})
+}
+
+// SpanErrorHandled reports whether err wraps an error whose span treatment was
+// applied through the logging context.
+func SpanErrorHandled(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	handling, ok := ctx.Value(spanErrorHandlingKey{}).(*spanErrorHandling)
+	if !ok {
+		return false
+	}
+
+	handling.mu.Lock()
+	defer handling.mu.Unlock()
+
+	for _, handled := range handling.handled {
+		if errors.Is(err, handled) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func markSpanErrorHandled(ctx context.Context, err error) {
+	handling, ok := ctx.Value(spanErrorHandlingKey{}).(*spanErrorHandling)
+	if !ok {
+		return
+	}
+
+	handling.mu.Lock()
+	defer handling.mu.Unlock()
+	handling.handled = append(handling.handled, err)
+}
+
 // recordSpan controls whether a non-canceled error is recorded on the span.
 //
 //go:noinline
@@ -36,6 +86,7 @@ func logErr(ctx context.Context, logger *slog.Logger, err error, level slog.Leve
 	if err == nil {
 		return
 	}
+	markSpanErrorHandled(ctx, err)
 
 	msg := err.Error()
 	detail := err.Error()

--- a/server/internal/oops/log_test.go
+++ b/server/internal/oops/log_test.go
@@ -1,0 +1,184 @@
+package oops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+)
+
+func TestLogError_LogsPlainErrorAndRecordsSpan(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	err := fmt.Errorf("load widgets: %w", errors.New("database unavailable"))
+
+	got := LogError(ctx, logger, err, slog.Group("attrs", slog.String("operation", "load")))
+
+	require.Same(t, err, got)
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "ERROR", entries[0].Level)
+	require.Equal(t, err.Error(), entries[0].Msg)
+	require.Equal(t, err.Error(), entries[0].Error)
+	require.Equal(t, "load", entries[0].Attrs["operation"])
+	require.Empty(t, entries[0].ErrorID)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Equal(t, err.Error(), spans[0].Status().Description)
+	require.Len(t, spans[0].Events(), 1)
+}
+
+func TestLogError_LogsShareableErrorDetails(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	err := E(CodeUnexpected, errors.New("database unavailable"), "unable to load widgets")
+
+	got := LogError(ctx, logger, err)
+
+	require.Same(t, err, got)
+	require.True(t, err.SpanHandled())
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "ERROR", entries[0].Level)
+	require.Equal(t, "unable to load widgets", entries[0].Msg)
+	require.Equal(t, "unable to load widgets: database unavailable", entries[0].Error)
+	require.Equal(t, err.id, entries[0].ErrorID)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Equal(t, err.String(), spans[0].Status().Description)
+	require.Len(t, spans[0].Events(), 1)
+}
+
+func TestLogError_PreservesWrapperContextAroundShareableError(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	shareable := E(CodeUnexpected, errors.New("database unavailable"), "unable to load widgets")
+	err := fmt.Errorf("refresh dashboard: %w", shareable)
+
+	got := LogError(ctx, logger, err)
+
+	require.Same(t, err, got)
+	require.True(t, shareable.SpanHandled())
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, err.Error(), entries[0].Msg)
+	require.Equal(t, err.Error(), entries[0].Error)
+	require.Equal(t, shareable.id, entries[0].ErrorID)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, err.Error(), spans[0].Status().Description)
+	require.Len(t, spans[0].Events(), 1)
+}
+
+func TestLogError_ClientCancellationLogsAtInfoWithoutRecordingSpan(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+	err := fmt.Errorf("read request body: %w", context.Canceled)
+
+	got := LogError(ctx, logger, err)
+
+	require.Same(t, err, got)
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "INFO", entries[0].Level)
+	require.Equal(t, err.Error(), entries[0].Error)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+	require.Empty(t, spans[0].Events())
+}
+
+func TestLogError_CancellationWithLiveContextRemainsError(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	err := fmt.Errorf("errgroup sibling: %w", context.Canceled)
+
+	got := LogError(ctx, logger, err)
+
+	require.Same(t, err, got)
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "ERROR", entries[0].Level)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Len(t, spans[0].Events(), 1)
+}
+
+func TestLogWarn_LogsPlainErrorWithoutRecordingSpan(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	err := errors.New("invalid credentials")
+
+	got := LogWarn(ctx, logger, err)
+
+	require.Same(t, err, got)
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "WARN", entries[0].Level)
+	require.Equal(t, err.Error(), entries[0].Msg)
+	require.Equal(t, err.Error(), entries[0].Error)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+	require.Empty(t, spans[0].Events())
+}
+
+func TestLogWarn_ShareableClientCancellationLogsAtInfo(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+	err := E(CodeUnexpected, fmt.Errorf("read request body: %w", context.Canceled), "request canceled")
+
+	got := LogWarn(ctx, logger, err)
+
+	require.Same(t, err, got)
+	require.True(t, err.SpanHandled())
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "INFO", entries[0].Level)
+	require.Equal(t, err.id, entries[0].ErrorID)
+	require.Equal(t, err.String(), entries[0].Error)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+	require.Empty(t, spans[0].Events())
+}
+
+func TestLogErrorAndLogWarn_NilErrorDoNothing(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+
+	require.NoError(t, LogError(ctx, logger, nil))
+	require.NoError(t, LogWarn(ctx, logger, nil))
+	require.Empty(t, logBuf.String())
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+	require.Empty(t, spans[0].Events())
+}


### PR DESCRIPTION
## Summary

- add shared `LogError` and `LogWarn` helpers for arbitrary errors
- preserve `ShareableError` identifiers and detailed messages without dropping wrapper context
- demote client cancellations and keep warning-level errors off OpenTelemetry spans
- cover plain, shareable, wrapped, canceled, warning, and nil error behavior

## Verification

- `mise exec -- go test ./server/internal/oops`
- `mise lint:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `oops.LogError` and `oops.LogWarn` and wires span error handling into tracing to standardize error logging, avoid duplicate span errors, and keep client cancellations and warnings out of error-rate metrics.

- `oops.LogError`: logs at error and records once on the current span; client-initiated cancellations log at info and skip span recording.
- `oops.LogWarn`: logs at warn and never records on the span; cancellations log at info.
- `ShareableError`: preserves stable error ID, uses the public message when top-level, retains wrapper context otherwise, and marks span handled.
- Tracing middleware now calls `oops.WithSpanErrorHandling` and skips fallback span recording when `oops.SpanErrorHandled(ctx, err)` is true; a logged warning does not suppress a different returned error.
- Both helpers return the input error; nil errors are no-ops; logs include a detailed error message attribute.

<sup>Written for commit 494bb30ba90aa989879db09b665e507390308d07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

