### PR TITLE
chore(admin): one queryOptions export per admin endpoint

### DIFF
--- a/client/admin/src/components/auth-gate.tsx
+++ b/client/admin/src/components/auth-gate.tsx
@@ -2,7 +2,8 @@ import type { JSX, ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { SpeakeasyMark } from "@/components/speakeasy-mark";
-import { adminSessionQuery, isRedirectingToLogin } from "@/lib/gramAdminApi";
+import { adminSessionQuery } from "@/lib/adminQueries";
+import { isRedirectingToLogin } from "@/lib/gramAdminApi";
 
 // Holds the first paint until the session check answers.
 //

--- a/client/admin/src/components/nav-user.tsx
+++ b/client/admin/src/components/nav-user.tsx
@@ -7,7 +7,8 @@ import {
 } from "lucide-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-import { adminSessionQuery, logout } from "@/lib/gramAdminApi";
+import { adminSessionQuery } from "@/lib/adminQueries";
+import { logout } from "@/lib/gramAdminApi";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { organizationQuery, organizationsListQuery } from "@/lib/adminQueries";
+import type { AdminOrganization } from "@/lib/gramAdminApi";
+
+function org(id: string): AdminOrganization {
+  return {
+    id,
+    name: id,
+    slug: id,
+    account_type: "free",
+    whitelisted: false,
+    member_count: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("organizationsListQuery", () => {
+  it("invalidates every filtered page from the unfiltered key", () => {
+    const qc = new QueryClient();
+    const filtered = organizationsListQuery({ q: "x", cursor: "page-2" });
+    qc.setQueryData(filtered.queryKey, { organizations: [] });
+    qc.setQueryData(["gram-admin-project", "p"], {});
+
+    void qc.invalidateQueries({ queryKey: organizationsListQuery().queryKey });
+
+    expect(qc.getQueryState(filtered.queryKey)?.isInvalidated).toBe(true);
+    expect(qc.getQueryState(["gram-admin-project", "p"])?.isInvalidated).toBe(
+      false,
+    );
+  });
+
+  it("caches a blank filter and an absent one as the same page", () => {
+    expect(
+      organizationsListQuery({ q: "", cursor: undefined }).queryKey,
+    ).toEqual(organizationsListQuery().queryKey);
+  });
+});
+
+describe("organizationQuery", () => {
+  // Asserts the id reaches the cache, not that the key reads any particular
+  // way. A key spelled out in the test would fail on a prefix rename, which is
+  // a refactor rather than a defect.
+  it("gives each organization its own cache entry", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(organizationQuery("org-a").queryKey, org("org-a"));
+    qc.setQueryData(organizationQuery("org-b").queryKey, org("org-b"));
+
+    expect(qc.getQueryData(organizationQuery("org-a").queryKey)?.id).toBe(
+      "org-a",
+    );
+  });
+});

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -1,0 +1,99 @@
+// One queryOptions export per admin endpoint.
+//
+// Every read and every invalidation goes through these, so a cache key is
+// written once. A key spelled out at a call site is the usual cause of a
+// mutation that updates the server and leaves the table showing the old row.
+
+import { queryOptions, type QueryKey } from "@tanstack/react-query";
+import {
+  getOrganization,
+  getProject,
+  getSession,
+  listOrganizationMembers,
+  listOrganizationProjects,
+  listOrganizations,
+  omitUnset,
+  type AdminOrganization,
+  type AdminProjectDetail,
+  type ListOrganizationMembersResult,
+  type ListOrganizationProjectsResult,
+  type ListOrganizationsParams,
+  type ListOrganizationsResult,
+} from "@/lib/gramAdminApi";
+
+// What queryOptions infers, named so the exports can carry the return type that
+// `typescript/explicit-module-boundary-types` demands. Writing the shape out by
+// hand instead would drop the tag queryOptions puts on queryKey, and that tag
+// is what tells setQueryData which payload the key holds.
+//
+// TKey has to be the exact tuple. Collapsing it to QueryKey fails to compile,
+// because `enabled` takes a Query<..., TKey> and that position is
+// contravariant. The `as const` on each key exists to produce that tuple.
+type AdminQuery<TData, TKey extends QueryKey> = ReturnType<
+  typeof queryOptions<TData, Error, TData, TKey>
+>;
+
+// The backend ends the session, never the client, so staleTime keeps a good
+// session from refetching. A failed check holds no data, which React Query
+// always treats as stale, so it still retries on focus and on reconnect.
+export const adminSessionQuery = queryOptions({
+  queryKey: ["adminSession"] as const,
+  queryFn: getSession,
+  staleTime: Infinity,
+});
+
+// Call with no argument for the key that covers every filter and every page:
+// invalidateQueries({ queryKey: organizationsListQuery().queryKey }).
+export function organizationsListQuery(
+  params: ListOrganizationsParams = {},
+): AdminQuery<
+  ListOrganizationsResult,
+  readonly ["gram-admin-organizations", ListOrganizationsParams]
+> {
+  return queryOptions({
+    queryKey: ["gram-admin-organizations", omitUnset(params)] as const,
+    queryFn: () => listOrganizations(params),
+  });
+}
+
+export function organizationQuery(
+  idOrSlug: string,
+): AdminQuery<AdminOrganization, readonly ["gram-admin-organization", string]> {
+  return queryOptions({
+    queryKey: ["gram-admin-organization", idOrSlug] as const,
+    queryFn: () => getOrganization(idOrSlug),
+  });
+}
+
+export function organizationProjectsQuery(
+  organizationID: string,
+): AdminQuery<
+  ListOrganizationProjectsResult,
+  readonly ["gram-admin-organization-projects", string]
+> {
+  return queryOptions({
+    queryKey: ["gram-admin-organization-projects", organizationID] as const,
+    queryFn: () => listOrganizationProjects(organizationID),
+  });
+}
+
+export function organizationMembersQuery(
+  organizationID: string,
+): AdminQuery<
+  ListOrganizationMembersResult,
+  readonly ["gram-admin-organization-members", string]
+> {
+  return queryOptions({
+    queryKey: ["gram-admin-organization-members", organizationID] as const,
+    queryFn: () => listOrganizationMembers(organizationID),
+  });
+}
+
+export function projectQuery(
+  idOrSlug: string,
+): AdminQuery<AdminProjectDetail, readonly ["gram-admin-project", string]> {
+  return queryOptions({
+    queryKey: ["gram-admin-project", idOrSlug] as const,
+    queryFn: () => getProject(idOrSlug),
+  });
+}

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GramAdminError,
+  errorMessage,
+  logout,
+  toSearchParams,
+} from "@/lib/gramAdminApi";
+
+describe("toSearchParams", () => {
+  it("repeats the key for each item of an array", () => {
+    const qs = toSearchParams({ type: ["free", "pro"], q: "", page: 2 });
+    expect(qs.toString()).toBe("type=free&type=pro&page=2");
+  });
+
+  it("omits the values the API reads as unset", () => {
+    const qs = toSearchParams({
+      q: undefined,
+      cursor: "",
+      type: [],
+      include_disabled: false,
+    });
+    expect(qs.toString()).toBe("");
+  });
+
+  it("encodes a value that needs escaping", () => {
+    const qs = toSearchParams({ q: "a b&c" });
+    expect(qs.toString()).toBe("q=a+b%26c");
+  });
+});
+
+describe("errorMessage", () => {
+  it("prefers the message the server sent when the operator can act on it", () => {
+    const e = new GramAdminError(
+      400,
+      { name: "bad_request", message: "at least one field must be supplied" },
+      "gram admin 400 Bad Request",
+    );
+    expect(errorMessage(e)).toBe("at least one field must be supplied");
+  });
+
+  // A 5xx message is the handler's verb phrase, "list organizations", not a
+  // sentence. The status line says more.
+  it("keeps the status line for a server fault", () => {
+    const e = new GramAdminError(
+      500,
+      { name: "internal", message: "list organizations" },
+      "gram admin 500 Internal Server Error",
+    );
+    expect(errorMessage(e)).toBe("gram admin 500 Internal Server Error");
+  });
+
+  it("falls back to the status line when the body carries no message", () => {
+    const e = new GramAdminError(404, null, "gram admin 404 Not Found");
+    expect(errorMessage(e)).toBe("gram admin 404 Not Found");
+  });
+});
+
+describe("logout", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads a 204 as success and asks for the account chooser", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+    );
+
+    await logout();
+
+    expect(window.location.href).toContain("prompt=select_account");
+  });
+
+  // The 401 handler retries with prompt=none, which the provider honours
+  // silently. Taking it here would sign the operator back in behind the Logout
+  // they just pressed.
+  it("reports a 401 instead of signing the operator back in", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
+    );
+    const before = window.location.href;
+
+    await expect(logout()).rejects.toThrow(GramAdminError);
+
+    expect(window.location.href).toBe(before);
+  });
+});

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -11,8 +11,6 @@
 // SameSite=None permits a cross-site cookie; it does not defeat third-party
 // cookie blocking. Same-origin is the fix.
 
