### PR TITLE
chore(admin): add a vitest runner, a component harness and a CI step

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1779,6 +1779,10 @@ jobs:
         run: aube run test
         working-directory: client/dashboard
 
+      - name: Test admin
+        run: aube run test
+        working-directory: client/admin
+
       - name: Prune aube store
         if: success()
         run: aube store prune

--- a/client/admin/.oxlintrc.json
+++ b/client/admin/.oxlintrc.json
@@ -49,7 +49,9 @@
       "files": [
         "**/*.config.{ts,js,mts,mjs}",
         "vite.config.ts",
-        "src/main.tsx"
+        "src/main.tsx",
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.spec.{ts,tsx}"
       ],
       "rules": {
         "typescript/explicit-module-boundary-types": "off"

--- a/client/admin/package.json
+++ b/client/admin/package.json
@@ -12,6 +12,8 @@
     "lint:format": "oxfmt --check .",
     "lint:no-barrels": "! grep -rEn '^export \\*' src --include='*.ts' --include='*.tsx' || (echo 'Barrel re-exports (export *) are not allowed. Re-export named symbols instead.' && exit 1)",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "tsc -b --noEmit"
   },
   "dependencies": {
@@ -30,13 +32,17 @@
   },
   "devDependencies": {
     "@tanstack/router-plugin": "1.168.25",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.13.2",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "happy-dom": "^20.11.1",
     "oxlint": "^1.71.0",
     "oxlint-tsgolint": "^0.23.0",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "^4.1.10"
   }
 }

--- a/client/admin/src/lib/badgeTone.test.ts
+++ b/client/admin/src/lib/badgeTone.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { badgeTone } from "./badgeTone";
+
+describe("badgeTone", () => {
+  // A literal list, not Object.keys: dropping a tone must fail the test rather
+  // than shrink what it checks.
+  it.each(["neutral", "success", "warning", "destructive"] as const)(
+    "%s is a non-empty class string",
+    (tone) => {
+      expect(badgeTone[tone].trim()).not.toBe("");
+    },
+  );
+});

--- a/client/admin/src/test/harness.test.tsx
+++ b/client/admin/src/test/harness.test.tsx
@@ -1,0 +1,73 @@
+import { useQuery } from "@tanstack/react-query";
+import { createRootRoute, createRoute } from "@tanstack/react-router";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Badge } from "@/components/ui/badge";
+import { badgeTone } from "@/lib/badgeTone";
+import { renderRouteTree, renderWithApp } from "./harness";
+
+afterEach(cleanup);
+
+function Probe() {
+  const { data } = useQuery({
+    queryKey: ["probe"],
+    queryFn: () => Promise.resolve("query ran"),
+  });
+  const [clicks, setClicks] = useState(0);
+
+  return (
+    <div>
+      <Badge variant="outline" className={badgeTone.warning}>
+        trialing
+      </Badge>
+      <p>{data}</p>
+      <button type="button" onClick={() => setClicks(clicks + 1)}>
+        clicked {clicks}
+      </button>
+    </div>
+  );
+}
+
+function SearchProbe() {
+  const { q } = organizationsRoute.useSearch();
+  return <p>q is {q}</p>;
+}
+
+const rootRoute = createRootRoute();
+const organizationsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/organizations",
+  validateSearch: (search: Record<string, unknown>): { q: string } => ({
+    q: typeof search["q"] === "string" ? search["q"] : "",
+  }),
+  component: SearchProbe,
+});
+
+describe("harness", () => {
+  it("mounts a component with a query client and a router at the given path", async () => {
+    const { router } = await renderWithApp(<Probe />, {
+      initialPath: "/organizations",
+    });
+
+    // getBy is safe: renderRouteTree awaits router.load() before it paints.
+    const badge = screen.getByText("trialing");
+    expect(badge.className.split(" ")).toEqual(
+      expect.arrayContaining(badgeTone.warning.split(" ")),
+    );
+    expect(await screen.findByText("query ran")).toBeTruthy();
+    expect(router.state.location.pathname).toBe("/organizations");
+
+    fireEvent.click(screen.getByRole("button", { name: "clicked 0" }));
+    expect(screen.getByRole("button", { name: "clicked 1" })).toBeTruthy();
+  });
+
+  it("mounts a route tree, so validateSearch and the route hooks run", async () => {
+    await renderRouteTree(rootRoute.addChildren([organizationsRoute]), {
+      initialPath: "/organizations?q=acme",
+    });
+
+    expect(screen.getByText("q is acme")).toBeTruthy();
+  });
+});

