### PR TITLE
fix: preserve finding context when creating regex exclusions

### DIFF
--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -43,6 +43,12 @@ import {
   type ExclusionOption,
 } from "./exclusion-options";
 import { hasRevealableEvent, REVEAL_SCOPE, useUnmaskedMatch } from "./unmask";
+import { EventMatchDialog, MaskedMatch } from "./risk-ui";
+import {
+  getCategoryCodeForFinding,
+  getRuleTitleFallback,
+  isJudgeSource,
+} from "./risk-utils";
 import { useRBAC } from "@/hooks/useRBAC";
 import { invalidateExclusionSurfaces } from "./exclusion-invalidation";
 import { useCelEngine } from "./use-cel-engine";
@@ -372,8 +378,19 @@ function ExclusionForm({
             <RadioGroup
               value={choice}
               onValueChange={(v) => {
-                setChoice(v as ExclusionOption["value"]);
-                if (v === "exact" && !single?.match) reveals.reveal();
+                const next = v as ExclusionOption["value"];
+                // Moving to the DSL box keeps the ready-made rule the user was
+                // on as a starting point instead of an empty textarea — but
+                // never clobbers criteria they already typed.
+                if (
+                  next === "custom" &&
+                  expression.trim() === "" &&
+                  picked?.fields
+                ) {
+                  setExpression(serializeExclusionExpression(picked.fields));
+                }
+                setChoice(next);
+                if (next === "exact" && !single?.match) reveals.reveal();
               }}
               className="gap-2"
             >
@@ -421,6 +438,10 @@ function ExclusionForm({
 
         {choice === "custom" && (
           <>
+            {results.length > 0 && (
+              <SelectedFindingsContext results={results} />
+            )}
+
             <div className="space-y-2">
               <Label>Suggest with AI</Label>
               <TextArea
@@ -507,6 +528,99 @@ function ExclusionForm({
         </Button>
       </SheetFooter>
     </>
+  );
+}
+
+// How many originating findings the custom branch lists before collapsing the
+// rest into a "+N more" line — the block is writing context, not a findings
+// table.
+const FINDINGS_CONTEXT_CAP = 5;
+
+// Customer-safe title for a context row: the detection rule's name, falling
+// back to the category code when the finding carries no rule id. Never the raw
+// scanner source.
+function findingContextTitle(result: RiskResult): string {
+  if (result.ruleId) return getRuleTitleFallback(result.ruleId);
+  return getCategoryCodeForFinding(result.source, result.ruleId);
+}
+
+// The findings the create was started from, kept visible in the "Write it
+// myself" branch so the criteria can be written against the real false
+// positives. Values stay behind the audited reveal flow (MaskedMatch, or the
+// event dialog for judge findings) — rendering this block never exposes a raw
+// match by itself.
+function SelectedFindingsContext({
+  results,
+}: {
+  results: RiskResult[];
+}): JSX.Element {
+  const shown = results.slice(0, FINDINGS_CONTEXT_CAP);
+  const hiddenCount = results.length - shown.length;
+  return (
+    <div className="space-y-2">
+      <Label>Selected findings</Label>
+      <div className="border">
+        {shown.map((result) => (
+          <SelectedFindingRow key={result.id} result={result} />
+        ))}
+        {hiddenCount > 0 && (
+          <div className="border-t px-3 py-2">
+            <Text className="text-muted-foreground" small>
+              +{hiddenCount} more in this selection
+            </Text>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SelectedFindingRow({ result }: { result: RiskResult }): JSX.Element {
+  return (
+    <div className="space-y-1 border-t px-3 py-2 first:border-t-0">
+      <div className="flex items-baseline justify-between gap-3">
+        <Text className="min-w-0 truncate" small>
+          {findingContextTitle(result)}
+        </Text>
+        {result.confidence !== undefined && (
+          <Text className="text-muted-foreground shrink-0 font-mono" small>
+            conf {result.confidence.toFixed(2)}
+          </Text>
+        )}
+      </div>
+      <div className="min-w-0">
+        <SelectedFindingMatch result={result} />
+      </div>
+    </div>
+  );
+}
+
+// The evidence cell for a context row, mirroring the findings tables: judge
+// findings show their rationale and open the flagged event in a dialog, other
+// findings go through the audited click-to-reveal. Chat surfaces carry the
+// plaintext on the finding itself, so there is nothing left to reveal there.
+function SelectedFindingMatch({ result }: { result: RiskResult }): JSX.Element {
+  if (isJudgeSource(result.source)) {
+    return (
+      <EventMatchDialog
+        resultId={result.id}
+        matchRedacted={result.matchRedacted}
+        rationale={result.description}
+      />
+    );
+  }
+  if (result.match) {
+    return (
+      <span
+        className="block min-w-0 overflow-x-auto font-mono text-xs whitespace-nowrap"
+        title={result.match}
+      >
+        {result.match}
+      </span>
+    );
+  }
+  return (
+    <MaskedMatch resultId={result.id} matchRedacted={result.matchRedacted} />
   );
 }
 


### PR DESCRIPTION
## Problem

In the exclusion creation flow, switching to the "Write it myself" (custom regex) branch dropped all context from the findings the exclusion was started from: no finding values were visible, the criteria textarea always started empty, and selections with no ready-made option landed directly on a bare textarea. Writing a pattern against the real false positives meant memorizing them first. (AIS-538)

## Changes

- **Selected-findings context block in the custom branch**: when the custom option is active and the create originated from findings, a compact list (capped at 5, with a "+N more" line) renders above the AI-suggest block. Each row shows a customer-safe rule title, confidence, and the evidence behind the existing audited reveal flow — `MaskedMatch` click-to-reveal for scanner findings, the rationale + `EventMatchDialog` for judge findings, and the plaintext directly on chat surfaces that already carry it. No raw value is exposed without a reveal.
- **Seed the criteria textarea when switching to custom**: moving from a picked ready-made option to "Write it myself" seeds the empty textarea with that option's serialized expression as a starting point. A non-empty expression the user already typed is never overwritten, and a pending exact option (reveal not yet resolved) seeds nothing.
- **Context independent of the radio-picker guard**: the block lives in the custom branch, not behind the `options.length > 1` picker guard — so multi-finding selections that share no rule/source (which open straight onto the textarea with no picker) now show their findings too.

## Testing

Run on the change at its base (the branch then rebased cleanly onto latest main; the interim upstream edit to this file, #5258, touches disjoint logic):

- `aube run -F dashboard type-check` — clean
- `aube run -F dashboard lint` — clean (ESLint + format)
- `aube run -F dashboard test` — 200 files / 1779 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves selected-finding context when switching to “Write it myself” during regex exclusion creation, so users can write patterns against real false positives. Previously the custom branch hid selected findings and opened an empty criteria box.

- Shows a compact “Selected findings” list in the custom branch (up to 5 items, then “+N more”) with rule title or category code, confidence, and evidence via existing reveal flows (`MaskedMatch` for scanner, `EventMatchDialog` for judge; chat surfaces show plaintext). No raw values are exposed without reveal.
- Seeds the criteria textarea with the picked ready-made option’s serialized expression when switching to custom. Does not overwrite user-typed content. Does not seed when the exact match option is pending reveal.
- Renders the context block even when no radio picker appears (e.g., mixed-source selections that open directly to the textarea).
- Scope: UI-only change to the exclusion sheet; no API or data model changes. Addresses Linear AIS-538.

<sup>Written for commit 83ce681cfbe32b2fe6f62eca4ae967a01a4ed0bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

