### PR TITLE
chore(dev): start admin-dashboard with aube, not pnpm

### DIFF
--- a/.mise-tasks/start/admin-dashboard.sh
+++ b/.mise-tasks/start/admin-dashboard.sh
@@ -5,4 +5,4 @@
 
 set -e
 
-exec pnpm --filter ./client/admin dev
+exec aube run --filter ./client/admin dev


### PR DESCRIPTION
`start:dashboard` and `start:dev-idp-dashboard` both run `aube run`, but `start:admin-dashboard` was still on raw `pnpm` from before the aube migration.

pnpm sees a `node_modules` tree aube manages, decides it needs to purge it, and cannot prompt for confirmation with no TTY:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
```

That fails the daemon under pitchfork, so `./zero` finishes with the admin dashboard down while every other service comes up.

## Testing

`pitchfork start admin-dashboard` goes from failing with the above to `started`, and the dashboard serves normally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the admin dashboard start script to `aube run` instead of `pnpm` to align with other dashboards and prevent non-TTY `pnpm` failures. Previously, `pnpm` attempted to purge `aube`-managed `node_modules`, failed with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY, and left the admin dashboard down under pitchfork.

- Change: `.mise-tasks/start/admin-dashboard.sh` now executes `aube run --filter ./client/admin dev`.
- Effect: `pitchfork start admin-dashboard` and `./zero` now start successfully; the dashboard serves normally.
- No config changes or migrations required.

<sup>Written for commit af0a9bd661b9c9aa99e68d79182f2dcef59f1f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

