### PR TITLE
feat: fold cost analytics email identities through the identity map

### DIFF
--- a/.changeset/canonical-email-fold.md
+++ b/.changeset/canonical-email-fold.md
@@ -1,0 +1,9 @@
+---
+"server": patch
+---
+
+Cost analytics email filters and group-bys can fold one employee's directory,
+personal, and case-variant emails into one canonical identity via the
+ClickHouse identity map, gated by a PostHog rollout flag with a shadow-compare
+mode that validates the fold on live traffic before serving it. Off by
+default; literal matching is unchanged.

--- a/.changeset/identity-map-sync-worker.md
+++ b/.changeset/identity-map-sync-worker.md
@@ -1,0 +1,10 @@
+---
+"server": patch
+---
+
+Add the identity map sync worker: a scheduled Temporal workflow rebuilds the
+ClickHouse identity_map fold table from the Postgres directory every 15
+minutes, mapping each unambiguous directory or linked-account email to its
+owning user. Full refresh into a staging table with an atomic swap, so
+deletions propagate and readers never observe a partial map. Nothing reads the
+map yet; analytics folding lands separately.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -816,7 +816,7 @@ func newStartCommand() *cli.Command {
 			telemLogger, shutdown := newTelemetryLogger(ctx, logger, tracerProvider, meterProvider, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled, telemetryLogPublisher)
 			telemetryLoggerShutdown = shutdown
 
-			telemSvc := tm.NewService(logger, tracerProvider, db, chDB, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
+			telemSvc := tm.NewService(logger, tracerProvider, db, chDB, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine, featureFlags)
 
 			// Wrap cache for hooks service in local development
 			var hooksCache cache.Cache = cache.NewRedisCacheAdapter(redisClient)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -613,7 +613,7 @@ func newWorkerCommand() *cli.Command {
 			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, tracerProvider, meterProvider, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled, telemetryLogPublisher)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
-			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
+			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine, featureFlags)
 
 			/**
 			 * BEGIN -- MCP service setup for agent client

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -476,6 +476,7 @@ const (
 	// denied the tool call (e.g. shadow-MCP guard). Its presence (non-empty)
 	// signals the trace should render as "blocked" in dashboards.
 	HookBlockReasonKey       = attribute.Key("gram.hook.block_reason")
+	IdentityMapEntryCountKey = attribute.Key("gram.identity_map.entry_count")
 	LiteLLMInstanceIDKey     = attribute.Key("gram.litellm.instance_id")
 	LiteLLMCallIDKey         = attribute.Key("gram.litellm.call_id")
 	LiteLLMTraceIDKey        = attribute.Key("gram.litellm.trace_id")
@@ -807,6 +808,9 @@ func SlogHookSource(v string) slog.Attr      { return slog.String(string(HookSou
 
 func HookBlockReason(v string) attribute.KeyValue { return HookBlockReasonKey.String(v) }
 func SlogHookBlockReason(v string) slog.Attr      { return slog.String(string(HookBlockReasonKey), v) }
+
+func IdentityMapEntryCount(v int) attribute.KeyValue { return IdentityMapEntryCountKey.Int(v) }
+func SlogIdentityMapEntryCount(v int) slog.Attr      { return slog.Int(string(IdentityMapEntryCountKey), v) }
 
 func HookHasPluginAuth(v bool) attribute.KeyValue { return HookHasPluginAuthKey.Bool(v) }
 func SlogHookHasPluginAuth(v bool) slog.Attr      { return slog.Bool(string(HookHasPluginAuthKey), v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -475,23 +475,26 @@ const (
 	// HookBlockReasonKey is set on hook telemetry entries when the Gram hook
 	// denied the tool call (e.g. shadow-MCP guard). Its presence (non-empty)
 	// signals the trace should render as "blocked" in dashboards.
-	HookBlockReasonKey       = attribute.Key("gram.hook.block_reason")
-	IdentityMapEntryCountKey = attribute.Key("gram.identity_map.entry_count")
-	LiteLLMInstanceIDKey     = attribute.Key("gram.litellm.instance_id")
-	LiteLLMCallIDKey         = attribute.Key("gram.litellm.call_id")
-	LiteLLMTraceIDKey        = attribute.Key("gram.litellm.trace_id")
-	LiteLLMUserIDKey         = attribute.Key("gram.litellm.user_id")
-	LiteLLMUserEmailKey      = attribute.Key("gram.litellm.user_email")
-	LiteLLMTeamIDKey         = attribute.Key("gram.litellm.team_id")
-	LiteLLMTeamAliasKey      = attribute.Key("gram.litellm.team_alias")
-	LiteLLMEndUserIDKey      = attribute.Key("gram.litellm.end_user_id")
-	LiteLLMOrganizationIDKey = attribute.Key("gram.litellm.org_id")
-	LiteLLMAPIKeyHashKey     = attribute.Key("gram.litellm.api_key_hash")
-	LiteLLMAPIKeyAliasKey    = attribute.Key("gram.litellm.api_key_alias")
-	LiteLLMInputCostKey      = attribute.Key("litellm.cost.input")
-	LiteLLMOutputCostKey     = attribute.Key("litellm.cost.output")
-	LiteLLMCacheReadCostKey  = attribute.Key("litellm.cost.cache_read")
-	LiteLLMCacheWriteCostKey = attribute.Key("litellm.cost.cache_creation")
+	HookBlockReasonKey             = attribute.Key("gram.hook.block_reason")
+	IdentityFoldCanonicalGroupsKey = attribute.Key("gram.identity_fold.canonical_groups")
+	IdentityFoldCostDeltaKey       = attribute.Key("gram.identity_fold.cost_delta")
+	IdentityFoldLiteralGroupsKey   = attribute.Key("gram.identity_fold.literal_groups")
+	IdentityMapEntryCountKey       = attribute.Key("gram.identity_map.entry_count")
+	LiteLLMInstanceIDKey           = attribute.Key("gram.litellm.instance_id")
+	LiteLLMCallIDKey               = attribute.Key("gram.litellm.call_id")
+	LiteLLMTraceIDKey              = attribute.Key("gram.litellm.trace_id")
+	LiteLLMUserIDKey               = attribute.Key("gram.litellm.user_id")
+	LiteLLMUserEmailKey            = attribute.Key("gram.litellm.user_email")
+	LiteLLMTeamIDKey               = attribute.Key("gram.litellm.team_id")
+	LiteLLMTeamAliasKey            = attribute.Key("gram.litellm.team_alias")
+	LiteLLMEndUserIDKey            = attribute.Key("gram.litellm.end_user_id")
+	LiteLLMOrganizationIDKey       = attribute.Key("gram.litellm.org_id")
+	LiteLLMAPIKeyHashKey           = attribute.Key("gram.litellm.api_key_hash")
+	LiteLLMAPIKeyAliasKey          = attribute.Key("gram.litellm.api_key_alias")
+	LiteLLMInputCostKey            = attribute.Key("litellm.cost.input")
+	LiteLLMOutputCostKey           = attribute.Key("litellm.cost.output")
+	LiteLLMCacheReadCostKey        = attribute.Key("litellm.cost.cache_read")
+	LiteLLMCacheWriteCostKey       = attribute.Key("litellm.cost.cache_creation")
 	// MCPMatchKey carries the server-level identifier the matcher resolved
 	// for a hook-time MCP tool call — an HTTP/SSE URL, a stdio command, or
 	// (as fallback) the `mcp__<server>__` prefix from the tool name. Set on
@@ -808,6 +811,24 @@ func SlogHookSource(v string) slog.Attr      { return slog.String(string(HookSou
 
 func HookBlockReason(v string) attribute.KeyValue { return HookBlockReasonKey.String(v) }
 func SlogHookBlockReason(v string) slog.Attr      { return slog.String(string(HookBlockReasonKey), v) }
+
+func IdentityFoldCanonicalGroups(v int) attribute.KeyValue {
+	return IdentityFoldCanonicalGroupsKey.Int(v)
+}
+
+func SlogIdentityFoldCanonicalGroups(v int) slog.Attr {
+	return slog.Int(string(IdentityFoldCanonicalGroupsKey), v)
+}
+
+func IdentityFoldCostDelta(v float64) attribute.KeyValue { return IdentityFoldCostDeltaKey.Float64(v) }
+func SlogIdentityFoldCostDelta(v float64) slog.Attr {
+	return slog.Float64(string(IdentityFoldCostDeltaKey), v)
+}
+
+func IdentityFoldLiteralGroups(v int) attribute.KeyValue { return IdentityFoldLiteralGroupsKey.Int(v) }
+func SlogIdentityFoldLiteralGroups(v int) slog.Attr {
+	return slog.Int(string(IdentityFoldLiteralGroupsKey), v)
+}
 
 func IdentityMapEntryCount(v int) attribute.KeyValue { return IdentityMapEntryCountKey.Int(v) }
 func SlogIdentityMapEntryCount(v int) slog.Attr      { return slog.Int(string(IdentityMapEntryCountKey), v) }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -304,7 +304,7 @@ func NewActivities(
 		sendOpenRouterCreditsAlerts:     activities.NewMaybeSendOpenRouterCreditsAlerts(logger, db, cacheAdapter, emailService, meterProvider),
 		firePlatformUsageMetrics:        activities.NewFirePlatformUsageMetrics(logger, billingTracker),
 		correlateClaudePrompts:          activities.NewCorrelateClaudePrompts(logger, db, chConn),
-		syncIdentityMap:                 activities.NewSyncIdentityMap(logger, db, chConn),
+		syncIdentityMap:                 activities.NewSyncIdentityMap(logger, db, chConn, cacheAdapter),
 		promoteStagedTelemetry:          activities.NewPromoteStagedTelemetry(logger, chConn, cacheAdapter, telemetryLogPublisher),
 		listStagedTelemetryProjects:     activities.NewListStagedTelemetryProjects(logger, chConn),
 		generateChatTitle:               activities.NewGenerateChatTitle(logger, db, chatClient),

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -102,6 +102,7 @@ type Activities struct {
 	sendOpenRouterCreditsAlerts     *activities.MaybeSendOpenRouterCreditsAlerts
 	firePlatformUsageMetrics        *activities.FirePlatformUsageMetrics
 	correlateClaudePrompts          *activities.CorrelateClaudePrompts
+	syncIdentityMap                 *activities.SyncIdentityMap
 	promoteStagedTelemetry          *activities.PromoteStagedTelemetry
 	listStagedTelemetryProjects     *activities.ListStagedTelemetryProjects
 	generateChatTitle               *activities.GenerateChatTitle
@@ -303,6 +304,7 @@ func NewActivities(
 		sendOpenRouterCreditsAlerts:     activities.NewMaybeSendOpenRouterCreditsAlerts(logger, db, cacheAdapter, emailService, meterProvider),
 		firePlatformUsageMetrics:        activities.NewFirePlatformUsageMetrics(logger, billingTracker),
 		correlateClaudePrompts:          activities.NewCorrelateClaudePrompts(logger, db, chConn),
+		syncIdentityMap:                 activities.NewSyncIdentityMap(logger, db, chConn),
 		promoteStagedTelemetry:          activities.NewPromoteStagedTelemetry(logger, chConn, cacheAdapter, telemetryLogPublisher),
 		listStagedTelemetryProjects:     activities.NewListStagedTelemetryProjects(logger, chConn),
 		generateChatTitle:               activities.NewGenerateChatTitle(logger, db, chatClient),
@@ -577,6 +579,10 @@ func (a *Activities) GenerateChatTitle(ctx context.Context, input activities.Gen
 
 func (a *Activities) CorrelateClaudePrompts(ctx context.Context, input activities.CorrelateClaudePromptsArgs) (*activities.CorrelateClaudePromptsResult, error) {
 	return a.correlateClaudePrompts.Do(ctx, input)
+}
+
+func (a *Activities) SyncIdentityMap(ctx context.Context) (*activities.SyncIdentityMapResult, error) {
+	return a.syncIdentityMap.Do(ctx)
 }
 
 func (a *Activities) PromoteStagedTelemetry(ctx context.Context, input activities.PromoteStagedTelemetryArgs) (*activities.PromoteStagedTelemetryResult, error) {

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -381,6 +381,11 @@ WHERE id = ANY(@ids::bigint[])
 -- email has no directory row in the org and exactly one connected owner with
 -- an unambiguous directory email claims it. Ambiguous emails are omitted so
 -- readers fall back to literal matching rather than guessing.
+--
+-- The owner-ambiguity count deliberately includes account links whose owner is
+-- since deleted or disconnected (matching the Go resolver): a second historical
+-- claimant has telemetry rows under the shared email, and folding it to the
+-- surviving owner would move the departed claimant's usage onto them.
 WITH directory AS (
     SELECT
         our.organization_id,

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -367,3 +367,69 @@ UPDATE publish_outbox SET
     updated_at = clock_timestamp()
 WHERE id = ANY(@ids::bigint[])
   AND lease_token = @lease_token::uuid;
+
+-- name: ListIdentityMapEntries :many
+-- Source of the ClickHouse identity_map fold table. Internal sync sweep that
+-- deliberately spans all organizations: the org boundary is carried in the
+-- output rows (organization_id keys the map), not the predicate; not reachable
+-- from user-facing handlers.
+--
+-- Encodes the employee identity fold rules (the SQL twin of telemetry's
+-- resolveEmployeeIdentity, which DNO-857 retires): a directory email maps to
+-- its user only when exactly one connected, non-deleted user claims it
+-- case-insensitively; a linked-account email maps to its owner only when the
+-- email has no directory row in the org and exactly one connected owner with
+-- an unambiguous directory email claims it. Ambiguous emails are omitted so
+-- readers fall back to literal matching rather than guessing.
+WITH directory AS (
+    SELECT
+        our.organization_id,
+        lower(btrim(u.email)) AS email_lower,
+        min(u.id) AS user_id,
+        count(*) AS claimants
+    FROM users u
+    JOIN organization_user_relationships our ON our.user_id = u.id
+    WHERE u.deleted_at IS NULL
+      AND our.deleted_at IS NULL
+      AND btrim(u.email) != ''
+    GROUP BY our.organization_id, lower(btrim(u.email))
+), account_owners AS (
+    SELECT ua.organization_id, lower(btrim(ua.email)) AS email_lower, ua.user_id
+    FROM user_accounts ua
+    WHERE ua.deleted_at IS NULL
+      AND ua.user_id IS NOT NULL
+      AND ua.email IS NOT NULL
+      AND btrim(ua.email) != ''
+    GROUP BY ua.organization_id, lower(btrim(ua.email)), ua.user_id
+), unique_account_owner AS (
+    SELECT organization_id, email_lower, min(user_id) AS user_id
+    FROM account_owners
+    GROUP BY organization_id, email_lower
+    HAVING count(*) = 1
+)
+SELECT
+    d.organization_id,
+    d.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM directory d
+WHERE d.claimants = 1
+UNION ALL
+SELECT
+    uao.organization_id,
+    uao.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM unique_account_owner uao
+JOIN users u ON u.id = uao.user_id AND u.deleted_at IS NULL
+JOIN directory d
+    ON d.organization_id = uao.organization_id
+    AND d.email_lower = lower(btrim(u.email))
+    AND d.user_id = u.id
+    AND d.claimants = 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM directory dd
+    WHERE dd.organization_id = uao.organization_id
+      AND dd.email_lower = uao.email_lower
+)
+ORDER BY organization_id, email_lower;

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -727,6 +727,11 @@ type ListIdentityMapEntriesRow struct {
 // email has no directory row in the org and exactly one connected owner with
 // an unambiguous directory email claims it. Ambiguous emails are omitted so
 // readers fall back to literal matching rather than guessing.
+//
+// The owner-ambiguity count deliberately includes account links whose owner is
+// since deleted or disconnected (matching the Go resolver): a second historical
+// claimant has telemetry rows under the shared email, and folding it to the
+// surviving owner would move the departed claimant's usage onto them.
 func (q *Queries) ListIdentityMapEntries(ctx context.Context) ([]ListIdentityMapEntriesRow, error) {
 	rows, err := q.db.Query(ctx, listIdentityMapEntries)
 	if err != nil {

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -653,6 +653,105 @@ func (q *Queries) GetUserEmailsByOrgIDs(ctx context.Context, dollar_1 []string) 
 	return items, nil
 }
 
+const listIdentityMapEntries = `-- name: ListIdentityMapEntries :many
+WITH directory AS (
+    SELECT
+        our.organization_id,
+        lower(btrim(u.email)) AS email_lower,
+        min(u.id) AS user_id,
+        count(*) AS claimants
+    FROM users u
+    JOIN organization_user_relationships our ON our.user_id = u.id
+    WHERE u.deleted_at IS NULL
+      AND our.deleted_at IS NULL
+      AND btrim(u.email) != ''
+    GROUP BY our.organization_id, lower(btrim(u.email))
+), account_owners AS (
+    SELECT ua.organization_id, lower(btrim(ua.email)) AS email_lower, ua.user_id
+    FROM user_accounts ua
+    WHERE ua.deleted_at IS NULL
+      AND ua.user_id IS NOT NULL
+      AND ua.email IS NOT NULL
+      AND btrim(ua.email) != ''
+    GROUP BY ua.organization_id, lower(btrim(ua.email)), ua.user_id
+), unique_account_owner AS (
+    SELECT organization_id, email_lower, min(user_id) AS user_id
+    FROM account_owners
+    GROUP BY organization_id, email_lower
+    HAVING count(*) = 1
+)
+SELECT
+    d.organization_id,
+    d.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM directory d
+WHERE d.claimants = 1
+UNION ALL
+SELECT
+    uao.organization_id,
+    uao.email_lower,
+    d.user_id::text AS canonical_user_id,
+    d.email_lower AS canonical_email
+FROM unique_account_owner uao
+JOIN users u ON u.id = uao.user_id AND u.deleted_at IS NULL
+JOIN directory d
+    ON d.organization_id = uao.organization_id
+    AND d.email_lower = lower(btrim(u.email))
+    AND d.user_id = u.id
+    AND d.claimants = 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM directory dd
+    WHERE dd.organization_id = uao.organization_id
+      AND dd.email_lower = uao.email_lower
+)
+ORDER BY organization_id, email_lower
+`
+
+type ListIdentityMapEntriesRow struct {
+	OrganizationID  string
+	EmailLower      string
+	CanonicalUserID string
+	CanonicalEmail  string
+}
+
+// Source of the ClickHouse identity_map fold table. Internal sync sweep that
+// deliberately spans all organizations: the org boundary is carried in the
+// output rows (organization_id keys the map), not the predicate; not reachable
+// from user-facing handlers.
+//
+// Encodes the employee identity fold rules (the SQL twin of telemetry's
+// resolveEmployeeIdentity, which DNO-857 retires): a directory email maps to
+// its user only when exactly one connected, non-deleted user claims it
+// case-insensitively; a linked-account email maps to its owner only when the
+// email has no directory row in the org and exactly one connected owner with
+// an unambiguous directory email claims it. Ambiguous emails are omitted so
+// readers fall back to literal matching rather than guessing.
+func (q *Queries) ListIdentityMapEntries(ctx context.Context) ([]ListIdentityMapEntriesRow, error) {
+	rows, err := q.db.Query(ctx, listIdentityMapEntries)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListIdentityMapEntriesRow
+	for rows.Next() {
+		var i ListIdentityMapEntriesRow
+		if err := rows.Scan(
+			&i.OrganizationID,
+			&i.EmailLower,
+			&i.CanonicalUserID,
+			&i.CanonicalEmail,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUnlinkedClaudeUserMessagesForCorrelation = `-- name: ListUnlinkedClaudeUserMessagesForCorrelation :many
 SELECT id, seq, content, created_at
 FROM chat_messages

--- a/server/internal/background/activities/sync_identity_map.go
+++ b/server/internal/background/activities/sync_identity_map.go
@@ -14,14 +14,30 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
+
+// identityMapReplaceLockKey serializes the whole staging rebuild + swap. The
+// TRUNCATE/INSERT/EXCHANGE sequence is not atomic in ClickHouse, so without a
+// single writer a retry can interleave with a timed-out predecessor's in-flight
+// statements and publish mixed data — or a delayed EXCHANGE can republish the
+// previous generation after a successor already swapped.
+const identityMapReplaceLockKey = "identity-map:replace-lock"
+
+// identityMapReplaceLockTTL outlives one activity attempt (2m StartToClose)
+// plus the ClickHouse connection's 60s server-side statement lifetime, so by
+// the time the lock lapses no statement from the holder can still land. The
+// activity's 8m ScheduleToCloseTimeout leaves room for a retry after a lapsed
+// lock; a fully exhausted budget just defers to the next tick.
+const identityMapReplaceLockTTL = 5 * time.Minute
 
 type identityMapStore interface {
 	ListIdentityMapEntries(ctx context.Context) ([]activitiesrepo.ListIdentityMapEntriesRow, error)
@@ -35,13 +51,15 @@ type SyncIdentityMap struct {
 	logger    *slog.Logger
 	store     identityMapStore
 	telemetry identityMapTelemetry
+	cache     cache.Cache
 }
 
-func NewSyncIdentityMap(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn) *SyncIdentityMap {
+func NewSyncIdentityMap(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn, cacheAdapter cache.Cache) *SyncIdentityMap {
 	return &SyncIdentityMap{
 		logger:    logger.With(attr.SlogComponent("sync_identity_map")),
 		store:     activitiesrepo.New(db),
 		telemetry: telemetryrepo.New(chConn),
+		cache:     cacheAdapter,
 	}
 }
 
@@ -65,8 +83,30 @@ func (s *SyncIdentityMap) Do(ctx context.Context) (*SyncIdentityMapResult, error
 		})
 	}
 
+	// Single-writer claim across the whole replacement. Losing the race defers
+	// to the holder (the retry or the next tick picks up after the claim
+	// clears); a claim leaked by a crashed attempt lapses at the TTL, after
+	// which no statement from that attempt can still be in flight.
+	claimed, err := s.cache.Add(ctx, identityMapReplaceLockKey, identityMapReplaceLockTTL)
+	if err != nil {
+		return nil, fmt.Errorf("claim identity map replacement lock: %w", err)
+	}
+	if !claimed {
+		return nil, fmt.Errorf("identity map replacement already in progress")
+	}
+
 	if err := s.telemetry.ReplaceIdentityMap(ctx, entries); err != nil {
+		// Deliberately keep the claim: this attempt may have statements in
+		// flight, and the TTL is what guarantees they are dead before the
+		// next writer starts.
 		return nil, fmt.Errorf("replace identity map: %w", err)
+	}
+
+	// Release on success only, so the schedule and link-event triggers are
+	// not blocked for the remainder of the TTL. Best effort: a leaked claim
+	// merely delays the next refresh.
+	if err := s.cache.Delete(context.WithoutCancel(ctx), identityMapReplaceLockKey); err != nil {
+		s.logger.WarnContext(ctx, "failed to release identity map replacement lock", attr.SlogError(err))
 	}
 
 	// This success line is the staleness signal: a quiet component means the

--- a/server/internal/background/activities/sync_identity_map.go
+++ b/server/internal/background/activities/sync_identity_map.go
@@ -1,0 +1,77 @@
+package activities
+
+// SyncIdentityMap rebuilds the ClickHouse employee identity fold map
+// (identity_map) from the Postgres directory. The source query encodes the
+// fold rules — a directory email maps to its user only when exactly one
+// connected user claims it, a linked-account email only when it has no
+// directory row and exactly one owner — so ambiguous identities are absent
+// and analytics readers fall back to literal email matching. Every pass is a
+// full refresh into a staging table swapped live with EXCHANGE TABLES:
+// deletions and unlinks propagate by omission, so a stalled sync means the
+// map drifts stale (it keeps folding by old links) rather than failing open.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+type identityMapStore interface {
+	ListIdentityMapEntries(ctx context.Context) ([]activitiesrepo.ListIdentityMapEntriesRow, error)
+}
+
+type identityMapTelemetry interface {
+	ReplaceIdentityMap(ctx context.Context, entries []telemetryrepo.IdentityMapEntry) error
+}
+
+type SyncIdentityMap struct {
+	logger    *slog.Logger
+	store     identityMapStore
+	telemetry identityMapTelemetry
+}
+
+func NewSyncIdentityMap(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn) *SyncIdentityMap {
+	return &SyncIdentityMap{
+		logger:    logger.With(attr.SlogComponent("sync_identity_map")),
+		store:     activitiesrepo.New(db),
+		telemetry: telemetryrepo.New(chConn),
+	}
+}
+
+type SyncIdentityMapResult struct {
+	Entries int
+}
+
+func (s *SyncIdentityMap) Do(ctx context.Context) (*SyncIdentityMapResult, error) {
+	rows, err := s.store.ListIdentityMapEntries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list identity map entries: %w", err)
+	}
+
+	entries := make([]telemetryrepo.IdentityMapEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, telemetryrepo.IdentityMapEntry{
+			OrgID:           row.OrganizationID,
+			EmailLower:      row.EmailLower,
+			CanonicalUserID: row.CanonicalUserID,
+			CanonicalEmail:  row.CanonicalEmail,
+		})
+	}
+
+	if err := s.telemetry.ReplaceIdentityMap(ctx, entries); err != nil {
+		return nil, fmt.Errorf("replace identity map: %w", err)
+	}
+
+	// This success line is the staleness signal: a quiet component means the
+	// map is drifting from Postgres until the next successful pass.
+	s.logger.InfoContext(ctx, "identity map synced", attr.SlogIdentityMapEntryCount(len(entries)))
+
+	return &SyncIdentityMapResult{Entries: len(entries)}, nil
+}

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -1,0 +1,195 @@
+package activities_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+func seedIdentityOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool) string {
+	t.Helper()
+
+	orgID := "org-" + uuid.NewString()[:8]
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Identity Map Test Org",
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	return orgID
+}
+
+func seedIdentityUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, email string) string {
+	t.Helper()
+
+	userID := uuid.NewString()
+	_, err := userrepo.New(conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: "identity-map-test",
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: orgID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	return userID
+}
+
+func seedIdentityAccount(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, userID *string, email string) {
+	t.Helper()
+
+	_, err := hooksrepo.New(conn).UpsertUserAccount(ctx, hooksrepo.UpsertUserAccountParams{
+		OrganizationID:      orgID,
+		Provider:            "anthropic",
+		ExternalAccountUuid: uuid.NewString(),
+		UserID:              conv.PtrToPGText(userID),
+		ExternalOrgID:       conv.PtrToPGText(nil),
+		ExternalAccountID:   conv.PtrToPGText(nil),
+		Email:               conv.ToPGText(email),
+		AccountType:         conv.ToPGText("personal"),
+	})
+	require.NoError(t, err)
+}
+
+// lookupFold reads the map through joinGet — the read contract; a composite-key
+// StorageJoin cannot be scanned with SELECT. Missing keys return two empty
+// strings.
+func lookupFold(t *testing.T, ctx context.Context, chConn clickhouse.Conn, orgID, emailLower string) (string, string) {
+	t.Helper()
+
+	var canonicalUserID, canonicalEmail string
+	require.NoError(t, chConn.QueryRow(ctx,
+		"SELECT joinGet('identity_map', 'canonical_user_id', ?, ?), joinGet('identity_map', 'canonical_email', ?, ?)",
+		orgID, emailLower, orgID, emailLower).Scan(&canonicalUserID, &canonicalEmail))
+	return canonicalUserID, canonicalEmail
+}
+
+func requireFoldsTo(t *testing.T, ctx context.Context, chConn clickhouse.Conn, orgID, emailLower, wantUserID, wantEmail string) {
+	t.Helper()
+
+	gotUserID, gotEmail := lookupFold(t, ctx, chConn, orgID, emailLower)
+	require.Equal(t, wantUserID, gotUserID)
+	require.Equal(t, wantEmail, gotEmail)
+}
+
+func requireAbsent(t *testing.T, ctx context.Context, chConn clickhouse.Conn, orgID, emailLower string) {
+	t.Helper()
+
+	gotUserID, gotEmail := lookupFold(t, ctx, chConn, orgID, emailLower)
+	require.Empty(t, gotUserID, "expected %s to be absent", emailLower)
+	require.Empty(t, gotEmail, "expected %s to be absent", emailLower)
+}
+
+func TestSyncIdentityMap_FoldRules(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	conn, err := infra.CloneTestDatabase(t, "sync_identity_map")
+	require.NoError(t, err)
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	org1 := seedIdentityOrg(t, ctx, conn)
+	org2 := seedIdentityOrg(t, ctx, conn)
+	suffix := uuid.NewString()[:8]
+
+	// Directory email with mixed case folds to itself; the linked personal
+	// account email (mixed case, padded) folds to the same user.
+	aliceEmail := "Alice-" + suffix + "@Example.COM"
+	aliceLower := "alice-" + suffix + "@example.com"
+	alice := seedIdentityUser(t, ctx, conn, org1, aliceEmail)
+	alicePersonal := "  Personal-Alice-" + suffix + "@Example.com  "
+	alicePersonalLower := "personal-alice-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &alice, alicePersonal)
+
+	// A shared account email claimed by two users stays out of the map.
+	bob := seedIdentityUser(t, ctx, conn, org1, "bob-"+suffix+"@example.com")
+	carol := seedIdentityUser(t, ctx, conn, org1, "carol-"+suffix+"@example.com")
+	sharedEmail := "shared-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &bob, sharedEmail)
+	seedIdentityAccount(t, ctx, conn, org1, &carol, sharedEmail)
+
+	// Case-variant directory duplicates: neither user's email enters the map,
+	// and an account owned by one of them is refused because its owner's
+	// directory identity is ambiguous.
+	dupeLower := "dupe-" + suffix + "@example.com"
+	dave := seedIdentityUser(t, ctx, conn, org1, "Dupe-"+suffix+"@example.com")
+	seedIdentityUser(t, ctx, conn, org1, "dupe-"+suffix+"@EXAMPLE.com")
+	davePersonal := "dave-personal-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &dave, davePersonal)
+
+	// Deleted rows: a deleted user, a deleted relationship, and a deleted
+	// account link all stay out.
+	fixtures := testrepo.New(conn)
+	frank := seedIdentityUser(t, ctx, conn, org1, "frank-"+suffix+"@example.com")
+	require.NoError(t, fixtures.ForceSoftDeleteUser(ctx, frank))
+	gina := seedIdentityUser(t, ctx, conn, org1, "gina-"+suffix+"@example.com")
+	require.NoError(t, fixtures.ForceSoftDeleteOrganizationUserRelationship(ctx, testrepo.ForceSoftDeleteOrganizationUserRelationshipParams{
+		OrganizationID: org1,
+		UserID:         conv.ToPGText(gina),
+	}))
+	henry := seedIdentityUser(t, ctx, conn, org1, "henry-"+suffix+"@example.com")
+	henryPersonal := "henry-personal-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, &henry, henryPersonal)
+	require.NoError(t, fixtures.ForceSoftDeleteUserAccountsByEmail(ctx, testrepo.ForceSoftDeleteUserAccountsByEmailParams{
+		OrganizationID: org1,
+		EmailLower:     henryPersonal,
+	}))
+
+	// An unattributed account (no user_id) resolves to nobody.
+	orphanEmail := "orphan-" + suffix + "@example.com"
+	seedIdentityAccount(t, ctx, conn, org1, nil, orphanEmail)
+
+	// Directory ownership wins over a linked account claiming the same email.
+	ivyEmail := "ivy-" + suffix + "@example.com"
+	ivy := seedIdentityUser(t, ctx, conn, org1, ivyEmail)
+	jack := seedIdentityUser(t, ctx, conn, org1, "jack-"+suffix+"@example.com")
+	seedIdentityAccount(t, ctx, conn, org1, &jack, ivyEmail)
+
+	// The same personal email linked in a different org folds independently.
+	org2User := seedIdentityUser(t, ctx, conn, org2, "other-"+suffix+"@example.com")
+	seedIdentityAccount(t, ctx, conn, org2, &org2User, alicePersonalLower)
+
+	act := activities.NewSyncIdentityMap(logger, conn, chConn)
+	result, err := act.Do(ctx)
+	require.NoError(t, err)
+	require.NotZero(t, result.Entries)
+
+	// A second pass is a full rebuild and swap; assertions below hold for the
+	// fresh generation, proving idempotency across the staging/live exchange.
+	secondResult, err := act.Do(ctx)
+	require.NoError(t, err)
+	require.Equal(t, result.Entries, secondResult.Entries)
+
+	requireFoldsTo(t, ctx, chConn, org1, aliceLower, alice, aliceLower)
+	requireFoldsTo(t, ctx, chConn, org1, alicePersonalLower, alice, aliceLower)
+	requireFoldsTo(t, ctx, chConn, org1, ivyEmail, ivy, ivyEmail)
+	requireFoldsTo(t, ctx, chConn, org2, alicePersonalLower, org2User, "other-"+suffix+"@example.com")
+
+	for _, absent := range []string{sharedEmail, dupeLower, davePersonal, "frank-" + suffix + "@example.com", "gina-" + suffix + "@example.com", henryPersonal, orphanEmail} {
+		requireAbsent(t, ctx, chConn, org1, absent)
+	}
+}

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -199,7 +199,7 @@ func TestSyncIdentityMap_FoldRules(t *testing.T) {
 // TestReplaceIdentityMap_GenerationSwap exercises the telemetry repo's staging
 // swap directly, covering the behaviors the fold-rule sync never reaches: the
 // duplicate-key rejection (the SQL source provably cannot emit duplicates, so
-// only a direct call can trip it), an insert spanning the 5000-row chunk
+// only a direct call can trip it), an insert spanning the insert-chunk
 // boundary, and a key vanishing with its old generation (deletions propagate
 // by omission).
 //
@@ -230,11 +230,13 @@ func TestReplaceIdentityMap_GenerationSwap(t *testing.T) { //nolint:paralleltest
 	require.ErrorContains(t, err, "duplicate identity map key")
 	requireFoldsTo(t, ctx, chConn, org, seedEmail, "user-a", seedEmail)
 
-	// One entry beyond the insert chunk size (identityMapInsertChunk = 5000):
+	// One entry beyond the insert chunk size, derived from the constant so the
+	// boundary stays exercised if the chunk size ever changes:
 	// rows land on both sides of the chunk boundary, and the seed key is gone
 	// with the generation that carried it.
-	entries := make([]telemetryrepo.IdentityMapEntry, 0, 5001)
-	for i := range 5001 {
+	boundary := telemetryrepo.IdentityMapInsertChunk + 1
+	entries := make([]telemetryrepo.IdentityMapEntry, 0, boundary)
+	for i := range boundary {
 		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
 		entries = append(entries, telemetryrepo.IdentityMapEntry{
 			OrgID:           org,
@@ -245,7 +247,7 @@ func TestReplaceIdentityMap_GenerationSwap(t *testing.T) { //nolint:paralleltest
 	}
 	require.NoError(t, repo.ReplaceIdentityMap(ctx, entries))
 
-	for _, i := range []int{0, 4999, 5000} {
+	for _, i := range []int{0, telemetryrepo.IdentityMapInsertChunk - 1, telemetryrepo.IdentityMapInsertChunk} {
 		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
 		requireFoldsTo(t, ctx, chConn, org, email, fmt.Sprintf("user-%d", i), email)
 	}

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -13,6 +14,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -175,7 +177,17 @@ func TestSyncIdentityMap_FoldRules(t *testing.T) {
 	org2User := seedIdentityUser(t, ctx, conn, org2, "other-"+suffix+"@example.com")
 	seedIdentityAccount(t, ctx, conn, org2, &org2User, alicePersonalLower)
 
-	act := activities.NewSyncIdentityMap(logger, conn, chConn)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
+
+	// A held replacement claim defers the sync instead of interleaving with
+	// the holder's statements; releasing it lets the retry proceed.
+	require.NoError(t, cacheAdapter.Set(ctx, "identity-map:replace-lock", "held", time.Minute))
+	act := activities.NewSyncIdentityMap(logger, conn, chConn, cacheAdapter)
+	_, err = act.Do(ctx)
+	require.ErrorContains(t, err, "already in progress")
+	require.NoError(t, cacheAdapter.Delete(ctx, "identity-map:replace-lock"))
 	result, err := act.Do(ctx)
 	require.NoError(t, err)
 	require.NotZero(t, result.Entries)

--- a/server/internal/background/activities/sync_identity_map_test.go
+++ b/server/internal/background/activities/sync_identity_map_test.go
@@ -2,6 +2,7 @@ package activities_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -15,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
@@ -192,4 +194,60 @@ func TestSyncIdentityMap_FoldRules(t *testing.T) {
 	for _, absent := range []string{sharedEmail, dupeLower, davePersonal, "frank-" + suffix + "@example.com", "gina-" + suffix + "@example.com", henryPersonal, orphanEmail} {
 		requireAbsent(t, ctx, chConn, org1, absent)
 	}
+}
+
+// TestReplaceIdentityMap_GenerationSwap exercises the telemetry repo's staging
+// swap directly, covering the behaviors the fold-rule sync never reaches: the
+// duplicate-key rejection (the SQL source provably cannot emit duplicates, so
+// only a direct call can trip it), an insert spanning the 5000-row chunk
+// boundary, and a key vanishing with its old generation (deletions propagate
+// by omission).
+//
+// Deliberately not parallel: identity_map is one package-global ClickHouse
+// table, and a full-refresh swap here would race the joinGet assertions in
+// TestSyncIdentityMap_FoldRules if the two tests overlapped.
+func TestReplaceIdentityMap_GenerationSwap(t *testing.T) { //nolint:paralleltest // Swaps the ClickHouse identity_map shared with TestSyncIdentityMap_FoldRules.
+	ctx := t.Context()
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	repo := telemetryrepo.New(chConn)
+	org := "org-" + uuid.NewString()[:8]
+	seedEmail := "seed-" + uuid.NewString()[:8] + "@example.com"
+
+	require.NoError(t, repo.ReplaceIdentityMap(ctx, []telemetryrepo.IdentityMapEntry{
+		{OrgID: org, EmailLower: seedEmail, CanonicalUserID: "user-a", CanonicalEmail: seedEmail},
+	}))
+	requireFoldsTo(t, ctx, chConn, org, seedEmail, "user-a", seedEmail)
+
+	// A duplicate (org, email) key is rejected before either table is touched,
+	// so the previous complete generation keeps serving.
+	err = repo.ReplaceIdentityMap(ctx, []telemetryrepo.IdentityMapEntry{
+		{OrgID: org, EmailLower: seedEmail, CanonicalUserID: "user-a", CanonicalEmail: seedEmail},
+		{OrgID: org, EmailLower: seedEmail, CanonicalUserID: "user-b", CanonicalEmail: seedEmail},
+	})
+	require.ErrorContains(t, err, "duplicate identity map key")
+	requireFoldsTo(t, ctx, chConn, org, seedEmail, "user-a", seedEmail)
+
+	// One entry beyond the insert chunk size (identityMapInsertChunk = 5000):
+	// rows land on both sides of the chunk boundary, and the seed key is gone
+	// with the generation that carried it.
+	entries := make([]telemetryrepo.IdentityMapEntry, 0, 5001)
+	for i := range 5001 {
+		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
+		entries = append(entries, telemetryrepo.IdentityMapEntry{
+			OrgID:           org,
+			EmailLower:      email,
+			CanonicalUserID: fmt.Sprintf("user-%d", i),
+			CanonicalEmail:  email,
+		})
+	}
+	require.NoError(t, repo.ReplaceIdentityMap(ctx, entries))
+
+	for _, i := range []int{0, 4999, 5000} {
+		email := fmt.Sprintf("bulk-%d-%s@example.com", i, org)
+		requireFoldsTo(t, ctx, chConn, org, email, fmt.Sprintf("user-%d", i), email)
+	}
+	requireAbsent(t, ctx, chConn, org, seedEmail)
 }

--- a/server/internal/background/sync_identity_map.go
+++ b/server/internal/background/sync_identity_map.go
@@ -30,8 +30,15 @@ const (
 )
 
 func SyncIdentityMapWorkflow(ctx workflow.Context) error {
+	// ScheduleToClose covers the full retry budget (3 attempts x 2m plus
+	// backoff, ~6m15s) with queue-wait slack, and sits under the 10m
+	// WorkflowRunTimeout so a backlogged task queue exhausts the activity's
+	// own budget rather than the workflow's. A timed-out refresh is benign:
+	// the live map stays on its previous complete generation until the next
+	// tick.
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 2 * time.Minute,
+		StartToCloseTimeout:    2 * time.Minute,
+		ScheduleToCloseTimeout: 8 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts:    3,
 			InitialInterval:    5 * time.Second,

--- a/server/internal/background/sync_identity_map.go
+++ b/server/internal/background/sync_identity_map.go
@@ -1,0 +1,89 @@
+package background
+
+// Identity map sync. The ClickHouse identity_map table folds each unambiguous
+// directory or linked-account email to its owning user so analytics reads can
+// resolve one employee to one identity (via joinGet). The schedule below is
+// the sole trigger: every tick performs a full rebuild from Postgres into
+// identity_map_staging and an atomic EXCHANGE TABLES swap, so link changes —
+// including deletions — converge within one interval and readers never see a
+// partial map. The interval is the accepted staleness bound for analytics
+// folding; there is deliberately no write-path trigger yet.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	identityMapSyncScheduleID = "v1:identity-map-sync-schedule"
+	identityMapSyncWorkflowID = identityMapSyncScheduleID + "/scheduled"
+	identityMapSyncInterval   = 15 * time.Minute
+)
+
+func SyncIdentityMapWorkflow(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 2 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    30 * time.Second,
+		},
+	})
+
+	var a *Activities
+	if err := workflow.ExecuteActivity(ctx, a.SyncIdentityMap).Get(ctx, nil); err != nil {
+		return fmt.Errorf("sync identity map: %w", err)
+	}
+	return nil
+}
+
+func AddIdentityMapSyncSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	sc := temporalEnv.Client().ScheduleClient()
+
+	spec := client.ScheduleSpec{
+		Intervals: []client.ScheduleIntervalSpec{{Every: identityMapSyncInterval}},
+	}
+	action := &client.ScheduleWorkflowAction{
+		ID:                 identityMapSyncWorkflowID,
+		Workflow:           SyncIdentityMapWorkflow,
+		TaskQueue:          string(temporalEnv.Queue()),
+		WorkflowRunTimeout: 10 * time.Minute,
+	}
+
+	_, err := sc.Create(ctx, client.ScheduleOptions{
+		ID:      identityMapSyncScheduleID,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Spec:    spec,
+		Action:  action,
+	})
+	switch {
+	case errors.Is(err, temporal.ErrScheduleAlreadyRunning):
+		// The schedule survives deploys; push the current spec and action so
+		// interval or workflow changes take effect on running environments.
+		if err := sc.GetHandle(ctx, identityMapSyncScheduleID).Update(ctx, client.ScheduleUpdateOptions{
+			DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+				input.Description.Schedule.Spec = &spec
+				input.Description.Schedule.Action = action
+				return &client.ScheduleUpdate{
+					Schedule:              &input.Description.Schedule,
+					TypedSearchAttributes: nil,
+				}, nil
+			},
+		}); err != nil {
+			return fmt.Errorf("update identity map sync schedule: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("create identity map sync schedule: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -408,6 +408,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.GenerateToolsetEmbeddings)
 	temporalWorker.RegisterActivity(activities.GenerateChatTitle)
 	temporalWorker.RegisterActivity(activities.CorrelateClaudePrompts)
+	temporalWorker.RegisterActivity(activities.SyncIdentityMap)
 	temporalWorker.RegisterActivity(activities.PromoteStagedTelemetry)
 	temporalWorker.RegisterActivity(activities.ListStagedTelemetryProjects)
 	temporalWorker.RegisterActivity(activities.SegmentChat)
@@ -523,6 +524,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(IndexToolsetWorkflow)
 	temporalWorker.RegisterWorkflow(GenerateChatTitleWorkflow)
 	temporalWorker.RegisterWorkflow(CorrelateClaudePromptsWorkflow)
+	temporalWorker.RegisterWorkflow(SyncIdentityMapWorkflow)
 	temporalWorker.RegisterWorkflow(PromoteStagedTelemetryWorkflow)
 	temporalWorker.RegisterWorkflow(StagedTelemetrySweepWorkflow)
 	temporalWorker.RegisterWorkflow(AnalyzeChatResolutionsWorkflow)
@@ -655,6 +657,10 @@ func NewTemporalWorker(
 
 	if err := AddStagedTelemetrySweepSchedule(context.Background(), env); err != nil {
 		logger.ErrorContext(context.Background(), "failed to add staged telemetry sweep schedule", attr.SlogError(err))
+	}
+
+	if err := AddIdentityMapSyncSchedule(context.Background(), env); err != nil {
+		logger.ErrorContext(context.Background(), "failed to add identity map sync schedule", attr.SlogError(err))
 	}
 
 	if err := AddSpendRuleEvaluationSchedule(context.Background(), env); err != nil {

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -75,6 +75,20 @@ const (
 	// controls both the UI and the API surface.
 	FlagRiskWatchdog Flag = "gram-risk-watchdog"
 
+	// FlagCanonicalIdentityFold serves cost analytics (telemetry.query /
+	// telemetry.listSessions) email filters and group-bys through the
+	// ClickHouse identity_map fold, so one employee's directory, personal,
+	// and case-variant emails read as one identity. Targeted by PostHog
+	// organization group (org slug), like FlagBudgets. Removed once the fold
+	// is GA (DNO-856).
+	FlagCanonicalIdentityFold Flag = "canonical-identity-fold"
+	// FlagCanonicalIdentityFoldShadow runs the folded variant of the
+	// telemetry.query table read alongside the literal one — serving the
+	// literal result — and logs divergence, validating the fold on real
+	// traffic before FlagCanonicalIdentityFold enables it anywhere. Ignored
+	// when the fold flag is on. Same targeting; removed with the fold flag.
+	FlagCanonicalIdentityFoldShadow Flag = "canonical-identity-fold-shadow"
+
 	// FlagHooksRollout gates the phased rollout of new observability (hooks)
 	// plugin generator versions. Unlike the other flags it is consulted via its
 	// PAYLOAD, not its boolean state: the flag carries a JSON payload

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -218,6 +218,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 		sessionCaptureEnabled,
 		posthog,
 		authzEngine,
+		nil,
 	)
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)

--- a/server/internal/telemetry/canonical_fold.go
+++ b/server/internal/telemetry/canonical_fold.go
@@ -21,6 +21,12 @@ import (
 // read cannot pile up goroutines behind a degraded ClickHouse.
 const shadowCompareTimeout = 30 * time.Second
 
+// maxConcurrentShadowCompares caps in-flight shadow re-queries across all
+// requests. Shadow is sampling, not accounting: when ClickHouse slows down and
+// the cap is hit, further comparisons are skipped rather than queued so
+// validation traffic cannot amplify the slowdown.
+const maxConcurrentShadowCompares = 4
+
 // queryTouchesEmail reports whether a request involves the email dimension at
 // all — the only case where folding changes anything, and the gate on paying
 // the flag-evaluation and shadow-compare cost.
@@ -79,8 +85,16 @@ func (s *Service) canonicalIdentityMode(ctx context.Context, orgID string) (fold
 // groups must preserve the cost total. Runs in the background off a detached
 // context so it never delays or fails the caller's request.
 func (s *Service) shadowCompareCanonicalFold(ctx context.Context, orgID string, params repo.AttributeMetricsQueryParams, literalRows []repo.AttributeMetricsRow) {
+	select {
+	case s.shadowFoldSem <- struct{}{}:
+	default:
+		s.logger.InfoContext(ctx, "identity fold shadow comparison skipped: concurrency cap reached", attr.SlogOrganizationID(orgID))
+		return
+	}
+
 	bgCtx := context.WithoutCancel(ctx)
 	go func() {
+		defer func() { <-s.shadowFoldSem }()
 		bgCtx, cancel := context.WithTimeout(bgCtx, shadowCompareTimeout)
 		defer cancel()
 

--- a/server/internal/telemetry/canonical_fold.go
+++ b/server/internal/telemetry/canonical_fold.go
@@ -1,0 +1,109 @@
+package telemetry
+
+// Rollout plumbing for canonical identity folding in the cost analytics
+// endpoints. Two PostHog flags gate the ClickHouse identity_map fold: the
+// fold flag switches email filters and group-bys onto canonical employee
+// identities, and the shadow flag runs the folded variant of the Query table
+// read alongside the literal one — serving the literal result — and logs how
+// the two diverge, so the fold can be validated on real traffic before any
+// org sees it.
+
+import (
+	"context"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+// shadowCompareTimeout bounds the background folded re-query so a slow shadow
+// read cannot pile up goroutines behind a degraded ClickHouse.
+const shadowCompareTimeout = 30 * time.Second
+
+// queryTouchesEmail reports whether a request involves the email dimension at
+// all — the only case where folding changes anything, and the gate on paying
+// the flag-evaluation and shadow-compare cost.
+func queryTouchesEmail(groupBy string, filters []repo.AttributeMetricsFilter) bool {
+	if groupBy == "email" {
+		return true
+	}
+	for _, f := range filters {
+		if f.Dimension == "email" && len(f.Values) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalIdentityMode resolves the rollout state for an organization: fold
+// serves canonical identities, shadow logs divergence while serving literal
+// results. Fold wins over shadow. Flag evaluation follows the budgets
+// pattern: PostHog organization-group targeting by org slug, degrading to
+// distinct-id-only evaluation when the slug lookup fails, and failing closed
+// (literal behavior) on flag errors.
+func (s *Service) canonicalIdentityMode(ctx context.Context, orgID string) (fold, shadow bool) {
+	if s.featureFlags == nil || orgID == "" {
+		return false, false
+	}
+
+	var groups map[string]string
+	org, err := s.orgsRepo.GetOrganizationMetadata(ctx, orgID)
+	if err != nil {
+		s.logger.WarnContext(ctx, "resolve organization slug for identity fold flag", attr.SlogError(err))
+	} else {
+		groups = feature.OrgProjectGroups(org.Slug, "")
+	}
+
+	fold, err = s.featureFlags.IsFlagEnabled(ctx, feature.FlagCanonicalIdentityFold, orgID, groups)
+	if err != nil {
+		s.logger.WarnContext(ctx, "identity fold flag check failed; serving literal identities", attr.SlogError(err))
+		return false, false
+	}
+	if fold {
+		return true, false
+	}
+
+	shadow, err = s.featureFlags.IsFlagEnabled(ctx, feature.FlagCanonicalIdentityFoldShadow, orgID, groups)
+	if err != nil {
+		s.logger.WarnContext(ctx, "identity fold shadow flag check failed", attr.SlogError(err))
+		return false, false
+	}
+	return false, shadow
+}
+
+// shadowCompareCanonicalFold re-runs the aggregate table query with folding
+// enabled and logs how it diverges from the literal rows already served. The
+// comparison is intentionally coarse — group count and summed total cost —
+// which is exactly what folding changes: identities collapsing into fewer
+// groups must preserve the cost total. Runs in the background off a detached
+// context so it never delays or fails the caller's request.
+func (s *Service) shadowCompareCanonicalFold(ctx context.Context, orgID string, params repo.AttributeMetricsQueryParams, literalRows []repo.AttributeMetricsRow) {
+	bgCtx := context.WithoutCancel(ctx)
+	go func() {
+		bgCtx, cancel := context.WithTimeout(bgCtx, shadowCompareTimeout)
+		defer cancel()
+
+		params.CanonicalIdentityOrg = orgID
+		foldedRows, err := s.chRepo.QueryAttributeMetricsTable(bgCtx, params)
+		if err != nil {
+			s.logger.WarnContext(bgCtx, "identity fold shadow query failed", attr.SlogError(err), attr.SlogOrganizationID(orgID))
+			return
+		}
+
+		literalCost, foldedCost := 0.0, 0.0
+		for _, row := range literalRows {
+			literalCost += row.TotalCost
+		}
+		for _, row := range foldedRows {
+			foldedCost += row.TotalCost
+		}
+
+		s.logger.InfoContext(bgCtx, "identity fold shadow comparison",
+			attr.SlogOrganizationID(orgID),
+			attr.SlogIdentityFoldLiteralGroups(len(literalRows)),
+			attr.SlogIdentityFoldCanonicalGroups(len(foldedRows)),
+			attr.SlogIdentityFoldCostDelta(foldedCost-literalCost),
+		)
+	}()
+}

--- a/server/internal/telemetry/canonical_fold_test.go
+++ b/server/internal/telemetry/canonical_fold_test.go
@@ -1,0 +1,266 @@
+package telemetry_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// seedIdentityMapEntry writes one fold entry the way the sync worker does,
+// minus the staging swap: ANY Join inserts are first-write-wins per key, and
+// each test uses its own org id, so direct inserts cannot collide across
+// parallel tests.
+func seedIdentityMapEntry(t *testing.T, ctx context.Context, ti *testInstance, orgID, emailLower, userID, canonicalEmail string) {
+	t.Helper()
+
+	require.NoError(t, ti.chConn.Exec(ctx,
+		"INSERT INTO identity_map (org_id, email_lower, canonical_user_id, canonical_email) VALUES (?, ?, ?, ?)",
+		orgID, emailLower, userID, canonicalEmail))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+}
+
+func foldTestContext(t *testing.T) (context.Context, *testInstance, string) {
+	t.Helper()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+	return ctx, ti, authCtx.ActiveOrganizationID
+}
+
+func TestCostAnalytics_CanonicalFold_FiltersFoldThroughMap(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, orgID := foldTestContext(t)
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	suffix := uuid.NewString()[:8]
+	workEmail := "work-" + suffix + "@example.com"
+	personalEmail := "personal-" + suffix + "@example.com"
+	userID := uuid.NewString()
+
+	// The map is the only identity source on this path: no Postgres rows are
+	// seeded, proving reads depend on identity_map alone.
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	now := time.Now().UTC()
+	workChatID := uuid.NewString()
+	personalChatID := uuid.NewString()
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), workChatID, 1, 100, 50, 0, 0, "opus", strings.ToUpper(workEmail[:1])+workEmail[1:], "Engineering", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-9*time.Minute), personalChatID, 2, 200, 100, 0, 0, "opus", strings.ToUpper(personalEmail), "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-8*time.Minute), uuid.NewString(), 9, 900, 900, 0, 0, "opus", "stranger-"+suffix+"@example.com", "Engineering", nil, "main", "", "", "", "")
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+	for _, email := range []string{workEmail, personalEmail, strings.ToUpper(personalEmail)} {
+		result, err := ti.service.Query(ctx, &gen.QueryPayload{
+			From:    from,
+			To:      to,
+			Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{email}}},
+			TopN:    10,
+			SortBy:  "total_cost",
+		})
+		require.NoError(t, err)
+		require.Len(t, result.Table, 1)
+		require.InDelta(t, 3, result.Table[0].Measures.TotalCost, 0.001)
+		require.Equal(t, int64(2), result.Table[0].Measures.TotalChats)
+
+		sessions, err := ti.service.ListSessions(ctx, &gen.ListSessionsPayload{
+			From:    from,
+			To:      to,
+			Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{email}}},
+			SortBy:  "total_cost",
+			Limit:   10,
+		})
+		require.NoError(t, err)
+		require.Len(t, sessions.Sessions, 2)
+
+		wideFrom, wideTo := summaryWindow(now)
+		wideSessions := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+			From:    wideFrom,
+			To:      wideTo,
+			Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{email}}},
+			SortBy:  "total_cost",
+			Limit:   10,
+		}, func(result *gen.ListSessionsResult) bool {
+			return len(result.Sessions) == 2
+		})
+		require.Equal(t, personalChatID, wideSessions.Sessions[0].GramChatID)
+		require.Equal(t, workChatID, wideSessions.Sessions[1].GramChatID)
+	}
+}
+
+func TestCostAnalytics_CanonicalFold_GroupByEmailFoldsBuckets(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, orgID := foldTestContext(t)
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	suffix := uuid.NewString()[:8]
+	workEmail := "gwork-" + suffix + "@example.com"
+	personalEmail := "gpersonal-" + suffix + "@example.com"
+	hostname := "ghost-" + suffix
+
+	userID := uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	now := time.Now().UTC()
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), uuid.NewString(), 1, 100, 50, 0, 0, "opus", workEmail, "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-9*time.Minute), uuid.NewString(), 2, 200, 100, 0, 0, "opus", strings.ToUpper(personalEmail), "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLogWithHostname(t, ctx, projectID, now.Add(-8*time.Minute), uuid.NewString(), 4, "", hostname)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	result, err := ti.service.Query(ctx, &gen.QueryPayload{
+		From:    now.Add(-time.Hour).Format(time.RFC3339),
+		To:      now.Add(time.Hour).Format(time.RFC3339),
+		GroupBy: conv.PtrEmpty("email"),
+		TopN:    10,
+		SortBy:  "total_cost",
+	})
+	require.NoError(t, err)
+
+	costs := make(map[string]float64, len(result.Table))
+	for _, row := range result.Table {
+		costs[row.GroupValue] = row.Measures.TotalCost
+	}
+	// One employee = one bucket labeled with the canonical email; the device
+	// hostname keeps its own literal bucket.
+	require.InDelta(t, 3, costs[workEmail], 0.001)
+	require.NotContains(t, costs, personalEmail)
+	require.NotContains(t, costs, strings.ToUpper(personalEmail))
+	require.InDelta(t, 4, costs[hostname], 0.001)
+}
+
+func TestCostAnalytics_CanonicalFold_UnmappedEmailStaysLiteral(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, orgID := foldTestContext(t)
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	suffix := uuid.NewString()[:8]
+	// Deliberately absent from identity_map — an ambiguous or unknown email.
+	unmapped := "unmapped-" + suffix + "@example.com"
+
+	now := time.Now().UTC()
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), uuid.NewString(), 5, 100, 50, 0, 0, "opus", strings.ToUpper(unmapped), "", nil, "main", "", "", "", "")
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// Case-insensitive literal matching survives for unmapped emails: both
+	// sides fall back to lower() through the same expression.
+	result, err := ti.service.Query(ctx, &gen.QueryPayload{
+		From:    now.Add(-time.Hour).Format(time.RFC3339),
+		To:      now.Add(time.Hour).Format(time.RFC3339),
+		Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{unmapped}}},
+		TopN:    10,
+		SortBy:  "total_cost",
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Table, 1)
+	require.InDelta(t, 5, result.Table[0].Measures.TotalCost, 0.001)
+}
+
+func TestCostAnalytics_CanonicalFold_SelfConsistentUnderMapLag(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, orgID := foldTestContext(t)
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	suffix := uuid.NewString()[:8]
+	workEmail := "lagwork-" + suffix + "@example.com"
+	personalEmail := "lagpersonal-" + suffix + "@example.com"
+
+	now := time.Now().UTC()
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), uuid.NewString(), 1, 100, 50, 0, 0, "opus", workEmail, "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-9*time.Minute), uuid.NewString(), 2, 200, 100, 0, 0, "opus", personalEmail, "", nil, "main", "", "", "", "")
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	query := func(email string) float64 {
+		result, err := ti.service.Query(ctx, &gen.QueryPayload{
+			From:    now.Add(-time.Hour).Format(time.RFC3339),
+			To:      now.Add(time.Hour).Format(time.RFC3339),
+			Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{email}}},
+			TopN:    10,
+			SortBy:  "total_cost",
+		})
+		require.NoError(t, err)
+		total := 0.0
+		for _, row := range result.Table {
+			total += row.Measures.TotalCost
+		}
+		return total
+	}
+
+	// Before the link syncs, both sides fold to the literal: the personal
+	// drill sees exactly the personal usage — never a partial mix.
+	require.InDelta(t, 2, query(personalEmail), 0.001)
+	require.InDelta(t, 1, query(workEmail), 0.001)
+
+	// The link arrives with the next map generation; both drills converge on
+	// the folded totals.
+	userID := uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+	require.InDelta(t, 3, query(personalEmail), 0.001)
+	require.InDelta(t, 3, query(workEmail), 0.001)
+}
+
+func TestCostAnalytics_CanonicalFold_ShadowServesLiteralResults(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, orgID := foldTestContext(t)
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFoldShadow, orgID, true)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	suffix := uuid.NewString()[:8]
+	workEmail := "swork-" + suffix + "@example.com"
+	personalEmail := "spersonal-" + suffix + "@example.com"
+	userID := uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	now := time.Now().UTC()
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), uuid.NewString(), 1, 100, 50, 0, 0, "opus", workEmail, "", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-9*time.Minute), uuid.NewString(), 2, 200, 100, 0, 0, "opus", personalEmail, "", nil, "main", "", "", "", "")
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// Shadow mode must not change served results: with no Postgres identity
+	// links, the literal path matches only the requested email even though the
+	// map would fold both.
+	result, err := ti.service.Query(ctx, &gen.QueryPayload{
+		From:    now.Add(-time.Hour).Format(time.RFC3339),
+		To:      now.Add(time.Hour).Format(time.RFC3339),
+		Filters: []*gen.QueryFilter{{Dimension: "email", Values: []string{workEmail}}},
+		TopN:    10,
+		SortBy:  "total_cost",
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Table, 1)
+	require.InDelta(t, 1, result.Table[0].Measures.TotalCost, 0.001)
+}

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -26,6 +26,7 @@ import (
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	hooksRepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	mcpserversRepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
@@ -59,6 +60,7 @@ type Service struct {
 	logsEnabled           FeatureChecker
 	sessionCaptureEnabled FeatureChecker
 	authz                 *authz.Engine
+	featureFlags          feature.Provider
 }
 
 var _ telem_gen.Service = (*Service)(nil)
@@ -76,6 +78,7 @@ func NewService(
 	sessionCaptureEnabled FeatureChecker,
 	posthogClient PosthogClient,
 	authzEngine *authz.Engine,
+	featureFlags feature.Provider,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("telemetry"))
 	chRepo := repo.New(chConn)
@@ -104,6 +107,7 @@ func NewService(
 		posthog:               posthogClient,
 		chatSessions:          chatSessions,
 		authz:                 authzEngine,
+		featureFlags:          featureFlags,
 	}
 }
 

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -61,6 +61,9 @@ type Service struct {
 	sessionCaptureEnabled FeatureChecker
 	authz                 *authz.Engine
 	featureFlags          feature.Provider
+	// shadowFoldSem bounds concurrent identity-fold shadow queries; see
+	// maxConcurrentShadowCompares.
+	shadowFoldSem chan struct{}
 }
 
 var _ telem_gen.Service = (*Service)(nil)
@@ -108,6 +111,7 @@ func NewService(
 		chatSessions:          chatSessions,
 		authz:                 authzEngine,
 		featureFlags:          featureFlags,
+		shadowFoldSem:         make(chan struct{}, maxConcurrentShadowCompares),
 	}
 }
 

--- a/server/internal/telemetry/query.go
+++ b/server/internal/telemetry/query.go
@@ -151,16 +151,31 @@ func (s *Service) Query(ctx context.Context, payload *telem_gen.QueryPayload) (*
 		filters = append(filters, repo.AttributeMetricsFilter{Dimension: f.Dimension, Values: f.Values})
 	}
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
-	filters = s.expandEmployeeEmailFilters(ctx, authCtx.ActiveOrganizationID, filters)
 
+	// Fold mode: canonical serves folded identities from the identity_map;
+	// shadow serves literal results and logs how the folded variant would
+	// differ; off keeps the Postgres-side per-request identity expansion.
+	var foldIdentities, shadowFold bool
+	if queryTouchesEmail(groupBy, filters) {
+		foldIdentities, shadowFold = s.canonicalIdentityMode(ctx, authCtx.ActiveOrganizationID)
+	}
+	if !foldIdentities {
+		filters = s.expandEmployeeEmailFilters(ctx, authCtx.ActiveOrganizationID, filters)
+	}
+
+	canonicalOrg := ""
+	if foldIdentities {
+		canonicalOrg = authCtx.ActiveOrganizationID
+	}
 	params := repo.AttributeMetricsQueryParams{
-		ProjectIDs:      scope.projectIDs,
-		TimeStart:       timeStart,
-		TimeEnd:         timeEnd,
-		GroupBy:         groupBy,
-		SortBy:          sortBy,
-		Filters:         filters,
-		IntervalSeconds: interval,
+		ProjectIDs:           scope.projectIDs,
+		TimeStart:            timeStart,
+		TimeEnd:              timeEnd,
+		GroupBy:              groupBy,
+		SortBy:               sortBy,
+		Filters:              filters,
+		IntervalSeconds:      interval,
+		CanonicalIdentityOrg: canonicalOrg,
 	}
 	useSkillVersions := groupBy == "skill_version"
 	for _, filter := range filters {
@@ -208,6 +223,12 @@ func (s *Service) Query(ctx context.Context, payload *telem_gen.QueryPayload) (*
 	})
 	if err := eg.Wait(); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error running analytics query")
+	}
+
+	// The skill-version path reads raw telemetry through its own builders;
+	// shadow only validates the aggregate fold it will actually replace.
+	if shadowFold && !useSkillVersions {
+		s.shadowCompareCanonicalFold(ctx, authCtx.ActiveOrganizationID, params, tableRows)
 	}
 
 	return buildQueryResult(groupBy, interval, timeStart, timeEnd, topN, tableRows, tsRows), nil
@@ -474,17 +495,28 @@ func (s *Service) ListSessions(ctx context.Context, payload *telem_gen.ListSessi
 		}
 		filters = append(filters, repo.AttributeMetricsFilter{Dimension: f.Dimension, Values: f.Values})
 	}
-	filters = s.expandEmployeeEmailFilters(ctx, authCtx.ActiveOrganizationID, filters)
+	var foldIdentities bool
+	if queryTouchesEmail("", filters) {
+		foldIdentities, _ = s.canonicalIdentityMode(ctx, authCtx.ActiveOrganizationID)
+	}
+	if !foldIdentities {
+		filters = s.expandEmployeeEmailFilters(ctx, authCtx.ActiveOrganizationID, filters)
+	}
 
+	canonicalOrg := ""
+	if foldIdentities {
+		canonicalOrg = authCtx.ActiveOrganizationID
+	}
 	params := repo.ListSessionsParams{
-		ProjectIDs:       projectIDs,
-		TimeStart:        timeStart,
-		TimeEnd:          timeEnd,
-		Filters:          filters,
-		SortBy:           sortBy,
-		CursorSortValue:  cursorSortValue,
-		CursorGramChatID: cursorGramChatID,
-		Limit:            limit + 1,
+		ProjectIDs:           projectIDs,
+		TimeStart:            timeStart,
+		TimeEnd:              timeEnd,
+		Filters:              filters,
+		SortBy:               sortBy,
+		CursorSortValue:      cursorSortValue,
+		CursorGramChatID:     cursorGramChatID,
+		Limit:                limit + 1,
+		CanonicalIdentityOrg: canonicalOrg,
 	}
 	// Wide windows are served from chat_session_summaries, narrow ones from
 	// raw telemetry_logs (repo.ListSessionsParams.UsesSummaryPath).

--- a/server/internal/telemetry/query.go
+++ b/server/internal/telemetry/query.go
@@ -159,6 +159,14 @@ func (s *Service) Query(ctx context.Context, payload *telem_gen.QueryPayload) (*
 	if queryTouchesEmail(groupBy, filters) {
 		foldIdentities, shadowFold = s.canonicalIdentityMode(ctx, authCtx.ActiveOrganizationID)
 	}
+	// Shadow must replay the exact query fold mode would run: the original
+	// request filters, folded in-query. Cloned before the Postgres expansion
+	// below mutates the elements — feeding already-expanded aliases into the
+	// fold would mask Postgres-ahead/map-lag divergence.
+	var shadowFilters []repo.AttributeMetricsFilter
+	if shadowFold {
+		shadowFilters = slices.Clone(filters)
+	}
 	if !foldIdentities {
 		filters = s.expandEmployeeEmailFilters(ctx, authCtx.ActiveOrganizationID, filters)
 	}
@@ -228,7 +236,9 @@ func (s *Service) Query(ctx context.Context, payload *telem_gen.QueryPayload) (*
 	// The skill-version path reads raw telemetry through its own builders;
 	// shadow only validates the aggregate fold it will actually replace.
 	if shadowFold && !useSkillVersions {
-		s.shadowCompareCanonicalFold(ctx, authCtx.ActiveOrganizationID, params, tableRows)
+		shadowParams := params
+		shadowParams.Filters = shadowFilters
+		s.shadowCompareCanonicalFold(ctx, authCtx.ActiveOrganizationID, shadowParams, tableRows)
 	}
 
 	return buildQueryResult(groupBy, interval, timeStart, timeEnd, topN, tableRows, tsRows), nil

--- a/server/internal/telemetry/repo/attribute_metrics.go
+++ b/server/internal/telemetry/repo/attribute_metrics.go
@@ -192,6 +192,11 @@ type AttributeMetricsQueryParams struct {
 	SortBy     string   // measure key used for ORDER BY (table only)
 	Filters    []AttributeMetricsFilter
 
+	// CanonicalIdentityOrg, when set, folds the email dimension through the
+	// identity_map: filters compare and group-bys bucket canonical employee
+	// identities instead of literal emails. Empty disables folding.
+	CanonicalIdentityOrg string
+
 	// IntervalSeconds is the timeseries bucket width. The source is bucketed
 	// hourly so this is expected to be a multiple of 3600.
 	IntervalSeconds int64
@@ -199,7 +204,7 @@ type AttributeMetricsQueryParams struct {
 
 // attributeGroupValueExpr returns the SQL expression to select/group by for the
 // requested dimension, and whether a GROUP BY on it is needed.
-func attributeGroupValueExpr(groupBy string) (expr string, grouped bool, err error) {
+func attributeGroupValueExpr(groupBy, canonicalOrgLit string) (expr string, grouped bool, err error) {
 	if groupBy == "" {
 		return "''", false, nil
 	}
@@ -217,6 +222,9 @@ func attributeGroupValueExpr(groupBy string) (expr string, grouped bool, err err
 	case attributeDimProject:
 		return "toString(" + dim.column + ")", true, nil
 	case attributeDimScalar:
+		if groupBy == "email" && canonicalOrgLit != "" {
+			return canonicalEmailExpr(canonicalOrgLit, "("+dim.column+")"), true, nil
+		}
 		return dim.column, true, nil
 	default:
 		return "", false, fmt.Errorf("unhandled dimension kind for %q", groupBy)
@@ -308,7 +316,7 @@ func arrayDimFilter(column string, values []string) squirrel.Sqlizer {
 }
 
 // applyAttributeFilters adds the WHERE predicates for the supplied filters.
-func applyAttributeFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter) (squirrel.SelectBuilder, error) {
+func applyAttributeFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter, canonicalOrgLit string) (squirrel.SelectBuilder, error) {
 	for _, f := range filters {
 		if len(f.Values) == 0 {
 			continue
@@ -321,9 +329,12 @@ func applyAttributeFilters(sb squirrel.SelectBuilder, filters []AttributeMetrics
 		case attributeDimArray:
 			sb = sb.Where(arrayDimFilter(dim.column, f.Values))
 		case attributeDimScalar, attributeDimProject:
-			if f.Dimension == "email" {
+			switch {
+			case f.Dimension == "email" && canonicalOrgLit != "":
+				sb = sb.Where(canonicalEmailFilter(canonicalOrgLit, "("+dim.column+")", f.Values))
+			case f.Dimension == "email":
 				sb = sb.Where(squirrel.Eq{"lower(" + dim.column + ")": normalizedEmailDimensionValues(f.Values)})
-			} else {
+			default:
 				sb = sb.Where(squirrel.Eq{dim.column: f.Values})
 			}
 		default:
@@ -345,7 +356,7 @@ func (q *Queries) QueryAttributeMetricsTable(ctx context.Context, arg AttributeM
 		return nil, nil
 	}
 
-	groupExpr, grouped, err := attributeGroupValueExpr(arg.GroupBy)
+	groupExpr, grouped, err := attributeGroupValueExpr(arg.GroupBy, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +375,7 @@ func (q *Queries) QueryAttributeMetricsTable(ctx context.Context, arg AttributeM
 		Where("time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeStart).
 		Where("time_bucket <= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeEnd)
 
-	sb, err = applyAttributeFilters(sb, arg.Filters)
+	sb, err = applyAttributeFilters(sb, arg.Filters, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
 		return nil, err
 	}
@@ -376,6 +387,7 @@ func (q *Queries) QueryAttributeMetricsTable(ctx context.Context, arg AttributeM
 	// column of the same base name.
 	sb = sb.OrderBy(measureAliasPrefix + arg.SortBy + " DESC")
 
+	sb = withCanonicalFoldSettings(sb, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	query, args, err := sb.ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("building attribute metrics table query: %w", err)
@@ -411,7 +423,7 @@ func (q *Queries) QueryAttributeMetricsTimeseries(ctx context.Context, arg Attri
 		return nil, nil
 	}
 
-	groupExpr, grouped, err := attributeGroupValueExpr(arg.GroupBy)
+	groupExpr, grouped, err := attributeGroupValueExpr(arg.GroupBy, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +443,7 @@ func (q *Queries) QueryAttributeMetricsTimeseries(ctx context.Context, arg Attri
 		Where("time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeStart).
 		Where("time_bucket <= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeEnd)
 
-	sb, err = applyAttributeFilters(sb, arg.Filters)
+	sb, err = applyAttributeFilters(sb, arg.Filters, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
 		return nil, err
 	}
@@ -442,6 +454,7 @@ func (q *Queries) QueryAttributeMetricsTimeseries(ctx context.Context, arg Attri
 	}
 	sb = sb.GroupBy(groupCols...)
 
+	sb = withCanonicalFoldSettings(sb, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	query, args, err := sb.ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("building attribute metrics timeseries query: %w", err)

--- a/server/internal/telemetry/repo/canonical_identity.go
+++ b/server/internal/telemetry/repo/canonical_identity.go
@@ -1,0 +1,162 @@
+package repo
+
+// Canonical identity folding for the email dimension. The ClickHouse
+// identity_map table (rebuilt from Postgres by the identity map sync worker)
+// maps each unambiguous directory or linked-account email to its owner's
+// directory email. Wrapping both sides of an email comparison — the column
+// AND the requested filter values — in the same joinGet fold makes one
+// employee's work, personal, and case-variant emails one identity, and makes
+// every query self-consistent against map refresh lag: filter input and rows
+// always resolve through the same map generation.
+//
+// Non-email values pass through untouched. The email dimension column doubles
+// as a device-hostname bucket (see the registry comment on "email"), and
+// hostnames must keep literal semantics; the position(_, '@') guard preserves
+// them. Unmapped emails — no directory row, deliberately-ambiguous shared
+// emails — fall back to lower(...), preserving the case-insensitive literal
+// matching that predates the fold.
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+)
+
+// identityOrgLiteralPattern is the allowlist for inlining an organization id
+// into SQL expressions. Group-by expressions are assembled as plain strings,
+// so the org id cannot be a bound parameter there; ids outside this charset
+// (which never occur for real orgs) disable folding rather than risk a broken
+// literal.
+var identityOrgLiteralPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// canonicalIdentityOrgLiteral returns the quoted SQL literal for an org id,
+// or "" when the id cannot be safely inlined (which disables folding).
+func canonicalIdentityOrgLiteral(orgID string) string {
+	if orgID == "" || !identityOrgLiteralPattern.MatchString(orgID) {
+		return ""
+	}
+	return "'" + orgID + "'"
+}
+
+// canonicalEmailExpr wraps a String column/expression in the identity fold.
+// Emails resolve to their canonical directory email (or lower(expr) when
+// unmapped); values without an "@" — hostnames, empty strings — pass through
+// verbatim. Folding never maps an empty value to a non-empty one or back, so
+// "(unset)"-bucket semantics are unchanged.
+func canonicalEmailExpr(orgLiteral, expr string) string {
+	get := "joinGet('identity_map', 'canonical_email', " + orgLiteral + ", lower(" + expr + "))"
+	return "if(position(" + expr + ", '@') > 0, coalesce(nullIf(" + get + ", ''), lower(" + expr + ")), " + expr + ")"
+}
+
+// canonicalEmailValueList renders the right-hand side of an IN comparison:
+// one SQL fragment per requested value, folding email values through the same
+// joinGet the column side uses and binding everything else literally. The
+// email constants are normalized (lowercased, trimmed) in Go, so only the
+// joinGet itself is left to ClickHouse.
+func canonicalEmailValueList(orgLiteral string, values []string) (fragments []string, args []any) {
+	fragments = make([]string, 0, len(values))
+	args = make([]any, 0, len(values)*2)
+	for _, value := range values {
+		if !strings.Contains(value, "@") {
+			fragments = append(fragments, "?")
+			args = append(args, value)
+			continue
+		}
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		fragments = append(fragments, "coalesce(nullIf(joinGet('identity_map', 'canonical_email', "+orgLiteral+", ?), ''), ?)")
+		args = append(args, normalized, normalized)
+	}
+	return fragments, args
+}
+
+// canonicalEmailFilter is the WHERE predicate for the email dimension on the
+// aggregate path: canonical(column) IN (canonical(v1), ...). Preserves the
+// literal "" bucket — an empty requested value binds as ” and an empty column
+// value folds to itself.
+func canonicalEmailFilter(orgLiteral, column string, values []string) squirrel.Sqlizer {
+	fragments, args := canonicalEmailValueList(orgLiteral, values)
+	return squirrel.Expr(canonicalEmailExpr(orgLiteral, column)+" IN ("+strings.Join(fragments, ", ")+")", args...)
+}
+
+// canonicalScalarRowPredicate mirrors sessionScalarRowPredicate with the fold
+// applied to both sides: a requested "" means "this row has an empty value".
+func canonicalScalarRowPredicate(orgLiteral, expr string, values []string) squirrel.Sqlizer {
+	folded := canonicalEmailExpr(orgLiteral, expr)
+	hasEmpty, nonEmpty := splitEmptyValue(values)
+
+	emptyPred := squirrel.Expr(expr + " = ''")
+	if len(nonEmpty) == 0 {
+		return emptyPred
+	}
+	fragments, args := canonicalEmailValueList(orgLiteral, nonEmpty)
+	nonEmptyPred := squirrel.Expr(folded+" IN ("+strings.Join(fragments, ", ")+")", args...)
+	if !hasEmpty {
+		return nonEmptyPred
+	}
+	return squirrel.Or{nonEmptyPred, emptyPred}
+}
+
+// canonicalScalarHaving mirrors sessionScalarHaving with the fold applied to
+// both sides: a chat matches when any row folds to a requested identity, and
+// a requested "" matches chats with no non-empty value on any row.
+func canonicalScalarHaving(orgLiteral, expr string, values []string) squirrel.Sqlizer {
+	folded := canonicalEmailExpr(orgLiteral, expr)
+	hasEmpty, nonEmpty := splitEmptyValue(values)
+
+	emptyPred := squirrel.Expr("countIf(" + expr + " != '') = 0")
+	if len(nonEmpty) == 0 {
+		return emptyPred
+	}
+	fragments, args := canonicalEmailValueList(orgLiteral, nonEmpty)
+	nonEmptyPred := squirrel.Expr("countIf("+folded+" IN ("+strings.Join(fragments, ", ")+")) > 0", args...)
+	if !hasEmpty {
+		return nonEmptyPred
+	}
+	return squirrel.Or{nonEmptyPred, emptyPred}
+}
+
+// canonicalSummaryValuesHaving mirrors sessionSummaryValuesHaving over the
+// summary path's per-chat email arrays, folding each element and each
+// requested value.
+func canonicalSummaryValuesHaving(orgLiteral, column string, values []string) squirrel.Sqlizer {
+	merged := "groupUniqArrayArray(arrayMap(x -> " + canonicalEmailExpr(orgLiteral, "x") + ", " + column + "))"
+	hasEmpty, nonEmpty := splitEmptyValue(values)
+
+	emptyPred := squirrel.Expr("NOT arrayExists(x -> x != '', " + merged + ")")
+	if len(nonEmpty) == 0 {
+		return emptyPred
+	}
+	fragments, args := canonicalEmailValueList(orgLiteral, nonEmpty)
+	nonEmptyPred := squirrel.Expr("hasAny("+merged+", array("+strings.Join(fragments, ", ")+"))", args...)
+	if !hasEmpty {
+		return nonEmptyPred
+	}
+	return squirrel.Or{nonEmptyPred, emptyPred}
+}
+
+// splitEmptyValue separates the "(unset)" bucket request from real values,
+// matching the split every session filter helper performs.
+func splitEmptyValue(values []string) (hasEmpty bool, nonEmpty []string) {
+	nonEmpty = make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+			continue
+		}
+		nonEmpty = append(nonEmpty, v)
+	}
+	return hasEmpty, nonEmpty
+}
+
+// withCanonicalFoldSettings disables the query condition cache on folded
+// queries. The cache stores per-granule WHERE results keyed by predicate, and
+// a predicate containing joinGet over the mutable identity_map is not safely
+// cacheable: after a map swap, cached granule verdicts from the previous
+// generation would silently mis-filter rows until eviction.
+func withCanonicalFoldSettings(sb squirrel.SelectBuilder, canonicalOrgLit string) squirrel.SelectBuilder {
+	if canonicalOrgLit == "" {
+		return sb
+	}
+	return sb.Suffix("SETTINGS use_query_condition_cache = 0")
+}

--- a/server/internal/telemetry/repo/canonical_identity_test.go
+++ b/server/internal/telemetry/repo/canonical_identity_test.go
@@ -1,0 +1,40 @@
+package repo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The skill-version path folds email filters through applySessionFilters like
+// every other folded query, so it must carry the same condition-cache guard:
+// per-granule predicate cache entries keyed on a joinGet over the mutable
+// identity_map would survive a map swap and mis-filter rows until eviction.
+func TestBuildSkillVersionMetricsQuery_CanonicalFoldDisablesConditionCache(t *testing.T) {
+	t.Parallel()
+
+	arg := AttributeMetricsQueryParams{
+		ProjectIDs:           []string{"11111111-1111-1111-1111-111111111111"},
+		TimeStart:            0,
+		TimeEnd:              1,
+		GroupBy:              "skill_version",
+		SortBy:               "total_cost",
+		Filters:              []AttributeMetricsFilter{{Dimension: "email", Values: []string{"person@example.com"}}},
+		CanonicalIdentityOrg: "org_0123456789",
+	}
+
+	for _, timeseries := range []bool{false, true} {
+		query, _, err := buildSkillVersionMetricsQuery(arg, timeseries)
+		require.NoError(t, err)
+		require.Contains(t, query, "joinGet('identity_map'", "email filter must fold on the skill-version path (timeseries=%v)", timeseries)
+		require.True(t, strings.HasSuffix(query, "SETTINGS use_query_condition_cache = 0"), "folded skill-version query must disable the query condition cache (timeseries=%v), got: %s", timeseries, query)
+	}
+
+	literal := arg
+	literal.CanonicalIdentityOrg = ""
+	query, _, err := buildSkillVersionMetricsQuery(literal, false)
+	require.NoError(t, err)
+	require.NotContains(t, query, "joinGet", "flag-off query must stay literal")
+	require.NotContains(t, query, "use_query_condition_cache", "flag-off query must not carry fold settings")
+}

--- a/server/internal/telemetry/repo/identity_map.go
+++ b/server/internal/telemetry/repo/identity_map.go
@@ -24,7 +24,22 @@ type IdentityMapEntry struct {
 // generations and never observe a partial rebuild. A full replace rather than
 // an incremental update: deletions and unlinks in Postgres propagate by simply
 // not being in the next generation.
+//
+// Entries must be unique per (org, email) key: the ANY Join engine silently
+// keeps the first row per key, which would make the fold target insertion-order
+// dependent. The rejection below turns a caller violating that contract into a
+// failed sync — the previous complete generation stays live — instead of an
+// arbitrary owner.
 func (q *Queries) ReplaceIdentityMap(ctx context.Context, entries []IdentityMapEntry) error {
+	seen := make(map[[2]string]struct{}, len(entries))
+	for _, entry := range entries {
+		key := [2]string{entry.OrgID, entry.EmailLower}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("duplicate identity map key for email %q", entry.EmailLower)
+		}
+		seen[key] = struct{}{}
+	}
+
 	if err := q.conn.Exec(ctx, "TRUNCATE TABLE identity_map_staging"); err != nil {
 		return fmt.Errorf("truncate identity_map_staging: %w", err)
 	}

--- a/server/internal/telemetry/repo/identity_map.go
+++ b/server/internal/telemetry/repo/identity_map.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// identityMapInsertChunk bounds one INSERT's bound-parameter count. The map is
+// IdentityMapInsertChunk bounds one INSERT's bound-parameter count. The map is
 // org-directory scale, so most syncs fit in a single chunk.
-const identityMapInsertChunk = 5000
+const IdentityMapInsertChunk = 5000
 
 // IdentityMapEntry is one row of the employee identity fold map: a normalized
 // email and the directory user it unambiguously resolves to within an org.
@@ -44,8 +44,8 @@ func (q *Queries) ReplaceIdentityMap(ctx context.Context, entries []IdentityMapE
 		return fmt.Errorf("truncate identity_map_staging: %w", err)
 	}
 
-	for start := 0; start < len(entries); start += identityMapInsertChunk {
-		chunk := entries[start:min(start+identityMapInsertChunk, len(entries))]
+	for start := 0; start < len(entries); start += IdentityMapInsertChunk {
+		chunk := entries[start:min(start+IdentityMapInsertChunk, len(entries))]
 		values := make([]string, 0, len(chunk))
 		args := make([]any, 0, len(chunk)*4)
 		for _, entry := range chunk {

--- a/server/internal/telemetry/repo/identity_map.go
+++ b/server/internal/telemetry/repo/identity_map.go
@@ -1,0 +1,51 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// identityMapInsertChunk bounds one INSERT's bound-parameter count. The map is
+// org-directory scale, so most syncs fit in a single chunk.
+const identityMapInsertChunk = 5000
+
+// IdentityMapEntry is one row of the employee identity fold map: a normalized
+// email and the directory user it unambiguously resolves to within an org.
+type IdentityMapEntry struct {
+	OrgID           string
+	EmailLower      string
+	CanonicalUserID string
+	CanonicalEmail  string
+}
+
+// ReplaceIdentityMap rebuilds identity_map_staging from entries and swaps it
+// live with EXCHANGE TABLES, so readers switch between complete map
+// generations and never observe a partial rebuild. A full replace rather than
+// an incremental update: deletions and unlinks in Postgres propagate by simply
+// not being in the next generation.
+func (q *Queries) ReplaceIdentityMap(ctx context.Context, entries []IdentityMapEntry) error {
+	if err := q.conn.Exec(ctx, "TRUNCATE TABLE identity_map_staging"); err != nil {
+		return fmt.Errorf("truncate identity_map_staging: %w", err)
+	}
+
+	for start := 0; start < len(entries); start += identityMapInsertChunk {
+		chunk := entries[start:min(start+identityMapInsertChunk, len(entries))]
+		values := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*4)
+		for _, entry := range chunk {
+			values = append(values, "(?, ?, ?, ?)")
+			args = append(args, entry.OrgID, entry.EmailLower, entry.CanonicalUserID, entry.CanonicalEmail)
+		}
+		query := "INSERT INTO identity_map_staging (org_id, email_lower, canonical_user_id, canonical_email) VALUES " + strings.Join(values, ", ")
+		if err := q.conn.Exec(ctx, query, args...); err != nil {
+			return fmt.Errorf("insert identity_map_staging chunk: %w", err)
+		}
+	}
+
+	if err := q.conn.Exec(ctx, "EXCHANGE TABLES identity_map_staging AND identity_map"); err != nil {
+		return fmt.Errorf("exchange identity_map tables: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -209,6 +209,11 @@ type ListSessionsParams struct {
 	CursorSortValue  *float64
 	CursorGramChatID string
 	Limit            int
+
+	// CanonicalIdentityOrg, when set, folds email filters through the
+	// identity_map so one employee's linked emails match as one identity.
+	// Empty disables folding.
+	CanonicalIdentityOrg string
 }
 
 // UsesSummaryPath reports whether the requested window is wide enough to be
@@ -249,7 +254,7 @@ type SessionSummary struct {
 // query_source/skill/agent/MCP values as a single api_request-row tuple. Keep
 // those filters co-located inside one countIf so drilling from the aggregate
 // table finds chats that have a row matching the same tuple.
-func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter) (squirrel.SelectBuilder, error) {
+func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter, canonicalOrgLit string) (squirrel.SelectBuilder, error) {
 	var coLocatedPredicates []squirrel.Sqlizer
 
 	for _, f := range filters {
@@ -264,6 +269,14 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 		case attributeDimProject:
 			sb = sb.Where(squirrel.Eq{dim.column: f.Values})
 		case attributeDimScalar:
+			if f.Dimension == "email" && canonicalOrgLit != "" {
+				if dim.coLocateSessionFilters {
+					coLocatedPredicates = append(coLocatedPredicates, canonicalScalarRowPredicate(canonicalOrgLit, "("+dim.column+")", f.Values))
+					continue
+				}
+				sb = sb.Having(canonicalScalarHaving(canonicalOrgLit, "("+dim.column+")", f.Values))
+				continue
+			}
 			values := f.Values
 			column := dim.column
 			if f.Dimension == "email" {
@@ -447,7 +460,7 @@ func (q *Queries) listSessionsFromRawLogs(ctx context.Context, arg ListSessionsP
 		Where(sessionSourceRowPredicate).
 		Where("chat_id != ''")
 
-	sb, err := applySessionFilters(sb, arg.Filters)
+	sb, err := applySessionFilters(sb, arg.Filters, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
 		return nil, err
 	}
@@ -461,6 +474,7 @@ func (q *Queries) listSessionsFromRawLogs(ctx context.Context, arg ListSessionsP
 	sb = sb.OrderBy("sort_value DESC", "gram_chat_id DESC").
 		Limit(uint64(arg.Limit)) //nolint:gosec // Limit is validated by the service layer.
 
+	sb = withCanonicalFoldSettings(sb, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	query, args, err := sb.ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("building list sessions query: %w", err)
@@ -535,7 +549,7 @@ func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSession
 		Where("s.time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?, 'UTC'))", arg.TimeStart).
 		Where("s.time_bucket <= fromUnixTimestamp64Nano(?, 'UTC')", arg.TimeEnd)
 
-	sb, err := applySessionSummaryFilters(sb, arg.Filters)
+	sb, err := applySessionSummaryFilters(sb, arg.Filters, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
 		return nil, err
 	}
@@ -557,6 +571,7 @@ func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSession
 	sb = sb.OrderBy("sort_value DESC", "gram_chat_id DESC").
 		Limit(uint64(arg.Limit)) //nolint:gosec // Limit is validated by the service layer.
 
+	sb = withCanonicalFoldSettings(sb, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	query, args, err := sb.ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("building list sessions summary query: %w", err)
@@ -576,7 +591,7 @@ func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSession
 // co-located Claude attribution dimensions match a single per-row tuple in
 // attribution_tuples, preserving drill-down semantics from the aggregate
 // cost table.
-func applySessionSummaryFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter) (squirrel.SelectBuilder, error) {
+func applySessionSummaryFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter, canonicalOrgLit string) (squirrel.SelectBuilder, error) {
 	var tuplePredicates []string
 	var tupleArgs []any
 
@@ -606,6 +621,10 @@ func applySessionSummaryFilters(sb squirrel.SelectBuilder, filters []AttributeMe
 		default:
 			column := "s." + dim.column
 			values := f.Values
+			if f.Dimension == "email" && canonicalOrgLit != "" {
+				sb = sb.Having(canonicalSummaryValuesHaving(canonicalOrgLit, column, f.Values))
+				continue
+			}
 			if f.Dimension == "email" {
 				column = "arrayMap(x -> lower(x), " + column + ")"
 				values = normalizedEmailDimensionValues(values)

--- a/server/internal/telemetry/repo/skill_version_metrics.go
+++ b/server/internal/telemetry/repo/skill_version_metrics.go
@@ -195,7 +195,7 @@ func buildSkillVersionMetricsQuery(arg AttributeMetricsQueryParams, timeseries b
 		existingFilters = append(existingFilters, filter)
 	}
 	var err error
-	sessionBuilder, err = applySessionFilters(sessionBuilder, existingFilters)
+	sessionBuilder, err = applySessionFilters(sessionBuilder, existingFilters, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
 		return "", nil, err
 	}

--- a/server/internal/telemetry/repo/skill_version_metrics.go
+++ b/server/internal/telemetry/repo/skill_version_metrics.go
@@ -264,6 +264,7 @@ func buildSkillVersionMetricsQuery(arg AttributeMetricsQueryParams, timeseries b
 		outer = outer.OrderBy(measureAliasPrefix + arg.SortBy + " DESC")
 	}
 
+	outer = withCanonicalFoldSettings(outer, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	query, args, err := outer.ToSql()
 	if err != nil {
 		return "", nil, fmt.Errorf("building skill version metrics query: %w", err)

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
@@ -58,6 +59,7 @@ type testInstance struct {
 	chConn             clickhouse.Conn
 	chClient           *repo.Queries
 	sessionManager     *sessions.Manager
+	featureFlags       *feature.InMemory
 	orgID              string
 	projectID          string
 	disabledLogsOrgID  string
@@ -124,7 +126,8 @@ func newTestLogsServiceWithSessionCapture(t *testing.T, sessionCapture bool) (co
 
 	telemLogger := telemetry.NewLogger(ctx, logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cache.NewRedisCacheAdapter(redisClient)), telemetry.NewNoopLogPublisher(testenv.NewLogger(t)))
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
+	featureFlags := &feature.InMemory{}
+	svc := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine, featureFlags)
 
 	return ctx, &testInstance{
 		service:            svc,
@@ -134,6 +137,7 @@ func newTestLogsServiceWithSessionCapture(t *testing.T, sessionCapture bool) (co
 		chConn:             chConn,
 		chClient:           chClient,
 		sessionManager:     sessionManager,
+		featureFlags:       featureFlags,
 		orgID:              authCtx.ActiveOrganizationID,
 		projectID:          authCtx.ProjectID.String(),
 		disabledLogsOrgID:  disabledLogsOrgID,

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -418,3 +418,26 @@ WHERE s.project_id = @project_id
     NOT @found_only::boolean
     OR (rr.source = 'prompt_injection' AND rr.found IS TRUE)
   );
+
+-- name: ForceSoftDeleteUser :exec
+-- Test-only fixture: soft-deletes a directory user to exercise deleted-row
+-- filtering in identity resolution.
+UPDATE users
+SET deleted_at = clock_timestamp()
+WHERE id = @id;
+
+-- name: ForceSoftDeleteOrganizationUserRelationship :exec
+-- Test-only fixture: soft-deletes an org membership to exercise deleted-row
+-- filtering in identity resolution.
+UPDATE organization_user_relationships
+SET deleted_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND user_id = @user_id;
+
+-- name: ForceSoftDeleteUserAccountsByEmail :exec
+-- Test-only fixture: soft-deletes an org's linked accounts by email to
+-- exercise deleted-row filtering in identity resolution.
+UPDATE user_accounts
+SET deleted_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND lower(email) = @email_lower::text;

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -311,6 +311,25 @@ func (q *Queries) ForceSoftDeleteChat(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const forceSoftDeleteOrganizationUserRelationship = `-- name: ForceSoftDeleteOrganizationUserRelationship :exec
+UPDATE organization_user_relationships
+SET deleted_at = clock_timestamp()
+WHERE organization_id = $1
+  AND user_id = $2
+`
+
+type ForceSoftDeleteOrganizationUserRelationshipParams struct {
+	OrganizationID string
+	UserID         pgtype.Text
+}
+
+// Test-only fixture: soft-deletes an org membership to exercise deleted-row
+// filtering in identity resolution.
+func (q *Queries) ForceSoftDeleteOrganizationUserRelationship(ctx context.Context, arg ForceSoftDeleteOrganizationUserRelationshipParams) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteOrganizationUserRelationship, arg.OrganizationID, arg.UserID)
+	return err
+}
+
 const forceSoftDeleteOrganizationUserRelationshipsFixture = `-- name: ForceSoftDeleteOrganizationUserRelationshipsFixture :exec
 UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp()
@@ -321,6 +340,38 @@ WHERE organization_id = $1
 // generated from deleted_at, so a soft delete has to set the timestamp.
 func (q *Queries) ForceSoftDeleteOrganizationUserRelationshipsFixture(ctx context.Context, organizationID string) error {
 	_, err := q.db.Exec(ctx, forceSoftDeleteOrganizationUserRelationshipsFixture, organizationID)
+	return err
+}
+
+const forceSoftDeleteUser = `-- name: ForceSoftDeleteUser :exec
+UPDATE users
+SET deleted_at = clock_timestamp()
+WHERE id = $1
+`
+
+// Test-only fixture: soft-deletes a directory user to exercise deleted-row
+// filtering in identity resolution.
+func (q *Queries) ForceSoftDeleteUser(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteUser, id)
+	return err
+}
+
+const forceSoftDeleteUserAccountsByEmail = `-- name: ForceSoftDeleteUserAccountsByEmail :exec
+UPDATE user_accounts
+SET deleted_at = clock_timestamp()
+WHERE organization_id = $1
+  AND lower(email) = $2::text
+`
+
+type ForceSoftDeleteUserAccountsByEmailParams struct {
+	OrganizationID string
+	EmailLower     string
+}
+
+// Test-only fixture: soft-deletes an org's linked accounts by email to
+// exercise deleted-row filtering in identity resolution.
+func (q *Queries) ForceSoftDeleteUserAccountsByEmail(ctx context.Context, arg ForceSoftDeleteUserAccountsByEmailParams) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteUserAccountsByEmail, arg.OrganizationID, arg.EmailLower)
 	return err
 }
 

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -148,7 +148,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	sessionCaptureEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 
 	telemLogger := telemetry.NewLogger(ctx, logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cacheAdapter), telemetry.NewNoopLogPublisher(testenv.NewLogger(t)))
-	telemService := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
+	telemService := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine, nil)
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)
 


### PR DESCRIPTION
Part of DNO-856 (Canonical Identity Map for Cost Analytics). Layer 3 of the stack — depends on #5248 (tables) and #5252 (sync worker).

## What

Behind the `canonical-identity-fold` PostHog flag (org-slug group targeting, like budgets), `telemetry.query` and `telemetry.listSessions` fold the email dimension through the ClickHouse `identity_map`: one employee's directory, personal, and case-variant emails read as **one identity**, in filters _and_ group-bys. A separate `canonical-identity-fold-shadow` flag re-runs the folded table query in the background and logs group-count/cost divergence while serving literal results — the validation phase before any org gets the fold.

The core is one expression, applied to **both sides** of every email comparison (column and requested values), so each query resolves through a single map generation and is self-consistent under refresh lag:

```sql
if(position(col, '@') > 0,
   coalesce(nullIf(joinGet('identity_map', 'canonical_email', <org>, lower(col)), ''), lower(col)),
   col)
```

- `@` guard: the email column doubles as the device-hostname bucket — hostnames and the `""` bucket keep literal semantics.
- `lower()` fallback: unmapped/ambiguous emails keep the case-insensitive literal matching from #5221.
- Group-by email now folds buckets and labels them with the canonical (directory) email.

Applied across the aggregate table/timeseries builders, all three session paths (co-located predicates, scalar HAVING, summary-array HAVING), with the org id inlined as a charset-validated literal (group-by expressions are plain strings, so it can't be a bound parameter).

## The subtle one: query condition cache

Folded queries run with `SETTINGS use_query_condition_cache = 0`. ClickHouse 25.x caches per-granule WHERE verdicts keyed by predicate; a predicate containing `joinGet` over the mutable `identity_map` is not safely cacheable — cached verdicts spanning a map swap silently mis-filter rows. Found by the map-lag regression test (a filter matched granules per the _previous_ map generation); reproduced, fixed, and covered.

## Off state

Flag off = exactly today's behavior: the Postgres-side `expandEmployeeEmailFilters` expansion from #5221 still runs, `lower()` matching unchanged. The expansion path is deleted when the flag is removed at GA (with DNO-857).

## Verification

- 310 telemetry tests incl. 5 new fold tests: work/personal/case-variant entry points across aggregate + raw-session + summary-session paths (map as the only identity source — no Postgres links seeded), group-by-email bucket folding with hostname isolation, unmapped-email literal fallback, map-lag self-consistency (both sides converge atomically when the map updates), and shadow-serves-literal.
- `mise lint:server`, `mise build:server`.
- Rollout per ticket: create both flags in PostHog, shadow-compare on real traffic, then enable per org.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds cost analytics email identities through ClickHouse `identity_map`, gated by flags, so one employee’s directory, personal, and case-variant emails resolve to one identity. Previously we matched in Postgres with case-insensitive literals; now both the email column and filter values resolve via `joinGet`, unmapped emails fall back to `lower()`, and device-hostname buckets stay literal.

- Applies the canonical email expression to filters and group-bys in `telemetry.query` and `telemetry.listSessions`; email group-bys are labeled with the canonical directory email.
- Disables ClickHouse query-condition cache on all folded queries, including the `skill_version` metrics path, to avoid stale WHERE verdicts across `identity_map` swaps.
- Evaluates flags only when the query touches the email dimension. Wires PostHog flags into the telemetry service; inlines a validated org id in expressions, with invalid ids degrading to literal behavior.
- Shadow mode re-runs the folded aggregate-table query in the background using the original request filters (cloned before Postgres expansion), logs literal vs folded group-count and total-cost deltas, and always serves literal results; bounded by a 30s timeout and a non-blocking concurrency cap that skips when saturated. No shadowing for `skill_version` queries.
- Tests cover fold semantics, unmapped fallback, map-lag self-consistency, the `skill_version` cache guard, and shadow behavior.

**Rollout**
- PostHog flags: `canonical-identity-fold` enables folding; `canonical-identity-fold-shadow` runs background comparisons only. Target by org slug; off by default. Shadow first, then enable fold per org. Ensure `identity_map` is populated in prod before enabling. Linked to Linear DNO-856.

<sup>Written for commit 2f2fa58704cb21b48c56b8988bc2e93acea65a1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