--- a/client/admin/src/test/harness.tsx
+++ b/client/admin/src/test/harness.tsx
@@ -1,0 +1,48 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  type AnyRoute,
+  type AnyRouter,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, type RenderResult } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+type Options = { initialPath?: string };
+type Mounted = Promise<RenderResult & { router: AnyRouter }>;
+
+// A bare root route, not routeTree.gen.ts: a test renders one component, not a
+// whole page's route.
+export function renderWithApp(ui: ReactNode, options?: Options): Mounted {
+  return renderRouteTree(createRootRoute({ component: () => ui }), options);
+}
+
+// For a test that needs the real route rather than one component: pass the tree
+// from routeTree.gen.ts so `validateSearch` and the route-scoped hooks run.
+export async function renderRouteTree(
+  routeTree: AnyRoute,
+  { initialPath = "/" }: Options = {},
+): Mounted {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  // The router resolves its matches asynchronously, so without this the first
+  // render paints an empty document and every caller needs findBy*.
+  await router.load();
+
+  return {
+    router,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
+  };
+}

--- a/client/admin/tsconfig.node.json
+++ b/client/admin/tsconfig.node.json
@@ -14,5 +14,5 @@
     "moduleDetection": "force",
     "noEmit": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/client/admin/vitest.config.ts
+++ b/client/admin/vitest.config.ts
@@ -1,0 +1,15 @@
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "happy-dom",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,12 @@ importers:
       '@tanstack/router-plugin':
         specifier: 1.168.25
         version: 1.168.25(@tanstack/react-router@1.170.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.3)(vite@8.2.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -146,6 +152,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.5(vite@8.2.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      happy-dom:
+        specifier: ^20.11.1
+        version: 20.11.1
       oxlint:
         specifier: ^1.71.0
         version: 1.77.0(oxlint-tsgolint@0.23.0)
@@ -158,6 +167,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.2)(happy-dom@20.11.1)(msw@2.15.0(@types/node@24.13.2)(typescript@7.0.2))(vite@8.2.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
 
   client/dashboard:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 10.4.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2


### PR DESCRIPTION
The admin app at `client/admin` has no test runner, so none of its code can be covered by an automated test.

This adds one, copying the setup `client/dashboard` already uses.

# What this adds

- `vitest` with a `happy-dom` environment and testing-library. Tests are co-located as `src/**/*.test.tsx`.
- `renderWithApp` and `renderRouteTree` in `client/admin/src/test/harness.tsx`. They mount a single component, or a real route tree, under a memory-history router and a query client.
- Two test files, 6 tests. A smoke test drives the harness end to end: the router path, a query, a click, and a `Badge` carrying `badgeTone` classes. A unit test asserts every `badgeTone` key holds a non-empty class string, which the smoke test cannot do because it renders only one tone. Together they prove the harness paints, the `@` import alias resolves, and the JSX transform works.
- A `Test admin` step inside the existing `client-test` CI job. A step rather than a new job, because a new job would be absent from `ci-gate.needs` and could fail while the one required check stayed green.

No product code changes.

# Notes for the reviewer

The environment is `happy-dom`, not `jsdom`. `client/dashboard` already runs `happy-dom`, and matching it keeps one DOM implementation in the lockfile.

The `client/admin` scripts still call `pnpm` while the dashboard scripts call `aube`, so CI now runs `pnpm lint` and `aube run test` side by side for this package. That split predates this change and is left alone.

The test run prints a Vite 8 warning about `__dirname` in `vitest.config.ts`. `client/dashboard/vitest.config.ts` has the same line, so fixing one file here would be half a migration. Both belong in one chore PR.

# How to verify

```
aube install --frozen-lockfile
aube run -F admin test
mise run lint:client
```

To confirm the tests bite, set the `warning` value in `client/admin/src/lib/badgeTone.ts` to an empty string and rerun. Both test files fail.

Part of AGE-3182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `vitest` runner and a minimal component/route harness for `client/admin`, and runs it in CI. This replaces the previous no-runner state and enables automated tests for upcoming admin work (AGE-3182). No product code changes.

- Configures `vitest` with `happy-dom`, `@testing-library/react`, and `@testing-library/dom`; tests live at `src/**/*.test.tsx`. The `@` alias resolves via `vitest.config.ts`.
- Introduces `renderWithApp` and `renderRouteTree` in `client/admin/src/test/harness.tsx` (TanStack Router with memory history + React Query). Both await `router.load()` for deterministic renders.
- Adds two tests: a harness smoke test (router path, query, click, `Badge` with `badgeTone`) and a unit test asserting non-empty class strings for all `badgeTone` keys.
- CI: adds a “Test admin” step inside the existing `client-test` job; keeps a single required gate green.
- Lint/config: `.oxlintrc.json` now includes test globs; `tsconfig.node.json` includes `vitest.config.ts`.
- Lockfile: regenerated to align with main’s `@types/react`/`@types/react-dom` bumps, fixing a merge-queue install mismatch.
- Local run: aube run -F admin test. `happy-dom` matches the dashboard to keep one DOM implementation.

<sup>Written for commit 6f4a8cace1bcbde26b38db831fa124d73a058207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

