### PR TITLE
feat(admin): sort and page the admin organizations list

### DIFF
--- a/.changeset/admin-sort-page-organizations.md
+++ b/.changeset/admin-sort-page-organizations.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+The admin organizations endpoint can now sort and page. A caller names a column, a direction and a 1-based page number, and gets that page back together with the number of organizations the filters matched. Sortable columns are name, slug, account type, member count, created date, disabled date and trial end date; an unknown column or direction falls back to the default order rather than failing a shared link. Cursor paging is untouched and still runs the deployed dashboard, so both walks work until the client half lands.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -55218,14 +55218,19 @@ components:
       properties:
         next_cursor:
           type: string
-          description: Cursor for the next page; empty when exhausted.
+          description: Cursor for the next page; empty when exhausted. Omitted in offset mode.
         organizations:
           type: array
           items:
             $ref: '#/components/schemas/AdminOrganization'
           description: The page of organizations.
+        total:
+          type: integer
+          description: Number of organizations matching the filters, before paging.
+          format: int64
       required:
         - organizations
+        - total
     AdminOpenRouterKey:
       type: object
       properties:

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -129,10 +129,11 @@ var AdminListOrganizationProjectsResult = Type("AdminListOrganizationProjectsRes
 })
 
 var AdminListOrganizationsResult = Type("AdminListOrganizationsResult", func() {
-	Required("organizations")
+	Required("organizations", "total")
 
 	Attribute("organizations", ArrayOf(AdminOrganization), "The page of organizations.")
-	Attribute("next_cursor", String, "Cursor for the next page; empty when exhausted.")
+	Attribute("next_cursor", String, "Cursor for the next page; empty when exhausted. Omitted in offset mode.")
+	Attribute("total", Int64, "Number of organizations matching the filters, before paging.")
 })
 
 var _ = Service("admin", func() {
@@ -340,8 +341,11 @@ var _ = Service("admin", func() {
 			Attribute("q", String, "Search term applied to name and slug (case-insensitive substring).")
 			Attribute("account_type", String, "Filter by gram_account_type (e.g. free, pro, enterprise).")
 			Attribute("include_disabled", Boolean, "Include organizations with disabled_at set. Defaults to false.")
-			Attribute("cursor", String, "Pagination cursor: id of the last item from the previous page.")
+			Attribute("cursor", String, "Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.")
 			Attribute("limit", Int, "Page size (default 50, max 100).")
+			Attribute("sort", String, "Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.")
+			Attribute("direction", String, "Sort direction, asc or desc. Any other value sorts ascending.")
+			Attribute("page", Int, "1-based page number for offset paging (default 1). Supplying it selects offset paging.")
 		})
 
 		Result(AdminListOrganizationsResult)
@@ -354,6 +358,9 @@ var _ = Service("admin", func() {
 			Param("include_disabled")
 			Param("cursor")
 			Param("limit")
+			Param("sort")
+			Param("direction")
+			Param("page")
 			Response(StatusOK)
 		})
 

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -344,7 +344,7 @@ var _ = Service("admin", func() {
 			Attribute("cursor", String, "Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.")
 			Attribute("limit", Int, "Page size (default 50, max 100).")
 			Attribute("sort", String, "Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.")
-			Attribute("direction", String, "Sort direction, asc or desc. Any other value sorts ascending.")
+			Attribute("direction", String, "Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.")
 			Attribute("page", Int, "1-based page number for offset paging (default 1). Supplying it selects offset paging.")
 		})
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -79,8 +79,10 @@ type AdminListOrganizationProjectsResult struct {
 type AdminListOrganizationsResult struct {
 	// The page of organizations.
 	Organizations []*AdminOrganization
-	// Cursor for the next page; empty when exhausted.
+	// Cursor for the next page; empty when exhausted. Omitted in offset mode.
 	NextCursor *string
+	// Number of organizations matching the filters, before paging.
+	Total int64
 }
 
 // AdminOrganization is the result type of the admin service updateOrganization
@@ -240,10 +242,20 @@ type ListOrganizationsPayload struct {
 	AccountType *string
 	// Include organizations with disabled_at set. Defaults to false.
 	IncludeDisabled *bool
-	// Pagination cursor: id of the last item from the previous page.
+	// Pagination cursor: id of the last item from the previous page. Ignored when
+	// sort or page is supplied.
 	Cursor *string
 	// Page size (default 50, max 100).
 	Limit *int
+	// Column to sort by: name, slug, account_type, member_count, created_at,
+	// disabled_at or trial_ends_at. Any other value sorts by id. Supplying it
+	// selects offset paging.
+	Sort *string
+	// Sort direction, asc or desc. Any other value sorts ascending.
+	Direction *string
+	// 1-based page number for offset paging (default 1). Supplying it selects
+	// offset paging.
+	Page *int
 }
 
 // LoginPayload is the payload type of the admin service login method.

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -251,7 +251,10 @@ type ListOrganizationsPayload struct {
 	// disabled_at or trial_ends_at. Any other value sorts by id. Supplying it
 	// selects offset paging.
 	Sort *string
-	// Sort direction, asc or desc. Any other value sorts ascending.
+	// Sort direction, asc or desc, applied to the column named by sort. Any other
+	// value sorts ascending. On its own it does nothing: without sort there is no
+	// column to reverse, so it neither reorders the results nor selects offset
+	// paging.
 	Direction *string
 	// 1-based page number for offset paging (default 1). Supplying it selects
 	// offset paging.

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -202,7 +202,7 @@ func BuildListOrganizationProjectsPayload(adminListOrganizationProjectsOrganizat
 
 // BuildListOrganizationsPayload builds the payload for the admin
 // listOrganizations endpoint from CLI flags.
-func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrganizationsAccountType string, adminListOrganizationsIncludeDisabled string, adminListOrganizationsCursor string, adminListOrganizationsLimit string, adminListOrganizationsAdminSessionToken string) (*admin.ListOrganizationsPayload, error) {
+func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrganizationsAccountType string, adminListOrganizationsIncludeDisabled string, adminListOrganizationsCursor string, adminListOrganizationsLimit string, adminListOrganizationsSort string, adminListOrganizationsDirection string, adminListOrganizationsPage string, adminListOrganizationsAdminSessionToken string) (*admin.ListOrganizationsPayload, error) {
 	var err error
 	var q *string
 	{
@@ -245,6 +245,30 @@ func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrga
 			}
 		}
 	}
+	var sort *string
+	{
+		if adminListOrganizationsSort != "" {
+			sort = &adminListOrganizationsSort
+		}
+	}
+	var direction *string
+	{
+		if adminListOrganizationsDirection != "" {
+			direction = &adminListOrganizationsDirection
+		}
+	}
+	var page *int
+	{
+		if adminListOrganizationsPage != "" {
+			var v int64
+			v, err = strconv.ParseInt(adminListOrganizationsPage, 10, strconv.IntSize)
+			val := int(v)
+			page = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for page, must be INT")
+			}
+		}
+	}
 	var adminSessionToken *string
 	{
 		if adminListOrganizationsAdminSessionToken != "" {
@@ -257,6 +281,9 @@ func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrga
 	v.IncludeDisabled = includeDisabled
 	v.Cursor = cursor
 	v.Limit = limit
+	v.Sort = sort
+	v.Direction = direction
+	v.Page = page
 	v.AdminSessionToken = adminSessionToken
 
 	return v, nil

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -1962,6 +1962,15 @@ func EncodeListOrganizationsRequest(encoder func(*http.Request) goahttp.Encoder)
 		if p.Limit != nil {
 			values.Add("limit", fmt.Sprintf("%v", *p.Limit))
 		}
+		if p.Sort != nil {
+			values.Add("sort", *p.Sort)
+		}
+		if p.Direction != nil {
+			values.Add("direction", *p.Direction)
+		}
+		if p.Page != nil {
+			values.Add("page", fmt.Sprintf("%v", *p.Page))
+		}
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -141,8 +141,10 @@ type ListOrganizationProjectsResponseBody struct {
 type ListOrganizationsResponseBody struct {
 	// The page of organizations.
 	Organizations []*AdminOrganizationResponseBody `form:"organizations,omitempty" json:"organizations,omitempty" xml:"organizations,omitempty"`
-	// Cursor for the next page; empty when exhausted.
+	// Cursor for the next page; empty when exhausted. Omitted in offset mode.
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
+	// Number of organizations matching the filters, before paging.
+	Total *int64 `form:"total,omitempty" json:"total,omitempty" xml:"total,omitempty"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -3181,6 +3183,7 @@ func NewListOrganizationProjectsGatewayError(body *ListOrganizationProjectsGatew
 func NewListOrganizationsAdminListOrganizationsResultOK(body *ListOrganizationsResponseBody) *admin.AdminListOrganizationsResult {
 	v := &admin.AdminListOrganizationsResult{
 		NextCursor: body.NextCursor,
+		Total:      *body.Total,
 	}
 	v.Organizations = make([]*admin.AdminOrganization, len(body.Organizations))
 	for i, val := range body.Organizations {
@@ -3535,6 +3538,9 @@ func ValidateListOrganizationProjectsResponseBody(body *ListOrganizationProjects
 func ValidateListOrganizationsResponseBody(body *ListOrganizationsResponseBody) (err error) {
 	if body.Organizations == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("organizations", "body"))
+	}
+	if body.Total == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("total", "body"))
 	}
 	for _, e := range body.Organizations {
 		if e != nil {

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -1675,6 +1675,9 @@ func DecodeListOrganizationsRequest(mux goahttp.Muxer, decoder func(*http.Reques
 			includeDisabled   *bool
 			cursor            *string
 			limit             *int
+			sort              *string
+			direction         *string
+			page              *int
 			adminSessionToken *string
 			err               error
 		)
@@ -1712,6 +1715,25 @@ func DecodeListOrganizationsRequest(mux goahttp.Muxer, decoder func(*http.Reques
 				limit = &pv
 			}
 		}
+		sortRaw := qp.Get("sort")
+		if sortRaw != "" {
+			sort = &sortRaw
+		}
+		directionRaw := qp.Get("direction")
+		if directionRaw != "" {
+			direction = &directionRaw
+		}
+		{
+			pageRaw := qp.Get("page")
+			if pageRaw != "" {
+				v, err2 := strconv.ParseInt(pageRaw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("page", pageRaw, "integer"))
+				}
+				pv := int(v)
+				page = &pv
+			}
+		}
 		adminSessionTokenRaw := r.Header.Get("Authorization")
 		if adminSessionTokenRaw != "" {
 			adminSessionToken = &adminSessionTokenRaw
@@ -1719,7 +1741,7 @@ func DecodeListOrganizationsRequest(mux goahttp.Muxer, decoder func(*http.Reques
 		if err != nil {
 			return payload, err
 		}
-		payload = NewListOrganizationsPayload(q, accountType, includeDisabled, cursor, limit, adminSessionToken)
+		payload = NewListOrganizationsPayload(q, accountType, includeDisabled, cursor, limit, sort, direction, page, adminSessionToken)
 		if payload.AdminSessionToken != nil {
 			if strings.Contains(*payload.AdminSessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -141,8 +141,10 @@ type ListOrganizationProjectsResponseBody struct {
 type ListOrganizationsResponseBody struct {
 	// The page of organizations.
 	Organizations []*AdminOrganizationResponseBody `form:"organizations" json:"organizations" xml:"organizations"`
-	// Cursor for the next page; empty when exhausted.
+	// Cursor for the next page; empty when exhausted. Omitted in offset mode.
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
+	// Number of organizations matching the filters, before paging.
+	Total int64 `form:"total" json:"total" xml:"total"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -1966,6 +1968,7 @@ func NewListOrganizationProjectsResponseBody(res *admin.AdminListOrganizationPro
 func NewListOrganizationsResponseBody(res *admin.AdminListOrganizationsResult) *ListOrganizationsResponseBody {
 	body := &ListOrganizationsResponseBody{
 		NextCursor: res.NextCursor,
+		Total:      res.Total,
 	}
 	if res.Organizations != nil {
 		body.Organizations = make([]*AdminOrganizationResponseBody, len(res.Organizations))
@@ -3350,13 +3353,16 @@ func NewListOrganizationProjectsPayload(organizationID string, adminSessionToken
 
 // NewListOrganizationsPayload builds a admin service listOrganizations
 // endpoint payload.
-func NewListOrganizationsPayload(q *string, accountType *string, includeDisabled *bool, cursor *string, limit *int, adminSessionToken *string) *admin.ListOrganizationsPayload {
+func NewListOrganizationsPayload(q *string, accountType *string, includeDisabled *bool, cursor *string, limit *int, sort *string, direction *string, page *int, adminSessionToken *string) *admin.ListOrganizationsPayload {
 	v := &admin.ListOrganizationsPayload{}
 	v.Q = q
 	v.AccountType = accountType
 	v.IncludeDisabled = includeDisabled
 	v.Cursor = cursor
 	v.Limit = limit
+	v.Sort = sort
+	v.Direction = direction
+	v.Page = page
 	v.AdminSessionToken = adminSessionToken
 
 	return v

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -362,6 +362,9 @@ func ParseEndpoint(
 		adminListOrganizationsIncludeDisabledFlag   = adminListOrganizationsFlags.String("include-disabled", "", "")
 		adminListOrganizationsCursorFlag            = adminListOrganizationsFlags.String("cursor", "", "")
 		adminListOrganizationsLimitFlag             = adminListOrganizationsFlags.String("limit", "", "")
+		adminListOrganizationsSortFlag              = adminListOrganizationsFlags.String("sort", "", "")
+		adminListOrganizationsDirectionFlag         = adminListOrganizationsFlags.String("direction", "", "")
+		adminListOrganizationsPageFlag              = adminListOrganizationsFlags.String("page", "", "")
 		adminListOrganizationsAdminSessionTokenFlag = adminListOrganizationsFlags.String("admin-session-token", "", "")
 
 		agentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
@@ -6276,7 +6279,7 @@ func ParseEndpoint(
 				data, err = adminc.BuildListOrganizationProjectsPayload(*adminListOrganizationProjectsOrganizationIDFlag, *adminListOrganizationProjectsAdminSessionTokenFlag)
 			case "list-organizations":
 				endpoint = c.ListOrganizations()
-				data, err = adminc.BuildListOrganizationsPayload(*adminListOrganizationsQFlag, *adminListOrganizationsAccountTypeFlag, *adminListOrganizationsIncludeDisabledFlag, *adminListOrganizationsCursorFlag, *adminListOrganizationsLimitFlag, *adminListOrganizationsAdminSessionTokenFlag)
+				data, err = adminc.BuildListOrganizationsPayload(*adminListOrganizationsQFlag, *adminListOrganizationsAccountTypeFlag, *adminListOrganizationsIncludeDisabledFlag, *adminListOrganizationsCursorFlag, *adminListOrganizationsLimitFlag, *adminListOrganizationsSortFlag, *adminListOrganizationsDirectionFlag, *adminListOrganizationsPageFlag, *adminListOrganizationsAdminSessionTokenFlag)
 			}
 		case "agent":
 			c := agentc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -8906,6 +8909,9 @@ func adminListOrganizationsUsage() {
 	fmt.Fprint(os.Stderr, " -include-disabled BOOL")
 	fmt.Fprint(os.Stderr, " -cursor STRING")
 	fmt.Fprint(os.Stderr, " -limit INT")
+	fmt.Fprint(os.Stderr, " -sort STRING")
+	fmt.Fprint(os.Stderr, " -direction STRING")
+	fmt.Fprint(os.Stderr, " -page INT")
 	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
 	fmt.Fprintln(os.Stderr)
 
@@ -8919,11 +8925,14 @@ func adminListOrganizationsUsage() {
 	fmt.Fprintln(os.Stderr, `    -include-disabled BOOL: `)
 	fmt.Fprintln(os.Stderr, `    -cursor STRING: `)
 	fmt.Fprintln(os.Stderr, `    -limit INT: `)
+	fmt.Fprintln(os.Stderr, `    -sort STRING: `)
+	fmt.Fprintln(os.Stderr, `    -direction STRING: `)
+	fmt.Fprintln(os.Stderr, `    -page INT: `)
 	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin list-organizations --q \"abc123\" --account-type \"abc123\" --include-disabled false --cursor \"abc123\" --limit 1 --admin-session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin list-organizations --q \"abc123\" --account-type \"abc123\" --include-disabled false --cursor \"abc123\" --limit 1 --sort \"abc123\" --direction \"abc123\" --page 1 --admin-session-token \"abc123\"")
 }
 
 // agentUsage displays the usage of the agent command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -639,11 +639,11 @@ paths:
                     description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.'
                     type: string
                 - allowEmptyValue: true
-                  description: Sort direction, asc or desc. Any other value sorts ascending.
+                  description: 'Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.'
                   in: query
                   name: direction
                   schema:
-                    description: Sort direction, asc or desc. Any other value sorts ascending.
+                    description: 'Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.'
                     type: string
                 - allowEmptyValue: true
                   description: 1-based page number for offset paging (default 1). Supplying it selects offset paging.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -617,11 +617,11 @@ paths:
                     description: Include organizations with disabled_at set. Defaults to false.
                     type: boolean
                 - allowEmptyValue: true
-                  description: 'Pagination cursor: id of the last item from the previous page.'
+                  description: 'Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.'
                   in: query
                   name: cursor
                   schema:
-                    description: 'Pagination cursor: id of the last item from the previous page.'
+                    description: 'Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.'
                     type: string
                 - allowEmptyValue: true
                   description: Page size (default 50, max 100).
@@ -629,6 +629,28 @@ paths:
                   name: limit
                   schema:
                     description: Page size (default 50, max 100).
+                    format: int64
+                    type: integer
+                - allowEmptyValue: true
+                  description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.'
+                  in: query
+                  name: sort
+                  schema:
+                    description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.'
+                    type: string
+                - allowEmptyValue: true
+                  description: Sort direction, asc or desc. Any other value sorts ascending.
+                  in: query
+                  name: direction
+                  schema:
+                    description: Sort direction, asc or desc. Any other value sorts ascending.
+                    type: string
+                - allowEmptyValue: true
+                  description: 1-based page number for offset paging (default 1). Supplying it selects offset paging.
+                  in: query
+                  name: page
+                  schema:
+                    description: 1-based page number for offset paging (default 1). Supplying it selects offset paging.
                     format: int64
                     type: integer
             responses:
@@ -55445,14 +55467,19 @@ components:
             properties:
                 next_cursor:
                     type: string
-                    description: Cursor for the next page; empty when exhausted.
+                    description: Cursor for the next page; empty when exhausted. Omitted in offset mode.
                 organizations:
                     type: array
                     items:
                         $ref: '#/components/schemas/AdminOrganization'
                     description: The page of organizations.
+                total:
+                    type: integer
+                    description: Number of organizations matching the filters, before paging.
+                    format: int64
             required:
                 - organizations
+                - total
         AdminOpenRouterKey:
             type: object
             properties:

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -388,9 +388,16 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 		return nil, oops.E(oops.CodeUnexpected, err, "list organizations").LogError(ctx, s.logger)
 	}
 
-	var total int64
-	if len(rows) > 0 {
-		total = rows[0].TotalCount
+	// Counted separately from the page. A page past the end holds no row to carry
+	// a count, and in cursor mode the page query has already discarded everything
+	// before the cursor.
+	total, err := queries.AdminCountOrganizations(ctx, repo.AdminCountOrganizationsParams{
+		Q:               conv.PtrToPGText(payload.Q),
+		AccountType:     conv.PtrToPGText(payload.AccountType),
+		IncludeDisabled: conv.PtrValOr(payload.IncludeDisabled, false),
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "count organizations").LogError(ctx, s.logger)
 	}
 
 	var nextCursor *string
@@ -421,8 +428,10 @@ func listOrganizationsOffset(page *int, limit int32) int64 {
 	}
 
 	// Cap the page so that a hand-typed page number cannot overflow the multiply
-	// into a negative offset, which Postgres rejects.
-	if maxPage := math.MaxInt64/int64(limit) + 1; n > maxPage {
+	// into a negative offset, which Postgres rejects. The ceiling carries no +1:
+	// limit is not a constant, so at limit 1 the addition overflows to MinInt64
+	// and the guard fires on every page.
+	if maxPage := math.MaxInt64 / int64(limit); n > maxPage {
 		n = maxPage
 	}
 

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -320,6 +320,11 @@ const (
 
 // The columns the ORDER BY ladder in AdminListOrganizations knows. The opaque
 // ids are absent on purpose: an order built from them tells an operator nothing.
+//
+// This map cannot widen what the ladder accepts. The ladder matches these seven
+// literals and nothing else, so an unrecognised sort key collapses to the
+// tiebreaker with or without the check here. It is defense in depth, and the one
+// place a reader can see the accepted set without reading the SQL.
 var listOrganizationsSortColumns = map[string]bool{
 	"name":          true,
 	"slug":          true,

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -316,6 +318,18 @@ const (
 	listOrganizationsMaxLimit     = 100
 )
 
+// The columns the ORDER BY ladder in AdminListOrganizations knows. The opaque
+// ids are absent on purpose: an order built from them tells an operator nothing.
+var listOrganizationsSortColumns = map[string]bool{
+	"name":          true,
+	"slug":          true,
+	"account_type":  true,
+	"member_count":  true,
+	"created_at":    true,
+	"disabled_at":   true,
+	"trial_ends_at": true,
+}
+
 func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrganizationsPayload) (*gen.AdminListOrganizationsResult, error) {
 	queries := repo.New(s.db)
 
@@ -331,20 +345,56 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 		limit = int32(l)
 	}
 
-	// Over-fetch one row to learn whether a next page exists.
+	// Sort or page selects offset paging. Without either, the request keeps the
+	// cursor walk the shipped dashboard still depends on.
+	offsetMode := payload.Sort != nil || payload.Page != nil
+
+	// An unknown sort key falls back to the default order instead of failing: the
+	// value comes from a URL operators paste to each other, and a typo should not
+	// break the page.
+	sortBy := ""
+	if payload.Sort != nil {
+		if key := strings.ToLower(*payload.Sort); listOrganizationsSortColumns[key] {
+			sortBy = key
+		}
+	}
+	sortDir := "asc"
+	if payload.Direction != nil && strings.EqualFold(*payload.Direction, "desc") {
+		sortDir = "desc"
+	}
+
+	var afterID pgtype.Text
+	var pageOffset int64
+	fetchLimit := limit
+	if offsetMode {
+		pageOffset = listOrganizationsOffset(payload.Page, limit)
+	} else {
+		afterID = conv.PtrToPGText(payload.Cursor)
+		// Over-fetch one row to learn whether a next page exists.
+		fetchLimit = limit + 1
+	}
+
 	rows, err := queries.AdminListOrganizations(ctx, repo.AdminListOrganizationsParams{
 		Q:               conv.PtrToPGText(payload.Q),
 		AccountType:     conv.PtrToPGText(payload.AccountType),
 		IncludeDisabled: conv.PtrValOr(payload.IncludeDisabled, false),
-		AfterID:         conv.PtrToPGText(payload.Cursor),
-		PageLimit:       limit + 1,
+		AfterID:         afterID,
+		SortBy:          sortBy,
+		SortDir:         sortDir,
+		PageOffset:      pageOffset,
+		PageLimit:       fetchLimit,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list organizations").LogError(ctx, s.logger)
 	}
 
+	var total int64
+	if len(rows) > 0 {
+		total = rows[0].TotalCount
+	}
+
 	var nextCursor *string
-	if len(rows) > int(limit) {
+	if !offsetMode && len(rows) > int(limit) {
 		rows = rows[:limit]
 		id := rows[limit-1].ID
 		nextCursor = &id
@@ -358,7 +408,25 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 	return &gen.AdminListOrganizationsResult{
 		Organizations: orgs,
 		NextCursor:    nextCursor,
+		Total:         total,
 	}, nil
+}
+
+// listOrganizationsOffset turns a 1-based page number into a row offset, with
+// pages below 1 clamping to the first page.
+func listOrganizationsOffset(page *int, limit int32) int64 {
+	n := int64(1)
+	if page != nil && *page > 1 {
+		n = int64(*page)
+	}
+
+	// Cap the page so that a hand-typed page number cannot overflow the multiply
+	// into a negative offset, which Postgres rejects.
+	if maxPage := math.MaxInt64/int64(limit) + 1; n > maxPage {
+		n = maxPage
+	}
+
+	return (n - 1) * int64(limit)
 }
 
 func (s *Service) ListOrganizationMembers(ctx context.Context, payload *gen.ListOrganizationMembersPayload) (*gen.AdminListOrganizationMembersResult, error) {

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -433,9 +433,10 @@ func listOrganizationsOffset(page *int, limit int32) int64 {
 	}
 
 	// Cap the page so that a hand-typed page number cannot overflow the multiply
-	// into a negative offset, which Postgres rejects. The ceiling carries no +1:
-	// limit is not a constant, so at limit 1 the addition overflows to MinInt64
-	// and the guard fires on every page.
+	// into a negative offset, which Postgres rejects. Do not add one to this
+	// ceiling. limit is a variable, so at limit 1 that addition would itself
+	// overflow to MinInt64, the guard would fire on every page, and every page
+	// would come back empty. That was the bug this replaced.
 	if maxPage := math.MaxInt64 / int64(limit); n > maxPage {
 		n = maxPage
 	}

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -580,7 +580,9 @@ func requireOrder(t *testing.T, ctx context.Context, svc *Service, payload *gen.
 }
 
 // The sort fixtures. Every sortable column ranks these four differently, so a
-// ladder arm wired to the wrong column shows up as a wrong order.
+// ladder arm wired to the wrong column shows up as a wrong order. No column may
+// rank them in id order either way round, or the tiebreaker alone reproduces the
+// expected order and a missing ladder arm reads as correct.
 const (
 	sortOrgA = "org_sort_a"
 	sortOrgB = "org_sort_b"
@@ -601,17 +603,17 @@ func seedSortFixtures(t *testing.T, ctx context.Context, conn *pgxpool.Pool) {
 	fixtures := []sortFixture{
 		{
 			org:         orgFixture{id: sortOrgA, name: "Cedar Systems", slug: "bravo-co", accountType: "enterprise", whitelisted: true, createdAt: new(base.Add(-10 * time.Hour)), disabledAt: new(base.Add(-8 * time.Hour))},
-			memberCount: 3,
+			memberCount: 1,
 			trialEndsAt: base.Add(24 * time.Hour),
 		},
 		{
 			org:         orgFixture{id: sortOrgB, name: "Alder Group", slug: "delta-co", accountType: "pro", whitelisted: true, createdAt: new(base.Add(-30 * time.Hour)), disabledAt: new(base.Add(-9 * time.Hour))},
-			memberCount: 2,
+			memberCount: 3,
 			trialEndsAt: base.Add(72 * time.Hour),
 		},
 		{
 			org:         orgFixture{id: sortOrgC, name: "Dogwood Ltd", slug: "alpha-co", accountType: "free", whitelisted: true, createdAt: new(base.Add(-40 * time.Hour)), disabledAt: new(base.Add(-7 * time.Hour))},
-			memberCount: 1,
+			memberCount: 2,
 			trialEndsAt: base.Add(96 * time.Hour),
 		},
 		{
@@ -652,7 +654,7 @@ func TestListOrganizations_SortsEveryWhitelistedColumn(t *testing.T) {
 		{sort: "name", wantAsc: []string{sortOrgB, sortOrgD, sortOrgA, sortOrgC}},
 		{sort: "slug", wantAsc: []string{sortOrgC, sortOrgA, sortOrgD, sortOrgB}},
 		{sort: "account_type", wantAsc: []string{sortOrgA, sortOrgC, sortOrgB, sortOrgD}},
-		{sort: "member_count", wantAsc: []string{sortOrgD, sortOrgC, sortOrgB, sortOrgA}},
+		{sort: "member_count", wantAsc: []string{sortOrgD, sortOrgA, sortOrgC, sortOrgB}},
 		{sort: "created_at", wantAsc: []string{sortOrgC, sortOrgB, sortOrgD, sortOrgA}},
 		{sort: "disabled_at", wantAsc: []string{sortOrgB, sortOrgA, sortOrgC, sortOrgD}},
 		{sort: "trial_ends_at", wantAsc: []string{sortOrgA, sortOrgD, sortOrgB, sortOrgC}},
@@ -965,4 +967,84 @@ func TestListOrganizations_OffsetModeIgnoresAndOmitsTheCursor(t *testing.T) {
 		res := requireOrder(t, ctx, svc, c.payload, c.want, c.name)
 		require.Nil(t, res.NextCursor, "offset mode reports no cursor for %s", c.name)
 	}
+}
+
+// A page number selects offset paging on its own, so a cursor left in the URL
+// beside it is ignored the same way a cursor beside a sort is.
+func TestListOrganizations_PageIgnoresAStaleCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedPageFixtures(t, ctx, conn)
+
+	byID := []string{"org_page_1", "org_page_2", "org_page_3", "org_page_4", "org_page_5"}
+
+	page1 := &gen.ListOrganizationsPayload{Limit: new(2), Page: new(1), Cursor: new("org_page_3")}
+	res := requireOrder(t, ctx, svc, page1, byID[0:2], "page 1 beside a stale cursor")
+	require.Nil(t, res.NextCursor)
+	require.Equal(t, int64(5), res.Total, "the stale cursor does not narrow the count either")
+
+	page2 := &gen.ListOrganizationsPayload{Limit: new(2), Page: new(2), Cursor: new("org_page_4")}
+	requireOrder(t, ctx, svc, page2, byID[2:4], "page 2 beside a stale cursor")
+}
+
+// The page size an operator can ask for is bounded at both ends. The design
+// declares no minimum, so limit=0 reaches the handler, and the offset is built by
+// dividing by the limit: without the fallback that division is a panic, not a
+// wrong page.
+func TestListOrganizations_LimitIsClampedToItsBounds(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	const seeded = 101
+	for i := range seeded {
+		id := fmt.Sprintf("org_limit_%03d", i)
+		seedOrg(t, ctx, conn, orgFixture{id: id, name: id, slug: id, whitelisted: true})
+	}
+
+	cases := []struct {
+		name  string
+		limit *int
+		want  int
+	}{
+		{name: "no limit takes the default", limit: nil, want: 50},
+		{name: "a limit inside the bounds is kept", limit: new(7), want: 7},
+		{name: "the maximum itself is kept", limit: new(100), want: 100},
+		{name: "a limit above the maximum clamps to it", limit: new(1000), want: 100},
+		{name: "zero falls back to the default", limit: new(0), want: 50},
+		{name: "a negative limit falls back to the default", limit: new(-5), want: 50},
+	}
+
+	for _, c := range cases {
+		res, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Sort: new("name"), Limit: c.limit, Page: new(1)})
+		require.NoError(t, err, "listing organizations for %s", c.name)
+		require.Len(t, res.Organizations, c.want, "page length for %s", c.name)
+		require.Equal(t, int64(seeded), res.Total, "total for %s", c.name)
+	}
+}
+
+// member_count is a sortable column, so the rows it counts have to be the live
+// memberships. A removed member must not keep ranking the organization.
+func TestListOrganizations_MemberCountSkipsRemovedMembers(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_gone_a", name: "Gone A", slug: "gone-a", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_gone_b", name: "Gone B", slug: "gone-b", whitelisted: true})
+
+	seedMembership(t, ctx, conn, "org_gone_a", "user_gone_1")
+	seedMembership(t, ctx, conn, "org_gone_a", "user_gone_2")
+	seedMembership(t, ctx, conn, "org_gone_b", "user_gone_3")
+
+	require.NoError(t, testrepo.New(conn).ForceSoftDeleteOrganizationUserRelationshipsFixture(ctx, "org_gone_a"))
+
+	res, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Sort: new("member_count"), Direction: new("desc")})
+	require.NoError(t, err)
+	require.Len(t, res.Organizations, 2)
+
+	require.Equal(t, "org_gone_b", res.Organizations[0].ID, "the organization with a live member ranks first")
+	require.Equal(t, 1, res.Organizations[0].MemberCount)
+	require.Equal(t, 0, res.Organizations[1].MemberCount, "removed members are not counted")
 }

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -807,8 +807,9 @@ func TestListOrganizations_OffsetPaging(t *testing.T) {
 		{name: "a page past the end is empty", page: new(4), want: []string{}},
 		{name: "an absurd page is empty, not an error", page: new(1 << 40), want: []string{}},
 
-		// The offset the query binds is an int32, so the largest page an operator
-		// can type must clamp rather than wrap into a negative offset.
+		// The query binds the offset as a bigint. The largest page an operator can
+		// type must still clamp, because the multiply that turns it into an offset
+		// would otherwise wrap past the end of int64 and back into a negative.
 		{name: "the largest page there is", page: ptrTo(math.MaxInt64), want: []string{}},
 	}
 
@@ -833,6 +834,16 @@ func TestListOrganizations_OffsetPaging(t *testing.T) {
 		}
 	}
 	require.Equal(t, pageOrgsByName, walked, "walking every page drops and repeats nothing")
+
+	// Limit 1 is its own boundary. The page ceiling divides by the limit, so a
+	// limit of 1 is the value an arithmetic slip in that ceiling breaks first,
+	// and every case above uses limit 2.
+	for page := 1; page <= len(pageOrgsByName); page++ {
+		payload := sortPayload("name", "asc")
+		payload.IncludeDisabled = nil
+		payload.Limit, payload.Page = new(1), new(page)
+		requireOrder(t, ctx, svc, payload, pageOrgsByName[page-1:page], fmt.Sprintf("limit 1, page %d", page))
+	}
 }
 
 // A page number alone selects offset paging, with the default order.
@@ -880,7 +891,12 @@ func TestListOrganizations_TotalCountsMatchesNotPageLength(t *testing.T) {
 		{name: "disabled included", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), IncludeDisabled: new(true)}, wantTotal: 8, wantLen: 2},
 		{name: "a filter matching nothing", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Q: new("no such organization")}, wantTotal: 0, wantLen: 0},
 
-		// The cursor walk reports the same total, so the two modes agree.
+		// A page past the end still reports what the filters matched. A client that
+		// lands there, from a bookmark or from a filter typed while sitting on a
+		// later page, needs the count to find its way back to a page that exists.
+		{name: "past the end", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), Page: new(9)}, wantTotal: 7, wantLen: 0},
+		{name: "past the end under a filter", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), Q: new("holdings"), Page: new(4)}, wantTotal: 5, wantLen: 0},
+
 		{name: "cursor mode", payload: &gen.ListOrganizationsPayload{Limit: new(2)}, wantTotal: 7, wantLen: 2},
 		{name: "cursor mode under a filter", payload: &gen.ListOrganizationsPayload{Limit: new(2), Q: new("holdings")}, wantTotal: 5, wantLen: 2},
 	}
@@ -890,6 +906,22 @@ func TestListOrganizations_TotalCountsMatchesNotPageLength(t *testing.T) {
 		require.NoError(t, err, "listing organizations for %s", c.name)
 		require.Equal(t, c.wantTotal, res.Total, "total for %s", c.name)
 		require.Len(t, res.Organizations, c.wantLen, "page length for %s", c.name)
+	}
+
+	// The count must not fall as the cursor advances. It counts the rows the
+	// filters matched, not the rows still ahead of the cursor, and the cursor walk
+	// is what the deployed dashboard runs.
+	var cursor *string
+	for page := 1; ; page++ {
+		res, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Limit: new(2), Cursor: cursor})
+		require.NoError(t, err, "cursor page %d", page)
+		require.Equal(t, int64(7), res.Total, "total on cursor page %d", page)
+
+		if res.NextCursor == nil {
+			require.Equal(t, 4, page, "the walk covers seven rows in four pages of two")
+			break
+		}
+		cursor = res.NextCursor
 	}
 }
 

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -2,6 +2,9 @@ package admin
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +27,7 @@ type orgFixture struct {
 	workosID    *string
 	whitelisted bool
 	disabledAt  *time.Time
+	createdAt   *time.Time
 }
 
 func seedOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool, f orgFixture) {
@@ -43,6 +47,7 @@ func seedOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool, f orgFixture
 		FreeTrialStartedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		FreeTrialEndsAt:    conv.ToPGTimestamptz(time.Now().UTC().Add(14 * 24 * time.Hour)),
 		DisabledAt:         conv.PtrToPGTimestamptz(f.disabledAt),
+		CreatedAt:          conv.PtrToPGTimestamptz(f.createdAt),
 	}
 
 	err := testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, params)
@@ -163,6 +168,7 @@ func TestListOrganizations_Empty(t *testing.T) {
 	require.NotNil(t, res)
 	require.Empty(t, res.Organizations)
 	require.Nil(t, res.NextCursor)
+	require.Equal(t, int64(0), res.Total)
 }
 
 func TestListOrganizations_DefaultExcludesDisabled(t *testing.T) {
@@ -279,6 +285,7 @@ func TestListOrganizations_CursorPagination(t *testing.T) {
 	require.Equal(t, "org_a", page1.Organizations[0].ID)
 	require.Equal(t, "org_b", page1.Organizations[1].ID)
 	require.Equal(t, "org_b", *page1.NextCursor)
+	require.Equal(t, int64(4), page1.Total, "the cursor walk reports the full match count too")
 
 	page2, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{Limit: &limit, Cursor: page1.NextCursor})
 	require.NoError(t, err)
@@ -542,5 +549,388 @@ func TestListOrganizations_SearchByIDRespectsFilters(t *testing.T) {
 			Cursor:          conv.PtrEmpty(c.cursor),
 		}
 		requireSearchMatches(t, ctx, svc, payload, c.wantIDs, c.name)
+	}
+}
+
+//go:fix inline
+func ptrTo[T any](v T) *T {
+	return new(v)
+}
+
+func reversed(ids []string) []string {
+	out := slices.Clone(ids)
+	slices.Reverse(out)
+	return out
+}
+
+// requireOrder asserts the exact ordered ids a payload returns.
+func requireOrder(t *testing.T, ctx context.Context, svc *Service, payload *gen.ListOrganizationsPayload, wantIDs []string, label string) *gen.AdminListOrganizationsResult {
+	t.Helper()
+
+	res, err := svc.ListOrganizations(ctx, payload)
+	require.NoError(t, err, "listing organizations for %s", label)
+
+	got := make([]string, 0, len(res.Organizations))
+	for _, o := range res.Organizations {
+		got = append(got, o.ID)
+	}
+	require.Equal(t, wantIDs, got, "organization order for %s", label)
+
+	return res
+}
+
+// The sort fixtures. Every sortable column ranks these four differently, so a
+// ladder arm wired to the wrong column shows up as a wrong order.
+const (
+	sortOrgA = "org_sort_a"
+	sortOrgB = "org_sort_b"
+	sortOrgC = "org_sort_c"
+	sortOrgD = "org_sort_d"
+)
+
+type sortFixture struct {
+	org         orgFixture
+	memberCount int
+	trialEndsAt time.Time
+}
+
+func seedSortFixtures(t *testing.T, ctx context.Context, conn *pgxpool.Pool) {
+	t.Helper()
+
+	base := time.Now().UTC()
+	fixtures := []sortFixture{
+		{
+			org:         orgFixture{id: sortOrgA, name: "Cedar Systems", slug: "bravo-co", accountType: "enterprise", whitelisted: true, createdAt: new(base.Add(-10 * time.Hour)), disabledAt: new(base.Add(-8 * time.Hour))},
+			memberCount: 3,
+			trialEndsAt: base.Add(24 * time.Hour),
+		},
+		{
+			org:         orgFixture{id: sortOrgB, name: "Alder Group", slug: "delta-co", accountType: "pro", whitelisted: true, createdAt: new(base.Add(-30 * time.Hour)), disabledAt: new(base.Add(-9 * time.Hour))},
+			memberCount: 2,
+			trialEndsAt: base.Add(72 * time.Hour),
+		},
+		{
+			org:         orgFixture{id: sortOrgC, name: "Dogwood Ltd", slug: "alpha-co", accountType: "free", whitelisted: true, createdAt: new(base.Add(-40 * time.Hour)), disabledAt: new(base.Add(-7 * time.Hour))},
+			memberCount: 1,
+			trialEndsAt: base.Add(96 * time.Hour),
+		},
+		{
+			org:         orgFixture{id: sortOrgD, name: "Birch Works", slug: "charlie-co", accountType: "starter", whitelisted: true, createdAt: new(base.Add(-20 * time.Hour)), disabledAt: new(base.Add(-6 * time.Hour))},
+			memberCount: 0,
+			trialEndsAt: base.Add(48 * time.Hour),
+		},
+	}
+
+	for _, f := range fixtures {
+		seedOrg(t, ctx, conn, f.org)
+		for i := range f.memberCount {
+			seedMembership(t, ctx, conn, f.org.id, fmt.Sprintf("user_%s_%d", f.org.id, i))
+		}
+		seedTrial(t, ctx, conn, trialFixture{orgID: f.org.id, endsAt: f.trialEndsAt})
+	}
+}
+
+// sortPayload builds an offset-mode request over the sort fixtures, which are all disabled.
+func sortPayload(sort, direction string) *gen.ListOrganizationsPayload {
+	return &gen.ListOrganizationsPayload{
+		Sort:            new(sort),
+		Direction:       new(direction),
+		IncludeDisabled: new(true),
+	}
+}
+
+func TestListOrganizations_SortsEveryWhitelistedColumn(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedSortFixtures(t, ctx, conn)
+
+	cases := []struct {
+		sort    string
+		wantAsc []string
+	}{
+		{sort: "name", wantAsc: []string{sortOrgB, sortOrgD, sortOrgA, sortOrgC}},
+		{sort: "slug", wantAsc: []string{sortOrgC, sortOrgA, sortOrgD, sortOrgB}},
+		{sort: "account_type", wantAsc: []string{sortOrgA, sortOrgC, sortOrgB, sortOrgD}},
+		{sort: "member_count", wantAsc: []string{sortOrgD, sortOrgC, sortOrgB, sortOrgA}},
+		{sort: "created_at", wantAsc: []string{sortOrgC, sortOrgB, sortOrgD, sortOrgA}},
+		{sort: "disabled_at", wantAsc: []string{sortOrgB, sortOrgA, sortOrgC, sortOrgD}},
+		{sort: "trial_ends_at", wantAsc: []string{sortOrgA, sortOrgD, sortOrgB, sortOrgC}},
+	}
+
+	for _, c := range cases {
+		requireOrder(t, ctx, svc, sortPayload(c.sort, "asc"), c.wantAsc, c.sort+" ascending")
+		requireOrder(t, ctx, svc, sortPayload(c.sort, "desc"), reversed(c.wantAsc), c.sort+" descending")
+	}
+}
+
+// A sort value arrives from a URL operators paste to each other, so a value the
+// API does not know falls back to the default order rather than failing the page.
+func TestListOrganizations_UnknownSortAndDirectionFallBack(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedSortFixtures(t, ctx, conn)
+
+	byID := []string{sortOrgA, sortOrgB, sortOrgC, sortOrgD}
+	nameAsc := []string{sortOrgB, sortOrgD, sortOrgA, sortOrgC}
+
+	cases := []struct {
+		name      string
+		sort      string
+		direction string
+		want      []string
+	}{
+		{name: "a column that does not exist", sort: "not_a_column", direction: "asc", want: byID},
+		{name: "a real column left out of the whitelist", sort: "workos_id", direction: "asc", want: byID},
+		{name: "the default column cannot be named", sort: "id", direction: "asc", want: byID},
+		{name: "an empty sort", sort: "", direction: "asc", want: byID},
+		{name: "a SQL fragment", sort: "name; DROP TABLE organization_metadata", direction: "asc", want: byID},
+		{name: "an unknown direction", sort: "name", direction: "sideways", want: nameAsc},
+		{name: "an empty direction", sort: "name", direction: "", want: nameAsc},
+		{name: "a direction spelled backwards", sort: "name", direction: "descending", want: nameAsc},
+
+		// Both values are matched case-insensitively: a hand-edited URL should not silently lose the sort.
+		{name: "a mixed case column and direction", sort: "Name", direction: "DESC", want: reversed(nameAsc)},
+	}
+
+	for _, c := range cases {
+		requireOrder(t, ctx, svc, sortPayload(c.sort, c.direction), c.want, c.name)
+	}
+}
+
+// Sorting by an empty date must not bury the rows an operator came to see, so
+// nulls stay at the bottom whichever way the direction points.
+func TestListOrganizations_NullDatesSortLast(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	const (
+		datedEarly = "org_null_dated_1"
+		datedLate  = "org_null_dated_2"
+		bareFirst  = "org_null_zbare_1"
+		bareSecond = "org_null_zbare_2"
+	)
+
+	base := time.Now().UTC()
+	seedOrg(t, ctx, conn, orgFixture{id: datedEarly, name: "Dated Early", slug: "dated-early", whitelisted: true, disabledAt: new(base.Add(-2 * time.Hour))})
+	seedOrg(t, ctx, conn, orgFixture{id: datedLate, name: "Dated Late", slug: "dated-late", whitelisted: true, disabledAt: new(base.Add(-1 * time.Hour))})
+	seedOrg(t, ctx, conn, orgFixture{id: bareFirst, name: "Bare One", slug: "bare-one", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: bareSecond, name: "Bare Two", slug: "bare-two", whitelisted: true})
+
+	seedTrial(t, ctx, conn, trialFixture{orgID: datedEarly, endsAt: base.Add(24 * time.Hour)})
+	seedTrial(t, ctx, conn, trialFixture{orgID: datedLate, endsAt: base.Add(48 * time.Hour)})
+
+	// The bare ids sort after the dated ones, so the tiebreaker orders the null tail.
+	cases := []struct {
+		sort      string
+		direction string
+		want      []string
+	}{
+		{sort: "disabled_at", direction: "asc", want: []string{datedEarly, datedLate, bareFirst, bareSecond}},
+		{sort: "disabled_at", direction: "desc", want: []string{datedLate, datedEarly, bareFirst, bareSecond}},
+		{sort: "trial_ends_at", direction: "asc", want: []string{datedEarly, datedLate, bareFirst, bareSecond}},
+		{sort: "trial_ends_at", direction: "desc", want: []string{datedLate, datedEarly, bareFirst, bareSecond}},
+	}
+
+	for _, c := range cases {
+		requireOrder(t, ctx, svc, sortPayload(c.sort, c.direction), c.want, c.sort+" "+c.direction)
+	}
+}
+
+// Rows that tie on the sort key fall back to the id, in one direction only.
+// Without that a page boundary can drop or repeat a row between two requests.
+func TestListOrganizations_TiesBreakOnIDInBothDirections(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// Seeded back to front, so an order that merely reflects the physical rows fails.
+	inserted := []string{"org_tie_d", "org_tie_c", "org_tie_b", "org_tie_a"}
+	for _, id := range inserted {
+		seedOrg(t, ctx, conn, orgFixture{id: id, name: "Same Name", slug: id, accountType: "free", whitelisted: true})
+	}
+
+	byID := []string{"org_tie_a", "org_tie_b", "org_tie_c", "org_tie_d"}
+
+	for _, direction := range []string{"asc", "desc"} {
+		for _, sort := range []string{"name", "account_type"} {
+			label := sort + " " + direction
+			requireOrder(t, ctx, svc, sortPayload(sort, direction), byID, label)
+			// Repeating the call pins the order down: an unordered tie group can come back either way.
+			requireOrder(t, ctx, svc, sortPayload(sort, direction), byID, label+", repeated")
+		}
+	}
+
+	// The same ties across a page boundary, which is where an unstable order loses rows.
+	page1 := sortPayload("name", "asc")
+	page1.Limit, page1.Page = new(2), new(1)
+	requireOrder(t, ctx, svc, page1, byID[:2], "tied page 1")
+
+	page2 := sortPayload("name", "asc")
+	page2.Limit, page2.Page = new(2), new(2)
+	requireOrder(t, ctx, svc, page2, byID[2:], "tied page 2")
+}
+
+// The page fixtures. The names run backwards against the ids, so a page that
+// quietly fell back to the default order reads as a wrong page.
+var pageOrgsByName = []string{"org_page_5", "org_page_4", "org_page_3", "org_page_2", "org_page_1"}
+
+func seedPageFixtures(t *testing.T, ctx context.Context, conn *pgxpool.Pool) {
+	t.Helper()
+
+	names := []string{"Echo Co", "Delta Co", "Charlie Co", "Bravo Co", "Alpha Co"}
+	for i, name := range names {
+		id := fmt.Sprintf("org_page_%d", i+1)
+		seedOrg(t, ctx, conn, orgFixture{id: id, name: name, slug: id, whitelisted: true})
+	}
+}
+
+func TestListOrganizations_OffsetPaging(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedPageFixtures(t, ctx, conn)
+
+	cases := []struct {
+		name string
+		page *int
+		want []string
+	}{
+		{name: "no page is the first page", page: nil, want: pageOrgsByName[0:2]},
+		{name: "page 1", page: new(1), want: pageOrgsByName[0:2]},
+		{name: "page 0 clamps to the first page", page: new(0), want: pageOrgsByName[0:2]},
+		{name: "a negative page clamps to the first page", page: new(-3), want: pageOrgsByName[0:2]},
+		{name: "page 2", page: new(2), want: pageOrgsByName[2:4]},
+		{name: "the last page is short", page: new(3), want: pageOrgsByName[4:5]},
+		{name: "a page past the end is empty", page: new(4), want: []string{}},
+		{name: "an absurd page is empty, not an error", page: new(1 << 40), want: []string{}},
+
+		// The offset the query binds is an int32, so the largest page an operator
+		// can type must clamp rather than wrap into a negative offset.
+		{name: "the largest page there is", page: ptrTo(math.MaxInt64), want: []string{}},
+	}
+
+	for _, c := range cases {
+		payload := sortPayload("name", "asc")
+		payload.IncludeDisabled = nil
+		payload.Limit, payload.Page = new(2), c.page
+		requireOrder(t, ctx, svc, payload, c.want, c.name)
+	}
+
+	// Walking the pages visits every organization exactly once.
+	var walked []string
+	for page := 1; page <= 3; page++ {
+		payload := sortPayload("name", "asc")
+		payload.IncludeDisabled = nil
+		payload.Limit, payload.Page = new(2), new(page)
+
+		res, err := svc.ListOrganizations(ctx, payload)
+		require.NoError(t, err)
+		for _, o := range res.Organizations {
+			walked = append(walked, o.ID)
+		}
+	}
+	require.Equal(t, pageOrgsByName, walked, "walking every page drops and repeats nothing")
+}
+
+// A page number alone selects offset paging, with the default order.
+func TestListOrganizations_PageWithoutSortUsesTheDefaultOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedPageFixtures(t, ctx, conn)
+
+	byID := []string{"org_page_1", "org_page_2", "org_page_3", "org_page_4", "org_page_5"}
+
+	page1 := requireOrder(t, ctx, svc, &gen.ListOrganizationsPayload{Limit: new(2), Page: new(1)}, byID[0:2], "page 1 without a sort")
+	require.Nil(t, page1.NextCursor)
+
+	requireOrder(t, ctx, svc, &gen.ListOrganizationsPayload{Limit: new(2), Page: new(2)}, byID[2:4], "page 2 without a sort")
+}
+
+// total reports the rows the filters matched, not the rows this page holds.
+func TestListOrganizations_TotalCountsMatchesNotPageLength(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	for i := range 5 {
+		id := fmt.Sprintf("org_total_holdings_%d", i)
+		seedOrg(t, ctx, conn, orgFixture{id: id, name: fmt.Sprintf("Holdings %d", i), slug: id, whitelisted: true})
+	}
+	for i := range 2 {
+		id := fmt.Sprintf("org_total_networks_%d", i)
+		seedOrg(t, ctx, conn, orgFixture{id: id, name: fmt.Sprintf("Networks %d", i), slug: id, accountType: "pro", whitelisted: true})
+	}
+	disabledAt := time.Now().UTC()
+	seedOrg(t, ctx, conn, orgFixture{id: "org_total_disabled", name: "Holdings Disabled", slug: "org_total_disabled", whitelisted: true, disabledAt: &disabledAt})
+
+	cases := []struct {
+		name      string
+		payload   *gen.ListOrganizationsPayload
+		wantTotal int64
+		wantLen   int
+	}{
+		{name: "no filter, first page", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), Page: new(1)}, wantTotal: 7, wantLen: 2},
+		{name: "no filter, last page", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), Page: new(4)}, wantTotal: 7, wantLen: 1},
+		{name: "search filter", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), Q: new("holdings")}, wantTotal: 5, wantLen: 2},
+		{name: "account type filter", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), AccountType: new("pro")}, wantTotal: 2, wantLen: 2},
+		{name: "disabled included", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Limit: new(2), IncludeDisabled: new(true)}, wantTotal: 8, wantLen: 2},
+		{name: "a filter matching nothing", payload: &gen.ListOrganizationsPayload{Sort: new("name"), Q: new("no such organization")}, wantTotal: 0, wantLen: 0},
+
+		// The cursor walk reports the same total, so the two modes agree.
+		{name: "cursor mode", payload: &gen.ListOrganizationsPayload{Limit: new(2)}, wantTotal: 7, wantLen: 2},
+		{name: "cursor mode under a filter", payload: &gen.ListOrganizationsPayload{Limit: new(2), Q: new("holdings")}, wantTotal: 5, wantLen: 2},
+	}
+
+	for _, c := range cases {
+		res, err := svc.ListOrganizations(ctx, c.payload)
+		require.NoError(t, err, "listing organizations for %s", c.name)
+		require.Equal(t, c.wantTotal, res.Total, "total for %s", c.name)
+		require.Len(t, res.Organizations, c.wantLen, "page length for %s", c.name)
+	}
+}
+
+// Offset mode drops the cursor: reporting one would invite a client to mix the
+// two walks, and the cursor cannot express a sorted position.
+func TestListOrganizations_OffsetModeIgnoresAndOmitsTheCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedPageFixtures(t, ctx, conn)
+
+	byID := []string{"org_page_1", "org_page_2", "org_page_3", "org_page_4", "org_page_5"}
+
+	// The cursor walk is untouched, including when only a direction is supplied.
+	for _, c := range []struct {
+		name    string
+		payload *gen.ListOrganizationsPayload
+	}{
+		{name: "no paging arguments", payload: &gen.ListOrganizationsPayload{Limit: new(2)}},
+		{name: "a direction alone", payload: &gen.ListOrganizationsPayload{Limit: new(2), Direction: new("desc")}},
+	} {
+		res := requireOrder(t, ctx, svc, c.payload, byID[0:2], c.name)
+		require.NotNil(t, res.NextCursor, "cursor mode still pages by cursor for %s", c.name)
+		require.Equal(t, "org_page_2", *res.NextCursor)
+	}
+
+	// Every offset-mode request omits it, including the ones that fall back to the default order.
+	for _, c := range []struct {
+		name    string
+		payload *gen.ListOrganizationsPayload
+		want    []string
+	}{
+		{name: "a sort", payload: &gen.ListOrganizationsPayload{Limit: new(2), Sort: new("name")}, want: pageOrgsByName[0:2]},
+		{name: "an unknown sort", payload: &gen.ListOrganizationsPayload{Limit: new(2), Sort: new("not_a_column")}, want: byID[0:2]},
+		{name: "a page alone", payload: &gen.ListOrganizationsPayload{Limit: new(2), Page: new(1)}, want: byID[0:2]},
+		{name: "a page past the end", payload: &gen.ListOrganizationsPayload{Limit: new(2), Page: new(9)}, want: []string{}},
+
+		// A cursor left over from the other walk is ignored, not applied on top of the offset.
+		{name: "a sort beside a stale cursor", payload: &gen.ListOrganizationsPayload{Limit: new(2), Sort: new("name"), Cursor: new("org_page_5")}, want: pageOrgsByName[0:2]},
+	} {
+		res := requireOrder(t, ctx, svc, c.payload, c.want, c.name)
+		require.Nil(t, res.NextCursor, "offset mode reports no cursor for %s", c.name)
 	}
 }

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -82,8 +82,7 @@ WITH filtered AS (
             FROM organization_user_relationships our
             WHERE our.organization_id = om.id
               AND our.deleted IS FALSE
-        )::bigint AS member_count,
-        count(*) OVER ()::bigint AS total_count
+        )::bigint AS member_count
     FROM organization_metadata om
     LEFT JOIN trials t ON t.organization_id = om.id
     WHERE
