### PR TITLE
fix: apply the hooks rollout gate to publish freshness status

### DIFF
--- a/.changeset/publish-status-hooks-rollout-gate.md
+++ b/.changeset/publish-status-hooks-rollout-gate.md
@@ -1,0 +1,14 @@
+---
+"server": patch
+---
+
+Apply the phased hooks rollout gate to the publish freshness read. A hooks
+generator version bump used to flip every rollout-gated org's publish status to
+"needs syncing" permanently: publishing carries a gated org's hooks subtree
+verbatim (by design), so the stored hooks version could never reach the current
+constant that GetPublishStatus compared against. The status read now runs the
+same eligibility check as the publish path and skips the hooks version/config
+comparison for orgs the rollout hasn't cleared — their published hooks are
+their target, so only MCP content changes count against freshness. Cleared
+orgs still read a pending hooks bump (or a deferred hook-config change) as
+stale, prompting the publish that applies it.

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1636,12 +1636,13 @@ func (s *Service) liveManifestVersion(ctx context.Context, ac *contextvalues.Aut
 }
 
 // publishUpToDate reports whether the project's current plugin state matches
-// what was last published, by recomputing the live MCP fingerprint the same way
-// publishProject does and comparing both it and the current hooks generator
-// version to what the connection last recorded. It returns nil ("unknown") when
-// freshness can't be determined — the connection predates the hooks/MCP split,
-// or recomputing the fingerprint fails — so a transient compute error degrades
-// the status read rather than failing it.
+// what a publish would produce for this org, by recomputing the live MCP
+// fingerprint the same way publishProject does and — only when the org is
+// cleared for the current hooks version by the phased rollout — comparing the
+// hooks generator version and config to what the connection last recorded. It
+// returns nil ("unknown") when freshness can't be determined — the connection
+// predates the hooks/MCP split, or recomputing the fingerprint fails — so a
+// transient compute error degrades the status read rather than failing it.
 func (s *Service) publishUpToDate(ctx context.Context, ac *contextvalues.AuthContext, conn repo.PluginGithubConnection) *bool {
 	// Connections published before the hooks/MCP split carry no stored MCP
 	// fingerprints, so there's nothing to compare against.
@@ -1693,13 +1694,28 @@ func (s *Service) publishUpToDate(ctx context.Context, ac *contextvalues.AuthCon
 		mcpFingerprints[mcpPlatformFingerprintKey] = publishedMCPFingerprints[mcpPlatformFingerprintKey]
 	}
 
-	// Up to date only when both components match what was last published: the MCP
-	// per-plugin fingerprints, the hooks generator version, and the hook-affecting
-	// config (so a marketplace rename or browser-login toggle that hasn't
-	// propagated to the hooks subtree yet reads as stale rather than current).
-	upToDate := maps.Equal(mcpFingerprints, publishedMCPFingerprints) &&
-		conv.FromPGTextOrEmpty[string](conn.PublishedHooksVersion) == hooksGeneratorVersion &&
-		storedHooksConfigHash(conn.PublishedHooksConfig) == hooksConfigHash(hooksConfigSnapshot(cfg))
+	// The hooks component counts against freshness only when the org is cleared
+	// for the current generator version. publishProject applies the same
+	// eligibility gate and carries a gated org's published hooks subtree
+	// verbatim, so for a gated org the published hooks ARE its target: comparing
+	// them against the current constant would read "stale" on every generator
+	// bump, and no publish could ever clear it. A hook-affecting config change
+	// while gated (hooksConfigDeferred) is likewise not actionable — it applies
+	// automatically once the rollout pin advances — so it must not read as stale
+	// either. The eligibility inputs mirror the dashboard publish path
+	// (PublishPlugins), which passes the same auth-context org id and slug.
+	hooksCurrent := true
+	if s.hooksRolloutEligible(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug) {
+		hooksCurrent = conv.FromPGTextOrEmpty[string](conn.PublishedHooksVersion) == hooksGeneratorVersion &&
+			storedHooksConfigHash(conn.PublishedHooksConfig) == hooksConfigHash(hooksConfigSnapshot(cfg))
+	}
+
+	// Up to date only when both components match what was last published: the
+	// MCP per-plugin fingerprints, and (for rollout-cleared orgs) the hooks
+	// generator version plus the hook-affecting config (so a marketplace rename
+	// or browser-login toggle that hasn't propagated to the hooks subtree yet
+	// reads as stale rather than current).
+	upToDate := maps.Equal(mcpFingerprints, publishedMCPFingerprints) && hooksCurrent
 	return &upToDate
 }
 

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -1388,6 +1388,80 @@ func TestPluginsService_GetPublishStatus_StaleAfterEdit(t *testing.T) {
 	require.NotNil(t, status.LastPublishedAt)
 }
 
