### PR TITLE
fix(email): restore branded Loops rendering

### DIFF
--- a/.agents/skills/craft-transactional-emails/SKILL.md
+++ b/.agents/skills/craft-transactional-emails/SKILL.md
@@ -15,8 +15,9 @@ inline MJML starter is the approved visual specification.
 - Never use customer or private production names, IDs, domains, addresses,
   URLs, or figures in source, temporary previews, screenshots, logs, or test
   sends. Use `Example Organization`, `person@example.com`, and `<ORG_ID>`.
-  The public Speakeasy font and favicon URLs in the approved starter are the
-  only production-asset exception; copy them unchanged when using that starter.
+  The public Speakeasy font and favicon URLs are allowed only in the approved
+  MJML specification/preview starter. Production LMX must use the canonical
+  Loops-hosted assets below.
 - Keep transactional content operational. No marketing copy or unsubscribe UI.
 
 ## Discover the contract
@@ -104,7 +105,8 @@ Identity map:
 - Keep condition-only variables in the Go and manifest contract.
 - LMX cannot embed raw HTML. Send scalar variables and compose the layout in LMX.
 - `<Image src>` must be a Loops-hosted upload. Do not use a repo-local or public
-  URL as `src`; use a text masthead until an upload is deliberately managed.
+  URL as `src`. The canonical spectrum rail and logo mark below are deliberately
+  managed Loops assets and must be copied unchanged.
 - Loops templates do not inherit a parent. Copy the starter into each `.lmx` and
   specialize its message content.
 - Keep labels, headline fragments, body copy, CTA labels, and footer reasons
@@ -112,21 +114,23 @@ Identity map:
   means the LMX may reference exactly those two variables—not generic chrome
   variables from either starter.
 
-### Approved LMX fallback
+### Approved production LMX translation
 
 `transactional_base.lmx` is the only production shell. Copy it; do not derive a
-new shell from another email. LMX cannot express the MJML’s raw spectrum table,
-hosted ABCDiatype/Tobias font faces, or public favicon URL. Until those assets are
-explicitly managed through Loops, the approved fallback is:
+new shell from another email. The production shell uses two Loops-hosted assets:
 
-- omit the spectrum rail rather than replace it with a new accent;
-- use the text-only `speakeasy` / `AI CONTROL PLANE` header;
-- use Inter with the declared UI sans fallback while retaining the approved
-  hierarchy, light palette, square black CTA, panels, and pale footer; translate
-  label text below 12px to Loops' 12px minimum.
+- spectrum rail: `https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png`
+- logo mark: `https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png`
 
-Those are constrained delivery fallbacks, not a second design. Do not add a dark
-masthead, neon accent, rounded cards, gradient, or substitute palette.
+Preserve both URLs: rail width `600`; logo-mark width `28`. LMX still cannot load the
+starter's hosted ABCDiatype/Tobias font faces or render a dashed one-sided
+footer border. Use Inter with the declared UI sans fallback and a pale solid
+divider while retaining the approved hierarchy, light palette, square black
+CTA, panels, and footer. Translate label text below 12px to Loops' 12px minimum.
+
+Those are constrained delivery fallbacks, not a second design. Do not remove
+the managed rail or mark, or add a dark masthead, neon accent, rounded cards,
+gradient, or substitute palette.
 
 ## Inline transactional mail starter
 

