### PR TITLE
fix: mark trials inactive in Loops on conversion and expiry

### DIFF
--- a/.changeset/trial-inactive-on-conversion.md
+++ b/.changeset/trial-inactive-on-conversion.md
@@ -1,0 +1,8 @@
+---
+"server": patch
+---
+
+Stop leftover trial reminder emails after a customer converts or a trial
+expires. `trialActive` is now cleared in Loops on Polar conversion, an admin
+account-type change, and demotion, so the 7-day and 1-day sequences no longer
+keep sending to paying or expired orgs.

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -29,6 +29,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
 
 func newAdminCommand() *cli.Command {
@@ -200,6 +202,12 @@ func newAdminCommand() *cli.Command {
 			Usage:   "Dev API key for OpenRouter (primarily for local development) - https://openrouter.ai/settings/keys",
 			EnvVars: []string{"OPENROUTER_DEV_KEY"},
 		},
+		&cli.StringFlag{
+			Name:     "loops-api-key",
+			Usage:    "Loops API key for trial lifecycle contact updates. Empty or 'unset' disables Loops writes.",
+			EnvVars:  []string{"LOOPS_API_KEY"},
+			Required: false,
+		},
 	}
 
 	return &cli.Command{
@@ -311,8 +319,10 @@ func newAdminCommand() *cli.Command {
 
 			adminWorkOSClient := newAdminWorkOSOrganizationCreator(ctx, logger, guardianPolicy, c)
 			adminTrialKeyReviver := newAdminTrialKeyReviver(ctx, logger, tracerProvider, guardianPolicy, db, redisClient, c)
+			loopsWorkflowClient := loops.NewWorkflowClient(ctx, logger, guardianPolicy, c.String("loops-api-key"))
+			trialNotifier := trialemails.NewService(db, loopsWorkflowClient, logger, c.String("site-url"))
 
-			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminTrialKeyReviver))
+			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminTrialKeyReviver, trialNotifier))
 
 			srv := &http.Server{
 				Addr:              c.String("address"),

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1413,7 +1413,7 @@ func newStartCommand() *cli.Command {
 			chat.Attach(mux, chatService)
 			variations.Attach(mux, variations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			customdomains.Attach(mux, customdomains.NewService(logger, tracerProvider, db, sessionManager, &background.CustomDomainRegistrationClient{TemporalEnv: temporalEnv}, authzEngine, auditLogger))
-			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, posthogClient, openRouter, authzEngine, telemetryrepo.New(chDB), auditLogger))
+			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, posthogClient, openRouter, authzEngine, telemetryrepo.New(chDB), auditLogger, trialEmailNotifier))
 			tm.Attach(mux, telemSvc)
 			functions.Attach(mux, functions.NewService(logger, tracerProvider, db, encryptionClient, tigrisStore))
 

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -903,11 +903,6 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
 	)
 
-	// Demotion cleared trialActive. Re-enter the Loops sequence for the new run.
-	if err := s.trial.TrialStarted(ctx, payload.ID); err != nil {
-		logger.ErrorContext(ctx, "failed to notify trial started", attr.SlogError(err))
-	}
-
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial re-arm")
 }
 

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -40,6 +40,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -62,6 +63,8 @@ type Service struct {
 	openRouter TrialKeyReviver
 
 	audit *audit.Logger
+
+	trial trialemails.Notifier
 }
 
 // TrialKeyReviver is the one method of openrouter.Provisioner a re-arm needs.
@@ -92,8 +95,13 @@ func NewService(
 	allowedOrigins []string,
 	workosClient orgprovision.WorkOSOrganizationCreator,
 	openRouter TrialKeyReviver,
+	trialNotifier trialemails.Notifier,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("admin"))
+
+	if trialNotifier == nil {
+		trialNotifier = trialemails.NoopNotifier{}
+	}
 
 	sessionStore := NewSessionStore(
 		cache.NewTypedObjectCache[Session](
@@ -120,6 +128,7 @@ func NewService(
 			cache.NewRedisCacheAdapter(redisClient),
 			cache.SuffixNone,
 		),
+		trial: trialNotifier,
 	}
 }
 
@@ -600,6 +609,14 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 		return nil, oops.E(oops.CodeUnexpected, err, "update organization").LogError(ctx, s.logger)
 	}
 
+	// Setting account type is how a trial becomes a signed contract. Stop
+	// pending trial reminders; trialActive stays true otherwise.
+	if payload.AccountType != nil {
+		if err := s.trial.TrialInactive(ctx, payload.ID); err != nil {
+			s.logger.ErrorContext(ctx, "failed to notify trial inactive", attr.SlogError(err), attr.SlogOrganizationID(payload.ID))
+		}
+	}
+
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after update")
 }
 
@@ -885,6 +902,11 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	logger.InfoContext(ctx, "re-armed enterprise trial",
 		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
 	)
