### PR TITLE
mig: partial index on trials for the hourly demotion sweep

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -102,6 +102,12 @@ CREATE TABLE IF NOT EXISTS trials (
   CONSTRAINT trials_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
 );
 
+-- Matches ListExpiredTrials: a row leaves the index as soon as it converts or
+-- demotes, so the hourly sweep stays proportional to live trials.
+CREATE INDEX IF NOT EXISTS trials_ends_at_idx
+ON trials (ends_at)
+WHERE converted_at IS NULL AND demoted_at IS NULL;
+
 -- Billing contract metadata for an organization. Currently holds the
 -- "tokens under management" (TUM) contract terms for enterprise accounts.
 CREATE TABLE IF NOT EXISTS billing_metadata (

--- a/server/migrations/20260817183037_trials-sweep-index.sql
+++ b/server/migrations/20260817183037_trials-sweep-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "trials_ends_at_idx" to table: "trials"
+CREATE INDEX CONCURRENTLY "trials_ends_at_idx" ON "trials" ("ends_at") WHERE ((converted_at IS NULL) AND (demoted_at IS NULL));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Ss7dhHW6vN3sYgz/vh6Y/9hEVDJSE7dTFo5dTEgch5A=
+h1:OCO3royo/C83HQRgLre4EsXCYeTDzzqfSqbFU1qeq5w=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -344,3 +344,4 @@ h1:Ss7dhHW6vN3sYgz/vh6Y/9hEVDJSE7dTFo5dTEgch5A=
 20260814152427_stripe-webhook-event-receipts.sql h1:DHqXglVOvTVASvRPZdwK5atcTJFIL1lo1lohJ8WPxSY=
 20260817091422_platform-mcp-assistant-attribution.sql h1:EmIu+c2TxVrO6ye3g0ksH6UAamXYERPU1a0QgzTog/8=
 20260817103730_sessions-add-last-used-at.sql h1:0jWcIgtofs44J8WODluI5Or8lBDyWXGq948j10Zi/o0=
+20260817183037_trials-sweep-index.sql h1:Vd4zXwW0xF48mg0dDPxAN9IzYgPMtUil9vcloAbuGjU=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`trials` is one row per self-signup organization and never shrinks: expired rows keep `demoted_at`, converted rows keep `converted_at`. The hourly demotion sweep (`ListExpiredTrials`) filters on `ends_at`, `converted_at IS NULL`, and `demoted_at IS NULL`, but the table only has a primary key on `organization_id`, so every sweep sequentially scans the whole table.

## What changed

- Declares partial index `trials_ends_at_idx` on `trials (ends_at) WHERE converted_at IS NULL AND demoted_at IS NULL`.
- Atlas generated `CREATE INDEX CONCURRENTLY` with `-- atlas:txmode none` (same pattern as `20260602183035_dashboard_trigger_unique_index.sql`).
- A row leaves the index as soon as it converts or demotes, so the index stays bounded to live trials.

No application code in this PR per the migrations-ship-alone rule.

Fixes AGE-3123.

## Review notes

- The index was described in PR #4982 when the table was created but never landed in `schema.sql`.
- Deferred out of PR #4983 (the demotion sweeper) because migrations ship alone.
- Regenerated after merging `main` so the timestamp sits after the later billing migrations (`20260814164256`).

## Testing

- `mise run db:diff trials-sweep-index` generated the migration; file was not hand-written.
- `mise run lint:migrations` txmode and ordering checks passed.
- `atlas migrate lint` against a clean `docker://pgvector/pgvector/pg17` dev database passed.
- `atlas migrate diff` reports no schema drift.
- Applied locally via `mise run db:migrate` on the first revision; `EXPLAIN ANALYZE` of `ListExpiredTrials` was an `Index Scan using trials_ends_at_idx` after 2000 converted/demoted rows (index estimated 2 rows).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3123](https://linear.app/speakeasy/issue/AGE-3123/mig-partial-index-on-trials-for-the-hourly-demotion-sweep)

<div><a href="https://cursor.com/agents/bc-8fba3ddd-a4e2-44c4-9305-1a1241fdac7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fba3ddd-a4e2-44c4-9305-1a1241fdac7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a partial index on `trials (ends_at)` where `converted_at IS NULL AND demoted_at IS NULL` so the hourly demotion sweep stops sequential-scanning the whole table. Previously it scanned all rows; now it index-scans live trials only, with no behavior change.

- Creates the index concurrently (`-- atlas:txmode none`) via migration and adds it to `schema.sql` to keep the schema in sync.
- Rows leave the index on convert/demote, keeping it bounded to active trials.
- No application code changes; the planner will use it for `ListExpiredTrials`. Satisfies Linear AGE-3123.

<sup>Written for commit 0fd311c07426a3799d4f47892935fff33a7a5324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

