### PR TITLE
fix(server): pin hook sessions to the chat's project

### DIFF
--- a/.changeset/hook-chat-project-pin.md
+++ b/.changeset/hook-chat-project-pin.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Hook ingest pins a session to the project that first created its chat, so a later request with a different project header cannot stamp messages onto that chat. Chat list counts and last-message times now ignore those sibling-project rows, matching the transcript the UI can actually load.

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -1066,3 +1066,44 @@ func TestListChats_Filter_Source_ExpandsAliases(t *testing.T) {
 	require.True(t, got[newStyle.String()], "expected claude-code chat in results")
 	require.True(t, got[legacy.String()], "expected legacy ClaudeCode chat in results")
 }
+
+func TestListChats_NumMessagesIgnoresOtherProjectRows(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+	r := repo.New(ti.conn)
+
+	chatID := seedChat(t, ctx, ti, "", "ext-drift", "drifted stamp chat")
+	early := time.Date(2026, 7, 16, 16, 20, 0, 0, time.UTC)
+	late := time.Date(2026, 7, 16, 21, 41, 0, 0, time.UTC)
+	_, err := r.SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: early, Valid: true},
+	})
+	require.NoError(t, err)
+	_, err = r.SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: early.Add(time.Minute), Valid: true},
+	})
+	require.NoError(t, err)
+
+	otherProject := createProjectInSameOrg(t, ti)
+	_, err = r.SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: otherProject, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: late, Valid: true},
+	})
+	require.NoError(t, err)
+
+	result, err := ti.service.ListChats(ctx, defaultPayload())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, chatID.String(), result.Chats[0].ID)
+	require.Equal(t, 2, result.Chats[0].NumMessages,
+		"list count must match the transcript, which filters project_id")
+	require.Equal(t, early.Add(time.Minute).Format(time.RFC3339), result.Chats[0].LastMessageTimestamp,
+		"a later sibling-project stamp must not move last_message_timestamp")
+}

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -562,6 +562,7 @@ candidate_chats AS (
         SELECT cmsrc.source
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
+          AND cmsrc.project_id = @project_id::uuid
           AND cmsrc.source IS NOT NULL
           AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
@@ -570,8 +571,10 @@ candidate_chats AS (
     )
 ),
 chat_activity AS (
-  -- Per-chat backward probe on chat_messages_chat_id_created_at_idx instead of
-  -- aggregating every candidate chat's full message history.
+  -- Per-chat backward probe on chat_messages_chat_id_project_id_created_at_idx
+  -- instead of aggregating every candidate chat's full message history.
+  -- project_id keeps a sibling-project stamp on the same chat_id from moving
+  -- the chat in the date-range filter.
   SELECT
     cc.id,
     COALESCE(last_msg.ts, cc.created_at) AS last_message_timestamp
@@ -580,6 +583,7 @@ chat_activity AS (
     SELECT MAX(cm.created_at) AS ts
     FROM chat_messages cm
     WHERE cm.chat_id = cc.id
+      AND cm.project_id = @project_id::uuid
   ) last_msg
 )
 SELECT COUNT(*) AS total
