### PR TITLE
chore(admin): add the react-grab element picker in dev

### DIFF
--- a/client/admin/package.json
+++ b/client/admin/package.json
@@ -42,6 +42,7 @@
     "happy-dom": "^20.11.1",
     "oxlint": "^1.71.0",
     "oxlint-tsgolint": "^0.23.0",
+    "react-grab": "^0.1.48",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "^4.1.10"

--- a/client/admin/src/main.tsx
+++ b/client/admin/src/main.tsx
@@ -6,6 +6,13 @@ import { AuthGate } from "@/components/auth-gate";
 import { routeTree } from "./routeTree.gen";
 import "./index.css";
 
+// Hover an element and press Cmd/Ctrl+C to copy its file, component and HTML
+// for pasting into a coding agent. `import.meta.env.DEV` is replaced with
+// `false` in production, so this import is tree-shaken out of the bundle.
+if (import.meta.env.DEV) {
+  void import("react-grab");
+}
+
 const root = document.getElementById("root");
 if (!root) {
   throw new Error("missing #root element");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1
+      react-grab:
+        specifier: ^0.1.48
+        version: 0.1.48(react@19.2.8)
       oxlint:
         specifier: ^1.71.0
         version: 1.77.0(oxlint-tsgolint@0.23.0)


### PR DESCRIPTION
The dashboard has had `react-grab` since its own `main.tsx`. This gives the admin app the same thing.

Hover any element, press Cmd or Ctrl and C, and its file, component and HTML land on the clipboard, ready to paste into a coding agent. It replaces reading a stack trace out of React DevTools by hand.

### It cannot reach production

The import sits behind `import.meta.env.DEV`, which Vite replaces with `false` in a production build, so the dynamic import is dropped.

Verified rather than assumed: after `aube run -F admin build`, no `react-grab` chunk is emitted and no shipped `.js` file mentions it. The only hit anywhere in `dist` is the source map, which carries original source text.

### The lockfile entry is hand written

Worth a look, because it is the unusual part.

Letting the installer add the dependency renormalised roughly 700 unrelated peer-dependency suffixes across the file, for a diff of **+606 / −820**. Every resolved entry `react-grab` needs already exists in the lockfile, because the dashboard depends on the same version, so the only thing genuinely missing was the importer entry for `client/admin`.

Writing those three lines by hand gives a **+3** diff instead of 1,426 changed lines. `aube install --frozen-lockfile`, which is what CI runs, accepts it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `react-grab` to the admin app in development to speed up debugging. Previously absent; now in dev you can hover an element and press Cmd/Ctrl+C to copy its file, component, and HTML. Production behavior is unchanged.

- Dev-only: dynamically imported behind import.meta.env.DEV; Vite drops it in production. Verified no emitted chunk or runtime references in the build.
- Lockfile: minimal, hand-edited importer entry for `react-grab` in `pnpm-lock.yaml` to avoid large unrelated renormalization.
- No migrations or config changes.

<sup>Written for commit 388ec5a13d414a30b97693823362a118e3c6e411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

