### PR TITLE
fix: withhold Polar credit fields from non-platform-admin getPeriodUsage callers

### DIFF
--- a/.changeset/withhold-polar-credits.md
+++ b/.changeset/withhold-polar-credits.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Withhold Polar `credits` and `included_credits` from non-platform-admin callers of `usage.getPeriodUsage`. The fields are now optional and omitted unless `authCtx.IsAdmin` is set, matching the existing admin-only billing meter in the dashboard.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -67211,14 +67211,14 @@ components:
           format: int64
         credits:
           type: integer
-          description: The number of credits used
+          description: The number of credits used. Only populated for platform admins.
           format: int64
         has_active_subscription:
           type: boolean
           description: Whether the project has an active subscription
         included_credits:
           type: integer
-          description: The number of credits included in the tier
+          description: The number of credits included in the tier. Only populated for platform admins.
           format: int64
         included_servers:
           type: integer
@@ -67242,8 +67242,6 @@ components:
         - servers
         - included_servers
         - actual_enabled_server_count
-        - credits
-        - included_credits
         - has_active_subscription
     PlatformMCPOnboardingSetupHandoff:
       type: object

--- a/client/dashboard/src/components/platform-admin-only-panel.test.tsx
+++ b/client/dashboard/src/components/platform-admin-only-panel.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const isPlatformAdmin = vi.fn();
+
+vi.mock("@/contexts/Auth", () => ({
+  useIsPlatformAdmin: () => isPlatformAdmin(),
+}));
+
+import { PlatformAdminOnlyPanel } from "./platform-admin-only-panel";
+
+afterEach(() => {
+  cleanup();
+  isPlatformAdmin.mockReset();
+});
+
+describe("PlatformAdminOnlyPanel", () => {
+  it("renders the title and children for a platform admin", () => {
+    isPlatformAdmin.mockReturnValue(true);
+
+    render(
+      <PlatformAdminOnlyPanel>
+        <div>admin content</div>
+      </PlatformAdminOnlyPanel>,
+    );
+
+    expect(screen.getByText("Platform Admin Only")).toBeTruthy();
+    expect(screen.getByText("admin content")).toBeTruthy();
+  });
+
+  it("renders nothing for a non-admin", () => {
+    isPlatformAdmin.mockReturnValue(false);
+
+    render(
+      <PlatformAdminOnlyPanel>
+        <div>admin content</div>
+      </PlatformAdminOnlyPanel>,
+    );
+
+    expect(screen.queryByText("Platform Admin Only")).toBeNull();
+    expect(screen.queryByText("admin content")).toBeNull();
+  });
+});

