### PR TITLE
feat(admin): match a pasted organization id in the admin search

### DIFF
--- a/.changeset/admin-search-organization-ids.md
+++ b/.changeset/admin-search-organization-ids.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+The admin organizations search now matches a pasted organization id or WorkOS id, so an engineer who pastes an id lands on that organization instead of an empty list. Both id matches are exact; name and slug keep matching as a case-insensitive substring.

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -407,3 +407,50 @@ func TestAdminListOrganizations_TrialState(t *testing.T) {
 	require.NotNil(t, byID["org_trial_none"].FreeTrialStartedAt)
 	require.NotNil(t, byID["org_trial_none"].FreeTrialEndsAt)
 }
+
+type searchByIDCase struct {
+	name    string
+	q       string
+	wantIDs []string
+}
+
+func TestListOrganizations_SearchByID(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	const (
+		alphaID   = "org_search_id_alpha"
+		bravoID   = "org_search_id_bravo"
+		charlieID = "org_search_id_charlie"
+
+		bravoWorkosID = "org_workos_placeholder_bravo"
+	)
+
+	workosID := bravoWorkosID
+	seedOrg(t, ctx, conn, orgFixture{id: alphaID, name: "Alpha Holdings", slug: "alpha-holdings", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: bravoID, name: "Bravo Holdings", slug: "bravo-holdings", workosID: &workosID, whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: charlieID, name: "Charlie Networks", slug: "charlie-networks", whitelisted: true})
+
+	cases := []searchByIDCase{
+		{name: "full organization id", q: alphaID, wantIDs: []string{alphaID}},
+		{name: "full workos id", q: bravoWorkosID, wantIDs: []string{bravoID}},
+		{name: "id no organization holds", q: "org_search_id_delta", wantIDs: nil},
+		// The id arms are exact, so a fragment of a real id matches nothing.
+		{name: "fragment of an organization id", q: "search_id_alpha", wantIDs: nil},
+		{name: "fragment of a workos id", q: "placeholder_bravo", wantIDs: nil},
+		{name: "name, unchanged by the id arms", q: "charlie", wantIDs: []string{charlieID}},
+	}
+
+	for _, c := range cases {
+		q := c.q
+		res, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Q: &q})
+		require.NoError(t, err, "searching for %s", c.name)
+
+		got := make([]string, len(res.Organizations))
+		for i, o := range res.Organizations {
+			got[i] = o.ID
+		}
+		require.ElementsMatch(t, c.wantIDs, got, "organizations matched by %s", c.name)
+	}
+}

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -414,6 +415,20 @@ type searchByIDCase struct {
 	wantIDs []string
 }
 
+// requireSearchMatches asserts the exact set of organizations a payload returns, ignoring order.
+func requireSearchMatches(t *testing.T, ctx context.Context, svc *Service, payload *gen.ListOrganizationsPayload, wantIDs []string, label string) {
+	t.Helper()
+
+	res, err := svc.ListOrganizations(ctx, payload)
+	require.NoError(t, err, "listing organizations for %s", label)
+
+	got := make([]string, len(res.Organizations))
+	for i, o := range res.Organizations {
+		got[i] = o.ID
+	}
+	require.ElementsMatch(t, wantIDs, got, "organizations matched by %s", label)
+}
+
 func TestListOrganizations_SearchByID(t *testing.T) {
 	t.Parallel()
 
@@ -443,14 +458,89 @@ func TestListOrganizations_SearchByID(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		q := c.q
-		res, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Q: &q})
-		require.NoError(t, err, "searching for %s", c.name)
+		requireSearchMatches(t, ctx, svc, &gen.ListOrganizationsPayload{Q: conv.PtrEmpty(c.q)}, c.wantIDs, c.name)
+	}
+}
 
