### PR TITLE
feat: sync employee identity map from Postgres to ClickHouse

### DIFF
--- a/.changeset/identity-map-sync-worker.md
+++ b/.changeset/identity-map-sync-worker.md
@@ -1,0 +1,10 @@
+---
+"server": patch
+---
+
+Add the identity map sync worker: a scheduled Temporal workflow rebuilds the
+ClickHouse identity_map fold table from the Postgres directory every 15
+minutes, mapping each unambiguous directory or linked-account email to its
+owning user. Full refresh into a staging table with an atomic swap, so
+deletions propagate and readers never observe a partial map. Nothing reads the
+map yet; analytics folding lands separately.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -476,6 +476,7 @@ const (
 	// denied the tool call (e.g. shadow-MCP guard). Its presence (non-empty)
 	// signals the trace should render as "blocked" in dashboards.
 	HookBlockReasonKey       = attribute.Key("gram.hook.block_reason")
+	IdentityMapEntryCountKey = attribute.Key("gram.identity_map.entry_count")
 	LiteLLMInstanceIDKey     = attribute.Key("gram.litellm.instance_id")
 	LiteLLMCallIDKey         = attribute.Key("gram.litellm.call_id")
 	LiteLLMTraceIDKey        = attribute.Key("gram.litellm.trace_id")
@@ -807,6 +808,9 @@ func SlogHookSource(v string) slog.Attr      { return slog.String(string(HookSou
 
 func HookBlockReason(v string) attribute.KeyValue { return HookBlockReasonKey.String(v) }
 func SlogHookBlockReason(v string) slog.Attr      { return slog.String(string(HookBlockReasonKey), v) }
+
+func IdentityMapEntryCount(v int) attribute.KeyValue { return IdentityMapEntryCountKey.Int(v) }
+func SlogIdentityMapEntryCount(v int) slog.Attr      { return slog.Int(string(IdentityMapEntryCountKey), v) }
 
 func HookHasPluginAuth(v bool) attribute.KeyValue { return HookHasPluginAuthKey.Bool(v) }
 func SlogHookHasPluginAuth(v bool) slog.Attr      { return slog.Bool(string(HookHasPluginAuthKey), v) }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -304,7 +304,7 @@ func NewActivities(
 		sendOpenRouterCreditsAlerts:     activities.NewMaybeSendOpenRouterCreditsAlerts(logger, db, cacheAdapter, emailService, meterProvider),
 		firePlatformUsageMetrics:        activities.NewFirePlatformUsageMetrics(logger, billingTracker),
 		correlateClaudePrompts:          activities.NewCorrelateClaudePrompts(logger, db, chConn),
-		syncIdentityMap:                 activities.NewSyncIdentityMap(logger, db, chConn),
+		syncIdentityMap:                 activities.NewSyncIdentityMap(logger, db, chConn, cacheAdapter),
 		promoteStagedTelemetry:          activities.NewPromoteStagedTelemetry(logger, chConn, cacheAdapter, telemetryLogPublisher),
 		listStagedTelemetryProjects:     activities.NewListStagedTelemetryProjects(logger, chConn),
 		generateChatTitle:               activities.NewGenerateChatTitle(logger, db, chatClient),

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -102,6 +102,7 @@ type Activities struct {
 	sendOpenRouterCreditsAlerts     *activities.MaybeSendOpenRouterCreditsAlerts
 	firePlatformUsageMetrics        *activities.FirePlatformUsageMetrics
 	correlateClaudePrompts          *activities.CorrelateClaudePrompts
+	syncIdentityMap                 *activities.SyncIdentityMap
 	promoteStagedTelemetry          *activities.PromoteStagedTelemetry
 	listStagedTelemetryProjects     *activities.ListStagedTelemetryProjects
 	generateChatTitle               *activities.GenerateChatTitle
@@ -303,6 +304,7 @@ func NewActivities(
 		sendOpenRouterCreditsAlerts:     activities.NewMaybeSendOpenRouterCreditsAlerts(logger, db, cacheAdapter, emailService, meterProvider),
 		firePlatformUsageMetrics:        activities.NewFirePlatformUsageMetrics(logger, billingTracker),
 		correlateClaudePrompts:          activities.NewCorrelateClaudePrompts(logger, db, chConn),
+		syncIdentityMap:                 activities.NewSyncIdentityMap(logger, db, chConn),
 		promoteStagedTelemetry:          activities.NewPromoteStagedTelemetry(logger, chConn, cacheAdapter, telemetryLogPublisher),
 		listStagedTelemetryProjects:     activities.NewListStagedTelemetryProjects(logger, chConn),
 		generateChatTitle:               activities.NewGenerateChatTitle(logger, db, chatClient),
@@ -577,6 +579,10 @@ func (a *Activities) GenerateChatTitle(ctx context.Context, input activities.Gen
 
 func (a *Activities) CorrelateClaudePrompts(ctx context.Context, input activities.CorrelateClaudePromptsArgs) (*activities.CorrelateClaudePromptsResult, error) {
 	return a.correlateClaudePrompts.Do(ctx, input)
+}
+
+func (a *Activities) SyncIdentityMap(ctx context.Context) (*activities.SyncIdentityMapResult, error) {
+	return a.syncIdentityMap.Do(ctx)
 }
 
 func (a *Activities) PromoteStagedTelemetry(ctx context.Context, input activities.PromoteStagedTelemetryArgs) (*activities.PromoteStagedTelemetryResult, error) {

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -381,6 +381,11 @@ WHERE id = ANY(@ids::bigint[])
 -- email has no directory row in the org and exactly one connected owner with
 -- an unambiguous directory email claims it. Ambiguous emails are omitted so
 -- readers fall back to literal matching rather than guessing.
+--
+-- The owner-ambiguity count deliberately includes account links whose owner is
+-- since deleted or disconnected (matching the Go resolver): a second historical
+-- claimant has telemetry rows under the shared email, and folding it to the
+-- surviving owner would move the departed claimant's usage onto them.
 WITH directory AS (
     SELECT
         our.organization_id,

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -367,3 +367,69 @@ UPDATE publish_outbox SET
     updated_at = clock_timestamp()
 WHERE id = ANY(@ids::bigint[])
   AND lease_token = @lease_token::uuid;
+
+-- name: ListIdentityMapEntries :many
+-- Source of the ClickHouse identity_map fold table. Internal sync sweep that
+-- deliberately spans all organizations: the org boundary is carried in the
+-- output rows (organization_id keys the map), not the predicate; not reachable
+-- from user-facing handlers.
+--
+-- Encodes the employee identity fold rules (the SQL twin of telemetry's
+-- resolveEmployeeIdentity, which DNO-857 retires): a directory email maps to
+-- its user only when exactly one connected, non-deleted user claims it
+-- case-insensitively; a linked-account email maps to its owner only when the
+-- email has no directory row in the org and exactly one connected owner with
+-- an unambiguous directory email claims it. Ambiguous emails are omitted so
+-- readers fall back to literal matching rather than guessing.
+WITH directory AS (
+    SELECT
+        our.organization_id,
+        lower(btrim(u.email)) AS email_lower,
+        min(u.id) AS user_id,
+        count(*) AS claimants
+    FROM users u
+    JOIN organization_user_relationships our ON our.user_id = u.id
+    WHERE u.deleted_at IS NULL
+      AND our.deleted_at IS NULL
+      AND btrim(u.email) != ''
+    GROUP BY our.organization_id, lower(btrim(u.email))
+), account_owners AS (
+    SELECT ua.organization_id, lower(btrim(ua.email)) AS email_lower, ua.user_id
+    FROM user_accounts ua
+    WHERE ua.deleted_at IS NULL
+      AND ua.user_id IS NOT NULL
+      AND ua.email IS NOT NULL
+      AND btrim(ua.email) != ''
+    GROUP BY ua.organization_id, lower(btrim(ua.email)), ua.user_id
+), unique_account_owner AS (
+    SELECT organization_id, email_lower, min(user_id) AS user_id
+    FROM account_owners
+    GROUP BY organization_id, email_lower
+    HAVING count(*) = 1
+)
+SELECT
+    d.organization_id,
+    d.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM directory d
+WHERE d.claimants = 1
+UNION ALL
+SELECT
+    uao.organization_id,
+    uao.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM unique_account_owner uao
+JOIN users u ON u.id = uao.user_id AND u.deleted_at IS NULL
+JOIN directory d
+    ON d.organization_id = uao.organization_id
+    AND d.email_lower = lower(btrim(u.email))
+    AND d.user_id = u.id
+    AND d.claimants = 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM directory dd
+    WHERE dd.organization_id = uao.organization_id
+      AND dd.email_lower = uao.email_lower
+)
+ORDER BY organization_id, email_lower;

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -727,6 +727,11 @@ type ListIdentityMapEntriesRow struct {
 // email has no directory row in the org and exactly one connected owner with
 // an unambiguous directory email claims it. Ambiguous emails are omitted so
 // readers fall back to literal matching rather than guessing.
+//
+// The owner-ambiguity count deliberately includes account links whose owner is
+// since deleted or disconnected (matching the Go resolver): a second historical
+// claimant has telemetry rows under the shared email, and folding it to the
+// surviving owner would move the departed claimant's usage onto them.
 func (q *Queries) ListIdentityMapEntries(ctx context.Context) ([]ListIdentityMapEntriesRow, error) {
 	rows, err := q.db.Query(ctx, listIdentityMapEntries)
 	if err != nil {

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -653,6 +653,105 @@ func (q *Queries) GetUserEmailsByOrgIDs(ctx context.Context, dollar_1 []string) 
 	return items, nil
 }
 
+const listIdentityMapEntries = `-- name: ListIdentityMapEntries :many
+WITH directory AS (
+    SELECT
+        our.organization_id,
+        lower(btrim(u.email)) AS email_lower,
+        min(u.id) AS user_id,
+        count(*) AS claimants
+    FROM users u
+    JOIN organization_user_relationships our ON our.user_id = u.id
+    WHERE u.deleted_at IS NULL
+      AND our.deleted_at IS NULL
+      AND btrim(u.email) != ''
+    GROUP BY our.organization_id, lower(btrim(u.email))
+), account_owners AS (
+    SELECT ua.organization_id, lower(btrim(ua.email)) AS email_lower, ua.user_id
+    FROM user_accounts ua
+    WHERE ua.deleted_at IS NULL
+      AND ua.user_id IS NOT NULL
+      AND ua.email IS NOT NULL
+      AND btrim(ua.email) != ''
+    GROUP BY ua.organization_id, lower(btrim(ua.email)), ua.user_id
+), unique_account_owner AS (
+    SELECT organization_id, email_lower, min(user_id) AS user_id
+    FROM account_owners
+    GROUP BY organization_id, email_lower
+    HAVING count(*) = 1
+)
+SELECT
+    d.organization_id,
+    d.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM directory d
+WHERE d.claimants = 1
+UNION ALL
+SELECT
+    uao.organization_id,
+    uao.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM unique_account_owner uao
+JOIN users u ON u.id = uao.user_id AND u.deleted_at IS NULL
+JOIN directory d
+    ON d.organization_id = uao.organization_id
+    AND d.email_lower = lower(btrim(u.email))
+    AND d.user_id = u.id
+    AND d.claimants = 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM directory dd
+    WHERE dd.organization_id = uao.organization_id
+      AND dd.email_lower = uao.email_lower
+)
+ORDER BY organization_id, email_lower
+`
+
+type ListIdentityMapEntriesRow struct {
+	OrganizationID  string
+	EmailLower      string
+	CanonicalUserID string
+	CanonicalEmail  string
+}
+
+// Source of the ClickHouse identity_map fold table. Internal sync sweep that
+// deliberately spans all organizations: the org boundary is carried in the
+// output rows (organization_id keys the map), not the predicate; not reachable
+// from user-facing handlers.
+//
+// Encodes the employee identity fold rules (the SQL twin of telemetry's
+// resolveEmployeeIdentity, which DNO-857 retires): a directory email maps to
+// its user only when exactly one connected, non-deleted user claims it
+// case-insensitively; a linked-account email maps to its owner only when the
+// email has no directory row in the org and exactly one connected owner with
+// an unambiguous directory email claims it. Ambiguous emails are omitted so
+// readers fall back to literal matching rather than guessing.
+func (q *Queries) ListIdentityMapEntries(ctx context.Context) ([]ListIdentityMapEntriesRow, error) {
+	rows, err := q.db.Query(ctx, listIdentityMapEntries)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListIdentityMapEntriesRow
+	for rows.Next() {
+		var i ListIdentityMapEntriesRow
+		if err := rows.Scan(
+			&i.OrganizationID,
+			&i.EmailLower,
+			&i.CanonicalUserID,
+			&i.CanonicalEmail,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUnlinkedClaudeUserMessagesForCorrelation = `-- name: ListUnlinkedClaudeUserMessagesForCorrelation :many
 SELECT id, seq, content, created_at
 FROM chat_messages

--- a/server/internal/background/activities/sync_identity_map.go
+++ b/server/internal/background/activities/sync_identity_map.go
@@ -14,14 +14,30 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
+
+// identityMapReplaceLockKey serializes the whole staging rebuild + swap. The
+// TRUNCATE/INSERT/EXCHANGE sequence is not atomic in ClickHouse, so without a
+// single writer a retry can interleave with a timed-out predecessor's in-flight
+// statements and publish mixed data — or a delayed EXCHANGE can republish the
+// previous generation after a successor already swapped.
+const identityMapReplaceLockKey = "identity-map:replace-lock"
+
+// identityMapReplaceLockTTL outlives one activity attempt (2m StartToClose)
+// plus the ClickHouse connection's 60s server-side statement lifetime, so by
+// the time the lock lapses no statement from the holder can still land. The
+// activity's 8m ScheduleToCloseTimeout leaves room for a retry after a lapsed
+// lock; a fully exhausted budget just defers to the next tick.
+const identityMapReplaceLockTTL = 5 * time.Minute
 
 type identityMapStore interface {
 	ListIdentityMapEntries(ctx context.Context) ([]activitiesrepo.ListIdentityMapEntriesRow, error)
@@ -35,13 +51,15 @@ type SyncIdentityMap struct {
 	logger    *slog.Logger
 	store     identityMapStore
 	telemetry identityMapTelemetry
+	cache     cache.Cache
 }
 
-func NewSyncIdentityMap(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn) *SyncIdentityMap {
+func NewSyncIdentityMap(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn, cacheAdapter cache.Cache) *SyncIdentityMap {
 	return &SyncIdentityMap{
 		logger:    logger.With(attr.SlogComponent("sync_identity_map")),
 		store:     activitiesrepo.New(db),
 		telemetry: telemetryrepo.New(chConn),
+		cache:     cacheAdapter,
 	}
 }
 
@@ -65,8 +83,30 @@ func (s *SyncIdentityMap) Do(ctx context.Context) (*SyncIdentityMapResult, error
 		})
 	}
 
+	// Single-writer claim across the whole replacement. Losing the race defers
+	// to the holder (the retry or the next tick picks up after the claim
+	// clears); a claim leaked by a crashed attempt lapses at the TTL, after
+	// which no statement from that attempt can still be in flight.
+	claimed, err := s.cache.Add(ctx, identityMapReplaceLockKey, identityMapReplaceLockTTL)
+	if err != nil {
+		return nil, fmt.Errorf("claim identity map replacement lock: %w", err)
+	}
+	if !claimed {
+		return nil, fmt.Errorf("identity map replacement already in progress")
+	}
+
 	if err := s.telemetry.ReplaceIdentityMap(ctx, entries); err != nil {
+		// Deliberately keep the claim: this attempt may have statements in
+		// flight, and the TTL is what guarantees they are dead before the
+		// next writer starts.
 		return nil, fmt.Errorf("replace identity map: %w", err)
+	}
+
+	// Release on success only, so the schedule and link-event triggers are
+	// not blocked for the remainder of the TTL. Best effort: a leaked claim
+	// merely delays the next refresh.
+	if err := s.cache.Delete(context.WithoutCancel(ctx), identityMapReplaceLockKey); err != nil {
+		s.logger.WarnContext(ctx, "failed to release identity map replacement lock", attr.SlogError(err))
 	}
 
 	// This success line is the staleness signal: a quiet component means the

--- a/server/internal/background/activities/sync_identity_map.go
+++ b/server/internal/background/activities/sync_identity_map.go
@@ -1,0 +1,77 @@
+package activities
+
+// SyncIdentityMap rebuilds the ClickHouse employee identity fold map
+// (identity_map) from the Postgres directory. The source query encodes the
+// fold rules — a directory email maps to its user only when exactly one
+// connected user claims it, a linked-account email only when it has no
+// directory row and exactly one owner — so ambiguous identities are absent
+// and analytics readers fall back to literal email matching. Every pass is a
+// full refresh into a staging table swapped live with EXCHANGE TABLES:
+// deletions and unlinks propagate by omission, so a stalled sync means the
+// map drifts stale (it keeps folding by old links) rather than failing open.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+type identityMapStore interface {
+	ListIdentityMapEntries(ctx context.Context) ([]activitiesrepo.ListIdentityMapEntriesRow, error)
+}
+
+type identityMapTelemetry interface {
+	ReplaceIdentityMap(ctx context.Context, entries []telemetryrepo.IdentityMapEntry) error
+}
+
+type SyncIdentityMap struct {
+	logger    *slog.Logger
+	store     identityMapStore
+	telemetry identityMapTelemetry
+}
+
+func NewSyncIdentityMap(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn) *SyncIdentityMap {
+	return &SyncIdentityMap{
+		logger:    logger.With(attr.SlogComponent("sync_identity_map")),
+		store:     activitiesrepo.New(db),
+		telemetry: telemetryrepo.New(chConn),
+	}
+}
+
+type SyncIdentityMapResult struct {
+	Entries int
+}
+
+func (s *SyncIdentityMap) Do(ctx context.Context) (*SyncIdentityMapResult, error) {
+	rows, err := s.store.ListIdentityMapEntries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list identity map entries: %w", err)
+	}
+
+	entries := make([]telemetryrepo.IdentityMapEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, telemetryrepo.IdentityMapEntry{
+			OrgID:           row.OrganizationID,
+			EmailLower:      row.EmailLower,
+			CanonicalUserID: row.CanonicalUserID,
+			CanonicalEmail:  row.CanonicalEmail,
+		})
+	}
+
+	if err := s.telemetry.ReplaceIdentityMap(ctx, entries); err != nil {
+		return nil, fmt.Errorf("replace identity map: %w", err)
+	}
+
+	// This success line is the staleness signal: a quiet component means the
+	// map is drifting from Postgres until the next successful pass.
+	s.logger.InfoContext(ctx, "identity map synced", attr.SlogIdentityMapEntryCount(len(entries)))
+
+	return &SyncIdentityMapResult{Entries: len(entries)}, nil
+}

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -1,0 +1,195 @@
+package activities_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+func seedIdentityOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool) string {
+	t.Helper()
+
+	orgID := "org-" + uuid.NewString()[:8]
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Identity Map Test Org",
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	return orgID
+}
+
+func seedIdentityUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, email string) string {
+	t.Helper()
+
+	userID := uuid.NewString()
+	_, err := userrepo.New(conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: "identity-map-test",
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: orgID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	return userID
+}
+
+func seedIdentityAccount(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, userID *string, email string) {
+	t.Helper()
+
+	_, err := hooksrepo.New(conn).UpsertUserAccount(ctx, hooksrepo.UpsertUserAccountParams{
+		OrganizationID:      orgID,
+		Provider:            "anthropic",
+		ExternalAccountUuid: uuid.NewString(),
+		UserID:              conv.PtrToPGText(userID),
+		ExternalOrgID:       conv.PtrToPGText(nil),
+		ExternalAccountID:   conv.PtrToPGText(nil),
+		Email:               conv.ToPGText(email),
+		AccountType:         conv.ToPGText("personal"),
+	})
+	require.NoError(t, err)
+}
+
+// lookupFold reads the map through joinGet — the read contract; a composite-key
+// StorageJoin cannot be scanned with SELECT. Missing keys return two empty
+// strings.
+func lookupFold(t *testing.T, ctx context.Context, chConn clickhouse.Conn, orgID, emailLower string) (string, string) {
+	t.Helper()
+
+	var canonicalUserID, canonicalEmail string
+	require.NoError(t, chConn.QueryRow(ctx,
+		"SELECT joinGet('identity_map', 'canonical_user_id', ?, ?), joinGet('identity_map', 'canonical_email', ?, ?)",
+		orgID, emailLower, orgID, emailLower).Scan(&canonicalUserID, &canonicalEmail))
+	return canonicalUserID, canonicalEmail
+}
+
+func requireFoldsTo(t *testing.T, ctx context.Context, chConn clickhouse.Conn, orgID, emailLower, wantUserID, wantEmail string) {
+	t.Helper()
+
+	gotUserID, gotEmail := lookupFold(t, ctx, chConn, orgID, emailLower)
+	require.Equal(t, wantUserID, gotUserID)
+	require.Equal(t, wantEmail, gotEmail)
+}
+
+func requireAbsent(t *testing.T, ctx context.Context, chConn clickhouse.Conn, orgID, emailLower string) {
+	t.Helper()
+
+	gotUserID, gotEmail := lookupFold(t, ctx, chConn, orgID, emailLower)
+	require.Empty(t, gotUserID, "expected %s to be absent", emailLower)
+	require.Empty(t, gotEmail, "expected %s to be absent", emailLower)
+}
+
+func TestSyncIdentityMap_FoldRules(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	conn, err := infra.CloneTestDatabase(t, "sync_identity_map")
+	require.NoError(t, err)
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	org1 := seedIdentityOrg(t, ctx, conn)
+	org2 := seedIdentityOrg(t, ctx, conn)
+	suffix := uuid.NewString()[:8]
+
+	// Directory email with mixed case folds to itself; the linked personal
+	// account email (mixed case, padded) folds to the same user.
+	aliceEmail := "Alice-" + suffix + "@Example.COM"
+	aliceLower := "alice-" + suffix + "@example.com"
+	alice := seedIdentityUser(t, ctx, conn, org1, aliceEmail)
+	alicePersonal := "  Personal-Alice-" + suffix + "@Example.com  "
+	alicePersonalLower := "personal-alice-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &alice, alicePersonal)
+
+	// A shared account email claimed by two users stays out of the map.
+	bob := seedIdentityUser(t, ctx, conn, org1, "bob-"+suffix+"@example.com")
+	carol := seedIdentityUser(t, ctx, conn, org1, "carol-"+suffix+"@example.com")
+	sharedEmail := "shared-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &bob, sharedEmail)
+	seedIdentityAccount(t, ctx, conn, org1, &carol, sharedEmail)
+
+	// Case-variant directory duplicates: neither user's email enters the map,
+	// and an account owned by one of them is refused because its owner's
+	// directory identity is ambiguous.
+	dupeLower := "dupe-" + suffix + "@example.com"
+	dave := seedIdentityUser(t, ctx, conn, org1, "Dupe-"+suffix+"@example.com")
+	seedIdentityUser(t, ctx, conn, org1, "dupe-"+suffix+"@EXAMPLE.com")
+	davePersonal := "dave-personal-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &dave, davePersonal)
+
+	// Deleted rows: a deleted user, a deleted relationship, and a deleted
+	// account link all stay out.
+	fixtures := testrepo.New(conn)
+	frank := seedIdentityUser(t, ctx, conn, org1, "frank-"+suffix+"@example.com")
+	require.NoError(t, fixtures.ForceSoftDeleteUser(ctx, frank))
+	gina := seedIdentityUser(t, ctx, conn, org1, "gina-"+suffix+"@example.com")
+	require.NoError(t, fixtures.ForceSoftDeleteOrganizationUserRelationship(ctx, testrepo.ForceSoftDeleteOrganizationUserRelationshipParams{
+		OrganizationID: org1,
+		UserID:         conv.ToPGText(gina),
+	}))
+	henry := seedIdentityUser(t, ctx, conn, org1, "henry-"+suffix+"@example.com")
+	henryPersonal := "henry-personal-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &henry, henryPersonal)
+	require.NoError(t, fixtures.ForceSoftDeleteUserAccountsByEmail(ctx, testrepo.ForceSoftDeleteUserAccountsByEmailParams{
+		OrganizationID: org1,
+		EmailLower:     henryPersonal,
+	}))
+
+	// An unattributed account (no user_id) resolves to nobody.
+	orphanEmail := "orphan-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, nil, orphanEmail)
+
+	// Directory ownership wins over a linked account claiming the same email.
+	ivyEmail := "ivy-" + suffix + "@example.com"
+	ivy := seedIdentityUser(t, ctx, conn, org1, ivyEmail)
+	jack := seedIdentityUser(t, ctx, conn, org1, "jack-"+suffix+"@example.com")
+	seedIdentityAccount(t, ctx, conn, org1, &jack, ivyEmail)
+
+	// The same personal email linked in a different org folds independently.
+	org2User := seedIdentityUser(t, ctx, conn, org2, "other-"+suffix+"@example.com")
+	seedIdentityAccount(t, ctx, conn, org2, &org2User, alicePersonalLower)
+
+	act := activities.NewSyncIdentityMap(logger, conn, chConn)
+	result, err := act.Do(ctx)
+	require.NoError(t, err)
+	require.NotZero(t, result.Entries)
+
+	// A second pass is a full rebuild and swap; assertions below hold for the
+	// fresh generation, proving idempotency across the staging/live exchange.
+	secondResult, err := act.Do(ctx)
+	require.NoError(t, err)
+	require.Equal(t, result.Entries, secondResult.Entries)
+
+	requireFoldsTo(t, ctx, chConn, org1, aliceLower, alice, aliceLower)
+	requireFoldsTo(t, ctx, chConn, org1, alicePersonalLower, alice, aliceLower)
+	requireFoldsTo(t, ctx, chConn, org1, ivyEmail, ivy, ivyEmail)
+	requireFoldsTo(t, ctx, chConn, org2, alicePersonalLower, org2User, "other-"+suffix+"@example.com")
+
+	for _, absent := range []string{sharedEmail, dupeLower, davePersonal, "frank-" + suffix + "@example.com", "gina-" + suffix + "@example.com", henryPersonal, orphanEmail} {
+		requireAbsent(t, ctx, chConn, org1, absent)
+	}
+}

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -199,7 +199,7 @@ func TestSyncIdentityMap_FoldRules(t *testing.T) {
 // TestReplaceIdentityMap_GenerationSwap exercises the telemetry repo's staging
 // swap directly, covering the behaviors the fold-rule sync never reaches: the
 // duplicate-key rejection (the SQL source provably cannot emit duplicates, so
-// only a direct call can trip it), an insert spanning the 5000-row chunk
+// only a direct call can trip it), an insert spanning the insert-chunk
 // boundary, and a key vanishing with its old generation (deletions propagate
 // by omission).
 //
@@ -230,11 +230,13 @@ func TestReplaceIdentityMap_GenerationSwap(t *testing.T) { //nolint:paralleltest
 	require.ErrorContains(t, err, "duplicate identity map key")
 	requireFoldsTo(t, ctx, chConn, org, seedEmail, "user-a", seedEmail)
 
-	// One entry beyond the insert chunk size (identityMapInsertChunk = 5000):
+	// One entry beyond the insert chunk size, derived from the constant so the
+	// boundary stays exercised if the chunk size ever changes:
 	// rows land on both sides of the chunk boundary, and the seed key is gone
 	// with the generation that carried it.
-	entries := make([]telemetryrepo.IdentityMapEntry, 0, 5001)
-	for i := range 5001 {
+	boundary := telemetryrepo.IdentityMapInsertChunk + 1
+	entries := make([]telemetryrepo.IdentityMapEntry, 0, boundary)
+	for i := range boundary {
 		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
 		entries = append(entries, telemetryrepo.IdentityMapEntry{
 			OrgID:           org,
@@ -245,7 +247,7 @@ func TestReplaceIdentityMap_GenerationSwap(t *testing.T) { //nolint:paralleltest
 	}
 	require.NoError(t, repo.ReplaceIdentityMap(ctx, entries))
 
-	for _, i := range []int{0, 4999, 5000} {
+	for _, i := range []int{0, telemetryrepo.IdentityMapInsertChunk - 1, telemetryrepo.IdentityMapInsertChunk} {
 		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
 		requireFoldsTo(t, ctx, chConn, org, email, fmt.Sprintf("user-%d", i), email)
 	}

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -13,6 +14,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -175,7 +177,17 @@ func TestSyncIdentityMap_FoldRules(t *testing.T) {
 	org2User := seedIdentityUser(t, ctx, conn, org2, "other-"+suffix+"@example.com")
 	seedIdentityAccount(t, ctx, conn, org2, &org2User, alicePersonalLower)
 
-	act := activities.NewSyncIdentityMap(logger, conn, chConn)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
+
+	// A held replacement claim defers the sync instead of interleaving with
+	// the holder's statements; releasing it lets the retry proceed.
+	require.NoError(t, cacheAdapter.Set(ctx, "identity-map:replace-lock", "held", time.Minute))
+	act := activities.NewSyncIdentityMap(logger, conn, chConn, cacheAdapter)
+	_, err = act.Do(ctx)
+	require.ErrorContains(t, err, "already in progress")
+	require.NoError(t, cacheAdapter.Delete(ctx, "identity-map:replace-lock"))
 	result, err := act.Do(ctx)
 	require.NoError(t, err)
 	require.NotZero(t, result.Entries)

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -2,6 +2,7 @@ package activities_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -15,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
@@ -192,4 +194,60 @@ func TestSyncIdentityMap_FoldRules(t *testing.T) {
 	for _, absent := range []string{sharedEmail, dupeLower, davePersonal, "frank-" + suffix + "@example.com", "gina-" + suffix + "@example.com", henryPersonal, orphanEmail} {
 		requireAbsent(t, ctx, chConn, org1, absent)
 	}
+}
+
+// TestReplaceIdentityMap_GenerationSwap exercises the telemetry repo's staging
+// swap directly, covering the behaviors the fold-rule sync never reaches: the
+// duplicate-key rejection (the SQL source provably cannot emit duplicates, so
+// only a direct call can trip it), an insert spanning the 5000-row chunk
+// boundary, and a key vanishing with its old generation (deletions propagate
+// by omission).
+//
+// Deliberately not parallel: identity_map is one package-global ClickHouse
+// table, and a full-refresh swap here would race the joinGet assertions in
+// TestSyncIdentityMap_FoldRules if the two tests overlapped.
+func TestReplaceIdentityMap_GenerationSwap(t *testing.T) { //nolint:paralleltest // Swaps the ClickHouse identity_map shared with TestSyncIdentityMap_FoldRules.
+	ctx := t.Context()
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	repo := telemetryrepo.New(chConn)
+	org := "org-" + uuid.NewString()[:8]
+	seedEmail := "seed-" + uuid.NewString()[:8] + "@example.com"
+
+	require.NoError(t, repo.ReplaceIdentityMap(ctx, []telemetryrepo.IdentityMapEntry{
+		{OrgID: org, EmailLower: seedEmail, CanonicalUserID: "user-a", CanonicalEmail: seedEmail},
+	}))
+	requireFoldsTo(t, ctx, chConn, org, seedEmail, "user-a", seedEmail)
+
+	// A duplicate (org, email) key is rejected before either table is touched,
+	// so the previous complete generation keeps serving.
+	err = repo.ReplaceIdentityMap(ctx, []telemetryrepo.IdentityMapEntry{
+		{OrgID: org, EmailLower: seedEmail, CanonicalUserID: "user-a", CanonicalEmail: seedEmail},
+		{OrgID: org, EmailLower: seedEmail, CanonicalUserID: "user-b", CanonicalEmail: seedEmail},
+	})
+	require.ErrorContains(t, err, "duplicate identity map key")
+	requireFoldsTo(t, ctx, chConn, org, seedEmail, "user-a", seedEmail)
+
+	// One entry beyond the insert chunk size (identityMapInsertChunk = 5000):
+	// rows land on both sides of the chunk boundary, and the seed key is gone
+	// with the generation that carried it.
+	entries := make([]telemetryrepo.IdentityMapEntry, 0, 5001)
+	for i := range 5001 {
+		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
+		entries = append(entries, telemetryrepo.IdentityMapEntry{
+			OrgID:           org,
+			EmailLower:      email,
+			CanonicalUserID: fmt.Sprintf("user-%d", i),
+			CanonicalEmail:  email,
+		})
+	}
+	require.NoError(t, repo.ReplaceIdentityMap(ctx, entries))
+
+	for _, i := range []int{0, 4999, 5000} {
+		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
+		requireFoldsTo(t, ctx, chConn, org, email, fmt.Sprintf("user-%d", i), email)
+	}
+	requireAbsent(t, ctx, chConn, org, seedEmail)
 }

--- a/server/internal/background/sync_identity_map.go
+++ b/server/internal/background/sync_identity_map.go
@@ -30,8 +30,15 @@ const (
 )
 
 func SyncIdentityMapWorkflow(ctx workflow.Context) error {
+	// ScheduleToClose covers the full retry budget (3 attempts x 2m plus
+	// backoff, ~6m15s) with queue-wait slack, and sits under the 10m
+	// WorkflowRunTimeout so a backlogged task queue exhausts the activity's
+	// own budget rather than the workflow's. A timed-out refresh is benign:
+	// the live map stays on its previous complete generation until the next
+	// tick.
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 2 * time.Minute,
+		StartToCloseTimeout:    2 * time.Minute,
+		ScheduleToCloseTimeout: 8 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts:    3,
 			InitialInterval:    5 * time.Second,

--- a/server/internal/background/sync_identity_map.go
+++ b/server/internal/background/sync_identity_map.go
@@ -1,0 +1,89 @@
+package background
+
+// Identity map sync. The ClickHouse identity_map table folds each unambiguous
+// directory or linked-account email to its owning user so analytics reads can
+// resolve one employee to one identity (via joinGet). The schedule below is
+// the sole trigger: every tick performs a full rebuild from Postgres into
+// identity_map_staging and an atomic EXCHANGE TABLES swap, so link changes —
+// including deletions — converge within one interval and readers never see a
+// partial map. The interval is the accepted staleness bound for analytics
+// folding; there is deliberately no write-path trigger yet.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	identityMapSyncScheduleID = "v1:identity-map-sync-schedule"
+	identityMapSyncWorkflowID = identityMapSyncScheduleID + "/scheduled"
+	identityMapSyncInterval   = 15 * time.Minute
+)
+
+func SyncIdentityMapWorkflow(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 2 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    30 * time.Second,
+		},
+	})
+
+	var a *Activities
+	if err := workflow.ExecuteActivity(ctx, a.SyncIdentityMap).Get(ctx, nil); err != nil {
+		return fmt.Errorf("sync identity map: %w", err)
+	}
+	return nil
+}
+
+func AddIdentityMapSyncSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	sc := temporalEnv.Client().ScheduleClient()
+
+	spec := client.ScheduleSpec{
+		Intervals: []client.ScheduleIntervalSpec{{Every: identityMapSyncInterval}},
+	}
+	action := &client.ScheduleWorkflowAction{
+		ID:                 identityMapSyncWorkflowID,
+		Workflow:           SyncIdentityMapWorkflow,
+		TaskQueue:          string(temporalEnv.Queue()),
+		WorkflowRunTimeout: 10 * time.Minute,
+	}
+
+	_, err := sc.Create(ctx, client.ScheduleOptions{
+		ID:      identityMapSyncScheduleID,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Spec:    spec,
+		Action:  action,
+	})
+	switch {
+	case errors.Is(err, temporal.ErrScheduleAlreadyRunning):
+		// The schedule survives deploys; push the current spec and action so
+		// interval or workflow changes take effect on running environments.
+		if err := sc.GetHandle(ctx, identityMapSyncScheduleID).Update(ctx, client.ScheduleUpdateOptions{
+			DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+				input.Description.Schedule.Spec = &spec
+				input.Description.Schedule.Action = action
+				return &client.ScheduleUpdate{
+					Schedule:              &input.Description.Schedule,
+					TypedSearchAttributes: nil,
+				}, nil
+			},
+		}); err != nil {
+			return fmt.Errorf("update identity map sync schedule: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("create identity map sync schedule: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -408,6 +408,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.GenerateToolsetEmbeddings)
 	temporalWorker.RegisterActivity(activities.GenerateChatTitle)
 	temporalWorker.RegisterActivity(activities.CorrelateClaudePrompts)
+	temporalWorker.RegisterActivity(activities.SyncIdentityMap)
 	temporalWorker.RegisterActivity(activities.PromoteStagedTelemetry)
 	temporalWorker.RegisterActivity(activities.ListStagedTelemetryProjects)
 	temporalWorker.RegisterActivity(activities.SegmentChat)
@@ -523,6 +524,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(IndexToolsetWorkflow)
 	temporalWorker.RegisterWorkflow(GenerateChatTitleWorkflow)
 	temporalWorker.RegisterWorkflow(CorrelateClaudePromptsWorkflow)
+	temporalWorker.RegisterWorkflow(SyncIdentityMapWorkflow)
 	temporalWorker.RegisterWorkflow(PromoteStagedTelemetryWorkflow)
 	temporalWorker.RegisterWorkflow(StagedTelemetrySweepWorkflow)
 	temporalWorker.RegisterWorkflow(AnalyzeChatResolutionsWorkflow)
@@ -655,6 +657,10 @@ func NewTemporalWorker(
 
 	if err := AddStagedTelemetrySweepSchedule(context.Background(), env); err != nil {
 		logger.ErrorContext(context.Background(), "failed to add staged telemetry sweep schedule", attr.SlogError(err))
+	}
+
+	if err := AddIdentityMapSyncSchedule(context.Background(), env); err != nil {
+		logger.ErrorContext(context.Background(), "failed to add identity map sync schedule", attr.SlogError(err))
 	}
 
 	if err := AddSpendRuleEvaluationSchedule(context.Background(), env); err != nil {

--- a/server/internal/telemetry/repo/identity_map.go
+++ b/server/internal/telemetry/repo/identity_map.go
@@ -24,7 +24,22 @@ type IdentityMapEntry struct {
 // generations and never observe a partial rebuild. A full replace rather than
 // an incremental update: deletions and unlinks in Postgres propagate by simply
 // not being in the next generation.
+//
+// Entries must be unique per (org, email) key: the ANY Join engine silently
+// keeps the first row per key, which would make the fold target insertion-order
+// dependent. The rejection below turns a caller violating that contract into a
+// failed sync — the previous complete generation stays live — instead of an
+// arbitrary owner.
 func (q *Queries) ReplaceIdentityMap(ctx context.Context, entries []IdentityMapEntry) error {
+	seen := make(map[[2]string]struct{}, len(entries))
+	for _, entry := range entries {
+		key := [2]string{entry.OrgID, entry.EmailLower}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("duplicate identity map key for email %q", entry.EmailLower)
+		}
+		seen[key] = struct{}{}
+	}
+
 	if err := q.conn.Exec(ctx, "TRUNCATE TABLE identity_map_staging"); err != nil {
 		return fmt.Errorf("truncate identity_map_staging: %w", err)
 	}

--- a/server/internal/telemetry/repo/identity_map.go
+++ b/server/internal/telemetry/repo/identity_map.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// identityMapInsertChunk bounds one INSERT's bound-parameter count. The map is
+// IdentityMapInsertChunk bounds one INSERT's bound-parameter count. The map is
 // org-directory scale, so most syncs fit in a single chunk.
-const identityMapInsertChunk = 5000
+const IdentityMapInsertChunk = 5000
 
 // IdentityMapEntry is one row of the employee identity fold map: a normalized
 // email and the directory user it unambiguously resolves to within an org.
@@ -44,8 +44,8 @@ func (q *Queries) ReplaceIdentityMap(ctx context.Context, entries []IdentityMapE
 		return fmt.Errorf("truncate identity_map_staging: %w", err)
 	}
 
-	for start := 0; start < len(entries); start += identityMapInsertChunk {
-		chunk := entries[start:min(start+identityMapInsertChunk, len(entries))]
+	for start := 0; start < len(entries); start += IdentityMapInsertChunk {
+		chunk := entries[start:min(start+IdentityMapInsertChunk, len(entries))]
 		values := make([]string, 0, len(chunk))
 		args := make([]any, 0, len(chunk)*4)
 		for _, entry := range chunk {

--- a/server/internal/telemetry/repo/identity_map.go
+++ b/server/internal/telemetry/repo/identity_map.go
@@ -1,0 +1,51 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// identityMapInsertChunk bounds one INSERT's bound-parameter count. The map is
+// org-directory scale, so most syncs fit in a single chunk.
+const identityMapInsertChunk = 5000
+
+// IdentityMapEntry is one row of the employee identity fold map: a normalized
+// email and the directory user it unambiguously resolves to within an org.
+type IdentityMapEntry struct {
+	OrgID           string
+	EmailLower      string
+	CanonicalUserID string
+	CanonicalEmail  string
+}
+
+// ReplaceIdentityMap rebuilds identity_map_staging from entries and swaps it
+// live with EXCHANGE TABLES, so readers switch between complete map
+// generations and never observe a partial rebuild. A full replace rather than
+// an incremental update: deletions and unlinks in Postgres propagate by simply
+// not being in the next generation.
+func (q *Queries) ReplaceIdentityMap(ctx context.Context, entries []IdentityMapEntry) error {
+	if err := q.conn.Exec(ctx, "TRUNCATE TABLE identity_map_staging"); err != nil {
+		return fmt.Errorf("truncate identity_map_staging: %w", err)
+	}
+
+	for start := 0; start < len(entries); start += identityMapInsertChunk {
+		chunk := entries[start:min(start+identityMapInsertChunk, len(entries))]
+		values := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*4)
+		for _, entry := range chunk {
+			values = append(values, "(?, ?, ?, ?)")
+			args = append(args, entry.OrgID, entry.EmailLower, entry.CanonicalUserID, entry.CanonicalEmail)
+		}
+		query := "INSERT INTO identity_map_staging (org_id, email_lower, canonical_user_id, canonical_email) VALUES " + strings.Join(values, ", ")
+		if err := q.conn.Exec(ctx, query, args...); err != nil {
+			return fmt.Errorf("insert identity_map_staging chunk: %w", err)
+		}
+	}
+
+	if err := q.conn.Exec(ctx, "EXCHANGE TABLES identity_map_staging AND identity_map"); err != nil {
+		return fmt.Errorf("exchange identity_map tables: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -418,3 +418,26 @@ WHERE s.project_id = @project_id
     NOT @found_only::boolean
     OR (rr.source = 'prompt_injection' AND rr.found IS TRUE)
   );
+
+-- name: ForceSoftDeleteUser :exec
+-- Test-only fixture: soft-deletes a directory user to exercise deleted-row
+-- filtering in identity resolution.
+UPDATE users
+SET deleted_at = clock_timestamp()
+WHERE id = @id;
+
+-- name: ForceSoftDeleteOrganizationUserRelationship :exec
+-- Test-only fixture: soft-deletes an org membership to exercise deleted-row
+-- filtering in identity resolution.
+UPDATE organization_user_relationships
+SET deleted_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND user_id = @user_id;
+
+-- name: ForceSoftDeleteUserAccountsByEmail :exec
+-- Test-only fixture: soft-deletes an org's linked accounts by email to
+-- exercise deleted-row filtering in identity resolution.
+UPDATE user_accounts
+SET deleted_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND lower(email) = @email_lower::text;

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -311,6 +311,25 @@ func (q *Queries) ForceSoftDeleteChat(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const forceSoftDeleteOrganizationUserRelationship = `-- name: ForceSoftDeleteOrganizationUserRelationship :exec
+UPDATE organization_user_relationships
+SET deleted_at = clock_timestamp()
+WHERE organization_id = $1
+  AND user_id = $2
+`
+
+type ForceSoftDeleteOrganizationUserRelationshipParams struct {
+	OrganizationID string
+	UserID         pgtype.Text
+}
+
+// Test-only fixture: soft-deletes an org membership to exercise deleted-row
+// filtering in identity resolution.
+func (q *Queries) ForceSoftDeleteOrganizationUserRelationship(ctx context.Context, arg ForceSoftDeleteOrganizationUserRelationshipParams) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteOrganizationUserRelationship, arg.OrganizationID, arg.UserID)
+	return err
+}
+
 const forceSoftDeleteOrganizationUserRelationshipsFixture = `-- name: ForceSoftDeleteOrganizationUserRelationshipsFixture :exec
 UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp()
@@ -321,6 +340,38 @@ WHERE organization_id = $1
 // generated from deleted_at, so a soft delete has to set the timestamp.
 func (q *Queries) ForceSoftDeleteOrganizationUserRelationshipsFixture(ctx context.Context, organizationID string) error {
 	_, err := q.db.Exec(ctx, forceSoftDeleteOrganizationUserRelationshipsFixture, organizationID)
+	return err
+}
+
+const forceSoftDeleteUser = `-- name: ForceSoftDeleteUser :exec
+UPDATE users
+SET deleted_at = clock_timestamp()
+WHERE id = $1
+`
+
+// Test-only fixture: soft-deletes a directory user to exercise deleted-row
+// filtering in identity resolution.
+func (q *Queries) ForceSoftDeleteUser(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteUser, id)
+	return err
+}
+
+const forceSoftDeleteUserAccountsByEmail = `-- name: ForceSoftDeleteUserAccountsByEmail :exec
+UPDATE user_accounts
+SET deleted_at = clock_timestamp()
+WHERE organization_id = $1
+  AND lower(email) = $2::text
+`
+
+type ForceSoftDeleteUserAccountsByEmailParams struct {
+	OrganizationID string
+	EmailLower     string
+}
+
+// Test-only fixture: soft-deletes an org's linked accounts by email to
+// exercise deleted-row filtering in identity resolution.
+func (q *Queries) ForceSoftDeleteUserAccountsByEmail(ctx context.Context, arg ForceSoftDeleteUserAccountsByEmailParams) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteUserAccountsByEmail, arg.OrganizationID, arg.EmailLower)
 	return err
 }
 


### PR DESCRIPTION
Part of DNO-854 (Canonical Identity Map for Cost Analytics). Second of two stacked PRs — depends on #5248 (the `identity_map` tables) and should merge after it.

## What

A scheduled Temporal workflow (every 15 minutes, `Overlap: SKIP`) rebuilds the ClickHouse `identity_map` fold table from the Postgres directory:

- **Source query** (`ListIdentityMapEntries`, worker-owned cross-subsystem queries file): encodes the employee identity fold rules in one place, mirroring telemetry's `resolveEmployeeIdentity` — a directory email maps to its user only when exactly one connected, non-deleted user claims it case-insensitively; a linked-account email maps to its owner only when it has no directory row in the org and exactly one connected owner with an unambiguous directory email claims it. Ambiguous emails are omitted so readers fall back to literal matching rather than guessing. Emails normalize as `lower(btrim(...))`, matching `conv.NormalizeEmail`.
- **Sync activity**: full refresh into `identity_map_staging`, then an atomic `EXCHANGE TABLES` swap — deletions and unlinks propagate by omission, and readers never observe a partial map. The success log line is the staleness signal.
- **Schedule**: `Create` → `ErrScheduleAlreadyRunning` → `Update`, same shape as the staged-telemetry sweep, so spec changes take effect across deploys.

Nothing reads the map yet — analytics folding flips in DNO-856 behind a flag with a shadow-compare phase.

## Notes for review

- The map is a one-directional derived copy: Postgres stays the sole identity authority, and each query in DNO-856 will canonicalize both comparison sides through the same map generation, so refresh lag cannot produce self-inconsistent results.
- Composite-key StorageJoin tables cannot be scanned with `SELECT` — reads go through `joinGet` only (the test asserts through it for exactly that reason).
- The all-orgs source query carries the org boundary in its output rows (`organization_id` keys the map) per the unscoped-query comment convention.
- No write-path trigger on account linking yet — deliberate; the 15-minute interval is the accepted staleness bound for analytics folding.

## Verification

- Integration test seeds the full rule matrix (mixed case + padding, shared account emails, case-variant directory duplicates, deleted user/relationship/account, unattributed accounts, directory-vs-account conflicts, cross-org same-email) against real Postgres + ClickHouse, runs the activity twice (idempotency across the staging/live exchange), and asserts through `joinGet`.
- `mise run test:server ./internal/background/activities ./internal/telemetry/repo` (256 tests), `mise run lint:server`, `mise build:server`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the ClickHouse identity map from Postgres every 15 minutes so analytics can fold emails to one user. Previously the ANY Join kept the first duplicate per key silently; now the sync rejects duplicate keys and serializes the staging swap behind a single-writer claim to prevent mixed generations.

- Fold rules: directory emails map only when exactly one connected, non-deleted user claims them; linked-account emails map only when no directory row exists in the org and exactly one owner with an unambiguous directory email claims it. Ambiguity counts include stale (deleted/disconnected) claimants. Ambiguous or deleted rows are omitted. Emails normalize via lower(btrim(...)).
- Sync: full refresh into `identity_map_staging` then atomic `EXCHANGE TABLES`. A Redis single-writer claim (5m TTL) covers TRUNCATE/INSERT/EXCHANGE; it is kept on failure and released on success. `ReplaceIdentityMap` rejects duplicate `(org_id, email_lower)` keys pre-swap so the previous complete map stays live.
- Schedule, reliability, and signals: Temporal schedule every 15m (Overlap: SKIP); activity StartToClose 2m, ScheduleToClose 8m, max 3 attempts; workflow run timeout 10m. Logs “identity map synced” with `gram.identity_map.entry_count`.
- Tests: end-to-end fold rules via `joinGet`, duplicate-key rejection, insert chunk boundary, deletion-by-omission, and single-writer-claim deferral.
- Rollout: nothing reads the map yet; analytics folding flips in DNO-856. Advances DNO-854. No migration actions.

<sup>Written for commit 82d4223e2874fea1b0fa8190ab7715f6c1d6ea99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

