### PR TITLE
feat(admin): build a login URL scoped to an organization

### DIFF
--- a/.changeset/admin-impersonation-url.md
+++ b/.changeset/admin-impersonation-url.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Add the URL contract that opens the customer-facing dashboard already scoped to a chosen organization, replacing the set-a-cookie-and-log-in-again routine. The slug rides in the `redirect` parameter of the login URL, which the server reads back as the first path segment of the destination; both sides are now pinned by tests so the shape cannot drift, because getting it wrong lands the operator on their own organization with no error. The row action that uses this link follows.

--- a/client/admin/src/lib/impersonation.test.ts
+++ b/client/admin/src/lib/impersonation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { impersonationUrl } from "./impersonation";
+
+describe("impersonationUrl", () => {
+  it("carries the slug as the first path segment of `redirect`", () => {
+    const href = impersonationUrl("acme-placeholder");
+    expect(href).toBeDefined();
+
+    const redirect = new URL(href!).searchParams.get("redirect");
+    // The server takes the first path segment of `redirect`, not of the login
+    // URL, whose own pathname is /rpc/auth.login. The reader is
+    // organizationSlugFromDestinationURL, server/internal/auth/impl.go:629-647,
+    // pinned against these same strings by
+    // server/internal/auth/org_slug_destination_test.go. Getting this wrong
+    // fails silently: the operator lands on their own default organization.
+    const slug = new URL(
+      redirect!,
+      "https://placeholder.invalid",
+    ).pathname.split("/")[1];
+    expect(slug).toBe("acme-placeholder");
+  });
+
+  it("targets the login endpoint on the configured app origin", () => {
+    const url = new URL(impersonationUrl("acme-placeholder")!);
+
+    expect(url.origin).toBe("https://app.gram.test");
+    expect(url.pathname).toBe("/rpc/auth.login");
+  });
+
+  it("returns undefined for a blank slug", () => {
+    expect(impersonationUrl("")).toBeUndefined();
+  });
+});