--- a/.mise-tasks/zero/emails.sh
+++ b/.mise-tasks/zero/emails.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#MISE description="Resolve existing Loops transactional email IDs for local development"
+#MISE dir="{{ config_root }}"
+
+#USAGE flag "--api-key <api-key>" env="LOOPS_API_KEY" required=#true help="Loops API key (defaults to LOOPS_API_KEY)"
+
+set -euo pipefail
+
+email_ids_file="$(mktemp)"
+trap 'rm -f "$email_ids_file"' EXIT
+
+LOOPS_API_KEY="$usage_api_key" mise exec -- \
+  go run ./server/cmd/sync-loops-email-templates \
+  --resolve-only \
+  --output "$email_ids_file"
+
+email_ids="$(jq -e -c '
+  if type == "object" and length > 0 then
+    .
+  else
+    error("expected a non-empty template ID map")
+  end
+' "$email_ids_file")"
+
+mise set --file mise.local.toml "GRAM_EMAIL_TEMPLATE_IDS=$email_ids"
+
+echo "✅ Resolved Loops transactional email IDs and updated GRAM_EMAIL_TEMPLATE_IDS in mise.local.toml."

--- a/server/cmd/sync-loops-email-templates/main.go
+++ b/server/cmd/sync-loops-email-templates/main.go
@@ -30,6 +30,7 @@ func run(ctx context.Context, args []string) error {
 	outputPath := flags.String("output", "", "JSON file to write with the resolved mapping")
 	baseURL := flags.String("base-url", loopsync.DefaultBaseURL, "Loops Content API base URL")
 	validateOnly := flags.Bool("validate-only", false, "validate repository templates without calling Loops")
+	resolveOnly := flags.Bool("resolve-only", false, "resolve existing Loops template IDs without modifying templates")
 	if err := flags.Parse(args); err != nil {
 		return fmt.Errorf("parse command flags: %w", err)
 	}
@@ -60,6 +61,13 @@ func run(ctx context.Context, args []string) error {
 	}
 	policy := guardian.NewDefaultPolicy(noop.NewTracerProvider())
 	client := loopsync.NewClient(*baseURL, apiKey, policy.PooledClient())
+	if *resolveOnly {
+		resolved, err := loopsync.ResolveExisting(ctx, client, manifest)
+		if err != nil {
+			return fmt.Errorf("resolve transactional email template IDs: %w", err)
+		}
+		return writeJSONAtomically(*outputPath, resolved)
+	}
 	resolved, err := (&loopsync.Reconciler{API: client, Log: os.Stdout}).Reconcile(ctx, manifest, existingIDs)
 	if err != nil {
 		return fmt.Errorf("reconcile transactional email templates: %w", err)

--- a/server/internal/email/loops/README.md
+++ b/server/internal/email/loops/README.md
@@ -32,7 +32,7 @@ headlines, square black actions, neutral outlined details, and a dashed pale
 footer. `weekly_usage_summary.mjml` specializes that system for a data-heavy
 report. Do not replace this language with a separate LMX-derived theme.
 
-`transactional_base.lmx` is the production translation. LMX cannot express the
-raw spectrum table, hosted font faces, or public favicon from MJML, so it uses
-the approved text-only header and Inter fallback while preserving the same
-hierarchy, palette, square action, panels, and pale footer.
+`transactional_base.lmx` is the production translation. It uses Loops-hosted
+copies of the spectrum rail and logo mark, plus the Inter fallback, while
+preserving the same hierarchy, palette, square action, panels, and pale footer.
+Copy those managed asset URLs unchanged into every production template.

--- a/server/internal/email/loops/access_request.lmx
+++ b/server/internal/email/loops/access_request.lmx
@@ -1,7 +1,11 @@
 <Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -11,6 +15,7 @@
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.requester_name} needs access</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Review the request for {data.organization_name} and grant only the scopes they need.</Paragraph>
 <Button href="{data.manage_access_link}" paddingRight="40" paddingBottom="48" paddingLeft="40">Review request →</Button>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">No access changes are made until an administrator approves the request.</Paragraph>

--- a/server/internal/email/loops/custom_domain_unhealthy.lmx
+++ b/server/internal/email/loops/custom_domain_unhealthy.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -15,6 +19,7 @@
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">{data.issue_message}</Paragraph>
 </Section>
 <Button href="{data.domain_link}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">Review domain →</Button>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this operational alert at {data.email} because this address is configured for custom domain health notifications.</Paragraph>

--- a/server/internal/email/loops/enterprise_admin_onboarding.lmx
+++ b/server/internal/email/loops/enterprise_admin_onboarding.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -11,6 +15,7 @@
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Set up your AI control plane</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Use the guided setup to configure Speakeasy for your organization. You can return to setup at any time.</Paragraph>
 <Button href="{data.setup_link}" paddingRight="40" paddingBottom="48" paddingLeft="40">Start setup →</Button>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this email because you were invited to administer Speakeasy for your organization.</Paragraph>

--- a/server/internal/email/loops/manifest.json
+++ b/server/internal/email/loops/manifest.json
@@ -96,7 +96,8 @@
         "previous_total_tokens",
         "total_change_percent",
         "view_usage_url"
-      ]
+      ],
+      "unused_variables": ["cycle_elapsed_percent"]
     }
   }
 }

