### PR TITLE
mig: add project_id to chat_messages listing indexes

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2069,6 +2069,12 @@ WHERE external_chat_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS chats_project_id_idx
 ON chats (project_id);
 
+-- FK target for a future chat_messages (chat_id, project_id) composite
+-- foreign key. id is already unique (PK); this index exists so a child can
+-- pin both columns without a table-level UNIQUE constraint.
+CREATE UNIQUE INDEX IF NOT EXISTS chats_id_project_id_key
+ON chats (id, project_id);
+
 CREATE TABLE IF NOT EXISTS assistants (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,
@@ -2445,10 +2451,24 @@ ON chat_messages (chat_id, generation, created_at, seq);
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_created_at_idx
 ON chat_messages (chat_id, created_at);
 
+-- Same listing probes with project_id so a count that filters to this
+-- project's rows stays index-only. The (chat_id, created_at) index above
+-- stays until a later contract migration after listing queries have moved
+-- onto this one.
+CREATE INDEX IF NOT EXISTS chat_messages_chat_id_project_id_created_at_idx
+ON chat_messages (chat_id, project_id, created_at);
+
 -- Latest non-empty source per chat as a single index-only probe (agent-type
 -- filter options via chats.listSources and the source filter on chats.list).
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_created_at_source_idx
 ON chat_messages (chat_id, created_at) INCLUDE (source)
+WHERE source IS NOT NULL AND source <> '';
+
+-- Source probe with project_id so a sibling-project stamp cannot advertise a
+-- source this project cannot load. Kept alongside the (chat_id, created_at)
+-- source index until listing queries have moved onto this one.
+CREATE INDEX IF NOT EXISTS chat_messages_chat_id_project_id_created_at_source_idx
+ON chat_messages (chat_id, project_id, created_at) INCLUDE (source)
 WHERE source IS NOT NULL AND source <> '';
 CREATE INDEX IF NOT EXISTS chat_messages_project_id_id_idx
 ON chat_messages (project_id, id)

--- a/server/migrations/20260813162334_chat-messages-project-listing-idx.sql
+++ b/server/migrations/20260813162334_chat-messages-project-listing-idx.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Create index "chat_messages_chat_id_project_id_created_at_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_chat_id_project_id_created_at_idx" ON "chat_messages" ("chat_id", "project_id", "created_at");
+-- Create index "chat_messages_chat_id_project_id_created_at_source_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_chat_id_project_id_created_at_source_idx" ON "chat_messages" ("chat_id", "project_id", "created_at") INCLUDE ("source") WHERE ((source IS NOT NULL) AND (source <> ''::text));
+-- Create index "chats_id_project_id_key" to table: "chats"
+CREATE UNIQUE INDEX CONCURRENTLY "chats_id_project_id_key" ON "chats" ("id", "project_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:CwwiHa4t2ZJQhlRi9iAlUpnjtlnFrHLTOgvXPCoMSd0=
+h1:iCl0J6o9Njam6QdNH6T+BDdo4C8JV0t9x8Laj6/7S3I=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -339,3 +339,4 @@ h1:CwwiHa4t2ZJQhlRi9iAlUpnjtlnFrHLTOgvXPCoMSd0=
 20260813104734_assistant-thread-events-trigger-idx.sql h1:25W52A5j1pRb6MmqC970tKXtnSatjdMovordpgUn8Gs=
 20260813140026_assistant-thread-events-trigger-instance-fkey-idx.sql h1:HOy5z8JXCh3rl8qfgYX7YXepyH8o4vezsEDruYeIT98=
 20260813150000_user-sessions-tool-selection.sql h1:6l17RI8mPHjZDTtBoUDL+EDSTouOLhTEhgWK0COmOz0=
+20260813162334_chat-messages-project-listing-idx.sql h1:S6w0TjA1PgZJ9AUJhYoYgW9BJ1d2bd0Zufp82IHJ2tM=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes part of DNO-810 (listing p95). Pair with #5239, which adds `project_id` predicates to the chat.list stats/source probes. Merge this first so those probes stay index-only.

## Change

Expand-only concurrent indexes:

- `chat_messages (chat_id, project_id, created_at)` — listing `num_messages` / `last_message_timestamp` probes
- `chat_messages (chat_id, project_id, created_at) INCLUDE (source)` where source is non-empty — listSources / source filter
- unique `chats (id, project_id)` — FK target for a later composite `(chat_id, project_id)` on `chat_messages`

The existing `(chat_id, created_at)` indexes stay until a contract migration after #5239 is live. No DML, no `NOT NULL`, no composite FK (those wait on the message restamp in #5239).

## Locking

`CREATE INDEX CONCURRENTLY` with `-- atlas:txmode none`. `chat_messages` is large and hot; a non-concurrent build would block writes.

PG305/PG306 do not apply (no CHECK/FK added).

## Follow-up

After #5239 is deployed and `RestampMismatchedChatMessageProjects` has run in prod (mismatched and null `project_id` counts are 0): drop the old listing indexes, add the composite FK, and make `chat_messages.project_id NOT NULL`. Keep the redundant read-path `project_id` filters.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-810](https://linear.app/speakeasy/issue/DNO-810/hook-ingest-misfiles-chat-messages-into-the-wrong-project-chat-lists)

<div><a href="https://cursor.com/agents/bc-b3100023-cc6d-49f7-8987-922ad16c088f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3100023-cc6d-49f7-8987-922ad16c088f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds composite `chat_messages` indexes that include `project_id` and a unique `chats (id, project_id)` index to keep `chat.list` listing and source probes index-only when filtering by project. This supports DNO-810 p95 goals without changing query behavior yet.

**Review and rollout**
- New indexes: `(chat_id, project_id, created_at)` and `(chat_id, project_id, created_at) INCLUDE (source) WHERE source <> ''`. Existing `(chat_id, created_at)` indexes remain until a follow-up.
- Adds unique `chats (id, project_id)` to prep a future `(chat_id, project_id)` FK from `chat_messages`.
- Built with `CREATE INDEX CONCURRENTLY` (`-- atlas:txmode none`), so no write locks.
- Merge before #5239 so stats/source probes stay index-only. Later, after #5239 and the restamp job report zero mismatches: drop the old `(chat_id, created_at)` indexes, add the composite FK, and set `chat_messages.project_id` NOT NULL.

<sup>Written for commit 2bebe92b6f80d343abab368dafbc2ae419cf8511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