+
+	// Demotion cleared trialActive. Re-enter the Loops sequence for the new run.
+	if err := s.trial.TrialStarted(ctx, payload.ID); err != nil {
+		logger.ErrorContext(ctx, "failed to notify trial started", attr.SlogError(err))
+	}
 
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial re-arm")
 }

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -160,6 +161,78 @@ func TestUpdateOrganization_NoFieldsRejected(t *testing.T) {
 	ctx, svc, _ := newTestAdminService(t)
 	_, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: "org_x"})
 	require.Error(t, err)
+}
+
+func TestUpdateOrganization_AccountTypeMarksTrialInactive(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	notifier := &fakeTrialNotifier{}
+	svc.trial = notifier
+
+	seedOrg(t, ctx, conn, orgFixture{
+		id:          "org_trial_convert",
+		name:        "Trial Convert",
+		slug:        "trial-convert",
+		accountType: "enterprise",
+		whitelisted: true,
+	})
+	newType := "enterprise"
+	res, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{
+		ID:          "org_trial_convert",
+		AccountType: &newType,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", res.AccountType)
+	require.Equal(t, []string{"org_trial_convert"}, notifier.inactive)
+}
+
+func TestUpdateOrganization_WhitelistedOnlyDoesNotMarkTrialInactive(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	notifier := &fakeTrialNotifier{}
+	svc.trial = notifier
+
+	seedOrg(t, ctx, conn, orgFixture{
+		id:          "org_trial_whitelist",
+		name:        "Trial Whitelist",
+		slug:        "trial-whitelist",
+		accountType: "enterprise",
+		whitelisted: true,
+	})
+	notWhitelisted := false
+	res, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{
+		ID:          "org_trial_whitelist",
+		Whitelisted: &notWhitelisted,
+	})
+	require.NoError(t, err)
+	require.False(t, res.Whitelisted)
+	require.Empty(t, notifier.inactive)
+}
+
+func TestUpdateOrganization_TrialInactiveFailureDoesNotFailUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	notifier := &fakeTrialNotifier{inactiveErr: errors.New("loops unavailable")}
+	svc.trial = notifier
+
+	seedOrg(t, ctx, conn, orgFixture{
+		id:          "org_trial_notify_fail",
+		name:        "Trial Notify Fail",
+		slug:        "trial-notify-fail",
+		accountType: "enterprise",
+		whitelisted: true,
+	})
+	newType := "pro"
+	res, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{
+		ID:          "org_trial_notify_fail",
+		AccountType: &newType,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "pro", res.AccountType)
+	require.Equal(t, []string{"org_trial_notify_fail"}, notifier.inactive)
 }
 
 func TestGetOrganization_NotFound(t *testing.T) {

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -241,7 +241,7 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.Equal(t, "enterprise", detail.AccountType)
 }
 
-func TestRearmTrial_MarksTrialStartedInLoops(t *testing.T) {
+func TestRearmTrial_DoesNotRestartLoopsSequence(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn, _ := newRearmService(t)
@@ -251,22 +251,8 @@ func TestRearmTrial_MarksTrialStartedInLoops(t *testing.T) {
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_loops", Days: 14})
 	require.NoError(t, err)
-	require.Equal(t, []string{"org_rearm_loops"}, notifier.started)
-}
-
-func TestRearmTrial_TrialStartedFailureDoesNotFailRearm(t *testing.T) {
-	t.Parallel()
-
-	ctx, svc, conn, _ := newRearmService(t)
-	notifier := &fakeTrialNotifier{startedErr: errors.New("loops unavailable")}
-	svc.trial = notifier
-	seedDemotedTrial(t, ctx, conn, "org_rearm_loops_fail", "enterprise")
-
-	res, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_loops_fail", Days: 14})
-	require.NoError(t, err)
-	require.Equal(t, "org_rearm_loops_fail", res.ID)
-	require.Equal(t, []string{"org_rearm_loops_fail"}, notifier.started)
-	require.False(t, readTrial(t, ctx, conn, "org_rearm_loops_fail").DemotedAt.Valid)
+	require.Empty(t, notifier.started)
+	require.Empty(t, notifier.inactive)
 }
 
 // MarkTrialDemoted only demotes an already-past ends_at, so a re-arm that

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -241,6 +241,34 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.Equal(t, "enterprise", detail.AccountType)
 }
 
+func TestRearmTrial_MarksTrialStartedInLoops(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	notifier := &fakeTrialNotifier{}
+	svc.trial = notifier
+	seedDemotedTrial(t, ctx, conn, "org_rearm_loops", "enterprise")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_loops", Days: 14})
+	require.NoError(t, err)
+	require.Equal(t, []string{"org_rearm_loops"}, notifier.started)
+}
+
+func TestRearmTrial_TrialStartedFailureDoesNotFailRearm(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	notifier := &fakeTrialNotifier{startedErr: errors.New("loops unavailable")}
+	svc.trial = notifier
+	seedDemotedTrial(t, ctx, conn, "org_rearm_loops_fail", "enterprise")
+
+	res, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_loops_fail", Days: 14})
+	require.NoError(t, err)
+	require.Equal(t, "org_rearm_loops_fail", res.ID)
+	require.Equal(t, []string{"org_rearm_loops_fail"}, notifier.started)
+	require.False(t, readTrial(t, ctx, conn, "org_rearm_loops_fail").DemotedAt.Valid)
+}
+
 // MarkTrialDemoted only demotes an already-past ends_at, so a re-arm that
 // cleared the stamp and left the date would be re-demoted on the next sweep.
 // The trial here ended 100 days ago, so a date computed from it is still past.

--- a/server/internal/admin/session_handler_test.go
+++ b/server/internal/admin/session_handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
 
 const testAdminHD = "example.com"
@@ -101,6 +102,7 @@ func newTestSessionService(t *testing.T, oidcClient *OIDCClient) *Service {
 		oidc:     oidcClient,
 		sessions: sessions,
 		verifier: NewVerifier(logger, sessions, oidcClient),
+		trial:    trialemails.NoopNotifier{},
 	}
 }
 

