### PR TITLE
feat(admin): disable and re-enable an organization

### DIFF
--- a/.changeset/admin-disable-organization.md
+++ b/.changeset/admin-disable-organization.md
@@ -22,6 +22,8 @@ organization's slug can be the same string, and the read that produced the
 response resolved either, so a write could return a different organization than
 the one it changed. Addressing one of these writes by slug now returns a
 not-found instead of a success describing an organization that was never
-touched. Reading an organization by slug is unchanged.
+touched. Reading an organization by slug still works, and when the same string
+is one organization's id and another's slug the exact id match now wins instead
+of the database picking either row.
 
 The admin dashboard row action and confirmation dialog follow.

--- a/.changeset/admin-disable-organization.md
+++ b/.changeset/admin-disable-organization.md
@@ -1,0 +1,19 @@
+---
+"server": patch
+---
+
+Platform admins can now disable an organization and undo it. Until now the only
+thing that could disable an organization was the WorkOS `organization.deleted`
+webhook, and nothing anywhere could re-enable one, so an operator had no way to
+cut off access or to reverse a disable that turned out to be wrong. Two admin
+endpoints cover both directions and report the organization back in its new
+state, which the existing list and detail endpoints already surface.
+
+Disabling is keyed on the Gram organization id rather than the WorkOS one, so an
+organization that was never linked to WorkOS can be disabled like any other.
+Disabling an organization that is already disabled keeps the original timestamp
+instead of moving it, so the record of when access was cut stays true. Neither
+direction touches the whitelist flag, which is the separate not-yet-approved
+gate, nor the WorkOS webhook cursor, which only the webhook path may write.
+
+The admin dashboard row action and confirmation dialog follow.

--- a/.changeset/admin-disable-organization.md
+++ b/.changeset/admin-disable-organization.md
@@ -16,4 +16,12 @@ instead of moving it, so the record of when access was cut stays true. Neither
 direction touches the whitelist flag, which is the separate not-yet-approved
 gate, nor the WorkOS webhook cursor, which only the webhook path may write.
 
+All three organization writes now read the organization back by id alone, which
+also corrects the existing update endpoint. An organization id and another
+organization's slug can be the same string, and the read that produced the
+response resolved either, so a write could return a different organization than
+the one it changed. Addressing one of these writes by slug now returns a
+not-found instead of a success describing an organization that was never
+touched. Reading an organization by slug is unchanged.
+
 The admin dashboard row action and confirmation dialog follow.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -59772,6 +59772,15 @@ components:
       required:
         - organization_id
         - key_type
+    DisableOrganizationRequestBody:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Organization ID.
+          minLength: 1
+      required:
+        - id
     DiscoverProtectedResourceMetadataRequestBody:
       type: object
       properties:

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -59916,6 +59916,15 @@ components:
       required:
         - organization_id
         - key_type
+    EnableOrganizationRequestBody:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Organization ID.
+          minLength: 1
+      required:
+        - id
     EncryptOpenRouterKeyRequestBody:
       type: object
       properties:

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -273,7 +273,9 @@ var _ = Service("admin", func() {
 			security.AdminAuthPayload()
 			Required("id")
 
-			Attribute("id", String, "Organization ID.")
+			Attribute("id", String, "Organization ID.", func() {
+				MinLength(1)
+			})
 		})
 
 		Result(AdminOrganization)
@@ -293,7 +295,9 @@ var _ = Service("admin", func() {
 			security.AdminAuthPayload()
 			Required("id")
 
-			Attribute("id", String, "Organization ID.")
+			Attribute("id", String, "Organization ID.", func() {
+				MinLength(1)
+			})
 		})
 
 		Result(AdminOrganization)

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -266,6 +266,46 @@ var _ = Service("admin", func() {
 		Meta("openapi:operationId", "adminUpdateOrganization")
 	})
 
