### PR TITLE
fix(email): simplify Loops template publishing

### DIFF
--- a/.agents/skills/craft-transactional-emails/SKILL.md
+++ b/.agents/skills/craft-transactional-emails/SKILL.md
@@ -1,21 +1,17 @@
 ---
 name: craft-transactional-emails
-description: Use when creating, restyling, reviewing, validating, syncing, or previewing Gram/Speakeasy transactional emails in Loops, LMX, or MJML, including email templates, branded email, Loops Content API, email screenshots, desktop/mobile QA, logical template IDs, or files under server/internal/email/loops/.
+description: Use when creating, restyling, reviewing, validating, or previewing Gram/Speakeasy transactional emails in LMX or MJML, including branded email, email screenshots, desktop/mobile QA, or files under server/internal/email/loops/.
 ---
 
 # Craft transactional emails
 
 LMX in `server/internal/email/loops/` is the production delivery source. The
-inline MJML starter is the approved visual specification. Release CI creates or
-updates Loops records and relays environment-specific IDs through gram-infra.
+inline MJML starter is the approved visual specification.
 
 ## Authorization and confidentiality
 
 - Repository edits do not authorize manual Loops reads, mutations, previews,
   test-sends, or publishes. Resolve each external action separately.
-- The checked-in gram-infra release workflow with `SYNC_LOOPS_EMAILS=true` is the
-  approved automated publish path. Do not set it for local runs or call the live
-  API while developing.
 - Never use customer or private production names, IDs, domains, addresses,
   URLs, or figures in source, temporary previews, screenshots, logs, or test
   sends. Use `Example Organization`, `person@example.com`, and `<ORG_ID>`.
@@ -29,8 +25,8 @@ updates Loops records and relays environment-specific IDs through gram-infra.
 2. Inspect `server/internal/email/template_<name>.go`, `templates.go`,
    `loops/manifest.json`, and the matching `.lmx` file.
 3. For an existing email, reuse its logical key. For a new email, choose one
-   snake-case key and use it unchanged in Go, manifest, managed name, and runtime
-   lookup. Never add a variable only in LMX or only in Go.
+   snake-case key and use it unchanged in Go, manifest, and managed name. Never
+   add a variable only in LMX or only in Go.
 4. Treat the inline MJML starter below as the approved visual source of truth.
    Preserve its spectrum rail, light canvas, Speakeasy wordmark, restrained mono
    labels, Tobias editorial headline, square black CTA, and dashed pale footer.
@@ -47,8 +43,7 @@ New-template checklist:
    `RegisteredTemplates` in `templates.go`.
 3. Copy `loops/transactional_base.lmx` to `loops/<key>.lmx`, specialize the
    message, and replace every generic variable with the typed contract.
-4. Add `manifest.json` metadata. This entry enrolls the template in merge-driven
-   creation; no provider ID belongs in Gram.
+4. Add `manifest.json` metadata. No provider ID belongs in Gram.
 
 `AddToAudience()` controls whether Loops also creates/updates a contact for the
 recipient. Default to `false` for operational alerts and one-off recipients.
@@ -86,12 +81,10 @@ existing templates; add only the new object under `templates`.
 
 Identity map:
 
-| Identity     | Example                                | Owner              | Human edit?      |
-| ------------ | -------------------------------------- | ------------------ | ---------------- |
-| Logical key  | `example_notice`                       | Gram Go + manifest | Yes, when adding |
-| Managed name | `gram.transactional.v2.example_notice` | Manifest/Loops     | Manifest only    |
-| Remote ID    | `cm...`                                | Loops              | Never            |
-| Key → ID map | `email-templates-dev.yaml`             | gram-infra CI      | Never            |
+| Identity     | Example                                | Owner              |
+| ------------ | -------------------------------------- | ------------------ |
+| Logical key  | `example_notice`                       | Gram Go + manifest |
+| Managed name | `gram.transactional.v2.example_notice` | Manifest/Loops     |
 
 - New managed names are `gram.transactional.v2.<logical_key>`.
 - Add the LMX file and a `manifest.json` entry with subject, preview, source, and
@@ -108,10 +101,7 @@ Identity map:
 - State the event or action directly. Delete vague lead-ins such as “a clear read
   on how your organization is tracking.” Prefer one verb-led CTA.
 - Use conditional `<Section>` blocks for variants. Do not invent fallback syntax.
-- Keep condition-only variables in the Go and manifest contract. Loops omits
-  variables used only by a Section `if` attribute from its published
-  `dataVariables` metadata; repository reconciliation accounts for that provider
-  behavior while continuing to verify every rendered variable exactly.
+- Keep condition-only variables in the Go and manifest contract.
 - LMX cannot embed raw HTML. Send scalar variables and compose the layout in LMX.
 - `<Image src>` must be a Loops-hosted upload. Do not use a repo-local or public
   URL as `src`; use a text masthead until an upload is deliberately managed.
@@ -368,16 +358,15 @@ git diff --check
 
 This checks manifest structure, XML well-formedness and explicit provider
 attribute ranges across every `.lmx` file recursively, declared/used variables,
-Go contracts, API reconciliation behavior, and runtime ID resolution. Merge CI
-then uses Loops compilation, optimistic revisions, Guardian, and publish; any
-Guardian error blocks the release preparation.
+and Go contracts.
 
 ## Screenshots and visual QA
 
 For every new template or layout change, create a temporary MJML specialization
-from the approved `transactional_base.mjml`. It is the canonical visual—not a
-proxy derived from LMX. Use the same copy/sections and generic sample values.
-Do not commit the proxy. A copy-only change using an already-reviewed
+from the approved `transactional_base.mjml` to review the intended design. These
+screenshots are design-spec previews, not renders of the production LMX in
+Loops. Use the same copy/sections and generic sample values. Do not commit the
+preview. A copy-only change using an already-reviewed
 layout may reuse existing shell references in `.playwright-cli/email-previews/`.
 If repo artifact writes are not authorized, keep everything under `/tmp/<task>/`.
 
@@ -396,61 +385,11 @@ kill "$preview_pid"
 
 This is **local visual-spec QA**. Inspect both PNGs with the image viewer. Reject overflow, weak hierarchy, empty
 blocks, broken images, unresolved variables, non-placeholder identity, or excess
-whitespace. MJML is a visual proxy, not proof that production LMX is identical.
-Passing local QA means the proxy compiles and both screenshots pass inspection;
-this satisfies repository-source QA. Report **production-render QA** as
+whitespace. Passing local QA means the design preview compiles and both
+screenshots pass inspection; it does not prove that production LMX renders
+identically. Report **production-render QA** as
 unverified unless a separately authorized Loops preview was also inspected.
 
 LMX has no local renderer. Production-render QA requires a separately authorized
 Loops draft preview; if unavailable, report it as incomplete. Guardian proves
 semantic validity, not Gmail/Outlook appearance.