--- a/server/internal/admin/setup_test.go
+++ b/server/internal/admin/setup_test.go
@@ -73,12 +73,11 @@ type fakeTrialNotifier struct {
 	started     []string
 	inactive    []string
 	inactiveErr error
-	startedErr  error
 }
 
 func (f *fakeTrialNotifier) TrialStarted(_ context.Context, organizationID string) error {
 	f.started = append(f.started, organizationID)
-	return f.startedErr
+	return nil
 }
 
 func (f *fakeTrialNotifier) AdminAdded(context.Context, string, string) error {

--- a/server/internal/admin/setup_test.go
+++ b/server/internal/admin/setup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/organizations/orgprovision"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
 
 var infra *testenv.Environment
@@ -51,6 +52,7 @@ func newTestAdminService(t *testing.T) (context.Context, *Service, *pgxpool.Pool
 		logger: logger,
 		db:     conn,
 		audit:  audit.NewLogger(),
+		trial:  trialemails.NoopNotifier{},
 	}
 
 	return ctx, svc, conn
@@ -65,4 +67,25 @@ func newTestAdminServiceWithWorkOS(t *testing.T, workos orgprovision.WorkOSOrgan
 	svc.workos = workos
 
 	return ctx, svc, conn
+}
+
+type fakeTrialNotifier struct {
+	started     []string
+	inactive    []string
+	inactiveErr error
+	startedErr  error
+}
+
+func (f *fakeTrialNotifier) TrialStarted(_ context.Context, organizationID string) error {
+	f.started = append(f.started, organizationID)
+	return f.startedErr
+}
+
+func (f *fakeTrialNotifier) AdminAdded(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeTrialNotifier) TrialInactive(_ context.Context, organizationID string) error {
+	f.inactive = append(f.inactive, organizationID)
+	return f.inactiveErr
 }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -361,7 +361,7 @@ func NewActivities(
 		publishOutbox:                   publish_outbox.New(logger, tracerProvider, meterProvider, db, publishers.Outbox),
 		pluginPublisher:                 activities.NewPluginPublisher(logger, db, pluginPublisher),
 		listSpendRuleOrgs:               spend_rules.NewListOrgs(logger, db),
-		demoteExpiredTrials:             activities.NewDemoteExpiredTrials(logger, db, openrouterProvisioner, auditLogger),
+		demoteExpiredTrials:             activities.NewDemoteExpiredTrials(logger, db, openrouterProvisioner, auditLogger, trialEmailsService),
 		evaluateOrgSpendRules:           spend_rules.NewEvaluateOrg(logger, tracerProvider, db, spendRulesCH, cacheAdapter, features),
 		// The judge draws on the same per-(org, model) bucket and the same
 		// completion client as every other platform judge, so efficacy scoring

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -23,6 +24,7 @@ type DemoteExpiredTrials struct {
 	repo       *trialsrepo.Queries
 	openRouter openrouter.Provisioner
 	audit      *audit.Logger
+	trial      trialemails.Notifier
 }
 
 func NewDemoteExpiredTrials(
@@ -30,13 +32,19 @@ func NewDemoteExpiredTrials(
 	db *pgxpool.Pool,
 	openRouterProvisioner openrouter.Provisioner,
 	auditLogger *audit.Logger,
+	trialNotifier trialemails.Notifier,
 ) *DemoteExpiredTrials {
+	if trialNotifier == nil {
+		trialNotifier = trialemails.NoopNotifier{}
+	}
+
 	return &DemoteExpiredTrials{
 		logger:     logger.With(attr.SlogComponent("demote_expired_trials")),
 		db:         db,
 		repo:       trialsrepo.New(db),
 		openRouter: openRouterProvisioner,
 		audit:      auditLogger,
+		trial:      trialNotifier,
 	}
 }
 
@@ -66,9 +74,12 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		// A conversion or a manual reinstatement landed between the list and
-		// this write. The organization is no longer ours to demote.
+		// this write. The organization is no longer ours to demote. Still
+		// clear trialActive so a retried demotion finishes the Loops update
+		// after a previous commit succeeded.
 		d.logger.InfoContext(ctx, "expired trial changed before demotion",
 			attr.SlogOrganizationID(args.OrganizationID))
+		d.notifyTrialInactive(ctx, args.OrganizationID)
 		return nil
 	case err != nil:
 		return fmt.Errorf("mark trial demoted: %w", err)
@@ -111,5 +122,12 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 		return fmt.Errorf("commit trial demotion: %w", err)
 	}
 
+	d.notifyTrialInactive(ctx, args.OrganizationID)
 	return nil
+}
+
+func (d *DemoteExpiredTrials) notifyTrialInactive(ctx context.Context, organizationID string) {
+	if err := d.trial.TrialInactive(ctx, organizationID); err != nil {
+		d.logger.ErrorContext(ctx, "failed to notify trial inactive", attr.SlogError(err), attr.SlogOrganizationID(organizationID))
+	}
 }

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -73,13 +73,14 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	trial, err := tx.MarkTrialDemoted(ctx, args.OrganizationID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		// A conversion, a completed demotion, or a reinstatement (ends_at
-		// moved forward) landed between the list and this write. Only a
-		// closed trial should drop out of the Loops sequence; a re-armed
-		// trial must keep trialActive so reminder mail still sends.
+		// A conversion, a completed demotion, or a re-arm (ends_at moved
+		// forward, stamps cleared) landed between the list and this write.
+		// Only a closed trial should drop out of the Loops sequence.
 		d.logger.InfoContext(ctx, "expired trial changed before demotion",
 			attr.SlogOrganizationID(args.OrganizationID))
-		d.notifyTrialInactiveIfClosed(ctx, args.OrganizationID)
+		if err := d.notifyTrialInactiveIfClosed(ctx, args.OrganizationID); err != nil {
+			return err
+		}
 		return nil
 	case err != nil:
 		return fmt.Errorf("mark trial demoted: %w", err)
@@ -126,19 +127,21 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	return nil
 }
 
-func (d *DemoteExpiredTrials) notifyTrialInactiveIfClosed(ctx context.Context, organizationID string) {
-	trial, err := d.repo.GetTrial(ctx, organizationID)
+func (d *DemoteExpiredTrials) notifyTrialInactiveIfClosed(ctx context.Context, organizationID string) error {
+	// GetActiveTrial is the armed-trial predicate. Re-read it immediately
+	// before Loops so a re-arm that landed after MarkTrialDemoted's
+	// ErrNoRows keeps trialActive. Lookup errors fail the activity so
+	// Temporal retries; notifier errors stay logged-only.
+	_, err := d.repo.GetActiveTrial(ctx, organizationID)
 	switch {
+	case err == nil:
+		return nil
 	case errors.Is(err, pgx.ErrNoRows):
-		return
-	case err != nil:
-		d.logger.ErrorContext(ctx, "lookup trial after demotion skip", attr.SlogError(err), attr.SlogOrganizationID(organizationID))
-		return
+		d.notifyTrialInactive(ctx, organizationID)
+		return nil
+	default:
+		return fmt.Errorf("revalidate trial before inactive notify: %w", err)
 	}
-	if !trial.ConvertedAt.Valid && !trial.DemotedAt.Valid {
-		return
-	}
-	d.notifyTrialInactive(ctx, organizationID)
 }
 
 func (d *DemoteExpiredTrials) notifyTrialInactive(ctx context.Context, organizationID string) {

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -73,13 +73,13 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	trial, err := tx.MarkTrialDemoted(ctx, args.OrganizationID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		// A conversion or a manual reinstatement landed between the list and
-		// this write. The organization is no longer ours to demote. Still
-		// clear trialActive so a retried demotion finishes the Loops update
-		// after a previous commit succeeded.
+		// A conversion, a completed demotion, or a reinstatement (ends_at
+		// moved forward) landed between the list and this write. Only a
+		// closed trial should drop out of the Loops sequence; a re-armed
+		// trial must keep trialActive so reminder mail still sends.
 		d.logger.InfoContext(ctx, "expired trial changed before demotion",
 			attr.SlogOrganizationID(args.OrganizationID))
-		d.notifyTrialInactive(ctx, args.OrganizationID)
+		d.notifyTrialInactiveIfClosed(ctx, args.OrganizationID)
 		return nil
 	case err != nil:
 		return fmt.Errorf("mark trial demoted: %w", err)
@@ -124,6 +124,21 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 
 	d.notifyTrialInactive(ctx, args.OrganizationID)
 	return nil
+}
+
+func (d *DemoteExpiredTrials) notifyTrialInactiveIfClosed(ctx context.Context, organizationID string) {
+	trial, err := d.repo.GetTrial(ctx, organizationID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return
+	case err != nil:
+		d.logger.ErrorContext(ctx, "lookup trial after demotion skip", attr.SlogError(err), attr.SlogOrganizationID(organizationID))
+		return
+	}
+	if !trial.ConvertedAt.Valid && !trial.DemotedAt.Valid {
+		return
+	}
+	d.notifyTrialInactive(ctx, organizationID)
 }
 
 func (d *DemoteExpiredTrials) notifyTrialInactive(ctx context.Context, organizationID string) {

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -41,11 +41,28 @@ func (p *trialProvisioner) DisableAPIKey(_ context.Context, orgID string, keyTyp
 	return nil
 }
 
+type fakeTrialNotifier struct {
+	inactive    []string
+	inactiveErr error
+}
+
+func (f *fakeTrialNotifier) TrialStarted(context.Context, string) error { return nil }
+
+func (f *fakeTrialNotifier) AdminAdded(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeTrialNotifier) TrialInactive(_ context.Context, organizationID string) error {
+	f.inactive = append(f.inactive, organizationID)
+	return f.inactiveErr
+}
+
 type trialTestInstance struct {
 	conn        *pgxpool.Pool
 	trials      *trialsrepo.Queries
 	orgs        *orgrepo.Queries
 	provisioner *trialProvisioner
+	notifier    *fakeTrialNotifier
 	activity    *activities.DemoteExpiredTrials
 }
 
@@ -58,17 +75,20 @@ func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
 	require.NoError(t, err)
 
 	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), disabled: nil, failWith: nil}
+	notifier := &fakeTrialNotifier{}
 
 	return ctx, &trialTestInstance{
 		conn:        conn,
 		trials:      trialsrepo.New(conn),
 		orgs:        orgrepo.New(conn),
 		provisioner: provisioner,
+		notifier:    notifier,
 		activity: activities.NewDemoteExpiredTrials(
 			testenv.NewLogger(t),
 			conn,
 			provisioner,
 			audit.NewLogger(),
+			notifier,
 		),
 	}
 }
@@ -130,6 +150,7 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	require.True(t, trial.DemotedAt.Valid)
 
 	require.ElementsMatch(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.disabled)
+	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)
@@ -196,6 +217,7 @@ func TestDemoteExpiredTrials_DemoteSkipsTrialConvertedAfterListing(t *testing.T)
 	require.False(t, trial.DemotedAt.Valid)
 
 	require.Empty(t, ti.provisioner.disabled, "a trial that converted keeps its keys")