+	Method("disableOrganization", func() {
+		Description("Disables an organization, recording the moment of the action in disabled_at. Idempotent: disabling an already-disabled organization keeps the original timestamp.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("id")
+
+			Attribute("id", String, "Organization ID.")
+		})
+
+		Result(AdminOrganization)
+
+		HTTP(func() {
+			POST("/admin/organization.disable")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminDisableOrganization")
+	})
+
+	Method("enableOrganization", func() {
+		Description("Re-enables a disabled organization by clearing disabled_at. Idempotent: an organization that is already active is unaffected.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("id")
+
+			Attribute("id", String, "Organization ID.")
+		})
+
+		Result(AdminOrganization)
+
+		HTTP(func() {
+			POST("/admin/organization.enable")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminEnableOrganization")
+	})
+
 	Method("getOrganization", func() {
 		Description("Returns full admin details for a single organization by id or slug.")
 

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -273,6 +273,11 @@ var _ = Service("admin", func() {
 			security.AdminAuthPayload()
 			Required("id")
 
+			// Disable and enable take structurally identical payloads, and Goa's
+			// OpenAPI emitter deduplicates request bodies by shape, so without an
+			// explicit typename both endpoints publish the same schema name.
+			Meta("openapi:typename", "DisableOrganizationRequestBody")
+
 			Attribute("id", String, "Organization ID.", func() {
 				MinLength(1)
 			})
@@ -294,6 +299,9 @@ var _ = Service("admin", func() {
 		Payload(func() {
 			security.AdminAuthPayload()
 			Required("id")
+
+			// See disableOrganization for why this needs an explicit typename.
+			Meta("openapi:typename", "EnableOrganizationRequestBody")
 
 			Attribute("id", String, "Organization ID.", func() {
 				MinLength(1)

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -20,6 +20,8 @@ type Client struct {
 	LogoutEndpoint                   goa.Endpoint
 	GetProjectEndpoint               goa.Endpoint
 	UpdateOrganizationEndpoint       goa.Endpoint
+	DisableOrganizationEndpoint      goa.Endpoint
+	EnableOrganizationEndpoint       goa.Endpoint
 	GetOrganizationEndpoint          goa.Endpoint
 	ListOrganizationMembersEndpoint  goa.Endpoint
 	ListOrganizationProjectsEndpoint goa.Endpoint
@@ -27,13 +29,15 @@ type Client struct {
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
 		LogoutEndpoint:                   logout,
 		GetProjectEndpoint:               getProject,
 		UpdateOrganizationEndpoint:       updateOrganization,
+		DisableOrganizationEndpoint:      disableOrganization,
+		EnableOrganizationEndpoint:       enableOrganization,
 		GetOrganizationEndpoint:          getOrganization,
 		ListOrganizationMembersEndpoint:  listOrganizationMembers,
 		ListOrganizationProjectsEndpoint: listOrganizationProjects,
@@ -142,6 +146,52 @@ func (c *Client) GetProject(ctx context.Context, p *GetProjectPayload) (res *Adm
 func (c *Client) UpdateOrganization(ctx context.Context, p *UpdateOrganizationPayload) (res *AdminOrganization, err error) {
 	var ires any
 	ires, err = c.UpdateOrganizationEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminOrganization), nil
+}
+
+// DisableOrganization calls the "disableOrganization" endpoint of the "admin"
+// service.
+// DisableOrganization may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) DisableOrganization(ctx context.Context, p *DisableOrganizationPayload) (res *AdminOrganization, err error) {
+	var ires any
+	ires, err = c.DisableOrganizationEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminOrganization), nil
+}
+
+// EnableOrganization calls the "enableOrganization" endpoint of the "admin"
+// service.
+// EnableOrganization may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) EnableOrganization(ctx context.Context, p *EnableOrganizationPayload) (res *AdminOrganization, err error) {
+	var ires any
+	ires, err = c.EnableOrganizationEndpoint(ctx, p)
 	if err != nil {
 		return
 	}

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -21,6 +21,8 @@ type Endpoints struct {
 	Logout                   goa.Endpoint
 	GetProject               goa.Endpoint
 	UpdateOrganization       goa.Endpoint
+	DisableOrganization      goa.Endpoint
+	EnableOrganization       goa.Endpoint
 	GetOrganization          goa.Endpoint
 	ListOrganizationMembers  goa.Endpoint
 	ListOrganizationProjects goa.Endpoint
@@ -37,6 +39,8 @@ func NewEndpoints(s Service) *Endpoints {
 		Logout:                   NewLogoutEndpoint(s),
 		GetProject:               NewGetProjectEndpoint(s, a.APIKeyAuth),
 		UpdateOrganization:       NewUpdateOrganizationEndpoint(s, a.APIKeyAuth),
+		DisableOrganization:      NewDisableOrganizationEndpoint(s, a.APIKeyAuth),
+		EnableOrganization:       NewEnableOrganizationEndpoint(s, a.APIKeyAuth),
 		GetOrganization:          NewGetOrganizationEndpoint(s, a.APIKeyAuth),
 		ListOrganizationMembers:  NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
 		ListOrganizationProjects: NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
@@ -51,6 +55,8 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.Logout = m(e.Logout)
 	e.GetProject = m(e.GetProject)
 	e.UpdateOrganization = m(e.UpdateOrganization)
+	e.DisableOrganization = m(e.DisableOrganization)
+	e.EnableOrganization = m(e.EnableOrganization)
 	e.GetOrganization = m(e.GetOrganization)
 	e.ListOrganizationMembers = m(e.ListOrganizationMembers)
 	e.ListOrganizationProjects = m(e.ListOrganizationProjects)
@@ -127,6 +133,52 @@ func NewUpdateOrganizationEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFu
 			return nil, err
 		}
 		return s.UpdateOrganization(ctx, p)
+	}
+}
+
+// NewDisableOrganizationEndpoint returns an endpoint function that calls the
+// method "disableOrganization" of service "admin".
+func NewDisableOrganizationEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*DisableOrganizationPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.DisableOrganization(ctx, p)
+	}
+}
+
+// NewEnableOrganizationEndpoint returns an endpoint function that calls the
+// method "enableOrganization" of service "admin".
+func NewEnableOrganizationEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*EnableOrganizationPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.EnableOrganization(ctx, p)
 	}
 }
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -28,6 +28,13 @@ type Service interface {
 	// Updates admin-managed fields on an organization. At least one of
 	// account_type or whitelisted must be supplied.
 	UpdateOrganization(context.Context, *UpdateOrganizationPayload) (res *AdminOrganization, err error)
+	// Disables an organization, recording the moment of the action in disabled_at.
+	// Idempotent: disabling an already-disabled organization keeps the original
+	// timestamp.
+	DisableOrganization(context.Context, *DisableOrganizationPayload) (res *AdminOrganization, err error)
+	// Re-enables a disabled organization by clearing disabled_at. Idempotent: an
+	// organization that is already active is unaffected.
+	EnableOrganization(context.Context, *EnableOrganizationPayload) (res *AdminOrganization, err error)
 	// Returns full admin details for a single organization by id or slug.
 	GetOrganization(context.Context, *GetOrganizationPayload) (res *AdminOrganization, err error)
 	// Lists members of an organization (admin view, no auth scoping).
@@ -58,7 +65,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [9]string{"login", "callback", "logout", "getProject", "updateOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations"}
+var MethodNames = [11]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations"}
 
 // AdminListOrganizationMembersResult is the result type of the admin service
 // listOrganizationMembers method.
@@ -199,6 +206,22 @@ type CallbackResult struct {
 	Location string
 	// The admin session cookie value
 	SessionID string
+}
+
+// DisableOrganizationPayload is the payload type of the admin service
+// disableOrganization method.
+type DisableOrganizationPayload struct {
+	AdminSessionToken *string
+	// Organization ID.
+	ID string
+}
+
+// EnableOrganizationPayload is the payload type of the admin service
+// enableOrganization method.
+type EnableOrganizationPayload struct {
+	AdminSessionToken *string
+	// Organization ID.
+	ID string
 }
 
 // GetOrganizationPayload is the payload type of the admin service

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -140,6 +140,56 @@ func BuildUpdateOrganizationPayload(adminUpdateOrganizationBody string, adminUpd
 	return v, nil
 }
 
+// BuildDisableOrganizationPayload builds the payload for the admin
+// disableOrganization endpoint from CLI flags.
+func BuildDisableOrganizationPayload(adminDisableOrganizationBody string, adminDisableOrganizationAdminSessionToken string) (*admin.DisableOrganizationPayload, error) {
+	var err error
+	var body DisableOrganizationRequestBody
+	{
+		err = json.Unmarshal([]byte(adminDisableOrganizationBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"abc123\"\n   }'")
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminDisableOrganizationAdminSessionToken != "" {
+			adminSessionToken = &adminDisableOrganizationAdminSessionToken
+		}
+	}
+	v := &admin.DisableOrganizationPayload{
+		ID: body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}
+
+// BuildEnableOrganizationPayload builds the payload for the admin
+// enableOrganization endpoint from CLI flags.
+func BuildEnableOrganizationPayload(adminEnableOrganizationBody string, adminEnableOrganizationAdminSessionToken string) (*admin.EnableOrganizationPayload, error) {
+	var err error
+	var body EnableOrganizationRequestBody
+	{
+		err = json.Unmarshal([]byte(adminEnableOrganizationBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"abc123\"\n   }'")
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminEnableOrganizationAdminSessionToken != "" {
+			adminSessionToken = &adminEnableOrganizationAdminSessionToken
+		}
+	}
+	v := &admin.EnableOrganizationPayload{
+		ID: body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}
+
 // BuildGetOrganizationPayload builds the payload for the admin getOrganization
 // endpoint from CLI flags.
 func BuildGetOrganizationPayload(adminGetOrganizationIDOrSlug string, adminGetOrganizationAdminSessionToken string) (*admin.GetOrganizationPayload, error) {

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -11,8 +11,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"unicode/utf8"
 
 	admin "github.com/speakeasy-api/gram/server/gen/admin"
+	goa "goa.design/goa/v3/pkg"
 )
 
 // BuildLoginPayload builds the payload for the admin login endpoint from CLI
@@ -148,7 +150,13 @@ func BuildDisableOrganizationPayload(adminDisableOrganizationBody string, adminD
 	{
 		err = json.Unmarshal([]byte(adminDisableOrganizationBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"abc123\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"aa\"\n   }'")
+		}
+		if utf8.RuneCountInString(body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", body.ID, utf8.RuneCountInString(body.ID), 1, true))
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 	var adminSessionToken *string
@@ -173,7 +181,13 @@ func BuildEnableOrganizationPayload(adminEnableOrganizationBody string, adminEna
 	{
 		err = json.Unmarshal([]byte(adminEnableOrganizationBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"abc123\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"aa\"\n   }'")
+		}
+		if utf8.RuneCountInString(body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", body.ID, utf8.RuneCountInString(body.ID), 1, true))
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 	var adminSessionToken *string

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -35,6 +35,14 @@ type Client struct {
 	// updateOrganization endpoint.
 	UpdateOrganizationDoer goahttp.Doer
 
+	// DisableOrganization Doer is the HTTP client used to make requests to the
+	// disableOrganization endpoint.
+	DisableOrganizationDoer goahttp.Doer
+
+	// EnableOrganization Doer is the HTTP client used to make requests to the
+	// enableOrganization endpoint.
+	EnableOrganizationDoer goahttp.Doer
+
 	// GetOrganization Doer is the HTTP client used to make requests to the
 	// getOrganization endpoint.
 	GetOrganizationDoer goahttp.Doer
@@ -76,6 +84,8 @@ func NewClient(
 		LogoutDoer:                   doer,
 		GetProjectDoer:               doer,
 		UpdateOrganizationDoer:       doer,
+		DisableOrganizationDoer:      doer,
+		EnableOrganizationDoer:       doer,
 		GetOrganizationDoer:          doer,
 		ListOrganizationMembersDoer:  doer,
 		ListOrganizationProjectsDoer: doer,
@@ -203,6 +213,54 @@ func (c *Client) UpdateOrganization() goa.Endpoint {
 		resp, err := c.UpdateOrganizationDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "updateOrganization", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// DisableOrganization returns an endpoint that makes HTTP requests to the
+// admin service disableOrganization server.
+func (c *Client) DisableOrganization() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeDisableOrganizationRequest(c.encoder)
+		decodeResponse = DecodeDisableOrganizationResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildDisableOrganizationRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.DisableOrganizationDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "disableOrganization", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// EnableOrganization returns an endpoint that makes HTTP requests to the admin
+// service enableOrganization server.
+func (c *Client) EnableOrganization() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeEnableOrganizationRequest(c.encoder)
+		decodeResponse = DecodeEnableOrganizationResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildEnableOrganizationRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.EnableOrganizationDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "enableOrganization", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -1218,6 +1218,475 @@ func DecodeUpdateOrganizationResponse(decoder func(*http.Response) goahttp.Decod
 	}
 }
 
+// BuildDisableOrganizationRequest instantiates a HTTP request object with
+// method and path set to call the "admin" service "disableOrganization"
+// endpoint
+func (c *Client) BuildDisableOrganizationRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: DisableOrganizationAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "disableOrganization", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeDisableOrganizationRequest returns an encoder for requests sent to the
+// admin disableOrganization server.
+func EncodeDisableOrganizationRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.DisableOrganizationPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "disableOrganization", "*admin.DisableOrganizationPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewDisableOrganizationRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "disableOrganization", err)
+		}
+		return nil
+	}
+}
+
+// DecodeDisableOrganizationResponse returns a decoder for responses returned
+// by the admin disableOrganization endpoint. restoreBody controls whether the
+// response body should be restored after having been read.
+// DecodeDisableOrganizationResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeDisableOrganizationResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body DisableOrganizationResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			res := NewDisableOrganizationAdminOrganizationOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body DisableOrganizationUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body DisableOrganizationForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body DisableOrganizationBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body DisableOrganizationNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body DisableOrganizationConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body DisableOrganizationUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body DisableOrganizationInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body DisableOrganizationInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+				}
+				err = ValidateDisableOrganizationInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+				}
+				return nil, NewDisableOrganizationInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body DisableOrganizationUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+				}
+				err = ValidateDisableOrganizationUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+				}
+				return nil, NewDisableOrganizationUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "disableOrganization", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body DisableOrganizationGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "disableOrganization", err)
+			}
+			err = ValidateDisableOrganizationGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "disableOrganization", err)
+			}
+			return nil, NewDisableOrganizationGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "disableOrganization", resp.StatusCode, string(body))
+		}
+	}
+}
+
+// BuildEnableOrganizationRequest instantiates a HTTP request object with
+// method and path set to call the "admin" service "enableOrganization" endpoint
+func (c *Client) BuildEnableOrganizationRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: EnableOrganizationAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "enableOrganization", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeEnableOrganizationRequest returns an encoder for requests sent to the
+// admin enableOrganization server.
+func EncodeEnableOrganizationRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.EnableOrganizationPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "enableOrganization", "*admin.EnableOrganizationPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewEnableOrganizationRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "enableOrganization", err)
+		}
+		return nil
+	}
+}
+
+// DecodeEnableOrganizationResponse returns a decoder for responses returned by
+// the admin enableOrganization endpoint. restoreBody controls whether the
+// response body should be restored after having been read.
+// DecodeEnableOrganizationResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeEnableOrganizationResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body EnableOrganizationResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			res := NewEnableOrganizationAdminOrganizationOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body EnableOrganizationUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body EnableOrganizationForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body EnableOrganizationBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body EnableOrganizationNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body EnableOrganizationConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body EnableOrganizationUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body EnableOrganizationInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body EnableOrganizationInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+				}
+				err = ValidateEnableOrganizationInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+				}
+				return nil, NewEnableOrganizationInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body EnableOrganizationUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+				}
+				err = ValidateEnableOrganizationUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+				}
+				return nil, NewEnableOrganizationUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "enableOrganization", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body EnableOrganizationGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "enableOrganization", err)
+			}
+			err = ValidateEnableOrganizationGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "enableOrganization", err)
+			}
+			return nil, NewEnableOrganizationGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "enableOrganization", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // BuildGetOrganizationRequest instantiates a HTTP request object with method
 // and path set to call the "admin" service "getOrganization" endpoint
 func (c *Client) BuildGetOrganizationRequest(ctx context.Context, v any) (*http.Request, error) {

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -32,6 +32,16 @@ func UpdateOrganizationAdminPath() string {
 	return "/admin/organization.update"
 }
 
+// DisableOrganizationAdminPath returns the URL path to the admin service disableOrganization HTTP endpoint.
+func DisableOrganizationAdminPath() string {
+	return "/admin/organization.disable"
+}
+
+// EnableOrganizationAdminPath returns the URL path to the admin service enableOrganization HTTP endpoint.
+func EnableOrganizationAdminPath() string {
+	return "/admin/organization.enable"
+}
+
 // GetOrganizationAdminPath returns the URL path to the admin service getOrganization HTTP endpoint.
 func GetOrganizationAdminPath() string {
 	return "/admin/organization.get"

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -23,6 +23,20 @@ type UpdateOrganizationRequestBody struct {
 	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
 }
 
+// DisableOrganizationRequestBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP request body.
+type DisableOrganizationRequestBody struct {
+	// Organization ID.
+	ID string `form:"id" json:"id" xml:"id"`
+}
+
+// EnableOrganizationRequestBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP request body.
+type EnableOrganizationRequestBody struct {
+	// Organization ID.
+	ID string `form:"id" json:"id" xml:"id"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -57,6 +71,74 @@ type GetProjectResponseBody struct {
 // UpdateOrganizationResponseBody is the type of the "admin" service
 // "updateOrganization" endpoint HTTP response body.
 type UpdateOrganizationResponseBody struct {
+	// The ID of the organization
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// The name of the organization
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// The slug of the organization
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount *int `form:"member_count,omitempty" json:"member_count,omitempty" xml:"member_count,omitempty"`
+	// The creation date of the organization.
+	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
+	// The last update date of the organization.
+	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
+}
+
+// DisableOrganizationResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body.
+type DisableOrganizationResponseBody struct {
+	// The ID of the organization
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// The name of the organization
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// The slug of the organization
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount *int `form:"member_count,omitempty" json:"member_count,omitempty" xml:"member_count,omitempty"`
+	// The creation date of the organization.
+	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
+	// The last update date of the organization.
+	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
+}
+
+// EnableOrganizationResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body.
+type EnableOrganizationResponseBody struct {
 	// The ID of the organization
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 	// The name of the organization
@@ -1051,6 +1133,375 @@ type UpdateOrganizationGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// DisableOrganizationUnauthorizedResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "unauthorized" error.
+type DisableOrganizationUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationForbiddenResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "forbidden" error.
+type DisableOrganizationForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationBadRequestResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "bad_request"
+// error.
+type DisableOrganizationBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationNotFoundResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "not_found" error.
+type DisableOrganizationNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationConflictResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "conflict" error.
+type DisableOrganizationConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationUnsupportedMediaResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "unsupported_media" error.
+type DisableOrganizationUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationInvalidResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "invalid" error.
+type DisableOrganizationInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationInvariantViolationResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "invariant_violation" error.
+type DisableOrganizationInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationUnexpectedResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "unexpected" error.
+type DisableOrganizationUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DisableOrganizationGatewayErrorResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "gateway_error" error.
+type DisableOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationUnauthorizedResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "unauthorized" error.
+type EnableOrganizationUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationForbiddenResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "forbidden" error.
+type EnableOrganizationForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationBadRequestResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "bad_request" error.
+type EnableOrganizationBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationNotFoundResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "not_found" error.
+type EnableOrganizationNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationConflictResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "conflict" error.
+type EnableOrganizationConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationUnsupportedMediaResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "unsupported_media" error.
+type EnableOrganizationUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationInvalidResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "invalid" error.
+type EnableOrganizationInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationInvariantViolationResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "invariant_violation" error.
+type EnableOrganizationInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationUnexpectedResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "unexpected" error.
+type EnableOrganizationUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// EnableOrganizationGatewayErrorResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "gateway_error" error.
+type EnableOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // GetOrganizationUnauthorizedResponseBody is the type of the "admin" service
 // "getOrganization" endpoint HTTP response body for the "unauthorized" error.
 type GetOrganizationUnauthorizedResponseBody struct {
@@ -1870,6 +2321,24 @@ func NewUpdateOrganizationRequestBody(p *admin.UpdateOrganizationPayload) *Updat
 	return body
 }
 
+// NewDisableOrganizationRequestBody builds the HTTP request body from the
+// payload of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationRequestBody(p *admin.DisableOrganizationPayload) *DisableOrganizationRequestBody {
+	body := &DisableOrganizationRequestBody{
+		ID: p.ID,
+	}
+	return body
+}
+
+// NewEnableOrganizationRequestBody builds the HTTP request body from the
+// payload of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationRequestBody(p *admin.EnableOrganizationPayload) *EnableOrganizationRequestBody {
+	body := &EnableOrganizationRequestBody{
+		ID: p.ID,
+	}
+	return body
+}
+
 // NewLoginResultTemporaryRedirect builds a "admin" service "login" endpoint
 // result from a HTTP "TemporaryRedirect" response.
 func NewLoginResultTemporaryRedirect(location string, stateCookie string) *admin.LoginResult {
@@ -2671,6 +3140,352 @@ func NewUpdateOrganizationGatewayError(body *UpdateOrganizationGatewayErrorRespo
 	return v
 }
 
+// NewDisableOrganizationAdminOrganizationOK builds a "admin" service
+// "disableOrganization" endpoint result from a HTTP "OK" response.
+func NewDisableOrganizationAdminOrganizationOK(body *DisableOrganizationResponseBody) *admin.AdminOrganization {
+	v := &admin.AdminOrganization{
+		ID:                 *body.ID,
+		Name:               *body.Name,
+		Slug:               *body.Slug,
+		AccountType:        *body.AccountType,
+		WorkosID:           body.WorkosID,
+		Whitelisted:        *body.Whitelisted,
+		DisabledAt:         body.DisabledAt,
+		FreeTrialStartedAt: body.FreeTrialStartedAt,
+		FreeTrialEndsAt:    body.FreeTrialEndsAt,
+		TrialState:         body.TrialState,
+		TrialEndsAt:        body.TrialEndsAt,
+		MemberCount:        *body.MemberCount,
+		CreatedAt:          *body.CreatedAt,
+		UpdatedAt:          *body.UpdatedAt,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationUnauthorized builds a admin service
+// disableOrganization endpoint unauthorized error.
+func NewDisableOrganizationUnauthorized(body *DisableOrganizationUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationForbidden builds a admin service disableOrganization
+// endpoint forbidden error.
+func NewDisableOrganizationForbidden(body *DisableOrganizationForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationBadRequest builds a admin service disableOrganization
+// endpoint bad_request error.
+func NewDisableOrganizationBadRequest(body *DisableOrganizationBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationNotFound builds a admin service disableOrganization
+// endpoint not_found error.
+func NewDisableOrganizationNotFound(body *DisableOrganizationNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationConflict builds a admin service disableOrganization
+// endpoint conflict error.
+func NewDisableOrganizationConflict(body *DisableOrganizationConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationUnsupportedMedia builds a admin service
+// disableOrganization endpoint unsupported_media error.
+func NewDisableOrganizationUnsupportedMedia(body *DisableOrganizationUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationInvalid builds a admin service disableOrganization
+// endpoint invalid error.
+func NewDisableOrganizationInvalid(body *DisableOrganizationInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationInvariantViolation builds a admin service
+// disableOrganization endpoint invariant_violation error.
+func NewDisableOrganizationInvariantViolation(body *DisableOrganizationInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationUnexpected builds a admin service disableOrganization
+// endpoint unexpected error.
+func NewDisableOrganizationUnexpected(body *DisableOrganizationUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDisableOrganizationGatewayError builds a admin service
+// disableOrganization endpoint gateway_error error.
+func NewDisableOrganizationGatewayError(body *DisableOrganizationGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationAdminOrganizationOK builds a "admin" service
+// "enableOrganization" endpoint result from a HTTP "OK" response.
+func NewEnableOrganizationAdminOrganizationOK(body *EnableOrganizationResponseBody) *admin.AdminOrganization {
+	v := &admin.AdminOrganization{
+		ID:                 *body.ID,
+		Name:               *body.Name,
+		Slug:               *body.Slug,
+		AccountType:        *body.AccountType,
+		WorkosID:           body.WorkosID,
+		Whitelisted:        *body.Whitelisted,
+		DisabledAt:         body.DisabledAt,
+		FreeTrialStartedAt: body.FreeTrialStartedAt,
+		FreeTrialEndsAt:    body.FreeTrialEndsAt,
+		TrialState:         body.TrialState,
+		TrialEndsAt:        body.TrialEndsAt,
+		MemberCount:        *body.MemberCount,
+		CreatedAt:          *body.CreatedAt,
+		UpdatedAt:          *body.UpdatedAt,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationUnauthorized builds a admin service enableOrganization
+// endpoint unauthorized error.
+func NewEnableOrganizationUnauthorized(body *EnableOrganizationUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationForbidden builds a admin service enableOrganization
+// endpoint forbidden error.
+func NewEnableOrganizationForbidden(body *EnableOrganizationForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationBadRequest builds a admin service enableOrganization
+// endpoint bad_request error.
+func NewEnableOrganizationBadRequest(body *EnableOrganizationBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationNotFound builds a admin service enableOrganization
+// endpoint not_found error.
+func NewEnableOrganizationNotFound(body *EnableOrganizationNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationConflict builds a admin service enableOrganization
+// endpoint conflict error.
+func NewEnableOrganizationConflict(body *EnableOrganizationConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationUnsupportedMedia builds a admin service
+// enableOrganization endpoint unsupported_media error.
+func NewEnableOrganizationUnsupportedMedia(body *EnableOrganizationUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationInvalid builds a admin service enableOrganization
+// endpoint invalid error.
+func NewEnableOrganizationInvalid(body *EnableOrganizationInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationInvariantViolation builds a admin service
+// enableOrganization endpoint invariant_violation error.
+func NewEnableOrganizationInvariantViolation(body *EnableOrganizationInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationUnexpected builds a admin service enableOrganization
+// endpoint unexpected error.
+func NewEnableOrganizationUnexpected(body *EnableOrganizationUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewEnableOrganizationGatewayError builds a admin service enableOrganization
+// endpoint gateway_error error.
+func NewEnableOrganizationGatewayError(body *EnableOrganizationGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewGetOrganizationAdminOrganizationOK builds a "admin" service
 // "getOrganization" endpoint result from a HTTP "OK" response.
 func NewGetOrganizationAdminOrganizationOK(body *GetOrganizationResponseBody) *admin.AdminOrganization {
@@ -3398,6 +4213,112 @@ func ValidateGetProjectResponseBody(body *GetProjectResponseBody) (err error) {
 // ValidateUpdateOrganizationResponseBody runs the validations defined on
 // UpdateOrganizationResponseBody
 func ValidateUpdateOrganizationResponseBody(body *UpdateOrganizationResponseBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.Slug == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if body.Whitelisted == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("whitelisted", "body"))
+	}
+	if body.MemberCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("member_count", "body"))
+	}
+	if body.CreatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
+	}
+	if body.UpdatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	if body.DisabledAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.disabled_at", *body.DisabledAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialStartedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_started_at", *body.FreeTrialStartedAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_ends_at", *body.FreeTrialEndsAt, goa.FormatDateTime))
+	}
+	if body.TrialState != nil {
+		if !(*body.TrialState == "none" || *body.TrialState == "running" || *body.TrialState == "ending_soon" || *body.TrialState == "expired" || *body.TrialState == "demoted" || *body.TrialState == "converted") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.trial_state", *body.TrialState, []any{"none", "running", "ending_soon", "expired", "demoted", "converted"}))
+		}
+	}
+	if body.TrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_ends_at", *body.TrialEndsAt, goa.FormatDateTime))
+	}
+	if body.CreatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
+	}
+	if body.UpdatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
+	}
+	return
+}
+
+// ValidateDisableOrganizationResponseBody runs the validations defined on
+// DisableOrganizationResponseBody
+func ValidateDisableOrganizationResponseBody(body *DisableOrganizationResponseBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.Slug == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if body.Whitelisted == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("whitelisted", "body"))
+	}
+	if body.MemberCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("member_count", "body"))
+	}
+	if body.CreatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
+	}
+	if body.UpdatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	if body.DisabledAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.disabled_at", *body.DisabledAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialStartedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_started_at", *body.FreeTrialStartedAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_ends_at", *body.FreeTrialEndsAt, goa.FormatDateTime))
+	}
+	if body.TrialState != nil {
+		if !(*body.TrialState == "none" || *body.TrialState == "running" || *body.TrialState == "ending_soon" || *body.TrialState == "expired" || *body.TrialState == "demoted" || *body.TrialState == "converted") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.trial_state", *body.TrialState, []any{"none", "running", "ending_soon", "expired", "demoted", "converted"}))
+		}
+	}
+	if body.TrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_ends_at", *body.TrialEndsAt, goa.FormatDateTime))
+	}
+	if body.CreatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
+	}
+	if body.UpdatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
+	}
+	return
+}
+
+// ValidateEnableOrganizationResponseBody runs the validations defined on
+// EnableOrganizationResponseBody
+func ValidateEnableOrganizationResponseBody(body *EnableOrganizationResponseBody) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}
@@ -4731,6 +5652,486 @@ func ValidateUpdateOrganizationUnexpectedResponseBody(body *UpdateOrganizationUn
 // ValidateUpdateOrganizationGatewayErrorResponseBody runs the validations
 // defined on updateOrganization_gateway_error_response_body
 func ValidateUpdateOrganizationGatewayErrorResponseBody(body *UpdateOrganizationGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationUnauthorizedResponseBody runs the validations
+// defined on disableOrganization_unauthorized_response_body
+func ValidateDisableOrganizationUnauthorizedResponseBody(body *DisableOrganizationUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationForbiddenResponseBody runs the validations
+// defined on disableOrganization_forbidden_response_body
+func ValidateDisableOrganizationForbiddenResponseBody(body *DisableOrganizationForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationBadRequestResponseBody runs the validations
+// defined on disableOrganization_bad_request_response_body
+func ValidateDisableOrganizationBadRequestResponseBody(body *DisableOrganizationBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationNotFoundResponseBody runs the validations defined
+// on disableOrganization_not_found_response_body
+func ValidateDisableOrganizationNotFoundResponseBody(body *DisableOrganizationNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationConflictResponseBody runs the validations defined
+// on disableOrganization_conflict_response_body
+func ValidateDisableOrganizationConflictResponseBody(body *DisableOrganizationConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationUnsupportedMediaResponseBody runs the validations
+// defined on disableOrganization_unsupported_media_response_body
+func ValidateDisableOrganizationUnsupportedMediaResponseBody(body *DisableOrganizationUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationInvalidResponseBody runs the validations defined
+// on disableOrganization_invalid_response_body
+func ValidateDisableOrganizationInvalidResponseBody(body *DisableOrganizationInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationInvariantViolationResponseBody runs the
+// validations defined on disableOrganization_invariant_violation_response_body
+func ValidateDisableOrganizationInvariantViolationResponseBody(body *DisableOrganizationInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationUnexpectedResponseBody runs the validations
+// defined on disableOrganization_unexpected_response_body
+func ValidateDisableOrganizationUnexpectedResponseBody(body *DisableOrganizationUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationGatewayErrorResponseBody runs the validations
+// defined on disableOrganization_gateway_error_response_body
+func ValidateDisableOrganizationGatewayErrorResponseBody(body *DisableOrganizationGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationUnauthorizedResponseBody runs the validations
+// defined on enableOrganization_unauthorized_response_body
+func ValidateEnableOrganizationUnauthorizedResponseBody(body *EnableOrganizationUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationForbiddenResponseBody runs the validations defined
+// on enableOrganization_forbidden_response_body
+func ValidateEnableOrganizationForbiddenResponseBody(body *EnableOrganizationForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationBadRequestResponseBody runs the validations
+// defined on enableOrganization_bad_request_response_body
+func ValidateEnableOrganizationBadRequestResponseBody(body *EnableOrganizationBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationNotFoundResponseBody runs the validations defined
+// on enableOrganization_not_found_response_body
+func ValidateEnableOrganizationNotFoundResponseBody(body *EnableOrganizationNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationConflictResponseBody runs the validations defined
+// on enableOrganization_conflict_response_body
+func ValidateEnableOrganizationConflictResponseBody(body *EnableOrganizationConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationUnsupportedMediaResponseBody runs the validations
+// defined on enableOrganization_unsupported_media_response_body
+func ValidateEnableOrganizationUnsupportedMediaResponseBody(body *EnableOrganizationUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationInvalidResponseBody runs the validations defined
+// on enableOrganization_invalid_response_body
+func ValidateEnableOrganizationInvalidResponseBody(body *EnableOrganizationInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationInvariantViolationResponseBody runs the
+// validations defined on enableOrganization_invariant_violation_response_body
+func ValidateEnableOrganizationInvariantViolationResponseBody(body *EnableOrganizationInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationUnexpectedResponseBody runs the validations
+// defined on enableOrganization_unexpected_response_body
+func ValidateEnableOrganizationUnexpectedResponseBody(body *EnableOrganizationUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationGatewayErrorResponseBody runs the validations
+// defined on enableOrganization_gateway_error_response_body
+func ValidateEnableOrganizationGatewayErrorResponseBody(body *EnableOrganizationGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -1046,6 +1046,432 @@ func EncodeUpdateOrganizationError(encoder func(context.Context, http.ResponseWr
 	}
 }
 
+// EncodeDisableOrganizationResponse returns an encoder for responses returned
+// by the admin disableOrganization endpoint.
+func EncodeDisableOrganizationResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminOrganization)
+		enc := encoder(ctx, w)
+		body := NewDisableOrganizationResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeDisableOrganizationRequest returns a decoder for requests sent to the
+// admin disableOrganization endpoint.
+func DecodeDisableOrganizationRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.DisableOrganizationPayload, error) {
+	return func(r *http.Request) (*admin.DisableOrganizationPayload, error) {
+		var payload *admin.DisableOrganizationPayload
+		var (
+			body DisableOrganizationRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateDisableOrganizationRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewDisableOrganizationPayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeDisableOrganizationError returns an encoder for errors returned by the
+// disableOrganization admin endpoint.
+func EncodeDisableOrganizationError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDisableOrganizationGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
+// EncodeEnableOrganizationResponse returns an encoder for responses returned
+// by the admin enableOrganization endpoint.
+func EncodeEnableOrganizationResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminOrganization)
+		enc := encoder(ctx, w)
+		body := NewEnableOrganizationResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeEnableOrganizationRequest returns a decoder for requests sent to the
+// admin enableOrganization endpoint.
+func DecodeEnableOrganizationRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.EnableOrganizationPayload, error) {
+	return func(r *http.Request) (*admin.EnableOrganizationPayload, error) {
+		var payload *admin.EnableOrganizationPayload
+		var (
+			body EnableOrganizationRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateEnableOrganizationRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewEnableOrganizationPayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeEnableOrganizationError returns an encoder for errors returned by the
+// enableOrganization admin endpoint.
+func EncodeEnableOrganizationError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewEnableOrganizationGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // EncodeGetOrganizationResponse returns an encoder for responses returned by
 // the admin getOrganization endpoint.
 func EncodeGetOrganizationResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -32,6 +32,16 @@ func UpdateOrganizationAdminPath() string {
 	return "/admin/organization.update"
 }
 
+// DisableOrganizationAdminPath returns the URL path to the admin service disableOrganization HTTP endpoint.
+func DisableOrganizationAdminPath() string {
+	return "/admin/organization.disable"
+}
+
+// EnableOrganizationAdminPath returns the URL path to the admin service enableOrganization HTTP endpoint.
+func EnableOrganizationAdminPath() string {
+	return "/admin/organization.enable"
+}
+
 // GetOrganizationAdminPath returns the URL path to the admin service getOrganization HTTP endpoint.
 func GetOrganizationAdminPath() string {
 	return "/admin/organization.get"

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -24,6 +24,8 @@ type Server struct {
 	Logout                   http.Handler
 	GetProject               http.Handler
 	UpdateOrganization       http.Handler
+	DisableOrganization      http.Handler
+	EnableOrganization       http.Handler
 	GetOrganization          http.Handler
 	ListOrganizationMembers  http.Handler
 	ListOrganizationProjects http.Handler
@@ -62,6 +64,8 @@ func New(
 			{"Logout", "POST", "/admin/auth.logout"},
 			{"GetProject", "GET", "/admin/project.get"},
 			{"UpdateOrganization", "POST", "/admin/organization.update"},
+			{"DisableOrganization", "POST", "/admin/organization.disable"},
+			{"EnableOrganization", "POST", "/admin/organization.enable"},
 			{"GetOrganization", "GET", "/admin/organization.get"},
 			{"ListOrganizationMembers", "GET", "/admin/organization.members"},
 			{"ListOrganizationProjects", "GET", "/admin/organization.projects"},
@@ -72,6 +76,8 @@ func New(
 		Logout:                   NewLogoutHandler(e.Logout, mux, decoder, encoder, errhandler, formatter),
 		GetProject:               NewGetProjectHandler(e.GetProject, mux, decoder, encoder, errhandler, formatter),
 		UpdateOrganization:       NewUpdateOrganizationHandler(e.UpdateOrganization, mux, decoder, encoder, errhandler, formatter),
+		DisableOrganization:      NewDisableOrganizationHandler(e.DisableOrganization, mux, decoder, encoder, errhandler, formatter),
+		EnableOrganization:       NewEnableOrganizationHandler(e.EnableOrganization, mux, decoder, encoder, errhandler, formatter),
 		GetOrganization:          NewGetOrganizationHandler(e.GetOrganization, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizationMembers:  NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizationProjects: NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
@@ -89,6 +95,8 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.Logout = m(s.Logout)
 	s.GetProject = m(s.GetProject)
 	s.UpdateOrganization = m(s.UpdateOrganization)
+	s.DisableOrganization = m(s.DisableOrganization)
+	s.EnableOrganization = m(s.EnableOrganization)
 	s.GetOrganization = m(s.GetOrganization)
 	s.ListOrganizationMembers = m(s.ListOrganizationMembers)
 	s.ListOrganizationProjects = m(s.ListOrganizationProjects)
@@ -105,6 +113,8 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountLogoutHandler(mux, h.Logout)
 	MountGetProjectHandler(mux, h.GetProject)
 	MountUpdateOrganizationHandler(mux, h.UpdateOrganization)
+	MountDisableOrganizationHandler(mux, h.DisableOrganization)
+	MountEnableOrganizationHandler(mux, h.EnableOrganization)
 	MountGetOrganizationHandler(mux, h.GetOrganization)
 	MountListOrganizationMembersHandler(mux, h.ListOrganizationMembers)
 	MountListOrganizationProjectsHandler(mux, h.ListOrganizationProjects)
@@ -358,6 +368,112 @@ func NewUpdateOrganizationHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "updateOrganization")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountDisableOrganizationHandler configures the mux to serve the "admin"
+// service "disableOrganization" endpoint.
+func MountDisableOrganizationHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/organization.disable", f)
+}
+
+// NewDisableOrganizationHandler creates a HTTP handler which loads the HTTP
+// request and calls the "admin" service "disableOrganization" endpoint.
+func NewDisableOrganizationHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeDisableOrganizationRequest(mux, decoder)
+		encodeResponse = EncodeDisableOrganizationResponse(encoder)
+		encodeError    = EncodeDisableOrganizationError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "disableOrganization")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountEnableOrganizationHandler configures the mux to serve the "admin"
+// service "enableOrganization" endpoint.
+func MountEnableOrganizationHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/organization.enable", f)
+}
+
+// NewEnableOrganizationHandler creates a HTTP handler which loads the HTTP
+// request and calls the "admin" service "enableOrganization" endpoint.
+func NewEnableOrganizationHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeEnableOrganizationRequest(mux, decoder)
+		encodeResponse = EncodeEnableOrganizationResponse(encoder)
+		encodeError    = EncodeEnableOrganizationError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "enableOrganization")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -23,6 +23,20 @@ type UpdateOrganizationRequestBody struct {
 	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
 }
 
+// DisableOrganizationRequestBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP request body.
+type DisableOrganizationRequestBody struct {
+	// Organization ID.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+}
+
+// EnableOrganizationRequestBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP request body.
+type EnableOrganizationRequestBody struct {
+	// Organization ID.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -57,6 +71,74 @@ type GetProjectResponseBody struct {
 // UpdateOrganizationResponseBody is the type of the "admin" service
 // "updateOrganization" endpoint HTTP response body.
 type UpdateOrganizationResponseBody struct {
+	// The ID of the organization
+	ID string `form:"id" json:"id" xml:"id"`
+	// The name of the organization
+	Name string `form:"name" json:"name" xml:"name"`
+	// The slug of the organization
+	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted bool `form:"whitelisted" json:"whitelisted" xml:"whitelisted"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount int `form:"member_count" json:"member_count" xml:"member_count"`
+	// The creation date of the organization.
+	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
+	// The last update date of the organization.
+	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
+}
+
+// DisableOrganizationResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body.
+type DisableOrganizationResponseBody struct {
+	// The ID of the organization
+	ID string `form:"id" json:"id" xml:"id"`
+	// The name of the organization
+	Name string `form:"name" json:"name" xml:"name"`
+	// The slug of the organization
+	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted bool `form:"whitelisted" json:"whitelisted" xml:"whitelisted"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount int `form:"member_count" json:"member_count" xml:"member_count"`
+	// The creation date of the organization.
+	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
+	// The last update date of the organization.
+	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
+}
+
+// EnableOrganizationResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body.
+type EnableOrganizationResponseBody struct {
 	// The ID of the organization
 	ID string `form:"id" json:"id" xml:"id"`
 	// The name of the organization
@@ -1051,6 +1133,375 @@ type UpdateOrganizationGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// DisableOrganizationUnauthorizedResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "unauthorized" error.
+type DisableOrganizationUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationForbiddenResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "forbidden" error.
+type DisableOrganizationForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationBadRequestResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "bad_request"
+// error.
+type DisableOrganizationBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationNotFoundResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "not_found" error.
+type DisableOrganizationNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationConflictResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "conflict" error.
+type DisableOrganizationConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationUnsupportedMediaResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "unsupported_media" error.
+type DisableOrganizationUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationInvalidResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "invalid" error.
+type DisableOrganizationInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationInvariantViolationResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "invariant_violation" error.
+type DisableOrganizationInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationUnexpectedResponseBody is the type of the "admin" service
+// "disableOrganization" endpoint HTTP response body for the "unexpected" error.
+type DisableOrganizationUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DisableOrganizationGatewayErrorResponseBody is the type of the "admin"
+// service "disableOrganization" endpoint HTTP response body for the
+// "gateway_error" error.
+type DisableOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationUnauthorizedResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "unauthorized" error.
+type EnableOrganizationUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationForbiddenResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "forbidden" error.
+type EnableOrganizationForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationBadRequestResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "bad_request" error.
+type EnableOrganizationBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationNotFoundResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "not_found" error.
+type EnableOrganizationNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationConflictResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "conflict" error.
+type EnableOrganizationConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationUnsupportedMediaResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "unsupported_media" error.
+type EnableOrganizationUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationInvalidResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "invalid" error.
+type EnableOrganizationInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationInvariantViolationResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "invariant_violation" error.
+type EnableOrganizationInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationUnexpectedResponseBody is the type of the "admin" service
+// "enableOrganization" endpoint HTTP response body for the "unexpected" error.
+type EnableOrganizationUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// EnableOrganizationGatewayErrorResponseBody is the type of the "admin"
+// service "enableOrganization" endpoint HTTP response body for the
+// "gateway_error" error.
+type EnableOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // GetOrganizationUnauthorizedResponseBody is the type of the "admin" service
 // "getOrganization" endpoint HTTP response body for the "unauthorized" error.
 type GetOrganizationUnauthorizedResponseBody struct {
@@ -1903,6 +2354,50 @@ func NewUpdateOrganizationResponseBody(res *admin.AdminOrganization) *UpdateOrga
 	return body
 }
 
+// NewDisableOrganizationResponseBody builds the HTTP response body from the
+// result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationResponseBody(res *admin.AdminOrganization) *DisableOrganizationResponseBody {
+	body := &DisableOrganizationResponseBody{
+		ID:                 res.ID,
+		Name:               res.Name,
+		Slug:               res.Slug,
+		AccountType:        res.AccountType,
+		WorkosID:           res.WorkosID,
+		Whitelisted:        res.Whitelisted,
+		DisabledAt:         res.DisabledAt,
+		FreeTrialStartedAt: res.FreeTrialStartedAt,
+		FreeTrialEndsAt:    res.FreeTrialEndsAt,
+		TrialState:         res.TrialState,
+		TrialEndsAt:        res.TrialEndsAt,
+		MemberCount:        res.MemberCount,
+		CreatedAt:          res.CreatedAt,
+		UpdatedAt:          res.UpdatedAt,
+	}
+	return body
+}
+
+// NewEnableOrganizationResponseBody builds the HTTP response body from the
+// result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationResponseBody(res *admin.AdminOrganization) *EnableOrganizationResponseBody {
+	body := &EnableOrganizationResponseBody{
+		ID:                 res.ID,
+		Name:               res.Name,
+		Slug:               res.Slug,
+		AccountType:        res.AccountType,
+		WorkosID:           res.WorkosID,
+		Whitelisted:        res.Whitelisted,
+		DisabledAt:         res.DisabledAt,
+		FreeTrialStartedAt: res.FreeTrialStartedAt,
+		FreeTrialEndsAt:    res.FreeTrialEndsAt,
+		TrialState:         res.TrialState,
+		TrialEndsAt:        res.TrialEndsAt,
+		MemberCount:        res.MemberCount,
+		CreatedAt:          res.CreatedAt,
+		UpdatedAt:          res.UpdatedAt,
+	}
+	return body
+}
+
 // NewGetOrganizationResponseBody builds the HTTP response body from the result
 // of the "getOrganization" endpoint of the "admin" service.
 func NewGetOrganizationResponseBody(res *admin.AdminOrganization) *GetOrganizationResponseBody {
@@ -2687,6 +3182,290 @@ func NewUpdateOrganizationGatewayErrorResponseBody(res *goa.ServiceError) *Updat
 	return body
 }
 
+// NewDisableOrganizationUnauthorizedResponseBody builds the HTTP response body
+// from the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationUnauthorizedResponseBody(res *goa.ServiceError) *DisableOrganizationUnauthorizedResponseBody {
+	body := &DisableOrganizationUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationForbiddenResponseBody builds the HTTP response body
+// from the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationForbiddenResponseBody(res *goa.ServiceError) *DisableOrganizationForbiddenResponseBody {
+	body := &DisableOrganizationForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationBadRequestResponseBody builds the HTTP response body
+// from the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationBadRequestResponseBody(res *goa.ServiceError) *DisableOrganizationBadRequestResponseBody {
+	body := &DisableOrganizationBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationNotFoundResponseBody builds the HTTP response body
+// from the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationNotFoundResponseBody(res *goa.ServiceError) *DisableOrganizationNotFoundResponseBody {
+	body := &DisableOrganizationNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationConflictResponseBody builds the HTTP response body
+// from the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationConflictResponseBody(res *goa.ServiceError) *DisableOrganizationConflictResponseBody {
+	body := &DisableOrganizationConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationUnsupportedMediaResponseBody builds the HTTP response
+// body from the result of the "disableOrganization" endpoint of the "admin"
+// service.
+func NewDisableOrganizationUnsupportedMediaResponseBody(res *goa.ServiceError) *DisableOrganizationUnsupportedMediaResponseBody {
+	body := &DisableOrganizationUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationInvalidResponseBody builds the HTTP response body from
+// the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationInvalidResponseBody(res *goa.ServiceError) *DisableOrganizationInvalidResponseBody {
+	body := &DisableOrganizationInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationInvariantViolationResponseBody builds the HTTP
+// response body from the result of the "disableOrganization" endpoint of the
+// "admin" service.
+func NewDisableOrganizationInvariantViolationResponseBody(res *goa.ServiceError) *DisableOrganizationInvariantViolationResponseBody {
+	body := &DisableOrganizationInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationUnexpectedResponseBody builds the HTTP response body
+// from the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationUnexpectedResponseBody(res *goa.ServiceError) *DisableOrganizationUnexpectedResponseBody {
+	body := &DisableOrganizationUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDisableOrganizationGatewayErrorResponseBody builds the HTTP response body
+// from the result of the "disableOrganization" endpoint of the "admin" service.
+func NewDisableOrganizationGatewayErrorResponseBody(res *goa.ServiceError) *DisableOrganizationGatewayErrorResponseBody {
+	body := &DisableOrganizationGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationUnauthorizedResponseBody builds the HTTP response body
+// from the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationUnauthorizedResponseBody(res *goa.ServiceError) *EnableOrganizationUnauthorizedResponseBody {
+	body := &EnableOrganizationUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationForbiddenResponseBody builds the HTTP response body
+// from the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationForbiddenResponseBody(res *goa.ServiceError) *EnableOrganizationForbiddenResponseBody {
+	body := &EnableOrganizationForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationBadRequestResponseBody builds the HTTP response body
+// from the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationBadRequestResponseBody(res *goa.ServiceError) *EnableOrganizationBadRequestResponseBody {
+	body := &EnableOrganizationBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationNotFoundResponseBody builds the HTTP response body from
+// the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationNotFoundResponseBody(res *goa.ServiceError) *EnableOrganizationNotFoundResponseBody {
+	body := &EnableOrganizationNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationConflictResponseBody builds the HTTP response body from
+// the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationConflictResponseBody(res *goa.ServiceError) *EnableOrganizationConflictResponseBody {
+	body := &EnableOrganizationConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationUnsupportedMediaResponseBody builds the HTTP response
+// body from the result of the "enableOrganization" endpoint of the "admin"
+// service.
+func NewEnableOrganizationUnsupportedMediaResponseBody(res *goa.ServiceError) *EnableOrganizationUnsupportedMediaResponseBody {
+	body := &EnableOrganizationUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationInvalidResponseBody builds the HTTP response body from
+// the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationInvalidResponseBody(res *goa.ServiceError) *EnableOrganizationInvalidResponseBody {
+	body := &EnableOrganizationInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationInvariantViolationResponseBody builds the HTTP response
+// body from the result of the "enableOrganization" endpoint of the "admin"
+// service.
+func NewEnableOrganizationInvariantViolationResponseBody(res *goa.ServiceError) *EnableOrganizationInvariantViolationResponseBody {
+	body := &EnableOrganizationInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationUnexpectedResponseBody builds the HTTP response body
+// from the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationUnexpectedResponseBody(res *goa.ServiceError) *EnableOrganizationUnexpectedResponseBody {
+	body := &EnableOrganizationUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewEnableOrganizationGatewayErrorResponseBody builds the HTTP response body
+// from the result of the "enableOrganization" endpoint of the "admin" service.
+func NewEnableOrganizationGatewayErrorResponseBody(res *goa.ServiceError) *EnableOrganizationGatewayErrorResponseBody {
+	body := &EnableOrganizationGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewGetOrganizationUnauthorizedResponseBody builds the HTTP response body
 // from the result of the "getOrganization" endpoint of the "admin" service.
 func NewGetOrganizationUnauthorizedResponseBody(res *goa.ServiceError) *GetOrganizationUnauthorizedResponseBody {
@@ -3321,6 +4100,28 @@ func NewUpdateOrganizationPayload(body *UpdateOrganizationRequestBody, adminSess
 	return v
 }
 
+// NewDisableOrganizationPayload builds a admin service disableOrganization
+// endpoint payload.
+func NewDisableOrganizationPayload(body *DisableOrganizationRequestBody, adminSessionToken *string) *admin.DisableOrganizationPayload {
+	v := &admin.DisableOrganizationPayload{
+		ID: *body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
+// NewEnableOrganizationPayload builds a admin service enableOrganization
+// endpoint payload.
+func NewEnableOrganizationPayload(body *EnableOrganizationRequestBody, adminSessionToken *string) *admin.EnableOrganizationPayload {
+	v := &admin.EnableOrganizationPayload{
+		ID: *body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
 // NewGetOrganizationPayload builds a admin service getOrganization endpoint
 // payload.
 func NewGetOrganizationPayload(idOrSlug string, adminSessionToken *string) *admin.GetOrganizationPayload {
@@ -3371,6 +4172,24 @@ func NewListOrganizationsPayload(q *string, accountType *string, includeDisabled
 // ValidateUpdateOrganizationRequestBody runs the validations defined on
 // UpdateOrganizationRequestBody
 func ValidateUpdateOrganizationRequestBody(body *UpdateOrganizationRequestBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	return
+}
+
+// ValidateDisableOrganizationRequestBody runs the validations defined on
+// DisableOrganizationRequestBody
+func ValidateDisableOrganizationRequestBody(body *DisableOrganizationRequestBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	return
+}
+
+// ValidateEnableOrganizationRequestBody runs the validations defined on
+// EnableOrganizationRequestBody
+func ValidateEnableOrganizationRequestBody(body *EnableOrganizationRequestBody) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -8,6 +8,8 @@
 package server
 
 import (
+	"unicode/utf8"
+
 	admin "github.com/speakeasy-api/gram/server/gen/admin"
 	goa "goa.design/goa/v3/pkg"
 )
@@ -4184,6 +4186,11 @@ func ValidateDisableOrganizationRequestBody(body *DisableOrganizationRequestBody
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}
+	if body.ID != nil {
+		if utf8.RuneCountInString(*body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
+		}
+	}
 	return
 }
 
@@ -4192,6 +4199,11 @@ func ValidateDisableOrganizationRequestBody(body *DisableOrganizationRequestBody
 func ValidateEnableOrganizationRequestBody(body *EnableOrganizationRequestBody) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.ID != nil {
+		if utf8.RuneCountInString(*body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
+		}
 	}
 	return
 }

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -8882,7 +8882,7 @@ func adminDisableOrganizationUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin disable-organization --body '{\n      \"id\": \"abc123\"\n   }' --admin-session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin disable-organization --body '{\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
 }
 
 func adminEnableOrganizationUsage() {
@@ -8902,7 +8902,7 @@ func adminEnableOrganizationUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin enable-organization --body '{\n      \"id\": \"abc123\"\n   }' --admin-session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin enable-organization --body '{\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
 }
 
 func adminGetOrganizationUsage() {

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -97,7 +97,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|upsert-shadow-mcp-inventory-policy-bypass|delete-shadow-mcp-inventory-policy-bypass|block-shadow-mcp-inventory-server|unblock-shadow-mcp-inventory-server|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|get-organization|list-organization-members|list-organization-projects|list-organizations)",
+		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -343,6 +343,14 @@ func ParseEndpoint(
 		adminUpdateOrganizationFlags                 = flag.NewFlagSet("update-organization", flag.ExitOnError)
 		adminUpdateOrganizationBodyFlag              = adminUpdateOrganizationFlags.String("body", "REQUIRED", "")
 		adminUpdateOrganizationAdminSessionTokenFlag = adminUpdateOrganizationFlags.String("admin-session-token", "", "")
+
+		adminDisableOrganizationFlags                 = flag.NewFlagSet("disable-organization", flag.ExitOnError)
+		adminDisableOrganizationBodyFlag              = adminDisableOrganizationFlags.String("body", "REQUIRED", "")
+		adminDisableOrganizationAdminSessionTokenFlag = adminDisableOrganizationFlags.String("admin-session-token", "", "")
+
+		adminEnableOrganizationFlags                 = flag.NewFlagSet("enable-organization", flag.ExitOnError)
+		adminEnableOrganizationBodyFlag              = adminEnableOrganizationFlags.String("body", "REQUIRED", "")
+		adminEnableOrganizationAdminSessionTokenFlag = adminEnableOrganizationFlags.String("admin-session-token", "", "")
 
 		adminGetOrganizationFlags                 = flag.NewFlagSet("get-organization", flag.ExitOnError)
 		adminGetOrganizationIDOrSlugFlag          = adminGetOrganizationFlags.String("id-or-slug", "REQUIRED", "")
@@ -3366,6 +3374,8 @@ func ParseEndpoint(
 	adminLogoutFlags.Usage = adminLogoutUsage
 	adminGetProjectFlags.Usage = adminGetProjectUsage
 	adminUpdateOrganizationFlags.Usage = adminUpdateOrganizationUsage
+	adminDisableOrganizationFlags.Usage = adminDisableOrganizationUsage
+	adminEnableOrganizationFlags.Usage = adminEnableOrganizationUsage
 	adminGetOrganizationFlags.Usage = adminGetOrganizationUsage
 	adminListOrganizationMembersFlags.Usage = adminListOrganizationMembersUsage
 	adminListOrganizationProjectsFlags.Usage = adminListOrganizationProjectsUsage
@@ -4300,6 +4310,12 @@ func ParseEndpoint(
 
 			case "update-organization":
 				epf = adminUpdateOrganizationFlags
+
+			case "disable-organization":
+				epf = adminDisableOrganizationFlags
+
+			case "enable-organization":
+				epf = adminEnableOrganizationFlags
 
 			case "get-organization":
 				epf = adminGetOrganizationFlags
@@ -6268,6 +6284,12 @@ func ParseEndpoint(
 			case "update-organization":
 				endpoint = c.UpdateOrganization()
 				data, err = adminc.BuildUpdateOrganizationPayload(*adminUpdateOrganizationBodyFlag, *adminUpdateOrganizationAdminSessionTokenFlag)
+			case "disable-organization":
+				endpoint = c.DisableOrganization()
+				data, err = adminc.BuildDisableOrganizationPayload(*adminDisableOrganizationBodyFlag, *adminDisableOrganizationAdminSessionTokenFlag)
+			case "enable-organization":
+				endpoint = c.EnableOrganization()
+				data, err = adminc.BuildEnableOrganizationPayload(*adminEnableOrganizationBodyFlag, *adminEnableOrganizationAdminSessionTokenFlag)
 			case "get-organization":
 				endpoint = c.GetOrganization()
 				data, err = adminc.BuildGetOrganizationPayload(*adminGetOrganizationIDOrSlugFlag, *adminGetOrganizationAdminSessionTokenFlag)
@@ -8729,6 +8751,8 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    logout: Logout implements logout.`)
 	fmt.Fprintln(os.Stderr, `    get-project: Returns full admin details for a project by id or slug, including aggregated counts of child resources.`)
 	fmt.Fprintln(os.Stderr, `    update-organization: Updates admin-managed fields on an organization. At least one of account_type or whitelisted must be supplied.`)
+	fmt.Fprintln(os.Stderr, `    disable-organization: Disables an organization, recording the moment of the action in disabled_at. Idempotent: disabling an already-disabled organization keeps the original timestamp.`)
+	fmt.Fprintln(os.Stderr, `    enable-organization: Re-enables a disabled organization by clearing disabled_at. Idempotent: an organization that is already active is unaffected.`)
 	fmt.Fprintln(os.Stderr, `    get-organization: Returns full admin details for a single organization by id or slug.`)
 	fmt.Fprintln(os.Stderr, `    list-organization-members: Lists members of an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organization-projects: Lists projects belonging to an organization (admin view, no auth scoping).`)
@@ -8839,6 +8863,46 @@ func adminUpdateOrganizationUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin update-organization --body '{\n      \"account_type\": \"abc123\",\n      \"id\": \"abc123\",\n      \"whitelisted\": false\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminDisableOrganizationUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin disable-organization", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Disables an organization, recording the moment of the action in disabled_at. Idempotent: disabling an already-disabled organization keeps the original timestamp.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin disable-organization --body '{\n      \"id\": \"abc123\"\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminEnableOrganizationUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin enable-organization", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Re-enables a disabled organization by clearing disabled_at. Idempotent: an organization that is already active is unaffected.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin enable-organization --body '{\n      \"id\": \"abc123\"\n   }' --admin-session-token \"abc123\"")
 }
 
 func adminGetOrganizationUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -365,7 +365,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/DisableOrganizationRequestBody'
+                            $ref: '#/components/schemas/EnableOrganizationRequestBody'
             responses:
                 "200":
                     description: OK response.
@@ -60317,6 +60317,15 @@ components:
             required:
                 - organization_id
                 - key_type
+        EnableOrganizationRequestBody:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Organization ID.
+                    minLength: 1
+            required:
+                - id
         EncryptOpenRouterKeyRequestBody:
             type: object
             properties:

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -277,6 +277,158 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Error'
+    /admin/organization.disable:
+        post:
+            tags:
+                - admin
+            summary: disableOrganization admin
+            description: 'Disables an organization, recording the moment of the action in disabled_at. Idempotent: disabling an already-disabled organization keeps the original timestamp.'
+            operationId: adminDisableOrganization
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ServeImageForm'
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminOrganization'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
+    /admin/organization.enable:
+        post:
+            tags:
+                - admin
+            summary: enableOrganization admin
+            description: 'Re-enables a disabled organization by clearing disabled_at. Idempotent: an organization that is already active is unaffected.'
+            operationId: adminEnableOrganization
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ServeImageForm'
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminOrganization'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/organization.get:
         get:
             tags:

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -289,7 +289,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/ServeImageForm'
+                            $ref: '#/components/schemas/DisableOrganizationRequestBody'
             responses:
                 "200":
                     description: OK response.
@@ -365,7 +365,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/ServeImageForm'
+                            $ref: '#/components/schemas/DisableOrganizationRequestBody'
             responses:
                 "200":
                     description: OK response.
@@ -60173,6 +60173,15 @@ components:
             required:
                 - organization_id
                 - key_type
+        DisableOrganizationRequestBody:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Organization ID.
+                    minLength: 1
+            required:
+                - id
         DiscoverProtectedResourceMetadataRequestBody:
             type: object
             properties:

--- a/server/internal/admin/disableorganization_test.go
+++ b/server/internal/admin/disableorganization_test.go
@@ -385,6 +385,29 @@ func TestAdminOrganizationWrites_ReturnTheOrganizationWritten(t *testing.T) {
 	require.True(t, readOrgState(t, ctx, conn, "org_shadow").Whitelisted, "the update must not land on the organization whose slug collides")
 }
 
+func TestGetOrganization_PrefersIDOverAnotherOrganizationsSlug(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// GetOrganization is the one read that still resolves slugs, so the same
+	// id/slug collision reaches it. Both rows satisfy the predicate and LIMIT 1
+	// on its own leaves the winner to the planner, so the query sorts the exact
+	// id match first. Without that ORDER BY this assertion depends on the plan
+	// rather than on the query, which is the state it is here to rule out.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_read_collide", name: "Target", slug: "target-read", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_read_shadow", name: "Shadow", slug: "org_read_collide", whitelisted: true})
+
+	byID, err := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: "org_read_collide"})
+	require.NoError(t, err)
+	require.Equal(t, "org_read_collide", byID.ID, "an exact id match must win over another organization's slug")
+
+	// Slug lookup is unchanged when nothing else claims the string as an id.
+	bySlug, err := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: "target-read"})
+	require.NoError(t, err)
+	require.Equal(t, "org_read_collide", bySlug.ID)
+}
+
 func TestDisableOrganization_TouchesOnlyTheTargetRow(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/admin/disableorganization_test.go
+++ b/server/internal/admin/disableorganization_test.go
@@ -50,15 +50,36 @@ func TestDisableOrganization_SetsDisabledAt(t *testing.T) {
 	ctx, svc, conn := newTestAdminService(t)
 
 	seedOrg(t, ctx, conn, orgFixture{id: "org_dis", name: "Dis Co", slug: "dis-co", whitelisted: true})
+	seeded := readOrgState(t, ctx, conn, "org_dis")
 
 	before := time.Now().UTC()
 	res, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_dis"})
 	require.NoError(t, err)
 	require.NotNil(t, res.DisabledAt, "the response must report the organization as disabled")
 
-	stamped := readDisabledAt(t, ctx, conn, "org_dis")
-	require.NotNil(t, stamped)
-	require.WithinDuration(t, before, *stamped, time.Minute, "disabled_at records the moment of the action")
+	after := readOrgState(t, ctx, conn, "org_dis")
+	require.True(t, after.DisabledAt.Valid)
+	stamped := after.DisabledAt.Time
+
+	// disabled_at must be the moment of the action, not the row's creation time
+	// and not an arbitrary offset from it. AGE-3187 counts organizations
+	// disabled in a window off this column, so a stamp that is merely "close to
+	// now" is not enough.
+	//
+	// The tight bounds compare two values written by the same statement, so
+	// they stay inside the database clock. `before` comes from the test host
+	// and the database runs in a container, and the two clocks can drift, so
+	// the cross-clock bound below is deliberately left loose.
+	require.True(t, stamped.After(seeded.CreatedAt.Time),
+		"disabled_at must be stamped at the disable, not carried from created_at: created %s, stamped %s", seeded.CreatedAt.Time, stamped)
+	require.WithinDuration(t, after.UpdatedAt.Time, stamped, time.Second,
+		"disabled_at and updated_at are stamped by one statement, so they must agree: updated %s, stamped %s", after.UpdatedAt.Time, stamped)
+	require.WithinDuration(t, before, stamped, time.Minute, "disabled_at must land near wall-clock now")
+
+	// updated_at is rendered to the operator by both the list and the get
+	// endpoints, so a write that left it behind is user-visible.
+	require.True(t, after.UpdatedAt.Time.After(seeded.UpdatedAt.Time),
+		"disable must move updated_at: was %s, now %s", seeded.UpdatedAt.Time, after.UpdatedAt.Time)
 
 	// The detail endpoint agrees with the write.
 	detail, err := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: "org_dis"})