-import { queryOptions } from "@tanstack/react-query";
-
 export class GramAdminError extends Error {
   status: number;
   body: unknown;
@@ -23,14 +21,63 @@ export class GramAdminError extends Error {
   }
 }
 
-// gramAdminFetch is a thin wrapper around fetch that:
-// - normalises the path to a root-relative URL,
-// - redirects into the OIDC flow on 401,
-// - throws on non-2xx with a typed error containing status + parsed body.
-export async function gramAdminFetch<T>(
+// A 4xx body names what the operator has to fix, such as "at least one of
+// account_type or whitelisted must be supplied". A 5xx body carries whatever
+// verb phrase the handler passed to oops.E, such as "list organizations"
+// (server/internal/admin/impl.go:343, surfaced by pp.go:83), which reads worse
+// than the status line. So trust the body below 500 and nowhere else.
+export function errorMessage(e: unknown): string {
+  if (
+    e instanceof GramAdminError &&
+    e.status < 500 &&
+    e.body &&
+    typeof e.body === "object"
+  ) {
+    const message = (e.body as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+export type QueryParams = Record<
+  string,
+  string | number | boolean | string[] | undefined
+>;
+
+// Values the admin API reads as unset. Every boolean it takes is an opt-in
+// flag, so `false` is the same request as no flag at all.
+//
+// A cache key runs through this too, so the key and the request agree on what
+// "unset" means. Without that, `{type: []}` and `{}` send one request and cache
+// two entries.
+export function omitUnset(params: QueryParams): QueryParams {
+  return Object.fromEntries(
+    Object.entries(params).filter(([, value]) => {
+      if (Array.isArray(value)) return value.length > 0;
+      return value !== undefined && value !== "" && value !== false;
+    }),
+  );
+}
+
+// An array becomes a repeated key (`type=free&type=pro`). Goa parses that into
+// a slice; a comma-joined value would arrive as one string.
+export function toSearchParams(params: QueryParams): URLSearchParams {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(omitUnset(params))) {
+    if (Array.isArray(value)) {
+      for (const item of value) qs.append(key, item);
+    } else {
+      qs.append(key, String(value));
+    }
+  }
+  return qs;
+}
+
+async function gramAdminRequest(
   path: string,
-  init?: RequestInit,
-): Promise<T> {
+  init: RequestInit | undefined,
+  redirectOnUnauthorized: boolean,
+): Promise<Response> {
   const url = path.startsWith("/") ? path : `/${path}`;
   // Accept is a default, not an override: a caller that sets its own wins.
   const headers = new Headers(init?.headers);
@@ -39,7 +86,7 @@ export async function gramAdminFetch<T>(
   }
   const res = await fetch(url, { ...init, headers });
 
-  if (res.status === 401) {
+  if (res.status === 401 && redirectOnUnauthorized) {
     // Top-level redirect into the OIDC flow. Use prompt=none so the identity
     // provider returns silently when the operator already has a session with
     // it. The gram admin backend falls back to interactive login if the
@@ -76,7 +123,22 @@ export async function gramAdminFetch<T>(
     );
   }
 
+  return res;
+}
+
+export async function gramAdminFetch<T>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await gramAdminRequest(path, init, true);
   return (await res.json()) as T;
+}
+
+// For an endpoint that answers 204. A mutation reports its own failure rather
+// than taking the 401 redirect, which would sign the operator back in behind
+// the action they just took.
+async function gramAdminSend(path: string, init?: RequestInit): Promise<void> {
+  await gramAdminRequest(path, init, false);
 }
 
 // True once gramAdminFetch has sent the browser to the login page. The document
@@ -100,33 +162,19 @@ export type AdminSessionInfo = {
   name?: string;
 };
 
-// The backend ends the session, never the client, so staleTime keeps a good
-// session from refetching. A failed check holds no data, which React Query
-// always treats as stale, so it still retries on focus and on reconnect.
-export const adminSessionQuery = queryOptions({
-  queryKey: ["adminSession"],
-  queryFn: () => gramAdminFetch<AdminSessionInfo>("/admin/session.get"),
-  staleTime: Infinity,
-});
+export function getSession(): Promise<AdminSessionInfo> {
+  return gramAdminFetch<AdminSessionInfo>("/admin/session.get");
+}
 
 // Ends the admin session, then sends the browser into the OIDC flow.
 //
-// The endpoint answers 204, so this cannot use gramAdminFetch, which always
-// parses a JSON body. The endpoint also deletes only the server-side record and
-// leaves the `gram_admin` cookie in the browser. The next request would
-// therefore 401, and the 401 handler retries with prompt=none, which the
-// identity provider honours silently and signs the operator straight back in.
-// Asking for select_account instead forces the account chooser, so logging out
-// is visible.
+// The endpoint deletes only the server-side record and leaves the `gram_admin`
+// cookie in the browser. The next request would therefore 401, and the 401
+// handler retries with prompt=none, which the identity provider honours
+// silently and signs the operator straight back in. Asking for select_account
+// instead forces the account chooser, so logging out is visible.
 export async function logout(): Promise<void> {
-  const res = await fetch("/admin/auth.logout", { method: "POST" });
-  if (!res.ok) {
-    throw new GramAdminError(
-      res.status,
-      null,
-      `gram admin logout ${res.status} ${res.statusText}`,
-    );
-  }
+  await gramAdminSend("/admin/auth.logout", { method: "POST" });
   window.location.href = "/admin/auth.login?prompt=select_account";
 }
 
@@ -163,15 +211,9 @@ export type ListOrganizationsParams = {
 export function listOrganizations(
   params: ListOrganizationsParams = {},
 ): Promise<ListOrganizationsResult> {
-  const qs = new URLSearchParams();
-  if (params.q) qs.set("q", params.q);
-  if (params.account_type) qs.set("account_type", params.account_type);
-  if (params.include_disabled) qs.set("include_disabled", "true");
-  if (params.cursor) qs.set("cursor", params.cursor);
-  if (params.limit !== undefined) qs.set("limit", String(params.limit));
-  const query = qs.toString();
+  const qs = toSearchParams(params).toString();
   return gramAdminFetch<ListOrganizationsResult>(
-    `/admin/organizations.list${query ? `?${query}` : ""}`,
+    `/admin/organizations.list${qs ? `?${qs}` : ""}`,
   );
 }
 
@@ -193,12 +235,12 @@ export type AdminProjectDetail = {
 };
 
 export function getProject(idOrSlug: string): Promise<AdminProjectDetail> {
-  const qs = new URLSearchParams({ id_or_slug: idOrSlug });
+  const qs = toSearchParams({ id_or_slug: idOrSlug });
   return gramAdminFetch<AdminProjectDetail>(`/admin/project.get?${qs}`);
 }
 
 export function getOrganization(idOrSlug: string): Promise<AdminOrganization> {
-  const qs = new URLSearchParams({ id_or_slug: idOrSlug });
+  const qs = toSearchParams({ id_or_slug: idOrSlug });
   return gramAdminFetch<AdminOrganization>(`/admin/organization.get?${qs}`);
 }
 
@@ -233,7 +275,7 @@ export type ListOrganizationProjectsResult = {
 export function listOrganizationProjects(
   organizationID: string,
 ): Promise<ListOrganizationProjectsResult> {
-  const qs = new URLSearchParams({ organization_id: organizationID });
+  const qs = toSearchParams({ organization_id: organizationID });
   return gramAdminFetch<ListOrganizationProjectsResult>(
     `/admin/organization.projects?${qs}`,
   );
@@ -255,7 +297,7 @@ export type ListOrganizationMembersResult = {
 export function listOrganizationMembers(
   organizationID: string,
 ): Promise<ListOrganizationMembersResult> {
-  const qs = new URLSearchParams({ organization_id: organizationID });
+  const qs = toSearchParams({ organization_id: organizationID });
   return gramAdminFetch<ListOrganizationMembersResult>(
     `/admin/organization.members?${qs}`,
   );

--- a/client/admin/src/pages/OrganizationDetail.tsx
+++ b/client/admin/src/pages/OrganizationDetail.tsx
@@ -16,9 +16,13 @@ import { useConfirmDialog } from "@/components/ConfirmDialog";
 import { ACCOUNT_TYPE_OPTIONS } from "@/lib/accountTypes";
 import { cn } from "@/lib/utils";
 import {
-  getOrganization,
-  listOrganizationProjects,
-  listOrganizationMembers,
+  organizationMembersQuery,
+  organizationProjectsQuery,
+  organizationQuery,
+  organizationsListQuery,
+} from "@/lib/adminQueries";
+import {
+  errorMessage,
   updateOrganization,
   type AdminOrganization,
   type AdminProject,
@@ -50,9 +54,8 @@ export function OrganizationDetail(): JSX.Element {
   const { idOrSlug } = useParams({ from: "/organizations/$idOrSlug" });
   const navigate = useNavigate();
 
-  const { data, isLoading, isError, error } = useQuery<AdminOrganization>({
-    queryKey: ["gram-admin-organization", idOrSlug],
-    queryFn: () => getOrganization(idOrSlug),
+  const { data, isLoading, isError, error } = useQuery({
+    ...organizationQuery(idOrSlug),
     enabled: !!idOrSlug,
   });
 
@@ -82,7 +85,7 @@ export function OrganizationDetail(): JSX.Element {
         )}
         {isError && (
           <span className="text-muted-foreground text-sm">
-            Error: {(error as Error).message}
+            Error: {errorMessage(error)}
           </span>
         )}
 
@@ -123,9 +126,11 @@ function OrgDetailsCard({ org }: { org: AdminOrganization }) {
       }),
     onSuccess: (updated) => {
       setDraft({});
-      qc.setQueryData(["gram-admin-organization", org.id], updated);
-      qc.setQueryData(["gram-admin-organization", org.slug], updated);
-      void qc.invalidateQueries({ queryKey: ["gram-admin-organizations"] });
+      qc.setQueryData(organizationQuery(org.id).queryKey, updated);
+      qc.setQueryData(organizationQuery(org.slug).queryKey, updated);
+      void qc.invalidateQueries({
+        queryKey: organizationsListQuery().queryKey,
+      });
     },
   });
 
@@ -250,7 +255,7 @@ function OrgDetailsCard({ org }: { org: AdminOrganization }) {
           </Button>
           {mut.isError && (
             <span className="text-muted-foreground text-sm">
-              Error: {(mut.error as Error).message}
+              Error: {errorMessage(mut.error)}
             </span>
           )}
         </div>
@@ -325,8 +330,7 @@ const PROJECT_COLUMNS: Column<AdminProject>[] = [
 function OrgProjectsPanel({ orgID }: { orgID: string }) {
   const navigate = useNavigate();
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["gram-admin-organization-projects", orgID],
-    queryFn: () => listOrganizationProjects(orgID),
+    ...organizationProjectsQuery(orgID),
     enabled: !!orgID,
   });
 
@@ -406,8 +410,7 @@ function membersMessage(isLoading: boolean, isError: boolean): string {
 
 function OrgMembersPanel({ orgID }: { orgID: string }) {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["gram-admin-organization-members", orgID],
-    queryFn: () => listOrganizationMembers(orgID),
+    ...organizationMembersQuery(orgID),
     enabled: !!orgID,
   });
 

--- a/client/admin/src/pages/OrganizationsList.tsx
+++ b/client/admin/src/pages/OrganizationsList.tsx
@@ -19,7 +19,8 @@ import {
 } from "@/components/ui/select";
 import { DataTable as Table, type Column } from "@/components/data-table";
 import { cn } from "@/lib/utils";
-import { listOrganizations, type AdminOrganization } from "@/lib/gramAdminApi";
+import { organizationQuery, organizationsListQuery } from "@/lib/adminQueries";
+import { errorMessage, type AdminOrganization } from "@/lib/gramAdminApi";
 import { ACCOUNT_TYPE_OPTIONS } from "@/lib/accountTypes";
 
 function fmtDateShort(iso?: string): string {
@@ -148,24 +149,14 @@ export function OrganizationsList(): JSX.Element {
     return () => clearTimeout(t);
   }, [search, debouncedSearch, resetPaging]);
 
-  const queryKey = useMemo(
-    () => [
-      "gram-admin-organizations",
-      { q: debouncedSearch, accountType, includeDisabled, cursor },
-    ],
-    [debouncedSearch, accountType, includeDisabled, cursor],
-  );
-
   const { data, isLoading, isError, error, isPlaceholderData } = useQuery({
-    queryKey,
-    queryFn: () =>
-      listOrganizations({
-        q: debouncedSearch || undefined,
-        account_type: accountType || undefined,
-        include_disabled: includeDisabled || undefined,
-        cursor,
-        limit: 50,
-      }),
+    ...organizationsListQuery({
+      q: debouncedSearch,
+      account_type: accountType,
+      include_disabled: includeDisabled,
+      cursor,
+      limit: 50,
+    }),
     // Every filter and every page is a separate cache entry. Without this the
     // table empties on each change and the rows jump.
     placeholderData: keepPreviousData,
@@ -190,7 +181,7 @@ export function OrganizationsList(): JSX.Element {
       const idOrSlug = org.slug || org.id;
       // The row already holds the whole record, so the detail page paints and
       // starts its own queries without a round trip to organization.get.
-      qc.setQueryData(["gram-admin-organization", idOrSlug], org);
+      qc.setQueryData(organizationQuery(idOrSlug).queryKey, org);
       void navigate({ to: "/organizations/$idOrSlug", params: { idOrSlug } });
     },
     [navigate, qc],
@@ -259,8 +250,7 @@ export function OrganizationsList(): JSX.Element {
             outside the empty state or the operator reads stale data as fresh. */}
         {isError && (
           <div className="text-muted-foreground mb-2 text-sm">
-            Could not refresh organizations:{" "}
-            {(error as Error)?.message ?? "unknown error"}
+            Could not refresh organizations: {errorMessage(error)}
           </div>
         )}
 

--- a/client/admin/src/pages/ProjectDetail.tsx
+++ b/client/admin/src/pages/ProjectDetail.tsx
@@ -8,7 +8,8 @@ import {
 } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { getProject, type AdminProjectDetail } from "@/lib/gramAdminApi";
+import { projectQuery } from "@/lib/adminQueries";
+import { errorMessage } from "@/lib/gramAdminApi";
 
 function fmtDate(iso?: string): string {
   if (!iso) return "-";
@@ -45,9 +46,8 @@ export function ProjectDetail(): JSX.Element {
   const navigate = useNavigate();
   const router = useRouter();
 
-  const { data, isLoading, isError, error } = useQuery<AdminProjectDetail>({
-    queryKey: ["gram-admin-project", idOrSlug],
-    queryFn: () => getProject(idOrSlug),
+  const { data, isLoading, isError, error } = useQuery({
+    ...projectQuery(idOrSlug),
     enabled: !!idOrSlug,
   });
 
@@ -84,7 +84,7 @@ export function ProjectDetail(): JSX.Element {
         )}
         {isError && (
           <span className="text-muted-foreground text-sm">
-            Error: {(error as Error).message}
+            Error: {errorMessage(error)}
           </span>
         )}
 


### PR DESCRIPTION
Every React Query call in `client/admin` spelled its own cache key as a string literal, and five call sites built a query string three different ways. A key written twice is how a mutation updates the server and leaves the table showing the old row.

This adds `client/admin/src/lib/adminQueries.ts`: one `queryOptions` export per admin endpoint. No `queryKey:` string literal is left in `client/admin/src`, every read goes through an export, and every invalidation goes through that export's `.queryKey`.

# What else moved

- **`toSearchParams`** replaces the five hand-rolled query-string builders. It repeats a key for each item of an array (`type=free&type=pro`), which is what Goa parses into a slice, and it omits what the API reads as unset. The same normalizer builds the cache key, so a filter the operator cleared cannot strand a second entry.
- **A no-content path.** `logout()` had its own `fetch` because the endpoint answers 204 and the shared wrapper always parsed JSON. It now calls `gramAdminSend`. That path deliberately does not take the 401 redirect: on logout a 401 would redirect to `prompt=none`, the provider would sign the operator straight back in, and the Logout they pressed would look like it failed.
- **`errorMessage(e)`** reads the message the service wrote instead of the status line, but only below 500. A 4xx body names what the operator has to fix. A 5xx body carries whatever verb phrase the handler passed to `oops.E`, such as `list organizations`, which reads worse than the status line.

# Notes for the reviewer

The return types in `adminQueries.ts` look heavy for what they say. `typescript/explicit-module-boundary-types` is an error in `client/admin/.oxlintrc.json`, and annotating the return loosely drops the tag `queryOptions` puts on `queryKey`, and that tag is what types the payload of `setQueryData`. With the code as written, `setQueryData(organizationQuery("x").queryKey, { totally: "wrong" })` is a type error. That is the whole reason the keys are `as const`.

`omitUnset` drops `false` as well as `undefined`, `""` and `[]`. Every boolean the admin API takes is an opt-in flag, so `include_disabled=false` is the same request as sending nothing.

# The one behavior change

The organizations list, the organization detail page and the project detail page now show the message the server sent on a 4xx, where they showed the status line before. A failed account-type save reads `at least one of account_type or whitelisted must be supplied` instead of `gram admin 400 Bad Request`. A 5xx still shows the status line.

Every request stays byte-identical.

# How to verify

```
aube run -F admin test        # 17 tests, 4 files
aube run -F admin type-check
CI=true mise run lint:client
```

Driven in the running app, the network tab shows the same query strings the old builders sent:

| Action         | Request                                                        |
| -------------- | -------------------------------------------------------------- |
| open the list  | `organizations.list?limit=50`                                  |
| search         | `organizations.list?q=<term>&limit=50`                         |
| show disabled  | `organizations.list?q=<term>&include_disabled=true&limit=50`   |
| filter by type | `organizations.list?q=<term>&account_type=enterprise&limit=50` |

Turning "show disabled" back off drops the parameter rather than sending `include_disabled=false`. Clicking a row still paints the detail page from the prefilled cache entry, both tabs load, and saving an account-type change posts and invalidates the list.

Part of AGE-3182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes `@tanstack/react-query` usage with one `queryOptions` export per admin endpoint and a shared query-string normalizer to prevent stale cache entries and mismatched invalidations. Behavior change: admin pages now show the server’s 4xx message via errorMessage, and logout sends without taking the 401 redirect to avoid immediate re-login.

- Replace all string-literal query keys and hand-built query strings with `adminQueries` exports and `toSearchParams`/`omitUnset`. Invalidate lists via `organizationsListQuery().queryKey`.
- Keys are `as const` to keep `setQueryData` type-safe; return types stay explicit to satisfy lint rules.
- Tests cover query-key invalidation across filtered pages, query-string encoding, error-message selection, and logout behavior; network requests remain byte-identical.
- Migration: when adding a new admin endpoint, add a `queryOptions` export in `adminQueries.ts`, use `toSearchParams` for its query string, and surface user-facing errors with errorMessage.
- Supports Linear AGE-3182 by making list filtering, cache prefill on navigation, and post-mutation invalidation consistent across the organizations and project pages.

<sup>Written for commit 85f0c19bc157d44faad0371dd1fbe4f30ab5759a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