--- a/client/dashboard/src/components/platform-admin-only-panel.tsx
+++ b/client/dashboard/src/components/platform-admin-only-panel.tsx
@@ -1,0 +1,33 @@
+import { Heading } from "@/components/ui/Heading";
+import { Stack } from "@/components/ui/Stack";
+import { useIsPlatformAdmin } from "@/contexts/Auth";
+import { ShieldAlert } from "lucide-react";
+import type { ReactNode } from "react";
+
+// Visual wrapper for Speakeasy-staff-only controls that sit on a customer-
+// visible page (project settings, billing meters). Renders nothing for
+// everyone else. The platform-admin flag is not an RBAC scope, so this is
+// presentation only — each enclosed surface still has to enforce the flag
+// server-side.
+export function PlatformAdminOnlyPanel({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element | null {
+  const isAdmin = useIsPlatformAdmin();
+  if (!isAdmin) {
+    return null;
+  }
+
+  return (
+    <div className="border-destructive-default bg-card border p-4">
+      <Stack direction="horizontal" align="center" gap={2} className="mb-3">
+        <ShieldAlert className="text-default-destructive h-5 w-5" />
+        <Heading variant="h4" className="text-default-destructive">
+          Platform Admin Only
+        </Heading>
+      </Stack>
+      {children}
+    </div>
+  );
+}

--- a/client/dashboard/src/components/platform-admin-only-panel.tsx
+++ b/client/dashboard/src/components/platform-admin-only-panel.tsx
@@ -14,8 +14,8 @@ export function PlatformAdminOnlyPanel({
 }: {
   children: ReactNode;
 }): JSX.Element | null {
-  const isAdmin = useIsPlatformAdmin();
-  if (!isAdmin) {
+  const isPlatformAdmin = useIsPlatformAdmin();
+  if (!isPlatformAdmin) {
     return null;
   }
 

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -167,16 +167,18 @@ const UsageSection = () => {
           )}
           {periodUsage?.credits != null &&
             periodUsage.includedCredits != null && (
-              <PlatformAdminOnlyPanel>
-                <UsageItem
-                  label="Chat Based Credits (Polar)"
-                  tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
-                  value={periodUsage.credits}
-                  included={periodUsage.includedCredits}
-                  overageIncrement={periodUsage.includedCredits}
-                  noMax={productTier === "enterprise"}
-                />
-              </PlatformAdminOnlyPanel>
+              <div className="pt-8">
+                <PlatformAdminOnlyPanel>
+                  <UsageItem
+                    label="Chat Based Credits (Polar)"
+                    tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
+                    value={periodUsage.credits}
+                    included={periodUsage.includedCredits}
+                    overageIncrement={periodUsage.includedCredits}
+                    noMax={productTier === "enterprise"}
+                  />
+                </PlatformAdminOnlyPanel>
+              </div>
             )}
         </div>
       </Page.Section.Body>

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -167,7 +167,7 @@ const UsageSection = () => {
           )}
           {periodUsage?.credits != null &&
             periodUsage.includedCredits != null && (
-              <div className="pt-8">
+              <div className="pt-4">
                 <PlatformAdminOnlyPanel>
                   <UsageItem
                     label="Chat Based Credits (Polar)"

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -142,19 +142,6 @@ const UsageSection = () => {
                 overageIncrement={1}
                 noMax={productTier === "enterprise"}
               />
-              {periodUsage.credits != null &&
-                periodUsage.includedCredits != null && (
-                  <PlatformAdminOnlyPanel>
-                    <UsageItem
-                      label="Chat Based Credits (Polar)"
-                      tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
-                      value={periodUsage.credits}
-                      included={periodUsage.includedCredits}
-                      overageIncrement={periodUsage.includedCredits}
-                      noMax={productTier === "enterprise"}
-                    />
-                  </PlatformAdminOnlyPanel>
-                )}
             </>
           ) : (
             <>
@@ -178,6 +165,19 @@ const UsageSection = () => {
               <Skeleton className="h-4 w-full" />
             </>
           )}
+          {periodUsage?.credits != null &&
+            periodUsage.includedCredits != null && (
+              <PlatformAdminOnlyPanel>
+                <UsageItem
+                  label="Chat Based Credits (Polar)"
+                  tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
+                  value={periodUsage.credits}
+                  included={periodUsage.includedCredits}
+                  overageIncrement={periodUsage.includedCredits}
+                  noMax={productTier === "enterprise"}
+                />
+              </PlatformAdminOnlyPanel>
+            )}
         </div>
       </Page.Section.Body>
     </Page.Section>

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -22,6 +22,7 @@ import { Stack } from "@/components/ui/Stack";
 import { cn } from "@/lib/utils";
 import { Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { PlatformAdminOnlyPanel } from "@/components/platform-admin-only-panel";
 import { RequireScope } from "@/components/require-scope";
 import { TopUpCTA, UsageProgress } from "@/components/billing/usage-controls";
 import { TumAdminSection } from "@/components/billing/tum-admin-section";
@@ -70,8 +71,6 @@ function BillingInner() {
 
 const UsageSection = () => {
   const productTier = useProductTier();
-
-  const isAdmin = useIsPlatformAdmin();
 
   const { data: creditUsage } = useGetCreditUsage();
   const { data: periodUsage } = useGetPeriodUsage(undefined, undefined, {
@@ -143,17 +142,18 @@ const UsageSection = () => {
                 overageIncrement={1}
                 noMax={productTier === "enterprise"}
               />
-              {isAdmin &&
-                periodUsage.credits != null &&
+              {periodUsage.credits != null &&
                 periodUsage.includedCredits != null && (
-                  <UsageItem
-                    label="Chat Based Credits (Polar) (ADMIN VIEW ONLY)"
-                    tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
-                    value={periodUsage.credits}
-                    included={periodUsage.includedCredits}
-                    overageIncrement={periodUsage.includedCredits}
-                    noMax={productTier === "enterprise"}
-                  />
+                  <PlatformAdminOnlyPanel>
+                    <UsageItem
+                      label="Chat Based Credits (Polar)"
+                      tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
+                      value={periodUsage.credits}
+                      included={periodUsage.includedCredits}
+                      overageIncrement={periodUsage.includedCredits}
+                      noMax={productTier === "enterprise"}
+                    />
+                  </PlatformAdminOnlyPanel>
                 )}
             </>
           ) : (

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -143,16 +143,18 @@ const UsageSection = () => {
                 overageIncrement={1}
                 noMax={productTier === "enterprise"}
               />
-              {isAdmin && (
-                <UsageItem
-                  label="Chat Based Credits (Polar) (ADMIN VIEW ONLY)"
-                  tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
-                  value={periodUsage.credits}
-                  included={periodUsage.includedCredits}
-                  overageIncrement={periodUsage.includedCredits}
-                  noMax={productTier === "enterprise"}
-                />
-              )}
+              {isAdmin &&
+                periodUsage.credits != null &&
+                periodUsage.includedCredits != null && (
+                  <UsageItem
+                    label="Chat Based Credits (Polar) (ADMIN VIEW ONLY)"
+                    tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
+                    value={periodUsage.credits}
+                    included={periodUsage.includedCredits}
+                    overageIncrement={periodUsage.includedCredits}
+                    noMax={productTier === "enterprise"}
+                  />
+                )}
             </>
           ) : (
             <>

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -45,7 +45,7 @@ export default function Billing(): JSX.Element {
 
 function BillingInner() {
   const productTier = useProductTier();
-  const isAdmin = useIsPlatformAdmin();
+  const isPlatformAdmin = useIsPlatformAdmin();
 
   // Enterprise contracts bill on tokens under management, so enterprise orgs
   // see the TUM view instead of the self-serve usage meters.
@@ -53,7 +53,7 @@ function BillingInner() {
     return (
       <>
         <TumUsageSection />
-        {isAdmin && <TumAdminSection />}
+        {isPlatformAdmin && <TumAdminSection />}
       </>
     );
   }

--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -1,18 +1,11 @@
 import { SettingsPage } from "@/components/page-templates";
-import { Heading } from "@/components/ui/Heading";
-import {
-  useIsPlatformAdmin,
-  useOrganization,
-  useProject,
-} from "@/contexts/Auth";
-import { ShieldAlert } from "lucide-react";
-import { Stack } from "@/components/ui/Stack";
+import { PlatformAdminOnlyPanel } from "@/components/platform-admin-only-panel";
+import { useOrganization, useProject } from "@/contexts/Auth";
 import { SettingsDangerZone } from "./SettingsDangerZone";
 import { RegistryCacheSection } from "./RegistryCacheSection";
 import { ModelProviderKeysSection } from "./ModelProviderKeysSection";
 
 export default function Settings(): JSX.Element {
-  const isAdmin = useIsPlatformAdmin();
   const organization = useOrganization();
   const project = useProject();
 
@@ -26,23 +19,15 @@ export default function Settings(): JSX.Element {
 
       <SettingsDangerZone />
 
-      {isAdmin && (
-        <div className="border-destructive-default bg-card border p-4">
-          <Stack direction="horizontal" align="center" gap={2} className="mb-3">
-            <ShieldAlert className="text-default-destructive h-5 w-5" />
-            <Heading variant="h4" className="text-default-destructive">
-              Platform Admin Only
-            </Heading>
-          </Stack>
-          <dl className="mb-4 grid grid-cols-[max-content_auto] gap-x-6 gap-y-2">
-            <dt className="text-end">Organization ID</dt>
-            <dd className="font-mono text-sm">{organization.id}</dd>
-            <dt className="text-end">Project ID</dt>
-            <dd className="font-mono text-sm">{project.id}</dd>
-          </dl>
-          <RegistryCacheSection />
-        </div>
-      )}
+      <PlatformAdminOnlyPanel>
+        <dl className="mb-4 grid grid-cols-[max-content_auto] gap-x-6 gap-y-2">
+          <dt className="text-end">Organization ID</dt>
+          <dd className="font-mono text-sm">{organization.id}</dd>
+          <dt className="text-end">Project ID</dt>
+          <dd className="font-mono text-sm">{project.id}</dd>
+        </dl>
+        <RegistryCacheSection />
+      </PlatformAdminOnlyPanel>
     </SettingsPage>
   );
 }

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -5113,7 +5113,7 @@ examples:
     speakeasy-default-get-period-usage:
       responses:
         "200":
-          application/json: {"actual_enabled_server_count": 754388, "credits": 298053, "has_active_subscription": true, "included_credits": 709134, "included_servers": 639183, "included_tool_calls": 793269, "servers": 254263, "tool_calls": 672011}
+          application/json: {"actual_enabled_server_count": 754388, "has_active_subscription": true, "included_servers": 639183, "included_tool_calls": 793269, "servers": 254263, "tool_calls": 672011}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": true}
         "500":

--- a/client/dashboard/src/sdk/src/models/components/periodusage.ts
+++ b/client/dashboard/src/sdk/src/models/components/periodusage.ts
@@ -14,17 +14,17 @@ export type PeriodUsage = {
    */
   actualEnabledServerCount: number;
   /**
-   * The number of credits used
+   * The number of credits used. Only populated for platform admins.
    */
-  credits: number;
+  credits?: number | undefined;
   /**
    * Whether the project has an active subscription
    */
   hasActiveSubscription: boolean;
   /**
-   * The number of credits included in the tier
+   * The number of credits included in the tier. Only populated for platform admins.
    */
-  includedCredits: number;
+  includedCredits?: number | undefined;
   /**
    * The number of servers included in the tier
    */
@@ -48,9 +48,9 @@ export const PeriodUsage$inboundSchema: z.ZodMiniType<PeriodUsage, unknown> = z
   .pipe(
     z.object({
       actual_enabled_server_count: z.int(),
-      credits: z.int(),
+      credits: z.optional(z.int()),
       has_active_subscription: z.boolean(),
-      included_credits: z.int(),
+      included_credits: z.optional(z.int()),
       included_servers: z.int(),
       included_tool_calls: z.int(),
       servers: z.int(),

--- a/server/design/usage/design.go
+++ b/server/design/usage/design.go
@@ -15,12 +15,12 @@ var PeriodUsage = Type("PeriodUsage", func() {
 	Attribute("included_servers", Int, "The number of servers included in the tier")
 	Attribute("actual_enabled_server_count", Int, "The number of servers enabled at the time of the request")
 
-	Attribute("credits", Int, "The number of credits used")
-	Attribute("included_credits", Int, "The number of credits included in the tier")
+	Attribute("credits", Int, "The number of credits used. Only populated for platform admins.")
+	Attribute("included_credits", Int, "The number of credits included in the tier. Only populated for platform admins.")
 
 	Attribute("has_active_subscription", Boolean, "Whether the project has an active subscription")
 
-	Required("tool_calls", "included_tool_calls", "servers", "included_servers", "actual_enabled_server_count", "credits", "included_credits", "has_active_subscription")
+	Required("tool_calls", "included_tool_calls", "servers", "included_servers", "actual_enabled_server_count", "has_active_subscription")
 })
 
 var TierLimits = Type("TierLimits", func() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -68006,14 +68006,14 @@ components:
                     format: int64
                 credits:
                     type: integer
-                    description: The number of credits used
+                    description: The number of credits used. Only populated for platform admins.
                     format: int64
                 has_active_subscription:
                     type: boolean
                     description: Whether the project has an active subscription
                 included_credits:
                     type: integer
-                    description: The number of credits included in the tier
+                    description: The number of credits included in the tier. Only populated for platform admins.
                     format: int64
                 included_servers:
                     type: integer
@@ -68037,8 +68037,6 @@ components:
                 - servers
                 - included_servers
                 - actual_enabled_server_count
-                - credits
-                - included_credits
                 - has_active_subscription
         PlatformMCPOnboardingSetupHandoff:
             type: object

--- a/server/gen/http/usage/client/types.go
+++ b/server/gen/http/usage/client/types.go
@@ -39,9 +39,10 @@ type GetPeriodUsageResponseBody struct {
 	IncludedServers *int `form:"included_servers,omitempty" json:"included_servers,omitempty" xml:"included_servers,omitempty"`
 	// The number of servers enabled at the time of the request
 	ActualEnabledServerCount *int `form:"actual_enabled_server_count,omitempty" json:"actual_enabled_server_count,omitempty" xml:"actual_enabled_server_count,omitempty"`
-	// The number of credits used
+	// The number of credits used. Only populated for platform admins.
 	Credits *int `form:"credits,omitempty" json:"credits,omitempty" xml:"credits,omitempty"`
-	// The number of credits included in the tier
+	// The number of credits included in the tier. Only populated for platform
+	// admins.
 	IncludedCredits *int `form:"included_credits,omitempty" json:"included_credits,omitempty" xml:"included_credits,omitempty"`
 	// Whether the project has an active subscription
 	HasActiveSubscription *bool `form:"has_active_subscription,omitempty" json:"has_active_subscription,omitempty" xml:"has_active_subscription,omitempty"`
@@ -1463,8 +1464,8 @@ func NewGetPeriodUsagePeriodUsageOK(body *GetPeriodUsageResponseBody) *usage.Per
 		Servers:                  *body.Servers,
 		IncludedServers:          *body.IncludedServers,
 		ActualEnabledServerCount: *body.ActualEnabledServerCount,
-		Credits:                  *body.Credits,
-		IncludedCredits:          *body.IncludedCredits,
+		Credits:                  body.Credits,
+		IncludedCredits:          body.IncludedCredits,
 		HasActiveSubscription:    *body.HasActiveSubscription,
 	}
 
@@ -2597,12 +2598,6 @@ func ValidateGetPeriodUsageResponseBody(body *GetPeriodUsageResponseBody) (err e
 	}
 	if body.ActualEnabledServerCount == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("actual_enabled_server_count", "body"))
-	}
-	if body.Credits == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("credits", "body"))
-	}
-	if body.IncludedCredits == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("included_credits", "body"))
 	}
 	if body.HasActiveSubscription == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("has_active_subscription", "body"))

--- a/server/gen/http/usage/server/types.go
+++ b/server/gen/http/usage/server/types.go
@@ -39,10 +39,11 @@ type GetPeriodUsageResponseBody struct {
 	IncludedServers int `form:"included_servers" json:"included_servers" xml:"included_servers"`
 	// The number of servers enabled at the time of the request
 	ActualEnabledServerCount int `form:"actual_enabled_server_count" json:"actual_enabled_server_count" xml:"actual_enabled_server_count"`
-	// The number of credits used
-	Credits int `form:"credits" json:"credits" xml:"credits"`
-	// The number of credits included in the tier
-	IncludedCredits int `form:"included_credits" json:"included_credits" xml:"included_credits"`
+	// The number of credits used. Only populated for platform admins.
+	Credits *int `form:"credits,omitempty" json:"credits,omitempty" xml:"credits,omitempty"`
+	// The number of credits included in the tier. Only populated for platform
+	// admins.
+	IncludedCredits *int `form:"included_credits,omitempty" json:"included_credits,omitempty" xml:"included_credits,omitempty"`
 	// Whether the project has an active subscription
 	HasActiveSubscription bool `form:"has_active_subscription" json:"has_active_subscription" xml:"has_active_subscription"`
 }

--- a/server/gen/usage/service.go
+++ b/server/gen/usage/service.go
@@ -97,10 +97,11 @@ type PeriodUsage struct {
 	IncludedServers int
 	// The number of servers enabled at the time of the request
 	ActualEnabledServerCount int
-	// The number of credits used
-	Credits int
-	// The number of credits included in the tier
-	IncludedCredits int
+	// The number of credits used. Only populated for platform admins.
+	Credits *int
+	// The number of credits included in the tier. Only populated for platform
+	// admins.
+	IncludedCredits *int
 	// Whether the project has an active subscription
 	HasActiveSubscription bool
 }

--- a/server/internal/billing/stub.go
+++ b/server/internal/billing/stub.go
@@ -352,13 +352,15 @@ func (s *StubClient) readPeriodUsage(orgID string) (*gen.PeriodUsage, error) {
 	}
 
 	tier := must.Value(s.GetUsageTiers(context.Background())).Pro
+	credits := 0
+	includedCredits := tier.IncludedCredits
 	zero := &gen.PeriodUsage{
 		ToolCalls:                0,
 		IncludedToolCalls:        tier.IncludedToolCalls,
 		Servers:                  0,
 		IncludedServers:          tier.IncludedServers,
-		Credits:                  0,
-		IncludedCredits:          tier.IncludedCredits,
+		Credits:                  &credits,
+		IncludedCredits:          &includedCredits,
 		HasActiveSubscription:    false,
 		ActualEnabledServerCount: 0,
 	}

--- a/server/internal/chat/balance_check_test.go
+++ b/server/internal/chat/balance_check_test.go
@@ -25,6 +25,13 @@ func (f *fakeBillingRepo) GetStoredPeriodUsage(_ context.Context, _ string) (*ge
 	return f.storedUsage, f.storedErr
 }
 
+func periodUsageCredits(credits, included int) *gen.PeriodUsage {
+	return &gen.PeriodUsage{
+		Credits:         &credits,
+		IncludedCredits: &included,
+	}
+}
+
 func newServiceWithBilling(t *testing.T, repo billing.Repository) *Service {
 	t.Helper()
 	return &Service{
@@ -38,7 +45,7 @@ func TestCheckCreditBalance_AllowsWhenUnderIncluded(t *testing.T) {
 	t.Parallel()
 
 	svc := newServiceWithBilling(t, &fakeBillingRepo{
-		storedUsage: &gen.PeriodUsage{Credits: 10, IncludedCredits: 100},
+		storedUsage: periodUsageCredits(10, 100),
 	})
 
 	require.NoError(t, svc.checkCreditBalance(t.Context(), "org-1", "free"))
@@ -48,7 +55,7 @@ func TestCheckCreditBalance_RejectsWhenAtLimit(t *testing.T) {
 	t.Parallel()
 
 	svc := newServiceWithBilling(t, &fakeBillingRepo{
-		storedUsage: &gen.PeriodUsage{Credits: 100, IncludedCredits: 100},
+		storedUsage: periodUsageCredits(100, 100),
 	})
 
 	err := svc.checkCreditBalance(t.Context(), "org-1", "free")
@@ -62,7 +69,7 @@ func TestCheckCreditBalance_RejectsWhenOverLimit(t *testing.T) {
 	t.Parallel()
 
 	svc := newServiceWithBilling(t, &fakeBillingRepo{
-		storedUsage: &gen.PeriodUsage{Credits: 250, IncludedCredits: 100},
+		storedUsage: periodUsageCredits(250, 100),
 	})
 
 	err := svc.checkCreditBalance(t.Context(), "org-1", "free")
@@ -79,7 +86,7 @@ func TestCheckCreditBalance_AllowsWhenIncludedZero(t *testing.T) {
 	// product config). Don't block — let the request through and rely on
 	// upstream OpenRouter key limit as the backstop.
 	svc := newServiceWithBilling(t, &fakeBillingRepo{
-		storedUsage: &gen.PeriodUsage{Credits: 0, IncludedCredits: 0},
+		storedUsage: periodUsageCredits(0, 0),
 	})
 
 	require.NoError(t, svc.checkCreditBalance(t.Context(), "org-1", "free"))

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1373,7 +1373,9 @@ func (s *Service) checkCreditBalance(ctx context.Context, orgID, accountType str
 		return nil
 	}
 
-	if pu.IncludedCredits > 0 && pu.Credits >= pu.IncludedCredits {
+	included := conv.PtrValOr(pu.IncludedCredits, 0)
+	used := conv.PtrValOr(pu.Credits, 0)
+	if included > 0 && used >= included {
 		return oops.C(oops.CodeInsufficientCredits).LogError(
 			ctx, s.logger,
 			attr.SlogOrganizationID(orgID),

--- a/server/internal/thirdparty/polar/client.go
+++ b/server/internal/thirdparty/polar/client.go
@@ -656,14 +656,16 @@ func (p *Client) getCustomer(ctx context.Context, orgID string) (*billing.Custom
 
 // readPeriodUsage reads the period usage from the customer state if available, otherwise reads the usage from the meters directly.
 func (p *Client) readPeriodUsage(ctx context.Context, orgID string, customer *polarComponents.CustomerState) (*gen.PeriodUsage, error) {
+	credits := -1
+	includedCredits := -1
 	usage := gen.PeriodUsage{
 		// Set to -1 so we can tell if we've failed to get the usage
 		ToolCalls:                -1,
 		IncludedToolCalls:        -1,
 		Servers:                  -1,
 		IncludedServers:          -1,
-		Credits:                  -1,
-		IncludedCredits:          -1,
+		Credits:                  nil,
+		IncludedCredits:          nil,
 		HasActiveSubscription:    false,
 		ActualEnabledServerCount: 0, // Not related to polar, populated elsewhere
 	}
@@ -712,9 +714,9 @@ func (p *Client) readPeriodUsage(ctx context.Context, orgID string, customer *po
 		}
 
 		if creditMeter != nil {
-			usage.Credits = int(creditMeter.ConsumedUnits)
+			credits = int(creditMeter.ConsumedUnits)
 			if creditMeter.CreditedUnits > 0 {
-				usage.IncludedCredits = int(creditMeter.CreditedUnits)
+				includedCredits = int(creditMeter.CreditedUnits)
 			}
 		}
 	}
@@ -729,7 +731,7 @@ func (p *Client) readPeriodUsage(ctx context.Context, orgID string, customer *po
 	// ran sequentially (~1s each to api.polar.sh), causing ~3s of unnecessary latency.
 	needToolCalls := usage.ToolCalls == -1
 	needServers := usage.Servers == -1
-	needCredits := usage.Credits == -1
+	needCredits := credits == -1
 
 	if needToolCalls || needServers || needCredits {
 		now := time.Now()
@@ -794,11 +796,11 @@ func (p *Client) readPeriodUsage(ctx context.Context, orgID string, customer *po
 			usage.Servers = int(res.Total)
 		}
 		if res := <-creditsCh; res != nil {
-			usage.Credits = int(res.Total)
+			credits = int(res.Total)
 		}
 	}
 
-	if usage.IncludedToolCalls == -1 || usage.IncludedServers == -1 || usage.IncludedCredits == -1 {
+	if usage.IncludedToolCalls == -1 || usage.IncludedServers == -1 || includedCredits == -1 {
 		freeTierProduct, err := p.getProductByID(ctx, p.catalog.ProductIDBase)
 		if err != nil {
 			return nil, fmt.Errorf("get free tier product: %w", err)
@@ -816,9 +818,11 @@ func (p *Client) readPeriodUsage(ctx context.Context, orgID string, customer *po
 
 		usage.IncludedToolCalls = conv.Ternary(usage.IncludedToolCalls == -1, freeTierLimits.ToolCalls, usage.IncludedToolCalls)
 		usage.IncludedServers = conv.Ternary(usage.IncludedServers == -1, freeTierLimits.Servers, usage.IncludedServers)
-		usage.IncludedCredits = conv.Ternary(usage.IncludedCredits == -1, freeTierLimits.Credits, usage.IncludedCredits)
+		includedCredits = conv.Ternary(includedCredits == -1, freeTierLimits.Credits, includedCredits)
 	}
 
+	usage.Credits = &credits
+	usage.IncludedCredits = &includedCredits
 	return &usage, nil
 }
 

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -280,14 +280,22 @@ func (s *Service) GetPeriodUsage(ctx context.Context, payload *gen.GetPeriodUsag
 		return nil, oops.E(oops.CodeUnexpected, err, "could not get public server count").LogError(ctx, s.logger)
 	}
 
+	// Polar credit meters are Speakeasy-internal; only expose them to
+	// platform admins. An org RBAC org:admin grant does not confer this.
+	var credits, includedCredits *int
+	if authCtx.IsAdmin {
+		credits = periodUsage.Credits
+		includedCredits = periodUsage.IncludedCredits
+	}
+
 	// We don't populate the maximums using GetUsageTiers because we want to reflect the actual granted credits, not the current product limits which may have changed.
 	return &gen.PeriodUsage{
 		ToolCalls:                periodUsage.ToolCalls,
 		IncludedToolCalls:        periodUsage.IncludedToolCalls,
 		Servers:                  periodUsage.Servers,
 		IncludedServers:          periodUsage.IncludedServers,
-		Credits:                  periodUsage.Credits,
-		IncludedCredits:          periodUsage.IncludedCredits,
+		Credits:                  credits,
+		IncludedCredits:          includedCredits,
 		HasActiveSubscription:    periodUsage.HasActiveSubscription,
 		ActualEnabledServerCount: int(actualEnabledServerCount),
 	}, nil

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -213,13 +213,14 @@ func testAuthContext(orgID string) context.Context {
 }
 
 func sampleUsage(toolCalls, servers, credits int) *gen.PeriodUsage {
+	includedCredits := 25
 	return &gen.PeriodUsage{
 		ToolCalls:                toolCalls,
 		IncludedToolCalls:        10000,
 		Servers:                  servers,
 		IncludedServers:          3,
-		Credits:                  credits,
-		IncludedCredits:          25,
+		Credits:                  &credits,
+		IncludedCredits:          &includedCredits,
 		HasActiveSubscription:    false,
 		ActualEnabledServerCount: 0,
 	}
@@ -243,7 +244,8 @@ func TestGetPeriodUsage_CacheHit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 42, result.ToolCalls)
 	require.Equal(t, 2, result.Servers)
-	require.Equal(t, 10, result.Credits)
+	require.Nil(t, result.Credits)
+	require.Nil(t, result.IncludedCredits)
 	require.Equal(t, 5, result.ActualEnabledServerCount) // from DB, not cache
 	billingMock.AssertNotCalled(t, "GetPeriodUsage", mock.Anything, mock.Anything)
 }
@@ -264,7 +266,8 @@ func TestGetPeriodUsage_CacheMissFallback(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 100, result.ToolCalls)
 	require.Equal(t, 5, result.Servers)
-	require.Equal(t, 20, result.Credits)
+	require.Nil(t, result.Credits)
+	require.Nil(t, result.IncludedCredits)
 	require.Equal(t, 3, result.ActualEnabledServerCount)
 	billingMock.AssertCalled(t, "GetPeriodUsage", mock.Anything, orgID)
 }
@@ -300,6 +303,31 @@ func TestGetPeriodUsage_NoAuthContext(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
+}
+
+func TestGetPeriodUsage_CreditsPlatformAdminOnly(t *testing.T) {
+	t.Parallel()
+	orgID := "org-credits-admin-only"
+	cached := sampleUsage(42, 2, 10)
+
+	billingMock := &mockBillingRepo{}
+	billingMock.On("GetStoredPeriodUsage", mock.Anything, orgID).Return(cached)
+	svc := newTestService(t, billingMock, orgID, 1)
+
+	memberResult, err := svc.GetPeriodUsage(testAuthContext(orgID), &gen.GetPeriodUsagePayload{})
+	require.NoError(t, err)
+	require.Equal(t, 42, memberResult.ToolCalls)
+	require.Equal(t, 2, memberResult.Servers)
+	require.Nil(t, memberResult.Credits)
+	require.Nil(t, memberResult.IncludedCredits)
+
+	adminResult, err := svc.GetPeriodUsage(testAdminAuthContext(orgID), &gen.GetPeriodUsagePayload{})
+	require.NoError(t, err)
+	require.Equal(t, 42, adminResult.ToolCalls)
+	require.NotNil(t, adminResult.Credits)
+	require.Equal(t, 10, *adminResult.Credits)
+	require.NotNil(t, adminResult.IncludedCredits)
+	require.Equal(t, 25, *adminResult.IncludedCredits)
 }
 
 func TestGetPeriodUsage_ActualServerCountFromDB(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes an API leak for **legacy Polar clients**. `GET /rpc/usage.getPeriodUsage` returned Speakeasy-internal Polar `credits` / `included_credits` to any caller with `org:read`. The Billing UI already hid those meters behind `useIsPlatformAdmin()`, but the RPC did not.

New clients are enterprise-only. They bill on TUM and never see Polar credit meters (enterprise Billing renders TUM only). This leak and this meter exist only on remaining free/pro Polar orgs.

The fields are now optional and populated only when `authCtx.IsAdmin` is true (`users.admin` / platform staff — not an org RBAC `org:admin` grant). Tool-call and server usage stay on the payload so the free-tier banner and server-enable dialog keep working for ordinary members on that legacy path.

The Polar credits meter on Billing uses the same **Platform Admin Only** callout as Project Settings (`PlatformAdminOnlyPanel`) and sits below the customer-facing OpenRouter Chat Based Credits meter.

Fixes AGE-3199.

## Demo

Billing page as a platform admin on a non-enterprise org. Customer-visible meters come first (Tool Calls, Servers, OpenRouter Chat Based Credits). Polar chat credits sit below them in the red **Platform Admin Only** callout.

![Billing page with Polar credits below OpenRouter Chat Based Credits](https://cursor.com/artifacts/c/art-143604bb-e120-4820-b3d4-2bef59a1aefa)

## Changes

- Move `credits` and `included_credits` out of `Required` on `PeriodUsage` so they can be omitted.
- Gate both fields in `GetPeriodUsage` on `authCtx.IsAdmin`.
- Update Polar, the billing stub, and the chat credit-balance check for pointer fields.
- Extract the Project Settings admin callout into `PlatformAdminOnlyPanel` and wrap the Polar credits meter with it.
- Place the Polar meter below the OpenRouter Chat Based Credits meter.

## Test plan

- [x] `TestGetPeriodUsage_CreditsPlatformAdminOnly` — members get `nil` credits; platform admins get the stored values
- [x] Existing `GetPeriodUsage` cache hit/miss tests now assert credits are withheld for non-admins
- [x] `TestCheckCreditBalance_*` still enforces the free-tier chat gate from stored usage
- [x] `PlatformAdminOnlyPanel` renders the title and children for admins, nothing for everyone else
- [x] `mise run lint:server`
- [x] `aube run -F dashboard type-check`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3199](https://linear.app/speakeasy/issue/AGE-3199/fix-withhold-polar-credit-fields-from-non-platform-admin-callers-of)

<div><a href="https://cursor.com/agents/bc-f6ca308d-f1d6-40dc-bf0a-cc1975e6eb34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ca308d-f1d6-40dc-bf0a-cc1975e6eb34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Withholds Polar credit fields from non–platform-admin responses of GET /rpc/usage.getPeriodUsage. Previously any org:read caller received real `credits` and `included_credits`; now only platform admins (`users.admin`) do. Non-admins see those fields omitted, and member-facing limits and dialogs keep working (AGE-3199).

- API/OpenAPI/SDK: `PeriodUsage.credits` and `included_credits` are optional and documented as admin-only; example payloads drop them. Regenerated dashboard SDK updates `PeriodUsage.credits?` and `includedCredits?`.
- Server: Gate the two fields in `GetPeriodUsage` on `authCtx.IsAdmin`; propagate pointers through the Polar client and billing stub; chat credit-balance checks use safe pointer defaults.
- Dashboard: Extract `PlatformAdminOnlyPanel` and wrap the Polar credits meter with it; place it below the OpenRouter Chat Based Credits meter with adjusted spacing; rename checks to `isPlatformAdmin`.
- Tests: Add platform-admin-only coverage for `GetPeriodUsage` and the panel; update chat balance and cache tests for optional credits.
- Required action: Treat `credits` and `included_credits` as optional in API/SDK consumers. No changes needed for tool/server-usage consumers.

<sup>Written for commit 39997780557979df85968214d53e903a71ac012c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