+	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 }
 
 // Temporal retries a failed activity, so a second demotion of the same trial
@@ -224,6 +246,7 @@ func TestDemoteExpiredTrials_DemoteIsIdempotent(t *testing.T) {
 	again, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)
 	require.Equal(t, after, again)
+	require.Equal(t, []string{orgID, orgID}, ti.notifier.inactive)
 }
 
 // The lockdown runs inside the demotion transaction on purpose: a stamped
@@ -250,4 +273,20 @@ func TestDemoteExpiredTrials_KeyLockdownFailureLeavesTrialArmed(t *testing.T) {
 	due, err := ti.activity.List(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{orgID}, due)
+	require.Empty(t, ti.notifier.inactive)
+}
+
+func TestDemoteExpiredTrials_TrialInactiveFailureDoesNotFailDemotion(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+	ti.notifier.inactiveErr = errors.New("loops unavailable")
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+
+	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, "free", org.GramAccountType)
+	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 }

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -93,9 +93,7 @@ func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
 	}
 }
 
-// newTrialOrg creates an enterprise organization that is whitelisted for the
-// duration of its trial, which is the state signup leaves behind.
-func newTrialOrg(t *testing.T, ctx context.Context, ti *trialTestInstance, endsAt time.Time) string {
+func newOrg(t *testing.T, ctx context.Context, ti *trialTestInstance) string {
 	t.Helper()
 
 	orgID := "org-" + uuid.NewString()[:8]
@@ -114,7 +112,16 @@ func newTrialOrg(t *testing.T, ctx context.Context, ti *trialTestInstance, endsA
 		GramAccountType: "enterprise",
 	}))
 
