### PR TITLE
chore(admin): move the admin tables onto TanStack Table

### DIFF
--- a/client/admin/package.json
+++ b/client/admin/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "catalog:",
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "1.170.20",
+    "@tanstack/react-table": "9.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "catalog:",

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -1,4 +1,12 @@
 // oxlint-disable react/only-export-components -- compound component (Object.assign) pattern
+import {
+  columnVisibilityFeature,
+  FlexRender,
+  tableFeatures,
+  type ReactTable,
+  type Row,
+  type RowData,
+} from "@tanstack/react-table";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -12,33 +20,33 @@ import {
 } from "@/components/ui/table";
 
 /**
- * Column-driven wrapper around the table primitives.
+ * Presentational wrapper around the table primitives, driven by a TanStack
+ * table instance.
  *
- * Two ways to use it:
+ * Compose it: `DataTable.Header`, `DataTable.Body`, `DataTable.Row`. A page
+ * keeps its own per-row classes and handlers that way.
  *
- *   - pass `data` + `rowKey` and let it render the header, the rows and the
- *     empty state;
- *   - pass children and compose `DataTable.Header` / `DataTable.Body` /
- *     `DataTable.Row` yourself when a page needs per-row classes or handlers.
- *
- * The `ui/table` primitives are stock shadcn, so the column sizing and the
- * padding scale live here rather than in the primitive.
+ * The `ui/table` primitives are stock shadcn, so the padding scale lives here
+ * rather than in the primitive.
  */
-
-export type TableCellPadding = "condensed" | "normal" | "spacious";
 
 /**
- * `'auto'` sizes a column to its content. Everything else takes the width
- * as given.
+ * The feature registry every admin table shares.
+ *
+ * Column visibility gates `row.getVisibleCells`, `column.getIsVisible` and
+ * `column.getCanHide`, which this wrapper and its header both call. A table
+ * with no Columns control still registers it for that reason.
  */
-export type ColumnWidth = "auto" | `${number}px` | `${number}%`;
+export const dataTableFeatures = tableFeatures({ columnVisibilityFeature });
 
-export type Column<T extends object> = {
-  key: keyof T | string;
-  header: React.ReactNode;
-  render?: (row: T) => React.ReactNode;
-  width?: ColumnWidth;
-};
+export type DataTableFeatures = typeof dataTableFeatures;
+
+export type DataTableInstance<T extends RowData> = ReactTable<
+  DataTableFeatures,
+  T
+>;
+
+export type TableCellPadding = "condensed" | "normal" | "spacious";
 
 // Applied to the table root so the scale reaches every th and td, including
 // the ones a page composes by hand.
@@ -48,75 +56,15 @@ const cellPaddingClasses: Record<TableCellPadding, string> = {
   spacious: "[&_th]:h-12 [&_th]:px-4 [&_td]:px-4 [&_td]:py-3",
 };
 
