### PR TITLE
chore(admin): seed fake organizations for the admin list

### DIFF
--- a/.mise-tasks/seed-admin-orgs.mts
+++ b/.mise-tasks/seed-admin-orgs.mts
@@ -1,0 +1,237 @@
+#!/usr/bin/env -S node --import tsx
+
+//MISE description="Seed fake organizations locally so the admin organizations list has paging, sorting, account types, disabled orgs and trial states to exercise"
+
+import crypto from "node:crypto";
+
+import { intro, log, outro } from "@clack/prompts";
+import { $ } from "zx";
+
+// Every seeded id and slug starts with this so real rows are never mistaken for
+// fixtures, and so `id NOT LIKE 'seedorg%'` isolates real data.
+const MARKER = "seedorg";
+
+const ADJECTIVES = [
+  "Northwind",
+  "Larkspur",
+  "Ironvale",
+  "Sablewood",
+  "Meridian",
+  "Copperline",
+  "Harborlight",
+  "Quillstone",
+];
+const NOUNS = [
+  "Analytics",
+  "Logistics",
+  "Robotics",
+  "Systems",
+  "Labs",
+  "Networks",
+  "Foundry",
+  "Dynamics",
+  "Ventures",
+  "Instruments",
+  "Collective",
+  "Partners",
+  "Optics",
+  "Forge",
+  "Provisions",
+  "Signals",
+];
+
+// One org per adjective/noun pair keeps every slug unique.
+const ORG_COUNT = ADJECTIVES.length * NOUNS.length;
+
+const MEMBER_NAMES = [
+  "Ada Kestrel",
+  "Bo Marlow",
+  "Cora Vance",
+  "Dev Aturi",
+  "Elin Sarto",
+  "Fen Okabe",
+  "Gwen Ashby",
+  "Hugo Petrov",
+  "Ida Renner",
+  "Jonas Wilde",
+  "Kira Lund",
+  "Liam Osei",
+];
+
+const ACCOUNT_TYPES = ["free", "pro", "enterprise"] as const;
+
+type Trial = {
+  endsInDays: number;
+  demotedDaysAgo?: number;
+  convertedDaysAgo?: number;
+};
+
+/** Trial state is derived from dates, so each row is an offset from now plus
+ *  the demoted/converted markers. Orgs past the end of this list never
+ *  started a trial. */
+const TRIALS: Trial[] = [
+  // running; the first two straddle the 7-day "ending soon" threshold, so a
+  // wrong threshold constant moves a row between the two states
+  { endsInDays: 7.1 },
+  { endsInDays: 9 },
+  { endsInDays: 13 },
+  { endsInDays: 18 },
+  { endsInDays: 24 },
+  { endsInDays: 31 },
+  { endsInDays: 40 },
+  { endsInDays: 55 },
+  // ending soon
+  { endsInDays: 6.9 },
+  { endsInDays: 5.5 },
+  { endsInDays: 4 },
+  { endsInDays: 2 },
+  { endsInDays: 0.5 },
+  // expired
+  { endsInDays: -1 },
+  { endsInDays: -6 },
+  { endsInDays: -15 },
+  { endsInDays: -40 },
+  { endsInDays: -120 },
+  // demoted; the last is demoted despite a future end date
+  { endsInDays: -30, demotedDaysAgo: 29 },
+  { endsInDays: -75, demotedDaysAgo: 74 },
+  { endsInDays: -200, demotedDaysAgo: 199 },
+  { endsInDays: 12, demotedDaysAgo: 3 },
+  // converted; the last is converted despite a future end date
+  { endsInDays: -20, convertedDaysAgo: 25 },
+  { endsInDays: -90, convertedDaysAgo: 95 },
+  { endsInDays: -300, convertedDaysAgo: 305 },
+  { endsInDays: 18, convertedDaysAgo: 4 },
+];
+
+function hash(value: string): string {
+  return crypto.createHash("sha1").update(value).digest("hex").slice(0, 16);
+}
+
+function sqlString(value: string | null): string {
+  if (value === null) return "NULL";
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function days(n: number): string {
+  return `now() + interval '${n} days'`;
+}
+
+async function psql(sql: string): Promise<string> {
+  const dbUser = process.env.DB_USER ?? "gram";
+  const dbName = process.env.DB_NAME ?? "gram";
+  // On stdin, not -c: the membership insert is larger than one argv entry.
+  const out = await $({
+    input: sql,
+  })`docker compose exec -T gram-db psql -U ${dbUser} -d ${dbName} -v ON_ERROR_STOP=1 -At`.quiet();
+  return out.stdout.trim();
+}
+
+async function main(): Promise<void> {
+  intro("Seeding fake organizations for the admin organizations list...");
+  let success = false;
+  using _ = {
+    [Symbol.dispose]() {
+      outro(success ? "Done." : "Seeding failed.");
+    },
+  };
+
+  const orgs = [...Array(ORG_COUNT).keys()].map((i) => {
+    const name = `${ADJECTIVES[i % ADJECTIVES.length]} ${NOUNS[Math.floor(i / ADJECTIVES.length)]}`;
+    const key = name.toLowerCase().replace(/ /g, "-");
+    const trial = TRIALS[i] ?? null;
+    const trialTier = i % 2 === 0 ? "pro" : "enterprise";
+    // Age rank is a permutation of i (47 is coprime with ORG_COUNT), so trial
+    // states interleave with the creation-date ordering instead of banding.
+    const age = ((i * 47) % ORG_COUNT) * 9;
+    return {
+      id: `${MARKER}_${key}`,
+      slug: `${MARKER}-${key}`,
+      name,
+      accountType: trial?.convertedDaysAgo
+        ? trialTier
+        : trial?.demotedDaysAgo
+          ? "free"
+          : ACCOUNT_TYPES[i % 3]!,
+      // Stride coprime with the account-type cycle so every type has disabled
+      // and enabled orgs.
+      disabled: i % 7 === 4,
+      workosId: i % 2 === 0 ? `${MARKER}_workos_${key}` : null,
+      createdAt: days(-age), // 9 days apart: several years of history
+      disabledAt: days(-1 - (i % 40)),
+      // The list column still reads free_trial_ends_at, so set it per row
+      // instead of letting the column default make every org look mid-trial.
+      freeTrialEndsAt: days(trial ? trial.endsInDays : -age + 14),
+      memberCount: 1 + (i % 12),
+      trial,
+      trialTier,
+    };
+  });
+
+  const orgValues = orgs
+    .map(
+      (o) =>
+        `(${sqlString(o.id)}, ${sqlString(o.name)}, ${sqlString(o.slug)}, ${o.createdAt}, ${o.createdAt}, ${sqlString(o.accountType)}, ${o.disabled ? o.disabledAt : "NULL"}, ${sqlString(o.workosId)}, ${o.createdAt}, ${o.freeTrialEndsAt})`,
+    )
+    .join(",\n");
+  // Every id is marker-prefixed and deterministic, so a conflict can only be a
+  // row this task wrote. Re-running re-anchors the dates to the current now().
+  await psql(
+    `INSERT INTO organization_metadata (id, name, slug, created_at, updated_at, gram_account_type, disabled_at, workos_id, free_trial_started_at, free_trial_ends_at) VALUES\n${orgValues}\nON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, slug = EXCLUDED.slug, created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at, gram_account_type = EXCLUDED.gram_account_type, disabled_at = EXCLUDED.disabled_at, workos_id = EXCLUDED.workos_id, free_trial_started_at = EXCLUDED.free_trial_started_at, free_trial_ends_at = EXCLUDED.free_trial_ends_at;`,
+  );
+
+  const trialValues = orgs
+    .filter((o) => o.trial)
+    .map(
+      (o) =>
+        `(${sqlString(o.id)}, ${sqlString(o.trialTier)}, ${days(o.trial!.endsInDays)}, ${o.trial!.convertedDaysAgo ? days(-o.trial!.convertedDaysAgo) : "NULL"}, ${o.trial!.demotedDaysAgo ? days(-o.trial!.demotedDaysAgo) : "NULL"})`,
+    )
+    .join(",\n");
+  await psql(
+    `INSERT INTO trials (organization_id, tier, ends_at, converted_at, demoted_at) VALUES\n${trialValues}\nON CONFLICT (organization_id) DO UPDATE SET tier = EXCLUDED.tier, ends_at = EXCLUDED.ends_at, converted_at = EXCLUDED.converted_at, demoted_at = EXCLUDED.demoted_at, updated_at = clock_timestamp();`,
+  );
+
+  // One shared pool of users; org i takes the first memberCount of them, so the
+  // Members column varies without seeding hundreds of user rows.
+  const members = MEMBER_NAMES.map((name) => {
+    const email = `${MARKER}.${name.toLowerCase().replace(/ /g, ".")}@example.com`;
+    return {
+      id: `${MARKER}_usr_${hash(email)}`,
+      email,
+      name,
+      workosId: `${MARKER}_workos_usr_${hash(email)}`,
+    };
+  });
+
+  const userValues = members
+    .map(
+      (m) =>
+        `(${sqlString(m.id)}, ${sqlString(m.email)}, ${sqlString(m.name)}, ${sqlString(m.workosId)})`,
+    )
+    .join(",\n");
+  await psql(
+    `INSERT INTO users (id, email, display_name, workos_id) VALUES\n${userValues}\nON CONFLICT DO NOTHING;`,
+  );
+
+  const relationshipValues = orgs
+    .flatMap((o) =>
+      members
+        .slice(0, o.memberCount)
+        .map(
+          (m) =>
+            `(${sqlString(o.id)}, ${sqlString(m.id)}, ${sqlString(m.workosId)}, ${sqlString(`${MARKER}_mem_${o.id}_${m.id}`)})`,
+        ),
+    )
+    .join(",\n");
+  await psql(
+    `INSERT INTO organization_user_relationships (organization_id, user_id, workos_user_id, workos_membership_id) VALUES\n${relationshipValues}\nON CONFLICT DO NOTHING;`,
+  );
+
+  const summary = await psql(
+    `SELECT count(*) || ' orgs, ' || count(*) FILTER (WHERE disabled_at IS NOT NULL) || ' disabled, ' || count(t.organization_id) || ' with a trial' FROM organization_metadata o LEFT JOIN trials t ON t.organization_id = o.id WHERE o.id LIKE '${MARKER}%';`,
+  );
+  log.info(`Seeded: ${summary}`);
+  success = true;
+}
+
+await main();

--- a/.mise-tasks/seed-admin-orgs.mts
+++ b/.mise-tasks/seed-admin-orgs.mts
@@ -161,7 +161,9 @@ async function main(): Promise<void> {
       disabledAt: days(-1 - (i % 40)),
       // The list column still reads free_trial_ends_at, so set it per row
       // instead of letting the column default make every org look mid-trial.
-      freeTrialEndsAt: days(trial ? trial.endsInDays : -age + 14),
+      // Signup plus 14 days, clamped into the past: without the clamp an org
+      // younger than 14 days gets a future date and reads as mid-trial.
+      freeTrialEndsAt: days(trial ? trial.endsInDays : Math.min(14 - age, -1)),
       memberCount: 1 + (i % 12),
       trial,
       trialTier,
@@ -224,7 +226,7 @@ async function main(): Promise<void> {
     )
     .join(",\n");
   await psql(
-    `INSERT INTO organization_user_relationships (organization_id, user_id, workos_user_id, workos_membership_id) VALUES\n${relationshipValues}\nON CONFLICT DO NOTHING;`,
+    `INSERT INTO organization_user_relationships (organization_id, user_id, workos_user_id, workos_membership_id) VALUES\n${relationshipValues}\nON CONFLICT (organization_id, user_id) DO UPDATE SET workos_user_id = EXCLUDED.workos_user_id, workos_membership_id = EXCLUDED.workos_membership_id, deleted_at = NULL, updated_at = clock_timestamp();`,
   );
 
   const summary = await psql(


### PR DESCRIPTION
A fresh local database holds two organizations. Both are enterprise, neither is disabled, and neither is on a trial. You cannot build or demonstrate paging, sorting, an account-type filter, a trial column, or bulk selection against that.

This adds `mise run seed-admin-orgs`, following the three `.mise-tasks/seed-*.mts` tasks already in the repository.

# What it writes

128 organizations, plus their users and memberships:

| Dimension       | Spread                                                          |
| --------------- | --------------------------------------------------------------- |
| Account type    | 44 free, 42 pro, 42 enterprise                                  |
| Disabled        | 18: 6 free, 5 pro, 7 enterprise                                 |
| Trials          | 26: 8 running, 5 ending soon, 5 expired, 4 demoted, 4 converted |
| Members per org | 1 to 12, from one shared pool of 12 users                       |
| Created         | 9 days apart, so sorting by age has something to sort           |

Two trials sit either side of the 7-day "ending soon" boundary, at 6.9 and 7.1 days. A wrong threshold constant moves a row between two states and you see it on screen.

# Notes for the reviewer

Every id and slug starts with `seedorg`. That gives you `id NOT LIKE 'seedorg%'` to isolate real data, and it means an id conflict can only be a row this task wrote on an earlier run.

Every insert is `ON CONFLICT DO UPDATE`, not `DO NOTHING`. All dates are relative to `now()`, so under `DO NOTHING` a re-run would leave the fixture where it was and every running trial would expire within a fortnight. The membership upsert also clears `deleted_at`, so a member you removed by hand comes back on the next run.

Names, emails, and WorkOS ids are invented. Emails use `example.com`.

SQL goes to `psql` on stdin rather than through `-c`. The membership insert is larger than one argv entry and `-c` fails with `spawn E2BIG`.

Like the three seed tasks already in `.mise-tasks/`, this one carries no unit test. A run plus SQL is the check.

# How to verify

```
mise run seed-admin-orgs
```

It prints `Seeded: 128 orgs, 18 disabled, 26 with a trial`. Then confirm the spread and confirm it left real rows alone:

```sql
-- Keep the marker filter on. Without it you count your own real rows too.
SELECT gram_account_type, count(*), count(*) FILTER (WHERE disabled_at IS NOT NULL)
FROM organization_metadata WHERE id LIKE 'seedorg%' GROUP BY 1 ORDER BY 1;

SELECT id LIKE 'seedorg%' AS seeded, count(*), max(updated_at)
FROM organization_metadata GROUP BY 1 ORDER BY 1;

-- No organization without a trial row may hold a future trial end date.
SELECT count(*) FILTER (WHERE o.free_trial_ends_at > now()), count(*)
FROM organization_metadata o LEFT JOIN trials t ON t.organization_id = o.id
WHERE o.id LIKE 'seedorg%' AND t.organization_id IS NULL;
```

The second query shows the seeded rows updated just now and the real rows untouched. The third returns `0 | 102`. Run the task twice: the counts do not move and the dates re-anchor.

Part of AGE-3182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
