### PR TITLE
fix(email): honor Loops LMX attribute ranges

### DIFF
--- a/.agents/skills/craft-transactional-emails/SKILL.md
+++ b/.agents/skills/craft-transactional-emails/SKILL.md
@@ -99,6 +99,11 @@ Identity map:
   contract.
 - Use `{data.variable_name}` everywhere; LMX names are case-sensitive. Never use
   `{DATA_VARIABLE:...}` in LMX.
+- Loops accepts `Columns.gap` only from 12 through 150 and
+  `Paragraph.fontSize` only from 12 through 64. The local manifest validator
+  enforces these provider ranges across every `.lmx` file in the template
+  directory, including the unregistered base. Translate MJML 10px/11px labels
+  to 12px in LMX; preserve their hierarchy, not prohibited literal sizes.
 - State the event or action directly. Delete vague lead-ins such as “a clear read
   on how your organization is tracking.” Prefer one verb-led CTA.
 - Use conditional `<Section>` blocks for variants. Do not invent fallback syntax.
@@ -122,7 +127,8 @@ explicitly managed through Loops, the approved fallback is:
 - omit the spectrum rail rather than replace it with a new accent;
 - use the text-only `speakeasy` / `AI CONTROL PLANE` header;
 - use Inter with the declared UI sans fallback while retaining the approved
-  sizes, hierarchy, light palette, square black CTA, panels, and pale footer.
+  hierarchy, light palette, square black CTA, panels, and pale footer; translate
+  label text below 12px to Loops' 12px minimum.
 
 Those are constrained delivery fallbacks, not a second design. Do not add a dark
 masthead, neon accent, rounded cards, gradient, or substitute palette.
@@ -355,10 +361,11 @@ mise lint:server
 git diff --check
 ```
 
-This checks manifest structure, XML well-formedness, declared/used variables,
-Go contracts, API reconciliation behavior, and runtime ID resolution. Merge CI
-then uses Loops compilation, optimistic revisions, Guardian, and publish; any
-Guardian error blocks the release preparation.
+This checks manifest structure, XML well-formedness and provider attribute
+ranges across every `.lmx` file, declared/used variables, Go contracts, API
+reconciliation behavior, and runtime ID resolution. Merge CI then uses Loops
+compilation, optimistic revisions, Guardian, and publish; any Guardian error
+blocks the release preparation.
 
 ## Screenshots and visual QA
 

--- a/.agents/skills/craft-transactional-emails/SKILL.md
+++ b/.agents/skills/craft-transactional-emails/SKILL.md
@@ -100,10 +100,11 @@ Identity map:
 - Use `{data.variable_name}` everywhere; LMX names are case-sensitive. Never use
   `{DATA_VARIABLE:...}` in LMX.
 - Loops accepts `Columns.gap` only from 12 through 150 and
-  `Paragraph.fontSize` only from 12 through 64. The local manifest validator
-  enforces these provider ranges across every `.lmx` file in the template
-  directory, including the unregistered base. Translate MJML 10px/11px labels
-  to 12px in LMX; preserve their hierarchy, not prohibited literal sizes.
+  `Paragraph.fontSize` only from 12 through 64 when those attributes are set;
+  omission uses Loops' accepted defaults. The local manifest validator enforces
+  explicit values across every `.lmx` file recursively, including unregistered
+  bases. Translate MJML 10px/11px labels to 12px in LMX; preserve their
+  hierarchy, not prohibited literal sizes.
 - State the event or action directly. Delete vague lead-ins such as “a clear read
   on how your organization is tracking.” Prefer one verb-led CTA.
 - Use conditional `<Section>` blocks for variants. Do not invent fallback syntax.
@@ -361,11 +362,11 @@ mise lint:server
 git diff --check
 ```
 