@@ -109,11 +130,16 @@ func TestEnableOrganization_ClearsDisabledAt(t *testing.T) {
 
 	disabledAt := time.Now().UTC().Add(-24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: "org_en", name: "En Co", slug: "en-co", whitelisted: true, disabledAt: &disabledAt})
+	seeded := readOrgState(t, ctx, conn, "org_en")
 
 	res, err := svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_en"})
 	require.NoError(t, err)
 	require.Nil(t, res.DisabledAt, "the response must report the organization as active")
-	require.Nil(t, readDisabledAt(t, ctx, conn, "org_en"))
+
+	after := readOrgState(t, ctx, conn, "org_en")
+	require.False(t, after.DisabledAt.Valid)
+	require.True(t, after.UpdatedAt.Time.After(seeded.UpdatedAt.Time),
+		"enable must move updated_at: was %s, now %s", seeded.UpdatedAt.Time, after.UpdatedAt.Time)
 }
 
 func TestEnableOrganization_NeverDisabled(t *testing.T) {
@@ -189,17 +215,53 @@ func TestDisableOrganization_LeavesWhitelistAlone(t *testing.T) {
 	ctx, svc, conn := newTestAdminService(t)
 
 	// Whitelisting is the not-yet-approved gate, a separate concept from being
-	// disabled. Neither direction may move it.
-	seedOrg(t, ctx, conn, orgFixture{id: "org_wl_on", name: "WL On", slug: "wl-on", whitelisted: true})
-	seedOrg(t, ctx, conn, orgFixture{id: "org_wl_off", name: "WL Off", slug: "wl-off", whitelisted: false})
+	// disabled. Neither direction may move it, in either polarity.
+	//
+	// A boolean column has four mutations, not two, and seeding only
+	// whitelisted organizations makes half of them unreachable: "disable must
+	// not GRANT the whitelist" cannot fail if every organization under test is
+	// already whitelisted. That half is the dangerous half. A disable that
+	// silently set the flag would push a not-yet-approved organization straight
+	// through the approval gate the moment an operator re-enabled it.
+	//
+	// So all four arms are seeded explicitly, and each asserts the column
+	// rather than the response, which keeps the read-after-write path out of
+	// the assertion.
+	seededDisabledAt := time.Now().UTC().Add(-time.Hour)
 
-	disabled, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_wl_on"})
-	require.NoError(t, err)
-	require.True(t, disabled.Whitelisted, "disabling must not revoke the whitelist")
+	cases := []struct {
+		id          string
+		slug        string
+		whitelisted bool
+		enable      bool
+	}{
+		{id: "org_wl_dis_on", slug: "wl-dis-on", whitelisted: true},
+		{id: "org_wl_dis_off", slug: "wl-dis-off", whitelisted: false},
+		{id: "org_wl_en_on", slug: "wl-en-on", whitelisted: true, enable: true},
+		{id: "org_wl_en_off", slug: "wl-en-off", whitelisted: false, enable: true},
+	}
 
-	enabled, err := svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_wl_off"})
-	require.NoError(t, err)
-	require.False(t, enabled.Whitelisted, "enabling must not grant the whitelist")
+	for _, tc := range cases {
+		fixture := orgFixture{id: tc.id, name: tc.id, slug: tc.slug, whitelisted: tc.whitelisted}
+		action := "disable"
+		if tc.enable {
+			action = "enable"
+			fixture.disabledAt = &seededDisabledAt
+		}
+		seedOrg(t, ctx, conn, fixture)
+
+		var err error
+		if tc.enable {
+			_, err = svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: tc.id})
+		} else {
+			_, err = svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: tc.id})
+		}
+		require.NoError(t, err)
+
+		state := readOrgState(t, ctx, conn, tc.id)
+		require.Equal(t, tc.enable, !state.DisabledAt.Valid, "%s must have taken effect on %s, or the whitelist assertion proves nothing", action, tc.id)
+		require.Equal(t, tc.whitelisted, state.Whitelisted, "%s must leave whitelisted at %v on %s", action, tc.whitelisted, tc.id)
+	}
 }
 
 func TestDisableOrganization_AgreesWithListGate(t *testing.T) {
@@ -251,6 +313,11 @@ func TestDisableOrganization_EmptyID(t *testing.T) {
 
 	seedOrg(t, ctx, conn, orgFixture{id: "org_bystander", name: "Bystander", slug: "bystander", whitelisted: true})
 
+	// An empty id is rejected as a 400 at the HTTP boundary by MinLength(1) in
+	// the design. That validation is generated into the request decoder, which
+	// a direct service call does not run, so the service-level contract is
+	// still not-found. Both layers matter: this one is what protects the
+	// database if a future caller reaches the service another way.
 	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: ""})
 	requireOopsCode(t, err, oops.CodeNotFound)
 