-
-## CI and runtime behavior
-
-A push to Gram `main` runs `.github/workflows/pr.yaml`, which dispatches
-gram-infra’s `Prepare Release`. The checked-out manifest is sufficient to trigger
-create/update, Guardian, publish, ID-overlay generation, and the release PR.
-
-Delivery timeline:
-
-1. Gram `main` dispatches a dev prepare after its CI and images pass.
-2. Prepare reconciles/publishes in dev and opens/updates the gram-infra dev
-   release PR with `email-templates-dev.yaml`.
-3. Merging that PR lets ArgoCD deploy the image and ID map to dev GKE.
-4. The merge triggers promotion. Each target prepare independently reconciles
-   its Loops environment, writes that environment's IDs, and opens its promotion
-   PR; merging it lets ArgoCD deploy the target map.
-
-Confirm success from the workflow summary, generated overlay diff, green pod
-startup, and the expected `GRAM_EMAIL_TEMPLATE_IDS` key count. A template-source
-task stops here. If the request also introduces a new sending event, wire its
-`email.Service.Send` call and add a focused event-path test in the same change.
-
-- First sync creates/reuses only the exact v2 managed name; legacy emails remain
-  untouched for rollback. Duplicate managed names fail closed.
-- A committed ID is authoritative. If it belongs to another name, CI stops.
-- A partial run is recoverable by exact managed name before its ID is committed.
-- gram-infra writes non-secret IDs to `email-templates-<env>.yaml`; Helm injects
-  JSON as `GRAM_EMAIL_TEMPLATE_IDS` into server and worker.
-- With Loops enabled, application startup rejects missing or unknown keys.
-- Do not hand-edit generated IDs or store them in Postgres.
-
-Recovery is safe and rerunnable:
-
-| Failure                       | Result / action                                              |
-| ----------------------------- | ------------------------------------------------------------ |
-| Created before ID commit      | Rerun; exact managed name recovers it                        |
-| Update/publish failure        | Rerun; existing draft is reconciled                          |
-| Guardian error                | Fix source; rerun release                                    |
-| Duplicate managed name        | Remove/rename duplicate in Loops with authorization          |
-| Revision conflict             | Rerun to fetch current revision; reconcile intentional edits |
-| Committed ID points elsewhere | Stop; repair generated mapping/provider state deliberately   |
-
-## Common failures
-
-- Uploading MJML through the Content API: automation requires LMX.
-- Adopting or renaming legacy Loops records instead of creating v2 records.
-- Treating the starter as runtime inheritance.
-- Committing an LMX variable absent from the Go template, or leaving dead backend
-  merge variables for raw HTML LMX cannot render.
-- Running live sync locally or exposing the API key in argv, output, or Git.

--- a/server/internal/email/loops/README.md
+++ b/server/internal/email/loops/README.md
@@ -7,30 +7,6 @@ Every application template has:
 - metadata and its exact variable contract in `manifest.json`;
 - an LMX body named `<logical_key>.lmx`.
 
-Loops assigns different transactional IDs in dev, test, and prod. Application
-code never owns those IDs. Release CI reconciles this source into the target
-Loops environment and commits the resolved key-to-ID map to gram-infra.
-
-## Lifecycle
-
-On the first release containing a manifest entry, CI:
-
-1. looks only for its managed name, `gram.transactional.v2.<logical_key>`;
-2. creates a new Loops transactional email when that name does not exist;
-3. updates the draft from the LMX source with optimistic revision protection;
-4. runs Loops Guardian and stops on any error;
-5. publishes the draft;
-6. writes the resolved non-secret ID to
-   `gram-infra/infra/helm/gram/email-templates-<env>.yaml`.
-
-Legacy Loops emails are not adopted, renamed, or deleted. They remain available
-for rollback. If CI creates a v2 email but fails before committing the mapping,
-the next run recovers it by exact managed name instead of creating a duplicate.
-
-After the first release, the committed ID is authoritative. CI verifies that it
-still belongs to the expected managed name, then updates it in place. An existing
-published message whose subject, preview, and LMX already match is left unchanged.
-
 ## Adding or changing a template
 
 1. Add or update the typed Go template and `RegisteredTemplates` entry.