-This checks manifest structure, XML well-formedness and provider attribute
-ranges across every `.lmx` file, declared/used variables, Go contracts, API
-reconciliation behavior, and runtime ID resolution. Merge CI then uses Loops
-compilation, optimistic revisions, Guardian, and publish; any Guardian error
-blocks the release preparation.
+This checks manifest structure, XML well-formedness and explicit provider
+attribute ranges across every `.lmx` file recursively, declared/used variables,
+Go contracts, API reconciliation behavior, and runtime ID resolution. Merge CI
+then uses Loops compilation, optimistic revisions, Guardian, and publish; any
+Guardian error blocks the release preparation.
 
 ## Screenshots and visual QA
 

--- a/server/internal/email/loops/README.md
+++ b/server/internal/email/loops/README.md
@@ -44,9 +44,9 @@ published message whose subject, preview, and LMX already match is left unchange
    ```
 
 Validation requires the manifest variable list to match the Go `Variables()`
-contract exactly. It also checks every `.lmx` file in this directory for XML
-well-formedness and Loops-supported attribute ranges, and rejects undeclared or
-accidentally unused variables in registered templates.
+contract exactly. It also checks every `.lmx` file recursively for XML
+well-formedness and explicitly set Loops-supported attribute ranges, and rejects
+undeclared or accidentally unused variables in registered templates.
 
 ## Design system
 

--- a/server/internal/email/loops/README.md
+++ b/server/internal/email/loops/README.md
@@ -44,8 +44,9 @@ published message whose subject, preview, and LMX already match is left unchange
    ```
 
 Validation requires the manifest variable list to match the Go `Variables()`
-contract exactly. It also checks XML well-formedness and rejects undeclared or
-accidentally unused LMX variables.
+contract exactly. It also checks every `.lmx` file in this directory for XML
+well-formedness and Loops-supported attribute ranges, and rejects undeclared or
+accidentally unused variables in registered templates.
 
 ## Design system
 

--- a/server/internal/email/loops/access_request.lmx
+++ b/server/internal/email/loops/access_request.lmx
@@ -1,13 +1,13 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" dividerColor="#BABABA" dividerBorderWidth="1" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">ACCESS REQUEST</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">ACCESS REQUEST</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.requester_name} needs access</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Review the request for {data.organization_name} and grant only the scopes they need.</Paragraph>
 <Button href="{data.manage_access_link}" paddingRight="40" paddingBottom="48" paddingLeft="40">Review request →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">No access changes are made until an administrator approves the request.</Paragraph>
 </Section>

--- a/server/internal/email/loops/custom_domain_unhealthy.lmx
+++ b/server/internal/email/loops/custom_domain_unhealthy.lmx
@@ -1,17 +1,17 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">CUSTOM DOMAIN · ACTION REQUIRED</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">CUSTOM DOMAIN · ACTION REQUIRED</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Your custom domain needs attention.</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Speakeasy detected a health issue with <Strong textColor="#121212">{data.domain}</Strong>. Review the reported issue and update the domain configuration.</Paragraph>
 <Section blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="10" lineHeight="140"><Strong textColor="#757575">REPORTED ISSUE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">REPORTED ISSUE</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">{data.issue_message}</Text></Paragraph>
 </Section>
 <Button href="{data.domain_link}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">Review domain →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this operational alert at {data.email} because this address is configured for custom domain health notifications.</Paragraph>
 </Section>

--- a/server/internal/email/loops/enterprise_admin_onboarding.lmx
+++ b/server/internal/email/loops/enterprise_admin_onboarding.lmx
@@ -1,13 +1,13 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">ENTERPRISE ONBOARDING</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">ENTERPRISE ONBOARDING</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Set up your AI control plane</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Use the guided setup to configure Speakeasy for your organization. You can return to setup at any time.</Paragraph>
 <Button href="{data.setup_link}" paddingRight="40" paddingBottom="48" paddingLeft="40">Start setup →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this email because you were invited to administer Speakeasy for your organization.</Paragraph>
 </Section>

