### PR TITLE
feat(dashboard): add cross-origin and cross-domain policy headers (AIS-432)

### DIFF
--- a/.changeset/dashboard-cross-origin-headers.md
+++ b/.changeset/dashboard-cross-origin-headers.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add three browser hardening headers to the dashboard HTML responses: `Cross-Origin-Resource-Policy: same-origin`, `Cross-Origin-Opener-Policy: same-origin`, and `X-Permitted-Cross-Domain-Policies: none`. A penetration test reported all three as missing. Each one is set per location, because an `add_header` inside an nginx location discards every `add_header` inherited from the server block. Static assets under `/assets` and `/external` keep `Access-Control-Allow-Origin: *` and receive no cross-origin policy, so cross-origin image loads continue to work.

--- a/.mise-tasks/smoke/headers.sh
+++ b/.mise-tasks/smoke/headers.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+#MISE dir="{{ config_root }}"
+#MISE description="Check that a Gram host returns every expected security response header"
+#USAGE arg "<target>" help="Host to check: dev, prod, or a full URL" default="dev"
+
+# Headers reach the browser from two layers: this dashboard nginx config,
+# which sets the cross-origin headers, and the shared edge configuration,
+# which sets the rest. Only a live request proves both survived, so check a
+# running host rather than a file.
+
+set -euo pipefail
+
+target="${1:-dev}"
+
+case "$target" in
+  dev) url="https://dev.getgram.ai/" ;;
+  prod) url="https://app.getgram.ai/" ;;
+  *) url="$target" ;;
+esac
+
+# Name and exact value. Every one of these is a fixed string we control.
+exact=(
+  "cross-origin-resource-policy|same-origin"
+  "cross-origin-opener-policy|same-origin"
+  "x-permitted-cross-domain-policies|none"
+  "x-content-type-options|nosniff"
+  "x-frame-options|deny"
+  "referrer-policy|strict-origin-when-cross-origin"
+  "x-xss-protection|1; mode=block"
+)
+
+# Values that change, or are too long to pin. Presence is the assertion.
+present=(
+  "strict-transport-security"
+  "content-security-policy"
+  "permissions-policy"
+  "reporting-endpoints"
+)
+
+response="$(curl --silent --show-error --output /dev/null --dump-header - \
+  --connect-timeout 5 --max-time 20 "$url")"
+
+status="$(printf '%s\n' "$response" | head -n1 | tr -d '\r')"
+headers="$(printf '%s\n' "$response" | tr -d '\r' | tr '[:upper:]' '[:lower:]')"
+
+echo "GET $url"
+echo "$status"
+echo
+
+failures=0
+
+header_value() {
+  printf '%s\n' "$headers" | sed -n "s/^$1: *//p" | head -n1
+}
+
+for entry in "${exact[@]}"; do
+  name="${entry%%|*}"
+  want="${entry#*|}"
+  got="$(header_value "$name")"
+
+  if [[ "$got" == "$want" ]]; then
+    echo "ok       $name: $got"
+  elif [[ -z "$got" ]]; then
+    echo "MISSING  $name (want \"$want\")"
+    failures=$((failures + 1))
+  else
+    echo "WRONG    $name: \"$got\" (want \"$want\")"
+    failures=$((failures + 1))
+  fi
+done
+
+for name in "${present[@]}"; do
+  got="$(header_value "$name")"
+
+  if [[ -n "$got" ]]; then
+    echo "ok       $name (present, ${#got} chars)"
+  else
+    echo "MISSING  $name"
+    failures=$((failures + 1))
+  fi
+done
+
+echo
+
+# Clear-Site-Data is absent here on purpose. It ships on the logout response
+# only. On GET / the "cookies" directive would delete the session cookie on
+# every page load and sign the user out. See AIS-551.
+if [[ -n "$(header_value "clear-site-data")" ]]; then
+  echo "WRONG    clear-site-data is set on GET /, which signs users out on every page load"
+  failures=$((failures + 1))
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures header check(s) failed"
+  exit 1
+fi
+
+echo "all header checks passed"