@@ -123,6 +122,29 @@ ORDER BY
     id ASC
 LIMIT sqlc.arg('page_limit')::int
 OFFSET sqlc.arg('page_offset')::bigint;
+
+-- name: AdminCountOrganizations :one
+-- The count cannot ride on the page query. That query carries the cursor
+-- predicate, so a window count inside it reports the rows after the cursor
+-- rather than the rows the filters matched, and a page past the end returns no
+-- row to carry a count at all. Keeping it out also leaves the page query free to
+-- terminate early on its index scan.
+--
+-- The filter arms must stay identical to AdminListOrganizations. The trials join
+-- is absent on purpose rather than by omission: organization_id is that table's
+-- primary key, so the left join there cannot change how many rows match.
+SELECT count(*)::bigint
+FROM organization_metadata om
+WHERE
+    (
+        sqlc.narg('q')::text IS NULL
+        OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
+        OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
+        OR om.id = sqlc.narg('q')::text
+        OR om.workos_id = sqlc.narg('q')::text
+    )
+    AND (sqlc.narg('account_type')::text IS NULL OR om.gram_account_type = sqlc.narg('account_type')::text)
+    AND (sqlc.arg('include_disabled')::boolean OR om.disabled_at IS NULL);
 
 -- name: AdminUpdateOrganization :exec
 -- Admin-only mutation. Both fields are optional — caller passes NULL to skip

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -51,51 +51,78 @@ WHERE p.slug = @slug
   AND p.deleted IS FALSE;
 
 -- name: AdminListOrganizations :many