--- a/client/admin/src/lib/impersonation.test.ts
+++ b/client/admin/src/lib/impersonation.test.ts
@@ -8,12 +8,7 @@ describe("impersonationUrl", () => {
     expect(href).toBeDefined();
 
     const redirect = new URL(href!).searchParams.get("redirect");
-    // The server takes the first path segment of `redirect`, not of the login
-    // URL, whose own pathname is /rpc/auth.login. The reader is
-    // organizationSlugFromDestinationURL, server/internal/auth/impl.go:629-647,
-    // pinned against these same strings by
-    // server/internal/auth/org_slug_destination_test.go. Getting this wrong
-    // fails silently: the operator lands on their own default organization.
+    // Pinned from the Go side too, by org_slug_destination_test.go.
     const slug = new URL(
       redirect!,
       "https://placeholder.invalid",

--- a/client/admin/src/lib/impersonation.ts
+++ b/client/admin/src/lib/impersonation.ts
@@ -1,0 +1,25 @@
+// Builds the link that drops an operator into the customer-facing dashboard
+// with a chosen organization active. There is no impersonation endpoint and no
+// cookie: the whole mechanism is the login endpoint's `redirect` parameter.
+//
+// The server decodes `redirect` into the login state, then reads the
+// organization slug back out of its first path segment
+// (organizationSlugFromDestinationURL, server/internal/auth/impl.go:629-647)
+// and, for an admin account, resolves that slug straight from the database
+// even when the operator is not a member (impl.go:411-418). A non-admin
+// account gets no error, just their own default organization.
+export function impersonationUrl(slug: string): string | undefined {
+  // Empty at build time when GRAM_APP_URL is unset. Callers drop the action
+  // rather than render a link that goes nowhere.
+  const appUrl = __GRAM_APP_URL__;
+  if (!appUrl || !slug) {
+    return undefined;
+  }
+
+  const url = new URL("/rpc/auth.login", appUrl);
+  // Relative on purpose. The server refuses to redirect off its own origin, so
+  // an absolute destination would be stripped back to this anyway.
+  url.searchParams.set("redirect", `/${slug}`);
+
+  return url.toString();
+}

--- a/client/admin/src/lib/impersonation.ts
+++ b/client/admin/src/lib/impersonation.ts
@@ -1,24 +1,12 @@
-// Builds the link that drops an operator into the customer-facing dashboard
-// with a chosen organization active. There is no impersonation endpoint and no
-// cookie: the whole mechanism is the login endpoint's `redirect` parameter.
-//
-// The server decodes `redirect` into the login state, then reads the
-// organization slug back out of its first path segment
-// (organizationSlugFromDestinationURL, server/internal/auth/impl.go:629-647)
-// and, for an admin account, resolves that slug straight from the database
-// even when the operator is not a member (impl.go:411-418). A non-admin
-// account gets no error, just their own default organization.
+// The slug rides in `redirect`, whose first path segment the server reads back
+// as the organization: organizationSlugFromDestinationURL, impl.go:629.
 export function impersonationUrl(slug: string): string | undefined {
-  // Empty at build time when GRAM_APP_URL is unset. Callers drop the action
-  // rather than render a link that goes nowhere.
   const appUrl = __GRAM_APP_URL__;
   if (!appUrl || !slug) {
     return undefined;
   }
 
   const url = new URL("/rpc/auth.login", appUrl);
-  // Relative on purpose. The server refuses to redirect off its own origin, so
-  // an absolute destination would be stripped back to this anyway.
   url.searchParams.set("redirect", `/${slug}`);
 
   return url.toString();

--- a/client/admin/src/vite-env.d.ts
+++ b/client/admin/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+// Injected at build time from GRAM_APP_URL.
+declare const __GRAM_APP_URL__: string | undefined;

--- a/client/admin/src/vite-env.d.ts
+++ b/client/admin/src/vite-env.d.ts
@@ -1,4 +1,3 @@
 /// <reference types="vite/client" />
 
-// Injected at build time from GRAM_APP_URL.
 declare const __GRAM_APP_URL__: string | undefined;

--- a/client/admin/vite.config.ts
+++ b/client/admin/vite.config.ts
@@ -59,6 +59,26 @@ export default defineConfig(({ command }) => {
   // has to be baked in. Empty is tolerated: impersonationUrl() returns
   // undefined and callers drop the action rather than ship a dead link.
   const appUrl = process.env["GRAM_APP_URL"] || "";
+  // Parsed, not prefix-matched. A build sends an operator to this origin to
+  // authenticate, so a plaintext value would put a login flow on the wire
+  // unprotected, and a bare `https://` passes a prefix test while naming no
+  // host. Failing here beats shipping a bundle that carries the bad origin.
+  if (appUrl) {
+    let parsed: URL;
+    try {
+      parsed = new URL(appUrl);
+    } catch {
+      throw new Error(`GRAM_APP_URL must be an absolute URL, got "${appUrl}"`);
+    }
+    if (parsed.protocol !== "https:") {
+      throw new Error(
+        `GRAM_APP_URL must use https, got "${parsed.protocol}//"`,
+      );
+    }
+    if (!parsed.hostname) {
+      throw new Error(`GRAM_APP_URL must name a host, got "${appUrl}"`);
+    }
+  }
 
   return {
     define: {

--- a/client/admin/vite.config.ts
+++ b/client/admin/vite.config.ts
@@ -54,7 +54,16 @@ export default defineConfig(({ command }) => {
     throw new Error("GRAM_ADMIN_BACKEND_URL must be set in development");
   }
 
+  // Origin of the customer-facing Gram app, which serves /rpc/auth.login. This
+  // app is on a different origin, so it has no runtime way to learn it and it
+  // has to be baked in. Empty is tolerated: impersonationUrl() returns
+  // undefined and callers drop the action rather than ship a dead link.
+  const appUrl = process.env["GRAM_APP_URL"] || "";
+
   return {
+    define: {
+      __GRAM_APP_URL__: JSON.stringify(appUrl),
+    },
     plugins: [
       // The generator reads src/routes and writes src/routeTree.gen.ts. It has
       // to run before the react plugin, because the react plugin transforms the

--- a/client/admin/vite.config.ts
+++ b/client/admin/vite.config.ts
@@ -54,15 +54,10 @@ export default defineConfig(({ command }) => {
     throw new Error("GRAM_ADMIN_BACKEND_URL must be set in development");
   }
 
-  // Origin of the customer-facing Gram app, which serves /rpc/auth.login. This
-  // app is on a different origin, so it has no runtime way to learn it and it
-  // has to be baked in. Empty is tolerated: impersonationUrl() returns
-  // undefined and callers drop the action rather than ship a dead link.
+  // Baked in: a different origin, so there is no runtime way to learn it.
+  // Empty disables the link.
   const appUrl = process.env["GRAM_APP_URL"] || "";
-  // Parsed, not prefix-matched. A build sends an operator to this origin to
-  // authenticate, so a plaintext value would put a login flow on the wire
-  // unprotected, and a bare `https://` passes a prefix test while naming no
-  // host. Failing here beats shipping a bundle that carries the bad origin.
+  // An operator authenticates at this origin, so plaintext is a downgrade.
   if (appUrl) {
     let parsed: URL;
     try {

--- a/client/admin/vitest.config.ts
+++ b/client/admin/vitest.config.ts
@@ -3,6 +3,13 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // vite.config.ts injects this too. Without it every test file that reaches
+  // impersonationUrl() dies with a ReferenceError. Tests get a fixed fake
+  // origin rather than "": an empty base is the "not configured" case, and
+  // pinning a real one lets a test assert the whole URL.
+  define: {
+    __GRAM_APP_URL__: JSON.stringify("https://app.gram.test"),
+  },
   plugins: [react()],
   resolve: {
     alias: {

--- a/client/admin/vitest.config.ts
+++ b/client/admin/vitest.config.ts
@@ -3,10 +3,7 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  // vite.config.ts injects this too. Without it every test file that reaches
-  // impersonationUrl() dies with a ReferenceError. Tests get a fixed fake
-  // origin rather than "": an empty base is the "not configured" case, and
-  // pinning a real one lets a test assert the whole URL.
+  // A real origin, not "": empty is the not-configured case.
   define: {
     __GRAM_APP_URL__: JSON.stringify("https://app.gram.test"),
   },

--- a/mise.toml
+++ b/mise.toml
@@ -137,11 +137,7 @@ GRAM_HOST = "localhost" # Only needed for local development. In production, you 
 GRAM_SITE_PORT = "5173"
 GRAM_SITE_URL = "https://{{env.GRAM_HOST}}:{{env.GRAM_SITE_PORT}}"
 GRAM_SERVER_URL = "https://{{env.GRAM_HOST}}:{{env.GRAM_SERVER_PORT}}"
-## Origin that serves /rpc/auth.login, baked into the admin dashboard build so
-## it can link an operator into the customer-facing app. It duplicates
-## GRAM_SERVER_URL locally, but cannot reuse it: the viteprod profile unsets
-## GRAM_SERVER_URL because the dashboard falls back to its own origin there,
-## and the admin dashboard cannot (its origin is the admin host).
+## Cannot reuse GRAM_SERVER_URL: viteprod unsets it.
 GRAM_APP_URL = "{{env.GRAM_SERVER_URL}}"
 GRAM_ASSETS_BACKEND = "fs"
 GRAM_ASSETS_URI = ".assets"

--- a/mise.toml
+++ b/mise.toml
@@ -137,6 +137,12 @@ GRAM_HOST = "localhost" # Only needed for local development. In production, you 
 GRAM_SITE_PORT = "5173"
 GRAM_SITE_URL = "https://{{env.GRAM_HOST}}:{{env.GRAM_SITE_PORT}}"
 GRAM_SERVER_URL = "https://{{env.GRAM_HOST}}:{{env.GRAM_SERVER_PORT}}"
+## Origin that serves /rpc/auth.login, baked into the admin dashboard build so
+## it can link an operator into the customer-facing app. It duplicates
+## GRAM_SERVER_URL locally, but cannot reuse it: the viteprod profile unsets
+## GRAM_SERVER_URL because the dashboard falls back to its own origin there,
+## and the admin dashboard cannot (its origin is the admin host).
+GRAM_APP_URL = "{{env.GRAM_SERVER_URL}}"
 GRAM_ASSETS_BACKEND = "fs"
 GRAM_ASSETS_URI = ".assets"
 ## The following variable is used to encrypt env vars stored in the database.

--- a/mise.viteprod.toml
+++ b/mise.viteprod.toml
@@ -5,10 +5,21 @@
 ## Both the Gram server and dashboard (client) are accessed on
 ## https://app.getgram.ai.
 GRAM_SERVER_URL = false
-## The admin dashboard is served from its own origin, so unlike the dashboard
-## it cannot fall back to window.location.origin. One image serves every
-## deployed environment, so this names production.
-GRAM_APP_URL = "https://app.getgram.ai"
+## Deliberately unset, which disables the impersonation link in every deployed
+## environment. impersonationUrl() returns undefined and its callers drop the
+## action, so no operator is offered a link that lies about where it goes.
+##
+## The admin dashboard cannot fall back to window.location.origin the way the
+## dashboard does, because it is served from its own origin. One image serves
+## every deployed environment, so a value here would name production and the
+## dev admin dashboard would send an operator into production data while they
+## believed they were in dev.
+##
+## The slice that adds the row action decides the per-environment channel. The
+## admin image has no envsubst pass today: `client/admin/Dockerfile` says it
+## needs none, because it otherwise talks to its API same-origin. This would be
+## the first cross-origin URL baked into the bundle.
+GRAM_APP_URL = false
 ## GRAM_API_URL is used primarily during local development. That may change in
 ## the future when we create separate builds per environment but until then we
 ## should unset it so it is not baked into bundles built with vite.

--- a/mise.viteprod.toml
+++ b/mise.viteprod.toml
@@ -5,6 +5,10 @@
 ## Both the Gram server and dashboard (client) are accessed on
 ## https://app.getgram.ai.
 GRAM_SERVER_URL = false
+## The admin dashboard is served from its own origin, so unlike the dashboard
+## it cannot fall back to window.location.origin. One image serves every
+## deployed environment, so this names production.
+GRAM_APP_URL = "https://app.getgram.ai"
 ## GRAM_API_URL is used primarily during local development. That may change in
 ## the future when we create separate builds per environment but until then we
 ## should unset it so it is not baked into bundles built with vite.

--- a/mise.viteprod.toml
+++ b/mise.viteprod.toml
@@ -5,20 +5,8 @@
 ## Both the Gram server and dashboard (client) are accessed on
 ## https://app.getgram.ai.
 GRAM_SERVER_URL = false
-## Deliberately unset, which disables the impersonation link in every deployed
-## environment. impersonationUrl() returns undefined and its callers drop the
-## action, so no operator is offered a link that lies about where it goes.
-##
-## The admin dashboard cannot fall back to window.location.origin the way the
-## dashboard does, because it is served from its own origin. One image serves
-## every deployed environment, so a value here would name production and the
-## dev admin dashboard would send an operator into production data while they
-## believed they were in dev.
-##
-## The slice that adds the row action decides the per-environment channel. The
-## admin image has no envsubst pass today: `client/admin/Dockerfile` says it
-## needs none, because it otherwise talks to its API same-origin. This would be
-## the first cross-origin URL baked into the bundle.
+## Unset on purpose: one image serves every environment, so any value here
+## would send the dev admin dashboard into production data. Disables the link.
 GRAM_APP_URL = false
 ## GRAM_API_URL is used primarily during local development. That may change in
 ## the future when we create separate builds per environment but until then we

--- a/server/internal/auth/org_slug_destination_test.go
+++ b/server/internal/auth/org_slug_destination_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrganizationSlugFromDestinationURL pins the destination URL shapes the
+// admin dashboard emits. The admin dashboard builds them in
+// client/admin/src/lib/impersonation.ts and puts them in the `redirect` query
+// parameter of the login URL, which becomes loginState.FinalDestinationURL.
+// A shape this function rejects has no visible failure mode: the operator
+// silently lands on their own default organization instead of the target.
+func TestOrganizationSlugFromDestinationURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		destinationURL string
+		want           string
+	}{
+		{
+			name:           "relative path, slug only",
+			destinationURL: "/acme-placeholder",
+			want:           "acme-placeholder",
+		},
+		{
+			name:           "relative path with trailing segments",
+			destinationURL: "/acme-placeholder/projects/default",
+			want:           "acme-placeholder",
+		},
+		{
+			name:           "absolute URL, slug only",
+			destinationURL: "https://app.example.test/acme-placeholder",
+			want:           "acme-placeholder",
+		},
+		{
+			name:           "absolute URL with trailing segments",
+			destinationURL: "https://app.example.test/acme-placeholder/projects/default",
+			want:           "acme-placeholder",
+		},
+		{
+			name:           "slug survives a query string",
+			destinationURL: "/acme-placeholder?tab=tools",
+			want:           "acme-placeholder",
+		},
+		{
+			name:           "empty destination",
+			destinationURL: "",
+			want:           "",
+		},
+		{
+			name:           "root path only",
+			destinationURL: "/",
+			want:           "",
+		},
+		{
+			name:           "absolute URL with no path",
+			destinationURL: "https://app.example.test",
+			want:           "",
+		},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.want, organizationSlugFromDestinationURL(tt.destinationURL), tt.name)
+	}
+}

--- a/server/internal/auth/org_slug_destination_test.go
+++ b/server/internal/auth/org_slug_destination_test.go
@@ -6,12 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOrganizationSlugFromDestinationURL pins the destination URL shapes the
-// admin dashboard emits. The admin dashboard builds them in
-// client/admin/src/lib/impersonation.ts and puts them in the `redirect` query
-// parameter of the login URL, which becomes loginState.FinalDestinationURL.
-// A shape this function rejects has no visible failure mode: the operator
-// silently lands on their own default organization instead of the target.
+// Pins the shapes client/admin/src/lib/impersonation.ts emits. A rejected
+// shape fails silently: the operator lands on their own default org.
 func TestOrganizationSlugFromDestinationURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Opening the customer-facing dashboard scoped to a chosen organization currently means setting a cookie by hand and logging in again. This lands the URL contract that replaces that, with tests on both sides of it.

This PR is the contract only. The row action that uses it is a follow-up.

### The shape

```
https://<app origin>/rpc/auth.login?redirect=%2F<slug>
```

The slug rides in the `redirect` query parameter, not in the login URL's pathname. `encodeStateParam` copies `payload.Redirect` into `loginState.FinalDestinationURL`, and `organizationSlugFromDestinationURL` relativises that and takes its first path segment.

`redirect` is relative rather than absolute because `callbackRedirectURL` passes the destination through `relativeURL` to block open redirects, so an absolute URL would be reduced to this anyway.

### Why two tests for one string

Getting this shape wrong fails **silently**: the operator lands on their own default organization instead of the target, with no error. So both sides pin the same function. The Go table test feeds the extractor the exact strings the client builds; the TypeScript test asserts the slug lands where the extractor reads it. Each test names the other, so they cannot drift apart unnoticed.

### The app URL is deliberately unset in deployed builds

`GRAM_APP_URL` is empty in `mise.viteprod.toml`, which disables the link everywhere it is deployed. `impersonationUrl()` returns `undefined` and callers drop the action.

One admin image serves every deployed environment, so any value here would name production, and the **dev** admin dashboard would send an operator into production data while they believed they were in dev. The admin bundle has no per-environment channel today: its Dockerfile states it needs no `envsubst` pass, because it otherwise reaches its API same-origin. This would be the first cross-origin URL baked into it.

The follow-up that adds the row action picks that channel. Until then nothing user-facing exists, so nothing can mislead.

AGE-3192

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a cross-app login URL that opens the customer dashboard scoped to a chosen organization, replacing the set-a-cookie-and-relogin flow. Before: operators wrote a cookie and logged in again. Now: navigate to `/rpc/auth.login?redirect=/<slug>`; the server reads the slug from `redirect`; admins land in the target org while non-admins land in their default org.

- Contract: the slug is the first path segment of the relative `redirect`. Admins resolve the slug even if not members; non-admins fall back to their default org.
- Client: adds `impersonationUrl(slug)` that builds a full URL or returns `undefined` when `__GRAM_APP_URL__` or the slug is blank. `__GRAM_APP_URL__` is injected from `GRAM_APP_URL`; the build rejects a non-absolute, non-https, or hostless `GRAM_APP_URL`.
- Tests: pins both sides. Go table test covers accepted destination shapes; TypeScript test asserts the builder’s exact URL, so they cannot drift.
- Rollout: `mise.toml` sets `GRAM_APP_URL = GRAM_SERVER_URL` for local dev; `mise.viteprod.toml` deliberately unsets it to disable the link in shipped images. The row action that uses this URL follows.
- Linear: satisfies AGE-3192.

<sup>Written for commit dbcab307b8416e1b00a0c17c00a01be9d9abe7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