--- a/.mise-tasks/smoke/headers.sh
+++ b/.mise-tasks/smoke/headers.sh
@@ -38,15 +38,29 @@ present=(
   "reporting-endpoints"
 )
 
-response="$(curl --silent --show-error --output /dev/null --dump-header - \
+dump="$(mktemp)"
+trap 'rm -f "$dump"' EXIT
+
+code="$(curl --silent --show-error --output /dev/null \
+  --dump-header "$dump" --write-out '%{http_code}' \
   --connect-timeout 5 --max-time 20 "$url")"
 
-status="$(printf '%s\n' "$response" | head -n1 | tr -d '\r')"
-headers="$(printf '%s\n' "$response" | tr -d '\r' | tr '[:upper:]' '[:lower:]')"
+headers="$(tr -d '\r' <"$dump" | tr '[:upper:]' '[:lower:]')"
 
 echo "GET $url"
-echo "$status"
+echo "HTTP $code"
 echo
+
+# Stop on a non-2xx response. An error page or a redirect can carry the full
+# header set while serving nobody, so accepting one would report success for
+# a broken host. Redirects matter here: the CDN host answers / with a 301
+# that no configured header ever reaches. Do not follow it, and do not pass
+# it either.
+if [[ "$code" != 2* ]]; then
+  echo "FAILED   want a 2xx response, got $code"
+  echo "         check the URL a browser loads, not a redirect or an error page"
+  exit 1
+fi
 
 failures=0
 