@@ -267,11 +334,55 @@ func TestDisableOrganization_DoesNotMatchOnSlug(t *testing.T) {
 
 	seedOrg(t, ctx, conn, orgFixture{id: "org_slug_only", name: "Slug Only", slug: "slug-only", whitelisted: true})
 
-	// The read path resolves id-or-slug; the write path is id-only. Passing a
-	// slug must fail rather than report a success the database never saw.
+	// This test pins the write side on its own: addressing a write by slug must
+	// change nothing and must not report success.
+	//
+	// It used to be the only test that killed deleting the `rows == 0` guard in
+	// both handlers, back when the read-after-write still resolved slugs: the
+	// read would find the row the write had missed and return 200. Now that the
+	// read is keyed on id alone it has the same predicate as the write, so
+	// deleting the guard is behaviour-preserving and no test can kill it. The
+	// guard stays because it makes the not-found contract a property of the
+	// handler rather than a consequence of the read, which is what stops the
+	// 200-on-an-untouched-row bug from returning if the read is ever widened
+	// again.
 	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "slug-only"})
 	requireOopsCode(t, err, oops.CodeNotFound)
 	require.Nil(t, readDisabledAt(t, ctx, conn, "org_slug_only"))
+}
+
+func TestAdminOrganizationWrites_ReturnTheOrganizationWritten(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// id and slug are both bare TEXT, so nothing stops one organization's slug
+	// from equalling another's id. Every admin write is keyed on id, so a
+	// read-after-write that also resolved slugs could return the bystander:
+	// the operator gets a 200 describing an organization that is still active
+	// and concludes the disable failed.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_collide", name: "Target", slug: "target-co", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_shadow", name: "Shadow", slug: "org_collide", whitelisted: true})
+
+	disabled, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_collide"})
+	require.NoError(t, err)
+	require.Equal(t, "org_collide", disabled.ID, "the response must describe the organization that was written")
+	require.NotNil(t, disabled.DisabledAt, "the response must show the write that just happened")
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_shadow"), "the write must not land on the organization whose slug collides")
+
+	enabled, err := svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_collide"})
+	require.NoError(t, err)
+	require.Equal(t, "org_collide", enabled.ID)
+	require.Nil(t, enabled.DisabledAt)
+
+	// The same helper serves UpdateOrganization, whose write has always been
+	// id-only.
+	whitelisted := false
+	updated, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: "org_collide", Whitelisted: &whitelisted})
+	require.NoError(t, err)
+	require.Equal(t, "org_collide", updated.ID)
+	require.False(t, updated.Whitelisted)
+	require.True(t, readOrgState(t, ctx, conn, "org_shadow").Whitelisted, "the update must not land on the organization whose slug collides")
 }
 
 func TestDisableOrganization_TouchesOnlyTheTargetRow(t *testing.T) {

--- a/server/internal/admin/disableorganization_test.go
+++ b/server/internal/admin/disableorganization_test.go
@@ -1,0 +1,297 @@
+package admin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+// readOrgState reads organization_metadata straight from the database rather
+// than through the API type. disabled_at matters at full precision here: the
+// API renders it as a second-resolution RFC3339 string, so a timestamp that
+// moved by microseconds would still compare equal.
+func readOrgState(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string) testrepo.GetOrganizationMetadataStateFixtureRow {
+	t.Helper()
+
+	row, err := testrepo.New(conn).GetOrganizationMetadataStateFixture(ctx, orgID)
+	require.NoError(t, err)
+	return row
+}
+
+func readDisabledAt(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string) *time.Time {
+	t.Helper()
+
+	disabledAt := readOrgState(t, ctx, conn, orgID).DisabledAt
+	if !disabledAt.Valid {
+		return nil
+	}
+	return &disabledAt.Time
+}
+
+func requireOopsCode(t *testing.T, err error, want oops.Code) {
+	t.Helper()
+
+	require.Error(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, want, oopsErr.Code)
+}
+
+func TestDisableOrganization_SetsDisabledAt(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_dis", name: "Dis Co", slug: "dis-co", whitelisted: true})
+
+	before := time.Now().UTC()
+	res, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_dis"})
+	require.NoError(t, err)
+	require.NotNil(t, res.DisabledAt, "the response must report the organization as disabled")
+
+	stamped := readDisabledAt(t, ctx, conn, "org_dis")
+	require.NotNil(t, stamped)
+	require.WithinDuration(t, before, *stamped, time.Minute, "disabled_at records the moment of the action")
+
+	// The detail endpoint agrees with the write.
+	detail, err := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: "org_dis"})
+	require.NoError(t, err)
+	require.NotNil(t, detail.DisabledAt)
+}
+
+func TestDisableOrganization_WithoutWorkosID(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// The whole reason the operator path needs its own query: no WorkOS linkage
+	// to key on.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_no_workos", name: "No Workos", slug: "no-workos", whitelisted: true, workosID: nil})
+
+	res, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_no_workos"})
+	require.NoError(t, err)
+	require.Nil(t, res.WorkosID, "fixture must really have no WorkOS id")
+	require.NotNil(t, res.DisabledAt)
+	require.NotNil(t, readDisabledAt(t, ctx, conn, "org_no_workos"))
+}
+
+func TestDisableOrganization_AlreadyDisabledKeepsTimestamp(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_twice", name: "Twice Co", slug: "twice-co", whitelisted: true})
+
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_twice"})
+	require.NoError(t, err)
+	first := readDisabledAt(t, ctx, conn, "org_twice")
+	require.NotNil(t, first)
+
+	_, err = svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_twice"})
+	require.NoError(t, err)
+	second := readDisabledAt(t, ctx, conn, "org_twice")
+	require.NotNil(t, second)
+
+	require.True(t, first.Equal(*second), "re-disabling must not move disabled_at: %s then %s", first, second)
+}
+
+func TestEnableOrganization_ClearsDisabledAt(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	disabledAt := time.Now().UTC().Add(-24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_en", name: "En Co", slug: "en-co", whitelisted: true, disabledAt: &disabledAt})
+
+	res, err := svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_en"})
+	require.NoError(t, err)
+	require.Nil(t, res.DisabledAt, "the response must report the organization as active")
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_en"))
+}
+
+func TestEnableOrganization_NeverDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_already_on", name: "On Co", slug: "on-co", whitelisted: true})
+
+	res, err := svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_already_on"})
+	require.NoError(t, err)
+	require.Nil(t, res.DisabledAt)
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_already_on"))
+}
+
+func TestDisableThenEnableOrganization_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_round", name: "Round Co", slug: "round-co", whitelisted: true})
+
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_round"})
+	require.NoError(t, err)
+	require.NotNil(t, readDisabledAt(t, ctx, conn, "org_round"))
+
+	_, err = svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_round"})
+	require.NoError(t, err)
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_round"))
+
+	// A second disable after a re-enable stamps a fresh timestamp rather than
+	// resurrecting the first one.
+	_, err = svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_round"})
+	require.NoError(t, err)
+	require.NotNil(t, readDisabledAt(t, ctx, conn, "org_round"))
+}
+
+func TestDisableOrganization_LeavesWorkosCursorAlone(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	workosID := "workos_org_placeholder"
+	cursor := "event_placeholder"
+	seedOrg(t, ctx, conn, orgFixture{
+		id:                "org_cursor",
+		name:              "Cursor Co",
+		slug:              "cursor-co",
+		whitelisted:       true,
+		workosID:          &workosID,
+		workosLastEventID: &cursor,
+	})
+	seeded := readOrgState(t, ctx, conn, "org_cursor").WorkosLastEventID
+	require.True(t, seeded.Valid, "the cursor must really be set, or the assertions below prove nothing")
+	require.Equal(t, cursor, seeded.String)
+
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_cursor"})
+	require.NoError(t, err)
+	got := readOrgState(t, ctx, conn, "org_cursor").WorkosLastEventID
+	require.True(t, got.Valid, "disable must not clear the webhook cursor")
+	require.Equal(t, cursor, got.String)
+
+	_, err = svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_cursor"})
+	require.NoError(t, err)
+	got = readOrgState(t, ctx, conn, "org_cursor").WorkosLastEventID
+	require.True(t, got.Valid, "enable must not clear the webhook cursor")
+	require.Equal(t, cursor, got.String)
+}
+
+func TestDisableOrganization_LeavesWhitelistAlone(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// Whitelisting is the not-yet-approved gate, a separate concept from being
+	// disabled. Neither direction may move it.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_wl_on", name: "WL On", slug: "wl-on", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_wl_off", name: "WL Off", slug: "wl-off", whitelisted: false})
+
+	disabled, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_wl_on"})
+	require.NoError(t, err)
+	require.True(t, disabled.Whitelisted, "disabling must not revoke the whitelist")
+
+	enabled, err := svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_wl_off"})
+	require.NoError(t, err)
+	require.False(t, enabled.Whitelisted, "enabling must not grant the whitelist")
+}
+
+func TestDisableOrganization_AgreesWithListGate(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_gate", name: "Gate Co", slug: "gate-co", whitelisted: true})
+
+	include := true
+	listIDs := func(payload *gen.ListOrganizationsPayload) []string {
+		res, err := svc.ListOrganizations(ctx, payload)
+		require.NoError(t, err)
+		ids := make([]string, 0, len(res.Organizations))
+		for _, o := range res.Organizations {
+			ids = append(ids, o.ID)
+		}
+		return ids
+	}
+
+	require.Contains(t, listIDs(&gen.ListOrganizationsPayload{}), "org_gate")
+
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_gate"})
+	require.NoError(t, err)
+	require.NotContains(t, listIDs(&gen.ListOrganizationsPayload{}), "org_gate", "a disabled organization drops out of the default list")
+	require.Contains(t, listIDs(&gen.ListOrganizationsPayload{IncludeDisabled: &include}), "org_gate")
+
+	_, err = svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_gate"})
+	require.NoError(t, err)
+	require.Contains(t, listIDs(&gen.ListOrganizationsPayload{}), "org_gate", "a re-enabled organization comes back to the default list")
+}
+
+func TestDisableOrganization_UnknownID(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, _ := newTestAdminService(t)
+
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_does_not_exist"})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	_, err = svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_does_not_exist"})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestDisableOrganization_EmptyID(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bystander", name: "Bystander", slug: "bystander", whitelisted: true})
+
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: ""})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	_, err = svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: ""})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_bystander"), "an unmatched id must not disable anything")
+}
+
+func TestDisableOrganization_DoesNotMatchOnSlug(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_slug_only", name: "Slug Only", slug: "slug-only", whitelisted: true})
+
+	// The read path resolves id-or-slug; the write path is id-only. Passing a
+	// slug must fail rather than report a success the database never saw.
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "slug-only"})
+	requireOopsCode(t, err, oops.CodeNotFound)
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_slug_only"))
+}
+
+func TestDisableOrganization_TouchesOnlyTheTargetRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_target", name: "Target", slug: "target", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_neighbour", name: "Neighbour", slug: "neighbour", whitelisted: true})
+
+	_, err := svc.DisableOrganization(ctx, &gen.DisableOrganizationPayload{ID: "org_target"})
+	require.NoError(t, err)
+	require.NotNil(t, readDisabledAt(t, ctx, conn, "org_target"))
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_neighbour"), "disable must not spill onto other organizations")
+
+	disabledAt := time.Now().UTC()
+	seedOrg(t, ctx, conn, orgFixture{id: "org_stays_off", name: "Stays Off", slug: "stays-off", whitelisted: true, disabledAt: &disabledAt})
+
+	_, err = svc.EnableOrganization(ctx, &gen.EnableOrganizationPayload{ID: "org_target"})
+	require.NoError(t, err)
+	require.Nil(t, readDisabledAt(t, ctx, conn, "org_target"))
+	require.NotNil(t, readDisabledAt(t, ctx, conn, "org_stays_off"), "enable must not spill onto other organizations")
+}

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -531,8 +531,14 @@ func (s *Service) EnableOrganization(ctx context.Context, payload *gen.EnableOrg
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enable")
 }
 