-SELECT
-    om.id,
-    om.name,
-    om.slug,
-    om.gram_account_type AS account_type,
-    om.workos_id,
-    om.whitelisted,
-    om.disabled_at,
-    om.free_trial_started_at,
-    om.free_trial_ends_at,
-    -- converted/demoted precede the dates: those rows keep an ends_at that would otherwise read as running or expired.
-    CASE
-        WHEN t.organization_id IS NULL THEN 'none'
-        WHEN t.converted_at IS NOT NULL THEN 'converted'
-        WHEN t.demoted_at IS NOT NULL THEN 'demoted'
-        WHEN t.ends_at <= now() THEN 'expired'
-        WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
-        ELSE 'running'
-    END::text AS trial_state,
-    t.ends_at AS trial_ends_at,
-    om.created_at,
-    om.updated_at,
-    (
-        SELECT count(*)
-        FROM organization_user_relationships our
-        WHERE our.organization_id = om.id
-          AND our.deleted IS FALSE
-    )::bigint AS member_count
-FROM organization_metadata om
-LEFT JOIN trials t ON t.organization_id = om.id
-WHERE
-    -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
-    -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
-    (
-        sqlc.narg('q')::text IS NULL
-        OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
-        OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
-        OR om.id = sqlc.narg('q')::text
-        OR om.workos_id = sqlc.narg('q')::text
-    )
-    AND (sqlc.narg('account_type')::text IS NULL OR om.gram_account_type = sqlc.narg('account_type')::text)
-    AND (sqlc.arg('include_disabled')::boolean OR om.disabled_at IS NULL)
-    AND (sqlc.narg('after_id')::text IS NULL OR om.id > sqlc.narg('after_id')::text)
-ORDER BY om.id ASC
-LIMIT sqlc.arg('page_limit')::int;
+-- Two paging modes share this query. A caller that supplies no sort key gets the
+-- cursor walk it always had: the sort ladder collapses to all-NULL and the
+-- tiebreaker alone orders the rows. A caller that supplies one gets offset paging.
+WITH filtered AS (
+    SELECT
+        om.id,
+        om.name,
+        om.slug,
+        om.gram_account_type AS account_type,
+        om.workos_id,
+        om.whitelisted,
+        om.disabled_at,
+        om.free_trial_started_at,
+        om.free_trial_ends_at,
+        -- converted/demoted precede the dates: those rows keep an ends_at that would otherwise read as running or expired.
+        CASE
+            WHEN t.organization_id IS NULL THEN 'none'
+            WHEN t.converted_at IS NOT NULL THEN 'converted'
+            WHEN t.demoted_at IS NOT NULL THEN 'demoted'
+            WHEN t.ends_at <= now() THEN 'expired'
+            WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
+            ELSE 'running'
+        END::text AS trial_state,
+        t.ends_at AS trial_ends_at,
+        om.created_at,
+        om.updated_at,
+        (
+            SELECT count(*)
+            FROM organization_user_relationships our
+            WHERE our.organization_id = om.id
+              AND our.deleted IS FALSE
+        )::bigint AS member_count,
+        count(*) OVER ()::bigint AS total_count
+    FROM organization_metadata om
+    LEFT JOIN trials t ON t.organization_id = om.id
+    WHERE
+        -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
+        -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
+        (
+            sqlc.narg('q')::text IS NULL
+            OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
+            OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
+            OR om.id = sqlc.narg('q')::text
+            OR om.workos_id = sqlc.narg('q')::text
+        )
+        AND (sqlc.narg('account_type')::text IS NULL OR om.gram_account_type = sqlc.narg('account_type')::text)
+        AND (sqlc.arg('include_disabled')::boolean OR om.disabled_at IS NULL)
+        AND (sqlc.narg('after_id')::text IS NULL OR om.id > sqlc.narg('after_id')::text)
+)
+SELECT * FROM filtered
+-- The sort key stays a bound parameter, never an interpolated column name, so no
+-- caller input reaches the parser. NULLS LAST on every arm keeps empty dates at
+-- the bottom whichever way the direction points.
+ORDER BY
+    CASE WHEN sqlc.arg('sort_by')::text = 'name' AND sqlc.arg('sort_dir')::text = 'asc' THEN name END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'name' AND sqlc.arg('sort_dir')::text = 'desc' THEN name END DESC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'slug' AND sqlc.arg('sort_dir')::text = 'asc' THEN slug END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'slug' AND sqlc.arg('sort_dir')::text = 'desc' THEN slug END DESC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'account_type' AND sqlc.arg('sort_dir')::text = 'asc' THEN account_type END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'account_type' AND sqlc.arg('sort_dir')::text = 'desc' THEN account_type END DESC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'member_count' AND sqlc.arg('sort_dir')::text = 'asc' THEN member_count END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'member_count' AND sqlc.arg('sort_dir')::text = 'desc' THEN member_count END DESC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'created_at' AND sqlc.arg('sort_dir')::text = 'asc' THEN created_at END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'created_at' AND sqlc.arg('sort_dir')::text = 'desc' THEN created_at END DESC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'disabled_at' AND sqlc.arg('sort_dir')::text = 'asc' THEN disabled_at END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'disabled_at' AND sqlc.arg('sort_dir')::text = 'desc' THEN disabled_at END DESC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'trial_ends_at' AND sqlc.arg('sort_dir')::text = 'asc' THEN trial_ends_at END ASC NULLS LAST,
+    CASE WHEN sqlc.arg('sort_by')::text = 'trial_ends_at' AND sqlc.arg('sort_dir')::text = 'desc' THEN trial_ends_at END DESC NULLS LAST,
+    -- Without this tiebreaker rows that tie on the sort key can swap between calls, which drops or repeats rows across a page boundary.
+    id ASC
+LIMIT sqlc.arg('page_limit')::int
+OFFSET sqlc.arg('page_offset')::bigint;
 
 -- name: AdminUpdateOrganization :exec
 -- Admin-only mutation. Both fields are optional — caller passes NULL to skip

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -101,8 +101,10 @@ WITH filtered AS (
 )
 SELECT * FROM filtered
 -- The sort key stays a bound parameter, never an interpolated column name, so no