+// publishedFreshnessFixture publishes a minimal project and rewinds its stored
+// hooks version to "0", simulating a hooks generator bump that shipped after the
+// org's last publish. Callers then read GetPublishStatus under different rollout
+// clearances.
+func publishedFreshnessFixture(t *testing.T, ctx context.Context, ti *testInstance, name string) {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: name})
+	require.NoError(t, err)
+
+	toolset := createTestToolset(t, ctx, ti.conn, name+"-toolset")
+	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
+		PluginID:    plugin.ID,
+		ToolsetID:   conv.PtrEmpty(toolset.ID.String()),
+		DisplayName: conv.PtrEmpty(name + " Server"),
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
+	require.NoError(t, err)
+
+	rewindPublishedHooksVersion(t, ctx, ti.conn, *authCtx.ProjectID, "0")
+}
+
+// A publish-status read must apply the same phased-rollout gate as the publish
+// path. An org not cleared for the current hooks generator version keeps its
+// published hooks by design — every publish carries them verbatim — so a
+// pending hooks bump must not read as "needs syncing": syncing cannot clear it,
+// and the chip would stick until the rollout pin advances.
+func TestPluginsService_GetPublishStatus_GatedOrgIgnoresPendingHooksBump(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	// nil feature provider + non-canary org slug → not cleared for the current
+	// hooks version (the gate fails closed).
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+
+	publishedFreshnessFixture(t, ctx, ti, "Gated Freshness")
+
+	status, err := ti.service.GetPublishStatus(ctx, &gen.GetPublishStatusPayload{})
+	require.NoError(t, err)
+	require.NotNil(t, status.UpToDate)
+	require.True(t, *status.UpToDate,
+		"a rollout-gated org pinned to older hooks must not read as needing sync")
+}
+
+// Once the rollout pin clears the org for the current hooks version, the same
+// pending hooks bump must read as stale, prompting a publish that applies it.
+func TestPluginsService_GetPublishStatus_EligibleOrgReadsPendingHooksBumpAsStale(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	features := &feature.InMemory{}
+	ctx, ti := newTestPluginsServiceWithGitHubAndFeatures(t, mock, features, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	// A pin above any plausible generator version clears this org for the bump.
+	features.SetFlagPayload(feature.FlagHooksRollout, authCtx.ActiveOrganizationID, []byte(`{"version": 9999}`))
+
+	publishedFreshnessFixture(t, ctx, ti, "Eligible Freshness")
+
+	status, err := ti.service.GetPublishStatus(ctx, &gen.GetPublishStatusPayload{})
+	require.NoError(t, err)
+	require.NotNil(t, status.UpToDate)
+	require.False(t, *status.UpToDate,
+		"a cleared org with a pending hooks bump must read as needing sync")
+}
+
 // A Remote MCP-backed (mcp_server) plugin server is emitted into the generated
 // bundle as an HTTP server pointing at its resolved endpoint URL, with no
 // static Authorization header — auth is handled at the HTTP layer via the


### PR DESCRIPTION
Fixes the stuck "Needs syncing" badge reported in INC-439.

## Problem

`GetPublishStatus` compared the connection's stored `published_hooks_version` against the current `hooksGeneratorVersion` constant unconditionally. But `publishProject` deliberately gates hooks upgrades behind the phased rollout (`hooksRolloutEligible`): an org that isn't cleared for the current version has its published hooks subtree carried verbatim and its stored version left untouched — on purpose.

So the moment a generator version bump deploys, every rollout-gated org's publish status reads `upToDate = false`, the dashboard shows "Needs syncing", and syncing can never clear it: the publish succeeds (MCP content updates fine) but correctly keeps the old hooks version, which the status read then flags as stale again. The same held for the hook-config hash comparison — a config change deferred by the gate (`hooksConfigDeferred`) read as stale despite not being actionable.

## Fix

`publishUpToDate` now runs the same eligibility check as the publish path (same auth-context org id + slug the dashboard publish uses):

- **Org not cleared for the current hooks version** — skip the hooks version/config comparisons. A gated org's published hooks are its target by definition, so only MCP content changes count against freshness.
- **Org cleared** — unchanged behavior: a pending hooks bump or hook-config change reads as stale, prompting the publish that applies it.

## Testing

- New test: a gated org with a pending hooks bump reads up to date (fails without the fix, verified).
- New test: a rollout-cleared org with the same pending bump reads stale.
- Existing publish-status freshness tests pass unchanged; `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the phased hooks rollout gate to publish freshness reads to stop gated orgs from showing a permanent “Needs syncing” after a hooks generator bump. Previously `GetPublishStatus` always compared stored hooks version/config to the current `hooksGeneratorVersion`; now `publishUpToDate` runs `hooksRolloutEligible` and skips hooks comparisons for orgs not cleared by the rollout, so only MCP content changes affect freshness for those orgs.

- Mirrors the publish path’s eligibility check (`PublishPlugins`/`publishProject`) using the same auth-context org id and slug.
- Behavior: gated orgs ignore hooks version/config in freshness; cleared orgs remain unchanged and read pending hooks/config as stale.
- Adds focused tests for both cases; no migrations or config changes required.

<sup>Written for commit 5cf937ed3fdea39f41108ef9d478c79f64353180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

