### PR TITLE
mig: add identity_map fold tables for employee identity analytics

### DIFF
--- a/.changeset/identity-map-clickhouse-tables.md
+++ b/.changeset/identity-map-clickhouse-tables.md
@@ -1,0 +1,8 @@
+---
+"server": patch
+---
+
+Add the ClickHouse identity_map fold tables (live + staging twin). Inert in
+this release: the sync worker and analytics readers land separately. The map
+folds each unambiguous directory or linked-account email to its owning user so
+analytics queries can resolve one employee to one identity via joinGet.

--- a/server/clickhouse/local/golang_migrate/20260813175845_identity-map.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260813175845_identity-map.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create "identity_map_staging" table
+DROP TABLE `identity_map_staging`;
+-- reverse: create "identity_map" table
+DROP TABLE `identity_map`;

--- a/server/clickhouse/local/golang_migrate/20260813175845_identity-map.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260813175845_identity-map.up.sql
@@ -1,0 +1,14 @@
+-- create "identity_map" table
+CREATE TABLE `identity_map` (
+  `org_id` String COMMENT 'Organization the identity belongs to.',
+  `email_lower` String COMMENT 'Normalized (lowercased, trimmed) email observed in telemetry.',
+  `canonical_user_id` String COMMENT 'Directory user id the email resolves to.',
+  `canonical_email` String COMMENT 'Normalized directory email of the owning user - the fold target for analytics.'
+) ENGINE = Join(ANY, LEFT, org_id, email_lower) COMMENT 'Employee identity fold map synced from Postgres. Maps each unambiguous directory or linked-account email to its owning user so analytics reads can fold one employee into one identity via joinGet, with missing keys returning the empty string to signal fall-back-to-literal. Ambiguous emails are deliberately absent.';
+-- create "identity_map_staging" table
+CREATE TABLE `identity_map_staging` (
+  `org_id` String COMMENT 'Organization the identity belongs to.',
+  `email_lower` String COMMENT 'Normalized (lowercased, trimmed) email observed in telemetry.',
+  `canonical_user_id` String COMMENT 'Directory user id the email resolves to.',
+  `canonical_email` String COMMENT 'Normalized directory email of the owning user - the fold target for analytics.'
+) ENGINE = Join(ANY, LEFT, org_id, email_lower) COMMENT 'Staging twin of identity_map. The sync worker rebuilds this table then swaps it live with EXCHANGE TABLES so readers never observe a partial map.';

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:0rR+UJolRapPBUsrFodmHjWjQ8oyTew2r2IOIZKy6lA=
+h1:wxcwixLPnXrxgnj9mIII9uUXtJ2fxJTMwbvUfCCTb3c=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -87,3 +87,4 @@ h1:0rR+UJolRapPBUsrFodmHjWjQ8oyTew2r2IOIZKy6lA=
 20260805105902_risk-findings-app-team-attribution.up.sql h1:UmQaEOmnP7ormKmGnaolNXAq2ogrRNVqxGj7EhfkGQ4=
 20260805161427_risk-findings-user-email.up.sql h1:2m9vZDNhLAZ2w5mVIS4vNtJtbTULtrHn+qZUU6ww3dE=
 20260811155533_challenge-bucket-summaries.up.sql h1:4+W+EYUk8z5tcrifQZAKKkecKy527L9MkVN/cWbPKhQ=
+20260813175845_identity-map.up.sql h1:2IG8WUJ7IjZ09mEZDv6Vm53g3w9a7wltgN4469roano=

--- a/server/clickhouse/migrations/20260813175839_identity-map.sql
+++ b/server/clickhouse/migrations/20260813175839_identity-map.sql
@@ -1,0 +1,14 @@
+-- Create "identity_map" table
+CREATE TABLE `identity_map` (
+  `org_id` String COMMENT 'Organization the identity belongs to.',
+  `email_lower` String COMMENT 'Normalized (lowercased, trimmed) email observed in telemetry.',
+  `canonical_user_id` String COMMENT 'Directory user id the email resolves to.',
+  `canonical_email` String COMMENT 'Normalized directory email of the owning user - the fold target for analytics.'
+) ENGINE = Join(ANY, LEFT, org_id, email_lower) COMMENT 'Employee identity fold map synced from Postgres. Maps each unambiguous directory or linked-account email to its owning user so analytics reads can fold one employee into one identity via joinGet, with missing keys returning the empty string to signal fall-back-to-literal. Ambiguous emails are deliberately absent.';
+-- Create "identity_map_staging" table
+CREATE TABLE `identity_map_staging` (
+  `org_id` String COMMENT 'Organization the identity belongs to.',
+  `email_lower` String COMMENT 'Normalized (lowercased, trimmed) email observed in telemetry.',
+  `canonical_user_id` String COMMENT 'Directory user id the email resolves to.',
+  `canonical_email` String COMMENT 'Normalized directory email of the owning user - the fold target for analytics.'
+) ENGINE = Join(ANY, LEFT, org_id, email_lower) COMMENT 'Staging twin of identity_map. The sync worker rebuilds this table then swaps it live with EXCHANGE TABLES so readers never observe a partial map.';

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:wqRCuiA4X/gRsCVatiyVFLaAAH+f1X9AHjcJoFb65TA=
+h1:k3pcJRdOaFeBWGHK3yFrIbkYbh+JUx7dXveuLf3ojc0=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -92,3 +92,4 @@ h1:wqRCuiA4X/gRsCVatiyVFLaAAH+f1X9AHjcJoFb65TA=
 20260805105857_risk-findings-app-team-attribution.sql h1:vfAJnjNr6OCXRxKCft2zjU02TZ6MjdfSMGqcLWchAos=
 20260805161421_risk-findings-user-email.sql h1:vIbFrSbYl1wNZ+j1o3GKTsE7s5yIFAQEcHhnqB2yW9Q=
 20260811155529_challenge-bucket-summaries.sql h1:9p9pNlNAgWvl6qsKuExCMP80qVONmNRxeThkJbBmkiE=