-		got := make([]string, len(res.Organizations))
-		for i, o := range res.Organizations {
-			got[i] = o.ID
+func TestListOrganizations_SearchByIDIsCaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// Both id spaces are opaque and case significant, and a real WorkOS id embeds an uppercase ULID.
+	const (
+		mixedID       = "org_search_id_MixedCase"
+		mixedWorkosID = "org_workos_placeholder_MixedCase"
+	)
+
+	workosID := mixedWorkosID
+	seedOrg(t, ctx, conn, orgFixture{id: mixedID, name: "Mixed Case Holdings", slug: "mixed-case-holdings", workosID: &workosID, whitelisted: true})
+
+	cases := []searchByIDCase{
+		{name: "organization id at its own casing", q: mixedID, wantIDs: []string{mixedID}},
+		{name: "organization id case folded", q: strings.ToLower(mixedID), wantIDs: nil},
+		{name: "workos id at its own casing", q: mixedWorkosID, wantIDs: []string{mixedID}},
+		{name: "workos id case folded", q: strings.ToLower(mixedWorkosID), wantIDs: nil},
+
+		// The contrast that makes the two case-folded rows above meaningful: name and slug still ignore casing.
+		{name: "name case folded", q: "mixed case holdings", wantIDs: []string{mixedID}},
+		{name: "slug upper cased", q: "MIXED-CASE-HOLDINGS", wantIDs: []string{mixedID}},
+	}
+
+	for _, c := range cases {
+		requireSearchMatches(t, ctx, svc, &gen.ListOrganizationsPayload{Q: conv.PtrEmpty(c.q)}, c.wantIDs, c.name)
+	}
+}
+
+type searchFilterCase struct {
+	name            string
+	q               string
+	includeDisabled bool
+	accountType     string
+	cursor          string
+	wantIDs         []string
+}
+
+// An id match is one arm of the q group, not an escape from the group: it still meets every other filter.
+func TestListOrganizations_SearchByIDRespectsFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	const (
+		disabledID = "org_search_id_disabled"
+		proID      = "org_search_id_pro"
+		cursorID   = "org_search_id_cursor"
+
+		disabledWorkosID = "org_workos_placeholder_disabled"
+	)
+
+	disabledAt := time.Now().UTC().Add(-24 * time.Hour)
+	workosID := disabledWorkosID
+	seedOrg(t, ctx, conn, orgFixture{id: disabledID, name: "Disabled Holdings", slug: "disabled-holdings", workosID: &workosID, whitelisted: true, disabledAt: &disabledAt})
+	seedOrg(t, ctx, conn, orgFixture{id: proID, name: "Pro Holdings", slug: "pro-holdings", accountType: "pro", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: cursorID, name: "Cursor Holdings", slug: "cursor-holdings", whitelisted: true})
+
+	cases := []searchFilterCase{
+		{name: "disabled organization by id, disabled excluded", q: disabledID, wantIDs: nil},
+		{name: "disabled organization by id, disabled included", q: disabledID, includeDisabled: true, wantIDs: []string{disabledID}},
+		{name: "disabled organization by workos id, disabled excluded", q: disabledWorkosID, wantIDs: nil},
+		{name: "disabled organization by workos id, disabled included", q: disabledWorkosID, includeDisabled: true, wantIDs: []string{disabledID}},
+
+		{name: "pro organization by id, filtered to free", q: proID, accountType: "free", wantIDs: nil},
+		{name: "pro organization by id, filtered to pro", q: proID, accountType: "pro", wantIDs: []string{proID}},
+
+		{name: "organization by id, at or before the cursor", q: cursorID, cursor: cursorID, wantIDs: nil},
+		{name: "organization by id, after the cursor", q: cursorID, cursor: "org_search_id_a", wantIDs: []string{cursorID}},
+	}
+
+	for _, c := range cases {
+		payload := &gen.ListOrganizationsPayload{
+			Q:               conv.PtrEmpty(c.q),
+			IncludeDisabled: conv.PtrEmpty(c.includeDisabled),
+			AccountType:     conv.PtrEmpty(c.accountType),
+			Cursor:          conv.PtrEmpty(c.cursor),
 		}
-		require.ElementsMatch(t, c.wantIDs, got, "organizations matched by %s", c.name)
+		requireSearchMatches(t, ctx, svc, payload, c.wantIDs, c.name)
 	}
 }

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -82,7 +82,14 @@ SELECT
 FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
 WHERE
