### PR TITLE
chore: cover auth.register through the HTTP stack in tests

### DIFF
--- a/server/internal/auth/register_test.go
+++ b/server/internal/auth/register_test.go
@@ -1,12 +1,19 @@
 package auth_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
 
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
+	authserver "github.com/speakeasy-api/gram/server/gen/http/auth/server"
+	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -534,4 +541,61 @@ func TestRegister_CreatesOrganizationForNameWithNoDerivableSlug(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, orgName, org.Name)
 	require.Regexp(t, `^org-[a-z1-9]{8}$`, org.Slug)
+}
+
+// TestRegisterHTTP_OrganizationlessSessionProvisionsOrg issues POST
+// /rpc/auth.register through the mounted HTTP stack so session
+// authentication and authz.PrepareContext run before the handler.
+func TestRegisterHTTP_OrganizationlessSessionProvisionsOrg(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	userInfo.Organizations = []MockOrganizationEntry{}
+	ctx, instance := newTestAuthServiceForOrganizationProvisioning(t, userInfo)
+
+	session := sessions.Session{
+		SessionID:            t.Name(),
+		UserID:               userInfo.UserID,
+		ActiveOrganizationID: "",
+		WorkOSSessionID:      "",
+	}
+	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
+
+	mux := goahttp.NewMuxer()
+	auth.Attach(mux, instance.service)
+
+	const orgName = "HTTP Register Org"
+	body, err := json.Marshal(map[string]string{"org_name": orgName})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/rpc/auth.register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Gram-Session", session.SessionID)
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+
+	stored, err := instance.sessionManager.GetSession(ctx, session.SessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, stored.ActiveOrganizationID)
+
+	org, err := orgRepo.New(instance.conn).GetOrganizationMetadata(ctx, stored.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, orgName, org.Name)
+
+	infoReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/rpc/auth.info", nil)
+	infoReq.Header.Set("Gram-Session", session.SessionID)
+	infoRec := httptest.NewRecorder()
+	mux.ServeHTTP(infoRec, infoReq)
+	require.Equal(t, http.StatusOK, infoRec.Code, infoRec.Body.String())
+
+	var info authserver.InfoResponseBody
+	require.NoError(t, json.Unmarshal(infoRec.Body.Bytes(), &info))
+	require.Equal(t, stored.ActiveOrganizationID, info.ActiveOrganizationID)
+	require.Len(t, info.Organizations, 1)
+	require.Equal(t, orgName, info.Organizations[0].Name)
+	require.Len(t, info.Organizations[0].Projects, 1)
+	require.Equal(t, "Default", info.Organizations[0].Projects[0].Name)
+	require.Equal(t, "default", info.Organizations[0].Projects[0].Slug)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pins `POST /rpc/auth.register` through the mounted HTTP stack so session authentication and `authz.PrepareContext` run before the handler.

Direct `Register()` tests skip that middleware, which is where an organization-less session previously 500'd (AGE-3176 / AGE-3127). This one case stores a session with no active organization, posts through the mux, and asserts a 200 plus the provisioned organization and default project.

## Test plan

- [x] `mise exec -- go test ./server/internal/auth/ -run TestRegisterHTTP_OrganizationlessSessionProvisionsOrg`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3176](https://linear.app/speakeasy/issue/AGE-3176/chore-cover-authregister-through-the-http-stack-in-tests)

<div><a href="https://cursor.com/agents/bc-559d1aa9-2aac-4cde-83a4-668fabc84ac0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-559d1aa9-2aac-4cde-83a4-668fabc84ac0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Covers `POST /rpc/auth.register` via the mounted HTTP stack so session auth and `authz.PrepareContext` run before the handler. This closes the gap where direct `Register()` tests bypassed middleware and missed the organization-less session 500 (AGE-3127); aligns with AGE-3176’s requirement for HTTP-path coverage. No runtime behavior change, tests only.

- Adds `TestRegisterHTTP_OrganizationlessSessionProvisionsOrg` in `server/internal/auth/register_test.go`. It stores a session with no active organization, posts to `POST /rpc/auth.register`, asserts 200 and that an organization and default project are provisioned, then verifies via `GET /rpc/auth.info`.
- Mounts the real routes using `goahttp.NewMuxer()` and `auth.Attach(...)` to exercise the full middleware path.

<sup>Written for commit b8abbf89aeb0d9135b4cb130032a5b0b06394597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