+// readOrganizationAfterWrite returns the organization a write just landed on.
+// The read is keyed on id alone because every admin write is, so resolving a
+// slug here could return a different organization than the one written.
 func (s *Service) readOrganizationAfterWrite(ctx context.Context, id string, errMsg string) (*gen.AdminOrganization, error) {
-	row, err := repo.New(s.db).AdminGetOrganizationByIDOrSlug(ctx, id)
+	row, err := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
+		ID:        id,
+		AllowSlug: false,
+	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
@@ -544,7 +550,10 @@ func (s *Service) readOrganizationAfterWrite(ctx context.Context, id string, err
 }
 
 func (s *Service) GetOrganization(ctx context.Context, payload *gen.GetOrganizationPayload) (*gen.AdminOrganization, error) {
-	row, err := repo.New(s.db).AdminGetOrganizationByIDOrSlug(ctx, payload.IDOrSlug)
+	row, err := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
+		ID:        payload.IDOrSlug,
+		AllowSlug: true,
+	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
@@ -554,7 +563,7 @@ func (s *Service) GetOrganization(ctx context.Context, payload *gen.GetOrganizat
 	return adminOrganizationFromGetRow(row), nil
 }
 
-func adminOrganizationFromGetRow(row repo.AdminGetOrganizationByIDOrSlugRow) *gen.AdminOrganization {
+func adminOrganizationFromGetRow(row repo.AdminGetOrganizationRow) *gen.AdminOrganization {
 	return &gen.AdminOrganization{
 		ID:                 row.ID,
 		Name:               row.Name,

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -504,12 +504,40 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 		return nil, oops.E(oops.CodeUnexpected, err, "update organization").LogError(ctx, s.logger)
 	}
 
-	row, err := queries.AdminGetOrganizationByIDOrSlug(ctx, payload.ID)
+	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after update")
+}
+
+func (s *Service) DisableOrganization(ctx context.Context, payload *gen.DisableOrganizationPayload) (*gen.AdminOrganization, error) {
+	rows, err := repo.New(s.db).AdminDisableOrganization(ctx, payload.ID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "disable organization").LogError(ctx, s.logger)
+	}
+	if rows == 0 {
+		return nil, oops.C(oops.CodeNotFound)
+	}
+
+	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after disable")
+}
+
+func (s *Service) EnableOrganization(ctx context.Context, payload *gen.EnableOrganizationPayload) (*gen.AdminOrganization, error) {
+	rows, err := repo.New(s.db).AdminEnableOrganization(ctx, payload.ID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "enable organization").LogError(ctx, s.logger)
+	}
+	if rows == 0 {
+		return nil, oops.C(oops.CodeNotFound)
+	}
+
+	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enable")
+}
+
+func (s *Service) readOrganizationAfterWrite(ctx context.Context, id string, errMsg string) (*gen.AdminOrganization, error) {
+	row, err := repo.New(s.db).AdminGetOrganizationByIDOrSlug(ctx, id)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "fetch organization after update").LogError(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "%s", errMsg).LogError(ctx, s.logger)
 	}
 
 	return adminOrganizationFromGetRow(row), nil

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -20,14 +20,15 @@ import (
 )
 
 type orgFixture struct {
-	id          string
-	name        string
-	slug        string
-	accountType string
-	workosID    *string
-	whitelisted bool
-	disabledAt  *time.Time
-	createdAt   *time.Time
+	id                string
+	name              string
+	slug              string
+	accountType       string
+	workosID          *string
+	workosLastEventID *string
+	whitelisted       bool
+	disabledAt        *time.Time
+	createdAt         *time.Time
 }
 
 func seedOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool, f orgFixture) {
@@ -52,6 +53,15 @@ func seedOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool, f orgFixture
 
 	err := testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, params)
 	require.NoError(t, err)