@@ -694,6 +698,7 @@ candidate_chats AS (
         SELECT cmsrc.source
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
+          AND cmsrc.project_id = @project_id::uuid
           AND cmsrc.source IS NOT NULL
           AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
@@ -702,8 +707,10 @@ candidate_chats AS (
     )
 ),
 chat_stats AS (
-  -- Per-chat probe on chat_messages_chat_id_created_at_idx (index-only count +
-  -- max) instead of aggregating every candidate chat's full message history.
+  -- Per-chat probe on chat_messages_chat_id_project_id_created_at_idx
+  -- (index-only count + max) instead of aggregating every candidate chat's
+  -- full message history. project_id keeps a sibling-project stamp on the
+  -- same chat_id from inflating num_messages or last_message_timestamp.
   SELECT
     cc.id,
     stats.num_messages,
@@ -716,6 +723,7 @@ chat_stats AS (
       MAX(cm.created_at) AS max_created_at
     FROM chat_messages cm
     WHERE cm.chat_id = cc.id
+      AND cm.project_id = @project_id::uuid
   ) stats
 ),
 filtered_chats AS (
@@ -748,7 +756,7 @@ limited_chats AS (
     fc.pinned_at,
     fc.litellm_proxied,
     fc.num_messages,
-    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
+    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND project_id = @project_id::uuid AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
     fc.last_message_timestamp,
     fc.account_type,
     fc.account_email,
@@ -786,6 +794,7 @@ chat_attribution AS (
       END
       FROM chat_messages
       WHERE chat_id = lc.id
+        AND project_id = @project_id::uuid
         AND source = 'litellm'
       ORDER BY created_at DESC
       LIMIT 1
@@ -831,16 +840,18 @@ FROM chat_attribution lc;
 -- agent-type filter options on the Agent Sessions page so the list reflects the
 -- sources actually present in the data rather than a hardcoded catalog.
 -- Driven from chats with a per-chat probe on
--- chat_messages_chat_id_created_at_source_idx for the latest non-empty source,
--- instead of sorting the project's entire message history. The lateral join
--- drops chats with no sourced messages, matching the previous inner-join
--- semantics.
+-- chat_messages_chat_id_project_id_created_at_source_idx for the latest
+-- non-empty source, instead of sorting the project's entire message history.
+-- The lateral join drops chats with no sourced messages, matching the previous
+-- inner-join semantics. project_id keeps a sibling-project stamp from
+-- advertising a source this project cannot load.
 SELECT DISTINCT latest.source
 FROM chats c
 CROSS JOIN LATERAL (
   SELECT cm.source
   FROM chat_messages cm
   WHERE cm.chat_id = c.id
+    AND cm.project_id = @project_id::uuid
     AND cm.source IS NOT NULL
     AND cm.source <> ''
   ORDER BY cm.created_at DESC
@@ -990,6 +1001,29 @@ LIMIT @lim::integer;
 -- message_capture_strategy.go.
 SELECT COUNT(*) FROM chat_messages
 WHERE chat_id = @chat_id AND project_id = @project_id::uuid;
+
+-- name: RestampMismatchedChatMessageProjects :execrows
+-- One-shot repair: copy chats.project_id onto chat_messages rows whose stamp
+-- drifted (or is NULL). Hook ingest used to accept any project header for a
+-- session-derived chat id, so a later request could file messages under a
+-- sibling project. Not project-scoped: every drifted row has to move, and the
+-- chat's project is the destination.
+UPDATE chat_messages cm
+SET project_id = c.project_id
+FROM chats c
+WHERE c.id = cm.chat_id
+  AND cm.project_id IS DISTINCT FROM c.project_id;
+
+-- name: CountChatMessagesWithMismatchedProject :one
+SELECT count(*)::bigint
+FROM chat_messages cm
+JOIN chats c ON c.id = cm.chat_id
+WHERE cm.project_id IS DISTINCT FROM c.project_id;
+
+-- name: CountChatMessagesWithNullProject :one
+SELECT count(*)::bigint
+FROM chat_messages
+WHERE project_id IS NULL;
 
 -- name: GetChatMessageStats :one
 -- Chat-wide aggregates (total message count + most recent message timestamp).
@@ -1447,7 +1481,7 @@ WHERE id IN (
     JOIN chat_messages cm ON crm.message_id = cm.id
     WHERE cr.chat_id = @chat_id
       AND cr.project_id = @project_id
-      AND cm.project_id = @project_id
+      AND cm.project_id = @project_id::uuid
       AND (cm.created_at, cm.seq) > (
         SELECT created_at, seq FROM chat_messages
         WHERE chat_messages.id = @after_message_id

--- a/server/internal/chat/queries_scoping_test.go
+++ b/server/internal/chat/queries_scoping_test.go
@@ -124,3 +124,57 @@ func TestQueries_GetMaxGenerationForChat_IsProjectScoped(t *testing.T) {
 	require.Equal(t, int32(0), genElsewhere,
 		"another project sees none of this chat's messages; dropping the project_id predicate would report 3")
 }
+
+func TestQueries_RestampMismatchedChatMessageProjects(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	r := repo.New(ti.conn)
+	ctx := initSessionCtx(t, ti)
+
+	chatID := seedChat(t, ctx, ti, "", "ext-user", "restamp session")
+	_, err := r.SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+
+	otherProject := createProjectInSameOrg(t, ti)
+	_, err = r.SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: otherProject, Valid: true},
+		CreatedAt: pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+	_, err = r.SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{},
+		CreatedAt: pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+
+	mismatched, err := r.CountChatMessagesWithMismatchedProject(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), mismatched)
+	nulls, err := r.CountChatMessagesWithNullProject(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), nulls)
+
+	n, err := r.RestampMismatchedChatMessageProjects(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), n)
+
+	mismatched, err = r.CountChatMessagesWithMismatchedProject(ctx)
+	require.NoError(t, err)
+	require.Zero(t, mismatched)
+	nulls, err = r.CountChatMessagesWithNullProject(ctx)
+	require.NoError(t, err)
+	require.Zero(t, nulls)
+
+	msgs, err := r.ListChatMessages(ctx, repo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: ti.projectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+}

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -93,6 +93,33 @@ func (q *Queries) CountChatMessages(ctx context.Context, arg CountChatMessagesPa
 	return count, err
 }
 
+const countChatMessagesWithMismatchedProject = `-- name: CountChatMessagesWithMismatchedProject :one
+SELECT count(*)::bigint
+FROM chat_messages cm
+JOIN chats c ON c.id = cm.chat_id
+WHERE cm.project_id IS DISTINCT FROM c.project_id
+`
+
+func (q *Queries) CountChatMessagesWithMismatchedProject(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, countChatMessagesWithMismatchedProject)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const countChatMessagesWithNullProject = `-- name: CountChatMessagesWithNullProject :one
+SELECT count(*)::bigint
+FROM chat_messages
+WHERE project_id IS NULL
+`
+
+func (q *Queries) CountChatMessagesWithNullProject(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, countChatMessagesWithNullProject)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const countChats = `-- name: CountChats :one
 WITH risk_counts AS (
   SELECT cm.chat_id, COUNT(*)::integer AS cnt
@@ -179,6 +206,7 @@ candidate_chats AS (
         SELECT cmsrc.source
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
+          AND cmsrc.project_id = $5::uuid
           AND cmsrc.source IS NOT NULL
           AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
@@ -187,8 +215,10 @@ candidate_chats AS (
     )
 ),
 chat_activity AS (
-  -- Per-chat backward probe on chat_messages_chat_id_created_at_idx instead of
-  -- aggregating every candidate chat's full message history.
+  -- Per-chat backward probe on chat_messages_chat_id_project_id_created_at_idx
+  -- instead of aggregating every candidate chat's full message history.
+  -- project_id keeps a sibling-project stamp on the same chat_id from moving
+  -- the chat in the date-range filter.
   SELECT
     cc.id,
     COALESCE(last_msg.ts, cc.created_at) AS last_message_timestamp
@@ -197,6 +227,7 @@ chat_activity AS (
     SELECT MAX(cm.created_at) AS ts
     FROM chat_messages cm
     WHERE cm.chat_id = cc.id
+      AND cm.project_id = $5::uuid
   ) last_msg
 )
 SELECT COUNT(*) AS total
@@ -602,7 +633,7 @@ WHERE id IN (
     JOIN chat_messages cm ON crm.message_id = cm.id
     WHERE cr.chat_id = $1
       AND cr.project_id = $2
-      AND cm.project_id = $2
+      AND cm.project_id = $2::uuid
       AND (cm.created_at, cm.seq) > (
         SELECT created_at, seq FROM chat_messages
         WHERE chat_messages.id = $3
@@ -1837,6 +1868,7 @@ CROSS JOIN LATERAL (
   SELECT cm.source
   FROM chat_messages cm
   WHERE cm.chat_id = c.id
+    AND cm.project_id = $1::uuid
     AND cm.source IS NOT NULL
     AND cm.source <> ''
   ORDER BY cm.created_at DESC
@@ -1871,10 +1903,11 @@ type ListChatSourcesParams struct {
 // agent-type filter options on the Agent Sessions page so the list reflects the
 // sources actually present in the data rather than a hardcoded catalog.
 // Driven from chats with a per-chat probe on
-// chat_messages_chat_id_created_at_source_idx for the latest non-empty source,
-// instead of sorting the project's entire message history. The lateral join
-// drops chats with no sourced messages, matching the previous inner-join
-// semantics.
+// chat_messages_chat_id_project_id_created_at_source_idx for the latest
+// non-empty source, instead of sorting the project's entire message history.
+// The lateral join drops chats with no sourced messages, matching the previous
+// inner-join semantics. project_id keeps a sibling-project stamp from
+// advertising a source this project cannot load.
 // Natively captured proxied sessions carry no litellm message rows (they are
 // suppressed as duplicates), so the LiteLLM filter option must also be offered
 // when any visible chat carries the chat-level proxied marker.
@@ -2098,6 +2131,7 @@ candidate_chats AS (
         SELECT cmsrc.source
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
+          AND cmsrc.project_id = $1::uuid
           AND cmsrc.source IS NOT NULL
           AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
@@ -2106,8 +2140,10 @@ candidate_chats AS (
     )
 ),
 chat_stats AS (
-  -- Per-chat probe on chat_messages_chat_id_created_at_idx (index-only count +
-  -- max) instead of aggregating every candidate chat's full message history.
+  -- Per-chat probe on chat_messages_chat_id_project_id_created_at_idx
+  -- (index-only count + max) instead of aggregating every candidate chat's
+  -- full message history. project_id keeps a sibling-project stamp on the
+  -- same chat_id from inflating num_messages or last_message_timestamp.
   SELECT
     cc.id,
     stats.num_messages,
@@ -2120,6 +2156,7 @@ chat_stats AS (
       MAX(cm.created_at) AS max_created_at
     FROM chat_messages cm
     WHERE cm.chat_id = cc.id
+      AND cm.project_id = $1::uuid
   ) stats
 ),
 filtered_chats AS (
@@ -2152,7 +2189,7 @@ limited_chats AS (
     fc.pinned_at,
     fc.litellm_proxied,
     fc.num_messages,
-    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
+    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND project_id = $1::uuid AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
     fc.last_message_timestamp,
     fc.account_type,
     fc.account_email,
@@ -2190,6 +2227,7 @@ chat_attribution AS (
       END
       FROM chat_messages
       WHERE chat_id = lc.id
+        AND project_id = $1::uuid
         AND source = 'litellm'
       ORDER BY created_at DESC
       LIMIT 1
@@ -2842,6 +2880,27 @@ func (q *Queries) RenameChat(ctx context.Context, arg RenameChatParams) error {
 		arg.ProjectID,
 	)
 	return err
+}
+
+const restampMismatchedChatMessageProjects = `-- name: RestampMismatchedChatMessageProjects :execrows
+UPDATE chat_messages cm
+SET project_id = c.project_id
+FROM chats c
+WHERE c.id = cm.chat_id
+  AND cm.project_id IS DISTINCT FROM c.project_id
+`
+
+// One-shot repair: copy chats.project_id onto chat_messages rows whose stamp
+// drifted (or is NULL). Hook ingest used to accept any project header for a
+// session-derived chat id, so a later request could file messages under a
+// sibling project. Not project-scoped: every drifted row has to move, and the
+// chat's project is the destination.
+func (q *Queries) RestampMismatchedChatMessageProjects(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, restampMismatchedChatMessageProjects)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const seedAssistant = `-- name: SeedAssistant :one

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -817,11 +817,25 @@ func (s *Service) persistHook(ctx context.Context, payload *gen.ClaudePayload, m
 
 	if isConversationEvent(payload.HookEventName) {
 		if err := s.persistConversationEvent(ctx, payload, metadata); err != nil {
-			s.logger.ErrorContext(ctx, "Failed to persist conversation event", attr.SlogError(err))
+			if errors.Is(err, errChatProjectMismatch) {
+				s.logger.WarnContext(ctx, "refusing to persist conversation event for a session bound to another project",
+					attr.SlogEvent("hooks_ingest_chat_project_mismatch"),
+					attr.SlogError(err),
+				)
+			} else {
+				s.logger.ErrorContext(ctx, "Failed to persist conversation event", attr.SlogError(err))
+			}
 		}
 	} else {
 		if err := s.persistToolCallEvent(ctx, payload, metadata); err != nil {
-			s.logger.ErrorContext(ctx, "Failed to persist tool call event", attr.SlogError(err))
+			if errors.Is(err, errChatProjectMismatch) {
+				s.logger.WarnContext(ctx, "refusing to persist tool call event for a session bound to another project",
+					attr.SlogEvent("hooks_ingest_chat_project_mismatch"),
+					attr.SlogError(err),
+				)
+			} else {
+				s.logger.ErrorContext(ctx, "Failed to persist tool call event", attr.SlogError(err))
+			}
 		}
 	}
 }

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -996,8 +997,14 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 	s.writeCanonicalTelemetry(ctx, payload, authCtx, &metadata, hookSource, timestamp, blockReason)
 	promptCaptured, err := s.persistCanonicalConversationEvent(ctx, payload, authCtx, &metadata, hookSource, timestamp)
 	if err != nil {
-		s.logger.WarnContext(ctx, "failed to persist canonical hook conversation event",
-			attr.SlogEvent("hooks_ingest_chat_persist_failed"),
+		event := "hooks_ingest_chat_persist_failed"
+		msg := "failed to persist canonical hook conversation event"
+		if errors.Is(err, errChatProjectMismatch) {
+			event = "hooks_ingest_chat_project_mismatch"
+			msg = "refusing to persist hook conversation event for a session bound to another project"
+		}
+		s.logger.WarnContext(ctx, msg,
+			attr.SlogEvent(event),
 			attr.SlogError(err),
 			attr.SlogHookSource(payload.Source.Adapter),
 			attr.SlogHookEvent(payload.Event.Type),
@@ -1008,8 +1015,14 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 		s.markNativePromptSession(ctx, authCtx.ProjectID.String(), canonicalSessionID(payload), payload.Source.Adapter)
 	}
 	if err := s.persistPromptAttachments(ctx, payload, authCtx, &metadata, timestamp); err != nil {
-		s.logger.WarnContext(ctx, "failed to persist prompt attachments",
-			attr.SlogEvent("hooks_ingest_prompt_attachment_persist_failed"),
+		event := "hooks_ingest_prompt_attachment_persist_failed"
+		msg := "failed to persist prompt attachments"
+		if errors.Is(err, errChatProjectMismatch) {
+			event = "hooks_ingest_chat_project_mismatch"
+			msg = "refusing to persist prompt attachments for a session bound to another project"
+		}
+		s.logger.WarnContext(ctx, msg,
+			attr.SlogEvent(event),
 			attr.SlogError(err),
 			attr.SlogHookSource(payload.Source.Adapter),
 			attr.SlogHookEvent(payload.Event.Type),
@@ -1713,6 +1726,10 @@ func (s *Service) persistPromptAttachments(ctx context.Context, payload *gen.Ing
 		return nil
 	}
 
+	if err := s.ensureHookChat(ctx, s.repo, metadata, chatID, projectID, canonicalChatTitle(payload, "")); err != nil {
+		return err
+	}
+
 	contents := make([][]byte, len(pending))
 	for i := range pending {
 		contents[i] = pending[i].content
@@ -1743,17 +1760,8 @@ func (s *Service) persistPromptAttachments(ctx context.Context, payload *gen.Ing
 	} else if !isForeignKeyViolation(err) {
 		return fmt.Errorf("insert prompt attachment content parts: %w", err)
 	}
-	_, upsertErr := s.repo.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
-		ID:             chatID,
-		ProjectID:      projectID,
-		OrganizationID: metadata.GramOrgID,
-		UserID:         conv.ToPGTextEmpty(metadata.UserID),
-		ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
-		UserAccountID:  conv.StringToNullUUID(metadata.UserAccountID),
-		Title:          conv.ToPGText(canonicalChatTitle(payload, "")),
-	})
-	if upsertErr != nil {
-		return fmt.Errorf("upsert claude code session for prompt attachments: %w", upsertErr)
+	if err := s.ensureHookChat(ctx, s.repo, metadata, chatID, projectID, canonicalChatTitle(payload, "")); err != nil {
+		return fmt.Errorf("upsert claude code session for prompt attachments: %w", err)
 	}
 	if _, err := queries.CreateChatContentPart(ctx, rows); err != nil {
 		return fmt.Errorf("insert prompt attachment content parts after creating chat: %w", err)

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -127,6 +127,15 @@ FROM skill_observations
 WHERE project_id = @project_id
 ORDER BY seen_at ASC, id ASC;
 
+-- name: GetChatProjectID :one
+-- Looks up a chat by id alone so hook ingest can refuse a write whose session
+-- already lives in another project. Session ids hash to chat ids with no
+-- project in the derivation, and an org-scoped key can present any project
+-- header in the org.
+SELECT project_id
+FROM chats
+WHERE id = @id;
+
 -- name: UpsertClaudeCodeSession :one
 INSERT INTO chats (
     id
@@ -150,9 +159,15 @@ VALUES (
     NOW(),
     NOW()
 )
+-- The conflict target is the bare primary key, so a later hook request for
+-- the same session with a different project header would otherwise land on
+-- that row, bump updated_at, and RETURNING would hand the caller an id that
+-- then accepts messages stamped with the new project. Rejecting the conflict
+-- yields no row.
 ON CONFLICT (id) DO UPDATE SET
     updated_at = NOW()
   , user_account_id = COALESCE(EXCLUDED.user_account_id, chats.user_account_id)
+WHERE chats.project_id = EXCLUDED.project_id
 RETURNING id;
 
 -- name: UpdateClaudeCodeSessionTimestamp :exec

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -129,6 +129,23 @@ func (q *Queries) FindAssistantToolCallMessageID(ctx context.Context, arg FindAs
 	return id, err
 }
 
+const getChatProjectID = `-- name: GetChatProjectID :one
+SELECT project_id
+FROM chats
+WHERE id = $1
+`
+
+// Looks up a chat by id alone so hook ingest can refuse a write whose session
+// already lives in another project. Session ids hash to chat ids with no
+// project in the derivation, and an org-scoped key can present any project
+// header in the org.
+func (q *Queries) GetChatProjectID(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, getChatProjectID, id)
+	var project_id uuid.UUID
+	err := row.Scan(&project_id)
+	return project_id, err
+}
+
 const getDeviceOwner = `-- name: GetDeviceOwner :one
 SELECT id, organization_id, provider, device_id, linked_user_id, first_seen_at, last_seen_at, created_at, updated_at, deleted_at, deleted FROM device_owners
 WHERE organization_id = $1
@@ -773,6 +790,7 @@ VALUES (
 ON CONFLICT (id) DO UPDATE SET
     updated_at = NOW()
   , user_account_id = COALESCE(EXCLUDED.user_account_id, chats.user_account_id)
+WHERE chats.project_id = EXCLUDED.project_id
 RETURNING id
 `
 
@@ -786,6 +804,11 @@ type UpsertClaudeCodeSessionParams struct {
 	Title          pgtype.Text
 }
 
+// The conflict target is the bare primary key, so a later hook request for
+// the same session with a different project header would otherwise land on
+// that row, bump updated_at, and RETURNING would hand the caller an id that
+// then accepts messages stamped with the new project. Rejecting the conflict
+// yields no row.
 func (q *Queries) UpsertClaudeCodeSession(ctx context.Context, arg UpsertClaudeCodeSessionParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, upsertClaudeCodeSession,
 		arg.ID,

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -30,6 +30,12 @@ import (
 // ErrChatNotFound indicates the chat (conversation) does not exist.
 var ErrChatNotFound = errors.New("chat not found")
 
+// errChatProjectMismatch is returned when a hook write names a chat that
+// already exists under a different project. Session ids hash to chat ids with
+// no project in the derivation, so an org-scoped key can otherwise stamp
+// messages onto a sibling project's chat.
+var errChatProjectMismatch = errors.New("chat belongs to another project")
+
 // isForeignKeyViolation checks if the error is a PostgreSQL foreign key constraint violation.
 // This indicates that the referenced chat does not exist.
 func isForeignKeyViolation(err error) bool {
@@ -38,6 +44,47 @@ func isForeignKeyViolation(err error) bool {
 		return pgErr.Code == pgerrcode.ForeignKeyViolation
 	}
 	return false
+}
+
+func (s *Service) ensureHookChat(
+	ctx context.Context,
+	queries *repo.Queries,
+	metadata *SessionMetadata,
+	chatID uuid.UUID,
+	projectID uuid.UUID,
+	title string,
+) error {
+	if queries == nil {
+		queries = s.repo
+	}
+
+	existing, err := queries.GetChatProjectID(ctx, chatID)
+	switch {
+	case err == nil:
+		if existing != projectID {
+			return errChatProjectMismatch
+		}
+		return nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return fmt.Errorf("get chat project: %w", err)
+	}
+
+	_, err = queries.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID:             chatID,
+		ProjectID:      projectID,
+		OrganizationID: metadata.GramOrgID,
+		UserID:         conv.ToPGTextEmpty(metadata.UserID),
+		ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
+		UserAccountID:  conv.StringToNullUUID(metadata.UserAccountID),
+		Title:          conv.ToPGText(title),
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return errChatProjectMismatch
+	case err != nil:
+		return fmt.Errorf("upsert claude code session: %w", err)
+	}
+	return nil
 }
 
 // isConversationEvent returns true if the event is a conversation capture event (not a tool call).
@@ -390,7 +437,12 @@ func (s *Service) insertMessageWithFallbackUpsertResult(
 		return n, nil
 	}
 
-	// Try to insert the message (the writer handles notification on success).
+	// Pin the session to this project (or create the chat) before writing so a
+	// sibling-project header cannot stamp messages onto an existing chat.
+	if err := s.ensureHookChat(ctx, s.repo, metadata, chatID, projectID, defaultTitle); err != nil {
+		return false, err
+	}
+
 	n, err := writeMessage()
 	if err == nil {
 		return n > 0, nil
@@ -401,18 +453,10 @@ func (s *Service) insertMessageWithFallbackUpsertResult(
 		return false, fmt.Errorf("insert chat message: %w", err)
 	}
 
-	// Create the chat and retry.
-	_, upsertErr := s.repo.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
-		ID:             chatID,
-		ProjectID:      projectID,
-		OrganizationID: metadata.GramOrgID,
-		UserID:         conv.ToPGTextEmpty(metadata.UserID),
-		ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
-		UserAccountID:  conv.StringToNullUUID(metadata.UserAccountID),
-		Title:          conv.ToPGText(defaultTitle),
-	})
-	if upsertErr != nil {
-		return false, fmt.Errorf("upsert claude code session after FK violation: %w", upsertErr)
+	// Create the chat and retry. A concurrent first-writer in another project
+	// loses here the same way UpsertChat does: no returned row.
+	if err := s.ensureHookChat(ctx, s.repo, metadata, chatID, projectID, defaultTitle); err != nil {
+		return false, fmt.Errorf("upsert claude code session after FK violation: %w", err)
 	}
 
 	n, err = writeMessage()
@@ -520,17 +564,8 @@ func (s *Service) insertUncorrelatedAgentPrompt(
 	// lock, keep both rows rather than guessing from prompt text and losing or
 	// misattributing a legitimate repeated native turn.
 
-	_, err = repo.New(tx).UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
-		ID:             msgParams.ChatID,
-		ProjectID:      projectID,
-		OrganizationID: metadata.GramOrgID,
-		UserID:         conv.ToPGTextEmpty(metadata.UserID),
-		ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
-		UserAccountID:  conv.StringToNullUUID(metadata.UserAccountID),
-		Title:          conv.ToPGText(defaultTitle),
-	})
-	if err != nil {
-		return false, fmt.Errorf("upsert claude code session: %w", err)
+	if err := s.ensureHookChat(ctx, repo.New(tx), metadata, msgParams.ChatID, projectID, defaultTitle); err != nil {
+		return false, err
 	}
 	params := []chatRepo.CreateChatMessageParams{msgParams}
 	n, err := s.writer.WriteInTx(ctx, tx, params)

--- a/server/internal/hooks/session_capture_test.go
+++ b/server/internal/hooks/session_capture_test.go
@@ -6,14 +6,18 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/hookevents"
+	"github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -516,4 +520,171 @@ func TestClaudeSessionEndDoesNotWakeBeforeTranscriptPersistence(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resolved)
 	require.Empty(t, ti.efficacySignals.signaled(), "durable observations, messages, and the sweep provide later wakes")
+}
+
+func TestUpsertClaudeCodeSession_RejectsForeignProject(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	otherProject, err := projectsrepo.New(ti.conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "hook-alt-project",
+		Slug:           "hook-alt-" + uuid.NewString()[:8],
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+
+	chatID := uuid.New()
+	hooksQueries := repo.New(ti.conn)
+	_, err = hooksQueries.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID:             chatID,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGTextEmpty(""),
+		ExternalUserID: conv.ToPGTextEmpty(""),
+		UserAccountID:  uuid.NullUUID{},
+		Title:          conv.ToPGText("original"),
+	})
+	require.NoError(t, err)
+
+	_, err = hooksQueries.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID:             chatID,
+		ProjectID:      otherProject.ID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGTextEmpty("attacker"),
+		ExternalUserID: conv.ToPGTextEmpty(""),
+		UserAccountID:  uuid.NullUUID{},
+		Title:          conv.ToPGText("hijacked"),
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	got, err := hooksQueries.GetChatProjectID(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, *authCtx.ProjectID, got)
+}
+
+func TestPersistConversationEvent_RejectsCrossProjectSession(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	otherProject, err := projectsrepo.New(ti.conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "hook-alt-session",
+		Slug:           "hook-alt-session-" + uuid.NewString()[:8],
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+
+	sessionID := uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+	const wantUserID = "cross-project-session-user"
+	const wantUserEmail = "cross-project@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, wantUserID, wantUserEmail)
+
+	metadata := &SessionMetadata{
+		SessionID:     sessionID,
+		ServiceName:   "claude-code",
+		UserEmail:     wantUserEmail,
+		UserID:        wantUserID,
+		ExternalOrgID: "",
+		GramOrgID:     authCtx.ActiveOrganizationID,
+		ProjectID:     authCtx.ProjectID.String(),
+	}
+	prompt := "first prompt"
+	require.NoError(t, ti.service.persistConversationEvent(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		Prompt:        &prompt,
+	}, metadata))
+
+	otherMetadata := *metadata
+	otherMetadata.ProjectID = otherProject.ID.String()
+	later := "should not land"
+	err = ti.service.persistConversationEvent(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		Prompt:        &later,
+	}, &otherMetadata)
+	require.ErrorIs(t, err, errChatProjectMismatch)
+
+	own, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, own, 1)
+	require.Equal(t, "first prompt", own[0].Content)
+
+	foreign, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: otherProject.ID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, foreign)
+
+	got, err := repo.New(ti.conn).GetChatProjectID(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, *authCtx.ProjectID, got)
+}
+
+func TestIngest_DoesNotMisfileChatIntoSiblingProject(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	otherProject, err := projectsrepo.New(ti.conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "hook-ingest-alt",
+		Slug:           "hook-ingest-alt-" + uuid.NewString()[:8],
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+
+	sessionID := "cross-project-ingest-" + uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+	prompt := "owned prompt"
+	payload := canonicalIngestPayload("claude", "prompt.submitted", sessionID)
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &prompt},
+	}
+	res, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", res.Decision)
+
+	nextAuth := *authCtx
+	nextAuth.ProjectID = &otherProject.ID
+	nextAuth.ProjectSlug = &otherProject.Slug
+	otherCtx := contextvalues.SetAuthContext(ctx, &nextAuth)
+	foreignPrompt := "sibling project prompt"
+	foreignPayload := canonicalIngestPayload("claude", "prompt.submitted", sessionID)
+	foreignPayload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &foreignPrompt},
+	}
+	res, err = ti.service.Ingest(otherCtx, foreignPayload)
+	require.NoError(t, err, "ingest stays non-blocking; the write is what must fail")
+	require.Equal(t, "allow", res.Decision)
+
+	own, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, own, 1)
+	require.Equal(t, "owned prompt", own[0].Content)
+
+	foreign, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: otherProject.ID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, foreign)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes DNO-810 (write-path + listing count). Merge #5240 first so listing stays index-only once the new `project_id` predicates are live.

## Problem

Hook ingest derived `chats.id` from the agent session id and stamped `chat_messages.project_id` from the request's project header independently. An org-scoped key can present any project in the org, so a later event for the same session filed messages under a sibling project. Those rows never render (`ListChatMessages` filters both ids) while the chat list counted them (`chat_id` only), so `num_messages` could exceed the transcript.

## Fix

- `UpsertClaudeCodeSession` now rejects a conflict whose stored `project_id` differs (same fence as `UpsertChat`).
- Hook message/attachment writes call `ensureHookChat` first: create the chat on miss, refuse a sibling-project stamp. Ingest stays non-blocking; the write is what fails (logged as `hooks_ingest_chat_project_mismatch`).
- List/count/source probes on `chat_messages` filter `project_id` so `num_messages` and `last_message_timestamp` match the rendered transcript.
- `RestampMismatchedChatMessageProjects` copies `chats.project_id` onto drifted or null message rows. Run this against prod after the write guard is live and before adding a composite FK / `NOT NULL`.

## Tests

- Cross-project `UpsertClaudeCodeSession` returns no row.
- Legacy persist and canonical ingest cannot file a second project's messages onto an existing session.
- List `num_messages` / last-message time ignore sibling-project stamps.
- Restamp clears mismatched and null `project_id` rows.

## Follow-ups (not in this PR)

- Index migration: #5240 extends listing indexes to `(chat_id, project_id, created_at)` so p95 stays flat. Merge that first.
- After restamp: unique `(id, project_id)` on `chats` (also in #5240), composite FK from `chat_messages`, `project_id NOT NULL`. Keep the redundant read-path `project_id` filters.
- Session-id derivation stays unsalted (namespace is fixed).

## Restamp

After deploy, from a one-shot against Postgres (dry-run the counts first):

```sql
SELECT count(*) FROM chat_messages cm
JOIN chats c ON c.id = cm.chat_id
WHERE cm.project_id IS DISTINCT FROM c.project_id;

SELECT count(*) FROM chat_messages WHERE project_id IS NULL;
```

Then the generated `RestampMismatchedChatMessageProjects` query, and re-check both counts are 0. Do not put this DML in a schema migration.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-810](https://linear.app/speakeasy/issue/DNO-810/hook-ingest-misfiles-chat-messages-into-the-wrong-project-chat-lists)

<div><a href="https://cursor.com/agents/bc-b3100023-cc6d-49f7-8987-922ad16c088f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3100023-cc6d-49f7-8987-922ad16c088f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins hook-ingest sessions to the chat’s project and scopes chat-list stats by project to prevent cross-project misfiling (DNO-810). Previously, later events could stamp messages under a sibling project; now writes to a session bound to another project are refused, and list counts/timestamps match the transcript the project can load.

**Review and rollout**
- Write guard: Upserts reject conflicts with a different project; hook writes call a chat check/create first and return a project-mismatch error on cross-project attempts. Ingest remains allow; persistence logs with event "hooks_ingest_chat_project_mismatch".
- Read scoping: Chat list/count/source probes add project_id predicates so num_messages and last_message_timestamp ignore sibling-project rows.
- Required before or with this change: deploy the companion index migration extending chat_messages indexes to include (chat_id, project_id, created_at) and (chat_id, project_id, created_at, source) to keep probes index-only.
- Required after deploy: run the one-shot restamp to copy chats.project_id onto drifted/null chat_messages rows, then verify mismatch and null counts drop to zero. Do not place this DML in a schema migration.

<sup>Written for commit f6b49c1aebc43342ebc5b249950f63388a427eeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

