### PR TITLE
feat: improve judge-based finding details and actions in Watchdog

### DIFF
--- a/client/dashboard/src/pages/security/risk-utils.ts
+++ b/client/dashboard/src/pages/security/risk-utils.ts
@@ -33,6 +33,15 @@ export function isJudgeSource(source: string | undefined): boolean {
   return source !== undefined && JUDGE_SOURCE_SET.has(source);
 }
 
+// A signal clusters findings on one rule, so a judge-backed signal is one
+// whose detection sources are judge detectors. Judge findings cannot be
+// meaningfully excluded — every one carries the same constant rule id, so a
+// rule exclusion would silence the whole detector — which is why exclusion
+// affordances hide behind this check and false-positive dismissal takes over.
+export function hasJudgeSource(sources: readonly string[]): boolean {
+  return sources.some(isJudgeSource);
+}
+
 const ruleIdToCategory = new Map<string, RuleCategory>();
 const ruleIdToTitle = new Map<string, string>();
 

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -10,16 +10,32 @@ import {
 } from "@/components/ui/Sheet";
 import { Separator } from "@/components/ui/Separator";
 import { Text } from "@/components/ui/Text";
+import { useSdkClient } from "@/contexts/Sdk";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import type { RiskSignal } from "@gram/client/models/components/risksignal.js";
 import { useRiskListResults } from "@gram/client/react-query/riskListResults.js";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
