### PR TITLE
fix: land demo org visitors on the default project

### DIFF
--- a/.changeset/demo-org-default-project-landing.md
+++ b/.changeset/demo-org-default-project-landing.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Land `/explore-demo` on the demo org's default project instead of org home, so new visitors see sample data without having to click into the project themselves.

--- a/client/dashboard/src/lib/demo.ts
+++ b/client/dashboard/src/lib/demo.ts
@@ -3,6 +3,12 @@
 // by the org slug on the frontend.
 export const DEMO_ORG_SLUG = "acme-demo";
 
+// The demo org is seeded with a single project. New visitors land here so
+// they see sample data instead of the empty org home.
+export const DEMO_PROJECT_SLUG = "default";
+
+export const DEMO_LANDING_PATH = `/${DEMO_ORG_SLUG}/projects/${DEMO_PROJECT_SLUG}`;
+
 // Set by the /explore-demo page before switching, so Exit demo can return a
 // multi-org user to the org they actually came from.
 export const PRE_DEMO_ORG_KEY = "gram:pre-demo-org";

--- a/client/dashboard/src/lib/demo.ts
+++ b/client/dashboard/src/lib/demo.ts
@@ -5,7 +5,7 @@ export const DEMO_ORG_SLUG = "acme-demo";
 
 // The demo org is seeded with a single project. New visitors land here so
 // they see sample data instead of the empty org home.
-export const DEMO_PROJECT_SLUG = "default";
+const DEMO_PROJECT_SLUG = "default";
 
 export const DEMO_LANDING_PATH = `/${DEMO_ORG_SLUG}/projects/${DEMO_PROJECT_SLUG}`;
 

--- a/client/dashboard/src/pages/demo/ExploreDemo.test.tsx
+++ b/client/dashboard/src/pages/demo/ExploreDemo.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GramError } from "@gram/client/models/errors/gramerror.js";
+import { DEMO_LANDING_PATH } from "@/lib/demo";
+
+const mocks = vi.hoisted(() => ({
+  enterDemo: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: () => ({
+    auth: { enterDemo: mocks.enterDemo, info: mocks.info },
+  }),
+}));
+
+vi.mock("@/pages/login/components/auth-shell", () => ({
+  AuthShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+function gramError(status: number): GramError {
+  return new GramError("request failed", {
+    response: new Response(null, { status }),
+    request: new Request("https://app.getgram.ai/rpc/auth.enterDemo"),
+    body: "",
+  });
+}
+
+describe("ExploreDemo", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("lands on the demo default project after enterDemo", async () => {
+    mocks.info.mockResolvedValue({
+      result: {
+        activeOrganizationId: "org-1",
+        organizations: [{ id: "org-1", slug: "my-org" }],
+      },
+    });
+    mocks.enterDemo.mockResolvedValue({});
+    const replace = vi.fn();
+    vi.stubGlobal("location", { replace });
+
+    const { default: ExploreDemo } = await import("./ExploreDemo");
+    render(<ExploreDemo />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(DEMO_LANDING_PATH);
+    });
+    expect(DEMO_LANDING_PATH).toBe("/acme-demo/projects/default");
+  });
+
+  it("bounces unauthenticated visitors through login back to /explore-demo", async () => {
+    mocks.info.mockRejectedValue(new Error("no session"));
+    mocks.enterDemo.mockRejectedValue(gramError(401));
+    const replace = vi.fn();
+    vi.stubGlobal("location", { replace });
+
+    const { default: ExploreDemo } = await import("./ExploreDemo");
+    render(<ExploreDemo />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        `/login?redirect=${encodeURIComponent("/explore-demo")}`,
+      );
+    });
+  });
+});