-function columnStyle<T extends object>(
-  column: Column<T>,
-): React.CSSProperties | undefined {
-  if (!column.width) return undefined;
-  // A width of 1% collapses the column onto its content under `table-layout:
-  // auto`, which is what `'auto'` meant on the old grid table.
-  return { width: column.width === "auto" ? "1%" : column.width };
-}
-
-type SharedProps<T extends object> = {
-  columns: Column<T>[];
+function DataTableRoot({
+  cellPadding = "normal",
+  className,
+  children,
+}: {
   cellPadding?: TableCellPadding;
   className?: string;
-};
-
-type WrapperProps<T extends object> = SharedProps<T> & {
   children: React.ReactNode;
-};
-
-type DataProps<T extends object> = SharedProps<T> & {
-  data: T[];
-  rowKey: (row: T) => string | number;
-  onRowClick?: (row: T) => void;
-  noResultsMessage?: React.ReactNode;
-};
-
-function isWrapperProps<T extends object>(
-  props: WrapperProps<T> | DataProps<T>,
-): props is WrapperProps<T> {
-  return "children" in props && props.children !== undefined;
-}
-
-function cellContent<T extends object>(row: T, column: Column<T>) {
-  if (column.render) {
-    return column.render(row);
-  }
-
-  return column.key in row ? String(row[column.key as keyof T]) : "";
-}
-
-function DataTableRoot<T extends object>(
-  props: WrapperProps<T> | DataProps<T>,
-) {
-  const { columns, cellPadding = "normal", className } = props;
-
-  const content = isWrapperProps(props) ? (
-    props.children
-  ) : (
-    <>
-      <DataTableHeader columns={columns} />
-      <TableBody>
-        {props.data.length === 0 ? (
-          <DataTableNoResultsMessage>
-            {props.noResultsMessage}
-          </DataTableNoResultsMessage>
-        ) : (
-          props.data.map((row) => (
-            <DataTableRow
-              key={props.rowKey(row)}
-              row={row}
-              columns={columns}
-              onClick={props.onRowClick}
-            />
-          ))
-        )}
-      </TableBody>
-    </>
-  );
-
+}) {
   return (
     // The stock table container sets `overflow-x: auto`, which also turns it
     // into a vertical scroll box. The sticky header would then pin to that box
@@ -124,40 +72,40 @@ function DataTableRoot<T extends object>(
     // the page keeps both the scrolling and the pinned header.
     <div className="[&>[data-slot=table-container]]:overflow-visible">
       <Table className={cn(cellPaddingClasses[cellPadding], className)}>
-        {content}
+        {children}
       </Table>
     </div>
   );
 }
 
-function DataTableHeader<T extends object>({
-  columns,
+function DataTableHeader<T extends RowData>({
+  table,
   className,
 }: {
-  columns: Column<T>[];
+  table: DataTableInstance<T>;
   className?: string;
 }) {
   return (
     <TableHeader className={cn("bg-muted sticky top-0 z-10", className)}>
-      <TableRow>
-        {columns.map((column) => (
-          <TableHead key={String(column.key)} style={columnStyle(column)}>
-            {column.header}
-          </TableHead>
-        ))}
-      </TableRow>
+      {table.getHeaderGroups().map((group) => (
+        <TableRow key={group.id}>
+          {group.headers.map((header) => (
+            <TableHead key={header.id}>
+              {header.isPlaceholder ? null : <FlexRender header={header} />}
+            </TableHead>
+          ))}
+        </TableRow>
+      ))}
     </TableHeader>
   );
 }
 
-function DataTableRow<T extends object>({
+function DataTableRow<T extends RowData>({
   row,
-  columns,
   onClick,
   className,
 }: {
-  row: T;
-  columns: Column<T>[];
+  row: Row<DataTableFeatures, T>;
   onClick?: (row: T) => void;
   className?: string;
 }) {
@@ -173,7 +121,7 @@ function DataTableRow<T extends object>({
         if ((event.target as HTMLElement).closest("a,button,input,label")) {
           return;
         }
-        onClick(row);
+        onClick(row.original);
       }
     : undefined;
 
@@ -182,9 +130,9 @@ function DataTableRow<T extends object>({
       className={cn(onClick && "cursor-pointer", className)}
       onClick={handleClick}
     >
-      {columns.map((column) => (
-        <TableCell key={String(column.key)}>
-          {cellContent(row, column)}
+      {row.getVisibleCells().map((cell) => (
+        <TableCell key={cell.id}>
+          <FlexRender cell={cell} />
         </TableCell>
       ))}
     </TableRow>

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -90,7 +90,10 @@ function DataTableHeader<T extends RowData>({
       {table.getHeaderGroups().map((group) => (
         <TableRow key={group.id}>
           {group.headers.map((header) => (
-            <TableHead key={header.id}>
+            // A placeholder header and a colSpan above 1 both appear only when
+            // columns are grouped. Handling one and not the other would leave a
+            // group heading sitting over a single column.
+            <TableHead key={header.id} colSpan={header.colSpan}>
               {header.isPlaceholder ? null : <FlexRender header={header} />}
             </TableHead>
           ))}

--- a/client/admin/src/pages/OrganizationDetail.test.tsx
+++ b/client/admin/src/pages/OrganizationDetail.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, fireEvent, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AdminOrganization,
+  AdminOrganizationMember,
+  AdminProject,
+} from "@/lib/gramAdminApi";
+
+import { routeTree } from "@/routeTree.gen";
+import { renderRouteTree } from "@/test/harness";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getOrganization: vi.fn(),
+  listOrganizationProjects: vi.fn(),
+  listOrganizationMembers: vi.fn(),
+}));
+
+// Only the endpoints this route reaches are replaced. The rest of the module
+// stays real, so toSearchParams still decides what a request carries.
+vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
+  return {
+    ...actual,
+    getSession: mocks.getSession,
+    getOrganization: mocks.getOrganization,
+    listOrganizationProjects: mocks.listOrganizationProjects,
+    listOrganizationMembers: mocks.listOrganizationMembers,
+  };
+});
+
+const ORG: AdminOrganization = {
+  id: "org_placeholder_one",
+  name: "Placeholder One",
+  slug: "placeholder-one",
+  account_type: "pro",
+  whitelisted: true,
+  member_count: 1,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-07T00:00:00Z",
+};
+
+const PROJECT: AdminProject = {
+  id: "proj_placeholder_one",
+  name: "Placeholder Project",
+  slug: "placeholder-project",
+  created_at: "2026-01-03T00:00:00Z",
+  updated_at: "2026-01-04T00:00:00Z",
+};
+
+const MEMBER: AdminOrganizationMember = {
+  id: "user_placeholder_one",
+  email: "member@example.test",
+  display_name: "Placeholder Member",
+  last_login: "2026-01-05T00:00:00Z",
+  created_at: "2026-01-06T00:00:00Z",
+  updated_at: "2026-01-06T00:00:00Z",
+};
+
+// Both panels render a date through toLocaleString, so the expected text has to
+// come out of the same formatter. Reading the field off the fixture is what the
+// assertion is for: the format is not.
+function longDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+// A Radix tab trigger selects on mousedown, not on click. The panel only
+// mounts once the organization lands, so the trigger is awaited.
+async function selectTab(name: string): Promise<void> {
+  const tab = await screen.findByRole("tab", { name });
+  fireEvent.mouseDown(tab, { button: 0, ctrlKey: false });
+}
+
+function cellsOf(row: HTMLElement): (string | null)[] {
+  return within(row)
+    .getAllByRole("cell")
+    .map((cell) => cell.textContent);
+}
+
+function rowFor(link: HTMLElement): HTMLTableRowElement {
+  const row = link.closest("tr");
+  if (!row) throw new Error("the link is not inside a row");
+  return row;
+}
+
+beforeEach(() => {
+  mocks.getSession.mockReset();
+  mocks.getSession.mockResolvedValue({
+    email: "ops@example.test",
+    name: "Ops",
+  });
+  mocks.getOrganization.mockReset();
+  mocks.getOrganization.mockResolvedValue(ORG);
+  mocks.listOrganizationProjects.mockReset();
+  mocks.listOrganizationProjects.mockResolvedValue({ projects: [PROJECT] });
+  mocks.listOrganizationMembers.mockReset();
+  mocks.listOrganizationMembers.mockResolvedValue({ members: [MEMBER] });
+});
+
+afterEach(cleanup);
+
+describe("organization detail", () => {
+  it("renders every projects cell out of the record that produced it", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    const link = await screen.findByRole("link", { name: PROJECT.name });
+    expect(link.getAttribute("href")).toBe(`/projects/${PROJECT.slug}`);
+
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual(["Name", "Slug", "ID", "Created"]);
+    expect(cellsOf(rowFor(link))).toEqual([
+      PROJECT.name,
+      PROJECT.slug,
+      PROJECT.id,
+      longDate(PROJECT.created_at),
+    ]);
+  });
+
+  it("renders every members cell out of the record that produced it", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+    // Radix leaves the other tab's content out of the document until it is
+    // selected.
+    await selectTab("Members");
+
+    const lastLogin = MEMBER.last_login;
+    if (!lastLogin) throw new Error("the member under test needs a last login");
+
+    const emailCell = await screen.findByRole("cell", { name: MEMBER.email });
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual(["Email", "Name", "ID", "Last login", "Joined"]);
+
+    const row = emailCell.closest("tr");
+    if (!row) throw new Error("the email cell is not inside a row");
+    expect(cellsOf(row)).toEqual([
+      MEMBER.email,
+      MEMBER.display_name,
+      MEMBER.id,
+      longDate(lastLogin),
+      longDate(MEMBER.created_at),
+    ]);
+  });
+});

--- a/client/admin/src/pages/OrganizationDetail.tsx
+++ b/client/admin/src/pages/OrganizationDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, type JSX } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
+import { createColumnHelper, useTable } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -11,7 +12,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { DataTable as Table, type Column } from "@/components/data-table";
+import {
+  dataTableFeatures,
+  DataTable as Table,
+  type DataTableFeatures,
+} from "@/components/data-table";
 import { useConfirmDialog } from "@/components/ConfirmDialog";
 import { ACCOUNT_TYPE_OPTIONS, isAccountType } from "@/lib/accountTypes";
 import { cn } from "@/lib/utils";
@@ -292,40 +297,43 @@ function projectsMessage(isLoading: boolean, isError: boolean): string {
   return "No projects in this organization";
 }
 
-const PROJECT_COLUMNS: Column<AdminProject>[] = [
-  {
-    key: "name",
+const projectColumn = createColumnHelper<DataTableFeatures, AdminProject>();
+
+const PROJECT_COLUMNS = projectColumn.columns([
+  projectColumn.accessor("name", {
     header: "Name",
     // The link, not the row, carries the keyboard path and the accessible
     // name. It also lets the operator open the project in a new tab.
-    render: (p) => (
+    cell: ({ row }) => (
       <Link
         to="/projects/$idOrSlug"
-        params={{ idOrSlug: p.slug || p.id }}
+        params={{ idOrSlug: row.original.slug || row.original.id }}
         className="text-sm underline-offset-4 hover:underline focus-visible:underline"
       >
-        {p.name}
+        {row.original.name}
       </Link>
     ),
-  },
-  {
-    key: "slug",
+  }),
+  projectColumn.accessor("slug", {
     header: "Slug",
-    render: (p) => <span className="text-sm">{p.slug}</span>,
-  },
-  {
-    key: "id",
+    cell: ({ row }) => <span className="text-sm">{row.original.slug}</span>,
+  }),
+  projectColumn.accessor("id", {
     header: "ID",
-    render: (p) => (
-      <span className="text-muted-foreground text-sm">{p.id}</span>
+    cell: ({ row }) => (
+      <span className="text-muted-foreground text-sm">{row.original.id}</span>
     ),
-  },
-  {
-    key: "created_at",
+  }),
+  projectColumn.accessor("created_at", {
     header: "Created",
-    render: (p) => <span className="text-sm">{fmtDate(p.created_at)}</span>,
-  },
-];
+    cell: ({ row }) => (
+      <span className="text-sm">{fmtDate(row.original.created_at)}</span>
+    ),
+  }),
+]);
+
+// A fresh fallback array each render would rebuild the row model every time.
+const NO_PROJECTS: AdminProject[] = [];
 
 function OrgProjectsPanel({ orgID }: { orgID: string }) {
   const navigate = useNavigate();
@@ -334,29 +342,35 @@ function OrgProjectsPanel({ orgID }: { orgID: string }) {
     enabled: !!orgID,
   });
 
-  const projects = data?.projects ?? [];
+  const table = useTable({
+    features: dataTableFeatures,
+    columns: PROJECT_COLUMNS,
+    data: data?.projects ?? NO_PROJECTS,
+    getRowId: (project) => project.id,
+  });
+
+  const rows = table.getRowModel().rows;
 
   return (
     <div className="max-h-96 overflow-auto rounded-lg border">
-      <Table columns={PROJECT_COLUMNS} cellPadding="condensed">
-        <Table.Header columns={PROJECT_COLUMNS} />
+      <Table cellPadding="condensed">
+        <Table.Header table={table} />
         <Table.Body>
-          {isLoading || projects.length === 0 ? (
+          {isLoading || rows.length === 0 ? (
             <Table.NoResultsMessage>
               <span className="text-muted-foreground text-sm">
                 {projectsMessage(isLoading, isError)}
               </span>
             </Table.NoResultsMessage>
           ) : (
-            projects.map((p) => (
+            rows.map((row) => (
               <Table.Row
-                key={p.id}
-                row={p}
-                columns={PROJECT_COLUMNS}
-                onClick={() => {
+                key={row.id}
+                row={row}
+                onClick={(project) => {
                   void navigate({
                     to: "/projects/$idOrSlug",
-                    params: { idOrSlug: p.slug || p.id },
+                    params: { idOrSlug: project.slug || project.id },
                   });
                 }}
               />
@@ -368,39 +382,51 @@ function OrgProjectsPanel({ orgID }: { orgID: string }) {
   );
 }
 
-const MEMBER_COLUMNS: Column<AdminOrganizationMember>[] = [
-  {
-    key: "email",
+const memberColumn = createColumnHelper<
+  DataTableFeatures,
+  AdminOrganizationMember
+>();
+
+const MEMBER_COLUMNS = memberColumn.columns([
+  memberColumn.accessor("email", {
     header: "Email",
-    render: (m) => <span className="text-sm">{m.email}</span>,
-  },
-  {
-    key: "display_name",
+    cell: ({ row }) => <span className="text-sm">{row.original.email}</span>,
+  }),
+  memberColumn.accessor("display_name", {
     header: "Name",
-    render: (m) => <span className="text-sm">{m.display_name}</span>,
-  },
-  {
-    key: "id",
-    header: "ID",
-    render: (m) => (
-      <span className="text-muted-foreground text-sm">{m.id}</span>
+    cell: ({ row }) => (
+      <span className="text-sm">{row.original.display_name}</span>
     ),
-  },
-  {
-    key: "last_login",
+  }),
+  memberColumn.accessor("id", {
+    header: "ID",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground text-sm">{row.original.id}</span>
+    ),
+  }),
+  memberColumn.accessor("last_login", {
     header: "Last login",
-    render: (m) => (
-      <span className={cn("text-sm", !m.last_login && "text-muted-foreground")}>
-        {fmtDate(m.last_login)}
+    cell: ({ row }) => (
+      <span
+        className={cn(
+          "text-sm",
+          !row.original.last_login && "text-muted-foreground",
+        )}
+      >
+        {fmtDate(row.original.last_login)}
       </span>
     ),
-  },
-  {
-    key: "created_at",
+  }),
+  memberColumn.accessor("created_at", {
     header: "Joined",
-    render: (m) => <span className="text-sm">{fmtDate(m.created_at)}</span>,
-  },
-];
+    cell: ({ row }) => (
+      <span className="text-sm">{fmtDate(row.original.created_at)}</span>
+    ),
+  }),
+]);
+
+// A fresh fallback array each render would rebuild the row model every time.
+const NO_MEMBERS: AdminOrganizationMember[] = [];
 
 function membersMessage(isLoading: boolean, isError: boolean): string {
   if (isLoading) return "Loading...";
@@ -414,23 +440,28 @@ function OrgMembersPanel({ orgID }: { orgID: string }) {
     enabled: !!orgID,
   });
 
-  const members = data?.members ?? [];
+  const table = useTable({
+    features: dataTableFeatures,
+    columns: MEMBER_COLUMNS,
+    data: data?.members ?? NO_MEMBERS,
+    getRowId: (member) => member.id,
+  });
+
+  const rows = table.getRowModel().rows;
 
   return (
     <div className="max-h-96 overflow-auto rounded-lg border">
-      <Table columns={MEMBER_COLUMNS} cellPadding="condensed">
-        <Table.Header columns={MEMBER_COLUMNS} />
+      <Table cellPadding="condensed">
+        <Table.Header table={table} />
         <Table.Body>
-          {isLoading || members.length === 0 ? (
+          {isLoading || rows.length === 0 ? (
             <Table.NoResultsMessage>
               <span className="text-muted-foreground text-sm">
                 {membersMessage(isLoading, isError)}
               </span>
             </Table.NoResultsMessage>
           ) : (
-            members.map((m) => (
-              <Table.Row key={m.id} row={m} columns={MEMBER_COLUMNS} />
-            ))
+            rows.map((row) => <Table.Row key={row.id} row={row} />)
           )}
         </Table.Body>
       </Table>

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -1,8 +1,12 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import type { Column, RowData } from "@tanstack/react-table";
 import { SearchIcon } from "lucide-react";
 import { useEffect, useState, type JSX } from "react";
 
-import type { Column } from "@/components/data-table";
+import type {
+  DataTableFeatures,
+  DataTableInstance,
+} from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -19,7 +23,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ACCOUNT_TYPE_OPTIONS, isAccountType } from "@/lib/accountTypes";
-import type { AdminOrganization } from "@/lib/gramAdminApi";
 import { cn } from "@/lib/utils";
 import type { OrganizationsSearch } from "@/routes/organizations.index";
 
@@ -134,21 +137,14 @@ export function Toolbar(): JSX.Element {
  * selected, so the slice that adds bulk actions swaps its contents in place
  * and no row moves under the pointer.
  */
-export function TableActionBar({
-  columns,
-  visibleColumns,
-  onToggleColumn,
+export function TableActionBar<T extends RowData>({
+  table,
 }: {
-  columns: Column<AdminOrganization>[];
-  visibleColumns: Column<AdminOrganization>[];
-  onToggleColumn: (key: string) => void;
+  table: DataTableInstance<T>;
 }): JSX.Element {
-  // The keys come from the array the table renders, not from a second walk of
-  // the same predicate, so the menu cannot disagree with the table about how
-  // many columns are left.
-  const visibleKeys = new Set(
-    visibleColumns.map((column) => String(column.key)),
-  );
+  // Read off the table rather than walked a second time here, so the menu
+  // cannot disagree with the table about how many columns are left.
+  const visibleCount = table.getVisibleLeafColumns().length;
 
   return (
     <div className="flex items-center gap-3 border-b px-3 py-2">
@@ -161,16 +157,16 @@ export function TableActionBar({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {columns.map((column) => {
-            const key = String(column.key);
-            const checked = visibleKeys.has(key);
+          {table.getAllLeafColumns().map((column) => {
+            const checked = column.getIsVisible();
             // Hiding the last one leaves a header with no cells above rows with
             // no cells. This menu still lists every column, so the operator can
             // climb back out, but the table is unreadable until they do.
-            const locked = checked && visibleKeys.size === 1;
+            const locked =
+              !column.getCanHide() || (checked && visibleCount === 1);
             return (
               <DropdownMenuCheckboxItem
-                key={key}
+                key={column.id}
                 checked={checked}
                 // Radix drops a `disabled` item out of the menu's roving focus,
                 // so a keyboard or a screen reader never reaches it. Marking it
@@ -183,10 +179,10 @@ export function TableActionBar({
                   if (locked) event.preventDefault();
                 }}
                 onCheckedChange={() => {
-                  if (!locked) onToggleColumn(key);
+                  if (!locked) column.toggleVisibility();
                 }}
               >
-                {column.header}
+                {columnLabel(column)}
               </DropdownMenuCheckboxItem>
             );
           })}
@@ -194,4 +190,13 @@ export function TableActionBar({
       </DropdownMenu>
     </div>
   );
+}
+
+// A header is a renderable in general, and only a string carries a label a
+// screen reader can announce here. The id is the readable fallback.
+function columnLabel<T extends RowData>(
+  column: Column<DataTableFeatures, T>,
+): string {
+  const { header } = column.columnDef;
+  return typeof header === "string" ? header : column.id;
 }

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
+import { createColumnHelper } from "@tanstack/react-table";
 
-import type { Column } from "@/components/data-table";
+import type { DataTableFeatures } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
@@ -13,85 +14,91 @@ function fmtDateShort(iso?: string): string {
   return d.toLocaleDateString();
 }
 
+const column = createColumnHelper<DataTableFeatures, AdminOrganization>();
+
 // Module scope gives the array one identity for the life of the tab, so the
-// memos on the page that take it as a dependency survive a re-render. The
-// header of each column doubles as its label in the Columns control.
-export const ORG_COLUMNS: Column<AdminOrganization>[] = [
-  {
-    key: "name",
+// table does not rebuild its column model on every render. The header of each
+// column doubles as its label in the Columns control.
+export const ORG_COLUMNS = column.columns([
+  column.accessor("name", {
     header: "Name",
     // The link, not the row, carries the keyboard path and the accessible
     // name. It also lets the operator open the organization in a new tab.
-    render: (org) => (
+    cell: ({ row }) => (
       <Link
         to="/organizations/$idOrSlug"
-        params={{ idOrSlug: org.slug || org.id }}
+        params={{ idOrSlug: row.original.slug || row.original.id }}
         className="text-sm underline-offset-4 hover:underline focus-visible:underline"
       >
-        {org.name}
+        {row.original.name}
       </Link>
     ),
-  },
-  {
-    key: "slug",
+  }),
+  column.accessor("slug", {
     header: "Slug",
-    render: (org) => <span className="text-sm">{org.slug}</span>,
-  },
-  {
-    key: "account_type",
+    cell: ({ row }) => <span className="text-sm">{row.original.slug}</span>,
+  }),
+  column.accessor("account_type", {
     header: "Type",
-    render: (org) => (
+    cell: ({ row }) => (
       <Badge variant="outline" className={badgeTone.neutral}>
-        {org.account_type}
+        {row.original.account_type}
       </Badge>
     ),
-  },
-  {
-    key: "member_count",
+  }),
+  column.accessor("member_count", {
     header: "Members",
-    render: (org) => <span className="text-sm">{org.member_count}</span>,
-  },
-  {
-    key: "workos_id",
+    cell: ({ row }) => (
+      <span className="text-sm">{row.original.member_count}</span>
+    ),
+  }),
+  column.accessor("workos_id", {
     header: "WorkOS",
-    render: (org) => (
-      <span
-        className={cn("text-sm", !org.workos_id && "text-muted-foreground")}
-      >
-        {org.workos_id ? `${org.workos_id.substring(0, 12)}...` : "-"}
-      </span>
-    ),
-  },
-  {
-    key: "disabled_at",
-    header: "Disabled",
-    render: (org) => (
-      <span
-        className={cn("text-sm", !org.disabled_at && "text-muted-foreground")}
-      >
-        {org.disabled_at ? fmtDateShort(org.disabled_at) : "-"}
-      </span>
-    ),
-  },
-  {
-    key: "free_trial_ends_at",
-    header: "Trial ends",
-    render: (org) => (
+    cell: ({ row }) => (
       <span
         className={cn(
           "text-sm",
-          !org.free_trial_ends_at && "text-muted-foreground",
+          !row.original.workos_id && "text-muted-foreground",
         )}
       >
-        {fmtDateShort(org.free_trial_ends_at)}
+        {row.original.workos_id
+          ? `${row.original.workos_id.substring(0, 12)}...`
+          : "-"}
       </span>
     ),
-  },
-  {
-    key: "created_at",
-    header: "Created",
-    render: (org) => (
-      <span className="text-sm">{fmtDateShort(org.created_at)}</span>
+  }),
+  column.accessor("disabled_at", {
+    header: "Disabled",
+    cell: ({ row }) => (
+      <span
+        className={cn(
+          "text-sm",
+          !row.original.disabled_at && "text-muted-foreground",
+        )}
+      >
+        {row.original.disabled_at
+          ? fmtDateShort(row.original.disabled_at)
+          : "-"}
+      </span>
     ),
-  },
-];
+  }),
+  column.accessor("free_trial_ends_at", {
+    header: "Trial ends",
+    cell: ({ row }) => (
+      <span
+        className={cn(
+          "text-sm",
+          !row.original.free_trial_ends_at && "text-muted-foreground",
+        )}
+      >
+        {fmtDateShort(row.original.free_trial_ends_at)}
+      </span>
+    ),
+  }),
+  column.accessor("created_at", {
+    header: "Created",
+    cell: ({ row }) => (
+      <span className="text-sm">{fmtDateShort(row.original.created_at)}</span>
+    ),
+  }),
+]);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -1,5 +1,10 @@
 import type { AnyRouter } from "@tanstack/react-router";
 import {
+  useTable,
+  type ColumnVisibilityState,
+  type Updater,
+} from "@tanstack/react-table";
+import {
   act,
   cleanup,
   fireEvent,
@@ -22,12 +27,14 @@ import type {
   ListOrganizationsParams,
   ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
+import { useState, type JSX } from "react";
+
 import { routeTree } from "@/routeTree.gen";
 import {
   organizationsSearchSchema,
   type OrganizationsSearch,
 } from "@/routes/organizations.index";
-import type { Column } from "@/components/data-table";
+import { dataTableFeatures } from "@/components/data-table";
 import { renderRouteTree } from "@/test/harness";
 
 import { ORG_COLUMNS } from "./columns";
@@ -245,6 +252,12 @@ describe("organizations list", () => {
     });
     expect(screen.queryByRole("columnheader", { name: "Slug" })).toBeNull();
 
+    // The row has to drop the same cell the header dropped, or every cell
+    // after it slides one column to the left.
+    expect(screen.getAllByRole("cell").length).toBe(
+      screen.getAllByRole("columnheader").length,
+    );
+
     // Reopening reads the menu against the page's own state. Without this the
     // bar could take a constant and its guard would never fire.
     openOn(screen.getByRole("button", { name: "Columns" }));
@@ -353,66 +366,136 @@ describe("organizations list", () => {
   });
 });
 
-// The bar takes its columns as props, so the last-column case is reachable
-// here without clicking seven items shut through a menu that closes each time.
+// The bar takes a table, so the last-column case is reachable here by handing
+// it a two column table rather than by clicking seven items shut through a
+// menu that closes each time.
 describe("TableActionBar", () => {
   const [FIRST, SECOND] = ORG_COLUMNS;
   if (!FIRST || !SECOND) throw new Error("ORG_COLUMNS needs two columns");
 
+  // An accessor column takes its id from its key unless it names one, and that
+  // id is what the visibility state is keyed by.
+  const SECOND_ID = String(SECOND.id ?? SECOND.accessorKey);
+
+  // Sliced, so the array carries the element type useTable asks for.
+  const MENU_COLUMNS = ORG_COLUMNS.slice(0, 2);
+
+  function ColumnsMenu({
+    initialVisibility,
+    onVisibilityChange,
+    columns,
+  }: {
+    initialVisibility: ColumnVisibilityState;
+    onVisibilityChange: (updater: Updater<ColumnVisibilityState>) => void;
+    columns: typeof MENU_COLUMNS;
+  }): JSX.Element {
+    const [columnVisibility, setColumnVisibility] = useState(initialVisibility);
+    const table = useTable({
+      features: dataTableFeatures,
+      columns,
+      data: ORGS,
+      getRowId: (org) => org.id,
+      state: { columnVisibility },
+      // The spy sits in front of the state, so a blocked toggle is a call that
+      // never happened rather than a state that happened to settle back.
+      onColumnVisibilityChange: (updater) => {
+        onVisibilityChange(updater);
+        setColumnVisibility(updater);
+      },
+    });
+    return <TableActionBar table={table} />;
+  }
+
   function openColumnsMenu(
-    visibleColumns: Column<AdminOrganization>[],
-  ): Mock<(key: string) => void> {
-    const onToggleColumn = vi.fn<(key: string) => void>();
+    initialVisibility: ColumnVisibilityState,
+    columns: typeof MENU_COLUMNS = MENU_COLUMNS,
+  ): Mock<(updater: Updater<ColumnVisibilityState>) => void> {
+    const onVisibilityChange =
+      vi.fn<(updater: Updater<ColumnVisibilityState>) => void>();
     render(
-      <TableActionBar
-        columns={ORG_COLUMNS}
-        visibleColumns={visibleColumns}
-        onToggleColumn={onToggleColumn}
+      <ColumnsMenu
+        initialVisibility={initialVisibility}
+        onVisibilityChange={onVisibilityChange}
+        columns={columns}
       />,
     );
     openOn(screen.getByRole("button", { name: "Columns" }));
-    return onToggleColumn;
+    return onVisibilityChange;
+  }
+
+  // A toggle that lands closes the menu. Reopening also reads the item back
+  // against the state that settled, not against the click that asked for it.
+  function reopenColumnsMenu(): void {
+    openOn(screen.getByRole("button", { name: "Columns" }));
   }
 
   // Found by the name an operator reads, so the query goes through the same
   // accessible name a screen reader would announce. A header is a node in
   // general, and only a string carries a name this query can match.
-  function itemFor(column: Column<AdminOrganization>): HTMLElement {
-    const { header } = column;
+  function itemFor(header: unknown): HTMLElement {
     if (typeof header !== "string") {
-      throw new Error(`column ${String(column.key)} needs a text header`);
+      throw new Error("the column under test needs a text header");
     }
     return screen.getByRole("menuitemcheckbox", { name: header });
   }
 
   it("stops the operator hiding the last visible column", () => {
-    const onToggleColumn = openColumnsMenu([FIRST]);
+    const onVisibilityChange = openColumnsMenu({ [SECOND_ID]: false });
 
-    const item = itemFor(FIRST);
+    const item = itemFor(FIRST.header);
     fireEvent.click(item);
-    expect(onToggleColumn).not.toHaveBeenCalled();
+    expect(onVisibilityChange).not.toHaveBeenCalled();
 
     // Marked rather than disabled. Radix drops a disabled item out of the
     // menu's roving focus, and a screen reader then never reaches it.
     expect(item.getAttribute("aria-disabled")).toBe("true");
     expect(item.hasAttribute("data-disabled")).toBe(false);
+
+    // The other half of the guard. Radix dismisses the menu on select unless
+    // the default is prevented, and a menu that closes on a locked item reads
+    // as if the click had worked.
+    expect(itemFor(FIRST.header)).toBe(item);
   });
 
   it("still unhides a column while only one is visible", () => {
-    const onToggleColumn = openColumnsMenu([FIRST]);
+    const onVisibilityChange = openColumnsMenu({ [SECOND_ID]: false });
 
-    fireEvent.click(itemFor(SECOND));
+    const item = itemFor(SECOND.header);
+    expect(item.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(item);
+    expect(onVisibilityChange).toHaveBeenCalled();
 
     // The lock holds the last visible column, not the whole menu. Locking the
     // menu would trap the operator in the state the lock exists to prevent.
-    expect(onToggleColumn).toHaveBeenCalledWith(String(SECOND.key));
+    reopenColumnsMenu();
+    expect(itemFor(SECOND.header).getAttribute("aria-checked")).toBe("true");
   });
 
   it("hides a column while a second one is still visible", () => {
-    const onToggleColumn = openColumnsMenu([FIRST, SECOND]);
+    const onVisibilityChange = openColumnsMenu({});
 
-    fireEvent.click(itemFor(FIRST));
-    expect(onToggleColumn).toHaveBeenCalledWith(String(FIRST.key));
+    fireEvent.click(itemFor(FIRST.header));
+    expect(onVisibilityChange).toHaveBeenCalled();
+
+    reopenColumnsMenu();
+    expect(itemFor(FIRST.header).getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("locks a column that opts out of hiding", () => {
+    // Both are visible, so the last-column rule is not what holds this one.
+    const onVisibilityChange = openColumnsMenu({}, [
+      { ...FIRST, enableHiding: false },
+      SECOND,
+    ]);
+
+    const item = itemFor(FIRST.header);
+    fireEvent.click(item);
+    expect(onVisibilityChange).not.toHaveBeenCalled();
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+
+    // The opt-out is per column, so the menu still works around it.
+    fireEvent.click(itemFor(SECOND.header));
+    expect(onVisibilityChange).toHaveBeenCalled();
   });
 });
 

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -11,6 +11,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import {
   afterEach,
@@ -46,32 +47,79 @@ const mocks = vi.hoisted(() => ({
       (params?: ListOrganizationsParams) => Promise<ListOrganizationsResult>
     >(),
   getSession: vi.fn(),
+  getOrganization: vi.fn(),
+  listOrganizationProjects: vi.fn(),
+  listOrganizationMembers: vi.fn(),
 }));
 
-// Only the two endpoints this page's route tree reaches are replaced. The rest
-// of the module stays real, so toSearchParams and omitUnset still decide what
-// counts as an unset param.
+// Only the endpoints this page's route tree reaches are replaced. The rest of
+// the module stays real, so toSearchParams and omitUnset still decide what
+// counts as an unset param. The three detail endpoints are here because a row
+// click leaves this page for the detail route.
 vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
   return {
     ...actual,
     listOrganizations: mocks.listOrganizations,
     getSession: mocks.getSession,
+    getOrganization: mocks.getOrganization,
+    listOrganizationProjects: mocks.listOrganizationProjects,
+    listOrganizationMembers: mocks.listOrganizationMembers,
   };
 });
 
+// Two rows, and every optional field set on one of them. One row forecloses
+// every ordering and keying fault by construction, and an unset optional field
+// renders the same dash whichever field the cell reads.
 const ORGS: AdminOrganization[] = [
   {
     id: "org_placeholder_one",
     name: "Placeholder One",
     slug: "placeholder-one",
     account_type: "pro",
+    workos_id: "workosplaceholderone",
     whitelisted: true,
+    disabled_at: "2026-03-04T00:00:00Z",
+    free_trial_started_at: "2026-02-01T00:00:00Z",
+    free_trial_ends_at: "2026-05-06T00:00:00Z",
     member_count: 3,
     created_at: "2026-01-02T00:00:00Z",
-    updated_at: "2026-01-02T00:00:00Z",
+    updated_at: "2026-01-07T00:00:00Z",
+  },
+  {
+    id: "org_placeholder_two",
+    name: "Placeholder Two",
+    slug: "placeholder-two",
+    account_type: "free",
+    whitelisted: false,
+    member_count: 7,
+    created_at: "2026-06-08T00:00:00Z",
+    updated_at: "2026-06-09T00:00:00Z",
   },
 ];
+
+// A page the cursor leads to. Nothing it holds appears on the first page, so a
+// row that survives the page change is a reused node rather than a match.
+const NEXT_PAGE_ORG: AdminOrganization = {
+  id: "org_placeholder_three",
+  name: "Placeholder Three",
+  slug: "placeholder-three",
+  account_type: "enterprise",
+  whitelisted: false,
+  member_count: 11,
+  created_at: "2026-07-10T00:00:00Z",
+  updated_at: "2026-07-11T00:00:00Z",
+};
+
+const [FIRST_ORG] = ORGS;
+if (!FIRST_ORG) throw new Error("ORGS needs a row");
+
+// The columns render a date through toLocaleDateString, so the expected text
+// has to come out of the same formatter. Reading the field off the fixture is
+// what the assertion is for: the format is not.
+function shortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
 
 function lastListParams(): ListOrganizationsParams {
   const call = mocks.listOrganizations.mock.calls.at(-1);
@@ -115,6 +163,14 @@ function openOn(trigger: HTMLElement): void {
   });
 }
 
+// Reached through the name link, so a test names the row the way an operator
+// would rather than by position.
+function rowFor(link: HTMLElement): HTMLTableRowElement {
+  const row = link.closest("tr");
+  if (!row) throw new Error("the name link is not inside a row");
+  return row;
+}
+
 function urlFor(search: Record<string, unknown>): string {
   // The router JSON-encodes a non-string value, so a bookmarked URL is built
   // the same way here rather than hand-written.
@@ -133,6 +189,12 @@ beforeEach(() => {
     email: "ops@example.test",
     name: "Ops",
   });
+  mocks.getOrganization.mockReset();
+  mocks.getOrganization.mockResolvedValue(FIRST_ORG);
+  mocks.listOrganizationProjects.mockReset();
+  mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
+  mocks.listOrganizationMembers.mockReset();
+  mocks.listOrganizationMembers.mockResolvedValue({ members: [] });
 });
 
 afterEach(cleanup);
@@ -252,10 +314,10 @@ describe("organizations list", () => {
     });
     expect(screen.queryByRole("columnheader", { name: "Slug" })).toBeNull();
 
-    // The row has to drop the same cell the header dropped, or every cell
+    // Every row has to drop the same cell the header dropped, or every cell
     // after it slides one column to the left.
     expect(screen.getAllByRole("cell").length).toBe(
-      screen.getAllByRole("columnheader").length,
+      screen.getAllByRole("columnheader").length * ORGS.length,
     );
 
     // Reopening reads the menu against the page's own state. Without this the
@@ -364,6 +426,118 @@ describe("organizations list", () => {
     // different result set.
     expect(lastListParams().cursor).toBeUndefined();
   });
+
+  it("renders every cell of a row out of the record that produced it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const { workos_id: workosID, disabled_at: disabledAt } = FIRST_ORG;
+    const trialEndsAt = FIRST_ORG.free_trial_ends_at;
+    if (!workosID || !disabledAt || !trialEndsAt) {
+      throw new Error("the row under test needs its optional fields set");
+    }
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    // The Name cell puts the name in the text and the slug in the href, so a
+    // cell that reads the wrong field cannot satisfy both.
+    expect(link.getAttribute("href")).toBe(`/organizations/${FIRST_ORG.slug}`);
+
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual([
+      "Name",
+      "Slug",
+      "Type",
+      "Members",
+      "WorkOS",
+      "Disabled",
+      "Trial ends",
+      "Created",
+    ]);
+    expect(
+      within(rowFor(link))
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent),
+    ).toEqual([
+      FIRST_ORG.name,
+      FIRST_ORG.slug,
+      FIRST_ORG.account_type,
+      String(FIRST_ORG.member_count),
+      // The truncation length is written out rather than imported. Reading the
+      // column's own constant would move this expectation along with it.
+      `${workosID.substring(0, 12)}...`,
+      shortDate(disabledAt),
+      shortDate(trialEndsAt),
+      shortDate(FIRST_ORG.created_at),
+    ]);
+  });
+
+  it("opens the organization when the operator clicks the row body", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    const [, slugCell] = within(rowFor(link)).getAllByRole("cell");
+    if (!slugCell) throw new Error("the row needs a second cell");
+
+    fireEvent.click(slugCell);
+
+    // The slug, not the id: the handler takes the record, and a handler handed
+    // the row wrapper instead would reach the id and seed the detail page's
+    // cache with a table object.
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        `/organizations/${FIRST_ORG.slug}`,
+      );
+    });
+  });
+
+  it("leaves the current tab in place when the operator command-clicks a name", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    fireEvent.click(link, { button: 0, metaKey: true });
+
+    // The browser opens the link in a background tab and the row handler has to
+    // stay out of it. Without the guard the list the operator meant to keep
+    // navigates away underneath the new tab.
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+    expect(router.state.location.pathname).toBe("/organizations");
+  });
+
+  it("drops focus rather than moving it to another organization on the next page", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    link.focus();
+    expect(document.activeElement).toBe(link);
+
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    // Keyed by index, React reuses this node for the next page's record and
+    // relabels it under the operator's focus. No focus event fires, so the next
+    // Enter opens an organization they never chose.
+    expect(link.isConnected).toBe(false);
+    expect(document.activeElement).toBe(document.body);
+  });
 });
 
 // The bar takes a table, so the last-column case is reachable here by handing
@@ -450,6 +624,14 @@ describe("TableActionBar", () => {
     // menu's roving focus, and a screen reader then never reaches it.
     expect(item.getAttribute("aria-disabled")).toBe("true");
     expect(item.hasAttribute("data-disabled")).toBe(false);
+
+    // The visual half of the same guard. Radix dims a `disabled` item for us
+    // and this one is not disabled, so a sighted operator otherwise reads a
+    // locked item as live and gets no answer when clicking it does nothing.
+    // A token, not a substring: the stock item already carries
+    // `data-[disabled]:opacity-50`.
+    expect(item.classList.contains("opacity-50")).toBe(true);
+    expect(itemFor(SECOND.header).classList.contains("opacity-50")).toBe(false);
 
     // The other half of the guard. Radix dismisses the menu on select unless
     // the default is prevented, and a menu that closes on a locked item reads

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -1,8 +1,9 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearch } from "@tanstack/react-router";
-import { useCallback, useMemo, useState, type JSX } from "react";
+import { useTable, type ColumnVisibilityState } from "@tanstack/react-table";
+import { useState, type JSX } from "react";
 
-import { DataTable as Table } from "@/components/data-table";
+import { dataTableFeatures, DataTable as Table } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
 import { organizationsListQuery } from "@/lib/adminQueries";
 import {
@@ -39,9 +40,8 @@ export function OrganizationsList(): JSX.Element {
 
   // Column visibility is deliberately not in the URL. It is a per-operator
   // preference, not part of the view a link carries, and it resets on reload.
-  const [hiddenColumns, setHiddenColumns] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
+  const [columnVisibility, setColumnVisibility] =
+    useState<ColumnVisibilityState>({});
 
   // One object is the source of both the request and the signature below. Two
   // hand-written lists drift: a slice that adds a filter to the request would
@@ -95,34 +95,20 @@ export function OrganizationsList(): JSX.Element {
     });
   };
 
-  const toggleColumn = useCallback((key: string) => {
-    setHiddenColumns((current) => {
-      const next = new Set(current);
-      if (!next.delete(key)) next.add(key);
-      return next;
-    });
-  }, []);
-
-  const visibleColumns = useMemo(
-    () =>
-      ORG_COLUMNS.filter((column) => !hiddenColumns.has(String(column.key))),
-    [hiddenColumns],
-  );
-
   const orgs = data?.organizations ?? NO_ORGS;
 
-  const rows = useMemo(
-    () =>
-      orgs.map((org) => (
-        <Table.Row
-          key={org.id}
-          row={org}
-          columns={visibleColumns}
-          onClick={openOrganization}
-        />
-      )),
-    [orgs, visibleColumns, openOrganization],
-  );
+  const table = useTable({
+    features: dataTableFeatures,
+    columns: ORG_COLUMNS,
+    data: orgs,
+    // Without this a row is keyed by its index, and React reuses those keys
+    // across a page change and across a filter change.
+    getRowId: (org) => org.id,
+    state: { columnVisibility },
+    onColumnVisibilityChange: setColumnVisibility,
+  });
+
+  const rows = table.getRowModel().rows;
 
   return (
     <div className="space-y-6">
@@ -138,11 +124,7 @@ export function OrganizationsList(): JSX.Element {
         )}
 
         <div className="rounded-lg border">
-          <TableActionBar
-            columns={ORG_COLUMNS}
-            visibleColumns={visibleColumns}
-            onToggleColumn={toggleColumn}
-          />
+          <TableActionBar table={table} />
 
           <div
             className={cn(
@@ -150,17 +132,23 @@ export function OrganizationsList(): JSX.Element {
               isPlaceholderData && "opacity-60",
             )}
           >
-            <Table columns={visibleColumns}>
-              <Table.Header columns={visibleColumns} />
+            <Table>
+              <Table.Header table={table} />
               <Table.Body>
-                {orgs.length === 0 ? (
+                {rows.length === 0 ? (
                   <Table.NoResultsMessage>
                     <span className="text-muted-foreground text-sm">
                       {emptyStateMessage(isLoading, isError)}
                     </span>
                   </Table.NoResultsMessage>
                 ) : (
-                  rows
+                  rows.map((row) => (
+                    <Table.Row
+                      key={row.id}
+                      row={row}
+                      onClick={openOrganization}
+                    />
+                  ))
                 )}
               </Table.Body>
             </Table>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@tanstack/react-router':
         specifier: 1.170.20
         version: 1.170.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-table':
+        specifier: 9.0.0
+        version: 9.0.0(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4346,6 +4349,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-table@9.0.0':
+    resolution: {integrity: sha512-Q/Z49MQcdMwge67U+LTjSEQJCnQE9/tNWK5IpiYex9JFDzfjNkLIi7yzGA4dfW4UpuMBrtqbSnSzn7oPr60T+w==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=18'
+
   '@tanstack/react-virtual@3.14.9':
     resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
     peerDependencies:
@@ -4418,6 +4427,10 @@ packages:
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/table-core@9.0.0':
+    resolution: {integrity: sha512-IyKCc4D7d/+I9euQntlVDQ7lnilmFRKpIROBeI5/866adFy+65xWvCFPz76NZ5j2lXe/RFDvFVV7bfETmwHEMA==}
+    engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
@@ -11998,6 +12011,12 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
+  '@tanstack/react-table@9.0.0(react@19.2.8)':
+    dependencies:
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.0.0
+      react: 19.2.8
+
   '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.17.7
@@ -12127,6 +12146,10 @@ snapshots:
   '@tanstack/store@0.11.1': {}
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/table-core@9.0.0':
+    dependencies:
+      '@tanstack/store': 0.11.1
 
   '@tanstack/virtual-core@3.17.7': {}
 


### PR DESCRIPTION
The admin tables ran on a hand-written `Column<T>` wrapper, so every piece of table state a later slice needs would have accreted by hand. This moves the three tables onto `@tanstack/react-table` and lets the library own that state.

**Nothing changes on screen.** `data-table.tsx` stays the presentational wrapper and keeps the shadcn primitives, the padding scale, the sticky header, the scroll-box override and the row-click guard. It now takes a table instance instead of a column array.

### What moved

- `render` becomes `cell`, and `rowKey` becomes `row.id` backed by `getRowId`.
- The Columns control reads `getAllLeafColumns`, `getIsVisible`, `getCanHide` and `getVisibleLeafColumns` in place of the page's own `Set<string>`. The last-visible-column lock keeps both halves of its guard and now also honours a column that sets `enableHiding: false`.
- Only `columnVisibilityFeature` is registered. Sorting and pagination stay server-side, and the library makes a client-side row model for either one a **type error** without its feature registered, so no manual flag is needed.
- Deleted on the way: per-column width, which no column ever set, and the data-driven mode of `DataTableRoot`, which no call site reached.

### Why 9.0.0 and not 9.1.2

`pnpm-workspace.yaml` sets `minimumReleaseAge` to seven days. Every 9.1.x release is newer than that until 2026-08-16, so they do not install. The forfeited delta is a pagination feature and a sorted-model fix, neither of which this code registers.

### Tests

The second commit is tests only. A conversion like this fails silently: the risk is entirely whether each rewritten cell still reads the field it used to read. The suite could not see that, so blanking every cell in the table passed. It now fails six tests.

Added: a whole-row content assertion for the list and both detail panels, a row-click test including a command-click that must not move the current tab, and coverage for `getRowId`. The fixture gained a second row, because one row forecloses every ordering and keying fault by construction. 50 tests to 56.

### One note for whoever adds the row menu

`getRowId` is load-bearing and easy to delete by accident. Without it, React reuses the row's `<a>` node across a cursor page change and relabels it, so an operator who focused one organization keeps focus on a different one with no focus event. There is now a test for it.

AGE-3182

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves admin tables to `@tanstack/react-table` so the library owns table state with no UI changes. Old behavior used a custom `Column<T>` wrapper and a local visibility set; new behavior builds a TanStack table via `useTable`, passes the instance into `DataTable`, and manages visibility through features. Header groups now render correctly with `colSpan`.

- `DataTable` takes a table instance; exported `dataTableFeatures` registers `columnVisibilityFeature` only. Headers/cells render with `FlexRender`, and grouped headers respect placeholders and `colSpan`.
- Converted organizations list and organization detail (Projects, Members) to `useTable` + `createColumnHelper`. `render` → `cell`; `rowKey` → `getRowId`.
- Columns menu reads `getAllLeafColumns`/`getVisibleLeafColumns`; locks the last visible column and respects `getCanHide`/`enableHiding: false`.
- Row clicks deliver `row.original` and ignore clicks inside links/buttons; `getRowId` keeps focus from jumping across pagination.
- Removed unused per-column width and the wrapper’s data-driven mode.
- Tests assert full-row cell content in list and both detail panels, row-click vs command-click behavior, focus on page change, and Columns menu locking.
- Adds `@tanstack/react-table@9.0.0` (workspace `minimumReleaseAge` blocks 9.1.x).

**Context for AGE-3182**
- Establishes the table state model for upcoming URLable views, sorting, paging, filters, and columns without adding client-side sort/paging.

<sup>Written for commit c80c1671016e5328cd3ad9ba53c06eb090401f55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