--- a/server/internal/email/loops/openrouter_chat_credits_threshold.lmx
+++ b/server/internal/email/loops/openrouter_chat_credits_threshold.lmx
@@ -1,20 +1,20 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">CHAT CREDIT ALERT</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">CHAT CREDIT ALERT</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of chat credits used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is approaching its platform-managed chat credit cap.</Paragraph>
 <Section if="{data.exhausted}" ifOperation="equal" ifValue="true" blockColor="#FFF1ED" blockBorderColor="#E8A18D" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="10" lineHeight="140"><Strong textColor="#C83228">CREDITS EXHAUSTED</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#C83228">CREDITS EXHAUSTED</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Chat surfaces may fail until credits reset or the limit changes.</Paragraph>
 </Section>
 <Section if="{data.exhausted}" ifOperation="equal" ifValue="false" blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="10" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Review usage before the cap is exhausted.</Paragraph>
 </Section>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated platform credit alert.</Paragraph>
 </Section>

--- a/server/internal/email/loops/openrouter_internal_credits_threshold.lmx
+++ b/server/internal/email/loops/openrouter_internal_credits_threshold.lmx
@@ -1,20 +1,20 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">INTERNAL AI CREDIT ALERT</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">INTERNAL AI CREDIT ALERT</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of internal credits used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is approaching the credit cap used for platform analysis.</Paragraph>
 <Section if="{data.exhausted}" ifOperation="equal" ifValue="true" blockColor="#FFF1ED" blockBorderColor="#E8A18D" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="10" lineHeight="140"><Strong textColor="#C83228">CREDITS EXHAUSTED</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#C83228">CREDITS EXHAUSTED</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Risk and analysis coverage may be reduced until credits reset or the limit changes.</Paragraph>
 </Section>
 <Section if="{data.exhausted}" ifOperation="equal" ifValue="false" blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="10" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Review usage before analysis coverage is affected.</Paragraph>
 </Section>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated platform credit alert.</Paragraph>
 </Section>

--- a/server/internal/email/loops/team_invite.lmx
+++ b/server/internal/email/loops/team_invite.lmx
@@ -1,13 +1,13 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">TEAM INVITE</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">TEAM INVITE</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Join {data.organization_name}</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.inviter_name} ({data.inviter_email}) invited you to collaborate in Gram.</Paragraph>
 <Button href="{data.invite_link}" paddingRight="40" paddingBottom="48" paddingLeft="40">Accept invitation →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">If you were not expecting this invitation, you can ignore this email.</Paragraph>
 </Section>

--- a/server/internal/email/loops/transactional_base.lmx
+++ b/server/internal/email/loops/transactional_base.lmx
@@ -1,17 +1,17 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">{data.email_eyebrow}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">{data.email_eyebrow}</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.email_headline}</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.email_body}</Paragraph>
 <Section blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="10" lineHeight="140"><Strong textColor="#757575">{data.detail_label}</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">{data.detail_label}</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">{data.detail_value}</Text></Paragraph>
 </Section>
 <Button href="{data.action_url}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">{data.action_label} →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">{data.footer_reason}</Paragraph>
 </Section>

--- a/server/internal/email/loops/tum_usage_overage.lmx
+++ b/server/internal/email/loops/tum_usage_overage.lmx
@@ -1,20 +1,20 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="30" heading2LineHeight="115" heading2LetterSpacing="-1" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#C83228">ALLOWANCE EXCEEDED · {data.organization_name}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#C83228">ALLOWANCE EXCEEDED · {data.organization_name}</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of allowance used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} has used {data.usage_tokens} against an allowance of {data.token_limit}.</Paragraph>
 <Section blockColor="#121212" paddingTop="28" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="140"><Strong textColor="#BABABA">OVER ALLOWANCE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#BABABA">OVER ALLOWANCE</Strong></Paragraph>
   <H2 paddingTop="10"><Text textColor="#FFFFFF">{data.overage_tokens}</Text></H2>
 </Section>
-<Columns gap="0" widths="50,50" stackOnMobile="true" paddingRight="40" paddingBottom="32" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="10" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br /><Text textColor="#121212">{data.cycle_start}</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph fontSize="10" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br /><Text textColor="#121212">{data.cycle_end}</Text></Paragraph></ColumnItem>
+<Columns gap="12" widths="50,50" stackOnMobile="true" paddingRight="40" paddingBottom="32" paddingLeft="40">
+  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br /><Text textColor="#121212">{data.cycle_start}</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br /><Text textColor="#121212">{data.cycle_end}</Text></Paragraph></ColumnItem>
 </Columns>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated billing usage alert.</Paragraph>
 </Section>

