### PR TITLE
fix: stop rejecting valid RE2 regexes from AI exclusion suggestions

### DIFF
--- a/.changeset/exclusion-regex-re2-validation.md
+++ b/.changeset/exclusion-regex-re2-validation.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"@gram/server": patch
+---
+
+Fix "Suggest with AI" exclusion suggestions being rejected as invalid regexes. The exclusion form now validates regex criteria with the same RE2 engine the platform matches with, so valid suggestions like `(?i)`-prefixed patterns save instead of failing with "Invalid regex pattern", server-side validation errors surface in the form, and a suggestion that fails validation is retried once with corrective feedback before falling back.

--- a/.changeset/exclusion-regex-re2-validation.md
+++ b/.changeset/exclusion-regex-re2-validation.md
@@ -1,6 +1,5 @@
 ---
 "dashboard": patch
-"@gram/server": patch
 ---
 
 Fix "Suggest with AI" exclusion suggestions being rejected as invalid regexes. The exclusion form now validates regex criteria with the same RE2 engine the platform matches with, so valid suggestions like `(?i)`-prefixed patterns save instead of failing with "Invalid regex pattern", server-side validation errors surface in the form, and a suggestion that fails validation is retried once with corrective feedback before falling back.

--- a/client/dashboard/src/pages/security/cel-wasm.ts
+++ b/client/dashboard/src/pages/security/cel-wasm.ts
@@ -74,6 +74,11 @@ export interface CelEngine {
   compile(expr: string): CelCompileResult;
   complete(srcUpToCursor: string): CelCompletion;
   evalDetection(expr: string, message: CelMessage): CelEvalResult;
+  /** Compile a bare regex with Go's RE2 `regexp` — the dialect the server
+   * validates against and the analyzers match with. JS `RegExp` is the wrong
+   * checker for these patterns: it rejects RE2's inline flags ("(?i)") and
+   * "(?P<name>)" groups and accepts lookarounds RE2 refuses. */
+  compileRegex(pattern: string): CelCompileResult;
 }
 
 // Raw shapes of the wasm globals (set by server/cmd/celwasm).
@@ -91,6 +96,7 @@ interface CelGlobals {
     expr: string,
     messageJSON: string,
   ) => { ok: boolean; matched?: boolean; spans?: string; error?: string };
+  __celRegexCompile?: (pattern: string) => CelCompileResult;
 }
 
 const WASM_URL = "/cel/cel.wasm";
@@ -162,7 +168,8 @@ async function start(): Promise<CelEngine> {
     !g.__celReference ||
     !g.__celComplete ||
     !g.__celCompile ||
-    !g.__celEval
+    !g.__celEval ||
+    !g.__celRegexCompile
   ) {
     throw new Error("CEL engine did not expose its interface");
   }
