### PR TITLE
fix: show resource names instead of ids in command palette recents

### DIFF
--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -18,6 +18,7 @@ import { AppLayout, LoginCheck, OrgLayout } from "./components/app-layout.tsx";
 import { CommandPalette } from "./components/command-palette";
 import {
   getRecentLabelOverride,
+  pageLabel,
   recordVisit,
   RECENTS_LABEL_OVERRIDE_EVENT,
 } from "./components/command-palette/recentlyVisited";
@@ -228,8 +229,8 @@ const RouteProvider = () => {
       });
 
     // Prefer a label a detail page registered for this href (e.g. the assistant
-    // name) over the URL-derived fallback, which for id-keyed pages is an opaque
-    // id like "Assistant · 0190abcd".
+    // or conversation name) over the URL-derived fallback, which for id-keyed
+    // pages is just the section title until the override arrives.
     record(
       getRecentLabelOverride(href) ??
         pageLabel(active.title, active.href(), location.pathname),
@@ -237,7 +238,7 @@ const RouteProvider = () => {
 
     // A detail page may register its label *after* this first record (its data
     // loads async). Re-record when that happens so the entry upgrades from the
-    // id fallback to the resource name.
+    // section title to the resource name.
     const onOverride = (event: Event) => {
       const detail = (event as CustomEvent<{ href: string }>).detail;
       if (detail?.href !== href) return;
@@ -384,30 +385,6 @@ const RouteProvider = () => {
   }, [routes, orgRoutes]);
 
   return routeElements;
-};
-
-// Opaque ids make poor Recents labels; detect UUIDs so detail pages keyed by id
-// fall back to "<Section> <short id>" instead of a raw UUID.
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-// Label a visited page for the Recents list. Section/list pages keep the route
-// title; detail pages prefer the human-readable last path segment (a slug like
-// "notion"), falling back to "<Title> <short id>" when that segment is opaque.
-const pageLabel = (
-  title: string,
-  baseHref: string,
-  pathname: string,
-): string => {
-  if (pathname === baseHref || !pathname.startsWith(baseHref)) return title;
-  const segment = decodeURIComponent(
-    pathname.split("/").filter(Boolean).pop() ?? "",
-  );
-  if (!segment) return title;
-  if (UUID_RE.test(segment) || segment.length > 24) {
-    return `${title} · ${segment.slice(0, 8)}`;
-  }
-  return segment;
 };
 
 // Convert a single route into a command-palette navigation action.

--- a/client/dashboard/src/components/command-palette/CommandPalette.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPalette.tsx
@@ -15,7 +15,11 @@ import { IconName } from "@/components/ui/Icon/names";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { requestAskAi } from "./askAiBridge";
-import { useRecentlyVisited, useRecentsUserId } from "./recentlyVisited";
+import {
+  getRecentLabelOverride,
+  useRecentlyVisited,
+  useRecentsUserId,
+} from "./recentlyVisited";
 import { ResourceResults } from "./ResourceResults";
 
 // Speakeasy brand spectrum — the same brand-language gradient the Project
@@ -178,19 +182,24 @@ export function CommandPalette(): JSX.Element {
             a closer text match (AGE-2808). */}
         {!hasQuery && recents.length > 0 && (
           <CommandGroup heading="Recently Visited">
-            {recents.map((recent) => (
-              <CommandItem
-                key={recent.href}
-                value={`recent ${recent.label} ${recent.href}`}
-                onSelect={() => handleRecentSelect(recent.href)}
-                className="flex items-center gap-2"
-              >
-                {recent.icon && (
-                  <Icon name={recent.icon as IconName} className="size-4" />
-                )}
-                <span className="truncate">{recent.label}</span>
-              </CommandItem>
-            ))}
+            {recents.map((recent) => {
+              // Prefer a live name override over a stored URL-derived fallback
+              // so id-keyed pages show the resource name once it has loaded.
+              const label = getRecentLabelOverride(recent.href) ?? recent.label;
+              return (
+                <CommandItem
+                  key={recent.href}
+                  value={`recent ${label} ${recent.href}`}
+                  onSelect={() => handleRecentSelect(recent.href)}
+                  className="flex items-center gap-2"
+                >
+                  {recent.icon && (
+                    <Icon name={recent.icon as IconName} className="size-4" />
+                  )}
+                  <span className="truncate">{label}</span>
+                </CommandItem>
+              );
+            })}
           </CommandGroup>
         )}
 

--- a/client/dashboard/src/components/command-palette/recentlyVisited.test.ts
+++ b/client/dashboard/src/components/command-palette/recentlyVisited.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { pageLabel } from "./recentlyVisited";
+
+const BASE = "/acme/projects/default";
+
+describe("pageLabel", () => {
+  it("uses the route title for the section itself", () => {
+    expect(pageLabel("Project Assistant", `${BASE}/chat`, `${BASE}/chat`)).toBe(
+      "Project Assistant",
+    );
+  });
+
+  it("uses a human slug on detail pages", () => {
+    expect(
+      pageLabel(
+        "Sources",
+        `${BASE}/sources`,
+        `${BASE}/sources/externalmcp/notion`,
+      ),
+    ).toBe("notion");
+  });
+
+  it("does not show a UUID as the label", () => {
+    expect(
+      pageLabel(
+        "Project Assistant",
+        `${BASE}/chat`,
+        `${BASE}/chat/b4b1d55f-1234-5678-9abc-def012345678`,
+      ),
+    ).toBe("Project Assistant");
+  });
+
+  it("does not show other opaque ids as the label", () => {
+    expect(
+      pageLabel(
+        "Assistants",
+        `${BASE}/assistants`,
+        `${BASE}/assistants/${"a".repeat(32)}`,
+      ),
+    ).toBe("Assistants");
+  });
+});

--- a/client/dashboard/src/components/command-palette/recentlyVisited.ts
+++ b/client/dashboard/src/components/command-palette/recentlyVisited.ts
@@ -22,14 +22,43 @@ export interface RecentEntry {
 const MAX_RECENTS = 6;
 const UPDATED_EVENT = "gram:recents-updated";
 
+// Opaque ids make poor Recents labels. UUIDs and other long tokens fall back
+// to the section title until a detail page registers a human name.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isOpaqueIdSegment(segment: string): boolean {
+  return UUID_RE.test(segment) || segment.length > 24;
+}
+
+/**
+ * Label a visited page for the Recents list. Section/list pages keep the route
+ * title; detail pages prefer the human-readable last path segment (a slug like
+ * "notion"). Opaque id segments are not shown — those pages register a name
+ * via `useRecentLabelOverride` once their record loads.
+ */
+export function pageLabel(
+  title: string,
+  baseHref: string,
+  pathname: string,
+): string {
+  if (pathname === baseHref || !pathname.startsWith(baseHref)) return title;
+  const segment = decodeURIComponent(
+    pathname.split("/").filter(Boolean).pop() ?? "",
+  );
+  if (!segment || isOpaqueIdSegment(segment)) return title;
+  return segment;
+}
+
 // --- Human label overrides for opaque-id detail pages ----------------------
 //
 // Visits are recorded centrally in App from the active route, which can only
 // derive a label from the URL. For pages keyed by an opaque id — e.g. the
-// assistant detail page at /assistants/<uuid> — that yields "Assistant · <id>"
-// instead of the assistant's name. Such pages register a readable label here
-// once their data resolves; App consults it when recording the visit and
-// re-records when an override arrives asynchronously.
+// assistant detail page at /assistants/<uuid> or a Project Assistant
+// conversation at /chat/<uuid> — that yields the section title instead of the
+// resource name. Such pages register a readable label here once their data
+// resolves; App consults it when recording the visit and re-records when an
+// override arrives asynchronously.
 const labelOverrides = new Map<string, string>();
 export const RECENTS_LABEL_OVERRIDE_EVENT = "gram:recents-label-override";
 
@@ -83,10 +112,9 @@ export function useRecentsUserId(enabled = true): string | undefined {
   return data?.result?.userId || undefined;
 }
 
-// Bump when the entry shape or href scheme changes so stale entries (e.g. older
-// deep-link-param hrefs that now collapse to page-level) are dropped instead of
-// lingering as duplicates.
-const STORAGE_VERSION = "v2";
+// Bump when the entry shape, href scheme, or label format changes so stale
+// entries (e.g. older "Title · <short id>" labels) are dropped.
+const STORAGE_VERSION = "v3";
 
 function storageKey(
   userId?: string,

--- a/client/dashboard/src/pages/assistants/Assistant.tsx
+++ b/client/dashboard/src/pages/assistants/Assistant.tsx
@@ -10,7 +10,7 @@ export default function AssistantPage(): JSX.Element {
 
 // Register the assistant's name as this page's command-palette "Recently
 // Visited" label. Without it, the visit is recorded by App from the URL alone,
-// which for this id-keyed route falls back to an opaque "Assistant · <id>".
+// which for this id-keyed route falls back to the section title.
 function useRecordAssistantRecent(): void {
   const { assistantId = "" } = useParams();
   const { pathname } = useLocation();

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -7,7 +7,13 @@ import {
   type KeyboardEvent,
   type ReactElement,
 } from "react";
-import { Link, Outlet, useNavigate, useParams } from "react-router";
+import {
+  Link,
+  Outlet,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router";
 import { AnimatePresence, motion } from "motion/react";
 import { useAui, useAuiState } from "@assistant-ui/react";
 import { ActiveChatTitle, Chat, ChatComposer } from "@/elements";
@@ -57,6 +63,8 @@ import {
 import { useChatLaunch } from "@/lib/chat-launch";
 import { cn } from "@/lib/utils";
 import { ReleaseStageBadge } from "@/components/release-stage-badge";
+import { useRecentLabelOverride } from "@/components/command-palette/recentlyVisited";
+import { FALLBACK_TITLE } from "@/elements/components/activeChatTitle.helpers";
 import { useRoutes } from "@/routes";
 
 // Shared square icon button used by the page chrome (back affordances).
@@ -1058,6 +1066,14 @@ function ConversationSurface({
 }: {
   chatId: string | undefined;
 }): ReactElement {
+  const { pathname } = useLocation();
+  const threadTitle = useAuiState((s) => s.threadListItem.title);
+  // Recents would otherwise keep the section title ("Project Assistant") because
+  // the conversation is keyed by an opaque chat id.
+  useRecentLabelOverride(
+    pathname,
+    threadTitle?.trim() || (chatId === "new" ? FALLBACK_TITLE : undefined),
+  );
   const activeRemoteId = useAuiState(
     ({ threadListItem }) => threadListItem.remoteId ?? null,
   );

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -2,6 +2,7 @@ import { StatTile, StatTileGroup } from "@/components/chart/stat-tile";
 import { InputField } from "@/components/moon/input-field";
 import { Page } from "@/components/page-layout";
 import { MCPStatusIndicator } from "@/components/mcp/MCPStatusIndicator";
+import { useRecentLabelOverride } from "@/components/command-palette/recentlyVisited";
 import { RequireScope } from "@/components/require-scope";
 import { ToolCollectionBadge } from "@/components/tool-collection-badge";
 import { Button as UiButton } from "@/components/ui/Button";
@@ -144,6 +145,7 @@ export default function PluginDetail(): JSX.Element | null {
   }, [pluginId]);
 
   const { data: plugin } = usePluginSuspense({ id: pluginId! });
+  useRecentLabelOverride(location.pathname, plugin.name);
   // Polled so the publish-freshness badges/banner pick up the Temporal
   // generator-rollout schedule's auto-sync without a manual refresh.
   const { data: publishStatus } = usePublishStatus(undefined, undefined, {

--- a/client/dashboard/src/pages/skills/SkillDetailRoot.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetailRoot.tsx
@@ -4,6 +4,7 @@ import {
   SecondaryRouteAction,
 } from "@/components/route-not-found-state";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { useRecentLabelOverride } from "@/components/command-palette/recentlyVisited";
 import { isNotFoundError } from "@/lib/route-errors";
 import { useRoutes } from "@/routes";
 import { useSkill } from "@gram/client/react-query/skill.js";
@@ -17,6 +18,7 @@ export default function SkillDetailRoot(): JSX.Element {
     throwOnError: false,
     enabled: !!skillId,
   });
+  useRecentLabelOverride(location.pathname, skillQuery.data?.skill.displayName);
   if (skillId) {
     const isBaseRoute =
       location.pathname === routes.skills.detail.href(skillId);


### PR DESCRIPTION
## Summary
- Command+K Recently Visited was labeling id-keyed pages from the URL (`Project Assistant · b4b1d55f`, `Plugins · 019f8534`).
- Opaque ids now fall back to the page title; chat conversations, plugins, and skills register their real names the same way assistants already did.
- Stale `Title · <short id>` recents entries are dropped.

## Test plan
- [ ] Visit a Project Assistant conversation (or a plugin/skill/assistant detail page) so the URL contains a UUID.
- [ ] Open Command+K with an empty query.
- [ ] Recently Visited shows the resource name, not `Title · <id>`.
- [ ] Slug-based pages (e.g. a source named `notion`) still show the slug.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show resource names in Command+K Recently Visited instead of opaque ids. Previously id-keyed pages showed a UUID or “Title · <short id>”; now they show the resource name, falling back to the section title until the name loads.

- Review notes
  - Derive fallback labels with `pageLabel` in `recentlyVisited.ts`; never show opaque id segments; tests added.
  - Command palette prefers live overrides via `getRecentLabelOverride`; `App` re-records on `RECENTS_LABEL_OVERRIDE_EVENT`.
  - Register overrides for chat conversations (including “New chat”), plugins, skills, and assistants.
  - Bump recents storage to v3 to drop stale “Title · <short id>” entries; slug-based pages still show the slug.

- Migration
  - For any new id-keyed detail page, call `useRecentLabelOverride(pathname, name)` after the data loads.

<sup>Written for commit 660cb87dc0ca8b0d4eacf81f30ed5d5f17a1d4ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