--- a/server/internal/email/loops/tum_usage_threshold.lmx
+++ b/server/internal/email/loops/tum_usage_threshold.lmx
@@ -1,16 +1,16 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">USAGE ALERT · {data.organization_name}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">USAGE ALERT · {data.organization_name}</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of allowance used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} has used {data.usage_tokens} of {data.token_limit} tokens under management.</Paragraph>
-<Columns gap="0" widths="50,50" stackOnMobile="true" blockColor="#FFFFFF" paddingRight="40" paddingBottom="32" paddingLeft="40">
-  <ColumnItem><Paragraph blockColor="#FFFFFF" fontSize="10" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br /><Text textColor="#121212">{data.cycle_start}</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph blockColor="#FFFFFF" fontSize="10" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br /><Text textColor="#121212">{data.cycle_end}</Text></Paragraph></ColumnItem>
+<Columns gap="12" widths="50,50" stackOnMobile="true" blockColor="#FFFFFF" paddingRight="40" paddingBottom="32" paddingLeft="40">
+  <ColumnItem><Paragraph blockColor="#FFFFFF" fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br /><Text textColor="#121212">{data.cycle_start}</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph blockColor="#FFFFFF" fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br /><Text textColor="#121212">{data.cycle_end}</Text></Paragraph></ColumnItem>
 </Columns>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated billing usage alert.</Paragraph>
 </Section>

--- a/server/internal/email/loops/weekly_usage_summary.lmx
+++ b/server/internal/email/loops/weekly_usage_summary.lmx
@@ -1,24 +1,24 @@
 <Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="48" heading2LineHeight="100" heading2LetterSpacing="-1.5" />
-<Columns gap="0" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="10" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="11" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">WEEKLY USAGE · {data.organization_name}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">WEEKLY USAGE · {data.organization_name}</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="36" paddingLeft="40">Your usage,<Br />at a glance.</H1>
 <Section blockColor="#121212" paddingTop="34" paddingRight="40" paddingBottom="36" paddingLeft="40">
-  <Paragraph fontSize="11" lineHeight="140"><Strong textColor="#BABABA">TOKENS MANAGED · CYCLE TO DATE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#BABABA">TOKENS MANAGED · CYCLE TO DATE</Strong></Paragraph>
   <H2 paddingTop="13"><Text textColor="#FFFFFF">{data.total_tokens}</Text></H2>
   <Paragraph fontSize="12" lineHeight="150" paddingTop="14"><Text textColor="#EBEBEB">{data.total_change_percent} vs. the same point last cycle</Text></Paragraph>
 </Section>
-<Columns gap="0" widths="33,34,33" verticalAlignment="top" stackOnMobile="true" paddingBottom="32">
-  <ColumnItem><Paragraph fontSize="10" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br /><Text textColor="#121212">{data.previous_total_tokens}</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph fontSize="10" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br /><Text textColor="#121212">{data.cycle_elapsed_percent}%</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph fontSize="10" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br /><Text textColor="#121212">{data.days_remaining}</Text></Paragraph></ColumnItem>
+<Columns gap="12" widths="33,34,33" verticalAlignment="top" stackOnMobile="true" paddingBottom="32">
+  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br /><Text textColor="#121212">{data.previous_total_tokens}</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br /><Text textColor="#121212">{data.cycle_elapsed_percent}%</Text></Paragraph></ColumnItem>
+  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br /><Text textColor="#121212">{data.days_remaining}</Text></Paragraph></ColumnItem>
 </Columns>
