### PR TITLE
fix: keep actively-running sessions in date-filtered agent sessions list

### DIFF
--- a/.changeset/agent-sessions-daterange-overlap.md
+++ b/.changeset/agent-sessions-daterange-overlap.md
@@ -1,0 +1,10 @@
+---
+"server": patch
+---
+
+Keep actively-running agent sessions listed under a date-range filter. The
+chat list previously required a session's newest message to fall inside the
+requested range, so a session that logged a message after the client's frozen
+`to` bound vanished from the Agent Sessions page until the range was
+re-selected. The range test is now interval overlap: last activity after the
+range opens and created before it closes.

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -729,6 +729,14 @@ func TestListChats_Filter_DateRange_ActiveChatNewerThanTo(t *testing.T) {
 	require.Equal(t, 1, result.Total)
 	require.Len(t, result.Chats, 1)
 	require.Equal(t, activeChat.String(), result.Chats[0].ID)
+
+	// A page past the end takes the CountChats fallback; it must apply the
+	// same overlap semantics and still count the active chat.
+	payload.Offset = 50
+	result, err = ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Empty(t, result.Chats)
 }
 
 func TestListChats_DateRangeAndSortUseLastMessageTimestamp(t *testing.T) {

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -698,6 +698,39 @@ func TestListChats_Filter_DateRange(t *testing.T) {
 	require.Equal(t, oldChat.String(), result.Chats[0].ID)
 }
 
+// TestListChats_Filter_DateRange_ActiveChatNewerThanTo verifies the range test
+// is interval overlap: a chat created inside the window stays listed even when
+// its newest message is more recent than the requested `to` bound. The
+// dashboard freezes `to` when a range is picked, so a still-running session
+// would otherwise vanish from the list as soon as another message lands.
+func TestListChats_Filter_DateRange_ActiveChatNewerThanTo(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := externalUserCtx(t, ti, "ext-active")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	activeChat := seedChatAtTime(t, ctx, ti, "ext-active", now.Add(-2*time.Hour))
+	_, err := repo.New(ti.conn).SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    activeChat,
+		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: now.Add(-time.Minute), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+
+	// `to` is older than the chat's newest message but newer than its creation.
+	from := now.Add(-24 * time.Hour).Format(time.RFC3339)
+	to := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	payload := defaultPayload()
+	payload.From = &from
+	payload.To = &to
+
+	result, err := ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, activeChat.String(), result.Chats[0].ID)
+}
+
 func TestListChats_DateRangeAndSortUseLastMessageTimestamp(t *testing.T) {
 	t.Parallel()
 	ti := newTestChatService(t)

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -574,6 +574,7 @@ chat_activity AS (
   -- aggregating every candidate chat's full message history.
   SELECT
     cc.id,
+    cc.created_at,
     COALESCE(last_msg.ts, cc.created_at) AS last_message_timestamp
   FROM candidate_chats cc
   CROSS JOIN LATERAL (
@@ -584,8 +585,11 @@ chat_activity AS (
 )
 SELECT COUNT(*) AS total
 FROM chat_activity ca
+-- Interval overlap, mirroring ListChats: last activity after the range opens,
+-- created before it closes. Bounding last_message_timestamp above would evict
+-- an actively-writing chat as soon as a message lands past the caller's @to.
 WHERE (@from_time::timestamptz IS NULL OR ca.last_message_timestamp >= @from_time)
-  AND (@to_time::timestamptz IS NULL OR ca.last_message_timestamp <= @to_time);
+  AND (@to_time::timestamptz IS NULL OR ca.created_at <= @to_time);
 
 -- name: ListChats :many
 -- Returns the page plus the pre-LIMIT total (total_count window column), so the
@@ -734,8 +738,14 @@ filtered_chats AS (
     cc.account_email
   FROM candidate_chats cc
   JOIN chat_stats cs ON cs.id = cc.id
+  -- The range test is interval overlap: the chat was active after the range
+  -- opened (last message >= @from_time) and existed before it closed
+  -- (created_at <= @to_time). Bounding last_message_timestamp above instead
+  -- would evict an actively-writing chat the moment a new message lands past
+  -- the caller's @to — the dashboard freezes @to when a range is picked, so
+  -- running sessions would flicker out of the list until the next reload.
   WHERE (@from_time::timestamptz IS NULL OR cs.last_message_timestamp >= @from_time)
-    AND (@to_time::timestamptz IS NULL OR cs.last_message_timestamp <= @to_time)
+    AND (@to_time::timestamptz IS NULL OR cc.created_at <= @to_time)
 ),
 limited_chats AS (
   SELECT

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -191,6 +191,7 @@ chat_activity AS (
   -- aggregating every candidate chat's full message history.
   SELECT
     cc.id,
+    cc.created_at,
     COALESCE(last_msg.ts, cc.created_at) AS last_message_timestamp
   FROM candidate_chats cc
   CROSS JOIN LATERAL (
@@ -202,7 +203,7 @@ chat_activity AS (
 SELECT COUNT(*) AS total
 FROM chat_activity ca
 WHERE ($1::timestamptz IS NULL OR ca.last_message_timestamp >= $1)
-  AND ($2::timestamptz IS NULL OR ca.last_message_timestamp <= $2)
+  AND ($2::timestamptz IS NULL OR ca.created_at <= $2)
 `
 
 type CountChatsParams struct {
@@ -233,6 +234,9 @@ type CountChatsParams struct {
 // filters become a cheap join instead of a correlated subquery per chat. The
 // parameter-only gate makes it a one-time filter that skips the scan entirely
 // when neither risk filter is active.
+// Interval overlap, mirroring ListChats: last activity after the range opens,
+// created before it closes. Bounding last_message_timestamp above would evict
+// an actively-writing chat as soon as a message lands past the caller's @to.
 func (q *Queries) CountChats(ctx context.Context, arg CountChatsParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countChats,
 		arg.FromTime,
@@ -2286,8 +2290,14 @@ filtered_chats AS (
     cc.account_email
   FROM candidate_chats cc
   JOIN chat_stats cs ON cs.id = cc.id
+  -- The range test is interval overlap: the chat was active after the range
+  -- opened (last message >= @from_time) and existed before it closed
+  -- (created_at <= @to_time). Bounding last_message_timestamp above instead
+  -- would evict an actively-writing chat the moment a new message lands past
+  -- the caller's @to — the dashboard freezes @to when a range is picked, so
+  -- running sessions would flicker out of the list until the next reload.
   WHERE ($13::timestamptz IS NULL OR cs.last_message_timestamp >= $13)
-    AND ($14::timestamptz IS NULL OR cs.last_message_timestamp <= $14)
+    AND ($14::timestamptz IS NULL OR cc.created_at <= $14)
 ),
 limited_chats AS (
   SELECT


### PR DESCRIPTION
## Summary

A still-running agent session intermittently vanishes from the Agent Sessions page whenever a date-range filter is active (including the default "Last 30 days"), then reappears after a reload or after re-picking the range. Reported internally against a long-running Claude Code session.

Root cause: `ListChats`/`CountChats` filtered on `last_message_timestamp BETWEEN @from AND @to`, i.e. a point-in-time check on the session's **newest** message. The dashboard freezes `to` at the moment the range preset is picked (`getPresetRange` → `new Date()`), so the instant an active session logs a message newer than that frozen bound, `MAX(chat_messages.created_at) > @to` and the session drops out of the list — while idle sessions stay put. On a busy session (multiple messages per minute) this races constantly, which is why it looks flaky.

## Fix

Make the range test an interval-overlap check in both `ListChats` and `CountChats`:

- was: `last_message_timestamp >= @from AND last_message_timestamp <= @to`
- now: `last_message_timestamp >= @from AND created_at <= @to`

A chat is in range when it was active after the window opened and existed before it closed. Sort semantics are unchanged (recency is still pure message time). Chats created after `to` remain excluded, as before.

## Testing

- New `TestListChats_Filter_DateRange_ActiveChatNewerThanTo`: a chat created inside the window whose newest message is past `to` stays listed.
- Full `server/internal/chat` suite passes.
- Reproduced the bug against prod data before the fix: a range whose `to` predates the session's newest message returned "No traces found" for a session with thousands of in-window messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep actively-running agent sessions visible under a date-range filter by switching the range test to interval overlap. Previously we required the newest message to be within the range; now we include sessions with last activity >= from and created_at <= to, preventing flicker when the dashboard’s frozen to bound is exceeded and keeping totals consistent.

- Updated filters in `server/internal/chat/queries.sql` (and regenerated `server/internal/chat/repo/queries.sql.go`) to use last_message_timestamp >= from and created_at <= to.
- Added `TestListChats_Filter_DateRange_ActiveChatNewerThanTo`, which also verifies the `CountChats` fallback applies the same overlap semantics when paginating past the end.
- Behavior: sort order unchanged (still by last_message_timestamp); sessions created after to remain excluded; no API or response changes.
- Rollout: no migrations; impact limited to date-filtered lists and counts.

<sup>Written for commit 186214ec5cfd36313cc91af255bf34ddf62fe76c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