+
+	// The webhook cursor is seeded separately so it stays out of the INSERT.
+	if f.workosLastEventID != nil {
+		err := testrepo.New(conn).SetWorkosLastEventIDFixture(ctx, testrepo.SetWorkosLastEventIDFixtureParams{
+			ID:                f.id,
+			WorkosLastEventID: conv.PtrToPGText(f.workosLastEventID),
+		})
+		require.NoError(t, err)
+	}
 }
 
 func seedMembership(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, userID string) {

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -158,6 +158,27 @@ SET
     updated_at = clock_timestamp()
 WHERE id = @id;
 
+-- name: AdminDisableOrganization :execrows
+-- Operator-initiated disable. Keyed on the Gram organization id rather than
+-- workos_id so an organization that was never linked to WorkOS can still be
+-- disabled. Deliberately leaves workos_last_event_id alone: that column is the
+-- WorkOS webhook cursor and this is not a WorkOS event, so stamping it would
+-- misrecord which event was last applied. Idempotent — the COALESCE keeps the
+-- original timestamp when the organization is already disabled.
+UPDATE organization_metadata
+SET disabled_at = COALESCE(disabled_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+WHERE id = @id;
+
+-- name: AdminEnableOrganization :execrows
+-- Undo of AdminDisableOrganization, and likewise blind to workos_last_event_id.
+-- Idempotent — enabling an already-active organization is a no-op beyond
+-- updated_at.
+UPDATE organization_metadata
+SET disabled_at = NULL,
+    updated_at = clock_timestamp()
+WHERE id = @id;
+
 -- name: AdminListProjectsForOrganization :many
 SELECT id, slug, name, created_at, updated_at
 FROM projects

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -208,7 +208,10 @@ LIMIT 200;
 -- id; a read-after-write that allowed slugs could then describe a different
 -- organization than the one just written, and the operator would see a 200
 -- reporting the write never happened. Reads that are not following a write pass
--- allow_slug true, which the dashboard relies on.
+-- allow_slug true, which the dashboard relies on. The ORDER BY settles the same
+-- collision for those reads: when the argument is one organization's id and
+-- another's slug both rows match, and LIMIT 1 on its own would pick either, so
+-- the exact id match is sorted first.
 SELECT
     om.id,
     om.name,
@@ -241,4 +244,5 @@ FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
 WHERE om.id = sqlc.arg('id')::text
    OR (sqlc.arg('allow_slug')::boolean AND om.slug = sqlc.arg('id')::text)
+ORDER BY (om.id = sqlc.arg('id')::text) DESC
 LIMIT 1;

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -202,7 +202,13 @@ WHERE our.organization_id = @organization_id
 ORDER BY u.email ASC
 LIMIT 200;
 
--- name: AdminGetOrganizationByIDOrSlug :one
+-- name: AdminGetOrganization :one
+-- Resolving a slug is opt-in because every admin write is keyed on id alone.
+-- Both columns are bare TEXT, so one organization's slug can equal another's
+-- id; a read-after-write that allowed slugs could then describe a different
+-- organization than the one just written, and the operator would see a 200
+-- reporting the write never happened. Reads that are not following a write pass
+-- allow_slug true, which the dashboard relies on.
 SELECT
     om.id,
     om.name,
@@ -233,6 +239,6 @@ SELECT
     )::bigint AS member_count
 FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
-WHERE om.id = sqlc.arg('id_or_slug')::text
-   OR om.slug = sqlc.arg('id_or_slug')::text
+WHERE om.id = sqlc.arg('id')::text
+   OR (sqlc.arg('allow_slug')::boolean AND om.slug = sqlc.arg('id')::text)
 LIMIT 1;

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -49,6 +49,45 @@ func (q *Queries) AdminCountOrganizations(ctx context.Context, arg AdminCountOrg
 	return column_1, err
 }
 
+const adminDisableOrganization = `-- name: AdminDisableOrganization :execrows
+UPDATE organization_metadata
+SET disabled_at = COALESCE(disabled_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+WHERE id = $1
+`
+
+// Operator-initiated disable. Keyed on the Gram organization id rather than
+// workos_id so an organization that was never linked to WorkOS can still be
+// disabled. Deliberately leaves workos_last_event_id alone: that column is the
+// WorkOS webhook cursor and this is not a WorkOS event, so stamping it would
+// misrecord which event was last applied. Idempotent — the COALESCE keeps the
+// original timestamp when the organization is already disabled.
+func (q *Queries) AdminDisableOrganization(ctx context.Context, id string) (int64, error) {
+	result, err := q.db.Exec(ctx, adminDisableOrganization, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const adminEnableOrganization = `-- name: AdminEnableOrganization :execrows
+UPDATE organization_metadata
+SET disabled_at = NULL,
+    updated_at = clock_timestamp()
+WHERE id = $1
+`
+
+// Undo of AdminDisableOrganization, and likewise blind to workos_last_event_id.
+// Idempotent — enabling an already-active organization is a no-op beyond
+// updated_at.
+func (q *Queries) AdminEnableOrganization(ctx context.Context, id string) (int64, error) {
+	result, err := q.db.Exec(ctx, adminEnableOrganization, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const adminGetOrganization = `-- name: AdminGetOrganization :one
 SELECT
     om.id,
@@ -82,6 +121,7 @@ FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
 WHERE om.id = $1::text
    OR ($2::boolean AND om.slug = $1::text)
+ORDER BY (om.id = $1::text) DESC
 LIMIT 1
 `
 
@@ -112,7 +152,10 @@ type AdminGetOrganizationRow struct {
 // id; a read-after-write that allowed slugs could then describe a different
 // organization than the one just written, and the operator would see a 200
 // reporting the write never happened. Reads that are not following a write pass
-// allow_slug true, which the dashboard relies on.
+// allow_slug true, which the dashboard relies on. The ORDER BY settles the same
+// collision for those reads: when the argument is one organization's id and
+// another's slug both rows match, and LIMIT 1 on its own would pick either, so
+// the exact id match is sorted first.
 func (q *Queries) AdminGetOrganization(ctx context.Context, arg AdminGetOrganizationParams) (AdminGetOrganizationRow, error) {
 	row := q.db.QueryRow(ctx, adminGetOrganization, arg.ID, arg.AllowSlug)
 	var i AdminGetOrganizationRow

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -49,7 +49,7 @@ func (q *Queries) AdminCountOrganizations(ctx context.Context, arg AdminCountOrg
 	return column_1, err
 }
 
-const adminGetOrganizationByIDOrSlug = `-- name: AdminGetOrganizationByIDOrSlug :one
+const adminGetOrganization = `-- name: AdminGetOrganization :one
 SELECT
     om.id,
     om.name,
@@ -81,11 +81,16 @@ SELECT
 FROM organization_metadata om
 LEFT JOIN trials t ON t.organization_id = om.id
 WHERE om.id = $1::text
-   OR om.slug = $1::text
+   OR ($2::boolean AND om.slug = $1::text)
 LIMIT 1
 `
 
-type AdminGetOrganizationByIDOrSlugRow struct {
+type AdminGetOrganizationParams struct {
+	ID        string
+	AllowSlug bool
+}
+
+type AdminGetOrganizationRow struct {
 	ID                 string
 	Name               string
 	Slug               string
@@ -102,9 +107,15 @@ type AdminGetOrganizationByIDOrSlugRow struct {
 	MemberCount        int64
 }
 
-func (q *Queries) AdminGetOrganizationByIDOrSlug(ctx context.Context, idOrSlug string) (AdminGetOrganizationByIDOrSlugRow, error) {
-	row := q.db.QueryRow(ctx, adminGetOrganizationByIDOrSlug, idOrSlug)
-	var i AdminGetOrganizationByIDOrSlugRow
+// Resolving a slug is opt-in because every admin write is keyed on id alone.
+// Both columns are bare TEXT, so one organization's slug can equal another's
+// id; a read-after-write that allowed slugs could then describe a different
+// organization than the one just written, and the operator would see a 200
+// reporting the write never happened. Reads that are not following a write pass
+// allow_slug true, which the dashboard relies on.
+func (q *Queries) AdminGetOrganization(ctx context.Context, arg AdminGetOrganizationParams) (AdminGetOrganizationRow, error) {
+	row := q.db.QueryRow(ctx, adminGetOrganization, arg.ID, arg.AllowSlug)
+	var i AdminGetOrganizationRow
 	err := row.Scan(
 		&i.ID,
 		&i.Name,

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -200,8 +200,11 @@ WHERE id = @id;
 -- and did not touch. disabled_at comes back at full precision: the admin API
 -- renders it as a second-resolution RFC3339 string, which hides a timestamp
 -- that moved by microseconds. workos_last_event_id is the WorkOS webhook
--- cursor, which only the webhook path may write.
-SELECT disabled_at, workos_last_event_id, whitelisted
+-- cursor, which only the webhook path may write. created_at and updated_at are
+-- the reference points for "did this write stamp the moment of the action":
+-- comparing a stamp against them keeps the comparison inside the database
+-- clock, which the test host's clock can drift from.
+SELECT disabled_at, workos_last_event_id, whitelisted, created_at, updated_at
 FROM organization_metadata
 WHERE id = @id;
 

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -184,6 +184,27 @@ INSERT INTO organization_metadata (
     COALESCE(sqlc.narg('created_at')::timestamptz, clock_timestamp())
 );
 
+-- name: SetWorkosLastEventIDFixture :exec
+-- Test-only fixture for seeding the WorkOS webhook cursor on an organization
+-- that already exists. Deliberately kept out of
+-- CreateOrganizationMetadataFixture: several branches add columns to that
+-- INSERT at once, and a column added mid-list renumbers every positional
+-- placeholder after it in the generated code, which a hand-resolved merge can
+-- get wrong while still compiling.
+UPDATE organization_metadata
+SET workos_last_event_id = @workos_last_event_id
+WHERE id = @id;
+
+-- name: GetOrganizationMetadataStateFixture :one
+-- Test-only fixture for asserting what a write to organization_metadata did
+-- and did not touch. disabled_at comes back at full precision: the admin API
+-- renders it as a second-resolution RFC3339 string, which hides a timestamp
+-- that moved by microseconds. workos_last_event_id is the WorkOS webhook
+-- cursor, which only the webhook path may write.
+SELECT disabled_at, workos_last_event_id, whitelisted
+FROM organization_metadata
+WHERE id = @id;
+
 -- name: CreateOrganizationUserRelationshipFixture :exec
 -- Test-only fixture for seeding membership counts.
 INSERT INTO organization_user_relationships (organization_id, user_id)

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -395,6 +395,30 @@ func (q *Queries) GetDeviceIntegrationSyncPushDigests(ctx context.Context, devic
 	return items, nil
 }
 
+const getOrganizationMetadataStateFixture = `-- name: GetOrganizationMetadataStateFixture :one
+SELECT disabled_at, workos_last_event_id, whitelisted
+FROM organization_metadata
+WHERE id = $1
+`
+
+type GetOrganizationMetadataStateFixtureRow struct {
+	DisabledAt        pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+	Whitelisted       bool
+}
+
+// Test-only fixture for asserting what a write to organization_metadata did
+// and did not touch. disabled_at comes back at full precision: the admin API
+// renders it as a second-resolution RFC3339 string, which hides a timestamp
+// that moved by microseconds. workos_last_event_id is the WorkOS webhook
+// cursor, which only the webhook path may write.
+func (q *Queries) GetOrganizationMetadataStateFixture(ctx context.Context, id string) (GetOrganizationMetadataStateFixtureRow, error) {
+	row := q.db.QueryRow(ctx, getOrganizationMetadataStateFixture, id)
+	var i GetOrganizationMetadataStateFixtureRow
+	err := row.Scan(&i.DisabledAt, &i.WorkosLastEventID, &i.Whitelisted)
+	return i, err
+}
+
 const getOutboxEntry = `-- name: GetOutboxEntry :one
 SELECT id FROM outbox WHERE id = $1
 `
@@ -1318,6 +1342,28 @@ type SetProjectSlugFixtureParams struct {
 
 func (q *Queries) SetProjectSlugFixture(ctx context.Context, arg SetProjectSlugFixtureParams) error {
 	_, err := q.db.Exec(ctx, setProjectSlugFixture, arg.Slug, arg.ID)
+	return err
+}
+
+const setWorkosLastEventIDFixture = `-- name: SetWorkosLastEventIDFixture :exec
+UPDATE organization_metadata
+SET workos_last_event_id = $1
+WHERE id = $2
+`
+
+type SetWorkosLastEventIDFixtureParams struct {
+	WorkosLastEventID pgtype.Text
+	ID                string
+}
+
+// Test-only fixture for seeding the WorkOS webhook cursor on an organization
+// that already exists. Deliberately kept out of
+// CreateOrganizationMetadataFixture: several branches add columns to that
+// INSERT at once, and a column added mid-list renumbers every positional
+// placeholder after it in the generated code, which a hand-resolved merge can
+// get wrong while still compiling.
+func (q *Queries) SetWorkosLastEventIDFixture(ctx context.Context, arg SetWorkosLastEventIDFixtureParams) error {
+	_, err := q.db.Exec(ctx, setWorkosLastEventIDFixture, arg.WorkosLastEventID, arg.ID)
 	return err
 }
 

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -396,7 +396,7 @@ func (q *Queries) GetDeviceIntegrationSyncPushDigests(ctx context.Context, devic
 }
 
 const getOrganizationMetadataStateFixture = `-- name: GetOrganizationMetadataStateFixture :one
-SELECT disabled_at, workos_last_event_id, whitelisted
+SELECT disabled_at, workos_last_event_id, whitelisted, created_at, updated_at
 FROM organization_metadata
 WHERE id = $1
 `
@@ -405,17 +405,28 @@ type GetOrganizationMetadataStateFixtureRow struct {
 	DisabledAt        pgtype.Timestamptz
 	WorkosLastEventID pgtype.Text
 	Whitelisted       bool
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
 }
 
 // Test-only fixture for asserting what a write to organization_metadata did
 // and did not touch. disabled_at comes back at full precision: the admin API
 // renders it as a second-resolution RFC3339 string, which hides a timestamp
 // that moved by microseconds. workos_last_event_id is the WorkOS webhook
-// cursor, which only the webhook path may write.
+// cursor, which only the webhook path may write. created_at and updated_at are
+// the reference points for "did this write stamp the moment of the action":
+// comparing a stamp against them keeps the comparison inside the database
+// clock, which the test host's clock can drift from.
 func (q *Queries) GetOrganizationMetadataStateFixture(ctx context.Context, id string) (GetOrganizationMetadataStateFixtureRow, error) {
 	row := q.db.QueryRow(ctx, getOrganizationMetadataStateFixture, id)
 	var i GetOrganizationMetadataStateFixtureRow
-	err := row.Scan(&i.DisabledAt, &i.WorkosLastEventID, &i.Whitelisted)
+	err := row.Scan(
+		&i.DisabledAt,
+		&i.WorkosLastEventID,
+		&i.Whitelisted,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
 	return i, err
 }
 


### PR DESCRIPTION
A platform admin cannot cut off an organization from the admin app, and cannot reverse a disable that turned out to be wrong. This adds both directions.

`organization_metadata.disabled_at` had exactly one writer, the WorkOS `organization.deleted` webhook, and nothing anywhere cleared it. Two new endpoints, `POST /admin/organization.disable` and `POST /admin/organization.enable`, cover both directions and return the organization in its new state, which the existing list and detail endpoints already render.

## Why the existing webhook query could not serve this

It keys on `workos_id`, which an organization may not have, and it stamps `workos_last_event_id`, the cursor recording which WorkOS event was last applied. An operator action is not a WorkOS event, so writing that column would misrecord the webhook's position. The two new queries key on the Gram organization id and leave the cursor alone.

Disable keeps a `COALESCE`, so re-disabling holds the original timestamp rather than moving it. AGE-3187 computes a "disabled this week" figure from it. Neither direction touches `whitelisted`, which is the separate not-yet-approved gate.

## A pre-existing read defect, fixed here on purpose

Every admin organization write is keyed on `id`, but the read that builds the response resolved id **or** slug. Both columns are bare `TEXT`, so one organization's slug can equal another's id, and the response could then describe an organization the write never touched. The operator sees a 200 saying the organization is still active and concludes the disable failed.

The collision has two halves, and both are closed here.

Slug resolution is now opt-in on that query. The read after a write passes it false, so it has the same predicate as the write, and a write addressed by slug now returns a not-found instead of a 200 describing an organization it never touched.

Reading an organization on its own still resolves slugs, which the dashboard depends on, so the collision still reaches that path. A colliding argument matches both rows there, and `LIMIT 1` on its own left the winner to the planner. That read now sorts `(om.id = @id) DESC`, so the exact id match wins. `TestGetOrganization_PrefersIDOverAnotherOrganizationsSlug` pins it.

**This changes the pre-existing update endpoint too, deliberately.** Its write was already id-only, so an update addressed by slug changed nothing and still returned 200 with the unchanged row, which is worse than a not-found. The only client caller passes `org.id`, so the shipped dashboard is unaffected.

The first commit's message says this hole was left alone as out of scope. A review round then found it reachable from two of the three write paths, so the second commit closes it. The commits read as that progression rather than as a contradiction.

## Evidence

A two-lens review round ran before this PR opened, and its findings are the second and third commits. The round's most useful result was two reviewers reporting **opposite verdicts** on whether `whitelisted` was pinned. Both were right: they had each run one diagonal of a two-by-two and generalised from it. A boolean column has four mutations, not two, and every organization the tests disabled was seeded whitelisted, so "disable must not **grant** the whitelist" could not fail by construction. That is the dangerous half: a disable that silently set the flag would push a not-yet-approved organization through the approval gate the moment an operator re-enabled it, and the suite would have stayed green.

22 mutations were run in total, covering the whitelist square in all four polarities, both timestamps in both directions, the WorkOS cursor, the list gate and the slug predicate on every read.

These five were re-run independently against the finished branch, and each is recorded with the named test that killed it, because a kill with no named failing test is a harness failure rather than a pass:

| Mutation | Result | Killed by |
| --- | --- | --- |
| disable also **grants** the whitelist | killed | `TestDisableOrganization_LeavesWhitelistAlone` |
| enable also **revokes** the whitelist | killed | `TestDisableOrganization_LeavesWhitelistAlone` |
| read-after-write resolves slugs again | killed | `TestAdminOrganizationWrites_ReturnTheOrganizationWritten` |
| `GetOrganization` stops resolving slugs | killed | `TestGetOrganization_BySlug` |
| **canary:** swapping the two `SET` clauses in disable | **survived** | — |

The first two are the pair that survived the original suite, so they are the reason the review round mattered. The canary is there because a sweep reporting everything killed is a broken harness until something proves otherwise. Postgres evaluates every `SET` expression against the pre-update row, so clause order is a provable no-op; it survived, and the full suite was green while it was applied.

## Reviewer notes

- Base is `main`, so every hygiene check runs. Nothing is skipped.
- `MinLength(1)` on the two new `id` attributes is not decoration. Goa deduplicates structurally identical schemas and reuses the first registered name, so a lone required string `id` matched the asset-serving form and the generated spec documented both endpoints as taking one. It also tightens validation at the HTTP boundary. Because the two bodies remain structurally identical, that same deduplication also published enable under `DisableOrganizationRequestBody`; both payloads now carry an explicit `openapi:typename`, as `externalkeys` and `skills` already do.
- Empty-id tests still expect not-found rather than 400. `MinLength(1)` generates into the request decoder, and these tests call the service directly, so both layers exist and the service-level contract is unchanged.
- **The generated `server/internal/admin/repo/queries.sql.go` conflicts with `walker/age-3185-sort-page-server`. Do not hand-resolve it.** sqlc uses positional placeholders, so a column added mid-list renumbers every later `$N`; a hand-merged file can compile and bind the wrong columns. Take one side wholesale and re-run `mise run gen:sqlc-server`.

## Known follow-up, not fixed here

`UpdateOrganization`'s query is `:exec`, so unlike disable and enable it has no `rows == 0` guard. Its not-found contract now rests entirely on the narrowed read. That behaviour is correct today, but it is a consequence of the read rather than a property of the handler, which is the fragility this PR's own comment warns about. Filed separately.

AGE-3190.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admins can disable and re-enable organizations via the admin API. Previously only the WorkOS webhook set disabled_at and nothing cleared it; now operators can cut off or restore access without touching whitelist or the WorkOS webhook cursor.

- Endpoints: POST /admin/organization.disable and POST /admin/organization.enable. Payload: { "id": string } with minLength(1) and explicit OpenAPI typenames. Both return 200 with the organization or 404 when no row matches.
- Behavior: keys on the Gram org id so orgs without a WorkOS id can be disabled. Disable uses COALESCE to keep the original timestamp; enable sets it to NULL. Neither touches whitelisted or workos_last_event_id; both update updated_at.
- Reads: after writes we now fetch by id only. General reads still allow slugs but prefer an exact id match on collision. Updates remain id-only; writing by slug returns not-found. Clients must send org.id.
- Tests/fixtures: added fixtures to seed/assert workos_last_event_id and full-precision disabled_at. Tests pin timestamp idempotency, whitelist unchanged, response identity under id/slug collisions, and orgs without a WorkOS id.
- Generated code: `goa` and `sqlc` outputs updated. If server/internal/admin/repo/queries.sql.go conflicts, re-run `mise run gen:sqlc-server`.
- Linear: Satisfies AGE-3190 (disable/enable from the list).

<sup>Written for commit fb07d6f71e8bf11eb2b63727c90617ba1302fbd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