--- caller input reaches the parser. NULLS LAST on every arm keeps empty dates at
--- the bottom whichever way the direction points.
+-- caller input reaches the parser. NULLS LAST is what keeps empty dates at the
+-- bottom under DESC, where Postgres would otherwise put them first; on the ASC
+-- arms it only spells out the default. Both are written out so the two arms of a
+-- column read alike.
 ORDER BY
     CASE WHEN sqlc.arg('sort_by')::text = 'name' AND sqlc.arg('sort_dir')::text = 'asc' THEN name END ASC NULLS LAST,
     CASE WHEN sqlc.arg('sort_by')::text = 'name' AND sqlc.arg('sort_dir')::text = 'desc' THEN name END DESC NULLS LAST,

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -12,6 +12,43 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const adminCountOrganizations = `-- name: AdminCountOrganizations :one
+SELECT count(*)::bigint
+FROM organization_metadata om
+WHERE
+    (
+        $1::text IS NULL
+        OR om.name ILIKE '%' || $1::text || '%'
+        OR om.slug ILIKE '%' || $1::text || '%'
+        OR om.id = $1::text
+        OR om.workos_id = $1::text
+    )
+    AND ($2::text IS NULL OR om.gram_account_type = $2::text)
+    AND ($3::boolean OR om.disabled_at IS NULL)
+`
+
+type AdminCountOrganizationsParams struct {
+	Q               pgtype.Text
+	AccountType     pgtype.Text
+	IncludeDisabled bool
+}
+
+// The count cannot ride on the page query. That query carries the cursor
+// predicate, so a window count inside it reports the rows after the cursor
+// rather than the rows the filters matched, and a page past the end returns no
+// row to carry a count at all. Keeping it out also leaves the page query free to
+// terminate early on its index scan.
+//
+// The filter arms must stay identical to AdminListOrganizations. The trials join
+// is absent on purpose rather than by omission: organization_id is that table's
+// primary key, so the left join there cannot change how many rows match.
+func (q *Queries) AdminCountOrganizations(ctx context.Context, arg AdminCountOrganizationsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, adminCountOrganizations, arg.Q, arg.AccountType, arg.IncludeDisabled)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const adminGetOrganizationByIDOrSlug = `-- name: AdminGetOrganizationByIDOrSlug :one
 SELECT
     om.id,
@@ -288,8 +325,7 @@ WITH filtered AS (
             FROM organization_user_relationships our
             WHERE our.organization_id = om.id
               AND our.deleted IS FALSE
-        )::bigint AS member_count,
-        count(*) OVER ()::bigint AS total_count
+        )::bigint AS member_count
     FROM organization_metadata om
     LEFT JOIN trials t ON t.organization_id = om.id
     WHERE
@@ -306,7 +342,7 @@ WITH filtered AS (
         AND ($7::boolean OR om.disabled_at IS NULL)
         AND ($8::text IS NULL OR om.id > $8::text)
 )
-SELECT id, name, slug, account_type, workos_id, whitelisted, disabled_at, free_trial_started_at, free_trial_ends_at, trial_state, trial_ends_at, created_at, updated_at, member_count, total_count FROM filtered
+SELECT id, name, slug, account_type, workos_id, whitelisted, disabled_at, free_trial_started_at, free_trial_ends_at, trial_state, trial_ends_at, created_at, updated_at, member_count FROM filtered
 ORDER BY
     CASE WHEN $1::text = 'name' AND $2::text = 'asc' THEN name END ASC NULLS LAST,
     CASE WHEN $1::text = 'name' AND $2::text = 'desc' THEN name END DESC NULLS LAST,
@@ -354,7 +390,6 @@ type AdminListOrganizationsRow struct {
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	MemberCount        int64
-	TotalCount         int64
 }
 
 // Two paging modes share this query. A caller that supplies no sort key gets the
@@ -396,7 +431,6 @@ func (q *Queries) AdminListOrganizations(ctx context.Context, arg AdminListOrgan
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.MemberCount,
-			&i.TotalCount,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -260,59 +260,83 @@ func (q *Queries) AdminListOrganizationMembers(ctx context.Context, organization
 }
 
 const adminListOrganizations = `-- name: AdminListOrganizations :many
