### PR TITLE
fix(email): handle conditional Loops variables

### DIFF
--- a/.agents/skills/craft-transactional-emails/SKILL.md
+++ b/.agents/skills/craft-transactional-emails/SKILL.md
@@ -108,6 +108,10 @@ Identity map:
 - State the event or action directly. Delete vague lead-ins such as “a clear read
   on how your organization is tracking.” Prefer one verb-led CTA.
 - Use conditional `<Section>` blocks for variants. Do not invent fallback syntax.
+- Keep condition-only variables in the Go and manifest contract. Loops omits
+  variables used only by a Section `if` attribute from its published
+  `dataVariables` metadata; repository reconciliation accounts for that provider
+  behavior while continuing to verify every rendered variable exactly.
 - LMX cannot embed raw HTML. Send scalar variables and compose the layout in LMX.
 - `<Image src>` must be a Loops-hosted upload. Do not use a repo-local or public
   URL as `src`; use a text masthead until an upload is deliberately managed.

--- a/server/internal/email/loops/README.md
+++ b/server/internal/email/loops/README.md
@@ -47,6 +47,9 @@ Validation requires the manifest variable list to match the Go `Variables()`
 contract exactly. It also checks every `.lmx` file recursively for XML
 well-formedness and explicitly set Loops-supported attribute ranges, and rejects
 undeclared or accidentally unused variables in registered templates.
+Variables used only by a Section `if` remain part of the application contract,
+although Loops omits them from the published `dataVariables` metadata; release
+verification compares that metadata against rendered variables only.
 
 ## Design system
 