+import { Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { toast } from "sonner";
 import { ExclusionEditor, type ExclusionSheetState } from "../exclusion-sheet";
-import { MaskedMatch, RevealAllProvider, RevealAllToggle } from "../risk-ui";
-import { getRuleTitleFallback, scoreToRating } from "../risk-utils";
+import {
+  EventMatchDialog,
+  MaskedMatch,
+  RevealAllProvider,
+  RevealAllToggle,
+} from "../risk-ui";
+import {
+  getCategoryCodeForFinding,
+  getRuleTitleFallback,
+  hasJudgeSource,
+  isJudgeSource,
+  scoreToRating,
+} from "../risk-utils";
 import { useDismissFinding } from "../useDismissFinding";
+import { collectFindingsForRules } from "./collect-findings";
+import { DismissFindingsDialog } from "./DismissFindingsDialog";
 import { SCORE_TEXT_COLOR } from "./signals-helpers";
 import { SignalTrend } from "./SignalsList";
 
@@ -101,6 +117,13 @@ function EvidenceRow({
   onExclude: (result: RiskResult) => void;
   onDismiss: (result: RiskResult) => void;
 }): JSX.Element {
+  // A judge finding's "match" is the entire flagged event (often absent on
+  // the realtime path), and its description carries the verdict rationale —
+  // so the evidence cell shows the rationale with the audited event dialog
+  // behind it instead of a redaction chip over content that may not exist.
+  // Judge findings also can't be excluded (their rule id is a constant for
+  // the whole detector), so the row offers only false-positive dismissal.
+  const judge = isJudgeSource(result.source);
   return (
     <div className="border-border overflow-hidden rounded-md border">
       <div className="flex items-center justify-between gap-2 px-3 py-2">
@@ -111,29 +134,44 @@ function EvidenceRow({
           {formatDistanceToNow(result.createdAt, { addSuffix: true })}
         </span>
       </div>
-      {/* The redacted match sits on an inverse code-block backdrop so the
-          red redaction chip carries the reference design's contrast. */}
-      <div className="bg-foreground px-3 py-4">
-        <MaskedMatch
-          tone="contrast"
-          wrap
-          resultId={result.id}
-          matchRedacted={result.matchRedacted}
-        />
-      </div>
+      {judge ? (
+        <div className="px-3 py-3">
+          <EventMatchDialog
+            resultId={result.id}
+            matchRedacted={result.matchRedacted}
+            rationale={result.description}
+          />
+        </div>
+      ) : (
+        // The redacted match sits on an inverse code-block backdrop so the
+        // red redaction chip carries the reference design's contrast.
+        <div className="bg-foreground px-3 py-4">
+          <MaskedMatch
+            tone="contrast"
+            wrap
+            resultId={result.id}
+            matchRedacted={result.matchRedacted}
+          />
+        </div>
+      )}
       <div className="flex items-center justify-between gap-2 px-3 py-2">
         <Text small muted className="truncate font-mono">
-          Triggered: {result.source} · {getRuleTitleFallback(result.ruleId)}{" "}
-          (conf {(result.confidence ?? 0).toFixed(2)})
+          {/* Category code, never the raw scanner source — and no rule title
+              for judge findings, whose single rule restates the category. */}
+          Triggered: {getCategoryCodeForFinding(result.source, result.ruleId)}
+          {!judge && ` · ${getRuleTitleFallback(result.ruleId)}`} (conf{" "}
+          {(result.confidence ?? 0).toFixed(2)})
         </Text>
         <span className="flex shrink-0 gap-1">
-          <Button
-            variant="tertiary"
-            size="sm"
-            onClick={() => onExclude(result)}
-          >
-            <Button.Text>Exclude</Button.Text>
-          </Button>
+          {!judge && (
+            <Button
+              variant="tertiary"
+              size="sm"
+              onClick={() => onExclude(result)}
+            >
+              <Button.Text>Exclude</Button.Text>
+            </Button>
+          )}
           <Button
             variant="tertiary"
             size="sm"
@@ -154,14 +192,23 @@ function EvidenceRow({
  */
 export function SignalDrawer({
   signal,
+  window,
   onClose,
 }: {
   signal: RiskSignal | null;
+  /** The page's active time window; scopes signal-level dismissal the same
+   * way the list's bulk "Mark as false positive" is scoped. */
+  window: { from?: Date; to?: Date };
   onClose: () => void;
 }): JSX.Element {
+  const client = useSdkClient();
   const { dismiss, isOptimisticallyDismissed } = useDismissFinding();
   const [exclusionState, setExclusionState] =
     useState<ExclusionSheetState | null>(null);
+  const [pendingDismiss, setPendingDismiss] = useState<RiskResult[] | null>(
+    null,
+  );
+  const [collecting, setCollecting] = useState(false);
   // Set when leaving the exclusion editor so the remounting detail view
   // slides back in from the left — but never on the drawer's first open,
   // where the Sheet's own slide already animates the content.
@@ -203,6 +250,35 @@ export function SignalDrawer({
     setExclusionState({ mode: "create", results: evidence });
   };
 
+  // Judge-backed signals get false-positive dismissal as the signal-level
+  // action instead of an exclusion rule. Same collect-then-confirm shape as
+  // the list's bulk action, scoped to this signal's rule and window.
+  const judgeSignal =
+    signal !== null && hasJudgeSource(signal.detectionSources);
+
+  const openSignalDismiss = async () => {
+    if (!signal) return;
+    setCollecting(true);
+    try {
+      const results = await collectFindingsForRules(
+        client,
+        [signal.ruleId],
+        window,
+      );
+      setPendingDismiss(results);
+    } catch {
+      toast.error("Failed to load this signal's findings.");
+    } finally {
+      setCollecting(false);
+    }
+  };
+
+  const confirmSignalDismiss = () => {
+    if (!pendingDismiss) return;
+    dismiss(pendingDismiss);
+    setPendingDismiss(null);
+  };
+
   return (
     <>
       <Sheet
@@ -211,6 +287,7 @@ export function SignalDrawer({
           if (!open) {
             setExclusionState(null);
             setReturningFromEditor(false);
+            setPendingDismiss(null);
             onClose();
           }
         }}
@@ -290,9 +367,29 @@ export function SignalDrawer({
                 </SheetHeader>
                 <div className="flex flex-1 flex-col gap-6 px-4 pb-6">
                   <div className="flex flex-wrap items-center gap-2">
-                    <Button variant="primary" onClick={openSignalExclusion}>
-                      <Button.Text>Create exclusion rule</Button.Text>
-                    </Button>
+                    {judgeSignal ? (
+                      <>
+                        <Button
+                          variant="primary"
+                          disabled={collecting}
+                          onClick={() => void openSignalDismiss()}
+                        >
+                          {collecting && (
+                            <Button.LeftIcon>
+                              <Loader2 className="size-4 animate-spin" />
+                            </Button.LeftIcon>
+                          )}
+                          <Button.Text>Mark all as false positive</Button.Text>
+                        </Button>
+                        <Text small muted>
+                          Prompt-based findings can't be excluded.
+                        </Text>
+                      </>
+                    ) : (
+                      <Button variant="primary" onClick={openSignalExclusion}>
+                        <Button.Text>Create exclusion rule</Button.Text>
+                      </Button>
+                    )}
                   </div>
                   <div className="relative flex-1">
                     <div className="space-y-6">
@@ -363,9 +460,13 @@ export function SignalDrawer({
                       <div className="space-y-2">
                         <div className="flex items-center justify-between">
                           <Text small muted className="font-medium uppercase">
-                            Evidence · redacted
+                            {/* Judge evidence shows rationales, not redacted
+                                matches, so the label and the reveal-all
+                                toggle (which only drives MaskedMatch rows)
+                                would both mislead there. */}
+                            {judgeSignal ? "Evidence" : "Evidence · redacted"}
                           </Text>
-                          <RevealAllToggle />
+                          {!judgeSignal && <RevealAllToggle />}
                         </div>
                         {evidenceQuery.isLoading && (
                           <Text small muted>
@@ -420,6 +521,12 @@ export function SignalDrawer({
           )}
         </SheetContent>
       </Sheet>
+      <DismissFindingsDialog
+        results={pendingDismiss}
+        subject="this signal"
+        onCancel={() => setPendingDismiss(null)}
+        onConfirm={confirmSignalDismiss}
+      />
     </>
   );
 }

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -17,7 +17,7 @@ import { useRiskListResults } from "@gram/client/react-query/riskListResults.js"
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { Loader2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ExclusionEditor, type ExclusionSheetState } from "../exclusion-sheet";
 import {
@@ -256,8 +256,19 @@ export function SignalDrawer({
   const judgeSignal =
     signal !== null && hasJudgeSource(signal.detectionSources);
 
+  // The drawer stays mounted across signal switches and closes, so a
+  // collection that was in flight when either happened must not open the
+  // confirm dialog with the previous signal's findings. The ref tracks the
+  // currently displayed signal; a finished collection only lands if it still
+  // matches.
+  const activeSignalKey = useRef<string | null>(null);
+  useEffect(() => {
+    activeSignalKey.current = signal?.key ?? null;
+  }, [signal]);
+
   const openSignalDismiss = async () => {
     if (!signal) return;
+    const requestKey = signal.key;
     setCollecting(true);
     try {
       const results = await collectFindingsForRules(
@@ -265,8 +276,10 @@ export function SignalDrawer({
         [signal.ruleId],
         window,
       );
+      if (activeSignalKey.current !== requestKey) return;
       setPendingDismiss(results);
     } catch {
+      if (activeSignalKey.current !== requestKey) return;
       toast.error("Failed to load this signal's findings.");
     } finally {
       setCollecting(false);

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -26,7 +26,11 @@ import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { getRuleTitleFallback, scoreToRating } from "../risk-utils";
+import {
+  getRuleTitleFallback,
+  hasJudgeSource,
+  scoreToRating,
+} from "../risk-utils";
 import { invalidateExclusionSurfaces } from "../exclusion-invalidation";
 import { useDismissFinding } from "../useDismissFinding";
 import {
@@ -164,9 +168,13 @@ function WatchdogContent(): JSX.Element {
     signalCount: number;
   } | null>(null);
   const [collecting, setCollecting] = useState(false);
-  const [pendingExclusions, setPendingExclusions] = useState<
-    RiskSignal[] | null
-  >(null);
+  const [pendingExclusions, setPendingExclusions] = useState<{
+    signals: RiskSignal[];
+    // Judge-backed signals in the selection, dropped from exclusion creation:
+    // their findings can't be excluded (constant rule id per detector), only
+    // dismissed. The dialog names how many were set aside.
+    skippedJudge: number;
+  } | null>(null);
   const [creatingExclusions, setCreatingExclusions] = useState(false);
 
   const handleDismissSelected = async () => {
@@ -197,7 +205,19 @@ function WatchdogContent(): JSX.Element {
   const handleExcludeSelected = () => {
     const selected = selection.selectedItems;
     if (selected.length === 0) return;
-    setPendingExclusions(selected);
+    const excludable = selected.filter(
+      (signal) => !hasJudgeSource(signal.detectionSources),
+    );
+    if (excludable.length === 0) {
+      toast.info(
+        "Prompt-based findings can't be excluded — mark them as false positives instead.",
+      );
+      return;
+    }
+    setPendingExclusions({
+      signals: excludable,
+      skippedJudge: selected.length - excludable.length,
+    });
   };
 
   const confirmCreateExclusions = async () => {
@@ -205,7 +225,7 @@ function WatchdogContent(): JSX.Element {
     setCreatingExclusions(true);
     let created = 0;
     const failed: string[] = [];
-    for (const signal of pendingExclusions) {
+    for (const signal of pendingExclusions.signals) {
       try {
         await createExclusionMutation.mutateAsync({
           request: {
@@ -402,6 +422,7 @@ function WatchdogContent(): JSX.Element {
               must live under a slot to render at all. */}
           <SignalDrawer
             signal={selectedSignal}
+            window={window}
             onClose={() => setUrlParam("signal", null)}
           />
           <DismissFindingsDialog
@@ -415,7 +436,8 @@ function WatchdogContent(): JSX.Element {
             onConfirm={confirmDismissSelected}
           />
           <CreateExclusionsDialog
-            signals={pendingExclusions}
+            signals={pendingExclusions?.signals ?? null}
+            skippedJudge={pendingExclusions?.skippedJudge ?? 0}
             creating={creatingExclusions}
             onCancel={() => setPendingExclusions(null)}
             onConfirm={() => void confirmCreateExclusions()}
@@ -483,11 +505,14 @@ function exclusionsDialogDescription(count: number): string {
 
 function CreateExclusionsDialog({
   signals,
+  skippedJudge,
   creating,
   onCancel,
   onConfirm,
 }: {
   signals: RiskSignal[] | null;
+  /** Judge-backed signals dropped from the selection — not excludable. */
+  skippedJudge: number;
   creating: boolean;
   onCancel: () => void;
   onConfirm: () => void;
@@ -513,6 +538,14 @@ function CreateExclusionsDialog({
             <li key={signal.key}>{getRuleTitleFallback(signal.ruleId)}</li>
           ))}
         </ul>
+        {skippedJudge > 0 && (
+          <Text small muted>
+            {skippedJudge} prompt-based{" "}
+            {skippedJudge === 1 ? "signal was" : "signals were"} left out —
+            those findings can't be excluded. Mark them as false positives
+            instead.
+          </Text>
+        )}
         <Dialog.Footer>
           <Button variant="tertiary" disabled={creating} onClick={onCancel}>
             <Button.Text>Cancel</Button.Text>


### PR DESCRIPTION
## Summary

Watchdog presented judge-backed findings (prompt policy / prompt injection) exactly like scanner findings, which broke down in three ways: the evidence card rendered a "Click to reveal" control over an event that is often empty (judge verdicts carry no match on the realtime path), the judge's verdict rationale was never shown, and exclusion CTAs were offered even though judge findings cannot be meaningfully excluded — every judge finding shares one constant rule id per detector, so a rule exclusion silences the whole detector.

Refs AIS-537.

## Changes

- **Evidence rows for judge findings** render the verdict rationale (`RiskResult.description`) via the existing `EventMatchDialog` — the audited, `chat:read`-gated flagged-event dialog — instead of `MaskedMatch` over a missing event. Non-judge rows are unchanged.
- **Exclusion CTAs hidden for judge findings**, with false-positive dismissal as the action instead:
  - per-evidence-row "Exclude" button hidden; "False positive" stays;
  - the signal-level "Create exclusion rule" button becomes "Mark all as false positive" for judge-backed signals (same collect-then-confirm flow as the list's bulk action, scoped to the page's time window), with a hint that prompt-based findings can't be excluded;
  - bulk "Set up exclusion rules" skips judge signals — an all-judge selection gets an explanatory toast, a mixed selection creates rules for the rest and the confirm dialog names how many prompt-based signals were left out.
- **Evidence footer** shows the customer-safe category code (`getCategoryCodeForFinding`) instead of the raw scanner source, and drops the redundant rule title on judge rows.
- **"Evidence · redacted" header and the reveal-all toggle** (which only drives `MaskedMatch` rows) are adjusted for judge-backed signals.
- New `hasJudgeSource` helper in `risk-utils.ts` for the signal-level check over `detectionSources`.

## Verification

- `aube run -F dashboard type-check` — clean (re-run after rebase onto main)
- `aube run -F dashboard lint` — clean
- `aube run -F dashboard test` — 200 files, 1779 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Watchdog now treats judge-based findings (prompt policy/prompt injection) differently from scanner findings to surface verdict rationale and prevent misleading exclusions. Also stabilizes drawer state for signal-level dismissal.

- Judge evidence rows render the rationale via the audited `EventMatchDialog` (gated by `chat:read`) instead of `MaskedMatch`; non-judge rows are unchanged.
- Exclusions are hidden for judge findings:
  - Per-evidence “Exclude” is removed; “False positive” remains.
  - The signal-level CTA becomes “Mark all as false positive” for judge-backed signals, scoped to the page’s time window, with a loading spinner and error toasts.
  - Bulk “Set up exclusion rules” skips judge-backed signals. All-judge selections show an info toast; mixed selections proceed and the confirm dialog names how many were skipped.
- Evidence footer shows the customer-safe category code and omits the rule title for judge findings; the “Evidence · redacted” label and reveal-all toggle only appear for non-judge signals.
- Adds `hasJudgeSource` and uses it in the drawer and bulk exclusion flow. `SignalDrawer` accepts a `window` prop to scope signal-level dismissal and clears pending dialogs on close; stale in-flight collections are ignored when switching signals.
- Aligns with Linear AIS-537 by surfacing verdict rationale and removing exclusion CTAs for judge-based findings.

<sup>Written for commit ed37d5a96e371f515ef5acd197486232a968306e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

