### PR TITLE
fix(admin): open the organizations peek panel from a control on the row

### DIFF
--- a/.changeset/admin-organizations-peek-panel.md
+++ b/.changeset/admin-organizations-peek-panel.md
@@ -2,12 +2,17 @@
 "admin": minor
 ---
 
-Peek at an organization beside the list. Alt-clicking a row in the admin
-organizations list docks a 400px panel next to the table instead of leaving the
-page, so the search term, the filters and the scroll position all survive the
-look-up. The panel shows account type, trial end, member count, creation date
-and both ids, with a copy control beside each id that confirms with a check.
-The table narrows to Name, Slug and Type while the panel is open and gives the
-operator's own column choices straight back when it closes. Arrow Down and
-Arrow Up walk the panel through the rows on screen and scroll each one into
-view; Escape closes it and puts the keyboard back on the row's name link.
+Peek at an organization beside the list. Every row in the admin organizations
+list carries a peek control that docks a 400px panel next to the table instead
+of leaving the page, so the search term, the filters and the scroll position
+all survive the look-up. The panel shows account type, trial end, member count,
+creation date and both ids, with a copy control beside each id that confirms
+with a check. The table narrows to Name, Slug and Type while the panel is open,
+and gives the operator's own column choices straight back when it closes.
+
+The control takes the mouse and the keyboard alike. It reports whether its own
+panel is open, and it closes the panel it opened. Arrow Down and Arrow Up walk
+the panel through the rows on screen and scroll each one into view, and Escape
+closes it. Every close puts the keyboard back on the control that opened the
+panel. A screen reader is told which organization the panel is showing, each
+time the panel opens, moves to another row, or closes.

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -10,6 +10,10 @@ import { cn } from "@/lib/utils";
 
 const COPY_CONFIRM_MS = 1500;
 
