### PR TITLE
fix(admin): show the trial state the trials table records

### DIFF
--- a/.changeset/admin-trial-column-real-state.md
+++ b/.changeset/admin-trial-column-real-state.md
@@ -4,16 +4,13 @@
 
 Show an organization's real trial state in the admin dashboard. The
 organizations list, the peek panel and the organization detail page all read
-`trial_state` and `trial_ends_at`, which the server derives from the `trials`
-table, instead of `free_trial_ends_at`.
+`trial_state` and `trial_ends_at` instead of `free_trial_ends_at`, which was
+defaulted for every organization and so reported a trial that never happened.
 
-That column is `NOT NULL` with a default of signup plus fourteen days and no
-application code ever writes it, so every organization reported a trial end
-date whether or not it ever trialled, and an operator who trusted the date
-acted on the wrong account. The list column is now headed `Trial` rather than
-`Trial ends`, and reads as a state: a badge carrying `Running`, `Ending soon`,
-`Expired`, `Demoted` or `Converted`, with the end date beside it only while the
-trial is still live. An organization that never trialled reads as a dash.
+The list column is now headed `Trial` rather than `Trial ends`, and reads as a
+state: a badge carrying `Running`, `Ending soon`, `Expired`, `Demoted` or
+`Converted`, with `ends` and the date beside it only while the trial is still
+live. An organization that never trialled reads as a dash.
 
 The three surfaces render one shared component, so the same organization cannot
 read one way in the list and another way on its own page. The old fields stay

--- a/.changeset/admin-trial-column-real-state.md
+++ b/.changeset/admin-trial-column-real-state.md
@@ -1,0 +1,20 @@
+---
+"admin": patch
+---
+
+Show an organization's real trial state in the admin dashboard. The
+organizations list, the peek panel and the organization detail page all read
+`trial_state` and `trial_ends_at`, which the server derives from the `trials`
+table, instead of `free_trial_ends_at`.
+
+That column is `NOT NULL` with a default of signup plus fourteen days and no
+application code ever writes it, so every organization reported a trial end
+date whether or not it ever trialled, and an operator who trusted the date
+acted on the wrong account. The list column is now headed `Trial` rather than
+`Trial ends`, and reads as a state: a badge carrying `Running`, `Ending soon`,
+`Expired`, `Demoted` or `Converted`, with the end date beside it only while the
+trial is still live. An organization that never trialled reads as a dash.
+
+The three surfaces render one shared component, so the same organization cannot
+read one way in the list and another way on its own page. The old fields stay
+on the API for now; a follow-up takes them off the wire.

--- a/client/admin/src/components/Trial.test.tsx
+++ b/client/admin/src/components/Trial.test.tsx
@@ -3,7 +3,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { Trial } from "@/components/Trial";
 import { badgeTone } from "@/lib/badgeTone";
-import type { AdminOrganization, TrialState } from "@/lib/gramAdminApi";
+import {
+  TRIAL_STATES,
+  type AdminOrganization,
+  type TrialState,
+} from "@/lib/gramAdminApi";
 
 const TRIAL_ENDS_AT = "2026-05-06T00:00:00Z";
 
@@ -23,12 +27,17 @@ const ORG: AdminOrganization = {
   updated_at: "2026-01-07T00:00:00Z",
 };
 
+// Walked at runtime, so a seventh state added to `TRIAL_STATES` fails a test
+// here whether or not the type annotation in `Trial.tsx` survived the edit
+// that added it.
+const DATED_STATES = TRIAL_STATES.filter((state) => state !== "none");
+
 function orgWith(trial: Partial<AdminOrganization>): AdminOrganization {
   return { ...ORG, ...trial };
 }
 
 function shortDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }
 
 function renderTrial(org: AdminOrganization): void {
@@ -39,14 +48,34 @@ function renderTrial(org: AdminOrganization): void {
   );
 }
 