-<Paragraph fontSize="10" lineHeight="140" paddingRight="40" paddingBottom="10" paddingLeft="40"><Strong textColor="#757575">BILLING CYCLE</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingRight="40" paddingBottom="10" paddingLeft="40"><Strong textColor="#757575">BILLING CYCLE</Strong></Paragraph>
 <Paragraph fontSize="14" lineHeight="160" paddingRight="40" paddingBottom="36" paddingLeft="40">Your current cycle ends on <Strong textColor="#121212">{data.cycle_end_date}</Strong>.</Paragraph>
 <Button href="{data.view_usage_url}" paddingRight="40" paddingBottom="48" paddingLeft="40">View detailed usage →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
-  <Paragraph fontSize="10" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this operational report because this address is configured for billing alerts in Speakeasy.</Paragraph>
 </Section>

--- a/server/internal/email/loopsync/manifest.go
+++ b/server/internal/email/loopsync/manifest.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -142,22 +143,32 @@ func (m *Manifest) Validate() error {
 }
 
 func validateLMXDirectory(dir string) error {
-	entries, err := os.ReadDir(dir)
+	root, err := os.OpenRoot(dir)
 	if err != nil {
-		return fmt.Errorf("read LMX directory: %w", err)
+		return fmt.Errorf("open LMX directory: %w", err)
 	}
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".lmx" {
-			continue
+	walkErr := fs.WalkDir(root.FS(), ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk LMX directory: %w", walkErr)
 		}
-		path := filepath.Join(dir, entry.Name())
-		lmx, err := os.ReadFile(path) // #nosec G304 -- path is an entry from the manifest directory
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".lmx" {
+			return nil
+		}
+		lmx, err := root.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("read LMX file %q: %w", entry.Name(), err)
+			return fmt.Errorf("read LMX file %q: %w", path, err)
 		}
 		if err := validateXML(lmx); err != nil {
-			return fmt.Errorf("validate LMX file %q: %w", entry.Name(), err)
+			return fmt.Errorf("validate LMX file %q: %w", path, err)
 		}
+		return nil
+	})
+	closeErr := root.Close()
+	if walkErr != nil {
+		return fmt.Errorf("validate LMX directory: %w", walkErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close LMX directory: %w", closeErr)
 	}
 	return nil
 }