--- a/server/internal/email/loops/manifest_contract_test.go
+++ b/server/internal/email/loops/manifest_contract_test.go
@@ -4,12 +4,18 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/email"
 	"github.com/speakeasy-api/gram/server/internal/email/loopsync"
+)
+
+const (
+	canonicalSpectrumImage = `<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />`
+	canonicalLogoImage     = `<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />`
 )
 
 func TestManifestMatchesApplicationTemplateContract(t *testing.T) {
@@ -32,5 +38,7 @@ func TestManifestMatchesApplicationTemplateContract(t *testing.T) {
 		declared := slices.Clone(spec.Variables)
 		slices.Sort(declared)
 		require.Equal(t, variables, declared, "variable contract for %q", tmpl.Key())
+		require.Equal(t, 1, strings.Count(spec.LMX, canonicalSpectrumImage), "canonical spectrum rail for %q", tmpl.Key())
+		require.Equal(t, 1, strings.Count(spec.LMX, canonicalLogoImage), "canonical logo mark for %q", tmpl.Key())
 	}
 }

--- a/server/internal/email/loops/openrouter_chat_credits_threshold.lmx
+++ b/server/internal/email/loops/openrouter_chat_credits_threshold.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -18,6 +22,7 @@
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Review usage before the cap is exhausted.</Paragraph>
 </Section>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated platform credit alert.</Paragraph>

--- a/server/internal/email/loops/openrouter_internal_credits_threshold.lmx
+++ b/server/internal/email/loops/openrouter_internal_credits_threshold.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#121212" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -18,6 +22,7 @@
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">ACTION</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8">Review usage before analysis coverage is affected.</Paragraph>
 </Section>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated platform credit alert.</Paragraph>

--- a/server/internal/email/loops/team_invite.lmx
+++ b/server/internal/email/loops/team_invite.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -11,6 +15,7 @@
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Join {data.organization_name}</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.inviter_name} ({data.inviter_email}) invited you to collaborate in Gram.</Paragraph>
 <Button href="{data.invite_link}" paddingRight="40" paddingBottom="48" paddingLeft="40">Accept invitation →</Button>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">If you were not expecting this invitation, you can ignore this email.</Paragraph>

--- a/server/internal/email/loops/transactional_base.lmx
+++ b/server/internal/email/loops/transactional_base.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -15,6 +19,7 @@
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">{data.detail_value}</Text></Paragraph>
 </Section>
 <Button href="{data.action_url}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">{data.action_label} →</Button>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">{data.footer_reason}</Paragraph>

--- a/server/internal/email/loops/tum_usage_overage.lmx
+++ b/server/internal/email/loops/tum_usage_overage.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#FFFFFF" heading2FontSize="30" heading2LineHeight="115" heading2LetterSpacing="-1" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#FFFFFF" heading2FontSize="30" heading2LineHeight="115" heading2LetterSpacing="-1" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -14,14 +18,17 @@
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#BABABA">OVER ALLOWANCE</Strong></Paragraph>
   <H2 paddingTop="10">{data.overage_tokens}</H2>
 </Section>