--- a/client/dashboard/src/pages/demo/ExploreDemo.test.tsx
+++ b/client/dashboard/src/pages/demo/ExploreDemo.test.tsx
@@ -2,12 +2,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
-import {
-  DEMO_LANDING_PATH,
-  DEMO_ORG_SLUG,
-  DEMO_PROJECT_SLUG,
-  PRE_DEMO_ORG_KEY,
-} from "@/lib/demo";
+import { DEMO_LANDING_PATH, DEMO_ORG_SLUG, PRE_DEMO_ORG_KEY } from "@/lib/demo";
 
 const mocks = vi.hoisted(() => ({
   enterDemo: vi.fn(),
@@ -57,9 +52,7 @@ describe("ExploreDemo", () => {
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith(DEMO_LANDING_PATH);
     });
-    expect(DEMO_LANDING_PATH).toBe(
-      `/${DEMO_ORG_SLUG}/projects/${DEMO_PROJECT_SLUG}`,
-    );
+    expect(DEMO_LANDING_PATH).toBe("/acme-demo/projects/default");
     expect(localStorage.getItem(PRE_DEMO_ORG_KEY)).toBe("org-1");
   });
 

--- a/client/dashboard/src/pages/demo/ExploreDemo.test.tsx
+++ b/client/dashboard/src/pages/demo/ExploreDemo.test.tsx
@@ -2,7 +2,12 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
-import { DEMO_LANDING_PATH } from "@/lib/demo";
+import {
+  DEMO_LANDING_PATH,
+  DEMO_ORG_SLUG,
+  DEMO_PROJECT_SLUG,
+  PRE_DEMO_ORG_KEY,
+} from "@/lib/demo";
 
 const mocks = vi.hoisted(() => ({
   enterDemo: vi.fn(),
@@ -32,6 +37,7 @@ describe("ExploreDemo", () => {
     cleanup();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it("lands on the demo default project after enterDemo", async () => {
@@ -51,7 +57,31 @@ describe("ExploreDemo", () => {
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith(DEMO_LANDING_PATH);
     });
-    expect(DEMO_LANDING_PATH).toBe("/acme-demo/projects/default");
+    expect(DEMO_LANDING_PATH).toBe(
+      `/${DEMO_ORG_SLUG}/projects/${DEMO_PROJECT_SLUG}`,
+    );
+    expect(localStorage.getItem(PRE_DEMO_ORG_KEY)).toBe("org-1");
+  });
+
+  it("does not stash the demo org as the pre-demo return target", async () => {
+    localStorage.setItem(PRE_DEMO_ORG_KEY, "existing-org");
+    mocks.info.mockResolvedValue({
+      result: {
+        activeOrganizationId: "demo-org",
+        organizations: [{ id: "demo-org", slug: DEMO_ORG_SLUG }],
+      },
+    });
+    mocks.enterDemo.mockResolvedValue({});
+    const replace = vi.fn();
+    vi.stubGlobal("location", { replace });
+
+    const { default: ExploreDemo } = await import("./ExploreDemo");
+    render(<ExploreDemo />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(DEMO_LANDING_PATH);
+    });
+    expect(localStorage.getItem(PRE_DEMO_ORG_KEY)).toBe("existing-org");
   });
 
   it("bounces unauthenticated visitors through login back to /explore-demo", async () => {

--- a/client/dashboard/src/pages/demo/ExploreDemo.tsx
+++ b/client/dashboard/src/pages/demo/ExploreDemo.tsx
@@ -1,4 +1,4 @@
-import { DEMO_ORG_SLUG, PRE_DEMO_ORG_KEY } from "@/lib/demo";
+import { DEMO_LANDING_PATH, DEMO_ORG_SLUG, PRE_DEMO_ORG_KEY } from "@/lib/demo";
 import { useSdkClient } from "@/contexts/Sdk";
 import { AuthShell } from "@/pages/login/components/auth-shell";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
@@ -6,8 +6,9 @@ import { useEffect, useRef, useState } from "react";
 
 /**
  * Stable link target for entering the shared read-only demo org: switches the
- * current session into it via auth.enterDemo, then reloads into the demo org
- * route. Logged-out visitors bounce through /login and land back here.
+ * current session into it via auth.enterDemo, then reloads into the demo
+ * default project. Logged-out visitors bounce through /login and land back
+ * here.
  */
 export default function ExploreDemo(): JSX.Element {
   const client = useSdkClient();
@@ -34,9 +35,12 @@ export default function ExploreDemo(): JSX.Element {
       }
       return client.auth.enterDemo();
     })().then(
-      // Land directly on the demo org route: a bare "/" gets reconciled
-      // against the last-visited org, which would switch the session back.
-      () => window.location.replace(`/${DEMO_ORG_SLUG}`),
+      // Land on the default project, not org home: a bare "/" gets
+      // reconciled against the last-visited org and would switch the
+      // session back, and org home has nothing interesting for a new
+      // visitor. The org slug must stay in the URL so AuthProvider does
+      // not bounce them out of the demo session.
+      () => window.location.replace(DEMO_LANDING_PATH),
       (err: unknown) => {
         // No session yet — bounce through login and come back here.
         if (err instanceof GramError && err.statusCode === 401) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AGE-3175. Visiting `/explore-demo` switched the session into the shared demo org and then reloaded onto org home, which has nothing interesting for a new visitor. They had to notice and click into the default project before any sample data showed up.

`/explore-demo` now reloads onto that project's home (`…/projects/default`) after `auth.enterDemo`. The org slug stays in the URL so AuthProvider does not bounce the session back to the last-visited org. Logged-out visitors still go through `/login?redirect=/explore-demo`.

## Testing
- `aube run -F dashboard test src/pages/demo/ExploreDemo.test.tsx` — landing path after `enterDemo`, and the unauthenticated login bounce.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3175](https://linear.app/speakeasy/issue/AGE-3175/fix-for-demo-org-land-a-new-user-in-the-default-project)

<div><a href="https://cursor.com/agents/bc-8fd16b22-30fe-4845-bbf0-e454ac308fbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fd16b22-30fe-4845-bbf0-e454ac308fbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Land `/explore-demo` on the demo org’s default project so new visitors see sample data immediately. Previously we reloaded to org home; now we redirect to `/acme-demo/projects/default` after `auth.enterDemo` and keep the org slug to prevent session bounce.

- Satisfies Linear AGE-3175.
- Redirect to `DEMO_LANDING_PATH` (`/acme-demo/projects/default`) after `auth.enterDemo`; keep the org slug in the URL.
- Store the active non-demo org in `PRE_DEMO_ORG_KEY`; do not stash the demo org.
- Unauthenticated visitors still go through `/login?redirect=/explore-demo`.
- Tests assert the literal landing path and pre-demo stash behavior; keep the demo project slug module-private to appease `knip`.

<sup>Written for commit c0c5a0f0bb5818d567f0805c3042a200ae103a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

