### PR TITLE
fix: reject post-login redirect targets that name another origin

### DIFF
--- a/.changeset/sparkly-crabs-attack.md
+++ b/.changeset/sparkly-crabs-attack.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Reject post-login redirect targets that a browser could read as another origin.

--- a/server/internal/admin/oauth.go
+++ b/server/internal/admin/oauth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -48,12 +49,19 @@ func pkceChallenge(verifier string) string {
 }
 
 // sanitizeReturnTo ensures the post-login redirect target is safe.
-// Relative paths are allowed unconditionally. Absolute URLs are allowed only
-// when their origin (scheme + "://" + host) appears in allowedOrigins, which
-// prevents open-redirect abuse while still allowing the Registry admin SPA
-// (a different domain) to be the post-auth landing page.
+// Relative paths are allowed as long as they cannot be read as naming another
+// origin. Absolute URLs are allowed only when their origin (scheme + "://" +
+// host) appears in allowedOrigins, which prevents open-redirect abuse while
+// still allowing the Registry admin SPA (a different domain) to be the
+// post-auth landing page.
 func sanitizeReturnTo(raw, fallback string, allowedOrigins []string) string {
 	if raw == "" {
+		return fallback
+	}
+	// A browser reads an unescaped backslash as a slash, so "/\evil.com" is a
+	// host to it and a literal path to url.Parse. A value that means two
+	// different things is not one worth honoring.
+	if strings.Contains(raw, `\`) {
 		return fallback
 	}
 	u, err := url.Parse(raw)
@@ -61,8 +69,11 @@ func sanitizeReturnTo(raw, fallback string, allowedOrigins []string) string {
 		return fallback
 	}
 	if u.Scheme == "" && u.Host == "" {
-		// Relative path — allow as long as there is a path.
-		if u.Path == "" {
+		// Relative path — allow as long as it is rooted at exactly one slash.
+		// url.Parse leaves "///evil.com" as a path, but a browser skips the extra
+		// slashes while looking for an authority and lands on evil.com.
+		path := u.EscapedPath()
+		if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
 			return fallback
 		}
 		return u.String()

--- a/server/internal/admin/oauth_test.go
+++ b/server/internal/admin/oauth_test.go
@@ -78,6 +78,36 @@ func TestSanitizeReturnTo(t *testing.T) {
 			want:           fallback,
 		},
 		{
+			name:           "protocol-relative url with an extra slash falls back",
+			raw:            "///evil.example.com/steal",
+			allowedOrigins: []string{"https://admin.example.com"},
+			want:           fallback,
+		},
+		{
+			name:           "protocol-relative url with many slashes falls back",
+			raw:            "////evil.example.com/steal",
+			allowedOrigins: []string{"https://admin.example.com"},
+			want:           fallback,
+		},
+		{
+			name:           "backslash authority falls back",
+			raw:            `/\evil.example.com/steal`,
+			allowedOrigins: []string{"https://admin.example.com"},
+			want:           fallback,
+		},
+		{
+			name:           "bare host falls back",
+			raw:            "evil.example.com/steal",
+			allowedOrigins: []string{"https://admin.example.com"},
+			want:           fallback,
+		},
+		{
+			name:           "allowed host in userinfo falls back",
+			raw:            "https://admin.example.com@evil.example.com/steal",
+			allowedOrigins: []string{"https://admin.example.com"},
+			want:           fallback,
+		},
+		{
 			name:           "path-less input falls back",
 			raw:            "?tab=members",
 			allowedOrigins: nil,

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -64,7 +64,7 @@ func TestService_Callback(t *testing.T) {
 			require.NoError(t, instance.createTestOrganization(ctx, org, userInfo.UserID))
 		}
 
-		redirectURL := "https://dev.getgram.ai/other-org/projects/default"
+		redirectURL := "http://localhost:3000/other-org/projects/default"
 		ctx, stateParam := instance.stateWithNonce(ctx, t, redirectURL)
 
 		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
@@ -194,7 +194,7 @@ func TestService_Callback(t *testing.T) {
 
 		// Set admin override to one org, but state param points to a different org.
 		ctx = contextvalues.SetAdminOverrideInContext(ctx, "override-org")
-		redirectURL := "https://dev.getgram.ai/state-org/projects/default"
+		redirectURL := "http://localhost:3000/state-org/projects/default"
 		ctx, stateParam := instance.stateWithNonce(ctx, t, redirectURL)
 
 		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
@@ -249,7 +249,7 @@ func TestService_Callback(t *testing.T) {
 		}
 
 		// State param points to state-target org, IDP selected idp-selected org.
-		redirectURL := "https://dev.getgram.ai/state-target/projects/default"
+		redirectURL := "http://localhost:3000/state-target/projects/default"
 		ctx, stateParam := instance.stateWithNonce(ctx, t, redirectURL)
 
 		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
@@ -287,7 +287,7 @@ func TestService_Callback(t *testing.T) {
 		}, ""))
 
 		// State param points to the non-member customer org (e.g. link from registry).
-		redirectURL := "https://dev.getgram.ai/customer-registry/projects/default"
+		redirectURL := "http://localhost:3000/customer-registry/projects/default"
 		ctx, stateParam := instance.stateWithNonce(ctx, t, redirectURL)
 
 		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
@@ -522,6 +522,38 @@ func TestService_Callback(t *testing.T) {
 
 		require.Equal(t, "/dashboard/projects/my-project", result.Location)
 		require.NotEmpty(t, result.SessionToken)
+	})
+
+	t.Run("callback refuses a state destination that leaves the dashboard origin", func(t *testing.T) {
+		t.Parallel()
+
+		// The state param is not signed, so an attacker can hand the callback any
+		// destination directly — this is the check the browser ultimately depends
+		// on. AIS-428 covered the first case: browsers read the leading "/\" as
+		// "//" and treat the rest as a host.
+		for _, redirectURL := range []string{
+			`/\attacker.example.net`,
+			`/\/attacker.example.net`,
+			"//attacker.example.net/phish",
+			"///attacker.example.net",
+			"https://attacker.example.net/phish",
+			"http://localhost:3000@attacker.example.net/",
+			"attacker.example.net",
+		} {
+			userInfo := defaultMockUserInfo()
+			ctx, instance := newTestAuthService(t, userInfo)
+
+			ctx, stateParam := instance.stateWithNonce(ctx, t, redirectURL)
+			result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
+				Code:  "mock_code",
+				State: &stateParam,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			require.Equal(t, instance.authConfigs.SignInRedirectURL, result.Location, "redirect %q must fall back to the sign-in URL", redirectURL)
+			require.NotEmpty(t, result.SessionToken)
+		}
 	})
 
 	t.Run("callback with complex state URL redirects correctly", func(t *testing.T) {

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -122,6 +122,11 @@ type Service struct {
 	trialBundleSeeder   EnterpriseTrialBundleSeeder
 	auditLogger         *audit.Logger
 	trialNotifier       trialemails.Notifier
+
+	// siteOrigin is the dashboard's "scheme://host", derived from
+	// cfg.SignInRedirectURL. It is the one absolute origin a post-login redirect
+	// target is allowed to name.
+	siteOrigin string
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -169,6 +174,7 @@ func NewService(
 		trialBundleSeeder:   trialBundleSeeder,
 		auditLogger:         auditLogger,
 		trialNotifier:       trialNotifier,
+		siteOrigin:          parseSiteOrigin(cfg.SignInRedirectURL),
 	}
 }
 
@@ -366,7 +372,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 			}, nil
 		}
 
-		if dispositionFromState(payload) == dispositionAssistants {
+		if s.dispositionFromState(payload) == dispositionAssistants {
 			location, err := s.autoProvisionForAssistants(ctx, userInfo, &session)
 			if err != nil {
 				return redirectWithError(authErrInit, err)
@@ -409,11 +415,11 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 	// First try the user's own orgs; for admins, fall back to a DB lookup
 	// since they may access orgs they aren't a member of.
 	if !activeOrgSelected {
-		if org, ok := activeOrganizationFromState(payload, userInfo.Organizations); ok {
+		if org, ok := s.activeOrganizationFromState(payload, userInfo.Organizations); ok {
 			activeOrgID = org.ID
 			activeOrgSelected = true
 		} else if userInfo.Admin {
-			if slug := organizationSlugFromState(payload); slug != "" {
+			if slug := s.organizationSlugFromState(payload); slug != "" {
 				if orgMeta, err := s.orgRepo.GetOrganizationMetadataBySlug(ctx, slug); err == nil {
 					activeOrgID = orgMeta.ID
 					activeOrgSelected = true
@@ -562,7 +568,13 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 		}
 	}
 
-	state := encodeStateParam(payload, nonce)
+	// Only a same-origin destination is worth carrying through the identity
+	// provider and back out into a Location header. Sanitizing here keeps a
+	// hostile value out of the state param altogether, rather than minting one
+	// and relying on the callback to disarm it later.
+	destination := safeRedirectPath(conv.PtrValOr(payload.Redirect, ""), s.siteOrigin)
+
+	state := encodeStateParam(destination, nonce)
 
 	// The company name is what marks a login as having begun on /sign-up, so it
 	// alone selects AuthKit's sign-up screen. Keeping one signal authoritative
@@ -593,18 +605,18 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 
 // organizationSlugFromState extracts the org slug from the state param's
 // final destination URL. Returns "" if the state is missing or has no org slug.
-func organizationSlugFromState(payload *gen.CallbackPayload) string {
+func (s *Service) organizationSlugFromState(payload *gen.CallbackPayload) string {
 	state := decodeStateParam(payload)
 	if state == nil {
 		return ""
 	}
-	return organizationSlugFromDestinationURL(state.FinalDestinationURL)
+	return s.organizationSlugFromDestinationURL(state.FinalDestinationURL)
 }
 
-func activeOrganizationFromState(payload *gen.CallbackPayload, organizations []sessions.Organization) (sessions.Organization, bool) {
+func (s *Service) activeOrganizationFromState(payload *gen.CallbackPayload, organizations []sessions.Organization) (sessions.Organization, bool) {
 	var empty sessions.Organization
 
-	orgSlug := organizationSlugFromState(payload)
+	orgSlug := s.organizationSlugFromState(payload)
 	if orgSlug == "" {
 		return empty, false
 	}
@@ -630,8 +642,8 @@ func activeOrganizationFromWorkOSID(workosOrgID string, organizations []sessions
 	return empty, false
 }
 
-func organizationSlugFromDestinationURL(destinationURL string) string {
-	location := relativeURL(destinationURL)
+func (s *Service) organizationSlugFromDestinationURL(destinationURL string) string {
+	location := safeRedirectPath(destinationURL, s.siteOrigin)
 	if location == "" {
 		return ""
 	}
@@ -1205,12 +1217,12 @@ func (s *Service) captureSignupTelemetry(ctx context.Context, email, orgName str
 	}
 }
 
-func dispositionFromState(payload *gen.CallbackPayload) string {
+func (s *Service) dispositionFromState(payload *gen.CallbackPayload) string {
 	state := decodeStateParam(payload)
 	if state == nil {
 		return ""
 	}
-	parsed, err := url.Parse(relativeURL(state.FinalDestinationURL))
+	parsed, err := url.Parse(safeRedirectPath(state.FinalDestinationURL, s.siteOrigin))
 	if err != nil {
 		return ""
 	}
@@ -1269,9 +1281,12 @@ type loginState struct {
 	Nonce               string `json:"nonce,omitempty"`
 }
 
-func encodeStateParam(payload *gen.LoginPayload, nonce string) string {
+// encodeStateParam packs the post-login destination and nonce into the state
+// param handed to the identity provider. The destination must already have been
+// through safeRedirectPath.
+func encodeStateParam(destination string, nonce string) string {
 	state := loginState{
-		FinalDestinationURL: conv.PtrValOr(payload.Redirect, ""),
+		FinalDestinationURL: destination,
 		Nonce:               nonce,
 	}
 
@@ -1391,9 +1406,11 @@ func (s *Service) buildCallbackURL(ctx context.Context) string {
 	return returnAddress + "/rpc/auth.callback"
 }
 
-// callbackRedirectURL determines the redirect location after authentication. It
-// only allows relative URLs to prevent open redirect attacks (see relativeURL).
-// If no redirect is found, fall back to SignInRedirectURL.
+// callbackRedirectURL determines the redirect location after authentication.
+// The state param is not signed, so a caller can hand the callback any
+// destination it likes; safeRedirectPath is what keeps that destination on the
+// dashboard's own origin. If no usable redirect is found, fall back to
+// SignInRedirectURL.
 func (s *Service) callbackRedirectURL(
 	ctx context.Context,
 	payload *gen.CallbackPayload,
@@ -1401,7 +1418,7 @@ func (s *Service) callbackRedirectURL(
 	var location string
 
 	if state := decodeStateParam(payload); state != nil {
-		location = relativeURL(state.FinalDestinationURL)
+		location = safeRedirectPath(state.FinalDestinationURL, s.siteOrigin)
 	}
 
 	if location != "" {
@@ -1412,36 +1429,4 @@ func (s *Service) callbackRedirectURL(
 	}
 
 	return s.cfg.SignInRedirectURL
-}
-
-// relativeURL converts any URL to a safe relative URL by extracting only the
-// path, query, and fragment components.
-//
-// Examples:
-//   - "/dashboard" → "/dashboard"
-//   - "/projects?id=123#section" → "/projects?id=123#section"
-//   - "http://localhost:3000/dashboard" → "/dashboard"
-//   - "https://evil-site.com/phishing" → "/phishing"
-//   - "//evil.com/phish" → ""
-//   - "invalid:///" → ""
-func relativeURL(urlStr string) string {
-	parsed, err := url.Parse(urlStr)
-	if err != nil {
-		return ""
-	}
-
-	isRelative := parsed.Host == "" && parsed.Scheme == ""
-	if isRelative {
-		return urlStr
-	}
-
-	rel := parsed.Path
-	if parsed.RawQuery != "" {
-		rel += "?" + parsed.RawQuery
-	}
-	if parsed.Fragment != "" {
-		rel += "#" + parsed.Fragment
-	}
-
-	return rel
 }

--- a/server/internal/auth/login_test.go
+++ b/server/internal/auth/login_test.go
@@ -109,8 +109,44 @@ func TestService_Login(t *testing.T) {
 		var state map[string]any
 		err = json.Unmarshal(stateBytes, &state)
 		require.NoError(t, err)
-		require.Equal(t, redirectURL, state["final_destination_url"])
+		require.Equal(t, "/dashboard/projects/my-project", state["final_destination_url"])
 		require.NotEmpty(t, state["nonce"], "state should contain a nonce")
+	})
+
+	t.Run("login drops a redirect that leaves the dashboard origin", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		ctx, instance := newTestAuthService(t, userInfo)
+
+		// AIS-428: browsers normalize the leading "/\" to "//", so storing this
+		// verbatim would hand the callback a protocol-relative destination.
+		for _, redirectURL := range []string{
+			`/\attacker.example.net`,
+			"//attacker.example.net/phish",
+			"https://attacker.example.net/phish",
+		} {
+			payload := &gen.LoginPayload{
+				Redirect: &redirectURL,
+			}
+			result, err := instance.service.Login(ctx, payload)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			parsedURL, err := url.Parse(result.Location)
+			require.NoError(t, err)
+			stateParam := parsedURL.Query().Get("state")
+			require.NotEmpty(t, stateParam, "state parameter should be present")
+
+			stateBytes, err := base64.RawURLEncoding.DecodeString(stateParam)
+			require.NoError(t, err)
+
+			var state map[string]any
+			err = json.Unmarshal(stateBytes, &state)
+			require.NoError(t, err)
+			require.Empty(t, state["final_destination_url"], "redirect %q must not reach the state param", redirectURL)
+			require.NotEmpty(t, state["nonce"], "state should contain a nonce")
+		}
 	})
 
 	t.Run("login with complex redirect URL encodes state correctly", func(t *testing.T) {
@@ -138,7 +174,7 @@ func TestService_Login(t *testing.T) {
 		var state map[string]any
 		err = json.Unmarshal(stateBytes, &state)
 		require.NoError(t, err)
-		require.Equal(t, redirectURL, state["final_destination_url"])
+		require.Equal(t, "/dashboard/projects/my-project?tab=settings&view=details", state["final_destination_url"])
 		require.NotEmpty(t, state["nonce"], "state should contain a nonce")
 	})
 

--- a/server/internal/auth/org_slug_destination_test.go
+++ b/server/internal/auth/org_slug_destination_test.go
@@ -8,8 +8,13 @@ import (
 
 // Pins the shapes client/admin/src/lib/impersonation.ts emits. A rejected
 // shape fails silently: the operator lands on their own default org.
+//
+// The slug is read out of the destination by safeRedirectPath, so an absolute
+// URL only yields a slug when it names the dashboard's own origin.
 func TestOrganizationSlugFromDestinationURL(t *testing.T) {
 	t.Parallel()
+
+	s := &Service{siteOrigin: "https://app.example.test"}
 
 	tests := []struct {
 		name           string
@@ -56,9 +61,14 @@ func TestOrganizationSlugFromDestinationURL(t *testing.T) {
 			destinationURL: "https://app.example.test",
 			want:           "",
 		},
+		{
+			name:           "absolute URL on another origin",
+			destinationURL: "https://attacker.example.net/acme-placeholder",
+			want:           "",
+		},
 	}
 
 	for _, tt := range tests {
-		require.Equal(t, tt.want, organizationSlugFromDestinationURL(tt.destinationURL), tt.name)
+		require.Equal(t, tt.want, s.organizationSlugFromDestinationURL(tt.destinationURL), tt.name)
 	}
 }

--- a/server/internal/auth/redirect.go
+++ b/server/internal/auth/redirect.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"net/url"
+	"strings"
+)
+
+// parseSiteOrigin reduces a configured site URL to the "scheme://host" that a
+// post-login redirect target must name to count as the dashboard itself.
+// Anything that is not an absolute URL yields "", which leaves relative paths
+// as the only redirect shape the sanitizer will accept.
+func parseSiteOrigin(rawSiteURL string) string {
+	parsed, err := url.Parse(rawSiteURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+
+	return strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+}
+
+// safeRedirectPath normalizes a caller-supplied post-login destination into a
+// rooted, same-origin path, or returns "" when the value cannot be trusted and
+// the caller should fall back to a destination of its own choosing.
+//
+// The result is handed to a browser in a Location header, so the only question
+// that matters is whether the browser could read it as another origin. Two
+// shapes allow that and both are refused here: an absolute URL naming a host
+// other than allowedOrigin, and anything a browser resolves as a
+// protocol-relative reference. The second has more spellings than it looks
+// like — "//evil.com", "///evil.com" (the URL parser skips the extra slashes
+// while looking for an authority), and "/\evil.com" (a backslash is read as a
+// slash). Requiring exactly one leading slash on a rebuilt, re-escaped path
+// rejects all of them.
+//
+// allowedOrigin is a "scheme://host" as produced by parseSiteOrigin. When it is
+// empty, only relative paths survive.
+func safeRedirectPath(raw string, allowedOrigin string) string {
+	if raw == "" {
+		return ""
+	}
+
+	// A browser reads an unescaped backslash as a slash, so "/\evil.com" is a
+	// host and "/a\b" is two path segments, while Go's url package reads both as
+	// literal path characters. Rather than pick a side, refuse the input: a
+	// destination that means one thing here and another in the browser is not a
+	// destination worth honoring, and nothing the dashboard links to has one.
+	if strings.Contains(raw, `\`) {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+
+	// A scheme or a host means the value is trying to name an origin — either an
+	// absolute URL or a protocol-relative one, which url.Parse reports as a host
+	// with an empty scheme. Compare on Host alone so that userinfo tricks such as
+	// "https://app.example.com@evil.com/" are judged by "evil.com".
+	if parsed.Scheme != "" || parsed.Host != "" {
+		origin := strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+		if allowedOrigin == "" || origin != allowedOrigin {
+			return ""
+		}
+	}
+
+	path := parsed.EscapedPath()
+	if path == "" && parsed.Host != "" {
+		// An allowed absolute URL with no path, e.g. "https://app.example.com",
+		// asks for the dashboard root.
+		path = "/"
+	}
+
+	if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
+		return ""
+	}
+
+	dest := path
+	if parsed.RawQuery != "" {
+		dest += "?" + parsed.RawQuery
+	}
+	if parsed.Fragment != "" {
+		dest += "#" + parsed.EscapedFragment()
+	}
+
+	return dest
+}

--- a/server/internal/auth/redirect.go
+++ b/server/internal/auth/redirect.go
@@ -15,7 +15,26 @@ func parseSiteOrigin(rawSiteURL string) string {
 		return ""
 	}
 
-	return strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+	return canonicalOrigin(parsed.Scheme, parsed.Host)
+}
+
+// canonicalOrigin renders a "scheme://host" with the scheme's default port
+// dropped, so "https://app.example.com:443" and "https://app.example.com"
+// compare equal. Browsers never spell out a default port, but a configured
+// site URL may well, and a mismatch there is silent: every absolute redirect
+// would fall back to the sign-in landing page instead of the destination.
+func canonicalOrigin(scheme, host string) string {
+	scheme = strings.ToLower(scheme)
+	host = strings.ToLower(host)
+
+	switch scheme {
+	case "https":
+		host = strings.TrimSuffix(host, ":443")
+	case "http":
+		host = strings.TrimSuffix(host, ":80")
+	}
+
+	return scheme + "://" + host
 }
 
 // safeRedirectPath normalizes a caller-supplied post-login destination into a
@@ -58,7 +77,7 @@ func safeRedirectPath(raw string, allowedOrigin string) string {
 	// with an empty scheme. Compare on Host alone so that userinfo tricks such as
 	// "https://app.example.com@evil.com/" are judged by "evil.com".
 	if parsed.Scheme != "" || parsed.Host != "" {
-		origin := strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+		origin := canonicalOrigin(parsed.Scheme, parsed.Host)
 		if allowedOrigin == "" || origin != allowedOrigin {
 			return ""
 		}

--- a/server/internal/auth/redirect_test.go
+++ b/server/internal/auth/redirect_test.go
@@ -18,6 +18,9 @@ func TestParseSiteOrigin(t *testing.T) {
 		{name: "trailing path is dropped", input: "http://localhost:3000/dashboard", want: "http://localhost:3000"},
 		{name: "port is part of the origin", input: "https://localhost:5173", want: "https://localhost:5173"},
 		{name: "case normalized", input: "HTTPS://App.Example.COM", want: "https://app.example.com"},
+		{name: "default https port is dropped", input: "https://app.example.com:443", want: "https://app.example.com"},
+		{name: "default http port is dropped", input: "http://app.example.com:80", want: "http://app.example.com"},
+		{name: "non-default port is kept", input: "https://app.example.com:8443", want: "https://app.example.com:8443"},
 		{name: "empty", input: "", want: ""},
 		{name: "relative", input: "/dashboard", want: ""},
 		{name: "scheme without host", input: "https://", want: ""},
@@ -52,6 +55,12 @@ func TestSafeRedirectPath(t *testing.T) {
 		{name: "same-origin absolute URL with query", input: "https://app.example.com/p?tab=settings", want: "/p?tab=settings"},
 		{name: "same-origin absolute URL without a path", input: "https://app.example.com", want: "/"},
 		{name: "same-origin absolute URL, mixed case host", input: "https://APP.example.com/dashboard", want: "/dashboard"},
+		{name: "same-origin absolute URL spelling the default port", input: "https://app.example.com:443/dashboard", want: "/dashboard"},
+
+		// An encoded slash is not a path separator to a browser, and the escaped
+		// form is what goes back out in the Location header, so "/%2F%2Fevil.com"
+		// stays a same-origin path rather than becoming "///evil.com".
+		{name: "encoded slashes stay a path", input: "/%2F%2Fattacker.example.net", want: "/%2F%2Fattacker.example.net"},
 
 		// AIS-428: a backslash after the leading slash is read by browsers as a
 		// second slash, turning the value into a protocol-relative reference.

--- a/server/internal/auth/redirect_test.go
+++ b/server/internal/auth/redirect_test.go
@@ -57,11 +57,6 @@ func TestSafeRedirectPath(t *testing.T) {
 		{name: "same-origin absolute URL, mixed case host", input: "https://APP.example.com/dashboard", want: "/dashboard"},
 		{name: "same-origin absolute URL spelling the default port", input: "https://app.example.com:443/dashboard", want: "/dashboard"},
 
-		// An encoded slash is not a path separator to a browser, and the escaped
-		// form is what goes back out in the Location header, so "/%2F%2Fevil.com"
-		// stays a same-origin path rather than becoming "///evil.com".
-		{name: "encoded slashes stay a path", input: "/%2F%2Fattacker.example.net", want: "/%2F%2Fattacker.example.net"},
-
 		// AIS-428: a backslash after the leading slash is read by browsers as a
 		// second slash, turning the value into a protocol-relative reference.
 		{name: "backslash authority", input: `/\attacker.example.net`, want: ""},
@@ -87,7 +82,9 @@ func TestSafeRedirectPath(t *testing.T) {
 		{name: "control character", input: "/\tdashboard", want: ""},
 
 		// Percent-encoded separators stay encoded, so they cannot re-form an
-		// authority once the browser reads the Location header.
+		// authority once the browser reads the Location header. The guard reads
+		// EscapedPath and the escaped form is what goes back out, so this stays a
+		// same-origin path rather than becoming "///attacker.example.net".
 		{name: "encoded double slash", input: "/%2F%2Fattacker.example.net", want: "/%2F%2Fattacker.example.net"},
 	}
 

--- a/server/internal/auth/redirect_test.go
+++ b/server/internal/auth/redirect_test.go
@@ -1,0 +1,103 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSiteOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "origin only", input: "https://app.example.com", want: "https://app.example.com"},
+		{name: "trailing path is dropped", input: "http://localhost:3000/dashboard", want: "http://localhost:3000"},
+		{name: "port is part of the origin", input: "https://localhost:5173", want: "https://localhost:5173"},
+		{name: "case normalized", input: "HTTPS://App.Example.COM", want: "https://app.example.com"},
+		{name: "empty", input: "", want: ""},
+		{name: "relative", input: "/dashboard", want: ""},
+		{name: "scheme without host", input: "https://", want: ""},
+		{name: "unparseable", input: "://nope", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, parseSiteOrigin(tt.input))
+		})
+	}
+}
+
+func TestSafeRedirectPath(t *testing.T) {
+	t.Parallel()
+
+	const origin = "https://app.example.com"
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Ordinary destinations the dashboard actually asks for.
+		{name: "rooted path", input: "/dashboard", want: "/dashboard"},
+		{name: "path with query and fragment", input: "/projects?id=123#section", want: "/projects?id=123#section"},
+		{name: "root", input: "/", want: "/"},
+		{name: "disposition query", input: "/?disposition=assistants", want: "/?disposition=assistants"},
+		{name: "same-origin absolute URL", input: "https://app.example.com/dashboard", want: "/dashboard"},
+		{name: "same-origin absolute URL with query", input: "https://app.example.com/p?tab=settings", want: "/p?tab=settings"},
+		{name: "same-origin absolute URL without a path", input: "https://app.example.com", want: "/"},
+		{name: "same-origin absolute URL, mixed case host", input: "https://APP.example.com/dashboard", want: "/dashboard"},
+
+		// AIS-428: a backslash after the leading slash is read by browsers as a
+		// second slash, turning the value into a protocol-relative reference.
+		{name: "backslash authority", input: `/\attacker.example.net`, want: ""},
+		{name: "backslash then slash authority", input: `/\/attacker.example.net`, want: ""},
+		{name: "double backslash authority", input: `\\attacker.example.net`, want: ""},
+		{name: "backslash inside a path", input: `/dashboard\projects`, want: ""},
+		{name: "encoded backslash is left alone", input: "/dashboard%5Cprojects", want: "/dashboard%5Cprojects"},
+
+		// Other spellings of "leave this origin".
+		{name: "protocol relative", input: "//attacker.example.net/phish", want: ""},
+		{name: "protocol relative with extra slash", input: "///attacker.example.net", want: ""},
+		{name: "foreign origin", input: "https://attacker.example.net/phish", want: ""},
+		{name: "foreign origin on the allowed scheme-less form", input: "//app.example.com", want: ""},
+		{name: "allowed host in userinfo", input: "https://app.example.com@attacker.example.net/", want: ""},
+		{name: "scheme mismatch on the allowed host", input: "http://app.example.com/dashboard", want: ""},
+		{name: "bare host", input: "attacker.example.net", want: ""},
+		{name: "javascript scheme", input: "javascript:alert(1)", want: ""},
+		{name: "data scheme", input: "data:text/html,<script>alert(1)</script>", want: ""},
+
+		// Values with nowhere sensible to go.
+		{name: "empty", input: "", want: ""},
+		{name: "query only", input: "?tab=settings", want: ""},
+		{name: "control character", input: "/\tdashboard", want: ""},
+
+		// Percent-encoded separators stay encoded, so they cannot re-form an
+		// authority once the browser reads the Location header.
+		{name: "encoded double slash", input: "/%2F%2Fattacker.example.net", want: "/%2F%2Fattacker.example.net"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, safeRedirectPath(tt.input, origin))
+		})
+	}
+}
+
+// TestSafeRedirectPathWithoutOrigin covers a misconfigured or unparseable site
+// URL: relative paths still work, and every absolute URL is refused rather than
+// silently trusted.
+func TestSafeRedirectPathWithoutOrigin(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "/dashboard", safeRedirectPath("/dashboard", ""))
+	require.Empty(t, safeRedirectPath("https://app.example.com/dashboard", ""))
+	require.Empty(t, safeRedirectPath("//app.example.com", ""))
+}


### PR DESCRIPTION
Closes AIS-428.

The post-login `redirect` param survives a round trip through the identity provider inside an unsigned `state` param, and comes back out of `/rpc/auth.callback` as a `Location` header. The old `relativeURL` helper tried to disarm a hostile value on the way out by keeping only the path, query, and fragment — which meant `https://evil.example.com/phishing` was not rejected but rewritten to `/phishing`, and several spellings a browser resolves as protocol-relative slipped through as literal paths.

## What changed

`server/internal/auth/redirect.go` (new) replaces `relativeURL` with `safeRedirectPath`, which normalizes a destination into a rooted, same-origin path or returns `""` so the caller falls back to `SignInRedirectURL`. It refuses the two shapes a browser could read as another origin:

- an absolute URL naming a host other than the dashboard's own origin — compared on `Host` alone, so `https://app.example.com@evil.example.com/` is judged by `evil.example.com`
- anything that resolves as a protocol-relative reference: `//evil.example.com`, `///evil.example.com` (the URL parser skips the extra slashes while hunting for an authority), and `/\evil.example.com` (a browser reads an unescaped backslash as a slash, Go's `net/url` does not)

The dashboard's origin is derived once at construction from `cfg.SignInRedirectURL` via `parseSiteOrigin`, so an absolute URL back to the dashboard itself still works. The state-reading helpers become methods on `Service` to reach it.

Sanitizing now also happens in `Login`, before the destination is minted into the `state` param, rather than only in the callback — a hostile value never enters the round trip in the first place.

`server/internal/admin/oauth.go` gets the same two hardenings for `sanitizeReturnTo`, which had its own copy of the rooted-path check. Its allowlist behaviour (the Registry admin SPA is on a different domain) is unchanged.

## Tests

New `redirect_test.go` covers `parseSiteOrigin` and `safeRedirectPath` with and without a configured origin. `callback_test.go` and `login_test.go` gain cases for the cross-origin and protocol-relative spellings; `oauth_test.go` gains the extra-slash, backslash, bare-host, and userinfo cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects post-login redirect targets that a browser could resolve to another origin, fixing AIS-428 (open redirect). Previously we rewrote absolute URLs into paths and allowed protocol‑relative and backslash forms; now we only accept a single‑slash‑rooted path on the dashboard origin (or admin‑allowlisted origins) and otherwise fall back to `SignInRedirectURL`.

- Adds safe redirect guards that accept only same-origin, single‑slash‑rooted paths and reject foreign origins, protocol‑relative spellings (`//` and extra slashes), any backslashes, bare hosts, and userinfo tricks. Origin comparison is canonicalized (lower case, default ports dropped). If the configured origin is unset or unparsable, only rooted relative paths are accepted. The same checks harden admin OAuth `sanitizeReturnTo`; its allowlist behavior is unchanged.
- `Login` sanitizes the requested redirect before minting `state`; `Callback` revalidates it. The `state` stores only the sanitized path, and readers moved onto `Service` to consult the configured origin. Org‑slug and disposition parsing now use the same sanitizer; absolute URLs yield a slug only when they name the dashboard origin.
- Required: set `SignInRedirectURL` to the dashboard URL; otherwise absolute redirects (even same‑host) will fall back.

<sup>Written for commit 3046a70823a7740df690e476491fd8280d1c03ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