--- a/server/internal/email/loopsync/manifest.go
+++ b/server/internal/email/loopsync/manifest.go
@@ -180,18 +180,10 @@ func validateLMXDirectory(dir string) error {
 }
 
 func validateXML(lmx []byte) error {
-	decoder := xml.NewDecoder(strings.NewReader("<Root>" + string(lmx) + "</Root>"))
-	for {
-		token, err := decoder.Token()
-		if errors.Is(err, io.EOF) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("read LMX token: %w", err)
-		}
+	return walkXML(lmx, func(token xml.Token) error {
 		start, ok := token.(xml.StartElement)
 		if !ok {
-			continue
+			return nil
 		}
 		switch start.Name.Local {
 		case "Columns":
@@ -203,7 +195,8 @@ func validateXML(lmx []byte) error {
 				return err
 			}
 		}
-	}
+		return nil
+	})
 }
 
 func validateIntegerAttribute(element xml.StartElement, name string, minimum, maximum int) error {
@@ -246,15 +239,7 @@ func extractPublishedDataVariables(subject, previewText string, lmx []byte) ([]s
 	published.WriteString(previewText)
 	published.WriteByte('\n')
 
-	decoder := xml.NewDecoder(strings.NewReader("<Root>" + string(lmx) + "</Root>"))
-	for {
-		token, err := decoder.Token()
-		if errors.Is(err, io.EOF) {
-			return extractDataVariables(published.String()), nil
-		}
-		if err != nil {
-			return nil, fmt.Errorf("read LMX token: %w", err)
-		}
+	err := walkXML(lmx, func(token xml.Token) error {
 		switch token := token.(type) {
 		case xml.StartElement:
 			for _, attribute := range token.Attr {
@@ -267,6 +252,27 @@ func extractPublishedDataVariables(subject, previewText string, lmx []byte) ([]s
 		case xml.CharData:
 			published.Write(token)
 			published.WriteByte('\n')
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return extractDataVariables(published.String()), nil
+}
+
+func walkXML(lmx []byte, visit func(xml.Token) error) error {
+	decoder := xml.NewDecoder(strings.NewReader("<Root>" + string(lmx) + "</Root>"))
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read LMX token: %w", err)
+		}
+		if err := visit(token); err != nil {
+			return err
 		}
 	}
 }

--- a/server/internal/email/loopsync/manifest.go
+++ b/server/internal/email/loopsync/manifest.go
@@ -33,14 +33,15 @@ type MessageDefaults struct {
 }
 
 type TemplateSpec struct {
-	ManagedName     string   `json:"managed_name"`
-	Subject         string   `json:"subject"`
-	PreviewText     string   `json:"preview_text"`
-	Source          string   `json:"source"`
-	Variables       []string `json:"variables"`
-	UnusedVariables []string `json:"unused_variables,omitempty"`
-	LMX             string   `json:"-"`
-	SourceVariables []string `json:"-"`
+	ManagedName        string   `json:"managed_name"`
+	Subject            string   `json:"subject"`
+	PreviewText        string   `json:"preview_text"`
+	Source             string   `json:"source"`
+	Variables          []string `json:"variables"`
+	UnusedVariables    []string `json:"unused_variables,omitempty"`
+	LMX                string   `json:"-"`
+	SourceVariables    []string `json:"-"`
+	PublishedVariables []string `json:"-"`
 }
 
 func LoadManifest(path string) (*Manifest, error) {
@@ -137,6 +138,11 @@ func (m *Manifest) Validate() error {
 
 		spec.LMX = strings.TrimSpace(string(lmx))
 		spec.SourceVariables = sourceVariables
+		publishedVariables, err := extractPublishedDataVariables(spec.Subject, spec.PreviewText, lmx)
+		if err != nil {
+			return fmt.Errorf("extract published LMX variables for %q: %w", key, err)
+		}
+		spec.PublishedVariables = publishedVariables
 		m.Templates[key] = spec
 	}
 	return nil
@@ -231,6 +237,38 @@ func extractDataVariables(content string) []string {
 	}
 	slices.Sort(variables)
 	return variables
+}
+
+func extractPublishedDataVariables(subject, previewText string, lmx []byte) ([]string, error) {
+	var published strings.Builder
+	published.WriteString(subject)
+	published.WriteByte('\n')
+	published.WriteString(previewText)
+	published.WriteByte('\n')
+
+	decoder := xml.NewDecoder(strings.NewReader("<Root>" + string(lmx) + "</Root>"))
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return extractDataVariables(published.String()), nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read LMX token: %w", err)
+		}
+		switch token := token.(type) {
+		case xml.StartElement:
+			for _, attribute := range token.Attr {
+				if token.Name.Local == "Section" && attribute.Name.Local == "if" {
+					continue
+				}
+				published.WriteString(attribute.Value)
+				published.WriteByte('\n')
+			}
+		case xml.CharData:
+			published.Write(token)
+			published.WriteByte('\n')
+		}
+	}
 }
 
 func makeUniqueSet(values []string) (map[string]struct{}, string) {

--- a/server/internal/email/loopsync/manifest_test.go
+++ b/server/internal/email/loopsync/manifest_test.go
@@ -149,6 +149,22 @@ func TestManifestValidate_ValidatesNestedUnregisteredLMXFiles(t *testing.T) {
 	require.ErrorContains(t, err, `Paragraph attribute "fontSize" must be an integer between 12 and 64 (got "10")`)
 }
 
+func TestManifestValidate_SeparatesConditionOnlyPublishedVariables(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest(t)
+	spec := manifest.Templates["example_notice"]
+	spec.Variables = []string{"resource_name", "show_resource"}
+	manifest.Templates["example_notice"] = spec
+	lmx := `<Section if="{data.show_resource}" ifOperation="equal" ifValue="true"><Paragraph>{data.resource_name}</Paragraph></Section>`
+	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
+
+	require.NoError(t, manifest.Validate())
+	spec = manifest.Templates["example_notice"]
+	require.Equal(t, []string{"resource_name", "show_resource"}, spec.SourceVariables)
+	require.Equal(t, []string{"resource_name"}, spec.PublishedVariables)
+}
+
 func validManifest(t *testing.T) *Manifest {
 	t.Helper()
 
@@ -164,14 +180,15 @@ func validManifest(t *testing.T) *Manifest {
 		},
 		Templates: map[string]TemplateSpec{
 			"example_notice": {
-				ManagedName:     "gram.transactional.v2.example_notice",
-				Subject:         "Example notice",
-				PreviewText:     "Review this notice.",
-				Source:          "example_notice.lmx",
-				Variables:       []string{"resource_name"},
-				UnusedVariables: nil,
-				LMX:             "",
-				SourceVariables: nil,
+				ManagedName:        "gram.transactional.v2.example_notice",
+				Subject:            "Example notice",
+				PreviewText:        "Review this notice.",
+				Source:             "example_notice.lmx",
+				Variables:          []string{"resource_name"},
+				UnusedVariables:    nil,
+				LMX:                "",
+				SourceVariables:    nil,
+				PublishedVariables: nil,
 			},
 		},
 		Dir: dir,

--- a/server/internal/email/loopsync/reconcile.go
+++ b/server/internal/email/loopsync/reconcile.go
@@ -150,7 +150,7 @@ func (r *Reconciler) verifyPublishedVariables(ctx context.Context, transactional
 	if err != nil {
 		return fmt.Errorf("verify published email: %w", err)
 	}
-	want := slices.Clone(spec.SourceVariables)
+	want := slices.Clone(spec.PublishedVariables)
 	got := slices.Clone(published.DataVariables)
 	slices.Sort(want)
 	slices.Sort(got)

--- a/server/internal/email/loopsync/reconcile_test.go
+++ b/server/internal/email/loopsync/reconcile_test.go
@@ -69,14 +69,63 @@ func testManifest() *Manifest {
 		},
 		Templates: map[string]TemplateSpec{
 			"team_invite": {
-				ManagedName:     "gram.transactional.v2.team_invite",
-				Subject:         "Join {data.organization_name}",
-				PreviewText:     "Invitation",
-				LMX:             "<Paragraph>Hello {data.organization_name}</Paragraph>",
-				SourceVariables: []string{"organization_name"},
+				ManagedName:        "gram.transactional.v2.team_invite",
+				Subject:            "Join {data.organization_name}",
+				PreviewText:        "Invitation",
+				LMX:                "<Paragraph>Hello {data.organization_name}</Paragraph>",
+				SourceVariables:    []string{"organization_name"},
+				PublishedVariables: []string{"organization_name"},
 			},
 		},
 	}
+}
+
+func TestReconcile_AllowsConditionOnlyVariableMissingFromPublishedContract(t *testing.T) {
+	t.Parallel()
+
+	manifest := testManifest()
+	spec := manifest.Templates["team_invite"]
+	spec.LMX = `<Section if="{data.exhausted}" ifOperation="equal" ifValue="true"><Paragraph>Hello {data.organization_name}</Paragraph></Section>`
+	spec.SourceVariables = []string{"exhausted", "organization_name"}
+	spec.PublishedVariables = []string{"organization_name"}
+	manifest.Templates["team_invite"] = spec
+
+	draftID := "message-1"
+	api := &fakeAPI{
+		transactional: TransactionalEmail{
+			ID:                  "transactional-1",
+			DraftEmailMessageID: &draftID,
+			DataVariables:       []string{"organization_name"},
+		},
+		message: EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
+	}
+
+	_, err := (&Reconciler{API: api}).Reconcile(t.Context(), manifest, map[string]string{})
+	require.NoError(t, err)
+}
+
+func TestReconcile_RejectsMissingRenderedVariableWithConditionOnlyVariable(t *testing.T) {
+	t.Parallel()
+
+	manifest := testManifest()
+	spec := manifest.Templates["team_invite"]
+	spec.LMX = `<Section if="{data.exhausted}" ifOperation="equal" ifValue="true"><Paragraph>Hello {data.organization_name}</Paragraph></Section>`
+	spec.SourceVariables = []string{"exhausted", "organization_name"}
+	spec.PublishedVariables = []string{"organization_name"}
+	manifest.Templates["team_invite"] = spec
+
+	draftID := "message-1"
+	api := &fakeAPI{
+		transactional: TransactionalEmail{
+			ID:                  "transactional-1",
+			DraftEmailMessageID: &draftID,
+			DataVariables:       []string{},
+		},
+		message: EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
+	}
+
+	_, err := (&Reconciler{API: api}).Reconcile(t.Context(), manifest, map[string]string{})
+	require.ErrorContains(t, err, "published data variable contract")
 }
 
 func TestReconcile_CreatesPublishesAndReturnsResolvedID(t *testing.T) {


### PR DESCRIPTION
## Summary

- keep condition-only LMX variables in the exact Go/manifest/source contract
- compare Loops published metadata against rendered variables while excluding only `Section.if` control variables
- retain exact failure behavior for missing or extra rendered variables
- document the observed provider behavior in the transactional-email skill

## Why

Dev reconciliation successfully published the first three templates, then Loops reported the chat-credit template's published `dataVariables` without `exhausted`. Loops uses that variable only to control conditional Sections and omits it from published metadata. This models that provider behavior without weakening the application send contract or rendered-variable drift checks.

## Validation

- `mise exec -- go run ./server/cmd/sync-loops-email-templates --validate-only`
- `mise exec -- go test ./server/internal/email/... ./server/cmd/sync-loops-email-templates`
- `mise lint:server`
- `mise run skills:sync`
- fresh-context skill evaluation: ship, 9.5/10
- `git diff --check`

## Visual QA

No email content or layout changed. The complete nine-template desktop/mobile preview set remains attached to #5238: https://github.com/speakeasy-api/gram/pull/5238#issuecomment-5283345472

Production reconciliation is the authorized verification path; no manual Loops mutation or test-send was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles Loops condition-only variables without weakening validation. Previously we matched Loops’ published `dataVariables` to every rendered variable; now we exclude variables used only in `Section.if` from the published contract while keeping them in the Go/manifest contract. Missing or extra rendered variables still fail.

- Adds `PublishedVariables` to `TemplateSpec` and computes it from subject, preview text, and LMX while ignoring `Section.if` attributes.
- Compares provider `dataVariables` against `PublishedVariables` (not `SourceVariables`) during reconciliation.
- Refactors LMX parsing to share token walking between validation and published-variable extraction.
- Updates transactional email skill and Loops README to document provider behavior.
- Tests cover separating condition-only variables and rejecting missing rendered variables.
- No migration required; template authors must continue declaring condition-only variables in Go and the manifest.

<sup>Written for commit 193ca2f556b03a7799ed45471869a1d76e5f0f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