--- a/server/internal/email/loopsync/manifest.go
+++ b/server/internal/email/loopsync/manifest.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -77,6 +78,9 @@ func (m *Manifest) Validate() error {
 	if m.Defaults.FromName == "" || m.Defaults.FromEmail == "" || m.Defaults.ReplyToEmail == "" {
 		return fmt.Errorf("email manifest: sender defaults are incomplete")
 	}
+	if err := validateLMXDirectory(m.Dir); err != nil {
+		return err
+	}
 
 	managedNames := make(map[string]string, len(m.Templates))
 	for key, spec := range m.Templates {
@@ -101,10 +105,6 @@ func (m *Manifest) Validate() error {
 		if err != nil {
 			return fmt.Errorf("read LMX for %q: %w", key, err)
 		}
-		if err := validateXML(lmx); err != nil {
-			return fmt.Errorf("validate LMX for %q: %w", key, err)
-		}
-
 		sourceVariables := extractDataVariables(spec.Subject + "\n" + spec.PreviewText + "\n" + string(lmx))
 		declared, duplicate := makeUniqueSet(spec.Variables)
 		if duplicate != "" {
@@ -141,17 +141,72 @@ func (m *Manifest) Validate() error {
 	return nil
 }
 
+func validateLMXDirectory(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read LMX directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".lmx" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		lmx, err := os.ReadFile(path) // #nosec G304 -- path is an entry from the manifest directory
+		if err != nil {
+			return fmt.Errorf("read LMX file %q: %w", entry.Name(), err)
+		}
+		if err := validateXML(lmx); err != nil {
+			return fmt.Errorf("validate LMX file %q: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
 func validateXML(lmx []byte) error {
 	decoder := xml.NewDecoder(strings.NewReader("<Root>" + string(lmx) + "</Root>"))
 	for {
-		_, err := decoder.Token()
+		token, err := decoder.Token()
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
 			return fmt.Errorf("read LMX token: %w", err)
 		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		switch start.Name.Local {
+		case "Columns":
+			if err := validateIntegerAttribute(start, "gap", 12, 150); err != nil {
+				return err
+			}
+		case "Paragraph":
+			if err := validateIntegerAttribute(start, "fontSize", 12, 64); err != nil {
+				return err
+			}
+		}
 	}
+}
+
+func validateIntegerAttribute(element xml.StartElement, name string, minimum, maximum int) error {
+	for _, attribute := range element.Attr {
+		if attribute.Name.Local != name {
+			continue
+		}
+		value, err := strconv.Atoi(attribute.Value)
+		if err != nil || value < minimum || value > maximum {
+			return fmt.Errorf(
+				"%s attribute %q must be an integer between %d and %d (got %q)",
+				element.Name.Local,
+				name,
+				minimum,
+				maximum,
+				attribute.Value,
+			)
+		}
+	}
+	return nil
 }
 
 func extractDataVariables(content string) []string {

--- a/server/internal/email/loopsync/manifest_test.go
+++ b/server/internal/email/loopsync/manifest_test.go
@@ -126,14 +126,26 @@ func TestManifestValidate_AcceptsProviderAttributeBoundaries(t *testing.T) {
 	require.NoError(t, manifest.Validate())
 }
 
-func TestManifestValidate_ValidatesUnregisteredLMXFiles(t *testing.T) {
+func TestManifestValidate_AcceptsOmittedProviderAttributes(t *testing.T) {
 	t.Parallel()
 
 	manifest := validManifest(t)
-	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "transactional_base.lmx"), []byte(`<Paragraph fontSize="10">Example</Paragraph>`), 0o600))
+	lmx := `<Columns><ColumnItem><Paragraph>{data.resource_name}</Paragraph></ColumnItem></Columns>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	require.NoError(t, manifest.Validate())
+}
+
+func TestManifestValidate_ValidatesNestedUnregisteredLMXFiles(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	nestedDir := filepath.Join(manifest.Dir, "starters")
+	require.NoError(t, os.Mkdir(nestedDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "transactional_base.lmx"), []byte(`<Paragraph fontSize="10">Example</Paragraph>`), 0o600))
 
 	err := manifest.Validate()
-	require.ErrorContains(t, err, `validate LMX file "transactional_base.lmx"`)
+	require.ErrorContains(t, err, "transactional_base.lmx")
 	require.ErrorContains(t, err, `Paragraph attribute "fontSize" must be an integer between 12 and 64 (got "10")`)
 }
 

--- a/server/internal/email/loopsync/manifest_test.go
+++ b/server/internal/email/loopsync/manifest_test.go
@@ -50,6 +50,93 @@ func TestLoadManifest_RejectsTrailingJSON(t *testing.T) {
 	require.Contains(t, err.Error(), "trailing data")
 }
 
+func TestManifestValidate_RejectsColumnsGapBelowProviderMinimum(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	lmx := `<Columns gap="0"><ColumnItem><Paragraph>{data.resource_name}</Paragraph></ColumnItem></Columns>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	err := manifest.Validate()
+	require.ErrorContains(t, err, `Columns attribute "gap" must be an integer between 12 and 150 (got "0")`)
+}
+
+func TestManifestValidate_RejectsParagraphFontSizeBelowProviderMinimum(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	lmx := `<Paragraph fontSize="10">{data.resource_name}</Paragraph>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	err := manifest.Validate()
+	require.ErrorContains(t, err, `Paragraph attribute "fontSize" must be an integer between 12 and 64 (got "10")`)
+}
+
+func TestManifestValidate_RejectsNonIntegerParagraphFontSize(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	lmx := `<Paragraph fontSize="small">{data.resource_name}</Paragraph>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	err := manifest.Validate()
+	require.ErrorContains(t, err, `Paragraph attribute "fontSize" must be an integer between 12 and 64 (got "small")`)
+}
+
+func TestManifestValidate_RejectsColumnsGapAboveProviderMaximum(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	lmx := `<Columns gap="151"><ColumnItem><Paragraph>{data.resource_name}</Paragraph></ColumnItem></Columns>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	err := manifest.Validate()
+	require.ErrorContains(t, err, `Columns attribute "gap" must be an integer between 12 and 150 (got "151")`)
+}
+
+func TestManifestValidate_RejectsNonIntegerColumnsGap(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	lmx := `<Columns gap="none"><ColumnItem><Paragraph>{data.resource_name}</Paragraph></ColumnItem></Columns>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	err := manifest.Validate()
+	require.ErrorContains(t, err, `Columns attribute "gap" must be an integer between 12 and 150 (got "none")`)
+}
+
+func TestManifestValidate_RejectsParagraphFontSizeAboveProviderMaximum(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	lmx := `<Paragraph fontSize="65">{data.resource_name}</Paragraph>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	err := manifest.Validate()
+	require.ErrorContains(t, err, `Paragraph attribute "fontSize" must be an integer between 12 and 64 (got "65")`)
+}
+
+func TestManifestValidate_AcceptsProviderAttributeBoundaries(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	lmx := `<Columns gap="12"><ColumnItem><Paragraph fontSize="12">{data.resource_name}</Paragraph></ColumnItem></Columns><Columns gap="150"><ColumnItem><Paragraph fontSize="64">Example</Paragraph></ColumnItem></Columns>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	require.NoError(t, manifest.Validate())
+}
+
+func TestManifestValidate_ValidatesUnregisteredLMXFiles(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "transactional_base.lmx"), []byte(`<Paragraph fontSize="10">Example</Paragraph>`), 0o600))
+
+	err := manifest.Validate()
+	require.ErrorContains(t, err, `validate LMX file "transactional_base.lmx"`)
+	require.ErrorContains(t, err, `Paragraph attribute "fontSize" must be an integer between 12 and 64 (got "10")`)
+}
+
 func validManifest(t *testing.T) *Manifest {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- translate compact LMX labels and column gaps to Loops-supported minimum values across all nine templates and the reusable base
- validate provider-supported `Columns.gap` and `Paragraph.fontSize` ranges locally across every `.lmx` file
- document the constrained MJML-to-LMX translation in the transactional-email skill

## Why

The first merge-driven dev reconciliation rejected the repository LMX before publish because Loops requires column gaps from 12–150 and paragraph font sizes from 12–64. This fixes every affected template and makes the same values fail `--validate-only` before merge.

## Validation

- `mise exec -- go run ./server/cmd/sync-loops-email-templates --validate-only`
- `mise exec -- go test ./server/internal/email/... ./server/cmd/sync-loops-email-templates`
- `mise lint:server`
- `mise run skills:sync`
- fresh-context skill evaluation: ship, 9.7/10
- `git diff --check`

## Visual QA

The canonical MJML design and copy are unchanged; this patch only adapts the production LMX fallback to provider minimums. Desktop/mobile previews for all nine templates remain attached to #5238: https://github.com/speakeasy-api/gram/pull/5238#issuecomment-5283345472

Production-render QA remains gated on the authorized release reconciliation; no manual Loops mutation or test-send was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors Loops’ LMX attribute ranges to prevent reconciliation failures. Previously some templates used Columns.gap=0 and Paragraph.fontSize 10–11 (rejected by Loops); now all use provider minimums and local validation enforces these limits.

- Updates all nine templates and the reusable base: normalize `Columns.gap` to 12 where 0, and raise any `Paragraph.fontSize` below 12 to 12. Visual hierarchy and copy remain; only minor spacing/text-size shifts.
- Extends validation: `Manifest.Validate()` now recursively checks every `.lmx` file (including unregistered nested bases) for XML well-formedness and explicit provider ranges (`Columns.gap` 12–150, `Paragraph.fontSize` 12–64). Omitted attributes are allowed; `--validate-only` and CI fail on violations.
- Adds tests for boundary values, non-integer attributes, omitted attributes, and nested unregistered files.
- Documents constraints and the MJML-to-LMX translation in the transactional-email skill and Loops README. No dashboard changes or migrations; next reconciliation should pass.

<sup>Written for commit 81ac90dc8e0a12e8c2ca99eecb0d582b156c10a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