-<Columns gap="12" paddingRight="40" paddingBottom="32" paddingLeft="40">
-  <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br />{data.cycle_start}</Paragraph>
-  </ColumnItem>
-  <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br />{data.cycle_end}</Paragraph>
-  </ColumnItem>
-</Columns>
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingRight="40" paddingBottom="32" paddingLeft="40">
+  <Columns gap="12">
+    <ColumnItem>
+      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br />{data.cycle_start}</Paragraph>
+    </ColumnItem>
+    <ColumnItem>
+      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br />{data.cycle_end}</Paragraph>
+    </ColumnItem>
+  </Columns>
+</Section>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated billing usage alert.</Paragraph>

--- a/server/internal/email/loops/tum_usage_threshold.lmx
+++ b/server/internal/email/loops/tum_usage_threshold.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="" buttonBodyXPadding="16" buttonBodyYPadding="12" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="4" buttonTextColor="" buttonTextFormat="0" buttonTextFontSize="16" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -10,14 +14,17 @@
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">USAGE ALERT · </Strong>{data.organization_name}</Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">{data.threshold_percent}% of allowance used</H1>
 <Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} has used {data.usage_tokens} of {data.token_limit} tokens under management.</Paragraph>
-<Columns gap="12" blockColor="#FFFFFF" paddingRight="40" paddingBottom="32" paddingLeft="40">
-  <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" blockColor="#FFFFFF" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br />{data.cycle_start}</Paragraph>
-  </ColumnItem>
-  <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" blockColor="#FFFFFF" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br />{data.cycle_end}</Paragraph>
-  </ColumnItem>
-</Columns>
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingRight="40" paddingBottom="32" paddingLeft="40">
+  <Columns gap="12">
+    <ColumnItem>
+      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE START</Strong><Br />{data.cycle_start}</Paragraph>
+    </ColumnItem>
+    <ColumnItem>
+      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24"><Strong textColor="#757575">CYCLE END</Strong><Br />{data.cycle_end}</Paragraph>
+    </ColumnItem>
+  </Columns>
+</Section>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">This is an automated billing usage alert.</Paragraph>

--- a/server/internal/email/loops/weekly_usage_summary.lmx
+++ b/server/internal/email/loops/weekly_usage_summary.lmx
@@ -1,7 +1,11 @@
-<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#FFFFFF" heading2FontSize="48" heading2LineHeight="100" heading2LetterSpacing="-1.5" heading3Color="#EBEBEB" heading3FontSize="12" heading3LineHeight="150" heading3LetterSpacing="0" />
-<Columns gap="12" widths="65,35" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="#FFFFFF" heading2FontSize="48" heading2LineHeight="100" heading2LetterSpacing="-1.5" heading3Color="#EBEBEB" heading3FontSize="12" heading3LineHeight="150" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
   <ColumnItem verticalAlignment="middle">
-    <Paragraph fontSize="21" lineHeight="100"><Strong>speakeasy</Strong></Paragraph>
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
   </ColumnItem>
   <ColumnItem verticalAlignment="middle">
     <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
@@ -14,20 +18,23 @@
   <H2 paddingTop="13">{data.total_tokens}</H2>
   <H3 paddingTop="14">{data.total_change_percent} vs. the same point last cycle</H3>
 </Section>