+function cell(): HTMLElement {
+  return screen.getByTestId("trial");
+}
+
 function trialText(): string {
-  return screen.getByTestId("trial").textContent ?? "";
+  return cell().textContent ?? "";
+}
+
+// What a sighted operator reads: the sr-only half is stripped, and the
+// aria-hidden half is not.
+function visibleText(): string {
+  return Array.from(cell().querySelectorAll(".sr-only")).reduce(
+    (text, hidden) => text.replace(hidden.textContent ?? "", ""),
+    trialText(),
+  );
+}
+
+// What a screen reader announces: the dash is aria-hidden, so it is not part
+// of the accessible name and the sr-only text is.
+function accessibleText(): string {
+  return Array.from(cell().querySelectorAll('[aria-hidden="true"]')).reduce(
+    (text, hidden) => text.replace(hidden.textContent ?? "", ""),
+    trialText(),
+  );
 }
 
 function queryBadge(): HTMLElement | null {
-  return screen
-    .getByTestId("trial")
-    .querySelector<HTMLElement>('[data-slot="badge"]');
+  return cell().querySelector<HTMLElement>('[data-slot="badge"]');
 }
 
 function badge(): HTMLElement {
@@ -63,15 +92,19 @@ describe("Trial", () => {
 
     // The stale field carries a date on this record. A dash is the only
     // reading that proves the cell is not on the old field.
-    expect(trialText()).toBe("-");
+    expect(visibleText()).toBe("-");
     expect(queryBadge()).toBeNull();
+    // A lone hyphen is announced as nothing, and this cell's whole value is
+    // that hyphen.
+    expect(accessibleText()).toBe("No trial");
   });
 
   it("reads a dash when the API sends no trial state at all", () => {
     renderTrial(ORG);
 
-    expect(trialText()).toBe("-");
+    expect(visibleText()).toBe("-");
     expect(queryBadge()).toBeNull();
+    expect(accessibleText()).toBe("No trial");
   });
 
   it("falls back to the dash for a state this build does not know", () => {
@@ -84,8 +117,22 @@ describe("Trial", () => {
     );
 
     // Not the raw enum name, and not a crash.
-    expect(trialText()).toBe("-");
+    expect(visibleText()).toBe("-");
     expect(queryBadge()).toBeNull();
+  });
+
+  it("does not pass an unrecognised state off as no trial", () => {
+    renderTrial(orgWith({ trial_state: "paused" as TrialState }));
+    const unrecognised = accessibleText();
+    cleanup();
+
+    renderTrial(orgWith({ trial_state: "none" }));
+
+    // Both read as a dash, which is right. Calling a state the server derived
+    // "no trial" is the laundering this column exists to stop, and a reader
+    // who cannot tell the two apart has no way to report the first.
+    expect(unrecognised).not.toBe(accessibleText());
+    expect(unrecognised).toBe("Trial state not recognised");
   });
 
   it("puts the end date beside a running trial and tones it as normal", () => {
@@ -93,7 +140,7 @@ describe("Trial", () => {
       orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),
     );
 
-    expect(trialText()).toBe(`Running${shortDate(TRIAL_ENDS_AT)}`);
+    expect(trialText()).toBe(`Running ends ${shortDate(TRIAL_ENDS_AT)}`);
     // Neutral, not warning: the server has a separate state for a trial about
     // to end, and toning every running trial as urgent wastes it.
     expect(badge().className).toContain(badgeTone.neutral);
@@ -104,8 +151,20 @@ describe("Trial", () => {
       orgWith({ trial_state: "ending_soon", trial_ends_at: TRIAL_ENDS_AT }),
     );
 
-    expect(trialText()).toBe(`Ending soon${shortDate(TRIAL_ENDS_AT)}`);
+    expect(trialText()).toBe(`Ending soon ends ${shortDate(TRIAL_ENDS_AT)}`);
     expect(badge().className).toContain(badgeTone.warning);
+  });
+
+  it("says the date is an end date, and separates it from the state", () => {
+    renderTrial(
+      orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    // The header reads `Trial` and no longer says what the date is, so the
+    // cell has to. The space is in the text, not only in the flex gap: a
+    // copied cell otherwise reads `Running5/6/2026`.
+    expect(trialText()).toContain(` ends ${shortDate(TRIAL_ENDS_AT)}`);
+    expect(trialText()).not.toContain(`Running${shortDate(TRIAL_ENDS_AT)}`);
   });
 
   it("renders a running trial differently from one that is ending soon", () => {
@@ -154,40 +213,42 @@ describe("Trial", () => {
     expect(badge().className).toContain(badgeTone.success);
   });
 
-  it("carries every state on a badge rather than as bare text", () => {
-    const states: TrialState[] = [
-      "running",
-      "ending_soon",
-      "expired",
-      "demoted",
-      "converted",
-    ];
+  it.each(DATED_STATES)(
+    "shows no date for %s where the record carries none",
+    (state) => {
+      renderTrial(orgWith({ trial_state: state, trial_ends_at: undefined }));
 
-    for (const state of states) {
+      // `free_trial_ends_at` still dates this record. Falling back to it,
+      // which is the shape a "be defensive about a missing date" edit takes,
+      // is this ticket's own bug coming back. A trailing bare `ends`, or a
+      // `Running-`, is the other way this goes wrong.
+      expect(trialText()).not.toContain(shortDate("2026-11-12T00:00:00Z"));
+      expect(trialText()).not.toContain("ends");
+      expect(trialText()).not.toContain("-");
+      expect(trialText()).toBe(badge().textContent);
+    },
+  );
+
+  it.each(DATED_STATES)(
+    "carries %s on a badge rather than as bare text",
+    (state) => {
       renderTrial(
         orgWith({ trial_state: state, trial_ends_at: TRIAL_ENDS_AT }),
       );
-      // The badge's own element, so text dropped out of a badge fails here
-      // even where the words are unchanged. The variant, not the classes it
-      // expands to: the tone rides in `className` and would satisfy a class
-      // assertion on its own.
+
+      // The badge's own element, so text dropped out of a badge fails here even
+      // where the words are unchanged. The variant, not the classes it expands
+      // to: the tone rides in `className` and would satisfy a class assertion on
+      // its own.
       expect(badge().textContent).not.toBe("");
       expect(badge().getAttribute("data-variant")).toBe("outline");
-      cleanup();
-    }
-  });
+    },
+  );
 
   it("gives each state its own words, so shared tones stay apart", () => {
     const labels = new Set<string>();
-    const states: TrialState[] = [
-      "running",
-      "ending_soon",
-      "expired",
-      "demoted",
-      "converted",
-    ];
 
-    for (const state of states) {
+    for (const state of DATED_STATES) {
       renderTrial(orgWith({ trial_state: state }));
       labels.add(badge().textContent ?? "");
       cleanup();
@@ -195,6 +256,6 @@ describe("Trial", () => {
 
     // `expired` and `demoted` share a tone. Their words are the only thing
     // left to tell them apart.
-    expect(labels.size).toBe(states.length);
+    expect(labels.size).toBe(DATED_STATES.length);
   });
 });

--- a/client/admin/src/components/Trial.test.tsx
+++ b/client/admin/src/components/Trial.test.tsx
@@ -1,0 +1,200 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Trial } from "@/components/Trial";
+import { badgeTone } from "@/lib/badgeTone";
+import type { AdminOrganization, TrialState } from "@/lib/gramAdminApi";
+
+const TRIAL_ENDS_AT = "2026-05-06T00:00:00Z";
+
+// The stale pair is set, and set to a different date, on every record here.
+// A surface that goes back to reading `free_trial_ends_at` then renders the
+// wrong date rather than the right one by luck.
+const ORG: AdminOrganization = {
+  id: "org_placeholder_one",
+  name: "Placeholder One",
+  slug: "placeholder-one",
+  account_type: "pro",
+  whitelisted: true,
+  free_trial_started_at: "2026-02-01T00:00:00Z",
+  free_trial_ends_at: "2026-11-12T00:00:00Z",
+  member_count: 3,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-07T00:00:00Z",
+};
+
+function orgWith(trial: Partial<AdminOrganization>): AdminOrganization {
+  return { ...ORG, ...trial };
+}
+
+function shortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+function renderTrial(org: AdminOrganization): void {
+  render(
+    <div data-testid="trial">
+      <Trial org={org} />
+    </div>,
+  );
+}
+
+function trialText(): string {
+  return screen.getByTestId("trial").textContent ?? "";
+}
+
+function queryBadge(): HTMLElement | null {
+  return screen
+    .getByTestId("trial")
+    .querySelector<HTMLElement>('[data-slot="badge"]');
+}
+
+function badge(): HTMLElement {
+  const found = queryBadge();
+  if (!found) throw new Error("the state is not on a badge");
+  return found;
+}
+
+afterEach(cleanup);
+
+describe("Trial", () => {
+  it("reads a dash for an organization that never trialled", () => {
+    renderTrial(orgWith({ trial_state: "none", trial_ends_at: undefined }));
+
+    // The stale field carries a date on this record. A dash is the only
+    // reading that proves the cell is not on the old field.
+    expect(trialText()).toBe("-");
+    expect(queryBadge()).toBeNull();
+  });
+
+  it("reads a dash when the API sends no trial state at all", () => {
+    renderTrial(ORG);
+
+    expect(trialText()).toBe("-");
+    expect(queryBadge()).toBeNull();
+  });
+
+  it("falls back to the dash for a state this build does not know", () => {
+    renderTrial(
+      orgWith({
+        // A seventh state the server may derive before this build ships.
+        trial_state: "paused" as TrialState,
+        trial_ends_at: TRIAL_ENDS_AT,
+      }),
+    );
+
+    // Not the raw enum name, and not a crash.
+    expect(trialText()).toBe("-");
+    expect(queryBadge()).toBeNull();
+  });
+
+  it("puts the end date beside a running trial and tones it as normal", () => {
+    renderTrial(
+      orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe(`Running${shortDate(TRIAL_ENDS_AT)}`);
+    // Neutral, not warning: the server has a separate state for a trial about
+    // to end, and toning every running trial as urgent wastes it.
+    expect(badge().className).toContain(badgeTone.neutral);
+  });
+
+  it("warns on a trial that is about to end, and still dates it", () => {
+    renderTrial(
+      orgWith({ trial_state: "ending_soon", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe(`Ending soon${shortDate(TRIAL_ENDS_AT)}`);
+    expect(badge().className).toContain(badgeTone.warning);
+  });
+
+  it("renders a running trial differently from one that is ending soon", () => {
+    renderTrial(
+      orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+    const running = { text: trialText(), tone: badge().className };
+    cleanup();
+
+    renderTrial(
+      orgWith({ trial_state: "ending_soon", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).not.toBe(running.text);
+    expect(badge().className).not.toBe(running.tone);
+  });
+
+  it("reads an expired trial as a failure and drops the date", () => {
+    renderTrial(
+      orgWith({ trial_state: "expired", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    // The date is set on the record and deliberately not shown: a finished
+    // trial's end date reads as a deadline still to come.
+    expect(trialText()).toBe("Expired");
+    expect(badge().className).toContain(badgeTone.destructive);
+  });
+
+  it("reads a demoted trial as a failure and drops the date", () => {
+    renderTrial(
+      orgWith({ trial_state: "demoted", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe("Demoted");
+    expect(badge().className).toContain(badgeTone.destructive);
+  });
+
+  it("reads a converted trial as a win", () => {
+    renderTrial(
+      orgWith({ trial_state: "converted", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe("Converted");
+    // Success, not destructive. A converted trial is the outcome the business
+    // wants, and a red badge sends an operator after a healthy account.
+    expect(badge().className).toContain(badgeTone.success);
+  });
+
+  it("carries every state on a badge rather than as bare text", () => {
+    const states: TrialState[] = [
+      "running",
+      "ending_soon",
+      "expired",
+      "demoted",
+      "converted",
+    ];
+
+    for (const state of states) {
+      renderTrial(
+        orgWith({ trial_state: state, trial_ends_at: TRIAL_ENDS_AT }),
+      );
+      // The badge's own element, so text dropped out of a badge fails here
+      // even where the words are unchanged. The variant, not the classes it
+      // expands to: the tone rides in `className` and would satisfy a class
+      // assertion on its own.
+      expect(badge().textContent).not.toBe("");
+      expect(badge().getAttribute("data-variant")).toBe("outline");
+      cleanup();
+    }
+  });
+
+  it("gives each state its own words, so shared tones stay apart", () => {
+    const labels = new Set<string>();
+    const states: TrialState[] = [
+      "running",
+      "ending_soon",
+      "expired",
+      "demoted",
+      "converted",
+    ];
+
+    for (const state of states) {
+      renderTrial(orgWith({ trial_state: state }));
+      labels.add(badge().textContent ?? "");
+      cleanup();
+    }
+
+    // `expired` and `demoted` share a tone. Their words are the only thing
+    // left to tell them apart.
+    expect(labels.size).toBe(states.length);
+  });
+});

--- a/client/admin/src/components/Trial.tsx
+++ b/client/admin/src/components/Trial.tsx
@@ -18,15 +18,17 @@ type TrialDisplay = {
 // away. `expired` and `demoted` share `destructive` because there are four
 // tones and five states; their words keep them apart.
 //
-// Exhaustive over the union minus `none`, so a seventh state added to
-// `TrialState` is a build failure here rather than a silent dash.
-const TRIAL_DISPLAY = {
+// The annotation is exhaustive over the union minus `none`, so a seventh state
+// is a build failure. It is not the only guard: `Trial.test.tsx` walks
+// `TRIAL_STATES` at runtime, so a seventh state fails a test even if this
+// annotation is edited away.
+const TRIAL_DISPLAY: Record<Exclude<TrialState, "none">, TrialDisplay> = {
   running: { label: "Running", tone: "neutral", showsEndDate: true },
   ending_soon: { label: "Ending soon", tone: "warning", showsEndDate: true },
   expired: { label: "Expired", tone: "destructive", showsEndDate: false },
   demoted: { label: "Demoted", tone: "destructive", showsEndDate: false },
   converted: { label: "Converted", tone: "success", showsEndDate: false },
-} as const satisfies Record<Exclude<TrialState, "none">, TrialDisplay>;
+};
 
 // Indexed as a plain string record on purpose. The server can start sending a
 // state this build has never heard of, and an unknown state has to read as no
@@ -41,7 +43,20 @@ export function Trial({ org }: { org: AdminOrganization }): JSX.Element {
   const display = DISPLAY_BY_STATE[org.trial_state ?? ""];
 
   if (!display) {
-    return <span className="text-muted-foreground text-sm">-</span>;
+    // A lone hyphen is the entire value of this cell, and a screen reader
+    // announces it as nothing at all. It also has to say which of the two
+    // silences this is. Reading a state the server derived but this build does
+    // not know as "never trialled" is the same laundering the column exists to
+    // stop, put back at the edge.
+    const unrecognised = Boolean(org.trial_state) && org.trial_state !== "none";
+    return (
+      <span className="text-muted-foreground text-sm">
+        <span aria-hidden="true">-</span>
+        <span className="sr-only">
+          {unrecognised ? "Trial state not recognised" : "No trial"}
+        </span>
+      </span>
+    );
   }
 
   return (
@@ -49,9 +64,16 @@ export function Trial({ org }: { org: AdminOrganization }): JSX.Element {
       <Badge variant="outline" className={badgeTone[display.tone]}>
         {display.label}
       </Badge>
-      {display.showsEndDate && org.trial_ends_at
-        ? fmtDateShort(org.trial_ends_at)
-        : null}
+      {display.showsEndDate && org.trial_ends_at ? (
+        <>
+          {/* An explicit space, because the flex gap is not in the text. A
+              copied cell otherwise reads `Running5/6/2026`. Whitespace-only
+              text is not rendered as a flex item, so nothing moves. */}{" "}
+          {/* "ends", because the header says `Trial` and no longer says what
+              the date is. A bare date beside a state reads as a start. */}
+          <span>ends {fmtDateShort(org.trial_ends_at)}</span>
+        </>
+      ) : null}
     </span>
   );
 }

--- a/client/admin/src/components/Trial.tsx
+++ b/client/admin/src/components/Trial.tsx
@@ -1,0 +1,57 @@
+import type { JSX } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { badgeTone } from "@/lib/badgeTone";
+import type { AdminOrganization, TrialState } from "@/lib/gramAdminApi";
+import { fmtDateShort } from "@/lib/utils";
+
+type TrialDisplay = {
+  label: string;
+  tone: keyof typeof badgeTone;
+  // Only while the trial is still live. A date beside a finished trial reads
+  // as a deadline the operator can still act on.
+  showsEndDate: boolean;
+};
+
+// `neutral` for a running trial and `warning` only for one about to end: the
+// server derives that distinction, and giving both the same tone throws it
+// away. `expired` and `demoted` share `destructive` because there are four
+// tones and five states; their words keep them apart.
+//
+// Exhaustive over the union minus `none`, so a seventh state added to
+// `TrialState` is a build failure here rather than a silent dash.
+const TRIAL_DISPLAY = {
+  running: { label: "Running", tone: "neutral", showsEndDate: true },
+  ending_soon: { label: "Ending soon", tone: "warning", showsEndDate: true },
+  expired: { label: "Expired", tone: "destructive", showsEndDate: false },
+  demoted: { label: "Demoted", tone: "destructive", showsEndDate: false },
+  converted: { label: "Converted", tone: "success", showsEndDate: false },
+} as const satisfies Record<Exclude<TrialState, "none">, TrialDisplay>;
+
+// Indexed as a plain string record on purpose. The server can start sending a
+// state this build has never heard of, and an unknown state has to read as no
+// trial rather than crash or put a raw enum name in front of an operator.
+const DISPLAY_BY_STATE: Record<string, TrialDisplay | undefined> =
+  TRIAL_DISPLAY;
+
+// The one account of an organization's trial. The row, the peek panel and the
+// detail page all render this, so the same organization cannot read one way in
+// the list and another way on its own page.
+export function Trial({ org }: { org: AdminOrganization }): JSX.Element {
+  const display = DISPLAY_BY_STATE[org.trial_state ?? ""];
+
+  if (!display) {
+    return <span className="text-muted-foreground text-sm">-</span>;
+  }
+
+  return (
+    <span className="flex items-center gap-1.5 text-sm">
+      <Badge variant="outline" className={badgeTone[display.tone]}>
+        {display.label}
+      </Badge>
+      {display.showsEndDate && org.trial_ends_at
+        ? fmtDateShort(org.trial_ends_at)
+        : null}
+    </span>
+  );
+}

--- a/client/admin/src/lib/badgeTone.test.ts
+++ b/client/admin/src/lib/badgeTone.test.ts
@@ -2,13 +2,93 @@ import { describe, expect, it } from "vitest";
 
 import { badgeTone } from "./badgeTone";
 
+// A literal list, not Object.keys: dropping a tone must fail these tests rather
+// than shrink what they check.
+const TONES = ["neutral", "success", "warning", "destructive"] as const;
+
+// Badge text is 12px at weight 500, which is not WCAG large text, so the AA
+// threshold is the 4.5:1 one rather than 3:1.
+const AA_NORMAL_TEXT = 4.5;
+
+type Rgb = [number, number, number];
+
+// The tones are Tailwind arbitrary values, so the colours are in the class
+// string and nowhere else. Reading them back out is the only way a test can
+// measure what actually ships. Tailwind writes a space as an underscore.
+function hslIn(classes: string, utility: string): Rgb {
+  const found = new RegExp(
+    `(?:^|\\s)${utility}-\\[hsl\\((\\d+)_(\\d+)%_(\\d+)%\\)\\]`,
+  ).exec(classes);
+  if (!found) throw new Error(`no ${utility} colour in "${classes}"`);
+  const [, h, s, l] = found;
+  return hslToRgb(Number(h), Number(s) / 100, Number(l) / 100);
+}
+
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  const sector = Math.floor(h / 60) % 6;
+  const rgb: Rgb[] = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x],
+  ];
+  const channels = rgb[sector] ?? rgb[0];
+  if (!channels) throw new Error(`unreachable sector ${sector}`);
+  return channels.map((v) => Math.round((v + m) * 255)) as Rgb;
+}
+
+// WCAG 2.x relative luminance and contrast.
+function luminance([r, g, b]: Rgb): number {
+  const [rl, gl, bl] = [r, g, b].map((raw) => {
+    const v = raw / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  }) as Rgb;
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x) as [
+    number,
+    number,
+  ];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
 describe("badgeTone", () => {
-  // A literal list, not Object.keys: dropping a tone must fail the test rather
-  // than shrink what it checks.
-  it.each(["neutral", "success", "warning", "destructive"] as const)(
-    "%s is a non-empty class string",
-    (tone) => {
-      expect(badgeTone[tone].trim()).not.toBe("");
-    },
-  );
+  it.each(TONES)("%s is a non-empty class string", (tone) => {
+    expect(badgeTone[tone].trim()).not.toBe("");
+  });
+
+  // Both schemes, because a tone that reads in one is not a tone that reads.
+  // Every consumer of `badgeTone` inherits whatever this allows, which is why
+  // the check lives beside the tones rather than beside any one badge.
+  it.each(TONES)("%s clears AA against its own light background", (tone) => {
+    const classes = badgeTone[tone];
+    expect(
+      contrast(hslIn(classes, "text"), hslIn(classes, "bg")),
+    ).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
+
+  it.each(TONES)("%s clears AA against its own dark background", (tone) => {
+    const classes = badgeTone[tone];
+    expect(
+      contrast(hslIn(classes, "dark:text"), hslIn(classes, "dark:bg")),
+    ).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
+
+  // The conversion and the formula are what every assertion above rests on, so
+  // they are pinned against a hand-worked case rather than trusted.
+  it("measures a known pair the way a browser does", () => {
+    expect(hslToRgb(21, 0.64, 0.43)).toEqual([180, 89, 39]);
+    expect(hslToRgb(29, 1, 0.95)).toEqual([255, 242, 229]);
+    // The ratio that failed review, to two decimal places.
+    expect(contrast([180, 89, 39], [255, 242, 229])).toBeCloseTo(4.34, 2);
+    // Black on white is the definition's own upper bound.
+    expect(contrast([0, 0, 0], [255, 255, 255])).toBeCloseTo(21, 5);
+  });
 });

--- a/client/admin/src/lib/badgeTone.ts
+++ b/client/admin/src/lib/badgeTone.ts
@@ -6,14 +6,23 @@
  * failure, and grey for a plain label. Every tone gives a full set of colours,
  * so `src/components/ui/badge.tsx` stays stock. Put a tone in `className` next
  * to `variant="outline"`. The tone then wins through tailwind-merge.
+ *
+ * Every tone carries badge text at 12px/500, which is not WCAG large text, so
+ * each foreground has to clear 4.5:1 against its own background in both
+ * schemes. `badgeTone.test.ts` measures that from these strings; do not add or
+ * retune a tone without reading what it says.
  */
 export const badgeTone = {
   neutral:
     "border-[hsl(0_0%_92%)] bg-[hsl(0_0%_98%)] text-[hsl(0_0%_33%)] uppercase dark:border-[hsl(0_0%_20%/56%)] dark:bg-[hsl(0_0%_7%)] dark:text-[hsl(0_0%_86%)]",
   success:
     "border-[hsl(99_30%_73%)] bg-[hsl(102_35%_93%)] text-[hsl(105_24%_27%)] uppercase dark:border-[hsl(105_24%_27%)] dark:bg-[hsl(105_24%_13%)] dark:text-[hsl(99_30%_73%)]",
+  // The light foreground is darkened from the moonshine original's
+  // `hsl(21 64% 43%)`, which measured 4.34:1 on this background and so failed
+  // AA. It is the only tone that did. The dark scheme, and the same colour
+  // where it serves as the dark border, are untouched.
   warning:
-    "border-[hsl(28_100%_74%)] bg-[hsl(29_100%_95%)] text-[hsl(21_64%_43%)] uppercase dark:border-[hsl(21_64%_43%)] dark:bg-[hsl(18_69%_24%)] dark:text-[hsl(28_100%_74%)]",
+    "border-[hsl(28_100%_74%)] bg-[hsl(29_100%_95%)] text-[hsl(21_70%_37%)] uppercase dark:border-[hsl(21_64%_43%)] dark:bg-[hsl(18_69%_24%)] dark:text-[hsl(28_100%_74%)]",
   destructive:
     "border-[hsl(3_78%_71%)] bg-[hsl(0_100%_97%)] text-[hsl(1_64%_32%)] uppercase dark:border-[hsl(1_64%_32%)] dark:bg-[hsl(0_62%_17%)] dark:text-[hsl(3_78%_71%)]",
 } as const;

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -178,8 +178,26 @@ export async function logout(): Promise<void> {
   window.location.href = "/admin/auth.login?prompt=select_account";
 }
 
+// Derived server-side from the `trials` table, so it is the only trustworthy
+// account of whether an organization ever trialled. Written out as a union
+// rather than as `string`: a typo in a state name has to be a build failure,
+// because every surface that reads it maps the state to a colour.
+export type TrialState =
+  | "none"
+  | "running"
+  | "ending_soon"
+  | "expired"
+  | "demoted"
+  | "converted";
+
 // Convenience method for the listOrganizations endpoint. Mirrors the backend
 // payload shape from server/gen/admin/service.go.
+//
+// `free_trial_started_at` and `free_trial_ends_at` are `NOT NULL` columns with
+// a signup-plus-fourteen-days default that no application code writes, so they
+// report a trial for every organization ever made. Nothing here reads them.
+// They stay declared only because the API still sends them; a follow-up takes
+// them off the wire.
 export type AdminOrganization = {
   id: string;
   name: string;
@@ -190,6 +208,8 @@ export type AdminOrganization = {
   disabled_at?: string;
   free_trial_started_at?: string;
   free_trial_ends_at?: string;
+  trial_state?: TrialState;
+  trial_ends_at?: string;
   member_count: number;
   created_at: string;
   updated_at: string;

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -179,16 +179,24 @@ export async function logout(): Promise<void> {
 }
 
 // Derived server-side from the `trials` table, so it is the only trustworthy
-// account of whether an organization ever trialled. Written out as a union
-// rather than as `string`: a typo in a state name has to be a build failure,
-// because every surface that reads it maps the state to a colour.
-export type TrialState =
-  | "none"
-  | "running"
-  | "ending_soon"
-  | "expired"
-  | "demoted"
-  | "converted";
+// account of whether an organization ever trialled.
+//
+// A runtime list with the union derived from it, rather than a bare union: a
+// test can then walk every state the server can send, so a seventh state added
+// here fails a test as well as the build. A type annotation alone is one
+// careless edit from being deleted, and nothing would notice.
+export const TRIAL_STATES = [
+  "none",
+  "running",
+  "ending_soon",
+  "expired",
+  "demoted",
+  "converted",
+] as const;
+
+// Not `string`: a typo in a state name has to be a build failure, because
+// every surface that reads it maps the state to a colour.
+export type TrialState = (typeof TRIAL_STATES)[number];
 
 // Convenience method for the listOrganizations endpoint. Mirrors the backend
 // payload shape from server/gen/admin/service.go.

--- a/client/admin/src/lib/utils.test.ts
+++ b/client/admin/src/lib/utils.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fmtDateShort } from "./utils";
+
+// Node re-reads the TZ variable when it next builds a Date, so the reader's
+// zone can be moved for the length of a call. Written out rather than left to
+// the machine: CI runs in UTC, where the fault this pins cannot appear at all
+// and every assertion about it would pass without meaning anything.
+//
+// Through `vi.stubEnv` rather than `process.env` directly, because the browser
+// build carries no node types and its restore is what the hook below relies on.
+function inZone<T>(tz: string, body: () => T): T {
+  vi.stubEnv("TZ", tz);
+  try {
+    return body();
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("fmtDateShort", () => {
+  it("reads a UTC midnight as that day, not the day before", () => {
+    // A trial end as the API sends it: midnight UTC.
+    const iso = "2026-05-06T00:00:00Z";
+
+    inZone("America/Los_Angeles", () => {
+      // The zone really moved, and in it this instant is the 5th locally.
+      // Without this the rest of the test proves nothing on a UTC runner.
+      expect(new Date(iso).getDate()).toBe(5);
+
+      // The regression itself: the reader's own zone is what shipped, and it
+      // names the day before the deadline.
+      expect(fmtDateShort(iso)).not.toBe(new Date(iso).toLocaleDateString());
+
+      // Midday UTC on the same date is the 6th in every populated zone, so it
+      // fixes the expected day without hard-coding a locale's date format.
+      expect(fmtDateShort(iso)).toBe(
+        new Date("2026-05-06T12:00:00Z").toLocaleDateString(),
+      );
+    });
+  });
+
+  it("reads the same instant the same way in every zone", () => {
+    const iso = "2026-05-06T00:00:00Z";
+    const zones = ["UTC", "America/Los_Angeles", "Asia/Tokyo", "Pacific/Apia"];
+
+    const rendered = new Set(
+      zones.map((tz) => inZone(tz, () => fmtDateShort(iso))),
+    );
+
+    // One reading, so two operators on two continents act on one date.
+    expect(rendered.size).toBe(1);
+  });
+
+  it("reads an unset date as a dash", () => {
+    expect(fmtDateShort(undefined)).toBe("-");
+    expect(fmtDateShort("")).toBe("-");
+  });
+
+  it("reads an unparseable date as a dash", () => {
+    // Not the literal string `Invalid Date`, which is what dropping the guard
+    // puts in front of an operator.
+    expect(fmtDateShort("not a date")).toBe("-");
+    expect(fmtDateShort("2026-13-45T00:00:00Z")).toBe("-");
+  });
+
+  it("drops the clock", () => {
+    const rendered = fmtDateShort("2026-05-06T13:45:12Z");
+
+    expect(rendered).toBe(fmtDateShort("2026-05-06T00:00:00Z"));
+    expect(rendered).not.toContain(":");
+  });
+});

--- a/client/admin/src/lib/utils.test.ts
+++ b/client/admin/src/lib/utils.test.ts
@@ -23,9 +23,10 @@ afterEach(() => {
 });
 
 describe("fmtDateShort", () => {
-  it("reads a UTC midnight as that day, not the day before", () => {
-    // A trial end as the API sends it: midnight UTC.
-    const iso = "2026-05-06T00:00:00Z";
+  it("reads a trial end as the server's day, not the reader's", () => {
+    // A trial end as the server stores it: the signup moment plus the trial
+    // length, in UTC. Early in the UTC day, which is where the fault shows.
+    const iso = "2026-05-06T03:00:00Z";
 
     inZone("America/Los_Angeles", () => {
       // The zone really moved, and in it this instant is the 5th locally.
@@ -45,7 +46,7 @@ describe("fmtDateShort", () => {
   });
 
   it("reads the same instant the same way in every zone", () => {
-    const iso = "2026-05-06T00:00:00Z";
+    const iso = "2026-05-06T03:00:00Z";
     const zones = ["UTC", "America/Los_Angeles", "Asia/Tokyo", "Pacific/Apia"];
 
     const rendered = new Set(

--- a/client/admin/src/lib/utils.ts
+++ b/client/admin/src/lib/utils.ts
@@ -9,18 +9,19 @@ export function cn(...inputs: ClassValue[]): string {
 // a panel reads it this way, so the same field cannot come out two ways on two
 // pages.
 //
-// The zone is the whole point. A trial ends at a UTC midnight, and rendering
-// that instant in the reader's own zone names the day before it everywhere west
-// of UTC: a trial ending 2026-05-06 reads as 5/5/2026 in California. An
-// operator who acts a day early demotes an account that still had a day.
-// Dropping the clock means the zone cannot be dropped too.
+// The zone is the whole point. `trial_ends_at` is a real instant, armed as the
+// signup moment plus the trial length, and the sweeper that demotes the account
+// compares it against server time. Rendered in the reader's own zone that
+// instant can name a different day than the one the server acts on: a trial
+// ending 2026-05-06T03:00Z reads as 5/5/2026 in California. An operator who
+// acts on that day demotes an account that still had a day. Dropping the clock
+// means the zone cannot be dropped too.
 //
-// This also moves the other fields formatted here, `created_at` and
-// `disabled_at`, which are real moments rather than UTC midnights. Their
-// rendered day now follows the server rather than the reader's clock, and can
-// differ by one near midnight. That is the right frame for an admin tool: two
-// operators in two zones read one organization the same way, and the day they
-// read is the day the database records.
+// The other fields formatted here, `created_at` and `disabled_at`, move with
+// it. Their rendered day now follows the server rather than the reader's clock,
+// and can differ by one near midnight. That is the right frame for an admin
+// tool: two operators in two zones read one organization the same way, and the
+// day they read is the day the database records.
 export function fmtDateShort(iso?: string): string {
   if (!iso) return "-";
   const d = new Date(iso);

--- a/client/admin/src/lib/utils.ts
+++ b/client/admin/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
+
+// Date only, no clock. Every surface that shows a date in a row or a panel
+// reads it this way, so the same field cannot come out two ways on two pages.
+export function fmtDateShort(iso?: string): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "-";
+  return d.toLocaleDateString();
+}

--- a/client/admin/src/lib/utils.ts
+++ b/client/admin/src/lib/utils.ts
@@ -5,11 +5,25 @@ export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
 
-// Date only, no clock. Every surface that shows a date in a row or a panel
-// reads it this way, so the same field cannot come out two ways on two pages.
+// Date only, no clock, read in UTC. Every surface that shows a date in a row or
+// a panel reads it this way, so the same field cannot come out two ways on two
+// pages.
+//
+// The zone is the whole point. A trial ends at a UTC midnight, and rendering
+// that instant in the reader's own zone names the day before it everywhere west
+// of UTC: a trial ending 2026-05-06 reads as 5/5/2026 in California. An
+// operator who acts a day early demotes an account that still had a day.
+// Dropping the clock means the zone cannot be dropped too.
+//
+// This also moves the other fields formatted here, `created_at` and
+// `disabled_at`, which are real moments rather than UTC midnights. Their
+// rendered day now follows the server rather than the reader's clock, and can
+// differ by one near midnight. That is the right frame for an admin tool: two
+// operators in two zones read one organization the same way, and the day they
+// read is the day the database records.
 export function fmtDateShort(iso?: string): string {
   if (!iso) return "-";
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "-";
-  return d.toLocaleDateString();
+  return d.toLocaleDateString(undefined, { timeZone: "UTC" });
 }

--- a/client/admin/src/pages/OrganizationDetail.test.tsx
+++ b/client/admin/src/pages/OrganizationDetail.test.tsx
@@ -36,6 +36,13 @@ const ORG: AdminOrganization = {
   slug: "placeholder-one",
   account_type: "pro",
   whitelisted: true,
+  // The stale pair, dated apart from the real trial on purpose. A page back on
+  // `free_trial_ends_at` then shows the wrong date rather than the right one
+  // by coincidence.
+  free_trial_started_at: "2026-02-01T00:00:00Z",
+  free_trial_ends_at: "2026-11-12T00:00:00Z",
+  trial_state: "running",
+  trial_ends_at: "2026-05-06T00:00:00Z",
   member_count: 1,
   created_at: "2026-01-02T00:00:00Z",
   updated_at: "2026-01-07T00:00:00Z",
@@ -63,6 +70,22 @@ const MEMBER: AdminOrganizationMember = {
 // assertion is for: the format is not.
 function longDate(iso: string): string {
   return new Date(iso).toLocaleString();
+}
+
+// The trial is a date without a clock wherever it is read, so it does not come
+// out of `longDate` with the timestamps around it.
+function shortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+// The field rows carry no role, so a test reaches one by its label and takes
+// the value beside it.
+function valueBeside(label: string): HTMLElement {
+  const value = screen.getByText(label).nextElementSibling;
+  if (!(value instanceof HTMLElement)) {
+    throw new Error(`the ${label} row has no value beside it`);
+  }
+  return value;
 }
 
 // A Radix tab trigger selects on mousedown, not on click. The panel only
@@ -101,6 +124,48 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("organization detail", () => {
+  it("reads the trial exactly the way the row does", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    const trialEndsAt = ORG.trial_ends_at;
+    if (!trialEndsAt) throw new Error("the record under test needs a trial");
+
+    const trial = await screen.findByText("Trial");
+    // Written out, not built from the component. The same string is asserted
+    // against the list's cell, which is the only way two pages that could
+    // drift apart are held together.
+    expect(valueBeside("Trial").textContent).toBe(
+      `Running${shortDate(trialEndsAt)}`,
+    );
+    expect(
+      trial.parentElement?.querySelector('[data-slot="badge"]'),
+    ).toBeTruthy();
+
+    // The defaulted pair is gone from the page, not merely unread: an operator
+    // who sees "Free trial ends" reads a date no organization ever earned.
+    expect(screen.queryByText("Free trial started")).toBeNull();
+    expect(screen.queryByText("Free trial ends")).toBeNull();
+  });
+
+  it("reads a dash for an organization that never trialled", async () => {
+    mocks.getOrganization.mockResolvedValue({
+      ...ORG,
+      trial_state: "none",
+      trial_ends_at: undefined,
+    });
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await screen.findByText("Trial");
+    // `free_trial_ends_at` still dates this record, which is the whole reason
+    // the page was moved off it.
+    expect(ORG.free_trial_ends_at).toBeTruthy();
+    expect(valueBeside("Trial").textContent).toBe("-");
+  });
+
   it("renders every projects cell out of the record that produced it", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,

--- a/client/admin/src/pages/OrganizationDetail.test.tsx
+++ b/client/admin/src/pages/OrganizationDetail.test.tsx
@@ -73,9 +73,11 @@ function longDate(iso: string): string {
 }
 
 // The trial is a date without a clock wherever it is read, so it does not come
-// out of `longDate` with the timestamps around it.
+// out of `longDate` with the timestamps around it. UTC, because that is the
+// zone the API states these dates in and the zone they are rendered in; see
+// `utils.test.ts`.
 function shortDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }
 
 // The field rows carry no role, so a test reaches one by its label and takes
@@ -137,7 +139,7 @@ describe("organization detail", () => {
     // against the list's cell, which is the only way two pages that could
     // drift apart are held together.
     expect(valueBeside("Trial").textContent).toBe(
-      `Running${shortDate(trialEndsAt)}`,
+      `Running ends ${shortDate(trialEndsAt)}`,
     );
     expect(
       trial.parentElement?.querySelector('[data-slot="badge"]'),
@@ -163,7 +165,7 @@ describe("organization detail", () => {
     // `free_trial_ends_at` still dates this record, which is the whole reason
     // the page was moved off it.
     expect(ORG.free_trial_ends_at).toBeTruthy();
-    expect(valueBeside("Trial").textContent).toBe("-");
+    expect(valueBeside("Trial").textContent).toBe("-No trial");
   });
 
   it("renders every projects cell out of the record that produced it", async () => {

--- a/client/admin/src/pages/OrganizationDetail.tsx
+++ b/client/admin/src/pages/OrganizationDetail.tsx
@@ -18,6 +18,7 @@ import {
   type DataTableFeatures,
 } from "@/components/data-table";
 import { useConfirmDialog } from "@/components/ConfirmDialog";
+import { Trial } from "@/components/Trial";
 import { ACCOUNT_TYPE_OPTIONS, isAccountType } from "@/lib/accountTypes";
 import { cn } from "@/lib/utils";
 import {
@@ -225,11 +226,8 @@ function OrgDetailsCard({ org }: { org: AdminOrganization }) {
           {fmtDate(org.disabled_at)}
         </span>
       </Row>
-      <Row label="Free trial started">
-        <span className="text-sm">{fmtDate(org.free_trial_started_at)}</span>
-      </Row>
-      <Row label="Free trial ends">
-        <span className="text-sm">{fmtDate(org.free_trial_ends_at)}</span>
+      <Row label="Trial">
+        <Trial org={org} />
       </Row>
       <Row label="Created">
         <span className="text-sm">{fmtDate(org.created_at)}</span>

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -14,8 +14,13 @@ const ORG: AdminOrganization = {
   account_type: "pro",
   workos_id: "org_workos_placeholder_identifier",
   whitelisted: true,
+  // The stale pair, dated apart from the real trial on purpose. A panel back
+  // on `free_trial_ends_at` then shows the wrong date rather than the right
+  // one by coincidence.
   free_trial_started_at: "2026-02-01T00:00:00Z",
-  free_trial_ends_at: "2026-05-06T00:00:00Z",
+  free_trial_ends_at: "2026-11-12T00:00:00Z",
+  trial_state: "running",
+  trial_ends_at: "2026-05-06T00:00:00Z",
   member_count: 3,
   created_at: "2026-01-02T00:00:00Z",
   updated_at: "2026-01-07T00:00:00Z",
@@ -72,20 +77,21 @@ describe("PeekPanel", () => {
   it("renders the record it was handed, field by field", async () => {
     await renderWithApp(<PeekPanel org={ORG} onClose={noop} />);
 
-    const { workos_id: workosID, free_trial_ends_at: trialEndsAt } = ORG;
+    const { workos_id: workosID, trial_ends_at: trialEndsAt } = ORG;
     if (!workosID || !trialEndsAt) {
       throw new Error("the record under test needs its optional fields set");
     }
 
     expect(screen.getByRole("heading", { name: ORG.name })).toBeTruthy();
     expect(screen.getAllByRole("term").map((term) => term.textContent)).toEqual(
-      ["Type", "Trial ends", "Members", "Created", "Org id", "WorkOS id"],
+      ["Type", "Trial", "Members", "Created", "Org id", "WorkOS id"],
     );
     expect(
       screen.getAllByRole("definition").map((value) => value.textContent),
     ).toEqual([
       ORG.account_type,
-      shortDate(trialEndsAt),
+      // The same state-then-date reading as the row, out of the same helper.
+      `Running${shortDate(trialEndsAt)}`,
       String(ORG.member_count),
       shortDate(ORG.created_at),
       ORG.id,
@@ -96,13 +102,21 @@ describe("PeekPanel", () => {
   it("renders a dash for the optional fields a record leaves unset", async () => {
     await renderWithApp(
       <PeekPanel
-        org={{ ...ORG, workos_id: undefined, free_trial_ends_at: undefined }}
+        org={{
+          ...ORG,
+          workos_id: undefined,
+          // The stale pair stays set. A panel that never trialled has to read
+          // as a dash even while the defaulted column still dates it.
+          trial_state: "none",
+          trial_ends_at: undefined,
+        }}
         onClose={noop}
       />,
     );
 
     const values = screen.getAllByRole("definition");
     expect(values.at(1)?.textContent).toBe("-");
+    expect(values.at(1)?.querySelector('[data-slot="badge"]')).toBeNull();
     expect(values.at(-1)?.textContent).toBe("-");
     expect(screen.queryByRole("button", { name: "Copy WorkOS id" })).toBeNull();
   });

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -46,8 +46,11 @@ function Peeking(): JSX.Element {
   );
 }
 
+// UTC, because the panel reads these dates in UTC. See `utils.test.ts`: an
+// API date is midnight UTC, and rendering it in the reader's own zone names the
+// day before west of Greenwich.
 function shortDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }
 
 function iconOf(button: HTMLElement): SVGElement {
@@ -91,7 +94,7 @@ describe("PeekPanel", () => {
     ).toEqual([
       ORG.account_type,
       // The same state-then-date reading as the row, out of the same helper.
-      `Running${shortDate(trialEndsAt)}`,
+      `Running ends ${shortDate(trialEndsAt)}`,
       String(ORG.member_count),
       shortDate(ORG.created_at),
       ORG.id,
@@ -115,7 +118,9 @@ describe("PeekPanel", () => {
     );
 
     const values = screen.getAllByRole("definition");
-    expect(values.at(1)?.textContent).toBe("-");
+    // A dash for the eye, and "No trial" for a reader that would otherwise be
+    // told nothing at all. `Trial.test.tsx` holds the two halves apart.
+    expect(values.at(1)?.textContent).toBe("-No trial");
     expect(values.at(1)?.querySelector('[data-slot="badge"]')).toBeNull();
     expect(values.at(-1)?.textContent).toBe("-");
     expect(screen.queryByRole("button", { name: "Copy WorkOS id" })).toBeNull();

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -46,9 +46,9 @@ function Peeking(): JSX.Element {
   );
 }
 
-// UTC, because the panel reads these dates in UTC. See `utils.test.ts`: an
-// API date is midnight UTC, and rendering it in the reader's own zone names the
-// day before west of Greenwich.
+// UTC, because the panel reads these dates in UTC. See `utils.test.ts`: an API
+// date is a real instant, and rendering it in the reader's own zone can name
+// the day before west of Greenwich.
 function shortDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -1,12 +1,13 @@
 import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
 import { useEffect, useRef, useState, type JSX, type ReactNode } from "react";
 
+import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
-import { cn } from "@/lib/utils";
+import { cn, fmtDateShort } from "@/lib/utils";
 
 const COPY_CONFIRM_MS = 1500;
 
@@ -15,13 +16,6 @@ const COPY_CONFIRM_MS = 1500;
 export const PEEK_PANEL_ID = "organization-peek-panel";
 
 function noop(): void {}
-
-function fmtDateShort(iso?: string): string {
-  if (!iso) return "-";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "-";
-  return d.toLocaleDateString();
-}
 
 function Field({
   label,
@@ -127,8 +121,8 @@ export function PeekPanel({
               {org.account_type}
             </Badge>
           </Field>
-          <Field label="Trial ends">
-            {fmtDateShort(org.free_trial_ends_at)}
+          <Field label="Trial">
+            <Trial org={org} />
           </Field>
           <Field label="Members">{org.member_count}</Field>
           <Field label="Created">{fmtDateShort(org.created_at)}</Field>

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -2,19 +2,13 @@ import { Link } from "@tanstack/react-router";
 import { createColumnHelper } from "@tanstack/react-table";
 
 import type { DataTableFeatures } from "@/components/data-table";
+import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
-import { cn } from "@/lib/utils";
+import { cn, fmtDateShort } from "@/lib/utils";
 
 import { PeekTrigger } from "./PeekTrigger";
-
-function fmtDateShort(iso?: string): string {
-  if (!iso) return "-";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "-";
-  return d.toLocaleDateString();
-}
 
 const column = createColumnHelper<DataTableFeatures, AdminOrganization>();
 
@@ -95,18 +89,11 @@ export const ORG_COLUMNS = column.columns([
       </span>
     ),
   }),
-  column.accessor("free_trial_ends_at", {
-    header: "Trial ends",
-    cell: ({ row }) => (
-      <span
-        className={cn(
-          "text-sm",
-          !row.original.free_trial_ends_at && "text-muted-foreground",
-        )}
-      >
-        {fmtDateShort(row.original.free_trial_ends_at)}
-      </span>
-    ),
+  // "Trial", not "Trial ends": the cell reads as a state, and the end date is
+  // the detail underneath it rather than the column's subject.
+  column.accessor("trial_state", {
+    header: "Trial",
+    cell: ({ row }) => <Trial org={row.original} />,
   }),
   column.accessor("created_at", {
     header: "Created",

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -126,9 +126,11 @@ if (!FIRST_ORG || !SECOND_ORG) throw new Error("ORGS needs two rows");
 
 // The columns render a date through toLocaleDateString, so the expected text
 // has to come out of the same formatter. Reading the field off the fixture is
-// what the assertion is for: the format is not.
+// what the assertion is for: the format is not. UTC, because that is the zone
+// the API states these dates in and the zone the table renders them in; see
+// `utils.test.ts`.
 function shortDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }
 
 function lastListParams(): ListOrganizationsParams {
@@ -179,6 +181,21 @@ function rowFor(link: HTMLElement): HTMLTableRowElement {
   const row = link.closest("tr");
   if (!row) throw new Error("the name link is not inside a row");
   return row;
+}
+
+// Taken by the header above it, not by counting cells. A column added beside
+// this one otherwise leaves the assertion reading its neighbour and still
+// passing or failing for reasons that have nothing to do with what it names.
+function cellUnder(row: HTMLElement, header: string): HTMLElement {
+  const at = screen
+    .getAllByRole("columnheader")
+    .map((column) => column.textContent)
+    .indexOf(header);
+  if (at < 0) throw new Error(`no ${header} column on the page`);
+
+  const cell = within(row).getAllByRole("cell").at(at);
+  if (!cell) throw new Error(`the row has no cell under ${header}`);
+  return cell;
 }
 
 // Found by the accessible name a screen reader announces, so the test reaches
@@ -526,10 +543,11 @@ describe("organizations list", () => {
       // column's own constant would move this expectation along with it.
       `${workosID.substring(0, 12)}...`,
       shortDate(disabledAt),
-      // The state leads and the end date follows it. The stale pair on this
-      // record carries a different date, so a cell back on the old field
-      // fails here on the date alone.
-      `Running${shortDate(trialEndsAt)}`,
+      // The state leads and the end date follows it, and the date says what it
+      // is: the header reads `Trial` and no longer does. The stale pair on this
+      // record carries a different date, so a cell back on the old field fails
+      // here on the date alone.
+      `Running ends ${shortDate(trialEndsAt)}`,
       shortDate(FIRST_ORG.created_at),
     ]);
   });
@@ -542,10 +560,33 @@ describe("organizations list", () => {
     expect(SECOND_ORG.free_trial_ends_at).toBeTruthy();
 
     const link = await screen.findByRole("link", { name: SECOND_ORG.name });
-    const [, , , , , , , trialCell] = within(rowFor(link)).getAllByRole("cell");
+    const trialCell = cellUnder(rowFor(link), "Trial");
 
-    expect(trialCell?.textContent).toBe("-");
-    expect(trialCell?.querySelector('[data-slot="badge"]')).toBeNull();
+    // The dash is what an operator reads; the words behind it are what a
+    // screen reader is given in place of a hyphen it announces as nothing.
+    expect(trialCell.textContent).toBe("-No trial");
+    expect(trialCell.querySelector('[data-slot="badge"]')).toBeNull();
+  });
+
+  it("lets the operator hide the trial column like any other", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    expect(screen.getByRole("columnheader", { name: "Trial" })).toBeTruthy();
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    const item = screen.getByRole("menuitemcheckbox", { name: "Trial" });
+    // Nothing about this column justifies pinning it on screen. An operator
+    // working a list of a hundred organizations gets to put away the columns
+    // they are not reading, and the bar locks a column only to keep the table
+    // from emptying out.
+    expect(item.getAttribute("aria-disabled")).not.toBe("true");
+    fireEvent.click(item);
+
+    // The open menu hides the rest of the page from the accessibility tree, so
+    // wait for a column that stays before reading the one that went.
+    await waitFor(() => {
+      expect(screen.getByRole("columnheader", { name: "Name" })).toBeTruthy();
+    });
+    expect(screen.queryByRole("columnheader", { name: "Trial" })).toBeNull();
   });
 
   it("opens the organization when the operator clicks the row body", async () => {

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -71,6 +71,11 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
 // Two rows, and every optional field set on one of them. One row forecloses
 // every ordering and keying fault by construction, and an unset optional field
 // renders the same dash whichever field the cell reads.
+//
+// Both rows carry the stale `free_trial_*` pair, and neither carries a date
+// there that the Trial cell should ever show. The second row is the one that
+// matters: it never trialled, and the stale pair still dates it, which is the
+// whole reason this column was rewritten.
 const ORGS: AdminOrganization[] = [
   {
     id: "org_placeholder_one",
@@ -81,7 +86,9 @@ const ORGS: AdminOrganization[] = [
     whitelisted: true,
     disabled_at: "2026-03-04T00:00:00Z",
     free_trial_started_at: "2026-02-01T00:00:00Z",
-    free_trial_ends_at: "2026-05-06T00:00:00Z",
+    free_trial_ends_at: "2026-11-12T00:00:00Z",
+    trial_state: "running",
+    trial_ends_at: "2026-05-06T00:00:00Z",
     member_count: 3,
     created_at: "2026-01-02T00:00:00Z",
     updated_at: "2026-01-07T00:00:00Z",
@@ -92,6 +99,9 @@ const ORGS: AdminOrganization[] = [
     slug: "placeholder-two",
     account_type: "free",
     whitelisted: false,
+    free_trial_started_at: "2026-06-08T00:00:00Z",
+    free_trial_ends_at: "2026-06-22T00:00:00Z",
+    trial_state: "none",
     member_count: 7,
     created_at: "2026-06-08T00:00:00Z",
     updated_at: "2026-06-09T00:00:00Z",
@@ -474,8 +484,11 @@ describe("organizations list", () => {
   it("renders every cell of a row out of the record that produced it", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    const { workos_id: workosID, disabled_at: disabledAt } = FIRST_ORG;
-    const trialEndsAt = FIRST_ORG.free_trial_ends_at;
+    const {
+      workos_id: workosID,
+      disabled_at: disabledAt,
+      trial_ends_at: trialEndsAt,
+    } = FIRST_ORG;
     if (!workosID || !disabledAt || !trialEndsAt) {
       throw new Error("the row under test needs its optional fields set");
     }
@@ -495,7 +508,7 @@ describe("organizations list", () => {
       "Members",
       "WorkOS",
       "Disabled",
-      "Trial ends",
+      "Trial",
       "Created",
     ]);
     expect(
@@ -513,9 +526,26 @@ describe("organizations list", () => {
       // column's own constant would move this expectation along with it.
       `${workosID.substring(0, 12)}...`,
       shortDate(disabledAt),
-      shortDate(trialEndsAt),
+      // The state leads and the end date follows it. The stale pair on this
+      // record carries a different date, so a cell back on the old field
+      // fails here on the date alone.
+      `Running${shortDate(trialEndsAt)}`,
       shortDate(FIRST_ORG.created_at),
     ]);
+  });
+
+  it("reads a dash in the trial cell of an organization that never trialled", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    // The row is dated by `free_trial_ends_at` all the same, which is the
+    // defaulted column this cell was moved off.
+    expect(SECOND_ORG.free_trial_ends_at).toBeTruthy();
+
+    const link = await screen.findByRole("link", { name: SECOND_ORG.name });
+    const [, , , , , , , trialCell] = within(rowFor(link)).getAllByRole("cell");
+
+    expect(trialCell?.textContent).toBe("-");
+    expect(trialCell?.querySelector('[data-slot="badge"]')).toBeNull();
   });
 
   it("opens the organization when the operator clicks the row body", async () => {
@@ -606,6 +636,23 @@ describe("organizations list peek", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual(["Peek", "Name", "Slug", "Type"]);
+  });
+
+  it("takes the trial column down with the rest while it is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    expect(screen.getByRole("columnheader", { name: "Trial" })).toBeTruthy();
+
+    await peekOn(FIRST_ORG.name);
+
+    // Its own test, because the set peek hides is keyed by column id in a
+    // plain string record. Renaming the column leaves a stale key that is
+    // neither a type error nor a failure anywhere else: the column simply
+    // stops hiding, and the panel opens into a table too wide to read.
+    expect(screen.queryByRole("columnheader", { name: "Trial" })).toBeNull();
+
+    fireEvent.keyDown(peekPanel(), { key: "Escape" });
+
+    expect(screen.getByRole("columnheader", { name: "Trial" })).toBeTruthy();
   });
 
   it("highlights the row it is peeking at and no other", async () => {
@@ -723,7 +770,7 @@ describe("organizations list peek", () => {
       "Members",
       "WorkOS",
       "Disabled",
-      "Trial ends",
+      "Trial",
       "Created",
     ]);
   });
@@ -815,7 +862,7 @@ describe("organizations list peek", () => {
       "Members",
       "WorkOS",
       "Disabled",
-      "Trial ends",
+      "Trial",
       "Created",
     ]);
   });

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -36,7 +36,7 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   member_count: false,
   workos_id: false,
   disabled_at: false,
-  free_trial_ends_at: false,
+  trial_state: false,
   created_at: false,
 };
 


### PR DESCRIPTION
The admin dashboard dated every organization's trial from a column that was defaulted for every organization, so it reported a trial that never happened.

`free_trial_ends_at` is `NOT NULL` with a default of signup plus fourteen days, and no application code writes it. The organizations list, the peek panel and the organization detail page all read it, so an operator who trusted the date acted on the wrong account. AGE-3184 shipped the server half in #5276 and was closed as done; the client half was never built, so all four of its acceptance criteria still failed.

All three surfaces now read `trial_state` and `trial_ends_at`, which the server derives from the `trials` table.

## What changes on screen

The list column is headed `Trial` rather than `Trial ends`, because it now reads as a state: a badge carrying Running, Ending soon, Expired, Demoted or Converted, with `ends` and the date beside it only while the trial is still live. An organization that never trialled reads as a dash.

One shared `Trial` component renders all three surfaces, so the same organization cannot read one way in the list and another way on its own page.

## Two defects found in review, not in the build

A three-lens review round ran before this PR opened. Both of these were introduced or first exposed here, and both are fixed in `30fa1d832`.

**Every date in the admin dashboard was rendering a day early.** `fmtDateShort` called `toLocaleDateString()` with no `timeZone`, so a UTC-midnight timestamp rendered as the previous day everywhere west of Greenwich. A trial ending `2026-05-06` read as `5/5/2026`. An operator who reads a deadline a day early chases or demotes an account that still has a day left, which is exactly what this column was rewritten to stop. It now formats in UTC.

Three other cells move with it deliberately: `created_at` in the list and the peek panel, and `disabled_at` in the list. Those are real moments rather than UTC midnights, so near midnight their rendered day can differ from the reader's own calendar. Agreeing with the server, and with every other operator, is the right frame for an admin tool.

**The `warning` badge failed WCAG AA.** Measured against the compiled CSS in Chromium, the light foreground was 4.34:1 on its own background. Badge text is 12px at weight 500, which is not WCAG large text, so the bar is 4.5:1. It was the only tone that failed, and no badge in this app carried it before this slice. `badgeTone.test.ts` now parses the colours back out of the class strings and measures every tone against its own background in both schemes, so a future tone cannot fail quietly.

## Accessibility

An organization that never trialled and a state this build does not recognise both read as a dash, which is correct, and until now they were byte-identical DOM. A lone hyphen is announced as nothing, so the dash is `aria-hidden` and carries either "No trial" or "Trial state not recognised" beside it. Calling a server-derived state "no trial" is the same laundering this column exists to stop.

The date is now labelled `ends`, since the header no longer says what it is, and the separator is an explicit text node as well as a flex gap, so a copied cell no longer reads `Running5/6/2026`.

## Tests

140 tests across 10 files, up from 114. 41 mutants were run one at a time with test and type-check per mutant, and the single survivor is provably equivalent: the `&& org.trial_ends_at` guard makes a `?? org.free_trial_ends_at` fallback unreachable, so no test can observe it. The real-shaped edit dies.

`TRIAL_STATES` is now a runtime list with the union derived from it. A seventh state was previously a build failure only while `Trial.tsx` happened to import `TrialState` for nothing else; now it fails a test as well.

## Scope

Client-only on purpose. `free_trial_started_at` and `free_trial_ends_at` stay declared on `AdminOrganization` because the API still sends them; nothing reads them. Taking them off the wire is **AGE-3207**, which also removes the cursor pagination the server slice is expanding past.

Test fixtures keep the stale pair deliberately, as a trap: a surface that regresses to reading it renders a visibly wrong date.

Stacked on `walker/age-3189-peek-trigger` (#5287), which owns three of the four files this touches.

AGE-3184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows each organization’s real trial state in the admin list, peek panel, and org detail so operators stop acting on defaulted dates. Previously these views read `free_trial_ends_at`; they now read `trial_state` and `trial_ends_at` and render a state badge, with an end date only while the trial is live. Dates in list and peek now render in UTC to match the server (the end is a live instant), and the warning badge meets WCAG AA.

- Column header is “Trial”. States: Running, Ending soon, Expired, Demoted, Converted. Never‑trialled renders a dash; unknown states fall back to a dash with “Trial state not recognised”.
- Adds a shared `Trial` component used by the list, peek panel, and org detail; the cell includes an explicit “ends ” separator.
- `fmtDateShort` formats in UTC to avoid off‑by‑one (affects trial end display, list Created, and list Disabled).
- Fixes badge contrast and adds screen‑reader text for dashed states.

**Rollout / Migration**
- No server changes; the client stops reading `free_trial_*`. The API still sends them; a follow‑up removes them (AGE-3207).
- Validations for AGE-3184: never‑trialled shows “-”, running/ending soon show “<state> ends <date>”, demoted/expired show a destructive badge without a date, converted shows success.

<sup>Written for commit a6725c5d4970c15ce78f7231e3688282c68bba16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