@@ -44,37 +20,19 @@ published message whose subject, preview, and LMX already match is left unchange
    ```
 
 Validation requires the manifest variable list to match the Go `Variables()`
-contract exactly. It also checks every `.lmx` file recursively for XML
+contract exactly. It checks every `.lmx` file recursively for XML
 well-formedness and explicitly set Loops-supported attribute ranges, and rejects
 undeclared or accidentally unused variables in registered templates.
-Variables used only by a Section `if` remain part of the application contract,
-although Loops omits them from the published `dataVariables` metadata; release
-verification compares that metadata against rendered variables only.
 
 ## Design system
 
-The approved visual source is `transactional_base.mjml`: a light editorial shell
+The intended design reference is `transactional_base.mjml`: a light editorial shell
 with the Speakeasy spectrum rail, wordmark, compact mono labels, Tobias display
 headlines, square black actions, neutral outlined details, and a dashed pale
 footer. `weekly_usage_summary.mjml` specializes that system for a data-heavy
 report. Do not replace this language with a separate LMX-derived theme.
 
-`transactional_base.lmx` is the canonical production translation. It uses the
-approved text-only header and Inter fallback because LMX cannot express the raw
-spectrum table, hosted font faces, or public favicon from MJML. It preserves the
-same hierarchy, palette, square action, panels, and pale footer rather than
-inventing replacements. Automated sync uses LMX because the Loops Content API
-does not accept MJML; the MJML files remain canonical for design and visual QA.
-
-## Release and runtime handoff
-
-Only the gram-infra GitHub release workflows set `SYNC_LOOPS_EMAILS=true`.
-The sync task reads the target environment's `LOOPS_API_KEY` directly from
-Secret Manager, masks it, and passes it only to the child process. The key is
-never written to Git, a command argument, or workflow output.
-
-The generated overlay is layered by ArgoCD and Helm serializes its `ids` map into
-`GRAM_EMAIL_TEMPLATE_IDS` for server and worker. When Loops is enabled, both
-processes fail startup if any registered key is missing or any unknown key is
-present. Local development accepts an empty map because the Loops transport is
-disabled there.
+`transactional_base.lmx` is the production translation. LMX cannot express the
+raw spectrum table, hosted font faces, or public favicon from MJML, so it uses
+the approved text-only header and Inter fallback while preserving the same
+hierarchy, palette, square action, panels, and pale footer.

--- a/server/internal/email/loops/access_request.lmx
+++ b/server/internal/email/loops/access_request.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" dividerColor="#BABABA" dividerBorderWidth="1" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">ACCESS REQUEST</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.requester_name} needs access</H1>

--- a/server/internal/email/loops/custom_domain_unhealthy.lmx
+++ b/server/internal/email/loops/custom_domain_unhealthy.lmx
@@ -1,14 +1,18 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">CUSTOM DOMAIN · ACTION REQUIRED</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Your custom domain needs attention.</H1>
-<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Speakeasy detected a health issue with <Strong textColor="#121212">{data.domain}</Strong>. Review the reported issue and update the domain configuration.</Paragraph>
-<Section blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Speakeasy detected a health issue with {data.domain}. Review the reported issue and update the domain configuration.</Paragraph>
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">REPORTED ISSUE</Strong></Paragraph>
-  <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">{data.issue_message}</Text></Paragraph>
+  <Paragraph fontSize="14" lineHeight="155" paddingTop="8">{data.issue_message}</Paragraph>
 </Section>
 <Button href="{data.domain_link}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">Review domain →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">

--- a/server/internal/email/loops/enterprise_admin_onboarding.lmx
+++ b/server/internal/email/loops/enterprise_admin_onboarding.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">ENTERPRISE ONBOARDING</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Set up your AI control plane</H1>

--- a/server/internal/email/loops/openrouter_chat_credits_threshold.lmx
+++ b/server/internal/email/loops/openrouter_chat_credits_threshold.lmx
@@ -1,16 +1,20 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">CHAT CREDIT ALERT</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of chat credits used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is approaching its platform-managed chat credit cap.</Paragraph>
-<Section if="{data.exhausted}" ifOperation="equal" ifValue="true" blockColor="#FFF1ED" blockBorderColor="#E8A18D" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+<Section blockColor="#FFF1ED" blockBorderWidth="1" blockBorderColor="#E8A18D" if="{data.exhausted}" ifOperation="equal" ifValue="true" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#C83228">CREDITS EXHAUSTED</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Chat surfaces may fail until credits reset or the limit changes.</Paragraph>
 </Section>
-<Section if="{data.exhausted}" ifOperation="equal" ifValue="false" blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" if="{data.exhausted}" ifOperation="equal" ifValue="false" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Review usage before the cap is exhausted.</Paragraph>
 </Section>

--- a/server/internal/email/loops/openrouter_internal_credits_threshold.lmx
+++ b/server/internal/email/loops/openrouter_internal_credits_threshold.lmx
@@ -1,16 +1,20 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">INTERNAL AI CREDIT ALERT</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of internal credits used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is approaching the credit cap used for platform analysis.</Paragraph>
-<Section if="{data.exhausted}" ifOperation="equal" ifValue="true" blockColor="#FFF1ED" blockBorderColor="#E8A18D" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+<Section blockColor="#FFF1ED" blockBorderWidth="1" blockBorderColor="#E8A18D" if="{data.exhausted}" ifOperation="equal" ifValue="true" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#C83228">CREDITS EXHAUSTED</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Risk and analysis coverage may be reduced until credits reset or the limit changes.</Paragraph>
 </Section>
-<Section if="{data.exhausted}" ifOperation="equal" ifValue="false" blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" if="{data.exhausted}" ifOperation="equal" ifValue="false" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Review usage before analysis coverage is affected.</Paragraph>
 </Section>

--- a/server/internal/email/loops/team_invite.lmx
+++ b/server/internal/email/loops/team_invite.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">TEAM INVITE</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Join {data.organization_name}</H1>

--- a/server/internal/email/loops/transactional_base.lmx
+++ b/server/internal/email/loops/transactional_base.lmx
@@ -7,12 +7,12 @@
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
   </ColumnItem>
 </Columns>
-<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40">{data.email_eyebrow}</Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">{data.email_eyebrow}</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.email_headline}</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.email_body}</Paragraph>
 <Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="12" lineHeight="140">{data.detail_label}</Paragraph>
-  <Paragraph fontSize="14" lineHeight="155" paddingTop="8">{data.detail_value}</Paragraph>
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">{data.detail_label}</Strong></Paragraph>
+  <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">{data.detail_value}</Text></Paragraph>
 </Section>
 <Button href="{data.action_url}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">{data.action_label} →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">

--- a/server/internal/email/loops/transactional_base.lmx
+++ b/server/internal/email/loops/transactional_base.lmx
@@ -1,14 +1,18 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
-<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">{data.email_eyebrow}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40">{data.email_eyebrow}</Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.email_headline}</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.email_body}</Paragraph>
-<Section blockColor="#FFFFFF" blockBorderColor="#DBDBDB" blockBorderWidth="1" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
-  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">{data.detail_label}</Strong></Paragraph>
-  <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">{data.detail_value}</Text></Paragraph>
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+  <Paragraph fontSize="12" lineHeight="140">{data.detail_label}</Paragraph>
+  <Paragraph fontSize="14" lineHeight="155" paddingTop="8">{data.detail_value}</Paragraph>
 </Section>
 <Button href="{data.action_url}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">{data.action_label} →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">

--- a/server/internal/email/loops/tum_usage_overage.lmx
+++ b/server/internal/email/loops/tum_usage_overage.lmx
@@ -1,18 +1,26 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="30" heading2LineHeight="115" heading2LetterSpacing="-1" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#FFFFFF" heading2FontSize="30" heading2LineHeight="115" heading2LetterSpacing="-1" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
-<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#C83228">ALLOWANCE EXCEEDED · {data.organization_name}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#C83228">ALLOWANCE EXCEEDED · </Strong>{data.organization_name}</Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of allowance used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} has used {data.usage_tokens} against an allowance of {data.token_limit}.</Paragraph>
 <Section blockColor="#121212" paddingTop="28" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#BABABA">OVER ALLOWANCE</Strong></Paragraph>
-  <H2 paddingTop="10"><Text textColor="#FFFFFF">{data.overage_tokens}</Text></H2>
+  <H2 paddingTop="10">{data.overage_tokens}</H2>
 </Section>
-<Columns gap="12" widths="50,50" stackOnMobile="true" paddingRight="40" paddingBottom="32" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br /><Text textColor="#121212">{data.cycle_start}</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br /><Text textColor="#121212">{data.cycle_end}</Text></Paragraph></ColumnItem>
+<Columns gap="12" paddingRight="40" paddingBottom="32" paddingLeft="40">
+  <ColumnItem>
+    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br />{data.cycle_start}</Paragraph>
+  </ColumnItem>
+  <ColumnItem>
+    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br />{data.cycle_end}</Paragraph>
+  </ColumnItem>
 </Columns>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>

--- a/server/internal/email/loops/tum_usage_threshold.lmx
+++ b/server/internal/email/loops/tum_usage_threshold.lmx
@@ -1,14 +1,22 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
-<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">USAGE ALERT · {data.organization_name}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">USAGE ALERT · </Strong>{data.organization_name}</Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of allowance used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} has used {data.usage_tokens} of {data.token_limit} tokens under management.</Paragraph>
-<Columns gap="12" widths="50,50" stackOnMobile="true" blockColor="#FFFFFF" paddingRight="40" paddingBottom="32" paddingLeft="40">
-  <ColumnItem><Paragraph blockColor="#FFFFFF" fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br /><Text textColor="#121212">{data.cycle_start}</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph blockColor="#FFFFFF" fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br /><Text textColor="#121212">{data.cycle_end}</Text></Paragraph></ColumnItem>
+<Columns gap="12" blockColor="#FFFFFF" paddingRight="40" paddingBottom="32" paddingLeft="40">
+  <ColumnItem>
+    <Paragraph fontSize="12" lineHeight="140" blockColor="#FFFFFF" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br />{data.cycle_start}</Paragraph>
+  </ColumnItem>
+  <ColumnItem>
+    <Paragraph fontSize="12" lineHeight="140" blockColor="#FFFFFF" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br />{data.cycle_end}</Paragraph>
+  </ColumnItem>
 </Columns>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>

--- a/server/internal/email/loops/weekly_usage_summary.lmx
+++ b/server/internal/email/loops/weekly_usage_summary.lmx
@@ -19,7 +19,7 @@
     <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br />{data.previous_total_tokens}</Paragraph>
   </ColumnItem>
   <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br />{data.cycle_elapsed_percent}<Text textColor="#121212">%</Text></Paragraph>
+    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br /><Text textColor="#121212">{data.cycle_elapsed_percent}%</Text></Paragraph>
   </ColumnItem>
   <ColumnItem>
     <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br />{data.days_remaining}</Paragraph>

--- a/server/internal/email/loops/weekly_usage_summary.lmx
+++ b/server/internal/email/loops/weekly_usage_summary.lmx
@@ -1,22 +1,32 @@
-<Style backgroundColor="#FAFAFA" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonTextColor="#FFFFFF" buttonBorderRadius="0" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonTextFontSize="13" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="48" heading2LineHeight="100" heading2LetterSpacing="-1.5" />
-<Columns gap="12" widths="65,35" verticalAlignment="middle" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
-  <ColumnItem><Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph align="right" fontSize="12" lineHeight="140"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph></ColumnItem>
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#FFFFFF" heading2FontSize="48" heading2LineHeight="100" heading2LetterSpacing="-1.5" heading3Color="#EBEBEB" heading3FontSize="12" heading3LineHeight="150" heading3LetterSpacing="0" />
+<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
 </Columns>
-<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">WEEKLY USAGE · {data.organization_name}</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">WEEKLY USAGE · </Strong>{data.organization_name}</Paragraph>
 <H1 paddingRight="40" paddingBottom="36" paddingLeft="40">Your usage,<Br />at a glance.</H1>
 <Section blockColor="#121212" paddingTop="34" paddingRight="40" paddingBottom="36" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#BABABA">TOKENS MANAGED · CYCLE TO DATE</Strong></Paragraph>
-  <H2 paddingTop="13"><Text textColor="#FFFFFF">{data.total_tokens}</Text></H2>
-  <Paragraph fontSize="12" lineHeight="150" paddingTop="14"><Text textColor="#EBEBEB">{data.total_change_percent} vs. the same point last cycle</Text></Paragraph>
+  <H2 paddingTop="13">{data.total_tokens}</H2>
+  <H3 paddingTop="14">{data.total_change_percent} vs. the same point last cycle</H3>
 </Section>
-<Columns gap="12" widths="33,34,33" verticalAlignment="top" stackOnMobile="true" paddingBottom="32">
-  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br /><Text textColor="#121212">{data.previous_total_tokens}</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br /><Text textColor="#121212">{data.cycle_elapsed_percent}%</Text></Paragraph></ColumnItem>
-  <ColumnItem><Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br /><Text textColor="#121212">{data.days_remaining}</Text></Paragraph></ColumnItem>
+<Columns gap="12" paddingBottom="32">
+  <ColumnItem>
+    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br />{data.previous_total_tokens}</Paragraph>
+  </ColumnItem>
+  <ColumnItem>
+    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br />{data.cycle_elapsed_percent}<Text textColor="#121212">%</Text></Paragraph>
+  </ColumnItem>
+  <ColumnItem>
+    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br />{data.days_remaining}</Paragraph>
+  </ColumnItem>
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingRight="40" paddingBottom="10" paddingLeft="40"><Strong textColor="#757575">BILLING CYCLE</Strong></Paragraph>
-<Paragraph fontSize="14" lineHeight="160" paddingRight="40" paddingBottom="36" paddingLeft="40">Your current cycle ends on <Strong textColor="#121212">{data.cycle_end_date}</Strong>.</Paragraph>
+<Paragraph fontSize="14" lineHeight="160" paddingRight="40" paddingBottom="36" paddingLeft="40">Your current cycle ends on {data.cycle_end_date}.</Paragraph>
 <Button href="{data.view_usage_url}" paddingRight="40" paddingBottom="48" paddingLeft="40">View detailed usage →</Button>
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>

--- a/server/internal/email/loopsync/client.go
+++ b/server/internal/email/loopsync/client.go
@@ -11,20 +11,20 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 const (
-	DefaultBaseURL = "https://app.loops.so/api/v1"
-	maxRetryDelay  = 30 * time.Second
+	DefaultBaseURL         = "https://app.loops.so/api/v1"
+	maxRetryDelay          = 30 * time.Second
+	mutationRequestSpacing = 3 * time.Second
 )
 
 type TransactionalEmail struct {
-	ID                                 string   `json:"id"`
-	Name                               string   `json:"name"`
-	DraftEmailMessageID                *string  `json:"draftEmailMessageId"`
-	DraftEmailMessageContentRevisionID *string  `json:"draftEmailMessageContentRevisionId"`
-	PublishedEmailMessageID            *string  `json:"publishedEmailMessageId"`
-	DataVariables                      []string `json:"dataVariables"`
+	ID                  string  `json:"id"`
+	Name                string  `json:"name"`
+	DraftEmailMessageID *string `json:"draftEmailMessageId"`
 }
 
 type EmailMessage struct {
@@ -57,7 +57,7 @@ type API interface {
 	GetEmailMessage(context.Context, string) (EmailMessage, error)
 	UpdateEmailMessage(context.Context, string, UpdateEmailMessageInput) (EmailMessage, error)
 	Guardian(context.Context, string) (GuardianResult, error)
-	Publish(context.Context, string) (TransactionalEmail, error)
+	Publish(context.Context, string) error
 }
 
 type UpdateEmailMessageInput struct {
@@ -71,9 +71,10 @@ type UpdateEmailMessageInput struct {
 }
 
 type Client struct {
-	baseURL    string
-	apiKey     string
-	httpClient HTTPDoer
+	baseURL         string
+	apiKey          string
+	httpClient      HTTPDoer
+	mutationLimiter *rate.Limiter
 }
 
 type HTTPDoer interface {
@@ -86,7 +87,12 @@ type requestOptions struct {
 }
 
 func NewClient(baseURL, apiKey string, httpClient HTTPDoer) *Client {
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), apiKey: apiKey, httpClient: httpClient}
+	return &Client{
+		baseURL:         strings.TrimRight(baseURL, "/"),
+		apiKey:          apiKey,
+		httpClient:      httpClient,
+		mutationLimiter: rate.NewLimiter(rate.Every(mutationRequestSpacing), 1),
+	}
 }
 
 func (c *Client) ListTransactionalEmails(ctx context.Context) ([]TransactionalEmail, error) {
@@ -152,10 +158,8 @@ func (c *Client) Guardian(ctx context.Context, id string) (GuardianResult, error
 	return result, err
 }
 
-func (c *Client) Publish(ctx context.Context, id string) (TransactionalEmail, error) {
-	var result TransactionalEmail
-	err := c.do(ctx, http.MethodPost, "/transactional-emails/"+url.PathEscape(id)+"/publish", nil, &result, requestOptions{expectedStatus: http.StatusOK, retryable: false})
-	return result, err
+func (c *Client) Publish(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodPost, "/transactional-emails/"+url.PathEscape(id)+"/publish", nil, nil, requestOptions{expectedStatus: http.StatusOK, retryable: false})
 }
 
 func (c *Client) do(ctx context.Context, method, path string, input, output any, options requestOptions) error {
@@ -169,6 +173,12 @@ func (c *Client) do(ctx context.Context, method, path string, input, output any,
 	}
 
 	for attempt := range 3 {
+		if method != http.MethodGet {
+			if err := c.mutationLimiter.Wait(ctx); err != nil {
+				return fmt.Errorf("wait for Loops Content API mutation rate limit: %w", err)
+			}
+		}
+
 		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(payload))
 		if err != nil {
 			return fmt.Errorf("build Loops request: %w", err)
@@ -197,7 +207,7 @@ func (c *Client) do(ctx context.Context, method, path string, input, output any,
 		}
 
 		if attempt < 2 && options.retryable && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500) {
-			delay := retryDelay(time.Now(), attempt, resp.Header.Get("Retry-After"))
+			delay := retryDelay(time.Now(), attempt, resp.Header.Get("Retry-After"), resp.StatusCode)
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("wait to retry Loops Content API: %w", ctx.Err())
@@ -218,8 +228,11 @@ func (c *Client) do(ctx context.Context, method, path string, input, output any,
 	return fmt.Errorf("loops Content API %s %s exhausted retries", method, path)
 }
 
-func retryDelay(now time.Time, attempt int, retryAfter string) time.Duration {
+func retryDelay(now time.Time, attempt int, retryAfter string, statusCode int) time.Duration {
 	delay := time.Duration(attempt+1) * time.Second
+	if statusCode == http.StatusTooManyRequests {
+		delay = maxRetryDelay
+	}
 	if seconds, err := strconv.Atoi(retryAfter); err == nil {
 		if seconds >= 0 {
 			maxSeconds := int(maxRetryDelay / time.Second)

--- a/server/internal/email/loopsync/client_test.go
+++ b/server/internal/email/loopsync/client_test.go
@@ -12,7 +12,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
+
+func newTestClient(baseURL, apiKey string, httpClient HTTPDoer) *Client {
+	client := NewClient(baseURL, apiKey, httpClient)
+	client.mutationLimiter = rate.NewLimiter(rate.Inf, 1)
+	return client
+}
+
+func TestNewClient_ConfiguresMutationPacing(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("https://example.com", "test-key", nil)
+	require.InDelta(t, float64(rate.Every(mutationRequestSpacing)), float64(client.mutationLimiter.Limit()), 0.000_001)
+	require.Equal(t, 1, client.mutationLimiter.Burst())
+}
 
 func TestClient_ListsAndCreatesTransactionalEmails(t *testing.T) {
 	t.Parallel()
@@ -42,17 +57,13 @@ func TestClient_ListsAndCreatesTransactionalEmails(t *testing.T) {
 
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
-	client := NewClient(server.URL+"/api/v1", "test-key", server.Client())
+	client := newTestClient(server.URL+"/api/v1", "test-key", server.Client())
 
 	listed, err := client.ListTransactionalEmails(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, []TransactionalEmail{{
-		ID:                                 "id-1",
-		Name:                               "gram.transactional.v2.team_invite",
-		DraftEmailMessageID:                nil,
-		DraftEmailMessageContentRevisionID: nil,
-		PublishedEmailMessageID:            nil,
-		DataVariables:                      nil,
+		ID:   "id-1",
+		Name: "gram.transactional.v2.team_invite",
 	}}, listed)
 
 	created, err := client.CreateTransactionalEmail(t.Context(), "gram.transactional.v2.team_invite")
@@ -101,7 +112,7 @@ func TestClient_TransactionalLifecycle(t *testing.T) {
 
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
-	client := NewClient(server.URL+"/api/v1", "test-key", server.Client())
+	client := newTestClient(server.URL+"/api/v1", "test-key", server.Client())
 
 	transactional, err := client.GetTransactionalEmail(t.Context(), "id-1")
 	require.NoError(t, err)
@@ -131,9 +142,7 @@ func TestClient_TransactionalLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, guardian.Errors)
 
-	published, err := client.Publish(t.Context(), "id-1")
-	require.NoError(t, err)
-	require.Equal(t, []string{"resource_name"}, published.DataVariables)
+	require.NoError(t, client.Publish(t.Context(), "id-1"))
 }
 
 func TestClient_DoesNotRetryCreate(t *testing.T) {
@@ -146,7 +155,7 @@ func TestClient_DoesNotRetryCreate(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "test-key", server.Client())
+	client := newTestClient(server.URL, "test-key", server.Client())
 	_, err := client.CreateTransactionalEmail(t.Context(), "gram.transactional.v2.example_notice")
 	require.Error(t, err)
 	require.Equal(t, int32(1), calls.Load())
@@ -166,7 +175,7 @@ func TestClient_RetriesRevisionGuardedUpdate(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := NewClient(server.URL, "test-key", server.Client())
+	client := newTestClient(server.URL, "test-key", server.Client())
 	message, err := client.UpdateEmailMessage(t.Context(), "message-1", UpdateEmailMessageInput{
 		ExpectedRevisionID: "revision-1",
 		Subject:            "Example notice",
@@ -186,14 +195,22 @@ func TestRetryDelay_HonorsHTTPDateBelowCap(t *testing.T) {
 
 	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
 	retryAt := now.Add(15 * time.Second)
-	require.Equal(t, 15*time.Second, retryDelay(now, 0, retryAt.Format(http.TimeFormat)))
+	require.Equal(t, 15*time.Second, retryDelay(now, 0, retryAt.Format(http.TimeFormat), http.StatusTooManyRequests))
 }
 
 func TestRetryDelay_CapsServerDelay(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
-	require.Equal(t, maxRetryDelay, retryDelay(now, 0, "3600"))
-	require.Equal(t, maxRetryDelay, retryDelay(now, 0, strconv.Itoa(math.MaxInt)))
-	require.Equal(t, maxRetryDelay, retryDelay(now, 0, now.Add(time.Hour).Format(http.TimeFormat)))
+	require.Equal(t, maxRetryDelay, retryDelay(now, 0, "3600", http.StatusTooManyRequests))
+	require.Equal(t, maxRetryDelay, retryDelay(now, 0, strconv.Itoa(math.MaxInt), http.StatusTooManyRequests))
+	require.Equal(t, maxRetryDelay, retryDelay(now, 0, now.Add(time.Hour).Format(http.TimeFormat), http.StatusTooManyRequests))
+}
+
+func TestRetryDelay_RateLimitWithoutHeaderUsesCap(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	require.Equal(t, maxRetryDelay, retryDelay(now, 0, "", http.StatusTooManyRequests))
+	require.Equal(t, time.Second, retryDelay(now, 0, "", http.StatusInternalServerError))
 }

--- a/server/internal/email/loopsync/manifest.go
+++ b/server/internal/email/loopsync/manifest.go
@@ -33,15 +33,13 @@ type MessageDefaults struct {
 }
 
 type TemplateSpec struct {
-	ManagedName        string   `json:"managed_name"`
-	Subject            string   `json:"subject"`
-	PreviewText        string   `json:"preview_text"`
-	Source             string   `json:"source"`
-	Variables          []string `json:"variables"`
-	UnusedVariables    []string `json:"unused_variables,omitempty"`
-	LMX                string   `json:"-"`
-	SourceVariables    []string `json:"-"`
-	PublishedVariables []string `json:"-"`
+	ManagedName     string   `json:"managed_name"`
+	Subject         string   `json:"subject"`
+	PreviewText     string   `json:"preview_text"`
+	Source          string   `json:"source"`
+	Variables       []string `json:"variables"`
+	UnusedVariables []string `json:"unused_variables,omitempty"`
+	LMX             string   `json:"-"`
 }
 
 func LoadManifest(path string) (*Manifest, error) {
@@ -137,12 +135,6 @@ func (m *Manifest) Validate() error {
 		}
 
 		spec.LMX = strings.TrimSpace(string(lmx))
-		spec.SourceVariables = sourceVariables
-		publishedVariables, err := extractPublishedDataVariables(spec.Subject, spec.PreviewText, lmx)
-		if err != nil {
-			return fmt.Errorf("extract published LMX variables for %q: %w", key, err)
-		}
-		spec.PublishedVariables = publishedVariables
 		m.Templates[key] = spec
 	}
 	return nil
@@ -230,35 +222,6 @@ func extractDataVariables(content string) []string {
 	}
 	slices.Sort(variables)
 	return variables
-}
-
-func extractPublishedDataVariables(subject, previewText string, lmx []byte) ([]string, error) {
-	var published strings.Builder
-	published.WriteString(subject)
-	published.WriteByte('\n')
-	published.WriteString(previewText)
-	published.WriteByte('\n')
-
-	err := walkXML(lmx, func(token xml.Token) error {
-		switch token := token.(type) {
-		case xml.StartElement:
-			for _, attribute := range token.Attr {
-				if token.Name.Local == "Section" && attribute.Name.Local == "if" {
-					continue
-				}
-				published.WriteString(attribute.Value)
-				published.WriteByte('\n')
-			}
-		case xml.CharData:
-			published.Write(token)
-			published.WriteByte('\n')
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return extractDataVariables(published.String()), nil
 }
 
 func walkXML(lmx []byte, visit func(xml.Token) error) error {

--- a/server/internal/email/loopsync/manifest_test.go
+++ b/server/internal/email/loopsync/manifest_test.go
@@ -149,7 +149,7 @@ func TestManifestValidate_ValidatesNestedUnregisteredLMXFiles(t *testing.T) {
 	require.ErrorContains(t, err, `Paragraph attribute "fontSize" must be an integer between 12 and 64 (got "10")`)
 }
 
-func TestManifestValidate_SeparatesConditionOnlyPublishedVariables(t *testing.T) {
+func TestManifestValidate_AcceptsConditionVariable(t *testing.T) {
 	t.Parallel()
 
 	manifest := validManifest(t)
@@ -160,9 +160,6 @@ func TestManifestValidate_SeparatesConditionOnlyPublishedVariables(t *testing.T)
 	require.NoError(t, os.WriteFile(filepath.Join(manifest.Dir, "example_notice.lmx"), []byte(lmx), 0o600))
 
 	require.NoError(t, manifest.Validate())
-	spec = manifest.Templates["example_notice"]
-	require.Equal(t, []string{"resource_name", "show_resource"}, spec.SourceVariables)
-	require.Equal(t, []string{"resource_name"}, spec.PublishedVariables)
 }
 
 func validManifest(t *testing.T) *Manifest {
@@ -180,15 +177,13 @@ func validManifest(t *testing.T) *Manifest {
 		},
 		Templates: map[string]TemplateSpec{
 			"example_notice": {
-				ManagedName:        "gram.transactional.v2.example_notice",
-				Subject:            "Example notice",
-				PreviewText:        "Review this notice.",
-				Source:             "example_notice.lmx",
-				Variables:          []string{"resource_name"},
-				UnusedVariables:    nil,
-				LMX:                "",
-				SourceVariables:    nil,
-				PublishedVariables: nil,
+				ManagedName:     "gram.transactional.v2.example_notice",
+				Subject:         "Example notice",
+				PreviewText:     "Review this notice.",
+				Source:          "example_notice.lmx",
+				Variables:       []string{"resource_name"},
+				UnusedVariables: nil,
+				LMX:             "",
 			},
 		},
 		Dir: dir,

--- a/server/internal/email/loopsync/reconcile.go
+++ b/server/internal/email/loopsync/reconcile.go
@@ -35,136 +35,89 @@ func (r *Reconciler) Reconcile(ctx context.Context, manifest *Manifest, existing
 	resolved := make(map[string]string, len(keys))
 	for _, key := range keys {
 		spec := manifest.Templates[key]
-		transactional, created, err := r.resolve(ctx, key, spec, existingIDs[key], byName)
+		transactional, err := r.resolve(ctx, key, spec, existingIDs[key], byName)
 		if err != nil {
 			return nil, err
 		}
 		resolved[key] = transactional.ID
 
-		changed, err := r.syncOne(ctx, manifest.Defaults, spec, transactional, created)
-		if err != nil {
+		if err := r.syncOne(ctx, manifest.Defaults, spec, transactional); err != nil {
 			return nil, fmt.Errorf("sync email template %q: %w", key, err)
 		}
 		if r.Log != nil {
-			status := "unchanged"
-			if changed {
-				status = "published"
-			}
-			_, _ = fmt.Fprintf(r.Log, "%s: %s\n", key, status)
+			_, _ = fmt.Fprintf(r.Log, "%s: published\n", key)
 		}
 	}
 	return resolved, nil
 }
 
-func (r *Reconciler) resolve(ctx context.Context, key string, spec TemplateSpec, mappedID string, byName map[string][]TransactionalEmail) (TransactionalEmail, bool, error) {
+func (r *Reconciler) resolve(ctx context.Context, key string, spec TemplateSpec, mappedID string, byName map[string][]TransactionalEmail) (TransactionalEmail, error) {
 	if mappedID != "" {
 		transactional, err := r.API.GetTransactionalEmail(ctx, mappedID)
 		if err != nil {
-			return TransactionalEmail{}, false, fmt.Errorf("resolve mapped email template %q: %w", key, err)
+			return TransactionalEmail{}, fmt.Errorf("resolve mapped email template %q: %w", key, err)
 		}
 		if transactional.Name != spec.ManagedName {
-			return TransactionalEmail{}, false, fmt.Errorf("resolve mapped email template %q: ID %q belongs to %q, want %q", key, mappedID, transactional.Name, spec.ManagedName)
+			return TransactionalEmail{}, fmt.Errorf("resolve mapped email template %q: ID %q belongs to %q, want %q", key, mappedID, transactional.Name, spec.ManagedName)
 		}
-		return transactional, false, nil
+		return transactional, nil
 	}
 
 	matches := byName[spec.ManagedName]
 	if len(matches) > 1 {
-		return TransactionalEmail{}, false, fmt.Errorf("resolve email template %q: found %d Loops emails named %q", key, len(matches), spec.ManagedName)
+		return TransactionalEmail{}, fmt.Errorf("resolve email template %q: found %d Loops emails named %q", key, len(matches), spec.ManagedName)
 	}
 	if len(matches) == 1 {
-		return matches[0], false, nil
+		return matches[0], nil
 	}
 
 	transactional, err := r.API.CreateTransactionalEmail(ctx, spec.ManagedName)
 	if err != nil {
-		return TransactionalEmail{}, false, fmt.Errorf("create email template %q: %w", key, err)
+		return TransactionalEmail{}, fmt.Errorf("create email template %q: %w", key, err)
 	}
-	return transactional, true, nil
+	return transactional, nil
 }
 
-func (r *Reconciler) syncOne(ctx context.Context, defaults MessageDefaults, spec TemplateSpec, transactional TransactionalEmail, created bool) (bool, error) {
-	if !created && transactional.PublishedEmailMessageID != nil {
-		published, err := r.API.GetEmailMessage(ctx, *transactional.PublishedEmailMessageID)
-		if err != nil {
-			return false, fmt.Errorf("get published message: %w", err)
-		}
-		if sameContent(published, defaults, spec) {
-			if err := r.verifyPublishedVariables(ctx, transactional.ID, spec); err != nil {
-				return false, err
-			}
-			return false, nil
-		}
-	}
-
+func (r *Reconciler) syncOne(ctx context.Context, defaults MessageDefaults, spec TemplateSpec, transactional TransactionalEmail) error {
 	transactional, err := r.API.EnsureDraft(ctx, transactional.ID)
 	if err != nil {
-		return false, fmt.Errorf("ensure draft: %w", err)
+		return fmt.Errorf("ensure draft: %w", err)
 	}
 	if transactional.DraftEmailMessageID == nil {
-		return false, fmt.Errorf("ensure draft: Loops returned no draft email message ID")
+		return fmt.Errorf("ensure draft: Loops returned no draft email message ID")
 	}
 
 	draft, err := r.API.GetEmailMessage(ctx, *transactional.DraftEmailMessageID)
 	if err != nil {
-		return false, fmt.Errorf("get draft message: %w", err)
+		return fmt.Errorf("get draft message: %w", err)
 	}
-	if !sameContent(draft, defaults, spec) {
-		draft, err = r.API.UpdateEmailMessage(ctx, draft.ID, UpdateEmailMessageInput{
-			ExpectedRevisionID: draft.ContentRevisionID,
-			Subject:            spec.Subject,
-			PreviewText:        spec.PreviewText,
-			FromName:           defaults.FromName,
-			FromEmail:          defaults.FromEmail,
-			ReplyToEmail:       defaults.ReplyToEmail,
-			LMX:                spec.LMX,
-		})
-		if err != nil {
-			return false, fmt.Errorf("update draft message: %w", err)
-		}
+	draft, err = r.API.UpdateEmailMessage(ctx, draft.ID, UpdateEmailMessageInput{
+		ExpectedRevisionID: draft.ContentRevisionID,
+		Subject:            spec.Subject,
+		PreviewText:        spec.PreviewText,
+		FromName:           defaults.FromName,
+		FromEmail:          defaults.FromEmail,
+		ReplyToEmail:       defaults.ReplyToEmail,
+		LMX:                spec.LMX,
+	})
+	if err != nil {
+		return fmt.Errorf("update draft message: %w", err)
 	}
 
 	guardian, err := r.API.Guardian(ctx, draft.ID)
 	if err != nil {
-		return false, fmt.Errorf("run Guardian: %w", err)
+		return fmt.Errorf("run Guardian: %w", err)
 	}
 	if len(guardian.Errors) > 0 {
 		messages := make([]string, 0, len(guardian.Errors))
 		for _, issue := range guardian.Errors {
 			messages = append(messages, issue.Rule+": "+issue.Description)
 		}
-		return false, fmt.Errorf("Guardian rejected draft: %s", strings.Join(messages, "; "))
+		return fmt.Errorf("Guardian rejected draft: %s", strings.Join(messages, "; "))
 	}
 
-	if _, err := r.API.Publish(ctx, transactional.ID); err != nil {
-		return false, fmt.Errorf("publish draft: %w", err)
-	}
-	if err := r.verifyPublishedVariables(ctx, transactional.ID, spec); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (r *Reconciler) verifyPublishedVariables(ctx context.Context, transactionalID string, spec TemplateSpec) error {
-	published, err := r.API.GetTransactionalEmail(ctx, transactionalID)
-	if err != nil {
-		return fmt.Errorf("verify published email: %w", err)
-	}
-	want := slices.Clone(spec.PublishedVariables)
-	got := slices.Clone(published.DataVariables)
-	slices.Sort(want)
-	slices.Sort(got)
-	if !slices.Equal(got, want) {
-		return fmt.Errorf("published data variable contract is %v, want %v", got, want)
+	if err := r.API.Publish(ctx, transactional.ID); err != nil {
+		return fmt.Errorf("publish draft: %w", err)
 	}
 	return nil
-}
-
-func sameContent(message EmailMessage, defaults MessageDefaults, spec TemplateSpec) bool {
-	return message.Subject == spec.Subject &&
-		message.PreviewText == spec.PreviewText &&
-		message.FromName == defaults.FromName &&
-		message.FromEmail == defaults.FromEmail &&
-		message.ReplyToEmail == defaults.ReplyToEmail &&
-		strings.TrimSpace(message.LMX) == spec.LMX
 }

--- a/server/internal/email/loopsync/reconcile_test.go
+++ b/server/internal/email/loopsync/reconcile_test.go
@@ -131,29 +131,6 @@ func TestReconcile_AlwaysUpdatesAndPublishesExistingTemplate(t *testing.T) {
 	require.Equal(t, 1, api.published)
 }
 
-func TestReconcile_RecoversUncommittedCreationByManagedName(t *testing.T) {
-	t.Parallel()
-
-	draftID := "message-draft"
-	transactional := TransactionalEmail{
-		ID:                  "transactional-existing",
-		Name:                "gram.transactional.v2.team_invite",
-		DraftEmailMessageID: &draftID,
-	}
-	api := &fakeAPI{
-		listed:        []TransactionalEmail{transactional},
-		transactional: transactional,
-		message:       EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
-	}
-
-	resolved, err := (&Reconciler{API: api}).Reconcile(t.Context(), testManifest(), map[string]string{})
-	require.NoError(t, err)
-	require.Equal(t, "transactional-existing", resolved["team_invite"])
-	require.Zero(t, api.created)
-	require.Equal(t, 1, api.updated)
-	require.Equal(t, 1, api.published)
-}
-
 func TestReconcile_TreatsSuccessfulPublishAsSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/email/loopsync/reconcile_test.go
+++ b/server/internal/email/loopsync/reconcile_test.go
@@ -54,9 +54,9 @@ func (f *fakeAPI) Guardian(context.Context, string) (GuardianResult, error) {
 	return f.guardian, nil
 }
 
-func (f *fakeAPI) Publish(context.Context, string) (TransactionalEmail, error) {
+func (f *fakeAPI) Publish(context.Context, string) error {
 	f.published++
-	return f.transactional, nil
+	return nil
 }
 
 func testManifest() *Manifest {
@@ -69,63 +69,17 @@ func testManifest() *Manifest {
 		},
 		Templates: map[string]TemplateSpec{
 			"team_invite": {
-				ManagedName:        "gram.transactional.v2.team_invite",
-				Subject:            "Join {data.organization_name}",
-				PreviewText:        "Invitation",
-				LMX:                "<Paragraph>Hello {data.organization_name}</Paragraph>",
-				SourceVariables:    []string{"organization_name"},
-				PublishedVariables: []string{"organization_name"},
+				ManagedName:     "gram.transactional.v2.team_invite",
+				Subject:         "Join {data.organization_name}",
+				PreviewText:     "Invitation",
+				Source:          "team_invite.lmx",
+				Variables:       []string{"organization_name"},
+				UnusedVariables: nil,
+				LMX:             "<Paragraph>Hello {data.organization_name}</Paragraph>",
 			},
 		},
+		Dir: "",
 	}
-}
-
-func TestReconcile_AllowsConditionOnlyVariableMissingFromPublishedContract(t *testing.T) {
-	t.Parallel()
-
-	manifest := testManifest()
-	spec := manifest.Templates["team_invite"]
-	spec.LMX = `<Section if="{data.exhausted}" ifOperation="equal" ifValue="true"><Paragraph>Hello {data.organization_name}</Paragraph></Section>`
-	spec.SourceVariables = []string{"exhausted", "organization_name"}
-	spec.PublishedVariables = []string{"organization_name"}
-	manifest.Templates["team_invite"] = spec
-
-	draftID := "message-1"
-	api := &fakeAPI{
-		transactional: TransactionalEmail{
-			ID:                  "transactional-1",
-			DraftEmailMessageID: &draftID,
-			DataVariables:       []string{"organization_name"},
-		},
-		message: EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
-	}
-
-	_, err := (&Reconciler{API: api}).Reconcile(t.Context(), manifest, map[string]string{})
-	require.NoError(t, err)
-}
-
-func TestReconcile_RejectsMissingRenderedVariableWithConditionOnlyVariable(t *testing.T) {
-	t.Parallel()
-
-	manifest := testManifest()
-	spec := manifest.Templates["team_invite"]
-	spec.LMX = `<Section if="{data.exhausted}" ifOperation="equal" ifValue="true"><Paragraph>Hello {data.organization_name}</Paragraph></Section>`
-	spec.SourceVariables = []string{"exhausted", "organization_name"}
-	spec.PublishedVariables = []string{"organization_name"}
-	manifest.Templates["team_invite"] = spec
-
-	draftID := "message-1"
-	api := &fakeAPI{
-		transactional: TransactionalEmail{
-			ID:                  "transactional-1",
-			DraftEmailMessageID: &draftID,
-			DataVariables:       []string{},
-		},
-		message: EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
-	}
-
-	_, err := (&Reconciler{API: api}).Reconcile(t.Context(), manifest, map[string]string{})
-	require.ErrorContains(t, err, "published data variable contract")
 }
 
 func TestReconcile_CreatesPublishesAndReturnsResolvedID(t *testing.T) {
@@ -133,12 +87,8 @@ func TestReconcile_CreatesPublishesAndReturnsResolvedID(t *testing.T) {
 
 	draftID := "message-1"
 	api := &fakeAPI{
-		transactional: TransactionalEmail{
-			ID:                  "transactional-1",
-			DraftEmailMessageID: &draftID,
-			DataVariables:       []string{"organization_name"},
-		},
-		message: EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
+		transactional: TransactionalEmail{ID: "transactional-1", DraftEmailMessageID: &draftID},
+		message:       EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
 	}
 
 	resolved, err := (&Reconciler{API: api}).Reconcile(t.Context(), testManifest(), map[string]string{})
@@ -149,27 +99,27 @@ func TestReconcile_CreatesPublishesAndReturnsResolvedID(t *testing.T) {
 	require.Equal(t, 1, api.published)
 }
 
-func TestReconcile_RecoversUncommittedCreationByManagedName(t *testing.T) {
+func TestReconcile_AlwaysUpdatesAndPublishesExistingTemplate(t *testing.T) {
 	t.Parallel()
 
-	publishedID := "message-published"
+	draftID := "message-draft"
 	transactional := TransactionalEmail{
-		ID:                      "transactional-existing",
-		Name:                    "gram.transactional.v2.team_invite",
-		PublishedEmailMessageID: &publishedID,
-		DataVariables:           []string{"organization_name"},
+		ID:                  "transactional-existing",
+		Name:                "gram.transactional.v2.team_invite",
+		DraftEmailMessageID: &draftID,
 	}
 	api := &fakeAPI{
 		listed:        []TransactionalEmail{transactional},
 		transactional: transactional,
 		message: EmailMessage{
-			ID:           publishedID,
-			Subject:      "Join {data.organization_name}",
-			PreviewText:  "Invitation",
-			FromName:     "Speakeasy",
-			FromEmail:    "gram",
-			ReplyToEmail: "gram@speakeasy.com",
-			LMX:          "<Paragraph>Hello {data.organization_name}</Paragraph>",
+			ID:                draftID,
+			Subject:           "Join {data.organization_name}",
+			PreviewText:       "Invitation",
+			FromName:          "Speakeasy",
+			FromEmail:         "gram",
+			ReplyToEmail:      "gram@speakeasy.com",
+			LMX:               "<Paragraph>Hello {data.organization_name}</Paragraph>",
+			ContentRevisionID: "revision-1",
 		},
 	}
 
@@ -177,58 +127,44 @@ func TestReconcile_RecoversUncommittedCreationByManagedName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "transactional-existing", resolved["team_invite"])
 	require.Zero(t, api.created)
-	require.Zero(t, api.updated)
-	require.Zero(t, api.published)
+	require.Equal(t, 1, api.updated)
+	require.Equal(t, 1, api.published)
 }
 
-func TestReconcile_LeavesMatchingPublishedMessageUnchangedWhenDraftExists(t *testing.T) {
+func TestReconcile_RecoversUncommittedCreationByManagedName(t *testing.T) {
 	t.Parallel()
 
 	draftID := "message-draft"
-	publishedID := "message-published"
 	transactional := TransactionalEmail{
-		ID:                      "transactional-existing",
-		Name:                    "gram.transactional.v2.team_invite",
-		DraftEmailMessageID:     &draftID,
-		PublishedEmailMessageID: &publishedID,
-		DataVariables:           []string{"organization_name"},
+		ID:                  "transactional-existing",
+		Name:                "gram.transactional.v2.team_invite",
+		DraftEmailMessageID: &draftID,
 	}
 	api := &fakeAPI{
 		listed:        []TransactionalEmail{transactional},
 		transactional: transactional,
-		message: EmailMessage{
-			ID:           publishedID,
-			Subject:      "Join {data.organization_name}",
-			PreviewText:  "Invitation",
-			FromName:     "Speakeasy",
-			FromEmail:    "gram",
-			ReplyToEmail: "gram@speakeasy.com",
-			LMX:          "<Paragraph>Hello {data.organization_name}</Paragraph>",
-		},
+		message:       EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
 	}
 
-	_, err := (&Reconciler{API: api}).Reconcile(t.Context(), testManifest(), map[string]string{})
+	resolved, err := (&Reconciler{API: api}).Reconcile(t.Context(), testManifest(), map[string]string{})
 	require.NoError(t, err)
-	require.Zero(t, api.updated)
-	require.Zero(t, api.published)
+	require.Equal(t, "transactional-existing", resolved["team_invite"])
+	require.Zero(t, api.created)
+	require.Equal(t, 1, api.updated)
+	require.Equal(t, 1, api.published)
 }
 
-func TestReconcile_VerifiesPublishedVariablesFromFreshTransactional(t *testing.T) {
+func TestReconcile_TreatsSuccessfulPublishAsSuccess(t *testing.T) {
 	t.Parallel()
 
 	draftID := "message-1"
 	api := &fakeAPI{
-		transactional: TransactionalEmail{
-			ID:                  "transactional-1",
-			DraftEmailMessageID: &draftID,
-			DataVariables:       []string{"unexpected"},
-		},
-		message: EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
+		transactional: TransactionalEmail{ID: "transactional-1", DraftEmailMessageID: &draftID},
+		message:       EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
 	}
 
 	_, err := (&Reconciler{API: api}).Reconcile(t.Context(), testManifest(), map[string]string{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "published data variable contract")
+	require.NoError(t, err)
 	require.Equal(t, 1, api.published)
 }
 
@@ -246,13 +182,9 @@ func TestReconcile_GuardianErrorsBlockPublish(t *testing.T) {
 
 	draftID := "message-1"
 	api := &fakeAPI{
-		transactional: TransactionalEmail{
-			ID:                  "transactional-1",
-			DraftEmailMessageID: &draftID,
-			DataVariables:       []string{"organization_name"},
-		},
-		message:  EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
-		guardian: GuardianResult{Errors: []GuardianIssue{{Rule: "missingButtonHrefs", Description: "button needs a link"}}},
+		transactional: TransactionalEmail{ID: "transactional-1", DraftEmailMessageID: &draftID},
+		message:       EmailMessage{ID: draftID, ContentRevisionID: "revision-1"},
+		guardian:      GuardianResult{Errors: []GuardianIssue{{Rule: "missingButtonHrefs", Description: "button needs a link"}}},
 	}
 
 	_, err := (&Reconciler{API: api}).Reconcile(t.Context(), testManifest(), map[string]string{})


### PR DESCRIPTION
## Summary

- always update, validate, and publish repository-managed Loops templates
- treat a successful publish response as success without content or metadata readback
- keep transactional-email guidance focused on authoring, local validation, and design-reference screenshots
- retain the approved LMX translation of the transactional email design

## Local validation

- `mise exec -- go test ./server/internal/email/... ./server/cmd/sync-loops-email-templates`
- `mise exec -- go run ./server/cmd/sync-loops-email-templates --validate-only`
- `mise lint:server`
- `mise run skills:sync`
- fresh-context skill evaluation: SHIP, 9.5/10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies Loops transactional template publishing: we now always update the draft, run Guardian, and publish, and we stop reading back provider metadata. Previously we sometimes skipped updates and verified Loops-published dataVariables; now a 200 OK from publish is success, which removes brittle verification and makes releases consistent.

- Changes in `server/internal/email/loopsync`:
  - Always update the draft from the manifest, run Guardian, then publish; log “published” for each template.
  - Treat publish 200 OK as success; stop verifying Loops `dataVariables`.
  - Add pacing for non-GET API calls (one every 3s) and cap 429 retries at the max delay even without `Retry-After`.
  - Change `Publish` to return only `error`; trim `TransactionalEmail` to `ID`, `Name`, and `DraftEmailMessageID`.
- Manifest and templates:
  - Remove published/source-variable extraction; validation still enforces exact Go-variable contracts and LMX/XML correctness.
  - Normalize LMX attributes and header layout across templates; keep the approved LMX translation of the design system.
- Docs and tests:
  - Trim `SKILL.md` and `loops/README.md` to focus on authoring, local validation, and MJML design-reference screenshots.
  - Add tests for mutation pacing and improved retry backoff; update client/reconciler tests to match the new API shapes.

- Required actions:
  - If you call `Publish` or read `TransactionalEmail` fields like `DataVariables` or `PublishedEmailMessageID`, update callers to ignore publish output and not depend on provider metadata.
  - Expect slower sync due to mutation pacing; ensure CI timeouts accommodate multiple templates.

<sup>Written for commit 313758d597c506daf88b4ee783ddbda38e8c8dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