-<Columns gap="12" paddingBottom="32">
-  <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br />{data.previous_total_tokens}</Paragraph>
-  </ColumnItem>
-  <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br /><Text textColor="#121212">{data.cycle_elapsed_percent}%</Text></Paragraph>
-  </ColumnItem>
-  <ColumnItem>
-    <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br />{data.days_remaining}</Paragraph>
-  </ColumnItem>
-</Columns>
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingBottom="32">
+  <Columns gap="12">
+    <ColumnItem>
+      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br />{data.previous_total_tokens}</Paragraph>
+    </ColumnItem>
+    <ColumnItem>
+      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br /><Text textColor="#121212">{data.cycle_elapsed_percent}%</Text></Paragraph>
+    </ColumnItem>
+    <ColumnItem>
+      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br />{data.days_remaining}</Paragraph>
+    </ColumnItem>
+  </Columns>
+</Section>
 <Paragraph fontSize="12" lineHeight="140" paddingRight="40" paddingBottom="10" paddingLeft="40"><Strong textColor="#757575">BILLING CYCLE</Strong></Paragraph>
 <Paragraph fontSize="14" lineHeight="160" paddingRight="40" paddingBottom="36" paddingLeft="40">Your current cycle ends on {data.cycle_end_date}.</Paragraph>
 <Button href="{data.view_usage_url}" paddingRight="40" paddingBottom="48" paddingLeft="40">View detailed usage →</Button>
+<Divider />
 <Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
   <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
   <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this operational report because this address is configured for billing alerts in Speakeasy.</Paragraph>

--- a/server/internal/email/loops/weekly_usage_summary.lmx
+++ b/server/internal/email/loops/weekly_usage_summary.lmx
@@ -19,19 +19,16 @@
   <H3 paddingTop="14">{data.total_change_percent} vs. the same point last cycle</H3>
 </Section>
 <Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingBottom="32">
-  <Columns gap="12">
+  <Columns gap="12" widths="50,50">
     <ColumnItem>
       <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">PREVIOUS CYCLE</Strong><Br />{data.previous_total_tokens}</Paragraph>
-    </ColumnItem>
-    <ColumnItem>
-      <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">CYCLE ELAPSED</Strong><Br /><Text textColor="#121212">{data.cycle_elapsed_percent}%</Text></Paragraph>
     </ColumnItem>
     <ColumnItem>
       <Paragraph fontSize="12" lineHeight="140" paddingTop="22" paddingRight="22" paddingBottom="20" paddingLeft="22"><Strong textColor="#757575">REMAINING</Strong><Br />{data.days_remaining}</Paragraph>
     </ColumnItem>
   </Columns>
 </Section>
-<Paragraph fontSize="12" lineHeight="140" paddingRight="40" paddingBottom="10" paddingLeft="40"><Strong textColor="#757575">BILLING CYCLE</Strong></Paragraph>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="32" paddingRight="40" paddingBottom="10" paddingLeft="40"><Strong textColor="#757575">BILLING CYCLE</Strong></Paragraph>
 <Paragraph fontSize="14" lineHeight="160" paddingRight="40" paddingBottom="36" paddingLeft="40">Your current cycle ends on {data.cycle_end_date}.</Paragraph>
 <Button href="{data.view_usage_url}" paddingRight="40" paddingBottom="48" paddingLeft="40">View detailed usage →</Button>
 <Divider />

--- a/server/internal/email/loops/weekly_usage_summary.mjml
+++ b/server/internal/email/loops/weekly_usage_summary.mjml
@@ -159,23 +159,7 @@
       </mj-column>
     </mj-section>
 
-    <mj-section css-class="mobile-pad" padding="32px 40px 0">
-      <mj-column>
-        <mj-text css-class="eyebrow" color="#757575" font-size="10px" line-height="1.4" padding="0 0 10px">
-          Billing cycle progress
-        </mj-text>
-        <mj-raw>
-          <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;background:#ebebeb;">
-            <tr>
-              <td width="{DATA_VARIABLE:cycle_elapsed_percent}%" height="8" bgcolor="#2874d7" style="font-size:0;line-height:0;">&nbsp;</td>
-              <td height="8" bgcolor="#ebebeb" style="font-size:0;line-height:0;">&nbsp;</td>
-            </tr>
-          </table>
-        </mj-raw>
-      </mj-column>
-    </mj-section>
-
-    <mj-section css-class="mobile-pad" padding="16px 40px 36px">
+    <mj-section css-class="mobile-pad" padding="32px 40px 36px">
       <mj-column>
         <mj-text color="#545454" font-size="14px" line-height="1.6" padding="0">
           Your current cycle ends on <strong style="color:#121212;font-weight:400;">{DATA_VARIABLE:cycle_end_date}</strong>.