+// One panel is on the page at a time, so a constant is enough and the row's
+// trigger can point `aria-controls` at it without threading an id through.
+export const PEEK_PANEL_ID = "organization-peek-panel";
+
 function noop(): void {}
 
 function fmtDateShort(iso?: string): string {
@@ -95,6 +99,7 @@ export function PeekPanel({
   return (
     <aside
       ref={root}
+      id={PEEK_PANEL_ID}
       tabIndex={-1}
       aria-label="Organization peek"
       className={cn("flex flex-col rounded-lg border outline-none", className)}

--- a/client/admin/src/pages/organizations/PeekTrigger.tsx
+++ b/client/admin/src/pages/organizations/PeekTrigger.tsx
@@ -1,0 +1,83 @@
+import { PanelRightIcon } from "lucide-react";
+import { createContext, useContext, type JSX, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { AdminOrganization } from "@/lib/gramAdminApi";
+
+import { PEEK_PANEL_ID } from "./PeekPanel";
+
+export type PeekControls = {
+  peekedId?: string;
+  togglePeek: (org: AdminOrganization) => void;
+};
+
+const PeekContext = createContext<PeekControls>({
+  togglePeek: () => {},
+});
+
+/**
+ * Peek state reaches the trigger cells through context, not through the column
+ * definitions: the row model memoises on the column array, so a column array
+ * rebuilt for each new `peekedId` would rebuild the model with it.
+ *
+ * The caller memoises `value`, or every trigger on the page re-renders on every
+ * render of the list.
+ */
+export function PeekProvider({
+  value,
+  children,
+}: {
+  value: PeekControls;
+  children: ReactNode;
+}): JSX.Element {
+  return <PeekContext.Provider value={value}>{children}</PeekContext.Provider>;
+}
+
+// The close path reaches the button through the peeked row and this selector,
+// rather than through `querySelector("button")`: later slices put more buttons
+// in the row.
+export const PEEK_TRIGGER_SELECTOR = "[data-peek-trigger]";
+
+export function PeekTrigger({ org }: { org: AdminOrganization }): JSX.Element {
+  const { peekedId, togglePeek } = useContext(PeekContext);
+  const isPeeked = peekedId === org.id;
+
+  return (
+    <Tooltip>
+      {/* The control is an icon on its own, so nothing on screen says what it
+          does until the pointer rests on it. The tooltip describes the
+          control; it does not name it, and the accessible name below is what
+          a screen reader still announces. */}
+      <TooltipTrigger asChild>
+        <Button
+          // Filled while open. Ghost hover is `bg-accent`, and the peeked row
+          // is `bg-muted`, and in this theme those two tokens hold the same
+          // grey: an open control styled with either disappears into the row
+          // it sits in and reads as a hover everywhere else.
+          variant={isPeeked ? "default" : "ghost"}
+          size="icon-xs"
+          data-peek-trigger=""
+          // Stable under the state change. A control whose accessible name
+          // moves as it is pressed is announced as a different control; the
+          // state rides on aria-expanded instead.
+          aria-label={`Peek at ${org.name}`}
+          aria-expanded={isPeeked}
+          // A peeked row always has its panel mounted, and aria-controls
+          // pointing at an absent id is invalid.
+          aria-controls={isPeeked ? PEEK_PANEL_ID : undefined}
+          onClick={() => togglePeek(org)}
+        >
+          <PanelRightIcon />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {isPeeked ? "Close peek" : "Peek without leaving the list"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/client/admin/src/pages/organizations/PeekTrigger.tsx
+++ b/client/admin/src/pages/organizations/PeekTrigger.tsx
@@ -1,5 +1,11 @@
 import { PanelRightIcon } from "lucide-react";
-import { createContext, useContext, type JSX, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  type JSX,
+  type ReactNode,
+} from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -46,9 +52,16 @@ export const PEEK_TRIGGER_SELECTOR = "[data-peek-trigger]";
 export function PeekTrigger({ org }: { org: AdminOrganization }): JSX.Element {
   const { peekedId, togglePeek } = useContext(PeekContext);
   const isPeeked = peekedId === org.id;
+  const [tipOpen, setTipOpen] = useState(false);
 
   return (
-    <Tooltip>
+    // Controlled, and held shut while this row's panel is open. The arrow keys
+    // carry the keyboard to the control of whichever row the peek moves to,
+    // and Radix opens a tooltip on a focus it did not trace to a pointer. So
+    // an uncontrolled tooltip pops open on every arrow press, and it takes the
+    // first Escape to dismiss itself before the panel gets one. An open panel
+    // describes this control better than the tooltip does anyway.
+    <Tooltip open={tipOpen && !isPeeked} onOpenChange={setTipOpen}>
       {/* The control is an icon on its own, so nothing on screen says what it
           does until the pointer rests on it. The tooltip describes the
           control; it does not name it, and the accessible name below is what
@@ -75,9 +88,7 @@ export function PeekTrigger({ org }: { org: AdminOrganization }): JSX.Element {
           <PanelRightIcon />
         </Button>
       </TooltipTrigger>
-      <TooltipContent>
-        {isPeeked ? "Close peek" : "Peek without leaving the list"}
-      </TooltipContent>
+      <TooltipContent>Peek without leaving the list</TooltipContent>
     </Tooltip>
   );
 }

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -144,7 +144,14 @@ export function TableActionBar<T extends RowData>({
 }): JSX.Element {
   // Read off the table rather than walked a second time here, so the menu
   // cannot disagree with the table about how many columns are left.
-  const visibleCount = table.getVisibleLeafColumns().length;
+  //
+  // Only the hideable ones count. A column that opts out of hiding is visible
+  // whatever the operator does, so counting it holds this total off the floor
+  // and the guard below never fires: the operator can then hide every column
+  // that carries data and be left with a table of controls and no records.
+  const visibleCount = table
+    .getVisibleLeafColumns()
+    .filter((column) => column.getCanHide()).length;
 
   return (
     <div className="flex items-center gap-3 border-b px-3 py-2">

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -92,7 +92,7 @@ export function Toolbar(): JSX.Element {
         <SearchIcon className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2" />
         <Input
           aria-label="Search organizations"
-          placeholder="Search by name or slug..."
+          placeholder="Search by name, slug or id..."
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           className="w-full py-1.5 pr-2 pl-8"

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { Column, RowData } from "@tanstack/react-table";
 import { SearchIcon } from "lucide-react";
-import { useEffect, useState, type JSX, type ReactNode } from "react";
+import { useEffect, useState, type JSX } from "react";
 
 import type {
   DataTableFeatures,
@@ -139,10 +139,8 @@ export function Toolbar(): JSX.Element {
  */
 export function TableActionBar<T extends RowData>({
   table,
-  hint,
 }: {
   table: DataTableInstance<T>;
-  hint?: ReactNode;
 }): JSX.Element {
   // Read off the table rather than walked a second time here, so the menu
   // cannot disagree with the table about how many columns are left.
@@ -152,7 +150,6 @@ export function TableActionBar<T extends RowData>({
     <div className="flex items-center gap-3 border-b px-3 py-2">
       <span className="text-muted-foreground text-xs">Nothing selected</span>
       <span className="flex-1" />
-      {hint}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="xs">

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -7,7 +7,7 @@ import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 import { cn } from "@/lib/utils";
 
-import { PeekTrigger } from "./rowActions";
+import { PeekTrigger } from "./PeekTrigger";
 
 function fmtDateShort(iso?: string): string {
   if (!iso) return "-";

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -7,6 +7,8 @@ import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 import { cn } from "@/lib/utils";
 
+import { PeekTrigger } from "./rowActions";
+
 function fmtDateShort(iso?: string): string {
   if (!iso) return "-";
   const d = new Date(iso);
@@ -20,6 +22,17 @@ const column = createColumnHelper<DataTableFeatures, AdminOrganization>();
 // table does not rebuild its column model on every render. The header of each
 // column doubles as its label in the Columns control.
 export const ORG_COLUMNS = column.columns([
+  // First, not last: peek hides five columns while it is open, so a trailing
+  // control would slide sideways at the moment the operator is using it.
+  column.display({
+    id: "peek",
+    // A plain string, so the Columns control lists it as "Peek" rather than
+    // falling back to the column id.
+    header: "Peek",
+    // Hiding the control would put peek back out of reach of the keyboard.
+    enableHiding: false,
+    cell: ({ row }) => <PeekTrigger org={row.original} />,
+  }),
   column.accessor("name", {
     header: "Name",
     // The link, not the row, carries the keyboard path and the accessible

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -188,6 +188,18 @@ function peekPanel(): HTMLElement {
   return screen.getByRole("complementary", { name: "Organization peek" });
 }
 
+function liveRegion(): HTMLElement {
+  return screen.getByRole("status");
+}
+
+// The region carries a zero-width space on every other announcement, so that a
+// sentence repeated word for word still changes the text node. Stripped here:
+// these assertions are about what is announced, not about the marker that
+// makes an unchanged sentence announceable.
+function announcement(): string {
+  return (liveRegion().textContent ?? "").replaceAll("\u200b", "");
+}
+
 function isPeeked(link: HTMLElement): boolean {
   return rowFor(link).classList.contains("bg-muted");
 }
@@ -613,9 +625,7 @@ describe("organizations list peek", () => {
     ).toBeTruthy();
     // Nothing else speaks when the panel already holds the focus and the
     // record under it changes.
-    expect(screen.getByRole("status").textContent).toBe(
-      `Peeking at ${SECOND_ORG.name}.`,
-    );
+    expect(announcement()).toBe(`Peeking at ${SECOND_ORG.name}.`);
     expect(isPeeked(screen.getByRole("link", { name: SECOND_ORG.name }))).toBe(
       true,
     );
@@ -799,7 +809,7 @@ describe("organizations list peek", () => {
     expect(
       screen.queryByRole("complementary", { name: "Organization peek" }),
     ).toBeNull();
-    expect(screen.getByRole("status").textContent).toBe("Peek closed.");
+    expect(announcement()).toBe("Peek closed.");
   });
 
   it("activating another row's control moves the peek to that row", async () => {
@@ -813,9 +823,7 @@ describe("organizations list peek", () => {
     expect(
       within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
     ).toBeTruthy();
-    expect(screen.getByRole("status").textContent).toBe(
-      `Peeking at ${SECOND_ORG.name}.`,
-    );
+    expect(announcement()).toBe(`Peeking at ${SECOND_ORG.name}.`);
   });
 
   it("the control reports whether its own panel is open", async () => {
@@ -848,13 +856,48 @@ describe("organizations list peek", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  it("announces a move onto an organization that shares the peeked one's name", async () => {
+    // Names are not unique. Two records, one name, so both announcements are
+    // the same sentence word for word.
+    const TWIN: AdminOrganization = {
+      ...SECOND_ORG,
+      id: "org_placeholder_twin",
+      slug: "placeholder-twin",
+      name: FIRST_ORG.name,
+    };
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: [FIRST_ORG, TWIN],
+    });
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const [first, twin] = await screen.findAllByRole("button", {
+      name: `Peek at ${FIRST_ORG.name}`,
+    });
+    if (!first || !twin) throw new Error("both rows need a control");
+
+    fireEvent.click(first);
+    const spoken = liveRegion().textContent;
+
+    fireEvent.click(twin);
+
+    // The panel moved to the other record.
+    expect(twin.getAttribute("aria-expanded")).toBe("true");
+    expect(first.getAttribute("aria-expanded")).toBe("false");
+    expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
+
+    // A live region speaks when its text changes. Set the same string twice
+    // and the DOM never moves, so the operator hears nothing at all while the
+    // panel in front of them swaps records.
+    expect(liveRegion().textContent).not.toBe(spoken);
+  });
+
   it("keeps an empty status region on the page before anything is peeked", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     await screen.findByRole("link", { name: FIRST_ORG.name });
 
     // A live region injected together with its text is not reliably announced,
     // so the region has to be on the page before it has anything to say.
-    expect(screen.getByRole("status").textContent).toBe("");
+    expect(announcement()).toBe("");
   });
 
   it("alt-clicking a row opens the organization rather than peeking at it", async () => {
@@ -931,7 +974,7 @@ describe("organizations list peek", () => {
       true,
     );
     // Worded apart from an operator's own close, which says nothing about why.
-    expect(screen.getByRole("status").textContent).toBe(
+    expect(announcement()).toBe(
       `Peek closed. ${FIRST_ORG.name} is no longer in the list.`,
     );
   });

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -918,6 +918,66 @@ describe("organizations list peek", () => {
     ).toHaveLength(1);
   });
 
+  it("carries the keyboard along when the arrow keys move the peek off a control", async () => {
+    // Three rows, because the trap only shows on the second press: the first
+    // move works and leaves the keyboard behind on the row it moved off.
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: [FIRST_ORG, SECOND_ORG, NEXT_PAGE_ORG],
+    });
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    // The control the peek moved to, or the next press meets the guard that
+    // keeps other rows' controls out of this handler and the operator is
+    // stuck on a control that answers nothing.
+    const second = await peekTrigger(SECOND_ORG.name);
+    expect(document.activeElement).toBe(second);
+
+    fireEvent.keyDown(second, { key: "ArrowDown" });
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: NEXT_PAGE_ORG.name }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(await peekTrigger(NEXT_PAGE_ORG.name));
+  });
+
+  it("closes on Escape after the arrow keys have moved the peek", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(FIRST_ORG.name);
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    const second = await peekTrigger(SECOND_ORG.name);
+    fireEvent.keyDown(second, { key: "Escape" });
+
+    // Escape has to keep working from wherever the arrow keys left the
+    // operator. A keyboard that can move but cannot close is trapped.
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+  });
+
+  it("leaves the keyboard in the panel when the arrow keys come from the panel", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    // The panel takes the focus on mount, and this is the panel's own record
+    // navigation.
+    expect(document.activeElement).toBe(peekPanel());
+
+    fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
+
+    // Following the peek out to the row control here would take the operator
+    // off the record they are reading and out of the panel they opened.
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(peekPanel());
+  });
+
   it("ignores the arrow keys on a control that is not the peeked row's", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     await peekOn(FIRST_ORG.name);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -594,7 +594,7 @@ describe("organizations list peek", () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
     });
-    const trigger = await peekOn(FIRST_ORG.name);
+    await peekOn(FIRST_ORG.name);
 
     expect(
       within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
@@ -602,10 +602,6 @@ describe("organizations list peek", () => {
     // The row's click handler navigates, and the control sits inside the row.
     // A control that let the click through would leave the list entirely.
     expect(router.state.location.pathname).toBe("/organizations");
-
-    // happy-dom synthesises no click from Enter or Space, so the element type
-    // is what proves the keyboard can operate this control at all.
-    expect(trigger.tagName).toBe("BUTTON");
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
@@ -824,7 +820,7 @@ describe("organizations list peek", () => {
     ]);
   });
 
-  it("activating the control twice closes the panel again", async () => {
+  it("closes the panel again when the same control is activated twice", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
     const trigger = await peekOn(FIRST_ORG.name);
@@ -838,7 +834,7 @@ describe("organizations list peek", () => {
     expect(announcement()).toBe("Peek closed.");
   });
 
-  it("activating another row's control moves the peek to that row", async () => {
+  it("moves the peek to another row when that row's control is activated", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
     await peekOn(FIRST_ORG.name);
@@ -852,7 +848,7 @@ describe("organizations list peek", () => {
     expect(announcement()).toBe(`Peeking at ${SECOND_ORG.name}.`);
   });
 
-  it("the control reports whether its own panel is open", async () => {
+  it("reports on each control whether its own panel is open", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
     const trigger = await peekOn(FIRST_ORG.name);
@@ -867,7 +863,7 @@ describe("organizations list peek", () => {
     expect(other.hasAttribute("aria-controls")).toBe(false);
   });
 
-  it("closing puts the keyboard back on the control that opened it", async () => {
+  it("returns the keyboard to the control that opened the panel", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
     const trigger = await peekOn(FIRST_ORG.name);
@@ -880,6 +876,16 @@ describe("organizations list peek", () => {
     );
 
     expect(document.activeElement).toBe(trigger);
+  });
+
+  it("gives the keyboard a control it can operate", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekTrigger(FIRST_ORG.name);
+
+    // A proxy, and an honest one: happy-dom synthesises no click from Enter
+    // or Space, so pressing them here proves nothing either way. The element
+    // type is what a browser reads to decide whether it should.
+    expect(trigger.tagName).toBe("BUTTON");
   });
 
   it("marks the open control apart from every other one", async () => {
@@ -1025,7 +1031,7 @@ describe("organizations list peek", () => {
     expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
   });
 
-  it("alt-clicking a row opens the organization rather than peeking at it", async () => {
+  it("opens the organization on an alt-click rather than peeking at it", async () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
     });

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -966,15 +966,18 @@ describe("organizations list peek", () => {
 // it a two column table rather than by clicking seven items shut through a
 // menu that closes each time.
 describe("TableActionBar", () => {
-  // Sliced, so the array carries the element type useTable asks for. Past the
-  // peek column, which opts out of hiding: the cases below are about the two
-  // rules the bar itself applies.
+  // Sliced, so the array carries the element type useTable asks for. Two data
+  // columns for the cases about the bar's own two rules, and the peek column
+  // beside one of them for the case where an unhideable column is in the count.
   const MENU_COLUMNS = ORG_COLUMNS.slice(1, 3);
+  const WITH_PEEK_COLUMN = ORG_COLUMNS.slice(0, 2);
 
   // Destructured off the tuple rather than off the slice, which widens each
   // element back to a bare column definition.
-  const [, FIRST, SECOND] = ORG_COLUMNS;
-  if (!FIRST || !SECOND) throw new Error("ORG_COLUMNS needs three columns");
+  const [PEEK, FIRST, SECOND, THIRD] = ORG_COLUMNS;
+  if (!PEEK || !FIRST || !SECOND || !THIRD) {
+    throw new Error("ORG_COLUMNS needs four columns");
+  }
 
   // An accessor column takes its id from its key unless it names one, and that
   // id is what the visibility state is keyed by.
@@ -1089,11 +1092,30 @@ describe("TableActionBar", () => {
     expect(itemFor(FIRST.header).getAttribute("aria-checked")).toBe("false");
   });
 
+  it("stops the operator hiding the last column that carries data", () => {
+    // Peek and Name, both visible. Peek opts out of hiding, so it is on screen
+    // whatever the operator does and it is not the column that keeps the table
+    // readable. Counting it would leave Name free to go, and the table behind
+    // this menu would be a strip of controls above rows holding no record.
+    const onVisibilityChange = openColumnsMenu({}, WITH_PEEK_COLUMN);
+
+    const item = itemFor(FIRST.header);
+    fireEvent.click(item);
+
+    expect(onVisibilityChange).not.toHaveBeenCalled();
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    // The peek column is locked too, by its own opt-out rather than by this
+    // rule, so the operator cannot reach the same state from the other side.
+    expect(itemFor(PEEK.header).getAttribute("aria-disabled")).toBe("true");
+  });
+
   it("locks a column that opts out of hiding", () => {
-    // Both are visible, so the last-column rule is not what holds this one.
+    // Three visible, two of them hideable, so the last-data-column rule is not
+    // what holds this one and hiding the next one along is still allowed.
     const onVisibilityChange = openColumnsMenu({}, [
       { ...FIRST, enableHiding: false },
       SECOND,
+      THIRD,
     ]);
 
     const item = itemFor(FIRST.header);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -171,10 +171,17 @@ function rowFor(link: HTMLElement): HTMLTableRowElement {
   return row;
 }
 
-function peekOn(link: HTMLElement): void {
-  const cell = within(rowFor(link)).getAllByRole("cell").at(-1);
-  if (!cell) throw new Error("the row needs a cell to click");
-  fireEvent.click(cell, { altKey: true });
+// Found by the accessible name a screen reader announces, so the test reaches
+// the control the way an operator does. Waiting on it is also waiting for the
+// rows, and it is present whether or not the name column is visible.
+function peekTrigger(name: string): Promise<HTMLElement> {
+  return screen.findByRole("button", { name: `Peek at ${name}` });
+}
+
+async function peekOn(name: string): Promise<HTMLElement> {
+  const trigger = await peekTrigger(name);
+  fireEvent.click(trigger);
+  return trigger;
 }
 
 function peekPanel(): HTMLElement {
@@ -458,6 +465,7 @@ describe("organizations list", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      "Peek",
       "Name",
       "Slug",
       "Type",
@@ -472,6 +480,8 @@ describe("organizations list", () => {
         .getAllByRole("cell")
         .map((cell) => cell.textContent),
     ).toEqual([
+      // The peek control carries an icon and its name is on the button.
+      "",
       FIRST_ORG.name,
       FIRST_ORG.slug,
       FIRST_ORG.account_type,
@@ -491,8 +501,10 @@ describe("organizations list", () => {
     });
 
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    const [, slugCell] = within(rowFor(link)).getAllByRole("cell");
-    if (!slugCell) throw new Error("the row needs a second cell");
+    // Past the peek control and the name link, so the click lands on the row
+    // body rather than on something that handles it first.
+    const [, , slugCell] = within(rowFor(link)).getAllByRole("cell");
+    if (!slugCell) throw new Error("the row needs a third cell");
 
     fireEvent.click(slugCell);
 
@@ -559,25 +571,29 @@ describe("organizations list peek", () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
     });
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-
-    peekOn(link);
+    const trigger = await peekOn(FIRST_ORG.name);
 
     expect(
       within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
     ).toBeTruthy();
+    // The row's click handler navigates, and the control sits inside the row.
+    // A control that let the click through would leave the list entirely.
     expect(router.state.location.pathname).toBe("/organizations");
+
+    // happy-dom synthesises no click from Enter or Space, so the element type
+    // is what proves the keyboard can operate this control at all.
+    expect(trigger.tagName).toBe("BUTTON");
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Slug", "Type"]);
+    ).toEqual(["Peek", "Name", "Slug", "Type"]);
   });
 
   it("highlights the row it is peeking at and no other", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
 
-    peekOn(link);
+    await peekOn(FIRST_ORG.name);
 
     expect(isPeeked(link)).toBe(true);
     expect(isPeeked(screen.getByRole("link", { name: SECOND_ORG.name }))).toBe(
@@ -588,13 +604,18 @@ describe("organizations list peek", () => {
   it("walks peek down the list and stops at the last row", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
 
     expect(
       within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
     ).toBeTruthy();
+    // Nothing else speaks when the panel already holds the focus and the
+    // record under it changes.
+    expect(screen.getByRole("status").textContent).toBe(
+      `Peeking at ${SECOND_ORG.name}.`,
+    );
     expect(isPeeked(screen.getByRole("link", { name: SECOND_ORG.name }))).toBe(
       true,
     );
@@ -608,8 +629,7 @@ describe("organizations list peek", () => {
 
   it("walks peek back up the list and stops at the first row", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const second = await screen.findByRole("link", { name: SECOND_ORG.name });
-    peekOn(second);
+    await peekOn(SECOND_ORG.name);
 
     fireEvent.keyDown(peekPanel(), { key: "ArrowUp" });
     expect(
@@ -624,8 +644,7 @@ describe("organizations list peek", () => {
 
   it("scrolls the row peek moves to into view", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     const second = rowFor(screen.getByRole("link", { name: SECOND_ORG.name }));
     const scrollIntoView = vi.spyOn(second, "scrollIntoView");
@@ -635,19 +654,16 @@ describe("organizations list peek", () => {
     expect(scrollIntoView).toHaveBeenCalled();
   });
 
-  it("closes on Escape and puts focus back on the row's name link", async () => {
+  it("closes on Escape and puts the keyboard back on the control", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(link);
+    const trigger = await peekOn(FIRST_ORG.name);
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
     expect(
       screen.queryByRole("complementary", { name: "Organization peek" }),
     ).toBeNull();
-    expect(document.activeElement).toBe(
-      screen.getByRole("link", { name: FIRST_ORG.name }),
-    );
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("gives the operator's own column visibility back when peek closes", async () => {
@@ -659,17 +675,17 @@ describe("organizations list peek", () => {
       expect(screen.queryByRole("columnheader", { name: "Slug" })).toBeNull();
     });
 
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(link);
+    await peekOn(FIRST_ORG.name);
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Type"]);
+    ).toEqual(["Peek", "Name", "Type"]);
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      "Peek",
       "Name",
       "Type",
       "Members",
@@ -690,14 +706,13 @@ describe("organizations list peek", () => {
     });
     expect(screen.queryByRole("columnheader", { name: "Name" })).toBeNull();
 
-    // The name link is gone with the column, so the row is reached by its slug.
-    const row = screen.getByText(FIRST_ORG.slug).closest("tr");
-    if (!row) throw new Error("the slug cell is not inside a row");
-    fireEvent.click(row, { altKey: true });
+    // The name link is gone with the column, and the control is not: it names
+    // the organization itself, so it is still reachable by that name.
+    await peekOn(FIRST_ORG.name);
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Slug", "Type"]);
+    ).toEqual(["Peek", "Name", "Slug", "Type"]);
     expect(screen.getByRole("link", { name: FIRST_ORG.name })).toBeTruthy();
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
@@ -709,7 +724,7 @@ describe("organizations list peek", () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
     const second = screen.getByRole("link", { name: SECOND_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     openOn(screen.getByRole("button", { name: "Columns" }));
     fireEvent.keyDown(screen.getByRole("menuitemcheckbox", { name: "Name" }), {
@@ -723,7 +738,7 @@ describe("organizations list peek", () => {
   it("leaves Escape to the Columns menu while it is open", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     openOn(screen.getByRole("button", { name: "Columns" }));
     fireEvent.keyDown(screen.getByRole("menuitemcheckbox", { name: "Name" }), {
@@ -743,8 +758,7 @@ describe("organizations list peek", () => {
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(link);
+    await peekOn(FIRST_ORG.name);
     expect(peekPanel()).toBeTruthy();
 
     const next = await screen.findByRole("button", { name: "Next" });
@@ -762,6 +776,7 @@ describe("organizations list peek", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      "Peek",
       "Name",
       "Slug",
       "Type",
@@ -772,21 +787,198 @@ describe("organizations list peek", () => {
       "Created",
     ]);
   });
+
+  it("activating the control twice closes the panel again", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    expect(peekPanel()).toBeTruthy();
+
+    fireEvent.click(trigger);
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Peek closed.");
+  });
+
+  it("activating another row's control moves the peek to that row", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await peekOn(FIRST_ORG.name);
+    await peekOn(SECOND_ORG.name);
+
+    // A toggle keyed on "some panel is open" rather than on this row would
+    // close the panel here instead of moving it.
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe(
+      `Peeking at ${SECOND_ORG.name}.`,
+    );
+  });
+
+  it("the control reports whether its own panel is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(other.getAttribute("aria-expanded")).toBe("false");
+
+    // Set only while the panel exists: aria-controls pointing at an absent id
+    // is invalid, so the row that is not peeked carries none.
+    expect(trigger.getAttribute("aria-controls")).toBe(peekPanel().id);
+    expect(other.hasAttribute("aria-controls")).toBe(false);
+  });
+
+  it("closing puts the keyboard back on the control that opened it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    // The panel takes the focus on mount, which is what puts Escape and the
+    // arrow keys within reach of the handler above the table.
+    expect(document.activeElement).toBe(peekPanel());
+
+    fireEvent.click(
+      within(peekPanel()).getByRole("button", { name: "Close peek" }),
+    );
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("keeps an empty status region on the page before anything is peeked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // A live region injected together with its text is not reliably announced,
+    // so the region has to be on the page before it has anything to say.
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it("alt-clicking a row opens the organization rather than peeking at it", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    const [, , slugCell] = within(rowFor(link)).getAllByRole("cell");
+    if (!slugCell) throw new Error("the row needs a third cell");
+
+    // The gesture is gone: browsers read Alt-click on an anchor as "save
+    // link", and the row's own handler carries no branch for it any more.
+    fireEvent.click(slugCell, { altKey: true });
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        `/organizations/${FIRST_ORG.slug}`,
+      );
+    });
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+  });
+
+  it("will not let the Columns menu hide the control", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    const item = screen.getByRole("menuitemcheckbox", { name: "Peek" });
+    fireEvent.click(item);
+
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    expect(item.getAttribute("aria-checked")).toBe("true");
+
+    // A locked item leaves the menu open, and an open Radix menu hides the
+    // rest of the page from the accessibility tree.
+    fireEvent.keyDown(item, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("columnheader", { name: "Peek" })).toBeTruthy();
+    });
+    expect(await peekTrigger(FIRST_ORG.name)).toBeTruthy();
+  });
+
+  it("puts the keyboard on the table, not on the body, when the peeked record leaves the list", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await peekOn(FIRST_ORG.name);
+    // The panel holds the focus, and it is about to unmount under it.
+    expect(document.activeElement).toBe(peekPanel());
+
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    // The scroll box around the table, reached through the table it holds
+    // rather than by class: it is the nearest thing to where the operator was.
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(document.body);
+    });
+    expect(document.activeElement?.contains(screen.getByRole("table"))).toBe(
+      true,
+    );
+    // Worded apart from an operator's own close, which says nothing about why.
+    expect(screen.getByRole("status").textContent).toBe(
+      `Peek closed. ${FIRST_ORG.name} is no longer in the list.`,
+    );
+  });
+
+  it("leaves the keyboard on the pager when the operator pages the peeked record away", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG], next_cursor: "cursor_page_three" }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await peekOn(FIRST_ORG.name);
+
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    // The operator drove this from the pager, so their focus is already on a
+    // live control. An unguarded rescue would take it off them.
+    next.focus();
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    expect(document.activeElement).toBe(next);
+  });
 });
 
 // The bar takes a table, so the last-column case is reachable here by handing
 // it a two column table rather than by clicking seven items shut through a
 // menu that closes each time.
 describe("TableActionBar", () => {
-  const [FIRST, SECOND] = ORG_COLUMNS;
-  if (!FIRST || !SECOND) throw new Error("ORG_COLUMNS needs two columns");
+  // Sliced, so the array carries the element type useTable asks for. Past the
+  // peek column, which opts out of hiding: the cases below are about the two
+  // rules the bar itself applies.
+  const MENU_COLUMNS = ORG_COLUMNS.slice(1, 3);
+
+  // Destructured off the tuple rather than off the slice, which widens each
+  // element back to a bare column definition.
+  const [, FIRST, SECOND] = ORG_COLUMNS;
+  if (!FIRST || !SECOND) throw new Error("ORG_COLUMNS needs three columns");
 
   // An accessor column takes its id from its key unless it names one, and that
   // id is what the visibility state is keyed by.
   const SECOND_ID = String(SECOND.id ?? SECOND.accessorKey);
-
-  // Sliced, so the array carries the element type useTable asks for.
-  const MENU_COLUMNS = ORG_COLUMNS.slice(0, 2);
 
   function ColumnsMenu({
     initialVisibility,

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -856,6 +856,36 @@ describe("organizations list peek", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  it("marks the open control apart from every other one", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+
+    // The variant, not the classes it expands to. Peek hides the name column
+    // it opened from, so the fill is the only thing left on screen that says
+    // which control the panel belongs to, and the ghost hover token and the
+    // peeked row token are the same grey in this theme.
+    expect(trigger.getAttribute("data-variant")).toBe("default");
+    expect(other.getAttribute("data-variant")).toBe("ghost");
+  });
+
+  it("describes the control to an operator who is not using a screen reader", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekTrigger(FIRST_ORG.name);
+
+    // An icon on its own says nothing to a sighted operator, and the label
+    // this replaces only ever announced itself to a screen reader.
+    fireEvent.focus(trigger);
+
+    const tip = await screen.findByRole("tooltip");
+    expect(tip.textContent).toBe("Peek without leaving the list");
+    // Describing the control must not rename it.
+    expect(
+      screen.getAllByRole("button", { name: `Peek at ${FIRST_ORG.name}` }),
+    ).toHaveLength(1);
+  });
+
   it("ignores the arrow keys on a control that is not the peeked row's", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     await peekOn(FIRST_ORG.name);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -247,6 +247,17 @@ describe("organizations list", () => {
     expect(lastListParams().q).toBe("acme");
   });
 
+  it("offers an id as a term the search box takes", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const input = screen.getByLabelText("Search organizations");
+
+    // The label names the target, not the terms, and it is pinned elsewhere
+    // because a screen reader announces it. An operator holding an
+    // organization id has only the placeholder to tell them it will match.
+    expect((input as HTMLInputElement).placeholder).toMatch(/\bid\b/i);
+  });
+
   it("holds a keystroke out of the URL until the debounce elapses", async () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
@@ -661,7 +672,9 @@ describe("organizations list peek", () => {
 
     fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
 
-    expect(scrollIntoView).toHaveBeenCalled();
+    // With the argument. `block: "center"` also counts as called, and it
+    // re-centres the whole list under every arrow press.
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
   });
 
   it("closes on Escape and puts the keyboard back on the control", async () => {
@@ -673,6 +686,19 @@ describe("organizations list peek", () => {
     expect(
       screen.queryByRole("complementary", { name: "Organization peek" }),
     ).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("returns the keyboard to the control of whichever row was peeked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(SECOND_ORG.name);
+
+    fireEvent.keyDown(peekPanel(), { key: "Escape" });
+
+    // The second row on purpose. A close that looks the control up across the
+    // whole page instead of inside the peeked row finds the first row's one,
+    // and every other focus test here peeks the first row, so it passes on
+    // luck and sends an operator who peeked row 40 back to row 1.
     expect(document.activeElement).toBe(trigger);
   });
 
@@ -979,6 +1005,26 @@ describe("organizations list peek", () => {
     expect(announcement()).toBe("");
   });
 
+  it("announces through one polite region that outlives every announcement", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const region = await screen.findByRole("status");
+
+    // Polite, or nothing is spoken at all and every assertion in this file
+    // about what the region says reads a dead feature's DOM text.
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    // Off screen. Otherwise the announcements pile up as stray text above the
+    // table, where a sighted operator reads them and nobody asked for them.
+    expect(region.classList.contains("sr-only")).toBe(true);
+
+    await peekOn(FIRST_ORG.name);
+
+    // The same node. A region that arrives together with its text is not
+    // announced, and a region keyed by its own text is a new one every time,
+    // which is the same defect wearing a different hat.
+    expect(liveRegion()).toBe(region);
+    expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
+  });
+
   it("alt-clicking a row opens the organization rather than peeking at it", async () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
@@ -1052,6 +1098,16 @@ describe("organizations list peek", () => {
     expect(document.activeElement?.contains(screen.getByRole("table"))).toBe(
       true,
     );
+    // happy-dom focuses elements a browser will not, so "activeElement moved"
+    // is no evidence that focus could land there at all. Every focus
+    // assertion in this file has to check the target is focusable in its own
+    // right, and this is that check.
+    expect(document.activeElement?.getAttribute("tabindex")).toBe("-1");
+    // The box around the table and nothing wider. `contains(table)` is true
+    // of every ancestor up to the document, so a rescue that landed on the
+    // wrapper holding the pager would satisfy the line above and drop the
+    // operator somewhere they can no longer see the record they lost.
+    expect(document.activeElement?.contains(next)).toBe(false);
     // Named, or the operator arrives somewhere their screen reader announces
     // as nothing at all.
     expect(document.activeElement).toBe(

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -856,6 +856,55 @@ describe("organizations list peek", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  it("ignores the arrow keys on a control that is not the peeked row's", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+
+    // An operator on another row's control presses this to scroll. Answering
+    // it would move the panel away from where they are looking, swallow the
+    // scroll, and leave them on a control still reporting itself closed.
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    other.dispatchEvent(event);
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("ignores Escape on a control that is not the peeked row's", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+    other.focus();
+
+    fireEvent.keyDown(other, { key: "Escape" });
+
+    // Closing from here would pull the keyboard onto the peeked row, which is
+    // a place the operator did not ask to go.
+    expect(peekPanel()).toBeTruthy();
+    expect(document.activeElement).toBe(other);
+  });
+
+  it("still closes on Escape pressed on the peeked row's own control", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(FIRST_ORG.name);
+    trigger.focus();
+
+    // The exemption has to be this narrow, or closing from the control that
+    // opened the panel stops working.
+    fireEvent.keyDown(trigger, { key: "Escape" });
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+  });
+
   it("announces a move onto an organization that shares the peeked one's name", async () => {
     // Names are not unique. Two records, one name, so both announcements are
     // the same sentence word for word.
@@ -972,6 +1021,11 @@ describe("organizations list peek", () => {
     });
     expect(document.activeElement?.contains(screen.getByRole("table"))).toBe(
       true,
+    );
+    // Named, or the operator arrives somewhere their screen reader announces
+    // as nothing at all.
+    expect(document.activeElement).toBe(
+      screen.getByRole("region", { name: "Organizations table" }),
     );
     // Worded apart from an operator's own close, which says nothing about why.
     expect(announcement()).toBe(

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -226,7 +226,6 @@ export function OrganizationsList(): JSX.Element {
     [peekedId, closePeek, openPeek],
   );
 
-  // Memoised, or every trigger cell re-renders on every render of the list.
   const peekControls = useMemo(
     () => ({ peekedId, togglePeek }),
     [peekedId, togglePeek],
@@ -288,8 +287,8 @@ export function OrganizationsList(): JSX.Element {
           {announcement.count % 2 === 1 ? ZERO_WIDTH_SPACE : ""}
         </div>
 
-        {/* Stretch, so the panel takes its height from the row. */}
         <PeekProvider value={peekControls}>
+          {/* Stretch, so the panel takes its height from the row. */}
           <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
             <div className="flex min-h-0 min-w-0 flex-1 flex-col">
               <div className="flex min-h-0 flex-1 flex-col rounded-lg border">

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -91,6 +91,10 @@ export function OrganizationsList(): JSX.Element {
   // Raised while rendering, read by the effect that rescues the keyboard.
   const [peekedRecordLeft, setPeekedRecordLeft] = useState(false);
 
+  // Raised by an arrow move that started on a peek control, read by the effect
+  // that follows the peek to the next row's control.
+  const [peekTookTheKeyboard, setPeekTookTheKeyboard] = useState(false);
+
   const announce = useCallback((text: string): void => {
     setAnnouncement((previous) => ({ text, count: previous.count + 1 }));
   }, []);
@@ -198,6 +202,22 @@ export function OrganizationsList(): JSX.Element {
     }
   }, [peekedRecordLeft]);
 
+  // After the commit, because the row the peek moved to is drawn in it and the
+  // ref only points at that row once it is. Same lookup the close path makes,
+  // through the peeked row rather than across the page.
+  //
+  // A screen reader announces the control focus lands on, which repeats what
+  // the live region is politely saying at the same moment. The repeat is
+  // wanted: the two carry the same organization name, so whichever one the
+  // reader drops, the operator still hears where the panel went.
+  useEffect(() => {
+    if (!peekTookTheKeyboard) return;
+    setPeekTookTheKeyboard(false);
+    peekedRow.current
+      ?.querySelector<HTMLElement>(PEEK_TRIGGER_SELECTOR)
+      ?.focus();
+  }, [peekTookTheKeyboard]);
+
   const closePeek = useCallback((): void => {
     const trigger = peekedRow.current?.querySelector<HTMLElement>(
       PEEK_TRIGGER_SELECTOR,
@@ -240,10 +260,11 @@ export function OrganizationsList(): JSX.Element {
     // standing on a control that still reports itself closed. Escape there
     // would drag the keyboard back to the peeked row. The peeked row's own
     // control is exempt: that one is the panel's control.
-    if (event.target instanceof HTMLElement) {
-      const trigger = event.target.closest(PEEK_TRIGGER_SELECTOR);
-      if (trigger && !peekedRow.current?.contains(trigger)) return;
-    }
+    const fromTrigger =
+      event.target instanceof HTMLElement
+        ? event.target.closest(PEEK_TRIGGER_SELECTOR)
+        : null;
+    if (fromTrigger && !peekedRow.current?.contains(fromTrigger)) return;
 
     if (event.key === "Escape") {
       event.preventDefault();
@@ -258,6 +279,15 @@ export function OrganizationsList(): JSX.Element {
     if (!next) return;
     event.preventDefault();
     openPeek(next.original);
+    // Only where the operator was already on a control. The peek moves out
+    // from under this one, and the exemption above is written in terms of the
+    // peeked row, so leaving the keyboard behind would strand it on a control
+    // that answers neither the arrow keys nor Escape.
+    //
+    // Focus stays put for anyone arrowing from inside the panel. That is the
+    // panel's own navigation, and pulling the keyboard out to a row control
+    // would take the operator off the record they are reading.
+    if (fromTrigger) setPeekTookTheKeyboard(true);
   };
 
   return (

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -2,13 +2,13 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearch } from "@tanstack/react-router";
 import { useTable, type ColumnVisibilityState } from "@tanstack/react-table";
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
   type JSX,
   type KeyboardEvent,
-  type MouseEvent,
 } from "react";
 
 import { dataTableFeatures, DataTable as Table } from "@/components/data-table";
@@ -24,7 +24,11 @@ import { cn } from "@/lib/utils";
 
 import { ORG_COLUMNS } from "./columns";
 import { PeekPanel } from "./PeekPanel";
-import { useOpenOrganization } from "./rowActions";
+import {
+  PEEK_TRIGGER_SELECTOR,
+  PeekProvider,
+  useOpenOrganization,
+} from "./rowActions";
 import { TableActionBar, Toolbar } from "./Toolbar";
 
 const ROUTE_ID = "/organizations/";
@@ -38,20 +42,6 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   free_trial_ends_at: false,
   created_at: false,
 };
-
-// Mac labels this key Option; everything else calls it Alt.
-const PEEK_KEY = navigator.userAgent.includes("Mac") ? "\u2325 Option" : "Alt";
-
-function PeekHint(): JSX.Element {
-  return (
-    <span className="text-muted-foreground hidden items-center gap-1 text-xs sm:flex">
-      <kbd className="bg-muted rounded border px-1.5 py-0.5 font-sans text-[11px] leading-none">
-        {PEEK_KEY}
-      </kbd>
-      + click a row to peek
-    </span>
-  );
-}
 
 const ARROW_STEP: Record<string, number | undefined> = {
   ArrowDown: 1,
@@ -79,9 +69,21 @@ export function OrganizationsList(): JSX.Element {
   const [columnVisibility, setColumnVisibility] =
     useState<ColumnVisibilityState>({});
 
-  // An id, not the record: a page or filter change replaces every row.
-  const [peekedId, setPeekedId] = useState<string>();
+  // An id and a name, not the record: a page or filter change replaces every
+  // row, and the panel renders from the live row. The name is carried only to
+  // word the announcement for a record that has already left the list.
+  const [peek, setPeek] = useState<{ id: string; name: string }>();
+  const peekedId = peek?.id;
   const peekedRow = useRef<HTMLTableRowElement>(null);
+  const scrollBox = useRef<HTMLDivElement>(null);
+
+  // Mounted for the life of the page. A live region that arrives in the same
+  // commit as its text is not reliably announced: the element has to be in the
+  // accessibility tree first.
+  const [announcement, setAnnouncement] = useState("");
+
+  // Raised while rendering, read by the effect that rescues the keyboard.
+  const [peekedRecordLeft, setPeekedRecordLeft] = useState(false);
 
   // One object is the source of both the request and the signature below. Two
   // hand-written lists drift: a slice that adds a filter to the request would
@@ -165,31 +167,57 @@ export function OrganizationsList(): JSX.Element {
   const peeked = peekedIndex === -1 ? undefined : rows[peekedIndex];
 
   // During render, not in an effect: an effect paints a dropped record first.
-  if (peekedId && !peeked) {
-    setPeekedId(undefined);
+  if (peek && !peeked) {
+    setPeek(undefined);
+    setAnnouncement(`Peek closed. ${peek.name} is no longer in the list.`);
+    setPeekedRecordLeft(true);
   }
 
   useEffect(() => {
     peekedRow.current?.scrollIntoView({ block: "nearest" });
   }, [peekedId]);
 
-  const closePeek = (): void => {
-    const link = peekedRow.current?.querySelector("a");
-    setPeekedId(undefined);
-    link?.focus();
-  };
-
-  const handleRowClick = (
-    org: AdminOrganization,
-    event: MouseEvent<HTMLTableRowElement>,
-  ): void => {
-    // Alt, not Meta (the browser's open-in-new-tab) and not Shift (range select).
-    if (event.altKey) {
-      setPeekedId(org.id);
-      return;
+  useEffect(() => {
+    if (!peekedRecordLeft) return;
+    setPeekedRecordLeft(false);
+    // Only where the panel took its focus down with it. An operator who paged
+    // or filtered the record away is already on a live control, and taking
+    // their place in the page is worse than the bug this rescues.
+    if (document.activeElement === document.body) {
+      scrollBox.current?.focus();
     }
-    openOrganization(org);
-  };
+  }, [peekedRecordLeft]);
+
+  const closePeek = useCallback((): void => {
+    const trigger = peekedRow.current?.querySelector<HTMLElement>(
+      PEEK_TRIGGER_SELECTOR,
+    );
+    setPeek(undefined);
+    setAnnouncement("Peek closed.");
+    trigger?.focus();
+  }, []);
+
+  const openPeek = useCallback((org: AdminOrganization): void => {
+    setPeek({ id: org.id, name: org.name });
+    setAnnouncement(`Peeking at ${org.name}.`);
+  }, []);
+
+  const togglePeek = useCallback(
+    (org: AdminOrganization): void => {
+      if (peekedId === org.id) {
+        closePeek();
+        return;
+      }
+      openPeek(org);
+    },
+    [peekedId, closePeek, openPeek],
+  );
+
+  // Memoised, or every trigger cell re-renders on every render of the list.
+  const peekControls = useMemo(
+    () => ({ peekedId, togglePeek }),
+    [peekedId, togglePeek],
+  );
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (!peeked || event.defaultPrevented) return;
@@ -206,7 +234,7 @@ export function OrganizationsList(): JSX.Element {
     const next = rows[peekedIndex + step];
     if (!next) return;
     event.preventDefault();
-    setPeekedId(next.id);
+    openPeek(next.original);
   };
 
   return (
@@ -222,75 +250,90 @@ export function OrganizationsList(): JSX.Element {
           </div>
         )}
 
-        {/* Stretch, so the panel takes its height from the row. */}
-        <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
-              <TableActionBar table={table} hint={<PeekHint />} />
+        {/* The only thing that speaks when the arrow keys swap the record under
+            a panel that already holds the focus. */}
+        <div role="status" className="sr-only">
+          {announcement}
+        </div>
 
-              <div
-                className={cn(
-                  "min-h-0 flex-1 overflow-auto",
-                  isPlaceholderData && "opacity-60",
-                )}
-              >
-                <Table>
-                  <Table.Header table={table} />
-                  <Table.Body>
-                    {rows.length === 0 ? (
-                      <Table.NoResultsMessage>
-                        <span className="text-muted-foreground text-sm">
-                          {emptyStateMessage(isLoading, isError)}
-                        </span>
-                      </Table.NoResultsMessage>
-                    ) : (
-                      rows.map((row) => {
-                        const isPeeked = row.id === peekedId;
-                        return (
-                          <Table.Row
-                            key={row.id}
-                            row={row}
-                            ref={isPeeked ? peekedRow : undefined}
-                            className={cn(isPeeked && "bg-muted")}
-                            onClick={handleRowClick}
-                          />
-                        );
-                      })
-                    )}
-                  </Table.Body>
-                </Table>
+        {/* Stretch, so the panel takes its height from the row. */}
+        <PeekProvider value={peekControls}>
+          <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+              <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
+                <TableActionBar table={table} />
+
+                <div
+                  ref={scrollBox}
+                  // A scroll box has to be reachable by keyboard in its own
+                  // right, and it is where focus lands when the peeked record
+                  // leaves the list with the keyboard on the panel. The focus
+                  // ring stays: nothing else on screen moves when focus
+                  // arrives here, so the ring is the only sign it did.
+                  tabIndex={-1}
+                  className={cn(
+                    "min-h-0 flex-1 overflow-auto",
+                    isPlaceholderData && "opacity-60",
+                  )}
+                >
+                  <Table>
+                    <Table.Header table={table} />
+                    <Table.Body>
+                      {rows.length === 0 ? (
+                        <Table.NoResultsMessage>
+                          <span className="text-muted-foreground text-sm">
+                            {emptyStateMessage(isLoading, isError)}
+                          </span>
+                        </Table.NoResultsMessage>
+                      ) : (
+                        rows.map((row) => {
+                          const isPeeked = row.id === peekedId;
+                          return (
+                            <Table.Row
+                              key={row.id}
+                              row={row}
+                              ref={isPeeked ? peekedRow : undefined}
+                              className={cn(isPeeked && "bg-muted")}
+                              onClick={openOrganization}
+                            />
+                          );
+                        })
+                      )}
+                    </Table.Body>
+                  </Table>
+                </div>
+              </div>
+
+              {/* Inside the table's column, so it does not run under the panel. */}
+              <div className="mt-3 flex items-center justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={isPlaceholderData || pager.stack.length === 0}
+                  onClick={goPrev}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={isPlaceholderData || !data?.next_cursor}
+                  onClick={goNext}
+                >
+                  Next
+                </Button>
               </div>
             </div>
 
-            {/* Inside the table's column, so it does not run under the panel. */}
-            <div className="mt-3 flex items-center justify-end gap-2">
-              <Button
-                variant="ghost"
-                size="xs"
-                disabled={isPlaceholderData || pager.stack.length === 0}
-                onClick={goPrev}
-              >
-                Previous
-              </Button>
-              <Button
-                variant="ghost"
-                size="xs"
-                disabled={isPlaceholderData || !data?.next_cursor}
-                onClick={goNext}
-              >
-                Next
-              </Button>
-            </div>
+            {peeked ? (
+              <PeekPanel
+                org={peeked.original}
+                onClose={closePeek}
+                className="w-100 shrink-0"
+              />
+            ) : null}
           </div>
-
-          {peeked ? (
-            <PeekPanel
-              org={peeked.original}
-              onClose={closePeek}
-              className="w-100 shrink-0"
-            />
-          ) : null}
-        </div>
+        </PeekProvider>
       </section>
     </div>
   );

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -238,6 +238,17 @@ export function OrganizationsList(): JSX.Element {
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (!peeked || event.defaultPrevented) return;
 
+    // Every row's peek control sits under this handler. An arrow key pressed
+    // on one of them is a reflex to scroll, and answering it moves the panel
+    // to a row the operator is not on, eats the scroll, and leaves them
+    // standing on a control that still reports itself closed. Escape there
+    // would drag the keyboard back to the peeked row. The peeked row's own
+    // control is exempt: that one is the panel's control.
+    if (event.target instanceof HTMLElement) {
+      const trigger = event.target.closest(PEEK_TRIGGER_SELECTOR);
+      if (trigger && !peekedRow.current?.contains(trigger)) return;
+    }
+
     if (event.key === "Escape") {
       event.preventDefault();
       closePeek();
@@ -289,11 +300,16 @@ export function OrganizationsList(): JSX.Element {
 
                 <div
                   ref={scrollBox}
-                  // A scroll box has to be reachable by keyboard in its own
-                  // right, and it is where focus lands when the peeked record
-                  // leaves the list with the keyboard on the panel. The focus
-                  // ring stays: nothing else on screen moves when focus
-                  // arrives here, so the ring is the only sign it did.
+                  // Named, because this is where the keyboard lands when the
+                  // peeked record leaves the list with the panel holding the
+                  // focus. An unnamed div would put the operator somewhere
+                  // their screen reader cannot describe.
+                  role="region"
+                  aria-label="Organizations table"
+                  // Programmatic only: -1 takes the box out of the tab order
+                  // and still lets that rescue focus it. The focus ring stays,
+                  // because nothing else on screen moves when focus arrives
+                  // here and the ring is the only sign that it did.
                   tabIndex={-1}
                   className={cn(
                     "min-h-0 flex-1 overflow-auto",

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -43,6 +43,10 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   created_at: false,
 };
 
+// Appended to every other announcement so an unchanged sentence still changes
+// the text node. Zero-width, so nothing is spoken and nothing takes up space.
+const ZERO_WIDTH_SPACE = "\u200b";
+
 const ARROW_STEP: Record<string, number | undefined> = {
   ArrowDown: 1,
   ArrowUp: -1,
@@ -80,10 +84,19 @@ export function OrganizationsList(): JSX.Element {
   // Mounted for the life of the page. A live region that arrives in the same
   // commit as its text is not reliably announced: the element has to be in the
   // accessibility tree first.
-  const [announcement, setAnnouncement] = useState("");
+  //
+  // The count rides along because a region is announced when its text changes.
+  // Organization names are not unique, so the same sentence can be set twice
+  // running; React bails on an equal string, the DOM text never moves, and the
+  // operator hears nothing while the panel visibly swaps records.
+  const [announcement, setAnnouncement] = useState({ text: "", count: 0 });
 
   // Raised while rendering, read by the effect that rescues the keyboard.
   const [peekedRecordLeft, setPeekedRecordLeft] = useState(false);
+
+  const announce = useCallback((text: string): void => {
+    setAnnouncement((previous) => ({ text, count: previous.count + 1 }));
+  }, []);
 
   // One object is the source of both the request and the signature below. Two
   // hand-written lists drift: a slice that adds a filter to the request would
@@ -169,7 +182,7 @@ export function OrganizationsList(): JSX.Element {
   // During render, not in an effect: an effect paints a dropped record first.
   if (peek && !peeked) {
     setPeek(undefined);
-    setAnnouncement(`Peek closed. ${peek.name} is no longer in the list.`);
+    announce(`Peek closed. ${peek.name} is no longer in the list.`);
     setPeekedRecordLeft(true);
   }
 
@@ -193,14 +206,17 @@ export function OrganizationsList(): JSX.Element {
       PEEK_TRIGGER_SELECTOR,
     );
     setPeek(undefined);
-    setAnnouncement("Peek closed.");
+    announce("Peek closed.");
     trigger?.focus();
-  }, []);
+  }, [announce]);
 
-  const openPeek = useCallback((org: AdminOrganization): void => {
-    setPeek({ id: org.id, name: org.name });
-    setAnnouncement(`Peeking at ${org.name}.`);
-  }, []);
+  const openPeek = useCallback(
+    (org: AdminOrganization): void => {
+      setPeek({ id: org.id, name: org.name });
+      announce(`Peeking at ${org.name}.`);
+    },
+    [announce],
+  );
 
   const togglePeek = useCallback(
     (org: AdminOrganization): void => {
@@ -251,9 +267,17 @@ export function OrganizationsList(): JSX.Element {
         )}
 
         {/* The only thing that speaks when the arrow keys swap the record under
-            a panel that already holds the focus. */}
-        <div role="status" className="sr-only">
-          {announcement}
+            a panel that already holds the focus.
+
+            `aria-live` is written out as well as implied by the role: a few
+            screen readers only honour the attribute. The zero-width space
+            alternates with the count so that a sentence set twice running
+            still reaches the accessibility tree as a change. It is not
+            announced, and it is not rendered anywhere a sighted operator
+            reads. */}
+        <div role="status" aria-live="polite" className="sr-only">
+          {announcement.text}
+          {announcement.count % 2 === 1 ? ZERO_WIDTH_SPACE : ""}
         </div>
 
         {/* Stretch, so the panel takes its height from the row. */}

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -24,11 +24,8 @@ import { cn } from "@/lib/utils";
 
 import { ORG_COLUMNS } from "./columns";
 import { PeekPanel } from "./PeekPanel";
-import {
-  PEEK_TRIGGER_SELECTOR,
-  PeekProvider,
-  useOpenOrganization,
-} from "./rowActions";
+import { PEEK_TRIGGER_SELECTOR, PeekProvider } from "./PeekTrigger";
+import { useOpenOrganization } from "./rowActions";
 import { TableActionBar, Toolbar } from "./Toolbar";
 
 const ROUTE_ID = "/organizations/";

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -14,9 +14,13 @@ import {
 } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { organizationQuery } from "@/lib/adminQueries";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
-import { cn } from "@/lib/utils";
 
 import { PEEK_PANEL_ID } from "./PeekPanel";
 
@@ -77,24 +81,36 @@ export function PeekTrigger({ org }: { org: AdminOrganization }): JSX.Element {
   const isPeeked = peekedId === org.id;
 
   return (
-    <Button
-      variant="ghost"
-      size="icon-xs"
-      data-peek-trigger=""
-      // Stable under the state change. A control whose accessible name moves as
-      // it is pressed is announced as a different control; the state rides on
-      // aria-expanded instead.
-      aria-label={`Peek at ${org.name}`}
-      aria-expanded={isPeeked}
-      // A peeked row always has its panel mounted, and aria-controls pointing
-      // at an absent id is invalid.
-      aria-controls={isPeeked ? PEEK_PANEL_ID : undefined}
-      // The row highlight alone does not say which control the operator is on,
-      // and hover styling would read as open under the pointer.
-      className={cn(isPeeked && "bg-accent text-accent-foreground")}
-      onClick={() => togglePeek(org)}
-    >
-      <PanelRightIcon />
-    </Button>
+    <Tooltip>
+      {/* The control is an icon on its own, so nothing on screen says what it
+          does until the pointer rests on it. The tooltip describes the
+          control; it does not name it, and the accessible name below is what
+          a screen reader still announces. */}
+      <TooltipTrigger asChild>
+        <Button
+          // Filled while open. Ghost hover is `bg-accent`, and the peeked row
+          // is `bg-muted`, and in this theme those two tokens hold the same
+          // grey: an open control styled with either disappears into the row
+          // it sits in and reads as a hover everywhere else.
+          variant={isPeeked ? "default" : "ghost"}
+          size="icon-xs"
+          data-peek-trigger=""
+          // Stable under the state change. A control whose accessible name
+          // moves as it is pressed is announced as a different control; the
+          // state rides on aria-expanded instead.
+          aria-label={`Peek at ${org.name}`}
+          aria-expanded={isPeeked}
+          // A peeked row always has its panel mounted, and aria-controls
+          // pointing at an absent id is invalid.
+          aria-controls={isPeeked ? PEEK_PANEL_ID : undefined}
+          onClick={() => togglePeek(org)}
+        >
+          <PanelRightIcon />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {isPeeked ? "Close peek" : "Peek without leaving the list"}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -1,9 +1,24 @@
+// oxlint-disable react/only-export-components -- the row's behavior is one
+// file on purpose (see below), so the hook and the controls sit beside the
+// components that use them. The cost is a full reload rather than a fast
+// refresh when this file changes in dev.
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { PanelRightIcon } from "lucide-react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  type JSX,
+  type ReactNode,
+} from "react";
 
+import { Button } from "@/components/ui/button";
 import { organizationQuery } from "@/lib/adminQueries";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
+import { cn } from "@/lib/utils";
+
+import { PEEK_PANEL_ID } from "./PeekPanel";
 
 // The row's own behavior lives here, so the slices that add a row menu, a
 // disable action and a trial extension all land in one file.
@@ -22,5 +37,64 @@ export function useOpenOrganization(): (org: AdminOrganization) => void {
       void navigate({ to: "/organizations/$idOrSlug", params: { idOrSlug } });
     },
     [navigate, qc],
+  );
+}
+
+export type PeekControls = {
+  peekedId?: string;
+  togglePeek: (org: AdminOrganization) => void;
+};
+
+const PeekContext = createContext<PeekControls>({
+  togglePeek: () => {},
+});
+
+/**
+ * Peek state reaches the trigger cells through context, not through the column
+ * definitions: the row model memoises on the column array, so a column array
+ * rebuilt for each new `peekedId` would rebuild the model with it.
+ *
+ * The caller memoises `value`, or every trigger on the page re-renders on every
+ * render of the list.
+ */
+export function PeekProvider({
+  value,
+  children,
+}: {
+  value: PeekControls;
+  children: ReactNode;
+}): JSX.Element {
+  return <PeekContext.Provider value={value}>{children}</PeekContext.Provider>;
+}
+
+// The close path reaches the button through the peeked row and this selector,
+// rather than through `querySelector("button")`: later slices put more buttons
+// in the row.
+export const PEEK_TRIGGER_SELECTOR = "[data-peek-trigger]";
+
+export function PeekTrigger({ org }: { org: AdminOrganization }): JSX.Element {
+  const { peekedId, togglePeek } = useContext(PeekContext);
+  const isPeeked = peekedId === org.id;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      data-peek-trigger=""
+      // Stable under the state change. A control whose accessible name moves as
+      // it is pressed is announced as a different control; the state rides on
+      // aria-expanded instead.
+      aria-label={`Peek at ${org.name}`}
+      aria-expanded={isPeeked}
+      // A peeked row always has its panel mounted, and aria-controls pointing
+      // at an absent id is invalid.
+      aria-controls={isPeeked ? PEEK_PANEL_ID : undefined}
+      // The row highlight alone does not say which control the operator is on,
+      // and hover styling would read as open under the pointer.
+      className={cn(isPeeked && "bg-accent text-accent-foreground")}
+      onClick={() => togglePeek(org)}
+    >
+      <PanelRightIcon />
+    </Button>
   );
 }

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -1,31 +1,14 @@
-// oxlint-disable react/only-export-components -- the row's behavior is one
-// file on purpose (see below), so the hook and the controls sit beside the
-// components that use them. The cost is a full reload rather than a fast
-// refresh when this file changes in dev.
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { PanelRightIcon } from "lucide-react";
-import {
-  createContext,
-  useCallback,
-  useContext,
-  type JSX,
-  type ReactNode,
-} from "react";
+import { useCallback } from "react";
 
-import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { organizationQuery } from "@/lib/adminQueries";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 
-import { PEEK_PANEL_ID } from "./PeekPanel";
-
 // The row's own behavior lives here, so the slices that add a row menu, a
-// disable action and a trial extension all land in one file.
+// disable action and a trial extension all land in one file. The peek control
+// is a component, and a file that mixes a hook with components loses fast
+// refresh, so it sits in `PeekTrigger.tsx` instead.
 export function useOpenOrganization(): (org: AdminOrganization) => void {
   const navigate = useNavigate();
   const qc = useQueryClient();
@@ -41,76 +24,5 @@ export function useOpenOrganization(): (org: AdminOrganization) => void {
       void navigate({ to: "/organizations/$idOrSlug", params: { idOrSlug } });
     },
     [navigate, qc],
-  );
-}
-
-export type PeekControls = {
-  peekedId?: string;
-  togglePeek: (org: AdminOrganization) => void;
-};
-
-const PeekContext = createContext<PeekControls>({
-  togglePeek: () => {},
-});
-
-/**
- * Peek state reaches the trigger cells through context, not through the column
- * definitions: the row model memoises on the column array, so a column array
- * rebuilt for each new `peekedId` would rebuild the model with it.
- *
- * The caller memoises `value`, or every trigger on the page re-renders on every
- * render of the list.
- */
-export function PeekProvider({
-  value,
-  children,
-}: {
-  value: PeekControls;
-  children: ReactNode;
-}): JSX.Element {
-  return <PeekContext.Provider value={value}>{children}</PeekContext.Provider>;
-}
-
-// The close path reaches the button through the peeked row and this selector,
-// rather than through `querySelector("button")`: later slices put more buttons
-// in the row.
-export const PEEK_TRIGGER_SELECTOR = "[data-peek-trigger]";
-
-export function PeekTrigger({ org }: { org: AdminOrganization }): JSX.Element {
-  const { peekedId, togglePeek } = useContext(PeekContext);
-  const isPeeked = peekedId === org.id;
-
-  return (
-    <Tooltip>
-      {/* The control is an icon on its own, so nothing on screen says what it
-          does until the pointer rests on it. The tooltip describes the
-          control; it does not name it, and the accessible name below is what
-          a screen reader still announces. */}
-      <TooltipTrigger asChild>
-        <Button
-          // Filled while open. Ghost hover is `bg-accent`, and the peeked row
-          // is `bg-muted`, and in this theme those two tokens hold the same
-          // grey: an open control styled with either disappears into the row
-          // it sits in and reads as a hover everywhere else.
-          variant={isPeeked ? "default" : "ghost"}
-          size="icon-xs"
-          data-peek-trigger=""
-          // Stable under the state change. A control whose accessible name
-          // moves as it is pressed is announced as a different control; the
-          // state rides on aria-expanded instead.
-          aria-label={`Peek at ${org.name}`}
-          aria-expanded={isPeeked}
-          // A peeked row always has its panel mounted, and aria-controls
-          // pointing at an absent id is invalid.
-          aria-controls={isPeeked ? PEEK_PANEL_ID : undefined}
-          onClick={() => togglePeek(org)}
-        >
-          <PanelRightIcon />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        {isPeeked ? "Close peek" : "Peek without leaving the list"}
-      </TooltipContent>
-    </Tooltip>
   );
 }


### PR DESCRIPTION

Peek at an organization was reachable only by holding Alt and clicking a row,
which no keyboard operator could do at all, and which the browser reads as
"save link" when the click lands on the organization's name. Every row now
carries a peek button.

## What changed

- A leading, unhideable `Peek` column whose cell is a `<button>`, one per row.
  It opens the panel on its own row and closes the panel it opened. Escape and
  the panel's own close control run the same path.
- The column is first because peek hides five columns while it is open, so a
  trailing control would slide sideways under the pointer. It cannot be hidden
  because a hidden control puts peek back out of reach of the keyboard.
- `aria-expanded` reports the state, and `aria-controls` points at the panel
  only while the panel exists. The accessible name (`Peek at {name}`) is stable
  under the toggle, so a screen reader does not announce a new control. A
  tooltip describes the control for an operator who is not using a screen
  reader, which is what the removed Alt-click hint used to do.
- The open control is the filled variant. Ghost hover is `bg-accent`, the
  peeked row is `bg-muted`, and this theme gives both the same grey, so any
  subtler treatment disappears into the row.
- Closing returns the keyboard to the button that opened the panel.
- The page carries one `role="status"` region for its whole life. It says which
  organization the panel is showing on open and on each arrow-key move, and it
  says when the panel closed and why. This is the only thing that speaks when
  the arrow keys swap the record under a panel that already holds the focus.
  Every announcement carries a counter that renders as a trailing zero-width
  space on odd counts, because organization names are not unique and React
  bails on a state set to the string already there.
- Escape and the arrow keys are ignored when they come from a peek control that
  is not the peeked row's. Without that, an operator who tabbed to row 3 and
  pressed Arrow Down to scroll moved the panel to row 2 and lost the scroll.
- When the peeked record leaves the list, focus moves to the table's scroll box
  (now a named `region` with `tabIndex={-1}`), but only where the panel took the
  keyboard down to `<body>` with it. An operator who paged or filtered the
  record away keeps their place on the control they used.
- The alt-click gesture and the hint that advertised it are gone.

The second commit is AGE-3204: the search placeholder now reads
`Search by name, slug or id...`, because the search matches an organization id
and a WorkOS id exactly as of #5286. The `Search organizations` label is
unchanged.

## Merge order

**This branch must not merge before #5286.** Without it the placeholder
promises id search that the server does not do yet. #5284 already owns
`Toolbar.tsx` on this stack, which is why #5286 could not carry the wording fix
itself.

## Verification

Each behaviour below was checked by mutation: the fix was broken on purpose,
one break at a time, and the named test had to fail.

| Mutation | Test that killed it |
| --- | --- |
| Trigger assigns instead of toggling | closes the panel again when the same control is activated twice |
| Toggle keys on any open panel, not this row | moves the peek to another row when that row's control is activated |
| `aria-expanded` dropped | reports on each control whether its own panel is open |
| Close returns focus to the row's name link | closes on Escape and puts the keyboard back on the control |
| Close looks the control up across the whole page | returns the keyboard to the control of whichever row was peeked |
| Focus rescue deleted | puts the keyboard on the table, not on the body, when the peeked record leaves the list |
| `activeElement === body` guard dropped | leaves the keyboard on the pager when the operator pages the peeked record away |
| Rescue target loses `tabIndex={-1}` | puts the keyboard on the table... (asserts the target is focusable) |
| Rescue target moved to the wrapper holding the pager | puts the keyboard on the table... (asserts it does not contain Next) |
| Rescue target loses its role and name | puts the keyboard on the table... (asserts the named region) |
| Live region rendered only while peeking | keeps an empty status region on the page before anything is peeked |
| `aria-live="off"` on the region | announces through one polite region that outlives every announcement |
| Region keyed by its own text, so it remounts | same test |
| `sr-only` dropped from the region | same test |
| Announcement counter dropped | announces a move onto an organization that shares the peeked one's name |
| Keyboard handler answers any control | ignores the arrow keys / ignores Escape on a control that is not the peeked row's |
| Open control styled like a hovered one | marks the open control apart from every other one |
| Tooltip removed | describes the control to an operator who is not using a screen reader |
| `scrollIntoView({ block: "center" })` | scrolls the row peek moves to into view |
| Placeholder reverted to name-or-slug | offers an id as a term the search box takes |
| Peek column counted as hideable | stops the operator hiding the last column that carries data |
| Alt-click branch kept alongside | opens the organization on an alt-click rather than peeking at it |

Local gates, all green: `type-check`, `lint:format`, `lint:no-barrels`,
`lint:oxlint`, `test` (99 tests).

## CI on this PR

The base is `walker/age-3189-peek`, not `main`, which changes what runs.

- `.github/workflows/pr.yaml` has no `branches:` filter, and its `changes` job
  carries a `stacked` step that diffs the head against `origin/main`. So
  **`client-build-lint` and `client-test` do run**, including "Lint admin" and
  "Test admin".
- `.github/workflows/hygiene.yaml` filters `branches: [main]`, so the whole
  workflow is skipped. **The PR title check, the changeset check and the
  migration check did not run**, and their absence reads as nothing rather than
  as a failure. The title format and the changeset were checked by hand;
  `changeset status` reported `admin` bumped at minor when it was last runnable.

## Conscious choices, not oversights

- **Doubled tab stops.** Every row now has two, the peek control and then the
  name link, so a 50-row page is 100 stops with no bypass. Common in admin
  tables, and the alternative puts peek back out of the keyboard's reach.
- **Safari focus steal, unproven here.** The focus rescue is guarded on
  `document.activeElement === document.body`, which assumes a mouse click
  leaves focus on the button. Safari does not focus buttons on click, so on
  Safari a mouse-driven page change that drops the peeked record may satisfy
  the guard and move focus. happy-dom cannot show this either way.
- **A trigger rendered invisible or without its icon survives the suite**,
  because every test finds it by accessible name. Class assertions are brittle
  and this belongs in a visual check.
- **The Columns menu is a dead control while peek is open**: checking a hidden
  column does nothing and reports neither refusal nor `aria-disabled`. That is
  pre-existing, and so is the same keyboard hijack from the pager and from
  buttons inside the panel. Both are filed as AGE-3206.

Closes AGE-3189 findings left open on #5284. Follow-ups: AGE-3204, AGE-3206.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes organization peek accessible and reliable by replacing the Alt-click gesture with a first-column Peek button on each row. This avoids browsers treating Alt-click as “save link,” keeps admins in the list, and fixes keyboard traps when moving peek between rows.

- Peek button toggles its own panel, uses a filled style when open, sets `aria-expanded`, and sets `aria-controls` only while the panel exists. A tooltip describes the control and is held closed while the panel is open. Closing (Escape, panel close, or re-click) returns focus to the button that opened it.
- Arrow keys move peek between rows and call `scrollIntoView({ block: "nearest" })`. When arrowing from the panel, focus stays in the panel; when arrowing from a row’s button, focus follows peek to the next row’s button. Escape/arrow keys pressed on another row’s button are ignored.
- A single, persistent polite live region announces open, move, and close. It includes a zero‑width‑space counter so repeated names still announce, and explicitly sets `aria-live="polite"`.
- If the peeked record disappears (filter/page), the panel closes with an announcement. Focus falls back to a named `region` wrapping the table only if the panel had focus; otherwise, focus stays where the operator acted (for example, on the pager).
- Columns menu now counts only hideable columns and prevents hiding the last data column. The Peek column is first and cannot be hidden.
- Removes the Alt‑click gesture and its hint. Updates the search placeholder to “Search by name, slug or id...”. Merge after server id search support in #5286.

Supports Linear AGE‑3189 (operators can answer account questions without leaving the list).

<sup>Written for commit e837feddb78e5541a10a8e74e40853326bf7c842. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