--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -25,9 +25,9 @@ server {
 
     # Serve static assets with an efficient cache policy. Note: with
     # GRAM_CDN_URL set, browsers fetch /assets from the CDN, whose origin is
-    # a GCS bucket rather than this nginx (see cdn.tf / cdn-bucket.tf in
-    # gram-infra); the LB there sets its own Access-Control-Allow-Origin: *,
-    # mirroring the header here. These headers still cover anything served
+    # a storage bucket rather than this nginx; the load balancer in front of
+    # that bucket sets its own Access-Control-Allow-Origin: *, mirroring the
+    # header here. These headers still cover anything served
     # directly from this container: CDN disabled (GRAM_CDN_URL empty), local
     # runs, or clients hitting the origin host. Vite emits
     # <script type="module" crossorigin> and stylesheet links, and devtools
@@ -47,10 +47,20 @@ server {
     # Serve HTML with no cache. Nothing on this host wants search indexing —
     # it is either behind login or a tokenized public share page — so noindex
     # everything ("always" keeps the header on error responses too).
+    #
+    # The three cross-origin headers repeat in both HTML locations below.
+    # add_header inside a location discards every add_header inherited from
+    # server, so a single server-level copy would vanish from all five
+    # locations in this file. Keep them off the asset locations above:
+    # /assets and /external are fetched by other origins on purpose, and a
+    # same-origin policy would block those loads.
     location ~* \.html$ {
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
         add_header X-Robots-Tag "noindex, nofollow" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
     }
 
     # Handle SPA routing
@@ -58,6 +68,9 @@ server {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
         add_header X-Robots-Tag "noindex, nofollow" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
     }
 
     # Error pages


### PR DESCRIPTION
A penetration test found that the dashboard hosts do not return three browser hardening headers. This PR adds them.

Closes AIS-432.

## What changed

`client/dashboard/nginx.conf` now sets three headers on the two HTML locations:

    Cross-Origin-Resource-Policy:      same-origin
    Cross-Origin-Opener-Policy:        same-origin
    X-Permitted-Cross-Domain-Policies: none

All three values match the report recommendation exactly, which removes any argument at retest.

## Why the dashboard nginx, and not the edge

The shared security headers we already send come from the edge configuration, which applies to every host and route: the dashboard, the API, MCP routes, and customer custom domains. A `same-origin` value applied there would also cover the paths that other origins fetch on purpose, and it would block the MCP install page logos that customer custom domains load.

`GET /` never reaches the Go server either. The edge routes `/` to the dashboard nginx pod, so no Go middleware runs on the response the scanner probes. This nginx config does set headers on that response, and the edge passes them through untouched.

So the whole change fits in one file, with no edge change and no blast radius beyond the dashboard.

## Why the headers repeat in two location blocks

An `add_header` inside an nginx `location` discards every `add_header` inherited from `server`. This file has five locations that already call `add_header`. A single server-level copy would silently vanish from all five, and no CI check would catch it.

## Blast radius

**Static assets are untouched.** `/assets/*` and `/external/sticker-logo.png` match earlier location blocks, so they keep `Access-Control-Allow-Origin: *` and receive no cross-origin policy. Those are the two paths that other origins legitimately fetch, including the MCP install page logos and the social preview image.

**COOP takes away nothing.** Every `window.open` call in the dashboard already passes `noopener`, and `client/dashboard/src/lib/safe-external-url.ts:33` explicitly sets `opened.opener = null`. The code already severs what COOP severs. The `postMessage` calls target iframe `contentWindow`, which COOP does not govern.

**CORP here is largely cosmetic**, and that is worth stating plainly. CORP is not enforced on top-level navigation, and these responses are navigations. It satisfies the scanner and protects very little. AIS-552 covers the surfaces where CORP does real work.

## Verification

I ran the real `nginxinc/nginx-unprivileged:alpine` image with this config mounted as the template. `nginx -t` passes.

| Path                           | Result                                                                   |
| ------------------------------ | ------------------------------------------------------------------------ |
| `/`, `/index.html`, SPA routes | three headers present                                                    |
| `/assets/app.css`              | untouched, keeps `Access-Control-Allow-Origin: *`                        |
| `/external/sticker-logo.png`   | untouched, keeps `Access-Control-Allow-Origin: *`                        |
| `/icons/decorative/*.webp`     | falls through to `location /`, gets the headers, loaded same-origin only |

This PR also adds `mise run smoke:headers [dev|prod|<url>]`. It asserts the full expected header set against a live host, not only the three new ones, so it catches the inheritance trap that a file grep cannot. Run it against dev after deploy, then against prod.

Against prod today it reproduces the finding exactly:

    MISSING  cross-origin-resource-policy (want "same-origin")
    MISSING  cross-origin-opener-policy (want "same-origin")
    MISSING  x-permitted-cross-domain-policies (want "none")
    ok       x-content-type-options: nosniff
    ok       x-frame-options: deny
    ok       referrer-policy: strict-origin-when-cross-origin
    ok       x-xss-protection: 1; mode=block
    ok       strict-transport-security (present, 35 chars)
    ok       content-security-policy (present, 1284 chars)
    ok       permissions-policy (present, 172 chars)
    ok       reporting-endpoints (present, 252 chars)

## Drive-by

The comment above the asset location named two infra file names from another repository. This PR drops the names and keeps the behaviour the comment documented.

## Not in this PR

The report listed seven headers. The other four each need their own decision, and each has a ticket:

| Header                       | Outcome                                                                         | Ticket  |
| ---------------------------- | ------------------------------------------------------------------------------- | ------- |
| Clear-Site-Data              | Already ships on logout. Add `"cache"`                                          | AIS-551 |
| Integrity-Policy             | Deferred. The build emits no integrity hashes yet                               | AIS-547 |
| Cross-Origin-Embedder-Policy | Rejected. Breaks the first script the page loads, and unlocks nothing Gram uses | AIS-548 |
| NEL                          | Rejected as suggested. The value names a report group that does not exist       | AIS-549 |

The `cdn.prod.getgram.ai` finding cannot be fixed. That response is a redirect issued before any backend is reached, so it can never carry a configured header. AIS-550 asks whether the redirect should exist at all.

Expect the retest to flag Clear-Site-Data again regardless. It ships on the logout response only, which is correct. On `GET /` the `"cookies"` directive would delete the session cookie on every page load and sign the user out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