--- a/server/internal/email/loops/weekly_usage_summary.mjml
+++ b/server/internal/email/loops/weekly_usage_summary.mjml
@@ -151,14 +151,6 @@
       </mj-column>
       <mj-column css-class="cycle-stat" padding="22px 22px 20px">
         <mj-text css-class="eyebrow" color="#757575" font-size="10px" line-height="1.4" padding="0 0 8px">
-          Cycle elapsed
-        </mj-text>
-        <mj-text css-class="display-copy" font-size="25px" line-height="1.2" padding="0">
-          {DATA_VARIABLE:cycle_elapsed_percent}%
-        </mj-text>
-      </mj-column>
-      <mj-column css-class="cycle-stat" padding="22px 22px 20px">
-        <mj-text css-class="eyebrow" color="#757575" font-size="10px" line-height="1.4" padding="0 0 8px">
           Remaining
         </mj-text>
         <mj-text css-class="display-copy" font-size="25px" line-height="1.2" padding="0">

--- a/server/internal/email/loopsync/client.go
+++ b/server/internal/email/loopsync/client.go
@@ -34,6 +34,7 @@ type EmailMessage struct {
 	FromName          string `json:"fromName"`
 	FromEmail         string `json:"fromEmail"`
 	ReplyToEmail      string `json:"replyToEmail"`
+	EmailFormat       string `json:"emailFormat"`
 	LMX               string `json:"lmx"`
 	ContentRevisionID string `json:"contentRevisionId"`
 }
@@ -67,6 +68,7 @@ type UpdateEmailMessageInput struct {
 	FromName           string `json:"fromName"`
 	FromEmail          string `json:"fromEmail"`
 	ReplyToEmail       string `json:"replyToEmail"`
+	EmailFormat        string `json:"emailFormat"`
 	LMX                string `json:"lmx"`
 }
 

--- a/server/internal/email/loopsync/client_test.go
+++ b/server/internal/email/loopsync/client_test.go
@@ -95,6 +95,7 @@ func TestClient_TransactionalLifecycle(t *testing.T) {
 				return
 			}
 			assert.Equal(t, "revision-1", input.ExpectedRevisionID)
+			assert.Equal(t, "styled", input.EmailFormat)
 			assert.Equal(t, "<Paragraph>{data.resource_name}</Paragraph>", input.LMX)
 			_, _ = w.Write([]byte(`{"id":"message-1","contentRevisionId":"revision-2"}`))
 		default:
@@ -133,6 +134,7 @@ func TestClient_TransactionalLifecycle(t *testing.T) {
 		FromName:           "Speakeasy",
 		FromEmail:          "gram",
 		ReplyToEmail:       "gram@speakeasy.com",
+		EmailFormat:        "styled",
 		LMX:                "<Paragraph>{data.resource_name}</Paragraph>",
 	})
 	require.NoError(t, err)
@@ -183,6 +185,7 @@ func TestClient_RetriesRevisionGuardedUpdate(t *testing.T) {
 		FromName:           "Example Sender",
 		FromEmail:          "notifications",
 		ReplyToEmail:       "person@example.com",
+		EmailFormat:        "styled",
 		LMX:                "<Paragraph>Example</Paragraph>",
 	})
 	require.NoError(t, err)