@@ -171,10 +178,12 @@ async function start(): Promise<CelEngine> {
   const compile = g.__celCompile;
   const rawComplete = g.__celComplete;
   const rawEval = g.__celEval;
+  const regexCompile = g.__celRegexCompile;
 
   return {
     reference,
     compile: (expr) => compile(expr),
+    compileRegex: (pattern) => regexCompile(pattern),
     complete: (src) => JSON.parse(rawComplete(src)) as CelCompletion,
     evalDetection: (expr, message) => {
       const r = rawEval(expr, JSON.stringify(message));

--- a/client/dashboard/src/pages/security/exclusion-expression.test.ts
+++ b/client/dashboard/src/pages/security/exclusion-expression.test.ts
@@ -71,8 +71,26 @@ describe("parseExclusionExpression", () => {
     expect(parseExclusionExpression("match = value").ok).toBe(false);
   });
 
-  it("rejects an invalid regex", () => {
-    expect(parseExclusionExpression('match ~= "("').ok).toBe(false);
+  it("parses RE2-only regex syntax that JS RegExp rejects", () => {
+    // Inline flags and (?P<name>) groups are valid RE2 — the dialect the
+    // server and analyzers compile. Pattern validity is checked against RE2
+    // (wasm engine at save time, API on create), never with JS RegExp, so
+    // parsing must not reject these.
+    expect(
+      parseExclusionExpression('match ~= "(?i)jane\\.doe@acme\\.com"'),
+    ).toMatchObject({
+      ok: true,
+      value: { matchType: "regex", matchValue: "(?i)jane\\.doe@acme\\.com" },
+    });
+    expect(
+      parseExclusionExpression('match ~= "(?P<user>[a-z]+)@acme\\.com"').ok,
+    ).toBe(true);
+  });
+
+  it("rejects an over-long regex", () => {
+    expect(parseExclusionExpression(`match ~= "${"a".repeat(513)}"`).ok).toBe(
+      false,
+    );
   });
 
   it("rejects two match clauses", () => {

--- a/client/dashboard/src/pages/security/exclusion-expression.ts
+++ b/client/dashboard/src/pages/security/exclusion-expression.ts
@@ -159,18 +159,20 @@ export function parseExclusionExpression(input: string): ParseResult {
     return { ok: false, error: "Enter an exclusion criteria expression." };
   }
 
-  if (primary.matchType === "regex") {
-    if (primary.value.length > REGEX_MAX_LENGTH) {
-      return {
-        ok: false,
-        error: `Regex pattern too long (max ${REGEX_MAX_LENGTH} characters).`,
-      };
-    }
-    try {
-      new RegExp(primary.value);
-    } catch {
-      return { ok: false, error: "Invalid regex pattern." };
-    }
+  // Regex pattern *validity* is deliberately not checked here: patterns are
+  // compiled by Go's RE2 (the suggestion endpoint, the create/update API, the
+  // analyzers), and JS `RegExp` is a different dialect — it throws on RE2's
+  // inline flags ("(?i)") and "(?P<name>)" groups and accepts lookarounds RE2
+  // rejects. The form validates via the wasm CEL engine's RE2 compiler before
+  // submit, and the API is the backstop.
+  if (
+    primary.matchType === "regex" &&
+    primary.value.length > REGEX_MAX_LENGTH
+  ) {
+    return {
+      ok: false,
+      error: `Regex pattern too long (max ${REGEX_MAX_LENGTH} characters).`,
+    };
   }
 
   return {

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -45,6 +45,7 @@ import {
 import { hasRevealableEvent, REVEAL_SCOPE, useUnmaskedMatch } from "./unmask";
 import { useRBAC } from "@/hooks/useRBAC";
 import { invalidateExclusionSurfaces } from "./exclusion-invalidation";
+import { useCelEngine } from "./use-cel-engine";
 
 const GLOBAL_SCOPE = "__global__";
 
@@ -88,6 +89,9 @@ export function ExclusionEditor({
 
   const invalidate = () => invalidateExclusionSurfaces(queryClient);
 
+  // Surface the API's message (e.g. "invalid regex pattern: …") rather than a
+  // generic failure: server-side validation is the backstop for anything the
+  // form couldn't check locally, so its reason must reach the operator.
   const createMutation = useRiskCreateExclusionMutation({
     onSuccess: () => {
       void invalidate();
@@ -96,7 +100,12 @@ export function ExclusionEditor({
       );
       onDone();
     },
-    onError: () => toast.error("Failed to create exclusion."),
+    onError: (err) =>
+      toast.error(
+        err instanceof Error && err.message
+          ? err.message
+          : "Failed to create exclusion.",
+      ),
   });
   const updateMutation = useRiskUpdateExclusionMutation({
     onSuccess: () => {
@@ -104,7 +113,12 @@ export function ExclusionEditor({
       toast.success("Exclusion updated. Findings will update shortly.");
       onDone();
     },
-    onError: () => toast.error("Failed to update exclusion."),
+    onError: (err) =>
+      toast.error(
+        err instanceof Error && err.message
+          ? err.message
+          : "Failed to update exclusion.",
+      ),
   });
 
   const editing = state.mode === "edit" ? state.exclusion : null;
@@ -262,6 +276,13 @@ function ExclusionForm({
   const [error, setError] = useState<string | null>(null);
   const [askPrompt, setAskPrompt] = useState("");
 
+  // Regex patterns are RE2 (compiled by Go on the server and in the
+  // analyzers), so save-time validation must use the wasm engine's RE2
+  // compiler — JS RegExp is a different dialect and rejects valid RE2 like
+  // "(?i)". Loaded only once the criteria box is visible (the wasm asset is
+  // large); if it isn't ready by save time the API validates instead.
+  const engineState = useCelEngine(choice === "custom");
+
   // Dedicated exclusion-suggestion endpoint. The structured fields it returns
   // are serialized through the same mapping the form parses on save, so a
   // suggestion the user accepts untouched is guaranteed to round-trip.
@@ -325,6 +346,13 @@ function ExclusionForm({
     if (!parsed.ok) {
       setError(parsed.error);
       return;
+    }
+    if (parsed.value.matchType === "regex" && engineState.status === "ready") {
+      const compiled = engineState.engine.compileRegex(parsed.value.matchValue);
+      if (!compiled.ok) {
+        setError(`Invalid regex pattern: ${compiled.error}`);
+        return;
+      }
     }
     setError(null);
     onSubmit({ fields: parsed.value, scope, enabled });

--- a/client/dashboard/src/pages/security/use-cel-engine.ts
+++ b/client/dashboard/src/pages/security/use-cel-engine.ts
@@ -8,11 +8,15 @@ export type CelEngineState =
 
 /** Load the wasm CEL engine once and expose its state. The engine is the same
  *  celenv the server runs, so a compile here matches what the server accepts on
- *  save; on load failure the caller falls back to server-side validation. */
-export function useCelEngine(): CelEngineState {
+ *  save; on load failure the caller falls back to server-side validation.
+ *  Pass `enabled: false` to defer the (large) wasm fetch until the surface
+ *  that needs the engine is actually shown; the state stays "loading" until
+ *  it flips to true. */
+export function useCelEngine(enabled = true): CelEngineState {
   const [state, setState] = useState<CelEngineState>({ status: "loading" });
 
   useEffect(() => {
+    if (!enabled) return;
     let alive = true;
     loadCelEngine().then(
       (engine) => alive && setState({ status: "ready", engine }),
@@ -26,7 +30,7 @@ export function useCelEngine(): CelEngineState {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [enabled]);
 
   return state;
 }

--- a/server/cmd/celwasm/main.go
+++ b/server/cmd/celwasm/main.go
@@ -3,11 +3,12 @@
 // Command celwasm exposes the risk CEL engine to the browser (the same celenv
 // the server runs), built for GOOS=js GOARCH=wasm. It sets globals
 // __celEngineReady (or __celInitError) and the funcs __celReference /
-// __celCompile / __celComplete / __celEval.
+// __celCompile / __celComplete / __celEval / __celRegexCompile.
 package main
 
 import (
 	"encoding/json"
+	"regexp"
 	"syscall/js"
 
 	"github.com/google/cel-go/cel"
@@ -31,6 +32,7 @@ func main() {
 	js.Global().Set("__celComplete", js.FuncOf(h.complete))
 	js.Global().Set("__celCompile", js.FuncOf(h.compile))
 	js.Global().Set("__celEval", js.FuncOf(h.eval))
+	js.Global().Set("__celRegexCompile", js.FuncOf(regexCompile))
 	js.Global().Set("__celEngineReady", js.ValueOf(true))
 
 	select {} // keep the Go runtime alive so the exported funcs stay callable
@@ -74,6 +76,18 @@ func (h *handle) compile(_ js.Value, args []js.Value) any {
 		return js.ValueOf(map[string]any{"ok": false, "error": err.Error()})
 	}
 	h.put(expr, prg)
+	return js.ValueOf(map[string]any{"ok": true})
+}
+
+// regexCompile(pattern) -> {ok} | {ok:false, error}. Validates a regex with
+// the same Go RE2 regexp the server and analyzers compile, so the browser
+// rejects exactly what the runtime rejects. JS RegExp is the wrong dialect
+// for this: it lacks RE2's inline flags ("(?i)") and "(?P<name>)" groups and
+// accepts lookarounds RE2 rejects.
+func regexCompile(_ js.Value, args []js.Value) any {
+	if _, err := regexp.Compile(arg(args, 0)); err != nil {
+		return js.ValueOf(map[string]any{"ok": false, "error": err.Error()})
+	}
 	return js.ValueOf(map[string]any{"ok": true})
 }
 

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -2848,11 +2848,14 @@ var exclusionMatchTypeAllow = map[string]bool{
 	"entity_type": true,
 }
 
-// errExclusionSuggestionInvalid marks a completion that came back but failed
-// validation (bad match_type, regex that does not compile as RE2, empty
-// value). Distinguishes "the model got it wrong" — worth one corrective
-// retry — from transport failures, which a retry with the same budget is
-// unlikely to fix.
+// errExclusionSuggestionInvalid marks a completion that parsed but failed
+// semantic validation (bad match_type, regex that does not compile as RE2,
+// empty value) — the one failure class where feeding the error back gives
+// the model something it can act on, so it is worth one corrective retry.
+// Transport failures, empty completions, and unparseable JSON stay outside
+// it: the retry prompt carries only the error text, not the model's raw
+// output, so a parse-level failure cannot self-correct and the second call
+// would be wasted.
 var errExclusionSuggestionInvalid = errors.New("invalid exclusion suggestion")
 
 func (s *Service) suggestExclusionViaLLM(ctx context.Context, orgID, projectID, userID, userEmail, userPrompt string, findings []repo.RiskResult, knownRuleIDs []string) (*gen.SuggestExclusionResult, error) {
@@ -2976,7 +2979,7 @@ func (s *Service) requestExclusionSuggestion(ctx context.Context, orgID, project
 
 	raw := strings.TrimSpace(openrouter.GetText(*response.Message))
 	if raw == "" {
-		return nil, fmt.Errorf("%w: empty completion content", errExclusionSuggestionInvalid)
+		return nil, fmt.Errorf("empty completion content")
 	}
 
 	var parsed struct {
@@ -2986,7 +2989,7 @@ func (s *Service) requestExclusionSuggestion(ctx context.Context, orgID, project
 		SourceFilter string `json:"source_filter"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return nil, fmt.Errorf("%w: parse llm response: %w", errExclusionSuggestionInvalid, err)
+		return nil, fmt.Errorf("parse llm response: %w", err)
 	}
 
 	parsed.MatchType = strings.ToLower(strings.TrimSpace(parsed.MatchType))

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -2848,6 +2848,13 @@ var exclusionMatchTypeAllow = map[string]bool{
 	"entity_type": true,
 }
 
+// errExclusionSuggestionInvalid marks a completion that came back but failed
+// validation (bad match_type, regex that does not compile as RE2, empty
+// value). Distinguishes "the model got it wrong" — worth one corrective
+// retry — from transport failures, which a retry with the same budget is
+// unlikely to fix.
+var errExclusionSuggestionInvalid = errors.New("invalid exclusion suggestion")
+
 func (s *Service) suggestExclusionViaLLM(ctx context.Context, orgID, projectID, userID, userEmail, userPrompt string, findings []repo.RiskResult, knownRuleIDs []string) (*gen.SuggestExclusionResult, error) {
 	systemPrompt := `You are a security-rules assistant for a runtime risk detection product.
 
@@ -2913,6 +2920,30 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 		Strict:      optionalnullable.From(&strict),
 	}
 
+	result, err := s.requestExclusionSuggestion(ctx, orgID, projectID, userID, userEmail, systemPrompt, userMessage, &jsonSchema)
+	if err == nil {
+		return result, nil
+	}
+	if !errors.Is(err, errExclusionSuggestionInvalid) {
+		return nil, err
+	}
+
+	// One corrective retry with the validation error fed back. Without it, a
+	// model slip (a lookahead in an otherwise fine regex, say) drops the
+	// caller onto the heuristic fallback — an exact match on the operator's
+	// entire prompt text — which reads as the AI failing outright.
+	retryMessage := fmt.Sprintf("%s\n\nYour previous suggestion was rejected: %v\nReturn a corrected JSON object that fixes this.", userMessage, err)
+	result, retryErr := s.requestExclusionSuggestion(ctx, orgID, projectID, userID, userEmail, systemPrompt, retryMessage, &jsonSchema)
+	if retryErr != nil {
+		return nil, fmt.Errorf("retry exclusion suggestion: %w (first attempt: %w)", retryErr, err)
+	}
+	return result, nil
+}
+
+// requestExclusionSuggestion performs a single completion round trip and
+// validates the response with the same gate the create/update exclusion
+// handlers use. Validation failures wrap errExclusionSuggestionInvalid.
+func (s *Service) requestExclusionSuggestion(ctx context.Context, orgID, projectID, userID, userEmail, systemPrompt, userMessage string, jsonSchema *or.ChatJSONSchemaConfig) (*gen.SuggestExclusionResult, error) {
 	suggestCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -2933,7 +2964,7 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 		ExternalUserID: "",
 		UserEmail:      userEmail,
 		HTTPMetadata:   nil,
-		JSONSchema:     &jsonSchema,
+		JSONSchema:     jsonSchema,
 		Reasoning:      nil,
 	})
 	if err != nil {
@@ -2945,7 +2976,7 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 
 	raw := strings.TrimSpace(openrouter.GetText(*response.Message))
 	if raw == "" {
-		return nil, fmt.Errorf("empty completion content")
+		return nil, fmt.Errorf("%w: empty completion content", errExclusionSuggestionInvalid)
 	}
 
 	var parsed struct {
@@ -2955,7 +2986,7 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 		SourceFilter string `json:"source_filter"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return nil, fmt.Errorf("parse llm response: %w", err)
+		return nil, fmt.Errorf("%w: parse llm response: %w", errExclusionSuggestionInvalid, err)
 	}
 
 	parsed.MatchType = strings.ToLower(strings.TrimSpace(parsed.MatchType))
@@ -2964,12 +2995,12 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 	parsed.SourceFilter = strings.TrimSpace(parsed.SourceFilter)
 
 	if !exclusionMatchTypeAllow[parsed.MatchType] {
-		return nil, fmt.Errorf("model returned invalid match_type %q", parsed.MatchType)
+		return nil, fmt.Errorf("%w: model returned invalid match_type %q", errExclusionSuggestionInvalid, parsed.MatchType)
 	}
 	// Same gate the create/update exclusion handlers apply: non-empty value,
 	// and a regex must compile (RE2) and fit the length cap.
 	if err := validateExclusionMatchValue(parsed.MatchType, parsed.MatchValue); err != nil {
-		return nil, fmt.Errorf("model returned invalid match_value: %w", err)
+		return nil, fmt.Errorf("%w: model returned invalid match_value: %w", errExclusionSuggestionInvalid, err)
 	}
 
 	return exclusionSuggestionResult(parsed.MatchType, parsed.MatchValue, parsed.RuleIDFilter, parsed.SourceFilter), nil

--- a/server/internal/risk/suggest_exclusion_test.go
+++ b/server/internal/risk/suggest_exclusion_test.go
@@ -264,6 +264,35 @@ func TestSuggestExclusion_InvalidTwice_FallsBackToHeuristic(t *testing.T) {
 	require.Equal(t, "stop flagging sandbox account ids", result.MatchValue)
 }
 
+// TestSuggestExclusion_UnparseableResponse_NoRetry: the corrective retry
+// prompt carries only the error text, not the model's raw output, so a
+// parse-level failure has nothing to self-correct against — it must skip the
+// retry and fall back after a single call.
+func TestSuggestExclusion_UnparseableResponse_NoRetry(t *testing.T) {
+	t.Parallel()
+	fake := &suggestExclusionCompletionClient{
+		responses: []*openrouter.CompletionResponse{
+			suggestExclusionResponse("not json at all"),
+		},
+		errs:     []error{nil},
+		requests: nil,
+	}
+	ctx, ti := newTestRiskService(t, func(ti *testInstance) { ti.completionClient = fake })
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	result, err := ti.service.SuggestExclusion(ctx, &gen.SuggestExclusionPayload{
+		Prompt: new("jane.doe@acme.com"),
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.requests, 1)
+	require.Equal(t, "exact", result.MatchType)
+	require.Equal(t, "jane.doe@acme.com", result.MatchValue)
+}
+
 // TestSuggestExclusion_TransportError_NoRetry: transport failures are not the
 // model's fault, so they skip the corrective retry and drop straight to the
 // heuristic fallback after a single call.

--- a/server/internal/risk/suggest_exclusion_test.go
+++ b/server/internal/risk/suggest_exclusion_test.go
@@ -1,16 +1,78 @@
 package risk_test
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	or "github.com/OpenRouterTeam/go-sdk/models/components"
+	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/risk"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
+
+// suggestExclusionCompletionClient scripts GetObjectCompletion calls so tests
+// can drive the parse/validate/retry path behind SuggestExclusion. Call i
+// returns responses[i]/errs[i]; every request is recorded.
+type suggestExclusionCompletionClient struct {
+	responses []*openrouter.CompletionResponse
+	errs      []error
+	requests  []openrouter.ObjectCompletionRequest
+}
+
+func (c *suggestExclusionCompletionClient) GetObjectCompletion(_ context.Context, request openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
+	i := len(c.requests)
+	c.requests = append(c.requests, request)
+	if i >= len(c.responses) {
+		return nil, errors.New("unexpected extra completion call")
+	}
+	return c.responses[i], c.errs[i]
+}
+
+func (c *suggestExclusionCompletionClient) GetCompletion(context.Context, openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *suggestExclusionCompletionClient) GetCompletionStream(context.Context, openrouter.CompletionRequest) (openrouter.StreamReader, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *suggestExclusionCompletionClient) CreateEmbeddings(context.Context, string, string, []string, ...openrouter.EmbeddingOption) ([][]float32, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *suggestExclusionCompletionClient) ResolveKey(context.Context, string, string, billing.ModelUsageSource, openrouter.KeyType) (openrouter.ResolvedKey, error) {
+	return openrouter.PlatformKey(), nil
+}
+
+func suggestExclusionResponse(text string) *openrouter.CompletionResponse {
+	content := or.CreateChatAssistantMessageContentStr(text)
+	msg := or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
+		Role:             or.ChatAssistantMessageRoleAssistant,
+		Content:          optionalnullable.From(&content),
+		Name:             nil,
+		ToolCalls:        nil,
+		Refusal:          nil,
+		Reasoning:        nil,
+		ReasoningDetails: nil,
+		Images:           nil,
+		Audio:            nil,
+	})
+	return &openrouter.CompletionResponse{
+		StartTime: time.Time{},
+		Message:   &msg,
+		Model:     "test-model",
+		Content:   text,
+	}
+}
 
 func TestSuggestExclusion_Unauthorized(t *testing.T) {
 	t.Parallel()
@@ -138,4 +200,92 @@ func TestSuggestExclusion_FindingIDsOnly_DifferentRuleSameSource_FallsBackToSour
 	require.NoError(t, err)
 	require.Equal(t, "source", result.MatchType)
 	require.Equal(t, "presidio", result.MatchValue)
+}
+
+// TestSuggestExclusion_RetriesOnceWhenModelReturnsInvalidRegex: a completion
+// whose regex does not compile as RE2 (a lookahead here) must trigger one
+// corrective retry carrying the validation error, and the retry's valid
+// suggestion — RE2-only syntax like "(?i)" included — must come back verbatim
+// rather than the whole-prompt heuristic fallback.
+func TestSuggestExclusion_RetriesOnceWhenModelReturnsInvalidRegex(t *testing.T) {
+	t.Parallel()
+	fake := &suggestExclusionCompletionClient{
+		responses: []*openrouter.CompletionResponse{
+			suggestExclusionResponse(`{"match_type":"regex","match_value":"(?=acct_)test","rule_id_filter":"","source_filter":""}`),
+			suggestExclusionResponse(`{"match_type":"regex","match_value":"(?i)^acct_(test|sandbox)_[a-z0-9]+$","rule_id_filter":"","source_filter":""}`),
+		},
+		errs:     []error{nil, nil},
+		requests: nil,
+	}
+	ctx, ti := newTestRiskService(t, func(ti *testInstance) { ti.completionClient = fake })
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	result, err := ti.service.SuggestExclusion(ctx, &gen.SuggestExclusionPayload{
+		Prompt: new("stop flagging sandbox account ids"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "regex", result.MatchType)
+	require.Equal(t, "(?i)^acct_(test|sandbox)_[a-z0-9]+$", result.MatchValue)
+	require.Len(t, fake.requests, 2)
+	require.Contains(t, fake.requests[1].Prompt, "rejected")
+	require.Contains(t, fake.requests[1].Prompt, "invalid regex pattern")
+}
+
+// TestSuggestExclusion_InvalidTwice_FallsBackToHeuristic: when the corrective
+// retry also fails validation, the handler falls back to the deterministic
+// heuristic (the operator's own prompt as an exact match) instead of erroring.
+func TestSuggestExclusion_InvalidTwice_FallsBackToHeuristic(t *testing.T) {
+	t.Parallel()
+	fake := &suggestExclusionCompletionClient{
+		responses: []*openrouter.CompletionResponse{
+			suggestExclusionResponse(`{"match_type":"regex","match_value":"(?=acct_)test","rule_id_filter":"","source_filter":""}`),
+			suggestExclusionResponse(`{"match_type":"regex","match_value":"(?!still)bad","rule_id_filter":"","source_filter":""}`),
+		},
+		errs:     []error{nil, nil},
+		requests: nil,
+	}
+	ctx, ti := newTestRiskService(t, func(ti *testInstance) { ti.completionClient = fake })
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	result, err := ti.service.SuggestExclusion(ctx, &gen.SuggestExclusionPayload{
+		Prompt: new("stop flagging sandbox account ids"),
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.requests, 2)
+	require.Equal(t, "exact", result.MatchType)
+	require.Equal(t, "stop flagging sandbox account ids", result.MatchValue)
+}
+
+// TestSuggestExclusion_TransportError_NoRetry: transport failures are not the
+// model's fault, so they skip the corrective retry and drop straight to the
+// heuristic fallback after a single call.
+func TestSuggestExclusion_TransportError_NoRetry(t *testing.T) {
+	t.Parallel()
+	fake := &suggestExclusionCompletionClient{
+		responses: []*openrouter.CompletionResponse{nil},
+		errs:      []error{errors.New("openrouter unreachable")},
+		requests:  nil,
+	}
+	ctx, ti := newTestRiskService(t, func(ti *testInstance) { ti.completionClient = fake })
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	result, err := ti.service.SuggestExclusion(ctx, &gen.SuggestExclusionPayload{
+		Prompt: new("jane.doe@acme.com"),
+	})
+	require.NoError(t, err)
+	require.Len(t, fake.requests, 1)
+	require.Equal(t, "exact", result.MatchType)
+	require.Equal(t, "jane.doe@acme.com", result.MatchValue)
 }


### PR DESCRIPTION
## Problem

"Suggest with AI" on the exclusion form appeared to generate invalid regexes (AIS-541). The suggestions were actually valid: the server prompts for and validates RE2, but the form's save-time check compiled patterns with JS `RegExp` — a different dialect that throws on RE2 inline flags (`(?i)`) and `(?P<name>)` groups. Any suggestion using those (most case-insensitive patterns) was rejected with "Invalid regex pattern." A real suggestion from a local run, `(?i)^[a-z0-9._%+-]+\+sandbox@acme\.com$`, compiles fine as RE2 and throws in JS.

## Changes

- **Validate with the runtime dialect.** New `__celRegexCompile` export on the CEL wasm engine (Go `regexp.Compile`, the same RE2 the API and analyzers use); the exclusion form now validates regex criteria through it before submit. The wasm loads lazily — only when the criteria editor is visible (`useCelEngine` gained an `enabled` flag).
- **Drop the JS `RegExp` check** from `parseExclusionExpression` (kept the 512-char cap). This also stops JS-only syntax (lookarounds) from passing the form and dying at the API.
- **Surface API validation messages** in the create/update error toasts instead of a generic "Failed to create exclusion." — the API is the backstop when the wasm engine isn't ready.
- **One corrective retry in `SuggestExclusion`**: a completion that fails validation (bad match_type, non-RE2 regex) is retried once with the validation error fed back before falling back to the whole-prompt heuristic. Transport errors still skip the retry.

## Testing

- Server: new scripted-completion tests for retry-on-invalid-regex, invalid-twice → heuristic fallback, transport-error → no retry.
- Client: parser tests assert RE2-only syntax parses and over-long patterns are rejected.
- Manually verified against a live LLM locally: previously-failing `(?i)` suggestions now save.

AIS-541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates exclusion regexes with RE2 at save time and in server suggestions, replacing JS RegExp checks that rejected valid RE2; addresses AIS-541. Previously inline flags and named groups failed the form; now the client compiles with RE2 and the API is the backstop.

- Adds a RE2 compile entrypoint to the CEL wasm engine and uses it via `useCelEngine(enabled)`; lazy-loads the wasm only when the criteria editor is visible.
- Drops JS RegExp validation from the parser (keeps the 512‑char limit); JS-only syntax (e.g., lookarounds) no longer slips through to fail at the API.
- On save, validates regexes client-side with RE2 when the engine is ready; surfaces API validation messages in create/update toasts when the API backstops.
- Suggestion handler retries once only for semantic validation failures (bad match_type or non‑RE2 regex); parse-level or transport errors skip retry and fall back to the prompt heuristic. Tests cover retry, double‑invalid fallback, no‑retry transport errors, and no‑retry unparseable responses.
- Includes a patch changeset for `dashboard`.

<sup>Written for commit eb5248dc036c1e878e137c77dd774f2a5615419b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