+20260813175839_identity-map.sql h1:7tYDG4ZwFxIti7uMPRmGN2IzESyzwkPEkng1sp8PdAg=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1495,3 +1495,23 @@ ORDER BY (organization_id, project_id, judge, created_at, id)
 TTL toDateTime(created_at) + INTERVAL 730 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Chat session analysis verdicts produced by the chat analysis judges.';
+
+-- Join engine (not a dictionary) so joinGet lookups need no source connection:
+-- a CLICKHOUSE-source dictionary authenticates its loopback load as the
+-- 'default' user, which does not exist in our deployments and would require
+-- environment-specific credentials in DDL.
+CREATE TABLE IF NOT EXISTS identity_map (
+    org_id String COMMENT 'Organization the identity belongs to.',
+    email_lower String COMMENT 'Normalized (lowercased, trimmed) email observed in telemetry.',
+    canonical_user_id String COMMENT 'Directory user id the email resolves to.',
+    canonical_email String COMMENT 'Normalized directory email of the owning user - the fold target for analytics.'
+) ENGINE = Join(ANY, LEFT, org_id, email_lower)
+COMMENT 'Employee identity fold map synced from Postgres. Maps each unambiguous directory or linked-account email to its owning user so analytics reads can fold one employee into one identity via joinGet, with missing keys returning the empty string to signal fall-back-to-literal. Ambiguous emails are deliberately absent.';
+
+CREATE TABLE IF NOT EXISTS identity_map_staging (
+    org_id String COMMENT 'Organization the identity belongs to.',
+    email_lower String COMMENT 'Normalized (lowercased, trimmed) email observed in telemetry.',
+    canonical_user_id String COMMENT 'Directory user id the email resolves to.',
+    canonical_email String COMMENT 'Normalized directory email of the owning user - the fold target for analytics.'
+) ENGINE = Join(ANY, LEFT, org_id, email_lower)
+COMMENT 'Staging twin of identity_map. The sync worker rebuilds this table then swaps it live with EXCHANGE TABLES so readers never observe a partial map.';


### PR DESCRIPTION
Part of DNO-855 (Canonical Identity Map for Cost Analytics). First of two stacked PRs — the Temporal sync worker (DNO-854) follows and depends on these tables.

## What

Adds two ClickHouse tables, inert in this release (nothing writes or reads them yet):

- `identity_map` — folds each unambiguous directory or linked-account email to its owning user, per organization, keyed `(org_id, email_lower)`.
- `identity_map_staging` — twin the sync worker rebuilds and swaps live with `EXCHANGE TABLES`, so readers never observe a partially built map.

## Why Join engine instead of a dictionary

The original design used a `complex_key_hashed` dictionary. Spiked and rejected: a `SOURCE(CLICKHOUSE(...))` dictionary performs its loopback load as the `default` user, which does not exist in our deployments — making it work would require environment-specific credentials embedded in DDL. `ENGINE = Join(ANY, LEFT, org_id, email_lower)` + `joinGet` gives the same one-expression scalar lookup with no source connection at all: hits return the canonical email, misses return `''`, which readers treat as fall-back-to-literal.

Verified locally: Atlas round-trips the Join engine DDL (clean re-diff), migration applies, and `INSERT → EXCHANGE TABLES → joinGet` hit/miss/cross-org behave as designed.

## Notes for review

- Both migration flavors generated by `mise run clickhouse:diff`; no hand edits.
- Join tables are memory-resident (the map is org-directory scale, trivially small) and persisted/reloaded across restarts.
- One follow-up check before readers flip (DNO-856): Join engine is not a replicated engine — confirm prod topology (single server vs multi-replica) supports it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ClickHouse Join-engine tables `identity_map` and `identity_map_staging` to back the employee identity fold map for canonical identity analytics (DNO-855). No behavior change now; they are inert until the sync worker (DNO-854) populates and readers (DNO-856) query them.

- Defines `identity_map` and `identity_map_staging` keyed `(org_id, email_lower)` with `canonical_user_id` and `canonical_email`; `joinGet` returns '' on misses.
- Uses Join engine instead of a CLICKHOUSE-source dictionary to avoid loopback auth as the non-existent `default` user; no source connection needed.
- Enables atomic swaps via `EXCHANGE TABLES` with the staging twin; safe on our Shared database (creates SharedJoin tables; replication and swaps supported).
- Includes Atlas and `golang_migrate` migrations and updates `schema.sql`; generated cleanly.
- Migration action: apply the ClickHouse migrations; no app changes required.

<sup>Written for commit dd7924bd6a4a60f7b6b63608ce118213578d0b6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