-	err = ti.trials.CreateTrial(ctx, trialsrepo.CreateTrialParams{
+	return orgID
+}
+
+// newTrialOrg creates an enterprise organization that is whitelisted for the
+// duration of its trial, which is the state signup leaves behind.
+func newTrialOrg(t *testing.T, ctx context.Context, ti *trialTestInstance, endsAt time.Time) string {
+	t.Helper()
+
+	orgID := newOrg(t, ctx, ti)
+	err := ti.trials.CreateTrial(ctx, trialsrepo.CreateTrialParams{
 		OrganizationID: orgID,
 		Tier:           "enterprise",
 		EndsAt:         pgtype.Timestamptz{Time: endsAt, InfinityModifier: pgtype.Finite, Valid: true},
@@ -276,7 +283,7 @@ func TestDemoteExpiredTrials_KeyLockdownFailureLeavesTrialArmed(t *testing.T) {
 	require.Empty(t, ti.notifier.inactive)
 }
 
-func TestDemoteExpiredTrials_DemoteSkipsReinstatedTrialEmails(t *testing.T) {
+func TestDemoteExpiredTrials_DemoteSkipsActiveUnexpiredTrialEmails(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTrialTestInstance(t)
@@ -289,6 +296,28 @@ func TestDemoteExpiredTrials_DemoteSkipsReinstatedTrialEmails(t *testing.T) {
 	require.Equal(t, "enterprise", org.GramAccountType)
 	require.True(t, org.Whitelisted)
 	require.Empty(t, ti.notifier.inactive)
+}
+
+func TestDemoteExpiredTrials_DemoteAlreadyDemotedWithFutureEndsAtStillNotifies(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newOrg(t, ctx, ti)
+	now := time.Now().UTC()
+	require.NoError(t, ti.trials.InsertTrialFixture(ctx, trialsrepo.InsertTrialFixtureParams{
+		OrganizationID: orgID,
+		CreatedAt:      pgtype.Timestamptz{Time: now.Add(-48 * time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		EndsAt:         pgtype.Timestamptz{Time: now.Add(24 * time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		ConvertedAt:    pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
+		DemotedAt:      pgtype.Timestamptz{Time: now.Add(-time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	}))
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+
+	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", org.GramAccountType)
+	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 }
 
 func TestDemoteExpiredTrials_TrialInactiveFailureDoesNotFailDemotion(t *testing.T) {

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -276,6 +276,21 @@ func TestDemoteExpiredTrials_KeyLockdownFailureLeavesTrialArmed(t *testing.T) {
 	require.Empty(t, ti.notifier.inactive)
 }
 
+func TestDemoteExpiredTrials_DemoteSkipsReinstatedTrialEmails(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(24*time.Hour).UTC())
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+
+	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", org.GramAccountType)
+	require.True(t, org.Whitelisted)
+	require.Empty(t, ti.notifier.inactive)
+}
+
 func TestDemoteExpiredTrials_TrialInactiveFailureDoesNotFailDemotion(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -29,6 +29,7 @@ import (
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -49,12 +50,17 @@ type Service struct {
 	auditLogger   *audit.Logger
 	posthogClient *posthog.Posthog
 	openRouter    openrouter.Provisioner
+	trial         trialemails.Notifier
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, billingRepo billing.Repository, serverURL *url.URL, posthogClient *posthog.Posthog, openRouter openrouter.Provisioner, authzEngine *authz.Engine, telemetryRepo *telemetryrepo.Queries, auditLogger *audit.Logger) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, billingRepo billing.Repository, serverURL *url.URL, posthogClient *posthog.Posthog, openRouter openrouter.Provisioner, authzEngine *authz.Engine, telemetryRepo *telemetryrepo.Queries, auditLogger *audit.Logger, trialNotifier trialemails.Notifier) *Service {
 	logger = logger.With(attr.SlogComponent("usage"))
+
+	if trialNotifier == nil {
+		trialNotifier = trialemails.NoopNotifier{}
+	}
 
 	return &Service{
 		tracer:        tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/usage"),
@@ -70,6 +76,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		auditLogger:   auditLogger,
 		posthogClient: posthogClient,
 		openRouter:    openRouter,
+		trial:         trialNotifier,
 	}
 }
 
@@ -209,6 +216,14 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 		"email":        webhookPayload.Data.Customer.Email,
 	}); err != nil {
 		logger.ErrorContext(ctx, "failed to capture posthog event", attr.SlogError(err))
+	}
+
+	// A paid Polar subscription ends the trial email sequence. trialActive
+	// stays true otherwise, so converted admins keep getting reminder mail.
+	if webhookPayload.Type == "subscription.created" || webhookPayload.Type == "subscription.active" {
+		if err := s.trial.TrialInactive(ctx, refreshedOrg.ID); err != nil {
+			logger.ErrorContext(ctx, "failed to notify trial inactive", attr.SlogError(err), attr.SlogOrganizationID(refreshedOrg.ID))
+		}
 	}
 
 	return nil

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -23,7 +24,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
@@ -120,7 +123,8 @@ func (m *mockBillingRepo) ValidateAndParseWebhookEvent(ctx context.Context, payl
 }
 
 func (m *mockBillingRepo) InvalidateBillingCustomerCaches(ctx context.Context, orgID string) error {
-	return fmt.Errorf("not implemented")
+	args := m.Called(ctx, orgID)
+	return args.Error(0)
 }
 
 func (m *mockBillingRepo) AttachAssistantsBenefit(ctx context.Context, orgID string, email string) (string, error) {
@@ -153,13 +157,31 @@ func newTestService(t *testing.T, billingRepo billing.Repository, orgID string, 
 	authzEngine := authz.NewEngine(logger, db, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 
 	return &Service{
-		tracer:      tp.Tracer("test"),
-		logger:      logger,
-		authz:       authzEngine,
-		repo:        repo.New(db),
-		billingRepo: billingRepo,
-		orgRepo:     orgRepo.New(db),
+		tracer:        tp.Tracer("test"),
+		logger:        logger,
+		authz:         authzEngine,
+		repo:          repo.New(db),
+		billingRepo:   billingRepo,
+		orgRepo:       orgRepo.New(db),
+		posthogClient: posthog.New(t.Context(), logger, "", "", ""),
+		trial:         trialemails.NoopNotifier{},
 	}
+}
+
+type fakeTrialNotifier struct {
+	inactive    []string
+	inactiveErr error
+}
+
+func (f *fakeTrialNotifier) TrialStarted(context.Context, string) error { return nil }
+
+func (f *fakeTrialNotifier) AdminAdded(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeTrialNotifier) TrialInactive(_ context.Context, organizationID string) error {
+	f.inactive = append(f.inactive, organizationID)
+	return f.inactiveErr
 }
 
 func seedEnabledToolsets(t *testing.T, db repo.DBTX, orgID string, serverCount int) {
@@ -321,6 +343,91 @@ func TestHandlePolarWebhook_OrgNotFound(t *testing.T) {
 		"a webhook for an unknown polar external id should map to CodeNotFound, not CodeUnexpected")
 	// We never get past the org lookup, so no cache invalidation should occur.
 	billingMock.AssertNotCalled(t, "InvalidateBillingCustomerCaches", mock.Anything, mock.Anything)
+}
+
+func seedWebhookOrg(t *testing.T, svc *Service, orgID string) {
+	t.Helper()
+
+	_, err := svc.orgRepo.UpsertOrganizationMetadata(t.Context(), orgRepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Trial Org",
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{String: "", Valid: false},
+		Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.orgRepo.SetAccountType(t.Context(), orgRepo.SetAccountTypeParams{
+		ID:              orgID,
+		GramAccountType: "enterprise",
+	}))
+}
+
+func newSubscriptionWebhookService(t *testing.T, orgID, eventType string) (*Service, *fakeTrialNotifier, *mockBillingRepo) {
+	t.Helper()
+
+	payload := &billing.PolarWebhookPayload{Type: eventType}
+	payload.Data.Customer = &billing.WebhookCustomer{
+		ExternalID: orgID,
+		Name:       "Trial Org",
+		Email:      "person@example.com",
+	}
+
+	billingMock := &mockBillingRepo{}
+	billingMock.On("ValidateAndParseWebhookEvent", mock.Anything, mock.Anything, mock.Anything).
+		Return(payload, nil)
+	billingMock.On("InvalidateBillingCustomerCaches", mock.Anything, orgID).Return(nil)
+	billingMock.On("GetPeriodUsage", mock.Anything, orgID).Return(sampleUsage(0, 0, 0), nil)
+
+	svc := newTestService(t, billingMock, orgID, 0)
+	seedWebhookOrg(t, svc, orgID)
+	notifier := &fakeTrialNotifier{}
+	svc.trial = notifier
+	return svc, notifier, billingMock
+}
+
+func TestHandlePolarWebhook_SubscriptionCreatedMarksTrialInactive(t *testing.T) {
+	t.Parallel()
+
+	orgID := "org-trial-converted"
+	svc, notifier, _ := newSubscriptionWebhookService(t, orgID, "subscription.created")
+
+	req := httptest.NewRequest(http.MethodPost, "/rpc/polar.webhook", strings.NewReader("{}"))
+	require.NoError(t, svc.HandlePolarWebhook(httptest.NewRecorder(), req))
+	require.Equal(t, []string{orgID}, notifier.inactive)
+}
+
+func TestHandlePolarWebhook_SubscriptionActiveMarksTrialInactive(t *testing.T) {
+	t.Parallel()
+
+	orgID := "org-trial-active"
+	svc, notifier, _ := newSubscriptionWebhookService(t, orgID, "subscription.active")
+
+	req := httptest.NewRequest(http.MethodPost, "/rpc/polar.webhook", strings.NewReader("{}"))
+	require.NoError(t, svc.HandlePolarWebhook(httptest.NewRecorder(), req))
+	require.Equal(t, []string{orgID}, notifier.inactive)
+}
+
+func TestHandlePolarWebhook_SubscriptionCanceledDoesNotMarkTrialInactive(t *testing.T) {
+	t.Parallel()
+
+	orgID := "org-trial-canceled"
+	svc, notifier, _ := newSubscriptionWebhookService(t, orgID, "subscription.canceled")
+
+	req := httptest.NewRequest(http.MethodPost, "/rpc/polar.webhook", strings.NewReader("{}"))
+	require.NoError(t, svc.HandlePolarWebhook(httptest.NewRecorder(), req))
+	require.Empty(t, notifier.inactive)
+}
+
+func TestHandlePolarWebhook_TrialInactiveFailureDoesNotFailWebhook(t *testing.T) {
+	t.Parallel()
+
+	orgID := "org-trial-notify-fail"
+	svc, notifier, _ := newSubscriptionWebhookService(t, orgID, "subscription.created")
+	notifier.inactiveErr = fmt.Errorf("loops unavailable")
+
+	req := httptest.NewRequest(http.MethodPost, "/rpc/polar.webhook", strings.NewReader("{}"))
+	require.NoError(t, svc.HandlePolarWebhook(httptest.NewRecorder(), req))
+	require.Equal(t, []string{orgID}, notifier.inactive)
 }
 
 func TestCreateTopUpCheckout_BillingErrorMapsToCodeUnexpected(t *testing.T) {

--- a/server/internal/usage/tum_test.go
+++ b/server/internal/usage/tum_test.go
@@ -26,6 +26,7 @@ import (
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
@@ -84,6 +85,7 @@ func newTUMTestService(t *testing.T, orgID string) (*Service, *pgxpool.Pool, dri
 		repo:          repo.New(db),
 		telemetryRepo: telemetryrepo.New(chConn),
 		auditLogger:   audit.NewLogger(),
+		trial:         trialemails.NoopNotifier{},
 	}
 
 	return svc, db, chConn, projectID


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`trialActive` was set to `true` when a trial started and never cleared. Loops audience filters for the 7-day and 1-day trial emails gate on `trialActive isTrue`, so converted customers kept getting reminder mail.

`Service.TrialInactive` and the Temporal workflow already existed. This wires the missing dispatch on conversion and expiry:

- **Conversion** — Polar `subscription.created` / `subscription.active` and the admin account-type setter call `TrialInactive` so Loops stops the sequence.
- **Expiry** — demotion clears `trialActive` after a successful lockout. The already-demoted/converted retry path also clears it. A still-armed trial (`GetActiveTrial`) is left alone so a no-op `Demote` on a running trial does not kill the original drip. Lookup errors fail the activity so Temporal retries; notifier errors stay logged-only.
- **Re-arm** — no Loops update. Re-arm is a manual extension after the original drip already ran; the workflow finishes on its own. We do not call `TrialStarted`.

Notifier failures are logged and do not fail the webhook, admin update, or demotion.

Fixes AGE-3180.

## Test plan

- [x] Polar webhook marks trial inactive on `subscription.created` and `subscription.active`
- [x] Polar `subscription.canceled` does not mark trial inactive
- [x] Polar notifier failure does not fail the webhook
- [x] Admin account-type update marks trial inactive; whitelist-only does not
- [x] Admin notifier failure does not fail the update
- [x] Admin re-arm does not call `TrialStarted` or `TrialInactive`
- [x] Demotion marks trial inactive after lockout and on the converted/already-demoted retry path
- [x] Demotion does not mark trial inactive when the trial is still active
- [x] A demoted row with a future `ends_at` still notifies
- [x] Demotion notifier failure does not fail the lockout
- [x] `mise lint:server` on the changed packages

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3180](https://linear.app/speakeasy/issue/AGE-3180/fix-mark-trials-inactive-in-loops-on-conversion-and-expiry)

<div><a href="https://cursor.com/agents/bc-f3e2170d-0959-4988-905d-8441ccd77752?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3e2170d-0959-4988-905d-8441ccd77752&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leftover trial reminder emails after conversion or expiry by clearing Loops `trialActive`. Previously it was never cleared, so converted admins kept receiving 7‑day/1‑day reminders. Addresses AGE‑3180.

- Conversion: `server/internal/usage` marks trials inactive on Polar `subscription.created` and `subscription.active` (no-op on `subscription.canceled`); notifier failures are logged and do not fail the webhook.
- Admin updates: `server/internal/admin` clears `trialActive` when `AccountType` is set; whitelist-only changes do not. Notifier errors are logged and do not fail the update.
- Expiry: `server/internal/background/activities/trial_demotion` clears `trialActive` after lockout; on a demotion race (`ErrNoRows`), re‑reads with `GetActiveTrial` and only clears when the trial is closed (converted or already demoted). Already‑demoted rows with future `ends_at` still notify. Lookup errors fail the activity for Temporal retry; notifier errors are logged-only.
- Re‑arm: Admin `trial.rearm` does not restart the Loops sequence (no `TrialStarted`); demotion already cleared `trialActive`.
- Wiring/Rollout: Inject the trial notifier into `admin`, `usage`, and the demotion activity. Add `--loops-api-key` to `gram admin` to enable Loops writes (empty or "unset" uses a no‑op notifier).

<sup>Written for commit fdec5c0f6dfdc35998df3a170bf88c36232ac802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