--- a/server/internal/email/loopsync/reconcile.go
+++ b/server/internal/email/loopsync/reconcile.go
@@ -98,6 +98,7 @@ func (r *Reconciler) syncOne(ctx context.Context, defaults MessageDefaults, spec
 		FromName:           defaults.FromName,
 		FromEmail:          defaults.FromEmail,
 		ReplyToEmail:       defaults.ReplyToEmail,
+		EmailFormat:        "styled",
 		LMX:                spec.LMX,
 	})
 	if err != nil {

--- a/server/internal/email/loopsync/reconcile.go
+++ b/server/internal/email/loopsync/reconcile.go
@@ -13,6 +13,29 @@ type Reconciler struct {
 	Log io.Writer
 }
 
+// ResolveExisting maps manifest keys to existing Loops transactional email IDs without modifying templates.
+func ResolveExisting(ctx context.Context, api API, manifest *Manifest) (map[string]string, error) {
+	all, err := api.ListTransactionalEmails(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list Loops transactional emails: %w", err)
+	}
+
+	byName := make(map[string][]TransactionalEmail, len(all))
+	for _, transactional := range all {
+		byName[transactional.Name] = append(byName[transactional.Name], transactional)
+	}
+
+	resolved := make(map[string]string, len(manifest.Templates))
+	for key, spec := range manifest.Templates {
+		matches := byName[spec.ManagedName]
+		if len(matches) != 1 {
+			return nil, fmt.Errorf("resolve email template %q: found %d Loops emails named %q", key, len(matches), spec.ManagedName)
+		}
+		resolved[key] = matches[0].ID
+	}
+	return resolved, nil
+}
+
 func (r *Reconciler) Reconcile(ctx context.Context, manifest *Manifest, existingIDs map[string]string) (map[string]string, error) {
 	if r.API == nil {
 		return nil, fmt.Errorf("reconcile email templates: API is required")

--- a/server/internal/email/loopsync/reconcile_test.go
+++ b/server/internal/email/loopsync/reconcile_test.go
@@ -46,6 +46,7 @@ func (f *fakeAPI) UpdateEmailMessage(_ context.Context, _ string, input UpdateEm
 	f.message.FromName = input.FromName
 	f.message.FromEmail = input.FromEmail
 	f.message.ReplyToEmail = input.ReplyToEmail
+	f.message.EmailFormat = input.EmailFormat
 	f.message.LMX = input.LMX
 	return f.message, nil
 }
@@ -97,6 +98,7 @@ func TestReconcile_CreatesPublishesAndReturnsResolvedID(t *testing.T) {
 	require.Equal(t, 1, api.created)
 	require.Equal(t, 1, api.updated)
 	require.Equal(t, 1, api.published)
+	require.Equal(t, "styled", api.message.EmailFormat)
 }
 
 func TestReconcile_AlwaysUpdatesAndPublishesExistingTemplate(t *testing.T) {


### PR DESCRIPTION
## Summary

- restore the approved Speakeasy visual language across all nine repo-managed Loops transactional emails
- make Loops publish templates as styled email content so the branding renders in production
- remove elapsed-percentage copy from the weekly usage summary and correct the billing-cycle spacing
- add a read-only `mise run zero:emails` initializer that resolves existing template IDs without publishing

## Validation

- visually verified the published Loops renders on desktop and mobile
- `mise exec -- go run ./server/cmd/sync-loops-email-templates --validate-only`
- `mise exec -- go test ./server/internal/email/... ./server/cmd/sync-loops-email-templates`
- `mise lint:server`
- `mise run skills:sync`

## Published Loops preview

Captured from the published Loops render with neutral sample values.

<img src="https://gist.githubusercontent.com/danielkov/a0f6fd4c8ee0e9e377e9a8ef37360ffe/raw/weekly_usage_summary-final-desktop.png" width="49%" alt="Weekly usage email desktop preview"> <img src="https://gist.githubusercontent.com/danielkov/a0f6fd4c8ee0e9e377e9a8ef37360ffe/raw/weekly_usage_summary-final-mobile.png" width="40%" alt="Weekly usage email mobile preview">