-    (sqlc.narg('q')::text IS NULL OR om.name ILIKE '%' || sqlc.narg('q')::text || '%' OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%')
+    -- The id arms match whole values only: both columns are unique-indexed, so equality stays index-usable where a wildcard ILIKE would force a sequential scan on every keystroke.
+    (
+        sqlc.narg('q')::text IS NULL
+        OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
+        OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
+        OR om.id = sqlc.narg('q')::text
+        OR om.workos_id = sqlc.narg('q')::text
+    )
     AND (sqlc.narg('account_type')::text IS NULL OR om.gram_account_type = sqlc.narg('account_type')::text)
     AND (sqlc.arg('include_disabled')::boolean OR om.disabled_at IS NULL)
     AND (sqlc.narg('after_id')::text IS NULL OR om.id > sqlc.narg('after_id')::text)

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -82,7 +82,8 @@ SELECT
 FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
 WHERE
-    -- The id arms match whole values only: both columns are unique-indexed, so equality stays index-usable where a wildcard ILIKE would force a sequential scan on every keystroke.
+    -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
+    -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
     (
         sqlc.narg('q')::text IS NULL
         OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -291,7 +291,8 @@ SELECT
 FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
 WHERE
-    -- The id arms match whole values only: both columns are unique-indexed, so equality stays index-usable where a wildcard ILIKE would force a sequential scan on every keystroke.
+    -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
+    -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
     (
         $1::text IS NULL
         OR om.name ILIKE '%' || $1::text || '%'

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -291,7 +291,14 @@ SELECT
 FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
 WHERE
-    ($1::text IS NULL OR om.name ILIKE '%' || $1::text || '%' OR om.slug ILIKE '%' || $1::text || '%')
+    -- The id arms match whole values only: both columns are unique-indexed, so equality stays index-usable where a wildcard ILIKE would force a sequential scan on every keystroke.
+    (
+        $1::text IS NULL
+        OR om.name ILIKE '%' || $1::text || '%'
+        OR om.slug ILIKE '%' || $1::text || '%'
+        OR om.id = $1::text
+        OR om.workos_id = $1::text
+    )
     AND ($2::text IS NULL OR om.gram_account_type = $2::text)
     AND ($3::boolean OR om.disabled_at IS NULL)
     AND ($4::text IS NULL OR om.id > $4::text)


### PR DESCRIPTION
The admin organizations search matched name and slug only, so an engineer who pasted an organization id or a WorkOS id into the search box got an empty list instead of that organization.

AGE-3188.

## What changed

`AdminListOrganizations` now also matches `q` against `organization_metadata.id` and `organization_metadata.workos_id`. That is the whole behaviour change. The admin toolbar already writes `q` into the URL and the organizations page already forwards it, so a pasted id starts working the moment the predicate widens — no client change is needed.

`impl.go` is untouched: sqlc collapses every `sqlc.narg('q')` occurrence into the same single `Q` field, so the params struct is unchanged.

## Why the id arms are exact rather than `ILIKE`

Substring matching on an opaque high-cardinality id produces incidental matches an operator cannot explain, and the gesture being fixed is a paste, not a partial type-in. That is the whole reason.

**It is not an index win, and an earlier revision of this description wrongly claimed it was.** The two `ILIKE` arms sit in the same `OR` group as the id arms, and Postgres can only build a `BitmapOr` when every disjunct is indexable. No trigram index exists in this schema, so the full predicate plans as a `Seq Scan` for any non-null `q` — confirmed by `EXPLAIN` even with `enable_seqscan=off`. The id arms alone would plan as a `BitmapOr` over the primary key and `organization_metadata_workos_id_key`, but they never appear alone. The comment in `queries.sql` was corrected in the second commit and now warns against restoring an optimisation that was never there.

Matching exactly makes both id arms case sensitive, which is correct for two opaque id spaces. `workos_id` is nullable and needs no guard: `NULL = 'anything'` yields NULL, not true, so an organization with no WorkOS link simply does not match.

Name and slug keep matching exactly as before — case-insensitive substring. The API expands only: same `q` parameter, no new parameter, no mode flag.

## Tests

`TestListOrganizations_SearchByID` covers a full organization id, a full WorkOS id, an id no organization holds, a fragment of each id, and a name-only term. The two fragment cases are what pin exact matching, so a later regression to `ILIKE` cannot pass silently.

The test was written against the unmodified predicate first and failed on exactly the two id cases. Six mutants were then applied to the predicate and every one was killed: dropping either id arm, matching `id` by substring, pointing the WorkOS arm at `slug`, joining the new arms with `AND` instead of `OR`, and neutering the whole `q` group.

`TestListOrganizations_SearchByNameOrSlug` passes unmodified.

## Known gap, deliberately not fixed here

Nothing trims `q` anywhere on the path, so a paste that carries a leading or trailing space still misses. It is recorded as a follow-up rather than widened into this slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admin organizations search now matches a pasted organization id or WorkOS id exactly, alongside the existing case-insensitive substring on name and slug. Previously, pasting an id returned no results; now the matching org is returned. Addresses Linear AGE-3188’s requirement to find an org by a pasted id.

**Review notes**
- Widens the SQL predicate to OR-match `om.id = q` and `om.workos_id = q`; the `q` parameter is unchanged and already flows from the toolbar. No client changes; sqlc params stay the same.
- Id matches are exact and case-sensitive; fragments do not match. Matches still respect `include_disabled`, `account_type`, and cursor filters. `workos_id` being NULL behaves correctly.
- Adds tests for full ids, case sensitivity, filter interaction, id fragments, non-existent id, and name search; name/slug behavior is unchanged.
- Updates the inline SQL comment to remove a false index rationale and document why exact matching is chosen.
- Known gap: leading/trailing spaces in `q` are not trimmed and can prevent matches (tracked separately).

<sup>Written for commit 26b4cb69f0b053dd72fd65827acd2af9cbe5b2f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

