### PR TITLE
feat(admin): peek at an organization beside the list

### DIFF
--- a/.changeset/admin-organizations-peek-panel.md
+++ b/.changeset/admin-organizations-peek-panel.md
@@ -1,0 +1,13 @@
+---
+"admin": minor
+---
+
+Peek at an organization beside the list. Alt-clicking a row in the admin
+organizations list docks a 400px panel next to the table instead of leaving the
+page, so the search term, the filters and the scroll position all survive the
+look-up. The panel shows account type, trial end, member count, creation date
+and both ids, with a copy control beside each id that confirms with a check.
+The table narrows to Name, Slug and Type while the panel is open and gives the
+operator's own column choices straight back when it closes. Arrow Down and
+Arrow Up walk the panel through the rows on screen and scroll each one into
+view; Escape closes it and puts the keyboard back on the row's name link.

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -110,8 +110,6 @@ function DataTableRow<T extends RowData>({
   ref,
 }: {
   row: Row<DataTableFeatures, T>;
-  // The event travels with the record. A page that reads a modifier key off
-  // the click has nowhere else to get it, and the record cannot carry it.
   onClick?: (row: T, event: React.MouseEvent<HTMLTableRowElement>) => void;
   className?: string;
   ref?: React.Ref<HTMLTableRowElement>;

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -107,10 +107,14 @@ function DataTableRow<T extends RowData>({
   row,
   onClick,
   className,
+  ref,
 }: {
   row: Row<DataTableFeatures, T>;
-  onClick?: (row: T) => void;
+  // The event travels with the record. A page that reads a modifier key off
+  // the click has nowhere else to get it, and the record cannot carry it.
+  onClick?: (row: T, event: React.MouseEvent<HTMLTableRowElement>) => void;
   className?: string;
+  ref?: React.Ref<HTMLTableRowElement>;
 }) {
   // The row itself stays a plain row: it takes no focus and it holds no
   // `button` role, because either one breaks the table structure the
@@ -124,12 +128,13 @@ function DataTableRow<T extends RowData>({
         if ((event.target as HTMLElement).closest("a,button,input,label")) {
           return;
         }
-        onClick(row.original);
+        onClick(row.original, event);
       }
     : undefined;
 
   return (
     <TableRow
+      ref={ref}
       className={cn(onClick && "cursor-pointer", className)}
       onClick={handleClick}
     >

--- a/client/admin/src/layouts/AdminLayout.tsx
+++ b/client/admin/src/layouts/AdminLayout.tsx
@@ -30,11 +30,7 @@ export function AdminLayout(): JSX.Element {
 
       <SidebarInset>
         <SiteHeader />
-        {/* The chain of min-h-0 is what lets a page ask for the height that is
-            left. One link without it makes every child below content-sized, so
-            a page that wants to fill has to guess a vh number instead. The
-            scroll sits on the innermost one, so a page taller than the shell
-            scrolls under the header rather than being cut off. */}
+        {/* One link without min-h-0 makes every child below content-sized. */}
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="@container/main flex min-h-0 flex-1 flex-col gap-2">
             <div className="flex min-h-0 flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">

--- a/client/admin/src/layouts/AdminLayout.tsx
+++ b/client/admin/src/layouts/AdminLayout.tsx
@@ -30,10 +30,15 @@ export function AdminLayout(): JSX.Element {
 
       <SidebarInset>
         <SiteHeader />
-        <div className="flex flex-1 flex-col">
-          <div className="@container/main flex flex-1 flex-col gap-2">
-            <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-              <div className="px-4 lg:px-6">
+        {/* The chain of min-h-0 is what lets a page ask for the height that is
+            left. One link without it makes every child below content-sized, so
+            a page that wants to fill has to guess a vh number instead. The
+            scroll sits on the innermost one, so a page taller than the shell
+            scrolls under the header rather than being cut off. */}
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="@container/main flex min-h-0 flex-1 flex-col gap-2">
+            <div className="flex min-h-0 flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+              <div className="flex min-h-0 flex-1 flex-col overflow-auto px-4 lg:px-6">
                 <Outlet />
               </div>
             </div>

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -1,0 +1,163 @@
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AdminOrganization } from "@/lib/gramAdminApi";
+import { renderWithApp } from "@/test/harness";
+
+import { PeekPanel } from "./PeekPanel";
+
+// Every optional field is set, so a field that reads the wrong record property
+// still has something to render and the assertion has to catch it by value.
+const ORG: AdminOrganization = {
+  id: "org_placeholder_one",
+  name: "Placeholder One",
+  slug: "placeholder-one",
+  account_type: "pro",
+  workos_id: "org_workos_placeholder_identifier",
+  whitelisted: true,
+  free_trial_started_at: "2026-02-01T00:00:00Z",
+  free_trial_ends_at: "2026-05-06T00:00:00Z",
+  member_count: 3,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-07T00:00:00Z",
+};
+
+// Written out rather than imported from the panel. Reading the constant under
+// test would move this expectation along with a shortened confirmation.
+const COPY_CONFIRM_MS = 1500;
+
+// The panel formats a date the same way the list column does, so the expected
+// text has to come out of the same formatter. The format is not what is asserted.
+function shortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+function iconOf(button: HTMLElement): SVGElement {
+  const icon = button.querySelector("svg");
+  if (!icon) throw new Error("the copy control needs an icon");
+  return icon;
+}
+
+const writeText = vi.fn<(text: string) => Promise<void>>(() =>
+  Promise.resolve(),
+);
+
+function noop(): void {}
+
+beforeEach(() => {
+  writeText.mockClear();
+  // happy-dom ships no clipboard, and a real one would be a shared surface
+  // between suites either way.
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(cleanup);
+
+describe("PeekPanel", () => {
+  it("renders the record it was handed, field by field", async () => {
+    await renderWithApp(<PeekPanel org={ORG} onClose={noop} />);
+
+    const { workos_id: workosID, free_trial_ends_at: trialEndsAt } = ORG;
+    if (!workosID || !trialEndsAt) {
+      throw new Error("the record under test needs its optional fields set");
+    }
+
+    expect(screen.getByRole("heading", { name: ORG.name })).toBeTruthy();
+    expect(screen.getAllByRole("term").map((term) => term.textContent)).toEqual(
+      ["Type", "Trial ends", "Members", "Created", "Org id", "WorkOS id"],
+    );
+    expect(
+      screen.getAllByRole("definition").map((value) => value.textContent),
+    ).toEqual([
+      ORG.account_type,
+      shortDate(trialEndsAt),
+      String(ORG.member_count),
+      shortDate(ORG.created_at),
+      ORG.id,
+      workosID,
+    ]);
+  });
+
+  it("renders a dash for the optional fields a record leaves unset", async () => {
+    await renderWithApp(
+      <PeekPanel
+        org={{ ...ORG, workos_id: undefined, free_trial_ends_at: undefined }}
+        onClose={noop}
+      />,
+    );
+
+    const values = screen.getAllByRole("definition");
+    expect(values.at(1)?.textContent).toBe("-");
+    expect(values.at(-1)?.textContent).toBe("-");
+    // Nothing to copy, so nothing offers to.
+    expect(screen.queryByRole("button", { name: "Copy WorkOS id" })).toBeNull();
+  });
+
+  it("copies the whole WorkOS id and confirms with a check", async () => {
+    await renderWithApp(<PeekPanel org={ORG} onClose={noop} />);
+
+    const { workos_id: workosID } = ORG;
+    if (!workosID) throw new Error("the record under test needs a WorkOS id");
+
+    const button = screen.getByRole("button", { name: "Copy WorkOS id" });
+    // Tokens, not substrings: every lucide icon also carries the class `lucide`.
+    expect(iconOf(button).classList.contains("lucide-copy")).toBe(true);
+    expect(iconOf(button).classList.contains("lucide-check")).toBe(false);
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(button);
+
+      // The whole id. The list column shows the first twelve characters, and an
+      // operator pasting that into WorkOS gets nothing back.
+      expect(writeText).toHaveBeenCalledWith(workosID);
+
+      // The name carries the confirmation as well as the icon does: a check on
+      // its own says nothing to a screen reader.
+      const confirmed = screen.getByRole("button", {
+        name: "WorkOS id copied",
+      });
+      expect(iconOf(confirmed).classList.contains("lucide-check")).toBe(true);
+      expect(iconOf(confirmed).classList.contains("lucide-copy")).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(COPY_CONFIRM_MS);
+      });
+      expect(
+        screen.getByRole("button", { name: "Copy WorkOS id" }),
+      ).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("copies the org id from its own control", async () => {
+    await renderWithApp(<PeekPanel org={ORG} onClose={noop} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Org id" }));
+
+    expect(writeText).toHaveBeenCalledWith(ORG.id);
+  });
+
+  it("takes focus when it opens, so the keyboard reaches it", async () => {
+    await renderWithApp(<PeekPanel org={ORG} onClose={noop} />);
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("complementary", { name: "Organization peek" }),
+    );
+  });
+
+  it("closes from its own control", async () => {
+    const onClose = vi.fn<() => void>();
+    await renderWithApp(<PeekPanel org={ORG} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close peek" }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -7,8 +7,6 @@ import { renderWithApp } from "@/test/harness";
 
 import { PeekPanel } from "./PeekPanel";
 
-// Every optional field is set, so a field that reads the wrong record property
-// still has something to render and the assertion has to catch it by value.
 const ORG: AdminOrganization = {
   id: "org_placeholder_one",
   name: "Placeholder One",
@@ -23,12 +21,8 @@ const ORG: AdminOrganization = {
   updated_at: "2026-01-07T00:00:00Z",
 };
 
-// Written out rather than imported from the panel. Reading the constant under
-// test would move this expectation along with a shortened confirmation.
 const COPY_CONFIRM_MS = 1500;
 
-// The panel formats a date the same way the list column does, so the expected
-// text has to come out of the same formatter. The format is not what is asserted.
 function shortDate(iso: string): string {
   return new Date(iso).toLocaleDateString();
 }
@@ -47,8 +41,6 @@ function noop(): void {}
 
 beforeEach(() => {
   writeText.mockClear();
-  // happy-dom ships no clipboard, and a real one would be a shared surface
-  // between suites either way.
   Object.defineProperty(navigator, "clipboard", {
     value: { writeText },
     configurable: true,
@@ -94,7 +86,6 @@ describe("PeekPanel", () => {
     const values = screen.getAllByRole("definition");
     expect(values.at(1)?.textContent).toBe("-");
     expect(values.at(-1)?.textContent).toBe("-");
-    // Nothing to copy, so nothing offers to.
     expect(screen.queryByRole("button", { name: "Copy WorkOS id" })).toBeNull();
   });
 
@@ -105,7 +96,6 @@ describe("PeekPanel", () => {
     if (!workosID) throw new Error("the record under test needs a WorkOS id");
 
     const button = screen.getByRole("button", { name: "Copy WorkOS id" });
-    // Tokens, not substrings: every lucide icon also carries the class `lucide`.
     expect(iconOf(button).classList.contains("lucide-copy")).toBe(true);
     expect(iconOf(button).classList.contains("lucide-check")).toBe(false);
 
@@ -113,12 +103,8 @@ describe("PeekPanel", () => {
     try {
       fireEvent.click(button);
 
-      // The whole id. The list column shows the first twelve characters, and an
-      // operator pasting that into WorkOS gets nothing back.
       expect(writeText).toHaveBeenCalledWith(workosID);
 
-      // The name carries the confirmation as well as the icon does: a check on
-      // its own says nothing to a screen reader.
       const confirmed = screen.getByRole("button", {
         name: "WorkOS id copied",
       });

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -21,7 +21,25 @@ const ORG: AdminOrganization = {
   updated_at: "2026-01-07T00:00:00Z",
 };
 
+const OTHER_ORG: AdminOrganization = {
+  ...ORG,
+  id: "org_placeholder_two",
+  name: "Placeholder Two",
+};
+
 const COPY_CONFIRM_MS = 1500;
+
+// Peek swaps the record under a mounted panel, so a test does too rather than
+// re-rendering, which would reset the state under test on its own.
+function Peeking(): JSX.Element {
+  const [org, setOrg] = useState(ORG);
+  return (
+    <>
+      <button onClick={() => setOrg(OTHER_ORG)}>next record</button>
+      <PeekPanel org={org} onClose={noop} />
+    </>
+  );
+}
 
 function shortDate(iso: string): string {
   return new Date(iso).toLocaleDateString();
@@ -135,24 +153,6 @@ describe("PeekPanel", () => {
   });
 
   it("drops the confirmation when peek moves to another record", async () => {
-    const OTHER: AdminOrganization = {
-      ...ORG,
-      id: "org_placeholder_two",
-      name: "Placeholder Two",
-    };
-
-    // Peek swaps the record under a mounted panel, so the test does too rather
-    // than re-rendering, which would reset the state under test on its own.
-    function Peeking(): JSX.Element {
-      const [org, setOrg] = useState(ORG);
-      return (
-        <>
-          <button onClick={() => setOrg(OTHER)}>next record</button>
-          <PeekPanel org={org} onClose={noop} />
-        </>
-      );
-    }
-
     await renderWithApp(<Peeking />);
 
     fireEvent.click(screen.getByRole("button", { name: "Copy Org id" }));
@@ -160,6 +160,27 @@ describe("PeekPanel", () => {
     expect(screen.getByRole("button", { name: "Org id copied" })).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "next record" }));
+
+    const control = screen.getByRole("button", { name: "Copy Org id" });
+    expect(iconOf(control).classList.contains("lucide-copy")).toBe(true);
+  });
+
+  it("keeps a write that lands after the move off the new record", async () => {
+    let land = noop;
+    writeText.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          land = () => resolve();
+        }),
+    );
+    await renderWithApp(<Peeking />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Org id" }));
+    fireEvent.click(screen.getByRole("button", { name: "next record" }));
+
+    await act(async () => {
+      land();
+    });
 
     const control = screen.getByRole("button", { name: "Copy Org id" });
     expect(iconOf(control).classList.contains("lucide-copy")).toBe(true);

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -105,6 +105,10 @@ describe("PeekPanel", () => {
 
       expect(writeText).toHaveBeenCalledWith(workosID);
 
+      // The confirmation waits on the clipboard promise, so flush microtasks.
+      // Fake timers do not stub those.
+      await act(async () => {});
+
       const confirmed = screen.getByRole("button", {
         name: "WorkOS id copied",
       });

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, screen } from "@testing-library/react";
-import { act } from "react";
+import { act, useState, type JSX } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AdminOrganization } from "@/lib/gramAdminApi";
@@ -132,6 +132,59 @@ describe("PeekPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy Org id" }));
 
     expect(writeText).toHaveBeenCalledWith(ORG.id);
+  });
+
+  it("drops the confirmation when peek moves to another record", async () => {
+    const OTHER: AdminOrganization = {
+      ...ORG,
+      id: "org_placeholder_two",
+      name: "Placeholder Two",
+    };
+
+    // Peek swaps the record under a mounted panel, so the test does too rather
+    // than re-rendering, which would reset the state under test on its own.
+    function Peeking(): JSX.Element {
+      const [org, setOrg] = useState(ORG);
+      return (
+        <>
+          <button onClick={() => setOrg(OTHER)}>next record</button>
+          <PeekPanel org={org} onClose={noop} />
+        </>
+      );
+    }
+
+    await renderWithApp(<Peeking />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy Org id" }));
+    await act(async () => {});
+    expect(screen.getByRole("button", { name: "Org id copied" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "next record" }));
+
+    const control = screen.getByRole("button", { name: "Copy Org id" });
+    expect(iconOf(control).classList.contains("lucide-copy")).toBe(true);
+  });
+
+  it("leaves the control inert where the browser gives no clipboard", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    await renderWithApp(<PeekPanel org={ORG} onClose={noop} />);
+
+    // React reports a throw from a handler as an uncaught error rather than
+    // letting fireEvent raise it, so the listener is what the assertion reads.
+    const uncaught = vi.fn<(event: ErrorEvent) => void>();
+    window.addEventListener("error", uncaught);
+    try {
+      fireEvent.click(screen.getByRole("button", { name: "Copy Org id" }));
+    } finally {
+      window.removeEventListener("error", uncaught);
+    }
+
+    expect(uncaught).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Copy Org id" })).toBeTruthy();
   });
 
   it("takes focus when it opens, so the keyboard reaches it", async () => {

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -1,0 +1,146 @@
+import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
+import { useEffect, useRef, useState, type JSX, type ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { badgeTone } from "@/lib/badgeTone";
+import type { AdminOrganization } from "@/lib/gramAdminApi";
+import { cn } from "@/lib/utils";
+
+const COPY_CONFIRM_MS = 1500;
+
+// The same formatter the Trial ends column uses, so the panel and the row it is
+// docked beside cannot disagree. Slice 2a replaces both with a shared
+// `formatTrial`, which does not exist yet.
+function fmtDateShort(iso?: string): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "-";
+  return d.toLocaleDateString();
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <>
+      <dt className="text-muted-foreground text-sm">{label}</dt>
+      <dd className="min-w-0 text-sm">{children}</dd>
+    </>
+  );
+}
+
+function CopyValue({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  return (
+    <span className="flex items-center gap-1">
+      <span className="truncate font-mono text-xs">{value}</span>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        // The name carries the confirmation as well as the icon does. A check
+        // on its own says nothing to a screen reader.
+        aria-label={copied ? `${label} copied` : `Copy ${label}`}
+        onClick={() => {
+          void navigator.clipboard.writeText(value);
+          setCopied(true);
+          clearTimeout(timer.current);
+          timer.current = setTimeout(() => setCopied(false), COPY_CONFIRM_MS);
+        }}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </Button>
+    </span>
+  );
+}
+
+/**
+ * One organization's account facts, docked beside the list.
+ *
+ * It answers the question that otherwise costs a trip to the detail page and
+ * the list's filters and scroll position with it, so it reads a record the
+ * table already holds and issues no request of its own.
+ */
+export function PeekPanel({
+  org,
+  onClose,
+  className,
+}: {
+  org: AdminOrganization;
+  onClose: () => void;
+  className?: string;
+}): JSX.Element {
+  const root = useRef<HTMLElement>(null);
+
+  // Opening the panel with the pointer leaves focus on the row body, which is
+  // not focusable, so the keyboard would have nowhere to send Escape or the
+  // arrow keys from.
+  useEffect(() => {
+    root.current?.focus();
+  }, []);
+
+  return (
+    <aside
+      ref={root}
+      tabIndex={-1}
+      aria-label="Organization peek"
+      className={cn("rounded-lg border p-4 outline-none", className)}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h5 className="truncate text-sm font-medium">{org.name}</h5>
+          <p className="text-muted-foreground truncate text-xs">{org.slug}</p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Close peek"
+          onClick={onClose}
+        >
+          <XIcon />
+        </Button>
+      </div>
+
+      <dl className="mt-3 grid grid-cols-[5.5rem_1fr] items-baseline gap-x-3 gap-y-1.5">
+        <Field label="Type">
+          <Badge variant="outline" className={badgeTone.neutral}>
+            {org.account_type}
+          </Badge>
+        </Field>
+        <Field label="Trial ends">{fmtDateShort(org.free_trial_ends_at)}</Field>
+        <Field label="Members">{org.member_count}</Field>
+        <Field label="Created">{fmtDateShort(org.created_at)}</Field>
+        <Field label="Org id">
+          <CopyValue label="Org id" value={org.id} />
+        </Field>
+        <Field label="WorkOS id">
+          {org.workos_id ? (
+            <CopyValue label="WorkOS id" value={org.workos_id} />
+          ) : (
+            "-"
+          )}
+        </Field>
+      </dl>
+
+      <Separator className="mt-4" />
+      {/* Mounted empty on purpose. Disable ships in 3b and Extend trial in 3c,
+          and reserving the strip now means neither one moves the grid above. */}
+      <div className="flex min-h-8 items-center gap-2" />
+    </aside>
+  );
+}

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -84,9 +84,9 @@ export function PeekPanel({
       ref={root}
       tabIndex={-1}
       aria-label="Organization peek"
-      className={cn("rounded-lg border p-4 outline-none", className)}
+      className={cn("flex flex-col rounded-lg border outline-none", className)}
     >
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex items-start justify-between gap-2 p-4 pb-3">
         <div className="min-w-0">
           <h5 className="truncate text-sm font-medium">{org.name}</h5>
           <p className="text-muted-foreground truncate text-xs">{org.slug}</p>
@@ -101,30 +101,35 @@ export function PeekPanel({
         </Button>
       </div>
 
-      <dl className="mt-3 grid grid-cols-[5.5rem_1fr] items-baseline gap-x-3 gap-y-1.5">
-        <Field label="Type">
-          <Badge variant="outline" className={badgeTone.neutral}>
-            {org.account_type}
-          </Badge>
-        </Field>
-        <Field label="Trial ends">{fmtDateShort(org.free_trial_ends_at)}</Field>
-        <Field label="Members">{org.member_count}</Field>
-        <Field label="Created">{fmtDateShort(org.created_at)}</Field>
-        <Field label="Org id">
-          <CopyValue label="Org id" value={org.id} />
-        </Field>
-        <Field label="WorkOS id">
-          {org.workos_id ? (
-            <CopyValue label="WorkOS id" value={org.workos_id} />
-          ) : (
-            "-"
-          )}
-        </Field>
-      </dl>
+      {/* min-h-0 or the fields refuse to shrink and push the actions off. */}
+      <div className="min-h-0 flex-1 overflow-auto px-4">
+        <dl className="grid grid-cols-[5.5rem_1fr] items-baseline gap-x-3 gap-y-1.5">
+          <Field label="Type">
+            <Badge variant="outline" className={badgeTone.neutral}>
+              {org.account_type}
+            </Badge>
+          </Field>
+          <Field label="Trial ends">
+            {fmtDateShort(org.free_trial_ends_at)}
+          </Field>
+          <Field label="Members">{org.member_count}</Field>
+          <Field label="Created">{fmtDateShort(org.created_at)}</Field>
+          <Field label="Org id">
+            <CopyValue label="Org id" value={org.id} />
+          </Field>
+          <Field label="WorkOS id">
+            {org.workos_id ? (
+              <CopyValue label="WorkOS id" value={org.workos_id} />
+            ) : (
+              "-"
+            )}
+          </Field>
+        </dl>
+      </div>
 
-      <Separator className="mt-4" />
+      <Separator />
       {/* Empty on purpose: reserved so later actions do not move the grid. */}
-      <div className="flex min-h-8 items-center gap-2" />
+      <div className="flex min-h-8 items-center gap-2 p-4" />
     </aside>
   );
 }

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -46,6 +46,13 @@ function CopyValue({
 
   useEffect(() => () => clearTimeout(timer.current), []);
 
+  // Peek swaps rows under the same element, so the confirmation would otherwise
+  // stand against an id it was never given.
+  useEffect(() => {
+    clearTimeout(timer.current);
+    setCopied(false);
+  }, [value]);
+
   return (
     <span className="flex items-center gap-1">
       <span className="truncate font-mono text-xs">{value}</span>
@@ -54,6 +61,8 @@ function CopyValue({
         size="icon-xs"
         aria-label={copied ? `${label} copied` : `Copy ${label}`}
         onClick={() => {
+          // Undefined outside a secure context, where the call would throw.
+          if (!navigator.clipboard?.writeText) return;
           // A check over a failed write sends the operator off with the wrong id.
           void navigator.clipboard.writeText(value).then(() => {
             setCopied(true);

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -41,17 +41,14 @@ function CopyValue({
   label: string;
   value: string;
 }): JSX.Element {
-  const [copied, setCopied] = useState(false);
+  // The value copied, not a flag. Peek swaps the record under a mounted panel,
+  // and a flag would stand as a confirmation against an id never copied,
+  // including where the write resolves after the swap.
+  const [copiedValue, setCopiedValue] = useState<string>();
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const copied = copiedValue === value;
 
   useEffect(() => () => clearTimeout(timer.current), []);
-
-  // Peek swaps rows under the same element, so the confirmation would otherwise
-  // stand against an id it was never given.
-  useEffect(() => {
-    clearTimeout(timer.current);
-    setCopied(false);
-  }, [value]);
 
   return (
     <span className="flex items-center gap-1">
@@ -65,9 +62,12 @@ function CopyValue({
           if (!navigator.clipboard?.writeText) return;
           // A check over a failed write sends the operator off with the wrong id.
           void navigator.clipboard.writeText(value).then(() => {
-            setCopied(true);
+            setCopiedValue(value);
             clearTimeout(timer.current);
-            timer.current = setTimeout(() => setCopied(false), COPY_CONFIRM_MS);
+            timer.current = setTimeout(
+              () => setCopiedValue(undefined),
+              COPY_CONFIRM_MS,
+            );
           }, noop);
         }}
       >

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -10,6 +10,8 @@ import { cn } from "@/lib/utils";
 
 const COPY_CONFIRM_MS = 1500;
 
+function noop(): void {}
+
 function fmtDateShort(iso?: string): string {
   if (!iso) return "-";
   const d = new Date(iso);
@@ -52,10 +54,12 @@ function CopyValue({
         size="icon-xs"
         aria-label={copied ? `${label} copied` : `Copy ${label}`}
         onClick={() => {
-          void navigator.clipboard.writeText(value);
-          setCopied(true);
-          clearTimeout(timer.current);
-          timer.current = setTimeout(() => setCopied(false), COPY_CONFIRM_MS);
+          // A check over a failed write sends the operator off with the wrong id.
+          void navigator.clipboard.writeText(value).then(() => {
+            setCopied(true);
+            clearTimeout(timer.current);
+            timer.current = setTimeout(() => setCopied(false), COPY_CONFIRM_MS);
+          }, noop);
         }}
       >
         {copied ? <CheckIcon /> : <CopyIcon />}
@@ -101,7 +105,7 @@ export function PeekPanel({
         </Button>
       </div>
 
-      {/* min-h-0 or the fields refuse to shrink and push the actions off. */}
+      {/* min-h-0 or the fields push the actions off the bottom. */}
       <div className="min-h-0 flex-1 overflow-auto px-4">
         <dl className="grid grid-cols-[5.5rem_1fr] items-baseline gap-x-3 gap-y-1.5">
           <Field label="Type">

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -10,9 +10,6 @@ import { cn } from "@/lib/utils";
 
 const COPY_CONFIRM_MS = 1500;
 
-// The same formatter the Trial ends column uses, so the panel and the row it is
-// docked beside cannot disagree. Slice 2a replaces both with a shared
-// `formatTrial`, which does not exist yet.
 function fmtDateShort(iso?: string): string {
   if (!iso) return "-";
   const d = new Date(iso);
@@ -53,8 +50,6 @@ function CopyValue({
       <Button
         variant="ghost"
         size="icon-xs"
-        // The name carries the confirmation as well as the icon does. A check
-        // on its own says nothing to a screen reader.
         aria-label={copied ? `${label} copied` : `Copy ${label}`}
         onClick={() => {
           void navigator.clipboard.writeText(value);
@@ -69,13 +64,6 @@ function CopyValue({
   );
 }
 
-/**
- * One organization's account facts, docked beside the list.
- *
- * It answers the question that otherwise costs a trip to the detail page and
- * the list's filters and scroll position with it, so it reads a record the
- * table already holds and issues no request of its own.
- */
 export function PeekPanel({
   org,
   onClose,
@@ -87,9 +75,6 @@ export function PeekPanel({
 }): JSX.Element {
   const root = useRef<HTMLElement>(null);
 
-  // Opening the panel with the pointer leaves focus on the row body, which is
-  // not focusable, so the keyboard would have nowhere to send Escape or the
-  // arrow keys from.
   useEffect(() => {
     root.current?.focus();
   }, []);
@@ -138,8 +123,7 @@ export function PeekPanel({
       </dl>
 
       <Separator className="mt-4" />
-      {/* Mounted empty on purpose. Disable ships in 3b and Extend trial in 3c,
-          and reserving the strip now means neither one moves the grid above. */}
+      {/* Empty on purpose: reserved so later actions do not move the grid. */}
       <div className="flex min-h-8 items-center gap-2" />
     </aside>
   );

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { Column, RowData } from "@tanstack/react-table";
 import { SearchIcon } from "lucide-react";
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useState, type JSX, type ReactNode } from "react";
 
 import type {
   DataTableFeatures,
@@ -139,8 +139,10 @@ export function Toolbar(): JSX.Element {
  */
 export function TableActionBar<T extends RowData>({
   table,
+  hint,
 }: {
   table: DataTableInstance<T>;
+  hint?: ReactNode;
 }): JSX.Element {
   // Read off the table rather than walked a second time here, so the menu
   // cannot disagree with the table about how many columns are left.
@@ -150,6 +152,7 @@ export function TableActionBar<T extends RowData>({
     <div className="flex items-center gap-3 border-b px-3 py-2">
       <span className="text-muted-foreground text-xs">Nothing selected</span>
       <span className="flex-1" />
+      {hint}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="xs">

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -111,8 +111,8 @@ const NEXT_PAGE_ORG: AdminOrganization = {
   updated_at: "2026-07-11T00:00:00Z",
 };
 
-const [FIRST_ORG] = ORGS;
-if (!FIRST_ORG) throw new Error("ORGS needs a row");
+const [FIRST_ORG, SECOND_ORG] = ORGS;
+if (!FIRST_ORG || !SECOND_ORG) throw new Error("ORGS needs two rows");
 
 // The columns render a date through toLocaleDateString, so the expected text
 // has to come out of the same formatter. Reading the field off the fixture is
@@ -169,6 +169,25 @@ function rowFor(link: HTMLElement): HTMLTableRowElement {
   const row = link.closest("tr");
   if (!row) throw new Error("the name link is not inside a row");
   return row;
+}
+
+// Alt, not meta and not shift: meta-click is the browser's open-in-new-tab, and
+// shift-click belongs to the range selection a later slice adds. The last cell,
+// because it holds no link whichever columns are on screen.
+function peekOn(link: HTMLElement): void {
+  const cell = within(rowFor(link)).getAllByRole("cell").at(-1);
+  if (!cell) throw new Error("the row needs a cell to click");
+  fireEvent.click(cell, { altKey: true });
+}
+
+function peekPanel(): HTMLElement {
+  return screen.getByRole("complementary", { name: "Organization peek" });
+}
+
+function isPeeked(link: HTMLElement): boolean {
+  // A token, not a substring: the stock row already carries
+  // `data-[state=selected]:bg-muted` and `hover:bg-muted/50`.
+  return rowFor(link).classList.contains("bg-muted");
 }
 
 function urlFor(search: Record<string, unknown>): string {
@@ -537,6 +556,208 @@ describe("organizations list", () => {
     // Enter opens an organization they never chose.
     expect(link.isConnected).toBe(false);
     expect(document.activeElement).toBe(document.body);
+  });
+});
+
+describe("organizations list peek", () => {
+  it("docks a panel beside the list rather than leaving the page", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    peekOn(link);
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    // The whole point of the panel. A detail page would take the filters and
+    // the scroll position with it.
+    expect(router.state.location.pathname).toBe("/organizations");
+
+    // Narrowed to the columns that identify a row. The panel carries the rest.
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual(["Name", "Slug", "Type"]);
+  });
+
+  it("highlights the row it is peeking at and no other", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    peekOn(link);
+
+    expect(isPeeked(link)).toBe(true);
+    expect(isPeeked(screen.getByRole("link", { name: SECOND_ORG.name }))).toBe(
+      false,
+    );
+  });
+
+  it("walks peek down the list and stops at the last row", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    peekOn(first);
+
+    fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+    expect(isPeeked(screen.getByRole("link", { name: SECOND_ORG.name }))).toBe(
+      true,
+    );
+    expect(isPeeked(first)).toBe(false);
+
+    // The next page is a different request and a different set of row nodes,
+    // and it would take the anchor peek walks from with it. So peek stops.
+    fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+  });
+
+  it("walks peek back up the list and stops at the first row", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const second = await screen.findByRole("link", { name: SECOND_ORG.name });
+    peekOn(second);
+
+    fireEvent.keyDown(peekPanel(), { key: "ArrowUp" });
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+
+    fireEvent.keyDown(peekPanel(), { key: "ArrowUp" });
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+  });
+
+  it("scrolls the row peek moves to into view", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    peekOn(first);
+
+    // The scroll box is capped at 60vh, so the row peek moves to can sit below
+    // the fold with nothing on screen to say peek moved at all.
+    const second = rowFor(screen.getByRole("link", { name: SECOND_ORG.name }));
+    const scrollIntoView = vi.spyOn(second, "scrollIntoView");
+
+    fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("closes on Escape and puts focus back on the row's name link", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    peekOn(link);
+
+    fireEvent.keyDown(peekPanel(), { key: "Escape" });
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    // The row itself takes no focus by design, so the link in its Name cell is
+    // where the keyboard goes back to.
+    expect(document.activeElement).toBe(
+      screen.getByRole("link", { name: FIRST_ORG.name }),
+    );
+  });
+
+  it("gives the operator's own column visibility back when peek closes", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Slug" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("columnheader", { name: "Slug" })).toBeNull();
+    });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    peekOn(link);
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual(["Name", "Type"]);
+
+    fireEvent.keyDown(peekPanel(), { key: "Escape" });
+
+    // Peek's own hides are derived on the way into the table, never written
+    // back, so closing it cannot undo a choice the operator made.
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual([
+      "Name",
+      "Type",
+      "Members",
+      "WorkOS",
+      "Disabled",
+      "Trial ends",
+      "Created",
+    ]);
+  });
+
+  // Radix renders the menu in a portal, but a portal still bubbles through the
+  // React tree, and an open menu hides the rest of the page from the
+  // accessibility tree. So both cases below read the highlight off the rows
+  // rather than querying the panel by role.
+  it("leaves the arrow keys to the Columns menu while it is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    const second = screen.getByRole("link", { name: SECOND_ORG.name });
+    peekOn(first);
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.keyDown(screen.getByRole("menuitemcheckbox", { name: "Name" }), {
+      key: "ArrowDown",
+    });
+
+    // The menu owns the arrow keys for its own roving focus.
+    expect(isPeeked(first)).toBe(true);
+    expect(isPeeked(second)).toBe(false);
+  });
+
+  it("leaves Escape to the Columns menu while it is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    peekOn(first);
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.keyDown(screen.getByRole("menuitemcheckbox", { name: "Name" }), {
+      key: "Escape",
+    });
+
+    // One Escape dismisses the menu. It must not take the panel with it.
+    expect(isPeeked(first)).toBe(true);
+  });
+
+  it("drops peek when the operator pages away from the record", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    peekOn(link);
+    expect(peekPanel()).toBeTruthy();
+
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    // Peek holds an id and resolves it against the rows on screen. Holding the
+    // record instead leaves a panel docked beside a table that no longer has it.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("complementary", { name: "Organization peek" }),
+      ).toBeNull();
+    });
   });
 });
 

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -171,9 +171,6 @@ function rowFor(link: HTMLElement): HTMLTableRowElement {
   return row;
 }
 
-// Alt, not meta and not shift: meta-click is the browser's open-in-new-tab, and
-// shift-click belongs to the range selection a later slice adds. The last cell,
-// because it holds no link whichever columns are on screen.
 function peekOn(link: HTMLElement): void {
   const cell = within(rowFor(link)).getAllByRole("cell").at(-1);
   if (!cell) throw new Error("the row needs a cell to click");
@@ -185,8 +182,6 @@ function peekPanel(): HTMLElement {
 }
 
 function isPeeked(link: HTMLElement): boolean {
-  // A token, not a substring: the stock row already carries
-  // `data-[state=selected]:bg-muted` and `hover:bg-muted/50`.
   return rowFor(link).classList.contains("bg-muted");
 }
 
@@ -571,11 +566,8 @@ describe("organizations list peek", () => {
     expect(
       within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
     ).toBeTruthy();
-    // The whole point of the panel. A detail page would take the filters and
-    // the scroll position with it.
     expect(router.state.location.pathname).toBe("/organizations");
 
-    // Narrowed to the columns that identify a row. The panel carries the rest.
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual(["Name", "Slug", "Type"]);
@@ -608,8 +600,6 @@ describe("organizations list peek", () => {
     );
     expect(isPeeked(first)).toBe(false);
 
-    // The next page is a different request and a different set of row nodes,
-    // and it would take the anchor peek walks from with it. So peek stops.
     fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
     expect(
       within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
@@ -637,8 +627,6 @@ describe("organizations list peek", () => {
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
     peekOn(first);
 
-    // The scroll box is capped at 60vh, so the row peek moves to can sit below
-    // the fold with nothing on screen to say peek moved at all.
     const second = rowFor(screen.getByRole("link", { name: SECOND_ORG.name }));
     const scrollIntoView = vi.spyOn(second, "scrollIntoView");
 
@@ -657,8 +645,6 @@ describe("organizations list peek", () => {
     expect(
       screen.queryByRole("complementary", { name: "Organization peek" }),
     ).toBeNull();
-    // The row itself takes no focus by design, so the link in its Name cell is
-    // where the keyboard goes back to.
     expect(document.activeElement).toBe(
       screen.getByRole("link", { name: FIRST_ORG.name }),
     );
@@ -681,8 +667,6 @@ describe("organizations list peek", () => {
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
-    // Peek's own hides are derived on the way into the table, never written
-    // back, so closing it cannot undo a choice the operator made.
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
@@ -696,10 +680,6 @@ describe("organizations list peek", () => {
     ]);
   });
 
-  // Radix renders the menu in a portal, but a portal still bubbles through the
-  // React tree, and an open menu hides the rest of the page from the
-  // accessibility tree. So both cases below read the highlight off the rows
-  // rather than querying the panel by role.
   it("leaves the arrow keys to the Columns menu while it is open", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
@@ -711,7 +691,6 @@ describe("organizations list peek", () => {
       key: "ArrowDown",
     });
 
-    // The menu owns the arrow keys for its own roving focus.
     expect(isPeeked(first)).toBe(true);
     expect(isPeeked(second)).toBe(false);
   });
@@ -726,7 +705,6 @@ describe("organizations list peek", () => {
       key: "Escape",
     });
 
-    // One Escape dismisses the menu. It must not take the panel with it.
     expect(isPeeked(first)).toBe(true);
   });
 
@@ -751,15 +729,11 @@ describe("organizations list peek", () => {
     fireEvent.click(next);
     await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
 
-    // Peek holds an id and resolves it against the rows on screen. Holding the
-    // record instead leaves a panel docked beside a table that no longer has it.
     await waitFor(() => {
       expect(
         screen.queryByRole("complementary", { name: "Organization peek" }),
       ).toBeNull();
     });
-    // The narrow column set is keyed on the same id, so an id left behind
-    // narrows the table with no panel beside it to explain why.
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -758,6 +758,20 @@ describe("organizations list peek", () => {
         screen.queryByRole("complementary", { name: "Organization peek" }),
       ).toBeNull();
     });
+    // The narrow column set is keyed on the same id, so an id left behind
+    // narrows the table with no panel beside it to explain why.
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual([
+      "Name",
+      "Slug",
+      "Type",
+      "Members",
+      "WorkOS",
+      "Disabled",
+      "Trial ends",
+      "Created",
+    ]);
   });
 });
 

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -680,6 +680,31 @@ describe("organizations list peek", () => {
     ]);
   });
 
+  it("shows the name column while it is open, even when the operator hid it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Name" }));
+    await waitFor(() => {
+      expect(screen.getByRole("columnheader", { name: "Slug" })).toBeTruthy();
+    });
+    expect(screen.queryByRole("columnheader", { name: "Name" })).toBeNull();
+
+    // The name link is gone with the column, so the row is reached by its slug.
+    const row = screen.getByText(FIRST_ORG.slug).closest("tr");
+    if (!row) throw new Error("the slug cell is not inside a row");
+    fireEvent.click(row, { altKey: true });
+
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual(["Name", "Slug", "Type"]);
+    expect(screen.getByRole("link", { name: FIRST_ORG.name })).toBeTruthy();
+
+    fireEvent.keyDown(peekPanel(), { key: "Escape" });
+
+    expect(screen.queryByRole("columnheader", { name: "Name" })).toBeNull();
+  });
+
   it("leaves the arrow keys to the Columns menu while it is open", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -31,12 +31,6 @@ const ROUTE_ID = "/organizations/";
 const PAGE_SIZE = 50;
 const NO_ORGS: AdminOrganization[] = [];
 
-// The columns peek keeps are the ones that name a row. Everything it hides is
-// in the panel beside the table, so nothing is lost and the table fits.
-//
-// Module scope: a value rebuilt on every render rebuilds the column model with
-// it. It is also merged over the operator's own visibility rather than written
-// into it, so closing peek cannot undo a choice they made.
 const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   member_count: false,
   workos_id: false,
@@ -71,8 +65,7 @@ export function OrganizationsList(): JSX.Element {
   const [columnVisibility, setColumnVisibility] =
     useState<ColumnVisibilityState>({});
 
-  // The id, never the record. A page change or a filter change replaces every
-  // row, and a panel holding the record outlives the table that produced it.
+  // An id, not the record: a page or filter change replaces every row.
   const [peekedId, setPeekedId] = useState<string>();
   const peekedRow = useRef<HTMLTableRowElement>(null);
 
@@ -130,8 +123,6 @@ export function OrganizationsList(): JSX.Element {
 
   const orgs = data?.organizations ?? NO_ORGS;
 
-  // Derived on the way in, so the forced hides never reach the operator's own
-  // state. Memoised because a fresh object each render is a fresh column model.
   const effectiveVisibility = useMemo(
     () =>
       peekedId
@@ -153,26 +144,20 @@ export function OrganizationsList(): JSX.Element {
 
   const rows = table.getRowModel().rows;
 
-  // One pass gives both the record the panel paints and the anchor the arrow
-  // keys step from.
+  // findIndex, not table.getRow: getRow throws once a page change drops the id.
   const peekedIndex = peekedId ? rows.findIndex((r) => r.id === peekedId) : -1;
   const peeked = peekedIndex === -1 ? undefined : rows[peekedIndex];
 
-  // Reset while rendering rather than in an effect, so the panel never paints a
-  // record the table on screen has already dropped.
+  // During render, not in an effect: an effect paints a dropped record first.
   if (peekedId && !peeked) {
     setPeekedId(undefined);
   }
 
   useEffect(() => {
-    // The scroll box is capped at 60vh, so a row the arrow keys move peek to
-    // can sit below the fold with nothing on screen to say peek moved.
     peekedRow.current?.scrollIntoView({ block: "nearest" });
   }, [peekedId]);
 
   const closePeek = (): void => {
-    // The row itself takes no focus by design, so the keyboard goes back to the
-    // link in its Name cell. Read before the state change, while it is on screen.
     const link = peekedRow.current?.querySelector("a");
     setPeekedId(undefined);
     link?.focus();
@@ -182,9 +167,7 @@ export function OrganizationsList(): JSX.Element {
     org: AdminOrganization,
     event: MouseEvent<HTMLTableRowElement>,
   ): void => {
-    // Alt, not meta and not shift: meta-click is the browser's own
-    // open-in-new-tab, and shift-click belongs to the range selection a later
-    // slice adds. A plain click still opens the organization.
+    // Alt, not Meta (the browser's open-in-new-tab) and not Shift (range select).
     if (event.altKey) {
       setPeekedId(org.id);
       return;
@@ -193,10 +176,6 @@ export function OrganizationsList(): JSX.Element {
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
-    // Radix renders the Columns menu in a portal, but a portal still bubbles
-    // through the React tree, and the menu owns the arrow keys for its roving
-    // focus and Escape for its own dismissal. It claims both by preventing the
-    // default, which is the general form of "this key is already spoken for".
     if (!peeked || event.defaultPrevented) return;
 
     if (event.key === "Escape") {
@@ -207,8 +186,7 @@ export function OrganizationsList(): JSX.Element {
 
     const step = ARROW_STEP[event.key];
     if (!step) return;
-    // Stop at the ends. Paging would replace every row node, taking the anchor
-    // peek walks from with it.
+    // Stop at the ends: paging replaces the row nodes the anchor depends on.
     const next = rows[peekedIndex + step];
     if (!next) return;
     event.preventDefault();
@@ -228,10 +206,6 @@ export function OrganizationsList(): JSX.Element {
           </div>
         )}
 
-        {/* Scoped here, not to the document: the handler has to reach the row
-            links and the panel, and stay out of the toolbar's search box and
-            account-type select above. The pager below stays full width, because
-            it moves the list rather than the record the panel holds. */}
         <div className="flex items-start gap-4" onKeyDown={handleKeyDown}>
           <div className="min-w-0 flex-1 rounded-lg border">
             <TableActionBar table={table} />

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -1,7 +1,15 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearch } from "@tanstack/react-router";
 import { useTable, type ColumnVisibilityState } from "@tanstack/react-table";
-import { useState, type JSX } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 
 import { dataTableFeatures, DataTable as Table } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
@@ -15,12 +23,37 @@ import {
 import { cn } from "@/lib/utils";
 
 import { ORG_COLUMNS } from "./columns";
+import { PeekPanel } from "./PeekPanel";
 import { useOpenOrganization } from "./rowActions";
 import { TableActionBar, Toolbar } from "./Toolbar";
 
 const ROUTE_ID = "/organizations/";
 const PAGE_SIZE = 50;
 const NO_ORGS: AdminOrganization[] = [];
+
+// The columns peek keeps are the ones that name a row. Everything it hides is
+// in the panel beside the table, so nothing is lost and the table fits.
+//
+// Module scope: a value rebuilt on every render rebuilds the column model with
+// it. It is also merged over the operator's own visibility rather than written
+// into it, so closing peek cannot undo a choice they made.
+const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
+  member_count: false,
+  workos_id: false,
+  disabled_at: false,
+  free_trial_ends_at: false,
+  created_at: false,
+};
+
+const ARROW_STEP: Record<string, number | undefined> = {
+  ArrowDown: 1,
+  ArrowUp: -1,
+};
+
+// Radix renders a menu and a select in a portal, but a portal still bubbles
+// through the React tree. Both own the arrow keys for roving focus and Escape
+// for dismissal, and a text field owns them too.
+const KEYS_NOT_OURS = '[role="menu"],[role="listbox"],input,textarea';
 
 function emptyStateMessage(isLoading: boolean, isError: boolean): string {
   if (isLoading) return "Loading...";
@@ -42,6 +75,11 @@ export function OrganizationsList(): JSX.Element {
   // preference, not part of the view a link carries, and it resets on reload.
   const [columnVisibility, setColumnVisibility] =
     useState<ColumnVisibilityState>({});
+
+  // The id, never the record. A page change or a filter change replaces every
+  // row, and a panel holding the record outlives the table that produced it.
+  const [peekedId, setPeekedId] = useState<string>();
+  const peekedRow = useRef<HTMLTableRowElement>(null);
 
   // One object is the source of both the request and the signature below. Two
   // hand-written lists drift: a slice that adds a filter to the request would
@@ -97,6 +135,16 @@ export function OrganizationsList(): JSX.Element {
 
   const orgs = data?.organizations ?? NO_ORGS;
 
+  // Derived on the way in, so the forced hides never reach the operator's own
+  // state. Memoised because a fresh object each render is a fresh column model.
+  const effectiveVisibility = useMemo(
+    () =>
+      peekedId
+        ? { ...columnVisibility, ...PEEK_HIDDEN_COLUMNS }
+        : columnVisibility,
+    [peekedId, columnVisibility],
+  );
+
   const table = useTable({
     features: dataTableFeatures,
     columns: ORG_COLUMNS,
@@ -104,11 +152,70 @@ export function OrganizationsList(): JSX.Element {
     // Without this a row is keyed by its index, and React reuses those keys
     // across a page change and across a filter change.
     getRowId: (org) => org.id,
-    state: { columnVisibility },
+    state: { columnVisibility: effectiveVisibility },
     onColumnVisibilityChange: setColumnVisibility,
   });
 
   const rows = table.getRowModel().rows;
+
+  // One pass gives both the record the panel paints and the anchor the arrow
+  // keys step from.
+  const peekedIndex = peekedId ? rows.findIndex((r) => r.id === peekedId) : -1;
+  const peeked = peekedIndex === -1 ? undefined : rows[peekedIndex];
+
+  // Reset while rendering rather than in an effect, so the panel never paints a
+  // record the table on screen has already dropped.
+  if (peekedId && !peeked) {
+    setPeekedId(undefined);
+  }
+
+  useEffect(() => {
+    // The scroll box is capped at 60vh, so a row the arrow keys move peek to
+    // can sit below the fold with nothing on screen to say peek moved.
+    peekedRow.current?.scrollIntoView({ block: "nearest" });
+  }, [peekedId]);
+
+  const closePeek = (): void => {
+    // The row itself takes no focus by design, so the keyboard goes back to the
+    // link in its Name cell. Read before the state change, while it is on screen.
+    const link = peekedRow.current?.querySelector("a");
+    setPeekedId(undefined);
+    link?.focus();
+  };
+
+  const handleRowClick = (
+    org: AdminOrganization,
+    event: MouseEvent<HTMLTableRowElement>,
+  ): void => {
+    // Alt, not meta and not shift: meta-click is the browser's own
+    // open-in-new-tab, and shift-click belongs to the range selection a later
+    // slice adds. A plain click still opens the organization.
+    if (event.altKey) {
+      setPeekedId(org.id);
+      return;
+    }
+    openOrganization(org);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (!peeked || event.defaultPrevented) return;
+    if ((event.target as HTMLElement).closest(KEYS_NOT_OURS)) return;
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closePeek();
+      return;
+    }
+
+    const step = ARROW_STEP[event.key];
+    if (!step) return;
+    // Stop at the ends. Paging would replace every row node, taking the anchor
+    // peek walks from with it.
+    const next = rows[peekedIndex + step];
+    if (!next) return;
+    event.preventDefault();
+    setPeekedId(next.id);
+  };
 
   return (
     <div className="space-y-6">
@@ -123,36 +230,55 @@ export function OrganizationsList(): JSX.Element {
           </div>
         )}
 
-        <div className="rounded-lg border">
-          <TableActionBar table={table} />
+        {/* Scoped here, not to the document: the handler has to reach the row
+            links and the panel, and stay out of the toolbar's search box and
+            account-type select above. The pager below stays full width, because
+            it moves the list rather than the record the panel holds. */}
+        <div className="flex items-start gap-4" onKeyDown={handleKeyDown}>
+          <div className="min-w-0 flex-1 rounded-lg border">
+            <TableActionBar table={table} />
 
-          <div
-            className={cn(
-              "max-h-[60vh] overflow-auto",
-              isPlaceholderData && "opacity-60",
-            )}
-          >
-            <Table>
-              <Table.Header table={table} />
-              <Table.Body>
-                {rows.length === 0 ? (
-                  <Table.NoResultsMessage>
-                    <span className="text-muted-foreground text-sm">
-                      {emptyStateMessage(isLoading, isError)}
-                    </span>
-                  </Table.NoResultsMessage>
-                ) : (
-                  rows.map((row) => (
-                    <Table.Row
-                      key={row.id}
-                      row={row}
-                      onClick={openOrganization}
-                    />
-                  ))
-                )}
-              </Table.Body>
-            </Table>
+            <div
+              className={cn(
+                "max-h-[60vh] overflow-auto",
+                isPlaceholderData && "opacity-60",
+              )}
+            >
+              <Table>
+                <Table.Header table={table} />
+                <Table.Body>
+                  {rows.length === 0 ? (
+                    <Table.NoResultsMessage>
+                      <span className="text-muted-foreground text-sm">
+                        {emptyStateMessage(isLoading, isError)}
+                      </span>
+                    </Table.NoResultsMessage>
+                  ) : (
+                    rows.map((row) => {
+                      const isPeeked = row.id === peekedId;
+                      return (
+                        <Table.Row
+                          key={row.id}
+                          row={row}
+                          ref={isPeeked ? peekedRow : undefined}
+                          className={cn(isPeeked && "bg-muted")}
+                          onClick={handleRowClick}
+                        />
+                      );
+                    })
+                  )}
+                </Table.Body>
+              </Table>
+            </div>
           </div>
+
+          {peeked ? (
+            <PeekPanel
+              org={peeked.original}
+              onClose={closePeek}
+              className="w-100 shrink-0"
+            />
+          ) : null}
         </div>
 
         {/* Placeholder rows belong to the previous filter, and so does the

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -39,6 +39,21 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   created_at: false,
 };
 
+// Mac reports "Mac" here and labels the key Option; every other platform calls
+// it Alt. Naming the wrong one makes the hint worse than no hint.
+const PEEK_KEY = navigator.userAgent.includes("Mac") ? "\u2325 Option" : "Alt";
+
+function PeekHint(): JSX.Element {
+  return (
+    <span className="text-muted-foreground hidden items-center gap-1 text-xs sm:flex">
+      <kbd className="bg-muted rounded border px-1.5 py-0.5 font-sans text-[11px] leading-none">
+        {PEEK_KEY}
+      </kbd>
+      + click a row to peek
+    </span>
+  );
+}
+
 const ARROW_STEP: Record<string, number | undefined> = {
   ArrowDown: 1,
   ArrowUp: -1,
@@ -208,7 +223,7 @@ export function OrganizationsList(): JSX.Element {
 
         <div className="flex items-start gap-4" onKeyDown={handleKeyDown}>
           <div className="min-w-0 flex-1 rounded-lg border">
-            <TableActionBar table={table} />
+            <TableActionBar table={table} hint={<PeekHint />} />
 
             <div
               className={cn(

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -286,7 +286,9 @@ export function OrganizationsList(): JSX.Element {
             <PeekPanel
               org={peeked.original}
               onClose={closePeek}
-              className="w-100 shrink-0"
+              // Same 60vh as the scroll box beside it, so the two line up top
+              // and bottom and the actions sit on the table's last row.
+              className="h-[60vh] w-100 shrink-0"
             />
           ) : null}
         </div>

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -39,8 +39,6 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   created_at: false,
 };
 
-const PEEK_KEPT_COLUMNS = ["name", "slug", "account_type"] as const;
-
 // Mac labels this key Option; everything else calls it Alt.
 const PEEK_KEY = navigator.userAgent.includes("Mac") ? "\u2325 Option" : "Alt";
 
@@ -139,16 +137,15 @@ export function OrganizationsList(): JSX.Element {
 
   const orgs = data?.organizations ?? NO_ORGS;
 
-  // The lock only sees the operator's own hides, so peek could empty the table.
-  const effectiveVisibility = useMemo(() => {
-    if (!peekedId) return columnVisibility;
-    const anyKept = PEEK_KEPT_COLUMNS.some(
-      (id) => columnVisibility[id] !== false,
-    );
-    return anyKept
-      ? { ...columnVisibility, ...PEEK_HIDDEN_COLUMNS }
-      : columnVisibility;
-  }, [peekedId, columnVisibility]);
+  // Name carries the row's only anchor, which peek closes back onto. Forcing it
+  // also keeps peek's own hiding from emptying the table.
+  const effectiveVisibility = useMemo(
+    () =>
+      peekedId
+        ? { ...columnVisibility, ...PEEK_HIDDEN_COLUMNS, name: true }
+        : columnVisibility,
+    [peekedId, columnVisibility],
+  );
 
   const table = useTable({
     features: dataTableFeatures,

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -222,40 +222,63 @@ export function OrganizationsList(): JSX.Element {
         )}
 
         <div className="flex items-start gap-4" onKeyDown={handleKeyDown}>
-          <div className="min-w-0 flex-1 rounded-lg border">
-            <TableActionBar table={table} hint={<PeekHint />} />
+          <div className="min-w-0 flex-1">
+            <div className="rounded-lg border">
+              <TableActionBar table={table} hint={<PeekHint />} />
 
-            <div
-              className={cn(
-                "max-h-[60vh] overflow-auto",
-                isPlaceholderData && "opacity-60",
-              )}
-            >
-              <Table>
-                <Table.Header table={table} />
-                <Table.Body>
-                  {rows.length === 0 ? (
-                    <Table.NoResultsMessage>
-                      <span className="text-muted-foreground text-sm">
-                        {emptyStateMessage(isLoading, isError)}
-                      </span>
-                    </Table.NoResultsMessage>
-                  ) : (
-                    rows.map((row) => {
-                      const isPeeked = row.id === peekedId;
-                      return (
-                        <Table.Row
-                          key={row.id}
-                          row={row}
-                          ref={isPeeked ? peekedRow : undefined}
-                          className={cn(isPeeked && "bg-muted")}
-                          onClick={handleRowClick}
-                        />
-                      );
-                    })
-                  )}
-                </Table.Body>
-              </Table>
+              <div
+                className={cn(
+                  "max-h-[60vh] overflow-auto",
+                  isPlaceholderData && "opacity-60",
+                )}
+              >
+                <Table>
+                  <Table.Header table={table} />
+                  <Table.Body>
+                    {rows.length === 0 ? (
+                      <Table.NoResultsMessage>
+                        <span className="text-muted-foreground text-sm">
+                          {emptyStateMessage(isLoading, isError)}
+                        </span>
+                      </Table.NoResultsMessage>
+                    ) : (
+                      rows.map((row) => {
+                        const isPeeked = row.id === peekedId;
+                        return (
+                          <Table.Row
+                            key={row.id}
+                            row={row}
+                            ref={isPeeked ? peekedRow : undefined}
+                            className={cn(isPeeked && "bg-muted")}
+                            onClick={handleRowClick}
+                          />
+                        );
+                      })
+                    )}
+                  </Table.Body>
+                </Table>
+              </div>
+            </div>
+
+            {/* Inside the table's column, not beside it: the pager moves the
+                list, and the panel holds one record the list may not carry. */}
+            <div className="mt-3 flex items-center justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={isPlaceholderData || pager.stack.length === 0}
+                onClick={goPrev}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={isPlaceholderData || !data?.next_cursor}
+                onClick={goNext}
+              >
+                Next
+              </Button>
             </div>
           </div>
 
@@ -266,27 +289,6 @@ export function OrganizationsList(): JSX.Element {
               className="w-100 shrink-0"
             />
           ) : null}
-        </div>
-
-        {/* Placeholder rows belong to the previous filter, and so does the
-            cursor beside them. Both controls wait for the real page. */}
-        <div className="mt-3 flex items-center justify-end gap-2">
-          <Button
-            variant="ghost"
-            size="xs"
-            disabled={isPlaceholderData || pager.stack.length === 0}
-            onClick={goPrev}
-          >
-            Previous
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            disabled={isPlaceholderData || !data?.next_cursor}
-            onClick={goNext}
-          >
-            Next
-          </Button>
         </div>
       </section>
     </div>

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -50,11 +50,6 @@ const ARROW_STEP: Record<string, number | undefined> = {
   ArrowUp: -1,
 };
 
-// Radix renders a menu and a select in a portal, but a portal still bubbles
-// through the React tree. Both own the arrow keys for roving focus and Escape
-// for dismissal, and a text field owns them too.
-const KEYS_NOT_OURS = '[role="menu"],[role="listbox"],input,textarea';
-
 function emptyStateMessage(isLoading: boolean, isError: boolean): string {
   if (isLoading) return "Loading...";
   if (isError) return "Unable to load organizations";
@@ -198,8 +193,11 @@ export function OrganizationsList(): JSX.Element {
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    // Radix renders the Columns menu in a portal, but a portal still bubbles
+    // through the React tree, and the menu owns the arrow keys for its roving
+    // focus and Escape for its own dismissal. It claims both by preventing the
+    // default, which is the general form of "this key is already spoken for".
     if (!peeked || event.defaultPrevented) return;
-    if ((event.target as HTMLElement).closest(KEYS_NOT_OURS)) return;
 
     if (event.key === "Escape") {
       event.preventDefault();

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -39,8 +39,9 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   created_at: false,
 };
 
-// Mac reports "Mac" here and labels the key Option; every other platform calls
-// it Alt. Naming the wrong one makes the hint worse than no hint.
+const PEEK_KEPT_COLUMNS = ["name", "slug", "account_type"] as const;
+
+// Mac labels this key Option; everything else calls it Alt.
 const PEEK_KEY = navigator.userAgent.includes("Mac") ? "\u2325 Option" : "Alt";
 
 function PeekHint(): JSX.Element {
@@ -138,13 +139,16 @@ export function OrganizationsList(): JSX.Element {
 
   const orgs = data?.organizations ?? NO_ORGS;
 
-  const effectiveVisibility = useMemo(
-    () =>
-      peekedId
-        ? { ...columnVisibility, ...PEEK_HIDDEN_COLUMNS }
-        : columnVisibility,
-    [peekedId, columnVisibility],
-  );
+  // The lock only sees the operator's own hides, so peek could empty the table.
+  const effectiveVisibility = useMemo(() => {
+    if (!peekedId) return columnVisibility;
+    const anyKept = PEEK_KEPT_COLUMNS.some(
+      (id) => columnVisibility[id] !== false,
+    );
+    return anyKept
+      ? { ...columnVisibility, ...PEEK_HIDDEN_COLUMNS }
+      : columnVisibility;
+  }, [peekedId, columnVisibility]);
 
   const table = useTable({
     features: dataTableFeatures,
@@ -221,8 +225,7 @@ export function OrganizationsList(): JSX.Element {
           </div>
         )}
 
-        {/* Stretch, not items-start: the panel takes its height from the row so
-            it lines up with the table without naming a height of its own. */}
+        {/* Stretch, so the panel takes its height from the row. */}
         <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
           <div className="flex min-h-0 min-w-0 flex-1 flex-col">
             <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
@@ -262,8 +265,7 @@ export function OrganizationsList(): JSX.Element {
               </div>
             </div>
 
-            {/* Inside the table's column, not beside it: the pager moves the
-                list, and the panel holds one record the list may not carry. */}
+            {/* Inside the table's column, so it does not run under the panel. */}
             <div className="mt-3 flex items-center justify-end gap-2">
               <Button
                 variant="ghost"

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -209,8 +209,8 @@ export function OrganizationsList(): JSX.Element {
   };
 
   return (
-    <div className="space-y-6">
-      <section>
+    <div className="flex h-full flex-col">
+      <section className="flex min-h-0 flex-1 flex-col">
         <Toolbar />
 
         {/* A failed refetch keeps the previous rows, so the failure has to show
@@ -221,14 +221,16 @@ export function OrganizationsList(): JSX.Element {
           </div>
         )}
 
-        <div className="flex items-start gap-4" onKeyDown={handleKeyDown}>
-          <div className="min-w-0 flex-1">
-            <div className="rounded-lg border">
+        {/* Stretch, not items-start: the panel takes its height from the row so
+            it lines up with the table without naming a height of its own. */}
+        <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
               <TableActionBar table={table} hint={<PeekHint />} />
 
               <div
                 className={cn(
-                  "max-h-[60vh] overflow-auto",
+                  "min-h-0 flex-1 overflow-auto",
                   isPlaceholderData && "opacity-60",
                 )}
               >
@@ -286,9 +288,7 @@ export function OrganizationsList(): JSX.Element {
             <PeekPanel
               org={peeked.original}
               onClose={closePeek}
-              // Same 60vh as the scroll box beside it, so the two line up top
-              // and bottom and the actions sit on the table's last row.
-              className="h-[60vh] w-100 shrink-0"
+              className="w-100 shrink-0"
             />
           ) : null}
         </div>


### PR DESCRIPTION
Answering one question about an organization costs a round trip out of the list and back, and the filters and scroll position go with it.

Alt-click a row and a panel docks beside the table with the full record. ArrowUp and ArrowDown walk it between rows. Escape closes it and puts focus back on the row's name link. A plain click still opens the detail page.

The action bar shows the shortcut, so the feature is discoverable without documentation.

### The shell now has a height

The list could not fill its container, because `AdminLayout`'s padding wrappers had no `flex-1` and no `min-h-0`. One missing link makes every child below content-sized, which is why the table box carried a `60vh` guess. The chain is fixed and both `60vh` values are gone: the table and the panel take the height that is left.

The scroll sits on the innermost wrapper, so a page taller than the shell scrolls under the header instead of being cut off. **This touches every admin page, not only this one.**

### Reviewed, and what is still open

An adversarial review found ten confirmed defects. Two are fixed here:

- Hiding the three columns peek keeps, then peeking, hid the other five and left a table with no columns at all. The last-column lock never fires, because it only counts the operator's own hides.
- The copy button drew its check before the clipboard write resolved, so a rejected write still said copied and the operator walked off with the wrong id.

**Three are deliberately not fixed here**, because they share one cause and one fix:

- Peek has no keyboard entry point. It is pointer-plus-modifier only, yet once open it is keyboard-driven.
- Alt-clicking the organization name, the widest target in the row, does nothing in the app and starts a download in a real browser.
- There is no click-again-to-dismiss.

All three want a visible per-row control instead of a modifier click. That control needs a cell in `columns.tsx`, which AGE-3184 owns, so it lands in a follow-up once that merges. The remaining findings, focus loss when the peeked row disappears and the missing live region, belong with that same pass.

### Notes

The panel's action strip is mounted empty on purpose. AGE-3190's Disable and AGE-3191's Extend trial land there, and reserving it now means neither moves the grid above it.

`data-table.tsx` gains two additive changes: the row click passes its event as a second argument, and the row forwards an optional `ref`. Without the first no modifier click is reachable from the page; without the second there is no way to scroll the peeked row into view. Existing callers are unaffected.

Peek state is not in the URL. It is a per-operator view, matching the policy AGE-3183 set for column visibility.

AGE-3189

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Peek at an organization beside the list to answer account questions without leaving the page. Before: clicking a row navigated away and lost filters and scroll. Now: Alt-click docks a 400px side panel; ArrowUp/ArrowDown move between rows; Escape closes; a normal click still opens the detail page. Satisfies Linear AGE-3189.

- Shows Type, Trial ends, Members, Created, Org id, and WorkOS id; copy controls wait for a successful clipboard write, do nothing if `navigator.clipboard` is unavailable, confirm with a check, reset when switching records, and tie the confirmation to the value written so late writes do not confirm on a new record.
- While peek is open, the table hides secondary columns and forces Name visible; it shows Name, Slug, and Type, then restores the operator’s column visibility on close and cannot empty the table.
- Highlights the peeked row, scrolls it into view when stepping, and returns focus to the row’s name link on close; paging or filtering drops peek and restores headers. The action bar shows an Alt+click hint. Keyboard handling is scoped so the Columns menu keeps arrow keys and Escape while open.

**Compatibility and rollout**
- The table row in `client/admin/src/components/data-table.tsx` now forwards an optional `ref` and passes the click event to `onClick` (so modifier keys are detectable). Existing callers are unaffected.
- `client/admin/src/layouts/AdminLayout.tsx` sets `min-h-0`/`flex-1` so pages fill the shell and scroll under the header. This touches all admin pages—sanity-check scrolling and overflow.

<sup>Written for commit 4be92f7bf0ef4984696e9f39d830ad2738fb9b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