-SELECT
-    om.id,
-    om.name,
-    om.slug,
-    om.gram_account_type AS account_type,
-    om.workos_id,
-    om.whitelisted,
-    om.disabled_at,
-    om.free_trial_started_at,
-    om.free_trial_ends_at,
-    -- converted/demoted precede the dates: those rows keep an ends_at that would otherwise read as running or expired.
-    CASE
-        WHEN t.organization_id IS NULL THEN 'none'
-        WHEN t.converted_at IS NOT NULL THEN 'converted'
-        WHEN t.demoted_at IS NOT NULL THEN 'demoted'
-        WHEN t.ends_at <= now() THEN 'expired'
-        WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
-        ELSE 'running'
-    END::text AS trial_state,
-    t.ends_at AS trial_ends_at,
-    om.created_at,
-    om.updated_at,
-    (
-        SELECT count(*)
-        FROM organization_user_relationships our
-        WHERE our.organization_id = om.id
-          AND our.deleted IS FALSE
-    )::bigint AS member_count
-FROM organization_metadata om
-LEFT JOIN trials t ON t.organization_id = om.id
-WHERE
-    -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
-    -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
-    (
-        $1::text IS NULL
-        OR om.name ILIKE '%' || $1::text || '%'
-        OR om.slug ILIKE '%' || $1::text || '%'
-        OR om.id = $1::text
-        OR om.workos_id = $1::text
-    )
-    AND ($2::text IS NULL OR om.gram_account_type = $2::text)
-    AND ($3::boolean OR om.disabled_at IS NULL)
-    AND ($4::text IS NULL OR om.id > $4::text)
-ORDER BY om.id ASC
-LIMIT $5::int
+WITH filtered AS (
+    SELECT
+        om.id,
+        om.name,
+        om.slug,
+        om.gram_account_type AS account_type,
+        om.workos_id,
+        om.whitelisted,
+        om.disabled_at,
+        om.free_trial_started_at,
+        om.free_trial_ends_at,
+        -- converted/demoted precede the dates: those rows keep an ends_at that would otherwise read as running or expired.
+        CASE
+            WHEN t.organization_id IS NULL THEN 'none'
+            WHEN t.converted_at IS NOT NULL THEN 'converted'
+            WHEN t.demoted_at IS NOT NULL THEN 'demoted'
+            WHEN t.ends_at <= now() THEN 'expired'
+            WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
+            ELSE 'running'
+        END::text AS trial_state,
+        t.ends_at AS trial_ends_at,
+        om.created_at,
+        om.updated_at,
+        (
+            SELECT count(*)
+            FROM organization_user_relationships our
+            WHERE our.organization_id = om.id
+              AND our.deleted IS FALSE
+        )::bigint AS member_count,
+        count(*) OVER ()::bigint AS total_count
+    FROM organization_metadata om
+    LEFT JOIN trials t ON t.organization_id = om.id
+    WHERE
+        -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
+        -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
+        (
+            $5::text IS NULL
+            OR om.name ILIKE '%' || $5::text || '%'
+            OR om.slug ILIKE '%' || $5::text || '%'
+            OR om.id = $5::text
+            OR om.workos_id = $5::text
+        )
+        AND ($6::text IS NULL OR om.gram_account_type = $6::text)
+        AND ($7::boolean OR om.disabled_at IS NULL)
+        AND ($8::text IS NULL OR om.id > $8::text)
+)
+SELECT id, name, slug, account_type, workos_id, whitelisted, disabled_at, free_trial_started_at, free_trial_ends_at, trial_state, trial_ends_at, created_at, updated_at, member_count, total_count FROM filtered
+ORDER BY
+    CASE WHEN $1::text = 'name' AND $2::text = 'asc' THEN name END ASC NULLS LAST,
+    CASE WHEN $1::text = 'name' AND $2::text = 'desc' THEN name END DESC NULLS LAST,
+    CASE WHEN $1::text = 'slug' AND $2::text = 'asc' THEN slug END ASC NULLS LAST,
+    CASE WHEN $1::text = 'slug' AND $2::text = 'desc' THEN slug END DESC NULLS LAST,
+    CASE WHEN $1::text = 'account_type' AND $2::text = 'asc' THEN account_type END ASC NULLS LAST,
+    CASE WHEN $1::text = 'account_type' AND $2::text = 'desc' THEN account_type END DESC NULLS LAST,
+    CASE WHEN $1::text = 'member_count' AND $2::text = 'asc' THEN member_count END ASC NULLS LAST,
+    CASE WHEN $1::text = 'member_count' AND $2::text = 'desc' THEN member_count END DESC NULLS LAST,
+    CASE WHEN $1::text = 'created_at' AND $2::text = 'asc' THEN created_at END ASC NULLS LAST,
+    CASE WHEN $1::text = 'created_at' AND $2::text = 'desc' THEN created_at END DESC NULLS LAST,
+    CASE WHEN $1::text = 'disabled_at' AND $2::text = 'asc' THEN disabled_at END ASC NULLS LAST,
+    CASE WHEN $1::text = 'disabled_at' AND $2::text = 'desc' THEN disabled_at END DESC NULLS LAST,
+    CASE WHEN $1::text = 'trial_ends_at' AND $2::text = 'asc' THEN trial_ends_at END ASC NULLS LAST,
+    CASE WHEN $1::text = 'trial_ends_at' AND $2::text = 'desc' THEN trial_ends_at END DESC NULLS LAST,
+    -- Without this tiebreaker rows that tie on the sort key can swap between calls, which drops or repeats rows across a page boundary.
+    id ASC
+LIMIT $4::int
+OFFSET $3::bigint
 `
 
 type AdminListOrganizationsParams struct {
+	SortBy          string
+	SortDir         string
+	PageOffset      int64
+	PageLimit       int32
 	Q               pgtype.Text
 	AccountType     pgtype.Text
 	IncludeDisabled bool
 	AfterID         pgtype.Text
-	PageLimit       int32
 }
 
 type AdminListOrganizationsRow struct {
@@ -330,15 +354,25 @@ type AdminListOrganizationsRow struct {
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	MemberCount        int64
+	TotalCount         int64
 }
 
+// Two paging modes share this query. A caller that supplies no sort key gets the
+// cursor walk it always had: the sort ladder collapses to all-NULL and the
+// tiebreaker alone orders the rows. A caller that supplies one gets offset paging.
+// The sort key stays a bound parameter, never an interpolated column name, so no
+// caller input reaches the parser. NULLS LAST on every arm keeps empty dates at
+// the bottom whichever way the direction points.
 func (q *Queries) AdminListOrganizations(ctx context.Context, arg AdminListOrganizationsParams) ([]AdminListOrganizationsRow, error) {
 	rows, err := q.db.Query(ctx, adminListOrganizations,
+		arg.SortBy,
+		arg.SortDir,
+		arg.PageOffset,
+		arg.PageLimit,
 		arg.Q,
 		arg.AccountType,
 		arg.IncludeDisabled,
 		arg.AfterID,
-		arg.PageLimit,
 	)
 	if err != nil {
 		return nil, err
@@ -362,6 +396,7 @@ func (q *Queries) AdminListOrganizations(ctx context.Context, arg AdminListOrgan
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.MemberCount,
+			&i.TotalCount,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -396,8 +396,10 @@ type AdminListOrganizationsRow struct {
 // cursor walk it always had: the sort ladder collapses to all-NULL and the
 // tiebreaker alone orders the rows. A caller that supplies one gets offset paging.
 // The sort key stays a bound parameter, never an interpolated column name, so no
-// caller input reaches the parser. NULLS LAST on every arm keeps empty dates at
-// the bottom whichever way the direction points.
+// caller input reaches the parser. NULLS LAST is what keeps empty dates at the
+// bottom under DESC, where Postgres would otherwise put them first; on the ASC
+// arms it only spells out the default. Both are written out so the two arms of a
+// column read alike.
 func (q *Queries) AdminListOrganizations(ctx context.Context, arg AdminListOrganizationsParams) ([]AdminListOrganizationsRow, error) {
 	rows, err := q.db.Query(ctx, adminListOrganizations,
 		arg.SortBy,

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -189,6 +189,13 @@ INSERT INTO organization_metadata (
 INSERT INTO organization_user_relationships (organization_id, user_id)
 VALUES (@organization_id, sqlc.narg('user_id')::text);
 
+-- name: ForceSoftDeleteOrganizationUserRelationshipsFixture :exec
+-- Test-only fixture for seeding a removed member. The deleted column is
+-- generated from deleted_at, so a soft delete has to set the timestamp.
+UPDATE organization_user_relationships
+SET deleted_at = clock_timestamp()
+WHERE organization_id = @organization_id;
+
 -- name: ForceSoftDeleteUserSessionIssuer :exec
 -- Test-only fixture for defensive paths that handle a dangling soft-delete FK.
 UPDATE user_session_issuers

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -158,7 +158,8 @@ WHERE id = @organization_id;
 -- Test-only fixture that lets seeders populate every column on
 -- organization_metadata. Prefer this over CreateOrganizationMetadata when a
 -- test needs to exercise filters that depend on account type, workos linkage,
--- disabled state, whitelist flag, or trial window.
+-- disabled state, whitelist flag, trial window, or age. Omit created_at to keep
+-- the column default.
 INSERT INTO organization_metadata (
     id,
     name,
@@ -168,7 +169,8 @@ INSERT INTO organization_metadata (
     whitelisted,
     free_trial_started_at,
     free_trial_ends_at,
-    disabled_at
+    disabled_at,
+    created_at
 ) VALUES (
     @id,
     @name,
@@ -178,7 +180,8 @@ INSERT INTO organization_metadata (
     @whitelisted,
     @free_trial_started_at,
     @free_trial_ends_at,
-    sqlc.narg('disabled_at')::timestamptz
+    sqlc.narg('disabled_at')::timestamptz,
+    COALESCE(sqlc.narg('created_at')::timestamptz, clock_timestamp())
 );
 
 -- name: CreateOrganizationUserRelationshipFixture :exec

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -295,6 +295,19 @@ func (q *Queries) ForceSoftDeleteChat(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const forceSoftDeleteOrganizationUserRelationshipsFixture = `-- name: ForceSoftDeleteOrganizationUserRelationshipsFixture :exec
+UPDATE organization_user_relationships
+SET deleted_at = clock_timestamp()
+WHERE organization_id = $1
+`
+
+// Test-only fixture for seeding a removed member. The deleted column is
+// generated from deleted_at, so a soft delete has to set the timestamp.
+func (q *Queries) ForceSoftDeleteOrganizationUserRelationshipsFixture(ctx context.Context, organizationID string) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteOrganizationUserRelationshipsFixture, organizationID)
+	return err
+}
+
 const forceSoftDeleteUserSessionIssuer = `-- name: ForceSoftDeleteUserSessionIssuer :exec
 UPDATE user_session_issuers
 SET deleted_at = clock_timestamp()

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -142,7 +142,8 @@ INSERT INTO organization_metadata (
     whitelisted,
     free_trial_started_at,
     free_trial_ends_at,
-    disabled_at
+    disabled_at,
+    created_at
 ) VALUES (
     $1,
     $2,
@@ -152,7 +153,8 @@ INSERT INTO organization_metadata (
     $6,
     $7,
     $8,
-    $9::timestamptz
+    $9::timestamptz,
+    COALESCE($10::timestamptz, clock_timestamp())
 )
 `
 
@@ -166,12 +168,14 @@ type CreateOrganizationMetadataFixtureParams struct {
 	FreeTrialStartedAt pgtype.Timestamptz
 	FreeTrialEndsAt    pgtype.Timestamptz
 	DisabledAt         pgtype.Timestamptz
+	CreatedAt          pgtype.Timestamptz
 }
 
 // Test-only fixture that lets seeders populate every column on
 // organization_metadata. Prefer this over CreateOrganizationMetadata when a
 // test needs to exercise filters that depend on account type, workos linkage,
-// disabled state, whitelist flag, or trial window.
+// disabled state, whitelist flag, trial window, or age. Omit created_at to keep
+// the column default.
 func (q *Queries) CreateOrganizationMetadataFixture(ctx context.Context, arg CreateOrganizationMetadataFixtureParams) error {
 	_, err := q.db.Exec(ctx, createOrganizationMetadataFixture,
 		arg.ID,
@@ -183,6 +187,7 @@ func (q *Queries) CreateOrganizationMetadataFixture(ctx context.Context, arg Cre
 		arg.FreeTrialStartedAt,
 		arg.FreeTrialEndsAt,
 		arg.DisabledAt,
+		arg.CreatedAt,
 	)
 	return err
 }


### PR DESCRIPTION
The admin organizations endpoint can now sort by any column and jump to a page, and it reports how many organizations the filters matched.

A caller names a column, a direction and a 1-based page number. Sortable columns are name, slug, account type, member count, created date, disabled date and trial end date. An unknown column or direction falls back to the default order rather than failing, so a shared link that outlives a column cannot 500.

**Additive on purpose.** Cursor paging keeps working and still runs the deployed dashboard. A server that dropped the cursor would leave the shipped Next button dead until the client half caught up. AGE-3207 removes the cursor once both halves are deployed.

## Three defects found in review, not in the build

A three-lens review round ran before this PR opened. All three were fixed before it was raised, and none would have been caught by the gates the build already passed.

**`limit=1` in offset mode always returned an empty page.** The overflow guard read `math.MaxInt64/int64(limit) + 1`. That is runtime arithmetic, so at limit 1 it wraps to `MinInt64`, every page trips the guard, and the offset wraps back to `MaxInt64`. The guard written to prevent an overflow was the only thing causing one. Every other limit behaved, which is why it survived: the existing boundary test only ever used limit 2.

**`total` was wrong in two ways, both from where the count lived.** It was read out of the first returned row, so any page past the end reported 0, leaving a client with nothing to compute a way back from. And `count(*) OVER ()` sat inside the CTE that the cursor predicate filters, so in cursor mode the count shrank as the operator paged: page 1 of a 5-row walk reported 5, page 2 reported 3. `total` is a required field, so any client reading it saw the count fall away.

Both are fixed by moving the count into its own query that carries the filters but not the cursor.

**That also removes a query-cost regression on the live path.** The window forced a `WindowAgg` over a sequential scan in place of an early-terminating index scan. Over 500 organizations at `LIMIT 51`, rows read went 51 to 500, shared buffers 156 to 1508, and the correlated `member_count` subplan ran for every matching organization instead of just the page. The commit message claimed cursor paging was untouched, which was true of its results and false of its cost. It is now true of both.

## Tests

504 added lines of tests. Beyond the fixes above, a mutation sweep of 84 mutations closed five coverage gaps:

- **One ORDER BY arm was unfalsifiable.** The `member_count` descending case expected exactly the order the `id ASC` tiebreaker produces alone, so that arm could be deleted with every test still green. It was the only one of the 14 arms that collided. The fixture is rebalanced so no column ranks the rows in id order in either direction, and the fixture comment now says why.
- **One untested guard stood between a query parameter and a panic.** Removing the `limit < 1` fallback makes the code evaluate `MaxInt64/0`, and `?limit=0` is reachable because the design declares no minimum. Reproducing it produced the real `integer divide by zero`.
- The maximum-limit clamp, a cursor supplied beside a page, and `member_count` skipping soft-deleted memberships were all untested and now are.

Two comments were also corrected to claim only what the code earns: the Go sort whitelist cannot widen the SQL ladder, and `NULLS LAST` is load bearing only on the descending arms.

`direction` supplied alone stays inert, since it has nothing to order by without a sort or a page. That is now stated in the design description rather than left for a caller to discover.

## Checks this stacked PR does not run

Base is `walker/age-3188-search-ids` (#5286), because this restructures the same query that PR just edited. `hygiene.yaml` filters on base `main`, so **the PR title lint, the changeset lint and the migration check do not run here.** Checked by hand: the title carries a `feat:` prefix, the changeset targets `admin` and matches the merged sibling, and there is no migration.

`sdk-gen-check` does run and passes; `.speakeasy/out.openapi.yaml` is regenerated in `7f0005b75`.

AGE-3185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sorting and page-based navigation to the admin organizations list and returns a required total match count. Previously results were id-ascending with cursor-only paging and no total; now callers can pass sort/direction/page for offset paging while cursor paging keeps working for existing clients.

- API: new `sort`, `direction`, and `page` query params; response now includes required `total`; `next_cursor` is omitted in offset mode and ignored if sent with sort/page. Supported sorts: name, slug, account_type, member_count, created_at, disabled_at, trial_ends_at. Unknown sort/direction fall back to defaults; `direction` alone is inert.
- Ordering rules: NULL date columns sort last in both directions; ties break on `id ASC` for stable pages.
- Limits and paging: limit defaults to 50 (max 100); values <= 0 fall back to default. Page ceiling fixed to avoid int64 overflow at `limit=1`.
- Count: computed via a separate filtered query (not windowed) so it stays correct in cursor mode and on pages past the end, and to restore the fast index-scan plan.
- Spec/tests: internal OpenAPI updated to add `total` and clarify cursor behavior; comprehensive tests cover sorting, offset vs cursor paging, limit clamps, and member_count excluding soft-deleted members. Aligns with Linear AGE-3185.

**Rollout**
- No migration required. Existing cursor-based clients continue to work; clients using offset paging must read `total` and must not rely on `next_cursor`.

<sup>Written for commit c3c8ea9d11e10c36567a1fe943c8021be1fa0f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

