### PR TITLE
fix(admin): answer the keyboard and the Columns menu while peek is open

### DIFF
--- a/.changeset/admin-organizations-peek-keyboard.md
+++ b/.changeset/admin-organizations-peek-keyboard.md
@@ -2,8 +2,13 @@
 "admin": patch
 ---
 
-Fix two ways the organizations list left a keyboard operator without an answer
-while the peek panel was open.
+Fix several ways the organizations list left a keyboard operator without an
+answer while the peek panel was open.
+
+The panel is now a tab stop with a visible focus ring. Arrow Up and Arrow Down
+on it walk the peek from record to record, and before this the only way to reach
+it was the focus it took when it opened: one Tab to the close button and record
+navigation was gone until the operator went back to the row's peek control.
 
 The panel's arrow keys now reach only the panel itself and the peek control of
 the row it is showing. Every other control under the list keeps its own keys
@@ -17,9 +22,15 @@ puts the keyboard back on the peek control of the row that was open. It still
 does nothing on the pager, and a tooltip or menu opened from inside the panel
 still takes the first Escape for itself.
 
-The Columns control also works again while the panel is open. Checking one of
-the columns the panel hides used to do nothing at all: the checkbox snapped
-back with no column, no refusal and nothing said. It now closes the panel and
-shows the column in the same moment, and says so, because asking for a column
-is asking to see it. A column the panel was not hiding leaves the panel where
-it is, and the keyboard stays in the Columns menu either way.
+The Columns control also works again while the panel is open. The panel
+overrides six columns: it hides five, and it forces Name on. A menu click on
+any of those used to do nothing an operator could see, because the panel's
+override outranked it. Checking one the panel hides snapped the checkbox back
+with no column and nothing said, and unchecking Name was worse: that one looked
+like nothing had happened, then took the Name column away later, when the panel
+closed.
+
+Toggling any of the six now closes the panel and applies the change in the
+same moment, and says which way it went, because toggling a column is asking
+for that column. A column the panel does not override leaves the panel where it
+is, and the keyboard stays in the Columns menu either way.

--- a/.changeset/admin-organizations-peek-keyboard.md
+++ b/.changeset/admin-organizations-peek-keyboard.md
@@ -5,11 +5,17 @@
 Fix two ways the organizations list left a keyboard operator without an answer
 while the peek panel was open.
 
-The panel's arrow keys and Escape now reach only the panel itself and the peek
-control of the row it is showing. Every other control under the list keeps its
-own keys back: Arrow Down on the pager, or on a button inside the panel body,
-scrolls the way it does anywhere else instead of walking the panel to a record
-the operator is not looking at and swallowing the scroll on the way.
+The panel's arrow keys now reach only the panel itself and the peek control of
+the row it is showing. Every other control under the list keeps its own keys
+back: Arrow Down on the pager, or on a button inside the panel body, scrolls the
+way it does anywhere else instead of walking the panel to a record the operator
+is not looking at and swallowing the scroll on the way.
+
+Escape is scoped wider, because it has no scrolling of its own to lose. It
+closes the panel from anywhere inside it, the buttons in its body included, and
+puts the keyboard back on the peek control of the row that was open. It still
+does nothing on the pager, and a tooltip or menu opened from inside the panel
+still takes the first Escape for itself.
 
 The Columns control also works again while the panel is open. Checking one of
 the columns the panel hides used to do nothing at all: the checkbox snapped

--- a/.changeset/admin-organizations-peek-keyboard.md
+++ b/.changeset/admin-organizations-peek-keyboard.md
@@ -1,0 +1,19 @@
+---
+"admin": patch
+---
+
+Fix two ways the organizations list left a keyboard operator without an answer
+while the peek panel was open.
+
+The panel's arrow keys and Escape now reach only the panel itself and the peek
+control of the row it is showing. Every other control under the list keeps its
+own keys back: Arrow Down on the pager, or on a button inside the panel body,
+scrolls the way it does anywhere else instead of walking the panel to a record
+the operator is not looking at and swallowing the scroll on the way.
+
+The Columns control also works again while the panel is open. Checking one of
+the columns the panel hides used to do nothing at all: the checkbox snapped
+back with no column, no refusal and nothing said. It now closes the panel and
+shows the column in the same moment, and says so, because asking for a column
+is asking to see it. A column the panel was not hiding leaves the panel where
+it is, and the keyboard stays in the Columns menu either way.

--- a/.changeset/admin-organizations-peek-panel.md
+++ b/.changeset/admin-organizations-peek-panel.md
@@ -2,12 +2,17 @@
 "admin": minor
 ---
 
-Peek at an organization beside the list. Alt-clicking a row in the admin
-organizations list docks a 400px panel next to the table instead of leaving the
-page, so the search term, the filters and the scroll position all survive the
-look-up. The panel shows account type, trial end, member count, creation date
-and both ids, with a copy control beside each id that confirms with a check.
-The table narrows to Name, Slug and Type while the panel is open and gives the
-operator's own column choices straight back when it closes. Arrow Down and
-Arrow Up walk the panel through the rows on screen and scroll each one into
-view; Escape closes it and puts the keyboard back on the row's name link.
+Peek at an organization beside the list. Every row in the admin organizations
+list carries a peek control that docks a 400px panel next to the table instead
+of leaving the page, so the search term, the filters and the scroll position
+all survive the look-up. The panel shows account type, trial end, member count,
+creation date and both ids, with a copy control beside each id that confirms
+with a check. The table narrows to Name, Slug and Type while the panel is open,
+and gives the operator's own column choices straight back when it closes.
+
+The control takes the mouse and the keyboard alike. It reports whether its own
+panel is open, and it closes the panel it opened. Arrow Down and Arrow Up walk
+the panel through the rows on screen and scroll each one into view, and Escape
+closes it. Every close puts the keyboard back on the control that opened the
+panel. A screen reader is told which organization the panel is showing, each
+time the panel opens, moves to another row, or closes.

--- a/.changeset/admin-trial-column-real-state.md
+++ b/.changeset/admin-trial-column-real-state.md
@@ -1,0 +1,17 @@
+---
+"admin": patch
+---
+
+Show an organization's real trial state in the admin dashboard. The
+organizations list, the peek panel and the organization detail page all read
+`trial_state` and `trial_ends_at` instead of `free_trial_ends_at`, which was
+defaulted for every organization and so reported a trial that never happened.
+
+The list column is now headed `Trial` rather than `Trial ends`, and reads as a
+state: a badge carrying `Running`, `Ending soon`, `Expired`, `Demoted` or
+`Converted`, with `ends` and the date beside it only while the trial is still
+live. An organization that never trialled reads as a dash.
+
+The three surfaces render one shared component, so the same organization cannot
+read one way in the list and another way on its own page. The old fields stay
+on the API for now; a follow-up takes them off the wire.

--- a/client/admin/src/components/Trial.test.tsx
+++ b/client/admin/src/components/Trial.test.tsx
@@ -1,0 +1,261 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Trial } from "@/components/Trial";
+import { badgeTone } from "@/lib/badgeTone";
+import {
+  TRIAL_STATES,
+  type AdminOrganization,
+  type TrialState,
+} from "@/lib/gramAdminApi";
+
+const TRIAL_ENDS_AT = "2026-05-06T00:00:00Z";
+
+// The stale pair is set, and set to a different date, on every record here.
+// A surface that goes back to reading `free_trial_ends_at` then renders the
+// wrong date rather than the right one by luck.
+const ORG: AdminOrganization = {
+  id: "org_placeholder_one",
+  name: "Placeholder One",
+  slug: "placeholder-one",
+  account_type: "pro",
+  whitelisted: true,
+  free_trial_started_at: "2026-02-01T00:00:00Z",
+  free_trial_ends_at: "2026-11-12T00:00:00Z",
+  member_count: 3,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-07T00:00:00Z",
+};
+
+// Walked at runtime, so a seventh state added to `TRIAL_STATES` fails a test
+// here whether or not the type annotation in `Trial.tsx` survived the edit
+// that added it.
+const DATED_STATES = TRIAL_STATES.filter((state) => state !== "none");
+
+function orgWith(trial: Partial<AdminOrganization>): AdminOrganization {
+  return { ...ORG, ...trial };
+}
+
+function shortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
+}
+
+function renderTrial(org: AdminOrganization): void {
+  render(
+    <div data-testid="trial">
+      <Trial org={org} />
+    </div>,
+  );
+}
+
+function cell(): HTMLElement {
+  return screen.getByTestId("trial");
+}
+
+function trialText(): string {
+  return cell().textContent ?? "";
+}
+
+// What a sighted operator reads: the sr-only half is stripped, and the
+// aria-hidden half is not.
+function visibleText(): string {
+  return Array.from(cell().querySelectorAll(".sr-only")).reduce(
+    (text, hidden) => text.replace(hidden.textContent ?? "", ""),
+    trialText(),
+  );
+}
+
+// What a screen reader announces: the dash is aria-hidden, so it is not part
+// of the accessible name and the sr-only text is.
+function accessibleText(): string {
+  return Array.from(cell().querySelectorAll('[aria-hidden="true"]')).reduce(
+    (text, hidden) => text.replace(hidden.textContent ?? "", ""),
+    trialText(),
+  );
+}
+
+function queryBadge(): HTMLElement | null {
+  return cell().querySelector<HTMLElement>('[data-slot="badge"]');
+}
+
+function badge(): HTMLElement {
+  const found = queryBadge();
+  if (!found) throw new Error("the state is not on a badge");
+  return found;
+}
+
+afterEach(cleanup);
+
+describe("Trial", () => {
+  it("reads a dash for an organization that never trialled", () => {
+    renderTrial(orgWith({ trial_state: "none", trial_ends_at: undefined }));
+
+    // The stale field carries a date on this record. A dash is the only
+    // reading that proves the cell is not on the old field.
+    expect(visibleText()).toBe("-");
+    expect(queryBadge()).toBeNull();
+    // A lone hyphen is announced as nothing, and this cell's whole value is
+    // that hyphen.
+    expect(accessibleText()).toBe("No trial");
+  });
+
+  it("reads a dash when the API sends no trial state at all", () => {
+    renderTrial(ORG);
+
+    expect(visibleText()).toBe("-");
+    expect(queryBadge()).toBeNull();
+    expect(accessibleText()).toBe("No trial");
+  });
+
+  it("falls back to the dash for a state this build does not know", () => {
+    renderTrial(
+      orgWith({
+        // A seventh state the server may derive before this build ships.
+        trial_state: "paused" as TrialState,
+        trial_ends_at: TRIAL_ENDS_AT,
+      }),
+    );
+
+    // Not the raw enum name, and not a crash.
+    expect(visibleText()).toBe("-");
+    expect(queryBadge()).toBeNull();
+  });
+
+  it("does not pass an unrecognised state off as no trial", () => {
+    renderTrial(orgWith({ trial_state: "paused" as TrialState }));
+    const unrecognised = accessibleText();
+    cleanup();
+
+    renderTrial(orgWith({ trial_state: "none" }));
+
+    // Both read as a dash, which is right. Calling a state the server derived
+    // "no trial" is the laundering this column exists to stop, and a reader
+    // who cannot tell the two apart has no way to report the first.
+    expect(unrecognised).not.toBe(accessibleText());
+    expect(unrecognised).toBe("Trial state not recognised");
+  });
+
+  it("puts the end date beside a running trial and tones it as normal", () => {
+    renderTrial(
+      orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe(`Running ends ${shortDate(TRIAL_ENDS_AT)}`);
+    // Neutral, not warning: the server has a separate state for a trial about
+    // to end, and toning every running trial as urgent wastes it.
+    expect(badge().className).toContain(badgeTone.neutral);
+  });
+
+  it("warns on a trial that is about to end, and still dates it", () => {
+    renderTrial(
+      orgWith({ trial_state: "ending_soon", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe(`Ending soon ends ${shortDate(TRIAL_ENDS_AT)}`);
+    expect(badge().className).toContain(badgeTone.warning);
+  });
+
+  it("says the date is an end date, and separates it from the state", () => {
+    renderTrial(
+      orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    // The header reads `Trial` and no longer says what the date is, so the
+    // cell has to. The space is in the text, not only in the flex gap: a
+    // copied cell otherwise reads `Running5/6/2026`.
+    expect(trialText()).toContain(` ends ${shortDate(TRIAL_ENDS_AT)}`);
+    expect(trialText()).not.toContain(`Running${shortDate(TRIAL_ENDS_AT)}`);
+  });
+
+  it("renders a running trial differently from one that is ending soon", () => {
+    renderTrial(
+      orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+    const running = { text: trialText(), tone: badge().className };
+    cleanup();
+
+    renderTrial(
+      orgWith({ trial_state: "ending_soon", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).not.toBe(running.text);
+    expect(badge().className).not.toBe(running.tone);
+  });
+
+  it("reads an expired trial as a failure and drops the date", () => {
+    renderTrial(
+      orgWith({ trial_state: "expired", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    // The date is set on the record and deliberately not shown: a finished
+    // trial's end date reads as a deadline still to come.
+    expect(trialText()).toBe("Expired");
+    expect(badge().className).toContain(badgeTone.destructive);
+  });
+
+  it("reads a demoted trial as a failure and drops the date", () => {
+    renderTrial(
+      orgWith({ trial_state: "demoted", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe("Demoted");
+    expect(badge().className).toContain(badgeTone.destructive);
+  });
+
+  it("reads a converted trial as a win", () => {
+    renderTrial(
+      orgWith({ trial_state: "converted", trial_ends_at: TRIAL_ENDS_AT }),
+    );
+
+    expect(trialText()).toBe("Converted");
+    // Success, not destructive. A converted trial is the outcome the business
+    // wants, and a red badge sends an operator after a healthy account.
+    expect(badge().className).toContain(badgeTone.success);
+  });
+
+  it.each(DATED_STATES)(
+    "shows no date for %s where the record carries none",
+    (state) => {
+      renderTrial(orgWith({ trial_state: state, trial_ends_at: undefined }));
+
+      // `free_trial_ends_at` still dates this record. Falling back to it,
+      // which is the shape a "be defensive about a missing date" edit takes,
+      // is this ticket's own bug coming back. A trailing bare `ends`, or a
+      // `Running-`, is the other way this goes wrong.
+      expect(trialText()).not.toContain(shortDate("2026-11-12T00:00:00Z"));
+      expect(trialText()).not.toContain("ends");
+      expect(trialText()).not.toContain("-");
+      expect(trialText()).toBe(badge().textContent);
+    },
+  );
+
+  it.each(DATED_STATES)(
+    "carries %s on a badge rather than as bare text",
+    (state) => {
+      renderTrial(
+        orgWith({ trial_state: state, trial_ends_at: TRIAL_ENDS_AT }),
+      );
+
+      // The badge's own element, so text dropped out of a badge fails here even
+      // where the words are unchanged. The variant, not the classes it expands
+      // to: the tone rides in `className` and would satisfy a class assertion on
+      // its own.
+      expect(badge().textContent).not.toBe("");
+      expect(badge().getAttribute("data-variant")).toBe("outline");
+    },
+  );
+
+  it("gives each state its own words, so shared tones stay apart", () => {
+    const labels = new Set<string>();
+
+    for (const state of DATED_STATES) {
+      renderTrial(orgWith({ trial_state: state }));
+      labels.add(badge().textContent ?? "");
+      cleanup();
+    }
+
+    // `expired` and `demoted` share a tone. Their words are the only thing
+    // left to tell them apart.
+    expect(labels.size).toBe(DATED_STATES.length);
+  });
+});

--- a/client/admin/src/components/Trial.test.tsx
+++ b/client/admin/src/components/Trial.test.tsx
@@ -135,6 +135,27 @@ describe("Trial", () => {
     expect(unrecognised).toBe("Trial state not recognised");
   });
 
+  // `TRIAL_DISPLAY` is an object literal, so it inherits `Object.prototype`.
+  // Indexing it with one of these names returns a truthy function, and the
+  // unknown-state branch is skipped: an empty badge, announcing nothing. The
+  // `paused` case above cannot catch it, because `paused` is genuinely absent
+  // from the prototype chain.
+  it.each(["constructor", "toString", "valueOf", "hasOwnProperty"])(
+    "reads the inherited key %s as an unrecognised state",
+    (inherited) => {
+      renderTrial(
+        orgWith({
+          trial_state: inherited as TrialState,
+          trial_ends_at: TRIAL_ENDS_AT,
+        }),
+      );
+
+      expect(visibleText()).toBe("-");
+      expect(queryBadge()).toBeNull();
+      expect(accessibleText()).toBe("Trial state not recognised");
+    },
+  );
+
   it("puts the end date beside a running trial and tones it as normal", () => {
     renderTrial(
       orgWith({ trial_state: "running", trial_ends_at: TRIAL_ENDS_AT }),

--- a/client/admin/src/components/Trial.tsx
+++ b/client/admin/src/components/Trial.tsx
@@ -36,11 +36,21 @@ const TRIAL_DISPLAY: Record<Exclude<TrialState, "none">, TrialDisplay> = {
 const DISPLAY_BY_STATE: Record<string, TrialDisplay | undefined> =
   TRIAL_DISPLAY;
 
+// Own properties only. A plain object literal inherits `Object.prototype`, so
+// indexing it with `constructor` or `toString` returns a truthy function and
+// the unknown-state branch below never runs, rendering an empty badge with no
+// announcement at all. That is the one thing this component must not do.
+function displayFor(state: string): TrialDisplay | undefined {
+  return Object.hasOwn(TRIAL_DISPLAY, state)
+    ? DISPLAY_BY_STATE[state]
+    : undefined;
+}
+
 // The one account of an organization's trial. The row, the peek panel and the
 // detail page all render this, so the same organization cannot read one way in
 // the list and another way on its own page.
 export function Trial({ org }: { org: AdminOrganization }): JSX.Element {
-  const display = DISPLAY_BY_STATE[org.trial_state ?? ""];
+  const display = displayFor(org.trial_state ?? "");
 
   if (!display) {
     // A lone hyphen is the entire value of this cell, and a screen reader

--- a/client/admin/src/components/Trial.tsx
+++ b/client/admin/src/components/Trial.tsx
@@ -1,0 +1,79 @@
+import type { JSX } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { badgeTone } from "@/lib/badgeTone";
+import type { AdminOrganization, TrialState } from "@/lib/gramAdminApi";
+import { fmtDateShort } from "@/lib/utils";
+
+type TrialDisplay = {
+  label: string;
+  tone: keyof typeof badgeTone;
+  // Only while the trial is still live. A date beside a finished trial reads
+  // as a deadline the operator can still act on.
+  showsEndDate: boolean;
+};
+
+// `neutral` for a running trial and `warning` only for one about to end: the
+// server derives that distinction, and giving both the same tone throws it
+// away. `expired` and `demoted` share `destructive` because there are four
+// tones and five states; their words keep them apart.
+//
+// The annotation is exhaustive over the union minus `none`, so a seventh state
+// is a build failure. It is not the only guard: `Trial.test.tsx` walks
+// `TRIAL_STATES` at runtime, so a seventh state fails a test even if this
+// annotation is edited away.
+const TRIAL_DISPLAY: Record<Exclude<TrialState, "none">, TrialDisplay> = {
+  running: { label: "Running", tone: "neutral", showsEndDate: true },
+  ending_soon: { label: "Ending soon", tone: "warning", showsEndDate: true },
+  expired: { label: "Expired", tone: "destructive", showsEndDate: false },
+  demoted: { label: "Demoted", tone: "destructive", showsEndDate: false },
+  converted: { label: "Converted", tone: "success", showsEndDate: false },
+};
+
+// Indexed as a plain string record on purpose. The server can start sending a
+// state this build has never heard of, and an unknown state has to read as no
+// trial rather than crash or put a raw enum name in front of an operator.
+const DISPLAY_BY_STATE: Record<string, TrialDisplay | undefined> =
+  TRIAL_DISPLAY;
+
+// The one account of an organization's trial. The row, the peek panel and the
+// detail page all render this, so the same organization cannot read one way in
+// the list and another way on its own page.
+export function Trial({ org }: { org: AdminOrganization }): JSX.Element {
+  const display = DISPLAY_BY_STATE[org.trial_state ?? ""];
+
+  if (!display) {
+    // A lone hyphen is the entire value of this cell, and a screen reader
+    // announces it as nothing at all. It also has to say which of the two
+    // silences this is. Reading a state the server derived but this build does
+    // not know as "never trialled" is the same laundering the column exists to
+    // stop, put back at the edge.
+    const unrecognised = Boolean(org.trial_state) && org.trial_state !== "none";
+    return (
+      <span className="text-muted-foreground text-sm">
+        <span aria-hidden="true">-</span>
+        <span className="sr-only">
+          {unrecognised ? "Trial state not recognised" : "No trial"}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex items-center gap-1.5 text-sm">
+      <Badge variant="outline" className={badgeTone[display.tone]}>
+        {display.label}
+      </Badge>
+      {display.showsEndDate && org.trial_ends_at ? (
+        <>
+          {/* An explicit space, because the flex gap is not in the text. A
+              copied cell otherwise reads `Running5/6/2026`. Whitespace-only
+              text is not rendered as a flex item, so nothing moves. */}{" "}
+          {/* "ends", because the header says `Trial` and no longer says what
+              the date is. A bare date beside a state reads as a start. */}
+          <span>ends {fmtDateShort(org.trial_ends_at)}</span>
+        </>
+      ) : null}
+    </span>
+  );
+}

--- a/client/admin/src/lib/badgeTone.test.ts
+++ b/client/admin/src/lib/badgeTone.test.ts
@@ -2,13 +2,93 @@ import { describe, expect, it } from "vitest";
 
 import { badgeTone } from "./badgeTone";
 
+// A literal list, not Object.keys: dropping a tone must fail these tests rather
+// than shrink what they check.
+const TONES = ["neutral", "success", "warning", "destructive"] as const;
+
+// Badge text is 12px at weight 500, which is not WCAG large text, so the AA
+// threshold is the 4.5:1 one rather than 3:1.
+const AA_NORMAL_TEXT = 4.5;
+
+type Rgb = [number, number, number];
+
+// The tones are Tailwind arbitrary values, so the colours are in the class
+// string and nowhere else. Reading them back out is the only way a test can
+// measure what actually ships. Tailwind writes a space as an underscore.
+function hslIn(classes: string, utility: string): Rgb {
+  const found = new RegExp(
+    `(?:^|\\s)${utility}-\\[hsl\\((\\d+)_(\\d+)%_(\\d+)%\\)\\]`,
+  ).exec(classes);
+  if (!found) throw new Error(`no ${utility} colour in "${classes}"`);
+  const [, h, s, l] = found;
+  return hslToRgb(Number(h), Number(s) / 100, Number(l) / 100);
+}
+
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  const sector = Math.floor(h / 60) % 6;
+  const rgb: Rgb[] = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x],
+  ];
+  const channels = rgb[sector] ?? rgb[0];
+  if (!channels) throw new Error(`unreachable sector ${sector}`);
+  return channels.map((v) => Math.round((v + m) * 255)) as Rgb;
+}
+
+// WCAG 2.x relative luminance and contrast.
+function luminance([r, g, b]: Rgb): number {
+  const [rl, gl, bl] = [r, g, b].map((raw) => {
+    const v = raw / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  }) as Rgb;
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x) as [
+    number,
+    number,
+  ];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
 describe("badgeTone", () => {
-  // A literal list, not Object.keys: dropping a tone must fail the test rather
-  // than shrink what it checks.
-  it.each(["neutral", "success", "warning", "destructive"] as const)(
-    "%s is a non-empty class string",
-    (tone) => {
-      expect(badgeTone[tone].trim()).not.toBe("");
-    },
-  );
+  it.each(TONES)("%s is a non-empty class string", (tone) => {
+    expect(badgeTone[tone].trim()).not.toBe("");
+  });
+
+  // Both schemes, because a tone that reads in one is not a tone that reads.
+  // Every consumer of `badgeTone` inherits whatever this allows, which is why
+  // the check lives beside the tones rather than beside any one badge.
+  it.each(TONES)("%s clears AA against its own light background", (tone) => {
+    const classes = badgeTone[tone];
+    expect(
+      contrast(hslIn(classes, "text"), hslIn(classes, "bg")),
+    ).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
+
+  it.each(TONES)("%s clears AA against its own dark background", (tone) => {
+    const classes = badgeTone[tone];
+    expect(
+      contrast(hslIn(classes, "dark:text"), hslIn(classes, "dark:bg")),
+    ).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
+
+  // The conversion and the formula are what every assertion above rests on, so
+  // they are pinned against a hand-worked case rather than trusted.
+  it("measures a known pair the way a browser does", () => {
+    expect(hslToRgb(21, 0.64, 0.43)).toEqual([180, 89, 39]);
+    expect(hslToRgb(29, 1, 0.95)).toEqual([255, 242, 229]);
+    // The ratio that failed review, to two decimal places.
+    expect(contrast([180, 89, 39], [255, 242, 229])).toBeCloseTo(4.34, 2);
+    // Black on white is the definition's own upper bound.
+    expect(contrast([0, 0, 0], [255, 255, 255])).toBeCloseTo(21, 5);
+  });
 });

--- a/client/admin/src/lib/badgeTone.ts
+++ b/client/admin/src/lib/badgeTone.ts
@@ -6,14 +6,23 @@
  * failure, and grey for a plain label. Every tone gives a full set of colours,
  * so `src/components/ui/badge.tsx` stays stock. Put a tone in `className` next
  * to `variant="outline"`. The tone then wins through tailwind-merge.
+ *
+ * Every tone carries badge text at 12px/500, which is not WCAG large text, so
+ * each foreground has to clear 4.5:1 against its own background in both
+ * schemes. `badgeTone.test.ts` measures that from these strings; do not add or
+ * retune a tone without reading what it says.
  */
 export const badgeTone = {
   neutral:
     "border-[hsl(0_0%_92%)] bg-[hsl(0_0%_98%)] text-[hsl(0_0%_33%)] uppercase dark:border-[hsl(0_0%_20%/56%)] dark:bg-[hsl(0_0%_7%)] dark:text-[hsl(0_0%_86%)]",
   success:
     "border-[hsl(99_30%_73%)] bg-[hsl(102_35%_93%)] text-[hsl(105_24%_27%)] uppercase dark:border-[hsl(105_24%_27%)] dark:bg-[hsl(105_24%_13%)] dark:text-[hsl(99_30%_73%)]",
+  // The light foreground is darkened from the moonshine original's
+  // `hsl(21 64% 43%)`, which measured 4.34:1 on this background and so failed
+  // AA. It is the only tone that did. The dark scheme, and the same colour
+  // where it serves as the dark border, are untouched.
   warning:
-    "border-[hsl(28_100%_74%)] bg-[hsl(29_100%_95%)] text-[hsl(21_64%_43%)] uppercase dark:border-[hsl(21_64%_43%)] dark:bg-[hsl(18_69%_24%)] dark:text-[hsl(28_100%_74%)]",
+    "border-[hsl(28_100%_74%)] bg-[hsl(29_100%_95%)] text-[hsl(21_70%_37%)] uppercase dark:border-[hsl(21_64%_43%)] dark:bg-[hsl(18_69%_24%)] dark:text-[hsl(28_100%_74%)]",
   destructive:
     "border-[hsl(3_78%_71%)] bg-[hsl(0_100%_97%)] text-[hsl(1_64%_32%)] uppercase dark:border-[hsl(1_64%_32%)] dark:bg-[hsl(0_62%_17%)] dark:text-[hsl(3_78%_71%)]",
 } as const;

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -178,8 +178,34 @@ export async function logout(): Promise<void> {
   window.location.href = "/admin/auth.login?prompt=select_account";
 }
 
+// Derived server-side from the `trials` table, so it is the only trustworthy
+// account of whether an organization ever trialled.
+//
+// A runtime list with the union derived from it, rather than a bare union: a
+// test can then walk every state the server can send, so a seventh state added
+// here fails a test as well as the build. A type annotation alone is one
+// careless edit from being deleted, and nothing would notice.
+export const TRIAL_STATES = [
+  "none",
+  "running",
+  "ending_soon",
+  "expired",
+  "demoted",
+  "converted",
+] as const;
+
+// Not `string`: a typo in a state name has to be a build failure, because
+// every surface that reads it maps the state to a colour.
+export type TrialState = (typeof TRIAL_STATES)[number];
+
 // Convenience method for the listOrganizations endpoint. Mirrors the backend
 // payload shape from server/gen/admin/service.go.
+//
+// `free_trial_started_at` and `free_trial_ends_at` are `NOT NULL` columns with
+// a signup-plus-fourteen-days default that no application code writes, so they
+// report a trial for every organization ever made. Nothing here reads them.
+// They stay declared only because the API still sends them; a follow-up takes
+// them off the wire.
 export type AdminOrganization = {
   id: string;
   name: string;
@@ -190,6 +216,8 @@ export type AdminOrganization = {
   disabled_at?: string;
   free_trial_started_at?: string;
   free_trial_ends_at?: string;
+  trial_state?: TrialState;
+  trial_ends_at?: string;
   member_count: number;
   created_at: string;
   updated_at: string;

--- a/client/admin/src/lib/utils.test.ts
+++ b/client/admin/src/lib/utils.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fmtDateShort } from "./utils";
+
+// Node re-reads the TZ variable when it next builds a Date, so the reader's
+// zone can be moved for the length of a call. Written out rather than left to
+// the machine: CI runs in UTC, where the fault this pins cannot appear at all
+// and every assertion about it would pass without meaning anything.
+//
+// Through `vi.stubEnv` rather than `process.env` directly, because the browser
+// build carries no node types and its restore is what the hook below relies on.
+function inZone<T>(tz: string, body: () => T): T {
+  vi.stubEnv("TZ", tz);
+  try {
+    return body();
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("fmtDateShort", () => {
+  it("reads a trial end as the server's day, not the reader's", () => {
+    // A trial end as the server stores it: the signup moment plus the trial
+    // length, in UTC. Early in the UTC day, which is where the fault shows.
+    const iso = "2026-05-06T03:00:00Z";
+
+    inZone("America/Los_Angeles", () => {
+      // The zone really moved, and in it this instant is the 5th locally.
+      // Without this the rest of the test proves nothing on a UTC runner.
+      expect(new Date(iso).getDate()).toBe(5);
+
+      // The regression itself: the reader's own zone is what shipped, and it
+      // names the day before the deadline.
+      expect(fmtDateShort(iso)).not.toBe(new Date(iso).toLocaleDateString());
+
+      // Midday UTC on the same date is the 6th in every populated zone, so it
+      // fixes the expected day without hard-coding a locale's date format.
+      expect(fmtDateShort(iso)).toBe(
+        new Date("2026-05-06T12:00:00Z").toLocaleDateString(),
+      );
+    });
+  });
+
+  it("reads the same instant the same way in every zone", () => {
+    const iso = "2026-05-06T03:00:00Z";
+    const zones = ["UTC", "America/Los_Angeles", "Asia/Tokyo", "Pacific/Apia"];
+
+    const rendered = new Set(
+      zones.map((tz) => inZone(tz, () => fmtDateShort(iso))),
+    );
+
+    // One reading, so two operators on two continents act on one date.
+    expect(rendered.size).toBe(1);
+  });
+
+  it("reads an unset date as a dash", () => {
+    expect(fmtDateShort(undefined)).toBe("-");
+    expect(fmtDateShort("")).toBe("-");
+  });
+
+  it("reads an unparseable date as a dash", () => {
+    // Not the literal string `Invalid Date`, which is what dropping the guard
+    // puts in front of an operator.
+    expect(fmtDateShort("not a date")).toBe("-");
+    expect(fmtDateShort("2026-13-45T00:00:00Z")).toBe("-");
+  });
+
+  it("drops the clock", () => {
+    const rendered = fmtDateShort("2026-05-06T13:45:12Z");
+
+    expect(rendered).toBe(fmtDateShort("2026-05-06T00:00:00Z"));
+    expect(rendered).not.toContain(":");
+  });
+});

--- a/client/admin/src/lib/utils.ts
+++ b/client/admin/src/lib/utils.ts
@@ -4,3 +4,27 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
+
+// Date only, no clock, read in UTC. Every surface that shows a date in a row or
+// a panel reads it this way, so the same field cannot come out two ways on two
+// pages.
+//
+// The zone is the whole point. `trial_ends_at` is a real instant, armed as the
+// signup moment plus the trial length, and the sweeper that demotes the account
+// compares it against server time. Rendered in the reader's own zone that
+// instant can name a different day than the one the server acts on: a trial
+// ending 2026-05-06T03:00Z reads as 5/5/2026 in California. An operator who
+// acts on that day demotes an account that still had a day. Dropping the clock
+// means the zone cannot be dropped too.
+//
+// The other fields formatted here, `created_at` and `disabled_at`, move with
+// it. Their rendered day now follows the server rather than the reader's clock,
+// and can differ by one near midnight. That is the right frame for an admin
+// tool: two operators in two zones read one organization the same way, and the
+// day they read is the day the database records.
+export function fmtDateShort(iso?: string): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "-";
+  return d.toLocaleDateString(undefined, { timeZone: "UTC" });
+}

--- a/client/admin/src/pages/OrganizationDetail.test.tsx
+++ b/client/admin/src/pages/OrganizationDetail.test.tsx
@@ -36,6 +36,13 @@ const ORG: AdminOrganization = {
   slug: "placeholder-one",
   account_type: "pro",
   whitelisted: true,
+  // The stale pair, dated apart from the real trial on purpose. A page back on
+  // `free_trial_ends_at` then shows the wrong date rather than the right one
+  // by coincidence.
+  free_trial_started_at: "2026-02-01T00:00:00Z",
+  free_trial_ends_at: "2026-11-12T00:00:00Z",
+  trial_state: "running",
+  trial_ends_at: "2026-05-06T00:00:00Z",
   member_count: 1,
   created_at: "2026-01-02T00:00:00Z",
   updated_at: "2026-01-07T00:00:00Z",
@@ -63,6 +70,24 @@ const MEMBER: AdminOrganizationMember = {
 // assertion is for: the format is not.
 function longDate(iso: string): string {
   return new Date(iso).toLocaleString();
+}
+
+// The trial is a date without a clock wherever it is read, so it does not come
+// out of `longDate` with the timestamps around it. UTC, because that is the
+// zone the API states these dates in and the zone they are rendered in; see
+// `utils.test.ts`.
+function shortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
+}
+
+// The field rows carry no role, so a test reaches one by its label and takes
+// the value beside it.
+function valueBeside(label: string): HTMLElement {
+  const value = screen.getByText(label).nextElementSibling;
+  if (!(value instanceof HTMLElement)) {
+    throw new Error(`the ${label} row has no value beside it`);
+  }
+  return value;
 }
 
 // A Radix tab trigger selects on mousedown, not on click. The panel only
@@ -101,6 +126,48 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("organization detail", () => {
+  it("reads the trial exactly the way the row does", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    const trialEndsAt = ORG.trial_ends_at;
+    if (!trialEndsAt) throw new Error("the record under test needs a trial");
+
+    const trial = await screen.findByText("Trial");
+    // Written out, not built from the component. The same string is asserted
+    // against the list's cell, which is the only way two pages that could
+    // drift apart are held together.
+    expect(valueBeside("Trial").textContent).toBe(
+      `Running ends ${shortDate(trialEndsAt)}`,
+    );
+    expect(
+      trial.parentElement?.querySelector('[data-slot="badge"]'),
+    ).toBeTruthy();
+
+    // The defaulted pair is gone from the page, not merely unread: an operator
+    // who sees "Free trial ends" reads a date no organization ever earned.
+    expect(screen.queryByText("Free trial started")).toBeNull();
+    expect(screen.queryByText("Free trial ends")).toBeNull();
+  });
+
+  it("reads a dash for an organization that never trialled", async () => {
+    mocks.getOrganization.mockResolvedValue({
+      ...ORG,
+      trial_state: "none",
+      trial_ends_at: undefined,
+    });
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await screen.findByText("Trial");
+    // `free_trial_ends_at` still dates this record, which is the whole reason
+    // the page was moved off it.
+    expect(ORG.free_trial_ends_at).toBeTruthy();
+    expect(valueBeside("Trial").textContent).toBe("-No trial");
+  });
+
   it("renders every projects cell out of the record that produced it", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,

--- a/client/admin/src/pages/OrganizationDetail.tsx
+++ b/client/admin/src/pages/OrganizationDetail.tsx
@@ -18,6 +18,7 @@ import {
   type DataTableFeatures,
 } from "@/components/data-table";
 import { useConfirmDialog } from "@/components/ConfirmDialog";
+import { Trial } from "@/components/Trial";
 import { ACCOUNT_TYPE_OPTIONS, isAccountType } from "@/lib/accountTypes";
 import { cn } from "@/lib/utils";
 import {
@@ -225,11 +226,8 @@ function OrgDetailsCard({ org }: { org: AdminOrganization }) {
           {fmtDate(org.disabled_at)}
         </span>
       </Row>
-      <Row label="Free trial started">
-        <span className="text-sm">{fmtDate(org.free_trial_started_at)}</span>
-      </Row>
-      <Row label="Free trial ends">
-        <span className="text-sm">{fmtDate(org.free_trial_ends_at)}</span>
+      <Row label="Trial">
+        <Trial org={org} />
       </Row>
       <Row label="Created">
         <span className="text-sm">{fmtDate(org.created_at)}</span>

--- a/client/admin/src/pages/organizations/PeekPanel.test.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.test.tsx
@@ -14,8 +14,13 @@ const ORG: AdminOrganization = {
   account_type: "pro",
   workos_id: "org_workos_placeholder_identifier",
   whitelisted: true,
+  // The stale pair, dated apart from the real trial on purpose. A panel back
+  // on `free_trial_ends_at` then shows the wrong date rather than the right
+  // one by coincidence.
   free_trial_started_at: "2026-02-01T00:00:00Z",
-  free_trial_ends_at: "2026-05-06T00:00:00Z",
+  free_trial_ends_at: "2026-11-12T00:00:00Z",
+  trial_state: "running",
+  trial_ends_at: "2026-05-06T00:00:00Z",
   member_count: 3,
   created_at: "2026-01-02T00:00:00Z",
   updated_at: "2026-01-07T00:00:00Z",
@@ -41,8 +46,11 @@ function Peeking(): JSX.Element {
   );
 }
 
+// UTC, because the panel reads these dates in UTC. See `utils.test.ts`: an API
+// date is a real instant, and rendering it in the reader's own zone can name
+// the day before west of Greenwich.
 function shortDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }
 
 function iconOf(button: HTMLElement): SVGElement {
@@ -72,20 +80,21 @@ describe("PeekPanel", () => {
   it("renders the record it was handed, field by field", async () => {
     await renderWithApp(<PeekPanel org={ORG} onClose={noop} />);
 
-    const { workos_id: workosID, free_trial_ends_at: trialEndsAt } = ORG;
+    const { workos_id: workosID, trial_ends_at: trialEndsAt } = ORG;
     if (!workosID || !trialEndsAt) {
       throw new Error("the record under test needs its optional fields set");
     }
 
     expect(screen.getByRole("heading", { name: ORG.name })).toBeTruthy();
     expect(screen.getAllByRole("term").map((term) => term.textContent)).toEqual(
-      ["Type", "Trial ends", "Members", "Created", "Org id", "WorkOS id"],
+      ["Type", "Trial", "Members", "Created", "Org id", "WorkOS id"],
     );
     expect(
       screen.getAllByRole("definition").map((value) => value.textContent),
     ).toEqual([
       ORG.account_type,
-      shortDate(trialEndsAt),
+      // The same state-then-date reading as the row, out of the same helper.
+      `Running ends ${shortDate(trialEndsAt)}`,
       String(ORG.member_count),
       shortDate(ORG.created_at),
       ORG.id,
@@ -96,13 +105,23 @@ describe("PeekPanel", () => {
   it("renders a dash for the optional fields a record leaves unset", async () => {
     await renderWithApp(
       <PeekPanel
-        org={{ ...ORG, workos_id: undefined, free_trial_ends_at: undefined }}
+        org={{
+          ...ORG,
+          workos_id: undefined,
+          // The stale pair stays set. A panel that never trialled has to read
+          // as a dash even while the defaulted column still dates it.
+          trial_state: "none",
+          trial_ends_at: undefined,
+        }}
         onClose={noop}
       />,
     );
 
     const values = screen.getAllByRole("definition");
-    expect(values.at(1)?.textContent).toBe("-");
+    // A dash for the eye, and "No trial" for a reader that would otherwise be
+    // told nothing at all. `Trial.test.tsx` holds the two halves apart.
+    expect(values.at(1)?.textContent).toBe("-No trial");
+    expect(values.at(1)?.querySelector('[data-slot="badge"]')).toBeNull();
     expect(values.at(-1)?.textContent).toBe("-");
     expect(screen.queryByRole("button", { name: "Copy WorkOS id" })).toBeNull();
   });

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -1,5 +1,12 @@
 import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
-import { useEffect, useRef, useState, type JSX, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type JSX,
+  type ReactNode,
+  type RefObject,
+} from "react";
 
 import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
@@ -79,16 +86,22 @@ export function PeekPanel({
   org,
   onClose,
   className,
+  ref,
 }: {
   org: AdminOrganization;
   onClose: () => void;
   className?: string;
+  // The caller's, where it has one. The list handles keys above both the table
+  // and this panel, and it has to tell the panel apart from the controls the
+  // panel contains.
+  ref?: RefObject<HTMLElement | null>;
 }): JSX.Element {
-  const root = useRef<HTMLElement>(null);
+  const own = useRef<HTMLElement>(null);
+  const root = ref ?? own;
 
   useEffect(() => {
     root.current?.focus();
-  }, []);
+  }, [root]);
 
   return (
     <aside

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -1,12 +1,13 @@
 import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
 import { useEffect, useRef, useState, type JSX, type ReactNode } from "react";
 
+import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
-import { cn } from "@/lib/utils";
+import { cn, fmtDateShort } from "@/lib/utils";
 
 const COPY_CONFIRM_MS = 1500;
 
@@ -15,13 +16,6 @@ const COPY_CONFIRM_MS = 1500;
 export const PEEK_PANEL_ID = "organization-peek-panel";
 
 function noop(): void {}
-
-function fmtDateShort(iso?: string): string {
-  if (!iso) return "-";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "-";
-  return d.toLocaleDateString();
-}
 
 function Field({
   label,
@@ -127,8 +121,8 @@ export function PeekPanel({
               {org.account_type}
             </Badge>
           </Field>
-          <Field label="Trial ends">
-            {fmtDateShort(org.free_trial_ends_at)}
+          <Field label="Trial">
+            <Trial org={org} />
           </Field>
           <Field label="Members">{org.member_count}</Field>
           <Field label="Created">{fmtDateShort(org.created_at)}</Field>

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -107,9 +107,18 @@ export function PeekPanel({
     <aside
       ref={root}
       id={PEEK_PANEL_ID}
-      tabIndex={-1}
+      // In the tab order, not just focusable. This node is the one place in the
+      // subtree where the arrow keys walk the peek from record to record, and
+      // at -1 the mount was the only way focus ever reached it: Tab moves to
+      // Close, and Shift+Tab back skips a tabindex="-1" node, so record
+      // navigation was gone for the rest of the panel's life.
+      //
+      // The ring comes with it. Nothing else on screen moves when focus lands
+      // here, so an invisible ring on the one node with its own keys is the
+      // worst of both.
+      tabIndex={0}
       aria-label="Organization peek"
-      className={cn("flex flex-col rounded-lg border outline-none", className)}
+      className={cn("flex flex-col rounded-lg border", className)}
     >
       <div className="flex items-start justify-between gap-2 p-4 pb-3">
         <div className="min-w-0">

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -10,6 +10,10 @@ import { cn } from "@/lib/utils";
 
 const COPY_CONFIRM_MS = 1500;
 
+// One panel is on the page at a time, so a constant is enough and the row's
+// trigger can point `aria-controls` at it without threading an id through.
+export const PEEK_PANEL_ID = "organization-peek-panel";
+
 function noop(): void {}
 
 function fmtDateShort(iso?: string): string {
@@ -95,6 +99,7 @@ export function PeekPanel({
   return (
     <aside
       ref={root}
+      id={PEEK_PANEL_ID}
       tabIndex={-1}
       aria-label="Organization peek"
       className={cn("flex flex-col rounded-lg border outline-none", className)}

--- a/client/admin/src/pages/organizations/PeekTrigger.tsx
+++ b/client/admin/src/pages/organizations/PeekTrigger.tsx
@@ -1,0 +1,94 @@
+import { PanelRightIcon } from "lucide-react";
+import {
+  createContext,
+  useContext,
+  useState,
+  type JSX,
+  type ReactNode,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { AdminOrganization } from "@/lib/gramAdminApi";
+
+import { PEEK_PANEL_ID } from "./PeekPanel";
+
+export type PeekControls = {
+  peekedId?: string;
+  togglePeek: (org: AdminOrganization) => void;
+};
+
+const PeekContext = createContext<PeekControls>({
+  togglePeek: () => {},
+});
+
+/**
+ * Peek state reaches the trigger cells through context, not through the column
+ * definitions: the row model memoises on the column array, so a column array
+ * rebuilt for each new `peekedId` would rebuild the model with it.
+ *
+ * The caller memoises `value`, or every trigger on the page re-renders on every
+ * render of the list.
+ */
+export function PeekProvider({
+  value,
+  children,
+}: {
+  value: PeekControls;
+  children: ReactNode;
+}): JSX.Element {
+  return <PeekContext.Provider value={value}>{children}</PeekContext.Provider>;
+}
+
+// The close path reaches the button through the peeked row and this selector,
+// rather than through `querySelector("button")`: later slices put more buttons
+// in the row.
+export const PEEK_TRIGGER_SELECTOR = "[data-peek-trigger]";
+
+export function PeekTrigger({ org }: { org: AdminOrganization }): JSX.Element {
+  const { peekedId, togglePeek } = useContext(PeekContext);
+  const isPeeked = peekedId === org.id;
+  const [tipOpen, setTipOpen] = useState(false);
+
+  return (
+    // Controlled, and held shut while this row's panel is open. The arrow keys
+    // carry the keyboard to the control of whichever row the peek moves to,
+    // and Radix opens a tooltip on a focus it did not trace to a pointer. So
+    // an uncontrolled tooltip pops open on every arrow press, and it takes the
+    // first Escape to dismiss itself before the panel gets one. An open panel
+    // describes this control better than the tooltip does anyway.
+    <Tooltip open={tipOpen && !isPeeked} onOpenChange={setTipOpen}>
+      {/* The control is an icon on its own, so nothing on screen says what it
+          does until the pointer rests on it. The tooltip describes the
+          control; it does not name it, and the accessible name below is what
+          a screen reader still announces. */}
+      <TooltipTrigger asChild>
+        <Button
+          // Filled while open. Ghost hover is `bg-accent`, and the peeked row
+          // is `bg-muted`, and in this theme those two tokens hold the same
+          // grey: an open control styled with either disappears into the row
+          // it sits in and reads as a hover everywhere else.
+          variant={isPeeked ? "default" : "ghost"}
+          size="icon-xs"
+          data-peek-trigger=""
+          // Stable under the state change. A control whose accessible name
+          // moves as it is pressed is announced as a different control; the
+          // state rides on aria-expanded instead.
+          aria-label={`Peek at ${org.name}`}
+          aria-expanded={isPeeked}
+          // A peeked row always has its panel mounted, and aria-controls
+          // pointing at an absent id is invalid.
+          aria-controls={isPeeked ? PEEK_PANEL_ID : undefined}
+          onClick={() => togglePeek(org)}
+        >
+          <PanelRightIcon />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Peek without leaving the list</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -139,8 +139,12 @@ export function Toolbar(): JSX.Element {
  */
 export function TableActionBar<T extends RowData>({
   table,
+  onColumnToggled,
 }: {
   table: DataTableInstance<T>;
+  // Told after a toggle lands, so a page that overrides what this menu writes
+  // can answer a request the menu cannot satisfy on its own.
+  onColumnToggled?: (columnId: string, label: string) => void;
 }): JSX.Element {
   // Read off the table rather than walked a second time here, so the menu
   // cannot disagree with the table about how many columns are left.
@@ -186,7 +190,9 @@ export function TableActionBar<T extends RowData>({
                   if (locked) event.preventDefault();
                 }}
                 onCheckedChange={() => {
-                  if (!locked) column.toggleVisibility();
+                  if (locked) return;
+                  column.toggleVisibility();
+                  onColumnToggled?.(column.id, columnLabel(column));
                 }}
               >
                 {columnLabel(column)}

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { Column, RowData } from "@tanstack/react-table";
 import { SearchIcon } from "lucide-react";
-import { useEffect, useState, type JSX, type ReactNode } from "react";
+import { useEffect, useState, type JSX } from "react";
 
 import type {
   DataTableFeatures,
@@ -92,7 +92,7 @@ export function Toolbar(): JSX.Element {
         <SearchIcon className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2" />
         <Input
           aria-label="Search organizations"
-          placeholder="Search by name or slug..."
+          placeholder="Search by name, slug or id..."
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           className="w-full py-1.5 pr-2 pl-8"
@@ -139,20 +139,24 @@ export function Toolbar(): JSX.Element {
  */
 export function TableActionBar<T extends RowData>({
   table,
-  hint,
 }: {
   table: DataTableInstance<T>;
-  hint?: ReactNode;
 }): JSX.Element {
   // Read off the table rather than walked a second time here, so the menu
   // cannot disagree with the table about how many columns are left.
-  const visibleCount = table.getVisibleLeafColumns().length;
+  //
+  // Only the hideable ones count. A column that opts out of hiding is visible
+  // whatever the operator does, so counting it holds this total off the floor
+  // and the guard below never fires: the operator can then hide every column
+  // that carries data and be left with a table of controls and no records.
+  const visibleCount = table
+    .getVisibleLeafColumns()
+    .filter((column) => column.getCanHide()).length;
 
   return (
     <div className="flex items-center gap-3 border-b px-3 py-2">
       <span className="text-muted-foreground text-xs">Nothing selected</span>
       <span className="flex-1" />
-      {hint}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="xs">

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -2,19 +2,13 @@ import { Link } from "@tanstack/react-router";
 import { createColumnHelper } from "@tanstack/react-table";
 
 import type { DataTableFeatures } from "@/components/data-table";
+import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
-import { cn } from "@/lib/utils";
+import { cn, fmtDateShort } from "@/lib/utils";
 
 import { PeekTrigger } from "./PeekTrigger";
-
-function fmtDateShort(iso?: string): string {
-  if (!iso) return "-";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "-";
-  return d.toLocaleDateString();
-}
 
 const column = createColumnHelper<DataTableFeatures, AdminOrganization>();
 
@@ -95,18 +89,11 @@ export const ORG_COLUMNS = column.columns([
       </span>
     ),
   }),
-  column.accessor("free_trial_ends_at", {
-    header: "Trial ends",
-    cell: ({ row }) => (
-      <span
-        className={cn(
-          "text-sm",
-          !row.original.free_trial_ends_at && "text-muted-foreground",
-        )}
-      >
-        {fmtDateShort(row.original.free_trial_ends_at)}
-      </span>
-    ),
+  // "Trial", not "Trial ends": the cell reads as a state, and the end date is
+  // the detail underneath it rather than the column's subject.
+  column.accessor("trial_state", {
+    header: "Trial",
+    cell: ({ row }) => <Trial org={row.original} />,
   }),
   column.accessor("created_at", {
     header: "Created",

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -7,6 +7,8 @@ import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 import { cn } from "@/lib/utils";
 
+import { PeekTrigger } from "./PeekTrigger";
+
 function fmtDateShort(iso?: string): string {
   if (!iso) return "-";
   const d = new Date(iso);
@@ -20,6 +22,17 @@ const column = createColumnHelper<DataTableFeatures, AdminOrganization>();
 // table does not rebuild its column model on every render. The header of each
 // column doubles as its label in the Columns control.
 export const ORG_COLUMNS = column.columns([
+  // First, not last: peek hides five columns while it is open, so a trailing
+  // control would slide sideways at the moment the operator is using it.
+  column.display({
+    id: "peek",
+    // A plain string, so the Columns control lists it as "Peek" rather than
+    // falling back to the column id.
+    header: "Peek",
+    // Hiding the control would put peek back out of reach of the keyboard.
+    enableHiding: false,
+    cell: ({ row }) => <PeekTrigger org={row.original} />,
+  }),
   column.accessor("name", {
     header: "Name",
     // The link, not the row, carries the keyboard path and the accessible

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -1192,6 +1192,72 @@ describe("organizations list peek", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it("closes on Escape pressed on a control inside the panel", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(FIRST_ORG.name);
+
+    // Escape is scoped wider than the arrow keys, and this is the case that
+    // separates them. It has no reflex of its own for the panel to steal, and
+    // it dismisses whichever surface holds the focus, so the button answers it
+    // rather than swallowing it and leaving the operator with a dead key.
+    const copy = within(peekPanel()).getByRole("button", {
+      name: "Copy Org id",
+    });
+    copy.focus();
+    fireEvent.keyDown(copy, { key: "Escape" });
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    // The button unmounts with the panel, so closing from inside it has to hand
+    // the keyboard somewhere or it lands on the body.
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("marks the Escape that closed the panel as answered", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    // Escape travels on past this handler, and a layer above it dismisses on
+    // the same key. Closing quietly spends one keypress on two surfaces, which
+    // is the mirror of the case above and the reason that guard can be trusted.
+    const copy = within(peekPanel()).getByRole("button", {
+      name: "Copy Org id",
+    });
+    // Dispatched through fireEvent rather than on the node, so the close it
+    // causes is flushed before the panel is looked for. The event is built here
+    // because the answer being asserted is on the event itself.
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(copy, event);
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves Escape alone inside the panel once something nearer has answered it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    // A tooltip or a popover opened from inside the panel calls preventDefault
+    // on the Escape that dismisses it. Closing the panel on that one takes the
+    // operator two surfaces back for one keypress, and this is the only path
+    // where it can happen: before Escape reached the panel body at all, the
+    // panel could not close underneath a control that had already answered.
+    const copy = within(peekPanel()).getByRole("button", {
+      name: "Copy Org id",
+    });
+    copy.addEventListener("keydown", (event) => event.preventDefault());
+    fireEvent.keyDown(copy, { key: "Escape" });
+
+    expect(peekPanel()).toBeTruthy();
+  });
+
   it("still closes on Escape pressed on the peeked row's own control", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const trigger = await peekOn(FIRST_ORG.name);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -171,14 +171,33 @@ function rowFor(link: HTMLElement): HTMLTableRowElement {
   return row;
 }
 
-function peekOn(link: HTMLElement): void {
-  const cell = within(rowFor(link)).getAllByRole("cell").at(-1);
-  if (!cell) throw new Error("the row needs a cell to click");
-  fireEvent.click(cell, { altKey: true });
+// Found by the accessible name a screen reader announces, so the test reaches
+// the control the way an operator does. Waiting on it is also waiting for the
+// rows, and it is present whether or not the name column is visible.
+function peekTrigger(name: string): Promise<HTMLElement> {
+  return screen.findByRole("button", { name: `Peek at ${name}` });
+}
+
+async function peekOn(name: string): Promise<HTMLElement> {
+  const trigger = await peekTrigger(name);
+  fireEvent.click(trigger);
+  return trigger;
 }
 
 function peekPanel(): HTMLElement {
   return screen.getByRole("complementary", { name: "Organization peek" });
+}
+
+function liveRegion(): HTMLElement {
+  return screen.getByRole("status");
+}
+
+// The region carries a zero-width space on every other announcement, so that a
+// sentence repeated word for word still changes the text node. Stripped here:
+// these assertions are about what is announced, not about the marker that
+// makes an unchanged sentence announceable.
+function announcement(): string {
+  return (liveRegion().textContent ?? "").replaceAll("\u200b", "");
 }
 
 function isPeeked(link: HTMLElement): boolean {
@@ -226,6 +245,17 @@ describe("organizations list", () => {
       expect(mocks.listOrganizations).toHaveBeenCalled();
     });
     expect(lastListParams().q).toBe("acme");
+  });
+
+  it("offers an id as a term the search box takes", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const input = screen.getByLabelText("Search organizations");
+
+    // The label names the target, not the terms, and it is pinned elsewhere
+    // because a screen reader announces it. An operator holding an
+    // organization id has only the placeholder to tell them it will match.
+    expect((input as HTMLInputElement).placeholder).toMatch(/\bid\b/i);
   });
 
   it("holds a keystroke out of the URL until the debounce elapses", async () => {
@@ -458,6 +488,7 @@ describe("organizations list", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      "Peek",
       "Name",
       "Slug",
       "Type",
@@ -472,6 +503,8 @@ describe("organizations list", () => {
         .getAllByRole("cell")
         .map((cell) => cell.textContent),
     ).toEqual([
+      // The peek control carries an icon and its name is on the button.
+      "",
       FIRST_ORG.name,
       FIRST_ORG.slug,
       FIRST_ORG.account_type,
@@ -491,8 +524,10 @@ describe("organizations list", () => {
     });
 
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    const [, slugCell] = within(rowFor(link)).getAllByRole("cell");
-    if (!slugCell) throw new Error("the row needs a second cell");
+    // Past the peek control and the name link, so the click lands on the row
+    // body rather than on something that handles it first.
+    const [, , slugCell] = within(rowFor(link)).getAllByRole("cell");
+    if (!slugCell) throw new Error("the row needs a third cell");
 
     fireEvent.click(slugCell);
 
@@ -559,25 +594,25 @@ describe("organizations list peek", () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
     });
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-
-    peekOn(link);
+    await peekOn(FIRST_ORG.name);
 
     expect(
       within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
     ).toBeTruthy();
+    // The row's click handler navigates, and the control sits inside the row.
+    // A control that let the click through would leave the list entirely.
     expect(router.state.location.pathname).toBe("/organizations");
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Slug", "Type"]);
+    ).toEqual(["Peek", "Name", "Slug", "Type"]);
   });
 
   it("highlights the row it is peeking at and no other", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
 
-    peekOn(link);
+    await peekOn(FIRST_ORG.name);
 
     expect(isPeeked(link)).toBe(true);
     expect(isPeeked(screen.getByRole("link", { name: SECOND_ORG.name }))).toBe(
@@ -588,13 +623,16 @@ describe("organizations list peek", () => {
   it("walks peek down the list and stops at the last row", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
 
     expect(
       within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
     ).toBeTruthy();
+    // Nothing else speaks when the panel already holds the focus and the
+    // record under it changes.
+    expect(announcement()).toBe(`Peeking at ${SECOND_ORG.name}.`);
     expect(isPeeked(screen.getByRole("link", { name: SECOND_ORG.name }))).toBe(
       true,
     );
@@ -608,8 +646,7 @@ describe("organizations list peek", () => {
 
   it("walks peek back up the list and stops at the first row", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const second = await screen.findByRole("link", { name: SECOND_ORG.name });
-    peekOn(second);
+    await peekOn(SECOND_ORG.name);
 
     fireEvent.keyDown(peekPanel(), { key: "ArrowUp" });
     expect(
@@ -624,30 +661,41 @@ describe("organizations list peek", () => {
 
   it("scrolls the row peek moves to into view", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     const second = rowFor(screen.getByRole("link", { name: SECOND_ORG.name }));
     const scrollIntoView = vi.spyOn(second, "scrollIntoView");
 
     fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
 
-    expect(scrollIntoView).toHaveBeenCalled();
+    // With the argument. `block: "center"` also counts as called, and it
+    // re-centres the whole list under every arrow press.
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
   });
 
-  it("closes on Escape and puts focus back on the row's name link", async () => {
+  it("closes on Escape and puts the keyboard back on the control", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(link);
+    const trigger = await peekOn(FIRST_ORG.name);
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
     expect(
       screen.queryByRole("complementary", { name: "Organization peek" }),
     ).toBeNull();
-    expect(document.activeElement).toBe(
-      screen.getByRole("link", { name: FIRST_ORG.name }),
-    );
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("returns the keyboard to the control of whichever row was peeked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(SECOND_ORG.name);
+
+    fireEvent.keyDown(peekPanel(), { key: "Escape" });
+
+    // The second row on purpose. A close that looks the control up across the
+    // whole page instead of inside the peeked row finds the first row's one,
+    // and every other focus test here peeks the first row, so it passes on
+    // luck and sends an operator who peeked row 40 back to row 1.
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("gives the operator's own column visibility back when peek closes", async () => {
@@ -659,17 +707,17 @@ describe("organizations list peek", () => {
       expect(screen.queryByRole("columnheader", { name: "Slug" })).toBeNull();
     });
 
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(link);
+    await peekOn(FIRST_ORG.name);
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Type"]);
+    ).toEqual(["Peek", "Name", "Type"]);
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      "Peek",
       "Name",
       "Type",
       "Members",
@@ -690,14 +738,13 @@ describe("organizations list peek", () => {
     });
     expect(screen.queryByRole("columnheader", { name: "Name" })).toBeNull();
 
-    // The name link is gone with the column, so the row is reached by its slug.
-    const row = screen.getByText(FIRST_ORG.slug).closest("tr");
-    if (!row) throw new Error("the slug cell is not inside a row");
-    fireEvent.click(row, { altKey: true });
+    // The name link is gone with the column, and the control is not: it names
+    // the organization itself, so it is still reachable by that name.
+    await peekOn(FIRST_ORG.name);
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Slug", "Type"]);
+    ).toEqual(["Peek", "Name", "Slug", "Type"]);
     expect(screen.getByRole("link", { name: FIRST_ORG.name })).toBeTruthy();
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
@@ -709,7 +756,7 @@ describe("organizations list peek", () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
     const second = screen.getByRole("link", { name: SECOND_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     openOn(screen.getByRole("button", { name: "Columns" }));
     fireEvent.keyDown(screen.getByRole("menuitemcheckbox", { name: "Name" }), {
@@ -723,7 +770,7 @@ describe("organizations list peek", () => {
   it("leaves Escape to the Columns menu while it is open", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(first);
+    await peekOn(FIRST_ORG.name);
 
     openOn(screen.getByRole("button", { name: "Columns" }));
     fireEvent.keyDown(screen.getByRole("menuitemcheckbox", { name: "Name" }), {
@@ -743,8 +790,7 @@ describe("organizations list peek", () => {
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    peekOn(link);
+    await peekOn(FIRST_ORG.name);
     expect(peekPanel()).toBeTruthy();
 
     const next = await screen.findByRole("button", { name: "Next" });
@@ -762,6 +808,7 @@ describe("organizations list peek", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      "Peek",
       "Name",
       "Slug",
       "Type",
@@ -772,21 +819,418 @@ describe("organizations list peek", () => {
       "Created",
     ]);
   });
+
+  it("closes the panel again when the same control is activated twice", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    expect(peekPanel()).toBeTruthy();
+
+    fireEvent.click(trigger);
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    expect(announcement()).toBe("Peek closed.");
+  });
+
+  it("moves the peek to another row when that row's control is activated", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await peekOn(FIRST_ORG.name);
+    await peekOn(SECOND_ORG.name);
+
+    // A toggle keyed on "some panel is open" rather than on this row would
+    // close the panel here instead of moving it.
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+    expect(announcement()).toBe(`Peeking at ${SECOND_ORG.name}.`);
+  });
+
+  it("reports on each control whether its own panel is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(other.getAttribute("aria-expanded")).toBe("false");
+
+    // Set only while the panel exists: aria-controls pointing at an absent id
+    // is invalid, so the row that is not peeked carries none.
+    expect(trigger.getAttribute("aria-controls")).toBe(peekPanel().id);
+    expect(other.hasAttribute("aria-controls")).toBe(false);
+  });
+
+  it("returns the keyboard to the control that opened the panel", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    // The panel takes the focus on mount, which is what puts Escape and the
+    // arrow keys within reach of the handler above the table.
+    expect(document.activeElement).toBe(peekPanel());
+
+    fireEvent.click(
+      within(peekPanel()).getByRole("button", { name: "Close peek" }),
+    );
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("gives the keyboard a control it can operate", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekTrigger(FIRST_ORG.name);
+
+    // A proxy, and an honest one: happy-dom synthesises no click from Enter
+    // or Space, so pressing them here proves nothing either way. The element
+    // type is what a browser reads to decide whether it should.
+    expect(trigger.tagName).toBe("BUTTON");
+  });
+
+  it("marks the open control apart from every other one", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+
+    // The variant, not the classes it expands to. Peek hides the name column
+    // it opened from, so the fill is the only thing left on screen that says
+    // which control the panel belongs to, and the ghost hover token and the
+    // peeked row token are the same grey in this theme.
+    expect(trigger.getAttribute("data-variant")).toBe("default");
+    expect(other.getAttribute("data-variant")).toBe("ghost");
+  });
+
+  it("describes the control to an operator who is not using a screen reader", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekTrigger(FIRST_ORG.name);
+
+    // An icon on its own says nothing to a sighted operator, and the label
+    // this replaces only ever announced itself to a screen reader.
+    fireEvent.focus(trigger);
+
+    const tip = await screen.findByRole("tooltip");
+    expect(tip.textContent).toBe("Peek without leaving the list");
+    // Describing the control must not rename it.
+    expect(
+      screen.getAllByRole("button", { name: `Peek at ${FIRST_ORG.name}` }),
+    ).toHaveLength(1);
+  });
+
+  it("carries the keyboard along when the arrow keys move the peek off a control", async () => {
+    // Three rows, because the trap only shows on the second press: the first
+    // move works and leaves the keyboard behind on the row it moved off.
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: [FIRST_ORG, SECOND_ORG, NEXT_PAGE_ORG],
+    });
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const trigger = await peekOn(FIRST_ORG.name);
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    // The control the peek moved to, or the next press meets the guard that
+    // keeps other rows' controls out of this handler and the operator is
+    // stuck on a control that answers nothing.
+    const second = await peekTrigger(SECOND_ORG.name);
+    expect(document.activeElement).toBe(second);
+
+    fireEvent.keyDown(second, { key: "ArrowDown" });
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: NEXT_PAGE_ORG.name }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(await peekTrigger(NEXT_PAGE_ORG.name));
+  });
+
+  it("closes on Escape after the arrow keys have moved the peek", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(FIRST_ORG.name);
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    const second = await peekTrigger(SECOND_ORG.name);
+    fireEvent.keyDown(second, { key: "Escape" });
+
+    // Escape has to keep working from wherever the arrow keys left the
+    // operator. A keyboard that can move but cannot close is trapped.
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+  });
+
+  it("leaves the keyboard in the panel when the arrow keys come from the panel", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    // The panel takes the focus on mount, and this is the panel's own record
+    // navigation.
+    expect(document.activeElement).toBe(peekPanel());
+
+    fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
+
+    // Following the peek out to the row control here would take the operator
+    // off the record they are reading and out of the panel they opened.
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(peekPanel());
+  });
+
+  it("ignores the arrow keys on a control that is not the peeked row's", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+
+    // An operator on another row's control presses this to scroll. Answering
+    // it would move the panel away from where they are looking, swallow the
+    // scroll, and leave them on a control still reporting itself closed.
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    other.dispatchEvent(event);
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("ignores Escape on a control that is not the peeked row's", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    const other = await peekTrigger(SECOND_ORG.name);
+    other.focus();
+
+    fireEvent.keyDown(other, { key: "Escape" });
+
+    // Closing from here would pull the keyboard onto the peeked row, which is
+    // a place the operator did not ask to go.
+    expect(peekPanel()).toBeTruthy();
+    expect(document.activeElement).toBe(other);
+  });
+
+  it("still closes on Escape pressed on the peeked row's own control", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(FIRST_ORG.name);
+    trigger.focus();
+
+    // The exemption has to be this narrow, or closing from the control that
+    // opened the panel stops working.
+    fireEvent.keyDown(trigger, { key: "Escape" });
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+  });
+
+  it("announces a move onto an organization that shares the peeked one's name", async () => {
+    // Names are not unique. Two records, one name, so both announcements are
+    // the same sentence word for word.
+    const TWIN: AdminOrganization = {
+      ...SECOND_ORG,
+      id: "org_placeholder_twin",
+      slug: "placeholder-twin",
+      name: FIRST_ORG.name,
+    };
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: [FIRST_ORG, TWIN],
+    });
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const [first, twin] = await screen.findAllByRole("button", {
+      name: `Peek at ${FIRST_ORG.name}`,
+    });
+    if (!first || !twin) throw new Error("both rows need a control");
+
+    fireEvent.click(first);
+    const spoken = liveRegion().textContent;
+
+    fireEvent.click(twin);
+
+    // The panel moved to the other record.
+    expect(twin.getAttribute("aria-expanded")).toBe("true");
+    expect(first.getAttribute("aria-expanded")).toBe("false");
+    expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
+
+    // A live region speaks when its text changes. Set the same string twice
+    // and the DOM never moves, so the operator hears nothing at all while the
+    // panel in front of them swaps records.
+    expect(liveRegion().textContent).not.toBe(spoken);
+  });
+
+  it("keeps an empty status region on the page before anything is peeked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // A live region injected together with its text is not reliably announced,
+    // so the region has to be on the page before it has anything to say.
+    expect(announcement()).toBe("");
+  });
+
+  it("announces through one polite region that outlives every announcement", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const region = await screen.findByRole("status");
+
+    // Polite, or nothing is spoken at all and every assertion in this file
+    // about what the region says reads a dead feature's DOM text.
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    // Off screen. Otherwise the announcements pile up as stray text above the
+    // table, where a sighted operator reads them and nobody asked for them.
+    expect(region.classList.contains("sr-only")).toBe(true);
+
+    await peekOn(FIRST_ORG.name);
+
+    // The same node. A region that arrives together with its text is not
+    // announced, and a region keyed by its own text is a new one every time,
+    // which is the same defect wearing a different hat.
+    expect(liveRegion()).toBe(region);
+    expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
+  });
+
+  it("opens the organization on an alt-click rather than peeking at it", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    const [, , slugCell] = within(rowFor(link)).getAllByRole("cell");
+    if (!slugCell) throw new Error("the row needs a third cell");
+
+    // The gesture is gone: browsers read Alt-click on an anchor as "save
+    // link", and the row's own handler carries no branch for it any more.
+    fireEvent.click(slugCell, { altKey: true });
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        `/organizations/${FIRST_ORG.slug}`,
+      );
+    });
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+  });
+
+  it("will not let the Columns menu hide the control", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    const item = screen.getByRole("menuitemcheckbox", { name: "Peek" });
+    fireEvent.click(item);
+
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    expect(item.getAttribute("aria-checked")).toBe("true");
+
+    // A locked item leaves the menu open, and an open Radix menu hides the
+    // rest of the page from the accessibility tree.
+    fireEvent.keyDown(item, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("columnheader", { name: "Peek" })).toBeTruthy();
+    });
+    expect(await peekTrigger(FIRST_ORG.name)).toBeTruthy();
+  });
+
+  it("puts the keyboard on the table, not on the body, when the peeked record leaves the list", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await peekOn(FIRST_ORG.name);
+    // The panel holds the focus, and it is about to unmount under it.
+    expect(document.activeElement).toBe(peekPanel());
+
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    // The scroll box around the table, reached through the table it holds
+    // rather than by class: it is the nearest thing to where the operator was.
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(document.body);
+    });
+    expect(document.activeElement?.contains(screen.getByRole("table"))).toBe(
+      true,
+    );
+    // happy-dom focuses elements a browser will not, so "activeElement moved"
+    // is no evidence that focus could land there at all. Every focus
+    // assertion in this file has to check the target is focusable in its own
+    // right, and this is that check.
+    expect(document.activeElement?.getAttribute("tabindex")).toBe("-1");
+    // The box around the table and nothing wider. `contains(table)` is true
+    // of every ancestor up to the document, so a rescue that landed on the
+    // wrapper holding the pager would satisfy the line above and drop the
+    // operator somewhere they can no longer see the record they lost.
+    expect(document.activeElement?.contains(next)).toBe(false);
+    // Named, or the operator arrives somewhere their screen reader announces
+    // as nothing at all.
+    expect(document.activeElement).toBe(
+      screen.getByRole("region", { name: "Organizations table" }),
+    );
+    // Worded apart from an operator's own close, which says nothing about why.
+    expect(announcement()).toBe(
+      `Peek closed. ${FIRST_ORG.name} is no longer in the list.`,
+    );
+  });
+
+  it("leaves the keyboard on the pager when the operator pages the peeked record away", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG], next_cursor: "cursor_page_three" }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await peekOn(FIRST_ORG.name);
+
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    // The operator drove this from the pager, so their focus is already on a
+    // live control. An unguarded rescue would take it off them.
+    next.focus();
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    expect(document.activeElement).toBe(next);
+  });
 });
 
 // The bar takes a table, so the last-column case is reachable here by handing
 // it a two column table rather than by clicking seven items shut through a
 // menu that closes each time.
 describe("TableActionBar", () => {
-  const [FIRST, SECOND] = ORG_COLUMNS;
-  if (!FIRST || !SECOND) throw new Error("ORG_COLUMNS needs two columns");
+  // Sliced, so the array carries the element type useTable asks for. Two data
+  // columns for the cases about the bar's own two rules, and the peek column
+  // beside one of them for the case where an unhideable column is in the count.
+  const MENU_COLUMNS = ORG_COLUMNS.slice(1, 3);
+  const WITH_PEEK_COLUMN = ORG_COLUMNS.slice(0, 2);
+
+  // Destructured off the tuple rather than off the slice, which widens each
+  // element back to a bare column definition.
+  const [PEEK, FIRST, SECOND, THIRD] = ORG_COLUMNS;
+  if (!PEEK || !FIRST || !SECOND || !THIRD) {
+    throw new Error("ORG_COLUMNS needs four columns");
+  }
 
   // An accessor column takes its id from its key unless it names one, and that
   // id is what the visibility state is keyed by.
   const SECOND_ID = String(SECOND.id ?? SECOND.accessorKey);
-
-  // Sliced, so the array carries the element type useTable asks for.
-  const MENU_COLUMNS = ORG_COLUMNS.slice(0, 2);
 
   function ColumnsMenu({
     initialVisibility,
@@ -897,11 +1341,30 @@ describe("TableActionBar", () => {
     expect(itemFor(FIRST.header).getAttribute("aria-checked")).toBe("false");
   });
 
+  it("stops the operator hiding the last column that carries data", () => {
+    // Peek and Name, both visible. Peek opts out of hiding, so it is on screen
+    // whatever the operator does and it is not the column that keeps the table
+    // readable. Counting it would leave Name free to go, and the table behind
+    // this menu would be a strip of controls above rows holding no record.
+    const onVisibilityChange = openColumnsMenu({}, WITH_PEEK_COLUMN);
+
+    const item = itemFor(FIRST.header);
+    fireEvent.click(item);
+
+    expect(onVisibilityChange).not.toHaveBeenCalled();
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    // The peek column is locked too, by its own opt-out rather than by this
+    // rule, so the operator cannot reach the same state from the other side.
+    expect(itemFor(PEEK.header).getAttribute("aria-disabled")).toBe("true");
+  });
+
   it("locks a column that opts out of hiding", () => {
-    // Both are visible, so the last-column rule is not what holds this one.
+    // Three visible, two of them hideable, so the last-data-column rule is not
+    // what holds this one and hiding the next one along is still allowed.
     const onVisibilityChange = openColumnsMenu({}, [
       { ...FIRST, enableHiding: false },
       SECOND,
+      THIRD,
     ]);
 
     const item = itemFor(FIRST.header);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -1314,6 +1314,93 @@ describe("organizations list peek", () => {
     expect(await peekTrigger(FIRST_ORG.name)).toBeTruthy();
   });
 
+  it("closes the peek to show a column the peek was hiding", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    expect(screen.queryByRole("columnheader", { name: "Members" })).toBeNull();
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Members" }));
+
+    // Checking a column is an unambiguous request to see it, and the panel is
+    // the only thing in the way. Granting it explains itself: the panel goes
+    // and the column arrives in the same commit, where the write on its own
+    // was swallowed and the checkbox snapped back with nothing to say.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: "Members" }),
+      ).toBeTruthy();
+    });
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    expect(announcement()).toBe("Peek closed to show the Members column.");
+  });
+
+  it("leaves the keyboard on the Columns control when a column closes the peek", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekOn(FIRST_ORG.name);
+    const columns = screen.getByRole("button", { name: "Columns" });
+
+    openOn(columns);
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Members" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: "Members" }),
+      ).toBeTruthy();
+    });
+    // An operator's own close puts the keyboard back on the peek control.
+    // Doing that here would drag them out of the menu they are working in and
+    // onto a row they were not looking at.
+    expect(document.activeElement).not.toBe(trigger);
+    expect(document.activeElement).toBe(columns);
+  });
+
+  it("keeps the peek open for a column the peek was not hiding", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // Hidden before the peek opens. Peek leaves this column visible, and a
+    // column the menu already reports as checked is not one an operator can
+    // ask for.
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Slug" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("columnheader", { name: "Slug" })).toBeNull();
+    });
+
+    await peekOn(FIRST_ORG.name);
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Slug" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("columnheader", { name: "Slug" })).toBeTruthy();
+    });
+    // Nothing was in the way of this one, so nothing has to give way for it.
+    // A panel that went here would be closing on any menu click at all.
+    expect(peekPanel()).toBeTruthy();
+    expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
+  });
+
+  it("says nothing about the peek when a column is toggled with none open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Members" }));
+
+    // The same column, and no panel in the way of it. Announcing a close here
+    // would report a panel that was never open, over a column that just went.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("columnheader", { name: "Members" }),
+      ).toBeNull();
+    });
+    expect(announcement()).toBe("");
+  });
+
   it("puts the keyboard on the table, not on the body, when the peeked record leaves the list", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(
@@ -1409,15 +1496,18 @@ describe("TableActionBar", () => {
 
   // An accessor column takes its id from its key unless it names one, and that
   // id is what the visibility state is keyed by.
+  const FIRST_ID = String(FIRST.id ?? FIRST.accessorKey);
   const SECOND_ID = String(SECOND.id ?? SECOND.accessorKey);
 
   function ColumnsMenu({
     initialVisibility,
     onVisibilityChange,
+    onColumnToggled,
     columns,
   }: {
     initialVisibility: ColumnVisibilityState;
     onVisibilityChange: (updater: Updater<ColumnVisibilityState>) => void;
+    onColumnToggled: (columnId: string, label: string) => void;
     columns: typeof MENU_COLUMNS;
   }): JSX.Element {
     const [columnVisibility, setColumnVisibility] = useState(initialVisibility);
@@ -1434,24 +1524,33 @@ describe("TableActionBar", () => {
         setColumnVisibility(updater);
       },
     });
-    return <TableActionBar table={table} />;
+    return <TableActionBar table={table} onColumnToggled={onColumnToggled} />;
   }
+
+  type MenuSpies = {
+    onVisibilityChange: Mock<(updater: Updater<ColumnVisibilityState>) => void>;
+    onColumnToggled: Mock<(columnId: string, label: string) => void>;
+  };
 
   function openColumnsMenu(
     initialVisibility: ColumnVisibilityState,
     columns: typeof MENU_COLUMNS = MENU_COLUMNS,
-  ): Mock<(updater: Updater<ColumnVisibilityState>) => void> {
-    const onVisibilityChange =
-      vi.fn<(updater: Updater<ColumnVisibilityState>) => void>();
+  ): MenuSpies {
+    const spies: MenuSpies = {
+      onVisibilityChange:
+        vi.fn<(updater: Updater<ColumnVisibilityState>) => void>(),
+      onColumnToggled: vi.fn<(columnId: string, label: string) => void>(),
+    };
     render(
       <ColumnsMenu
         initialVisibility={initialVisibility}
-        onVisibilityChange={onVisibilityChange}
+        onVisibilityChange={spies.onVisibilityChange}
+        onColumnToggled={spies.onColumnToggled}
         columns={columns}
       />,
     );
     openOn(screen.getByRole("button", { name: "Columns" }));
-    return onVisibilityChange;
+    return spies;
   }
 
   // A toggle that lands closes the menu. Reopening also reads the item back
@@ -1471,7 +1570,7 @@ describe("TableActionBar", () => {
   }
 
   it("stops the operator hiding the last visible column", () => {
-    const onVisibilityChange = openColumnsMenu({ [SECOND_ID]: false });
+    const { onVisibilityChange } = openColumnsMenu({ [SECOND_ID]: false });
 
     const item = itemFor(FIRST.header);
     fireEvent.click(item);
@@ -1497,7 +1596,7 @@ describe("TableActionBar", () => {
   });
 
   it("still unhides a column while only one is visible", () => {
-    const onVisibilityChange = openColumnsMenu({ [SECOND_ID]: false });
+    const { onVisibilityChange } = openColumnsMenu({ [SECOND_ID]: false });
 
     const item = itemFor(SECOND.header);
     expect(item.getAttribute("aria-checked")).toBe("false");
@@ -1511,7 +1610,7 @@ describe("TableActionBar", () => {
   });
 
   it("hides a column while a second one is still visible", () => {
-    const onVisibilityChange = openColumnsMenu({});
+    const { onVisibilityChange } = openColumnsMenu({});
 
     fireEvent.click(itemFor(FIRST.header));
     expect(onVisibilityChange).toHaveBeenCalled();
@@ -1520,12 +1619,35 @@ describe("TableActionBar", () => {
     expect(itemFor(FIRST.header).getAttribute("aria-checked")).toBe("false");
   });
 
+  it("reports a toggle that landed, by column and by the name on the item", () => {
+    const { onColumnToggled } = openColumnsMenu({});
+
+    const item = itemFor(FIRST.header);
+    fireEvent.click(item);
+
+    // The label as well as the id, because the page that acts on this holds
+    // only the id and cannot name the column back to the operator without it.
+    // Read off the item, so the two cannot disagree about what it is called.
+    expect(onColumnToggled).toHaveBeenCalledWith(FIRST_ID, item.textContent);
+  });
+
+  it("reports nothing for a toggle the lock refused", () => {
+    const { onColumnToggled } = openColumnsMenu({ [SECOND_ID]: false });
+
+    fireEvent.click(itemFor(FIRST.header));
+
+    // Radix fires onCheckedChange whether or not the select was prevented, so
+    // an unguarded report would tell the page a column changed when the lock
+    // had just held it where it was.
+    expect(onColumnToggled).not.toHaveBeenCalled();
+  });
+
   it("stops the operator hiding the last column that carries data", () => {
     // Peek and Name, both visible. Peek opts out of hiding, so it is on screen
     // whatever the operator does and it is not the column that keeps the table
     // readable. Counting it would leave Name free to go, and the table behind
     // this menu would be a strip of controls above rows holding no record.
-    const onVisibilityChange = openColumnsMenu({}, WITH_PEEK_COLUMN);
+    const { onVisibilityChange } = openColumnsMenu({}, WITH_PEEK_COLUMN);
 
     const item = itemFor(FIRST.header);
     fireEvent.click(item);
@@ -1540,7 +1662,7 @@ describe("TableActionBar", () => {
   it("locks a column that opts out of hiding", () => {
     // Three visible, two of them hideable, so the last-data-column rule is not
     // what holds this one and hiding the next one along is still allowed.
-    const onVisibilityChange = openColumnsMenu({}, [
+    const { onVisibilityChange } = openColumnsMenu({}, [
       { ...FIRST, enableHiding: false },
       SECOND,
       THIRD,

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -1101,6 +1101,97 @@ describe("organizations list peek", () => {
     expect(document.activeElement).toBe(other);
   });
 
+  it("leaves a key alone once something nearer has answered it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    await peekOn(FIRST_ORG.name);
+
+    // React listens at the root, so a native listener on the panel stands in
+    // for anything inside it that answers the key first. Moving the peek on
+    // top of that answer would act on a key already spoken for.
+    const panel = peekPanel();
+    panel.addEventListener("keydown", (event) => event.preventDefault());
+    fireEvent.keyDown(panel, { key: "ArrowDown" });
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    expect(isPeeked(first)).toBe(true);
+  });
+
+  it("ignores the arrow keys pressed on the pager", async () => {
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: ORGS,
+      next_cursor: "cursor_page_two",
+    });
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    await peekOn(FIRST_ORG.name);
+
+    const next = screen.getByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    next.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    next.dispatchEvent(event);
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    expect(isPeeked(first)).toBe(true);
+    // The pager sits under the same handler as the panel. Answering it here
+    // also eats the scroll the operator pressed the key for.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("ignores Escape pressed on the pager", async () => {
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: ORGS,
+      next_cursor: "cursor_page_two",
+    });
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    const next = screen.getByRole("button", { name: "Next" });
+    next.focus();
+    fireEvent.keyDown(next, { key: "Escape" });
+
+    // Closing from here would pull the keyboard off the pager and onto the
+    // peeked row, which is a place the operator did not ask to go.
+    expect(peekPanel()).toBeTruthy();
+    expect(document.activeElement).toBe(next);
+  });
+
+  it("ignores the arrow keys pressed on a control inside the panel", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    await peekOn(FIRST_ORG.name);
+
+    // Inside the panel, and not the panel. The panel's own record navigation
+    // belongs to the container that holds the focus; a button in the body has
+    // its own keys, and the operator pressing this one wants to scroll.
+    const copy = within(peekPanel()).getByRole("button", {
+      name: "Copy Org id",
+    });
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    copy.dispatchEvent(event);
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    expect(isPeeked(first)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it("still closes on Escape pressed on the peeked row's own control", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const trigger = await peekOn(FIRST_ORG.name);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -71,6 +71,11 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
 // Two rows, and every optional field set on one of them. One row forecloses
 // every ordering and keying fault by construction, and an unset optional field
 // renders the same dash whichever field the cell reads.
+//
+// Both rows carry the stale `free_trial_*` pair, and neither carries a date
+// there that the Trial cell should ever show. The second row is the one that
+// matters: it never trialled, and the stale pair still dates it, which is the
+// whole reason this column was rewritten.
 const ORGS: AdminOrganization[] = [
   {
     id: "org_placeholder_one",
@@ -81,7 +86,9 @@ const ORGS: AdminOrganization[] = [
     whitelisted: true,
     disabled_at: "2026-03-04T00:00:00Z",
     free_trial_started_at: "2026-02-01T00:00:00Z",
-    free_trial_ends_at: "2026-05-06T00:00:00Z",
+    free_trial_ends_at: "2026-11-12T00:00:00Z",
+    trial_state: "running",
+    trial_ends_at: "2026-05-06T00:00:00Z",
     member_count: 3,
     created_at: "2026-01-02T00:00:00Z",
     updated_at: "2026-01-07T00:00:00Z",
@@ -92,6 +99,9 @@ const ORGS: AdminOrganization[] = [
     slug: "placeholder-two",
     account_type: "free",
     whitelisted: false,
+    free_trial_started_at: "2026-06-08T00:00:00Z",
+    free_trial_ends_at: "2026-06-22T00:00:00Z",
+    trial_state: "none",
     member_count: 7,
     created_at: "2026-06-08T00:00:00Z",
     updated_at: "2026-06-09T00:00:00Z",
@@ -116,9 +126,11 @@ if (!FIRST_ORG || !SECOND_ORG) throw new Error("ORGS needs two rows");
 
 // The columns render a date through toLocaleDateString, so the expected text
 // has to come out of the same formatter. Reading the field off the fixture is
-// what the assertion is for: the format is not.
+// what the assertion is for: the format is not. UTC, because that is the zone
+// the API states these dates in and the zone the table renders them in; see
+// `utils.test.ts`.
 function shortDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
+  return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }
 
 function lastListParams(): ListOrganizationsParams {
@@ -169,6 +181,21 @@ function rowFor(link: HTMLElement): HTMLTableRowElement {
   const row = link.closest("tr");
   if (!row) throw new Error("the name link is not inside a row");
   return row;
+}
+
+// Taken by the header above it, not by counting cells. A column added beside
+// this one otherwise leaves the assertion reading its neighbour and still
+// passing or failing for reasons that have nothing to do with what it names.
+function cellUnder(row: HTMLElement, header: string): HTMLElement {
+  const at = screen
+    .getAllByRole("columnheader")
+    .map((column) => column.textContent)
+    .indexOf(header);
+  if (at < 0) throw new Error(`no ${header} column on the page`);
+
+  const cell = within(row).getAllByRole("cell").at(at);
+  if (!cell) throw new Error(`the row has no cell under ${header}`);
+  return cell;
 }
 
 // Found by the accessible name a screen reader announces, so the test reaches
@@ -474,8 +501,11 @@ describe("organizations list", () => {
   it("renders every cell of a row out of the record that produced it", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    const { workos_id: workosID, disabled_at: disabledAt } = FIRST_ORG;
-    const trialEndsAt = FIRST_ORG.free_trial_ends_at;
+    const {
+      workos_id: workosID,
+      disabled_at: disabledAt,
+      trial_ends_at: trialEndsAt,
+    } = FIRST_ORG;
     if (!workosID || !disabledAt || !trialEndsAt) {
       throw new Error("the row under test needs its optional fields set");
     }
@@ -495,7 +525,7 @@ describe("organizations list", () => {
       "Members",
       "WorkOS",
       "Disabled",
-      "Trial ends",
+      "Trial",
       "Created",
     ]);
     expect(
@@ -513,9 +543,50 @@ describe("organizations list", () => {
       // column's own constant would move this expectation along with it.
       `${workosID.substring(0, 12)}...`,
       shortDate(disabledAt),
-      shortDate(trialEndsAt),
+      // The state leads and the end date follows it, and the date says what it
+      // is: the header reads `Trial` and no longer does. The stale pair on this
+      // record carries a different date, so a cell back on the old field fails
+      // here on the date alone.
+      `Running ends ${shortDate(trialEndsAt)}`,
       shortDate(FIRST_ORG.created_at),
     ]);
+  });
+
+  it("reads a dash in the trial cell of an organization that never trialled", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    // The row is dated by `free_trial_ends_at` all the same, which is the
+    // defaulted column this cell was moved off.
+    expect(SECOND_ORG.free_trial_ends_at).toBeTruthy();
+
+    const link = await screen.findByRole("link", { name: SECOND_ORG.name });
+    const trialCell = cellUnder(rowFor(link), "Trial");
+
+    // The dash is what an operator reads; the words behind it are what a
+    // screen reader is given in place of a hyphen it announces as nothing.
+    expect(trialCell.textContent).toBe("-No trial");
+    expect(trialCell.querySelector('[data-slot="badge"]')).toBeNull();
+  });
+
+  it("lets the operator hide the trial column like any other", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    expect(screen.getByRole("columnheader", { name: "Trial" })).toBeTruthy();
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    const item = screen.getByRole("menuitemcheckbox", { name: "Trial" });
+    // Nothing about this column justifies pinning it on screen. An operator
+    // working a list of a hundred organizations gets to put away the columns
+    // they are not reading, and the bar locks a column only to keep the table
+    // from emptying out.
+    expect(item.getAttribute("aria-disabled")).not.toBe("true");
+    fireEvent.click(item);
+
+    // The open menu hides the rest of the page from the accessibility tree, so
+    // wait for a column that stays before reading the one that went.
+    await waitFor(() => {
+      expect(screen.getByRole("columnheader", { name: "Name" })).toBeTruthy();
+    });
+    expect(screen.queryByRole("columnheader", { name: "Trial" })).toBeNull();
   });
 
   it("opens the organization when the operator clicks the row body", async () => {
@@ -606,6 +677,23 @@ describe("organizations list peek", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual(["Peek", "Name", "Slug", "Type"]);
+  });
+
+  it("takes the trial column down with the rest while it is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    expect(screen.getByRole("columnheader", { name: "Trial" })).toBeTruthy();
+
+    await peekOn(FIRST_ORG.name);
+
+    // Its own test, because the set peek hides is keyed by column id in a
+    // plain string record. Renaming the column leaves a stale key that is
+    // neither a type error nor a failure anywhere else: the column simply
+    // stops hiding, and the panel opens into a table too wide to read.
+    expect(screen.queryByRole("columnheader", { name: "Trial" })).toBeNull();
+
+    fireEvent.keyDown(peekPanel(), { key: "Escape" });
+
+    expect(screen.getByRole("columnheader", { name: "Trial" })).toBeTruthy();
   });
 
   it("highlights the row it is peeking at and no other", async () => {
@@ -723,7 +811,7 @@ describe("organizations list peek", () => {
       "Members",
       "WorkOS",
       "Disabled",
-      "Trial ends",
+      "Trial",
       "Created",
     ]);
   });
@@ -815,7 +903,7 @@ describe("organizations list peek", () => {
       "Members",
       "WorkOS",
       "Disabled",
-      "Trial ends",
+      "Trial",
       "Created",
     ]);
   });

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -231,6 +231,19 @@ function isPeeked(link: HTMLElement): boolean {
   return rowFor(link).classList.contains("bg-muted");
 }
 
+// Sequential navigation order, which is what Tab and Shift+Tab walk. Document
+// order over the nodes the spec puts in that sequence, so a tabindex="-1" node
+// is left out: focusable, and deliberately not a stop.
+const TAB_STOPS = "a[href], button, input, select, textarea, [tabindex]";
+
+function tabStopBefore(target: HTMLElement): HTMLElement | null {
+  const stops = [...document.querySelectorAll<HTMLElement>(TAB_STOPS)].filter(
+    (el) => el.tabIndex >= 0 && !el.hasAttribute("disabled"),
+  );
+  const at = stops.indexOf(target);
+  return at > 0 ? (stops[at - 1] ?? null) : null;
+}
+
 function urlFor(search: Record<string, unknown>): string {
   // The router JSON-encodes a non-string value, so a bookmarked URL is built
   // the same way here rather than hand-written.
@@ -1119,6 +1132,49 @@ describe("organizations list peek", () => {
     expect(isPeeked(first)).toBe(true);
   });
 
+  it("marks the arrow key that moved the peek as answered", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    const panel = peekPanel();
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(panel, event);
+
+    // The mirror of every case that asserts the key was left alone. Moving the
+    // peek and letting the key travel on scrolls the list out from under the
+    // record it just moved to, which is the same eaten-scroll complaint from
+    // the other side.
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("puts the panel in the tab order so the arrow keys stay reachable", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    const panel = peekPanel();
+    const close = within(panel).getByRole("button", { name: "Close peek" });
+
+    // Shift+Tab off Close has to land here. Sequential navigation skips a
+    // tabindex="-1" node, so with the panel out of the order the focus it takes
+    // on mount was the only focus it ever got: one Tab to Close and the record
+    // navigation below was gone for the rest of the panel's life.
+    expect(tabStopBefore(close)).toBe(panel);
+
+    panel.focus();
+    fireEvent.keyDown(panel, { key: "ArrowDown" });
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+    ).toBeTruthy();
+  });
+
   it("ignores the arrow keys pressed on the pager", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
@@ -1263,13 +1319,22 @@ describe("organizations list peek", () => {
     const trigger = await peekOn(FIRST_ORG.name);
     trigger.focus();
 
-    // The exemption has to be this narrow, or closing from the control that
+    // The allow-list has to keep this arm, or closing from the control that
     // opened the panel stops working.
-    fireEvent.keyDown(trigger, { key: "Escape" });
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(trigger, event);
 
     expect(
       screen.queryByRole("complementary", { name: "Organization peek" }),
     ).toBeNull();
+    // Both arms of the allow-list answer the key the same way. Marking one and
+    // not the other leaves the unmarked close travelling on to whatever else
+    // dismisses on Escape.
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("announces a move onto an organization that shares the peeked one's name", async () => {
@@ -1405,22 +1470,86 @@ describe("organizations list peek", () => {
 
   it("leaves the keyboard on the Columns control when a column closes the peek", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const trigger = await peekOn(FIRST_ORG.name);
+    await peekOn(FIRST_ORG.name);
     const columns = screen.getByRole("button", { name: "Columns" });
+    const table = screen.getByRole("region", { name: "Organizations table" });
 
     openOn(columns);
-    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Members" }));
+
+    // Every node focus passes through, not just where it ends up. Radix pulls
+    // the keyboard back to this trigger as the menu closes, which happens after
+    // the page has had its turn, so the end state is the same whatever the page
+    // did in between and asserting only that state asserts Radix.
+    const visited: Node[] = [];
+    const record = (event: FocusEvent): void => {
+      if (event.target instanceof Node) visited.push(event.target);
+    };
+    document.addEventListener("focusin", record);
+    try {
+      fireEvent.click(
+        screen.getByRole("menuitemcheckbox", { name: "Members" }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByRole("columnheader", { name: "Members" }),
+        ).toBeTruthy();
+      });
+    } finally {
+      document.removeEventListener("focusin", record);
+    }
+
+    // An operator's own close puts the keyboard back on the peek control, and
+    // the rescue that catches a peeked record leaving the list puts it on the
+    // table. Either one here drags them out of the menu they are working in,
+    // even for the moment before Radix takes the keyboard back: a screen reader
+    // announces wherever it landed. So the rule is the whole region, not the
+    // two nodes that happen to be reachable from this handler today.
+    expect(visited.filter((node) => table.contains(node))).toEqual([]);
+    expect(document.activeElement).toBe(columns);
+  });
+
+  it("closes the peek to show the Trial column the peek was hiding", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    expect(screen.queryByRole("columnheader", { name: "Trial" })).toBeNull();
+
+    // A second column out of the set, because one member travelling this path
+    // does not show the set travels it. Peek hides five and the menu can write
+    // all five.
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Trial" }));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("columnheader", { name: "Members" }),
-      ).toBeTruthy();
+      expect(screen.getByRole("columnheader", { name: "Trial" })).toBeTruthy();
     });
-    // An operator's own close puts the keyboard back on the peek control.
-    // Doing that here would drag them out of the menu they are working in and
-    // onto a row they were not looking at.
-    expect(document.activeElement).not.toBe(trigger);
-    expect(document.activeElement).toBe(columns);
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    expect(announcement()).toBe("Peek closed to show the Trial column.");
+  });
+
+  it("closes the peek to hide the column the peek was forcing visible", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeTruthy();
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Name" }));
+
+    // The override runs both ways, and this is the other way. Peek is the only
+    // reason Name is on screen, so unchecking it is a request peek is in the
+    // way of just as much as a request to show one it hides. Left unanswered,
+    // the write lands under the override and the column goes when the peek
+    // closes, at a moment the operator cannot connect to this click.
+    await waitFor(() => {
+      expect(screen.queryByRole("columnheader", { name: "Name" })).toBeNull();
+    });
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    // "show" here would be a false sentence, and one wording cannot serve both
+    // directions.
+    expect(announcement()).toBe("Peek closed to hide the Name column.");
   });
 
   it("keeps the peek open for a column the peek was not hiding", async () => {
@@ -1463,6 +1592,22 @@ describe("organizations list peek", () => {
       expect(
         screen.queryByRole("columnheader", { name: "Members" }),
       ).toBeNull();
+    });
+    expect(announcement()).toBe("");
+  });
+
+  it("says nothing about the peek when a column peek never touches is toggled with none open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Slug" }));
+
+    // Neither condition holds: no panel, and a column no panel would override.
+    // The test above it varies only one of the two, so between them a handler
+    // that announced on both being false would have nothing to fail.
+    await waitFor(() => {
+      expect(screen.queryByRole("columnheader", { name: "Slug" })).toBeNull();
     });
     expect(announcement()).toBe("");
   });

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -36,7 +36,7 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   member_count: false,
   workos_id: false,
   disabled_at: false,
-  free_trial_ends_at: false,
+  trial_state: false,
   created_at: false,
 };
 

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -2,13 +2,13 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearch } from "@tanstack/react-router";
 import { useTable, type ColumnVisibilityState } from "@tanstack/react-table";
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
   type JSX,
   type KeyboardEvent,
-  type MouseEvent,
 } from "react";
 
 import { dataTableFeatures, DataTable as Table } from "@/components/data-table";
@@ -24,6 +24,7 @@ import { cn } from "@/lib/utils";
 
 import { ORG_COLUMNS } from "./columns";
 import { PeekPanel } from "./PeekPanel";
+import { PEEK_TRIGGER_SELECTOR, PeekProvider } from "./PeekTrigger";
 import { useOpenOrganization } from "./rowActions";
 import { TableActionBar, Toolbar } from "./Toolbar";
 
@@ -39,19 +40,9 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   created_at: false,
 };
 
-// Mac labels this key Option; everything else calls it Alt.
-const PEEK_KEY = navigator.userAgent.includes("Mac") ? "\u2325 Option" : "Alt";
-
-function PeekHint(): JSX.Element {
-  return (
-    <span className="text-muted-foreground hidden items-center gap-1 text-xs sm:flex">
-      <kbd className="bg-muted rounded border px-1.5 py-0.5 font-sans text-[11px] leading-none">
-        {PEEK_KEY}
-      </kbd>
-      + click a row to peek
-    </span>
-  );
-}
+// Appended to every other announcement so an unchanged sentence still changes
+// the text node. Zero-width, so nothing is spoken and nothing takes up space.
+const ZERO_WIDTH_SPACE = "\u200b";
 
 const ARROW_STEP: Record<string, number | undefined> = {
   ArrowDown: 1,
@@ -79,9 +70,34 @@ export function OrganizationsList(): JSX.Element {
   const [columnVisibility, setColumnVisibility] =
     useState<ColumnVisibilityState>({});
 
-  // An id, not the record: a page or filter change replaces every row.
-  const [peekedId, setPeekedId] = useState<string>();
+  // An id and a name, not the record: a page or filter change replaces every
+  // row, and the panel renders from the live row. The name is carried only to
+  // word the announcement for a record that has already left the list.
+  const [peek, setPeek] = useState<{ id: string; name: string }>();
+  const peekedId = peek?.id;
   const peekedRow = useRef<HTMLTableRowElement>(null);
+  const scrollBox = useRef<HTMLDivElement>(null);
+
+  // Mounted for the life of the page. A live region that arrives in the same
+  // commit as its text is not reliably announced: the element has to be in the
+  // accessibility tree first.
+  //
+  // The count rides along because a region is announced when its text changes.
+  // Organization names are not unique, so the same sentence can be set twice
+  // running; React bails on an equal string, the DOM text never moves, and the
+  // operator hears nothing while the panel visibly swaps records.
+  const [announcement, setAnnouncement] = useState({ text: "", count: 0 });
+
+  // Raised while rendering, read by the effect that rescues the keyboard.
+  const [peekedRecordLeft, setPeekedRecordLeft] = useState(false);
+
+  // Raised by an arrow move that started on a peek control, read by the effect
+  // that follows the peek to the next row's control.
+  const [peekTookTheKeyboard, setPeekTookTheKeyboard] = useState(false);
+
+  const announce = useCallback((text: string): void => {
+    setAnnouncement((previous) => ({ text, count: previous.count + 1 }));
+  }, []);
 
   // One object is the source of both the request and the signature below. Two
   // hand-written lists drift: a slice that adds a filter to the request would
@@ -165,34 +181,90 @@ export function OrganizationsList(): JSX.Element {
   const peeked = peekedIndex === -1 ? undefined : rows[peekedIndex];
 
   // During render, not in an effect: an effect paints a dropped record first.
-  if (peekedId && !peeked) {
-    setPeekedId(undefined);
+  if (peek && !peeked) {
+    setPeek(undefined);
+    announce(`Peek closed. ${peek.name} is no longer in the list.`);
+    setPeekedRecordLeft(true);
   }
 
   useEffect(() => {
     peekedRow.current?.scrollIntoView({ block: "nearest" });
   }, [peekedId]);
 
-  const closePeek = (): void => {
-    const link = peekedRow.current?.querySelector("a");
-    setPeekedId(undefined);
-    link?.focus();
-  };
-
-  const handleRowClick = (
-    org: AdminOrganization,
-    event: MouseEvent<HTMLTableRowElement>,
-  ): void => {
-    // Alt, not Meta (the browser's open-in-new-tab) and not Shift (range select).
-    if (event.altKey) {
-      setPeekedId(org.id);
-      return;
+  useEffect(() => {
+    if (!peekedRecordLeft) return;
+    setPeekedRecordLeft(false);
+    // Only where the panel took its focus down with it. An operator who paged
+    // or filtered the record away is already on a live control, and taking
+    // their place in the page is worse than the bug this rescues.
+    if (document.activeElement === document.body) {
+      scrollBox.current?.focus();
     }
-    openOrganization(org);
-  };
+  }, [peekedRecordLeft]);
+
+  // After the commit, because the row the peek moved to is drawn in it and the
+  // ref only points at that row once it is. Same lookup the close path makes,
+  // through the peeked row rather than across the page.
+  //
+  // A screen reader announces the control focus lands on, which repeats what
+  // the live region is politely saying at the same moment. The repeat is
+  // wanted: the two carry the same organization name, so whichever one the
+  // reader drops, the operator still hears where the panel went.
+  useEffect(() => {
+    if (!peekTookTheKeyboard) return;
+    setPeekTookTheKeyboard(false);
+    peekedRow.current
+      ?.querySelector<HTMLElement>(PEEK_TRIGGER_SELECTOR)
+      ?.focus();
+  }, [peekTookTheKeyboard]);
+
+  const closePeek = useCallback((): void => {
+    const trigger = peekedRow.current?.querySelector<HTMLElement>(
+      PEEK_TRIGGER_SELECTOR,
+    );
+    setPeek(undefined);
+    announce("Peek closed.");
+    trigger?.focus();
+  }, [announce]);
+
+  const openPeek = useCallback(
+    (org: AdminOrganization): void => {
+      setPeek({ id: org.id, name: org.name });
+      announce(`Peeking at ${org.name}.`);
+    },
+    [announce],
+  );
+
+  const togglePeek = useCallback(
+    (org: AdminOrganization): void => {
+      if (peekedId === org.id) {
+        closePeek();
+        return;
+      }
+      openPeek(org);
+    },
+    [peekedId, closePeek, openPeek],
+  );
+
+  const peekControls = useMemo(
+    () => ({ peekedId, togglePeek }),
+    [peekedId, togglePeek],
+  );
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (!peeked || event.defaultPrevented) return;
+
+    // Every row's peek control sits under this handler. An arrow key pressed
+    // on one of them is a reflex to scroll, and answering it moves the panel
+    // to a row the operator is not on, eats the scroll, and leaves them
+    // standing on a control that still reports itself closed. Escape there
+    // would drag the keyboard back to the peeked row. The peeked row's own
+    // control is exempt: that one is the panel's control.
+    const fromTrigger =
+      event.target instanceof HTMLElement
+        ? event.target.closest(PEEK_TRIGGER_SELECTOR)
+        : null;
+    if (fromTrigger && !peekedRow.current?.contains(fromTrigger)) return;
 
     if (event.key === "Escape") {
       event.preventDefault();
@@ -206,7 +278,16 @@ export function OrganizationsList(): JSX.Element {
     const next = rows[peekedIndex + step];
     if (!next) return;
     event.preventDefault();
-    setPeekedId(next.id);
+    openPeek(next.original);
+    // Only where the operator was already on a control. The peek moves out
+    // from under this one, and the exemption above is written in terms of the
+    // peeked row, so leaving the keyboard behind would strand it on a control
+    // that answers neither the arrow keys nor Escape.
+    //
+    // Focus stays put for anyone arrowing from inside the panel. That is the
+    // panel's own navigation, and pulling the keyboard out to a row control
+    // would take the operator off the record they are reading.
+    if (fromTrigger) setPeekTookTheKeyboard(true);
   };
 
   return (
@@ -222,75 +303,103 @@ export function OrganizationsList(): JSX.Element {
           </div>
         )}
 
-        {/* Stretch, so the panel takes its height from the row. */}
-        <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
-              <TableActionBar table={table} hint={<PeekHint />} />
+        {/* The only thing that speaks when the arrow keys swap the record under
+            a panel that already holds the focus.
 
-              <div
-                className={cn(
-                  "min-h-0 flex-1 overflow-auto",
-                  isPlaceholderData && "opacity-60",
-                )}
-              >
-                <Table>
-                  <Table.Header table={table} />
-                  <Table.Body>
-                    {rows.length === 0 ? (
-                      <Table.NoResultsMessage>
-                        <span className="text-muted-foreground text-sm">
-                          {emptyStateMessage(isLoading, isError)}
-                        </span>
-                      </Table.NoResultsMessage>
-                    ) : (
-                      rows.map((row) => {
-                        const isPeeked = row.id === peekedId;
-                        return (
-                          <Table.Row
-                            key={row.id}
-                            row={row}
-                            ref={isPeeked ? peekedRow : undefined}
-                            className={cn(isPeeked && "bg-muted")}
-                            onClick={handleRowClick}
-                          />
-                        );
-                      })
-                    )}
-                  </Table.Body>
-                </Table>
+            `aria-live` is written out as well as implied by the role: a few
+            screen readers only honour the attribute. The zero-width space
+            alternates with the count so that a sentence set twice running
+            still reaches the accessibility tree as a change. It is not
+            announced, and it is not rendered anywhere a sighted operator
+            reads. */}
+        <div role="status" aria-live="polite" className="sr-only">
+          {announcement.text}
+          {announcement.count % 2 === 1 ? ZERO_WIDTH_SPACE : ""}
+        </div>
+
+        <PeekProvider value={peekControls}>
+          {/* Stretch, so the panel takes its height from the row. */}
+          <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+              <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
+                <TableActionBar table={table} />
+
+                <div
+                  ref={scrollBox}
+                  // Named, because this is where the keyboard lands when the
+                  // peeked record leaves the list with the panel holding the
+                  // focus. An unnamed div would put the operator somewhere
+                  // their screen reader cannot describe.
+                  role="region"
+                  aria-label="Organizations table"
+                  // Programmatic only: -1 takes the box out of the tab order
+                  // and still lets that rescue focus it. The focus ring stays,
+                  // because nothing else on screen moves when focus arrives
+                  // here and the ring is the only sign that it did.
+                  tabIndex={-1}
+                  className={cn(
+                    "min-h-0 flex-1 overflow-auto",
+                    isPlaceholderData && "opacity-60",
+                  )}
+                >
+                  <Table>
+                    <Table.Header table={table} />
+                    <Table.Body>
+                      {rows.length === 0 ? (
+                        <Table.NoResultsMessage>
+                          <span className="text-muted-foreground text-sm">
+                            {emptyStateMessage(isLoading, isError)}
+                          </span>
+                        </Table.NoResultsMessage>
+                      ) : (
+                        rows.map((row) => {
+                          const isPeeked = row.id === peekedId;
+                          return (
+                            <Table.Row
+                              key={row.id}
+                              row={row}
+                              ref={isPeeked ? peekedRow : undefined}
+                              className={cn(isPeeked && "bg-muted")}
+                              onClick={openOrganization}
+                            />
+                          );
+                        })
+                      )}
+                    </Table.Body>
+                  </Table>
+                </div>
+              </div>
+
+              {/* Inside the table's column, so it does not run under the panel. */}
+              <div className="mt-3 flex items-center justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={isPlaceholderData || pager.stack.length === 0}
+                  onClick={goPrev}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={isPlaceholderData || !data?.next_cursor}
+                  onClick={goNext}
+                >
+                  Next
+                </Button>
               </div>
             </div>
 
-            {/* Inside the table's column, so it does not run under the panel. */}
-            <div className="mt-3 flex items-center justify-end gap-2">
-              <Button
-                variant="ghost"
-                size="xs"
-                disabled={isPlaceholderData || pager.stack.length === 0}
-                onClick={goPrev}
-              >
-                Previous
-              </Button>
-              <Button
-                variant="ghost"
-                size="xs"
-                disabled={isPlaceholderData || !data?.next_cursor}
-                onClick={goNext}
-              >
-                Next
-              </Button>
-            </div>
+            {peeked ? (
+              <PeekPanel
+                org={peeked.original}
+                onClose={closePeek}
+                className="w-100 shrink-0"
+              />
+            ) : null}
           </div>
-
-          {peeked ? (
-            <PeekPanel
-              org={peeked.original}
-              onClose={closePeek}
-              className="w-100 shrink-0"
-            />
-          ) : null}
-        </div>
+        </PeekProvider>
       </section>
     </div>
   );

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -76,6 +76,7 @@ export function OrganizationsList(): JSX.Element {
   const [peek, setPeek] = useState<{ id: string; name: string }>();
   const peekedId = peek?.id;
   const peekedRow = useRef<HTMLTableRowElement>(null);
+  const peekPanel = useRef<HTMLElement>(null);
   const scrollBox = useRef<HTMLDivElement>(null);
 
   // Mounted for the life of the page. A live region that arrives in the same
@@ -254,17 +255,23 @@ export function OrganizationsList(): JSX.Element {
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (!peeked || event.defaultPrevented) return;
 
-    // Every row's peek control sits under this handler. An arrow key pressed
-    // on one of them is a reflex to scroll, and answering it moves the panel
-    // to a row the operator is not on, eats the scroll, and leaves them
-    // standing on a control that still reports itself closed. Escape there
-    // would drag the keyboard back to the peeked row. The peeked row's own
-    // control is exempt: that one is the panel's control.
+    // Two controls answer here, and everything else under this handler keeps
+    // its own keys: the pager, another row's peek control, a button in the
+    // panel body. An arrow key on one of those is a reflex to scroll, and
+    // answering it moves the panel to a record the operator is not on and eats
+    // the scroll on the way. Escape on one of them would drag the keyboard
+    // back to the peeked row.
+    //
+    // The panel container, not its contents: a control in the panel body is
+    // the case above, so admitting the whole subtree would fix nothing.
     const fromTrigger =
       event.target instanceof HTMLElement
         ? event.target.closest(PEEK_TRIGGER_SELECTOR)
         : null;
-    if (fromTrigger && !peekedRow.current?.contains(fromTrigger)) return;
+    const fromPeekedTrigger =
+      fromTrigger !== null && peekedRow.current?.contains(fromTrigger) === true;
+    const fromPanel = event.target === peekPanel.current;
+    if (!fromPeekedTrigger && !fromPanel) return;
 
     if (event.key === "Escape") {
       event.preventDefault();
@@ -280,14 +287,14 @@ export function OrganizationsList(): JSX.Element {
     event.preventDefault();
     openPeek(next.original);
     // Only where the operator was already on a control. The peek moves out
-    // from under this one, and the exemption above is written in terms of the
+    // from under this one, and the allow-list above is written in terms of the
     // peeked row, so leaving the keyboard behind would strand it on a control
     // that answers neither the arrow keys nor Escape.
     //
-    // Focus stays put for anyone arrowing from inside the panel. That is the
-    // panel's own navigation, and pulling the keyboard out to a row control
-    // would take the operator off the record they are reading.
-    if (fromTrigger) setPeekTookTheKeyboard(true);
+    // Focus stays put for anyone arrowing from the panel. That is the panel's
+    // own navigation, and pulling the keyboard out to a row control would take
+    // the operator off the record they are reading.
+    if (fromPeekedTrigger) setPeekTookTheKeyboard(true);
   };
 
   return (
@@ -393,6 +400,7 @@ export function OrganizationsList(): JSX.Element {
 
             {peeked ? (
               <PeekPanel
+                ref={peekPanel}
                 org={peeked.original}
                 onClose={closePeek}
                 className="w-100 shrink-0"

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -252,6 +252,24 @@ export function OrganizationsList(): JSX.Element {
     [peekedId, togglePeek],
   );
 
+  // Peek narrows the table, so a column it hides is one this menu can write
+  // and nothing on screen answers: the checkbox snaps back with no column, no
+  // refusal and no reason. Checking a column is an unambiguous request to see
+  // it, so the panel gives way rather than the request. The column arrives in
+  // the commit the panel leaves in, which is the whole explanation, and
+  // reopening peek is one click.
+  //
+  // The keyboard is left where it is. The operator is in the Columns menu, and
+  // Radix puts them back on its trigger as it closes.
+  const handleColumnToggled = useCallback(
+    (columnId: string, label: string): void => {
+      if (!peekedId || !(columnId in PEEK_HIDDEN_COLUMNS)) return;
+      setPeek(undefined);
+      announce(`Peek closed to show the ${label} column.`);
+    },
+    [peekedId, announce],
+  );
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (!peeked || event.defaultPrevented) return;
 
@@ -329,7 +347,10 @@ export function OrganizationsList(): JSX.Element {
           <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
             <div className="flex min-h-0 min-w-0 flex-1 flex-col">
               <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
-                <TableActionBar table={table} />
+                <TableActionBar
+                  table={table}
+                  onColumnToggled={handleColumnToggled}
+                />
 
                 <div
                   ref={scrollBox}

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -271,27 +271,31 @@ export function OrganizationsList(): JSX.Element {
   );
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    // Ahead of both allow-lists below. Radix calls preventDefault when it
+    // handles Escape itself, so a tooltip or a popover opened from inside the
+    // panel takes the first Escape and the panel does not close underneath it.
     if (!peeked || event.defaultPrevented) return;
 
-    // Two controls answer here, and everything else under this handler keeps
-    // its own keys: the pager, another row's peek control, a button in the
-    // panel body. An arrow key on one of those is a reflex to scroll, and
-    // answering it moves the panel to a record the operator is not on and eats
-    // the scroll on the way. Escape on one of them would drag the keyboard
-    // back to the peeked row.
-    //
-    // The panel container, not its contents: a control in the panel body is
-    // the case above, so admitting the whole subtree would fix nothing.
+    // Nothing else under this handler answers either key. The pager and another
+    // row's peek control keep their own, and the two keys below are scoped
+    // separately because they fail in different ways.
     const fromTrigger =
       event.target instanceof HTMLElement
         ? event.target.closest(PEEK_TRIGGER_SELECTOR)
         : null;
     const fromPeekedTrigger =
       fromTrigger !== null && peekedRow.current?.contains(fromTrigger) === true;
-    const fromPanel = event.target === peekPanel.current;
-    if (!fromPeekedTrigger && !fromPanel) return;
 
     if (event.key === "Escape") {
+      // The whole panel, its contents included. Escape has no reflex of its own
+      // for the panel to steal, and it is the dismiss gesture for whichever
+      // surface holds focus, so a button in the panel body has to answer it.
+      // Closing does not drop the keyboard: closePeek moves it to the peeked
+      // row's control, off the subtree that is about to unmount.
+      const insidePanel =
+        event.target instanceof HTMLElement &&
+        peekPanel.current?.contains(event.target) === true;
+      if (!fromPeekedTrigger && !insidePanel) return;
       event.preventDefault();
       closePeek();
       return;
@@ -299,15 +303,20 @@ export function OrganizationsList(): JSX.Element {
 
     const step = ARROW_STEP[event.key];
     if (!step) return;
+    // The panel container only, not its contents. An arrow key on a button in
+    // the panel body is a reflex to scroll, and answering it would move the
+    // panel to a record the operator is not on and eat the scroll on the way.
+    const fromPanel = event.target === peekPanel.current;
+    if (!fromPeekedTrigger && !fromPanel) return;
     // Stop at the ends: paging replaces the row nodes the anchor depends on.
     const next = rows[peekedIndex + step];
     if (!next) return;
     event.preventDefault();
     openPeek(next.original);
     // Only where the operator was already on a control. The peek moves out
-    // from under this one, and the allow-list above is written in terms of the
-    // peeked row, so leaving the keyboard behind would strand it on a control
-    // that answers neither the arrow keys nor Escape.
+    // from under this one, and the arrow allow-list above is written in terms
+    // of the peeked row, so leaving the keyboard behind would strand it on a
+    // control that answers neither the arrow keys nor Escape.
     //
     // Focus stays put for anyone arrowing from the panel. That is the panel's
     // own navigation, and pulling the keyboard out to a row control would take

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -40,6 +40,16 @@ const PEEK_HIDDEN_COLUMNS: ColumnVisibilityState = {
   created_at: false,
 };
 
+// Every column peek overrides while it is open, and the value it forces. The
+// table's visibility and the Columns menu's guard both read this one map, so
+// they cannot disagree about the set: a guard naming only the hidden half
+// answers only half the writes the menu cannot satisfy, and the other half land
+// and take effect later, when the peek closes.
+const PEEK_COLUMN_OVERRIDES: ColumnVisibilityState = {
+  ...PEEK_HIDDEN_COLUMNS,
+  name: true,
+};
+
 // Appended to every other announcement so an unchanged sentence still changes
 // the text node. Zero-width, so nothing is spoken and nothing takes up space.
 const ZERO_WIDTH_SPACE = "\u200b";
@@ -159,7 +169,7 @@ export function OrganizationsList(): JSX.Element {
   const effectiveVisibility = useMemo(
     () =>
       peekedId
-        ? { ...columnVisibility, ...PEEK_HIDDEN_COLUMNS, name: true }
+        ? { ...columnVisibility, ...PEEK_COLUMN_OVERRIDES }
         : columnVisibility,
     [peekedId, columnVisibility],
   );
@@ -252,20 +262,32 @@ export function OrganizationsList(): JSX.Element {
     [peekedId, togglePeek],
   );
 
-  // Peek narrows the table, so a column it hides is one this menu can write
-  // and nothing on screen answers: the checkbox snaps back with no column, no
-  // refusal and no reason. Checking a column is an unambiguous request to see
-  // it, so the panel gives way rather than the request. The column arrives in
-  // the commit the panel leaves in, which is the whole explanation, and
-  // reopening peek is one click.
+  // Peek overrides these columns, so a write the menu makes to one of them is a
+  // write nothing on screen answers: the checkbox snaps back with no column, no
+  // refusal and no reason. Toggling a column is an unambiguous request about
+  // that column, so the panel gives way rather than the request. The column
+  // arrives in the commit the panel leaves in, which is the whole explanation,
+  // and reopening peek is one click.
+  //
+  // Both directions, because peek forces some columns off and Name on. The
+  // operator unchecking Name is asking to hide it, and refusing that one is the
+  // worse half: the write lands under the override and detonates later, when
+  // the peek closes and the column the row is anchored on disappears at a
+  // moment the operator has no reason to connect to the click.
   //
   // The keyboard is left where it is. The operator is in the Columns menu, and
   // Radix puts them back on its trigger as it closes.
   const handleColumnToggled = useCallback(
     (columnId: string, label: string): void => {
-      if (!peekedId || !(columnId in PEEK_HIDDEN_COLUMNS)) return;
+      if (!peekedId || !Object.hasOwn(PEEK_COLUMN_OVERRIDES, columnId)) return;
       setPeek(undefined);
-      announce(`Peek closed to show the ${label} column.`);
+      // Which way the operator was asking. Peek forcing the column visible
+      // means the request was to hide it, and one wording for both is false
+      // half the time.
+      const wasForcedVisible = PEEK_COLUMN_OVERRIDES[columnId] === true;
+      announce(
+        `Peek closed to ${wasForcedVisible ? "hide" : "show"} the ${label} column.`,
+      );
     },
     [peekedId, announce],
   );
@@ -321,6 +343,10 @@ export function OrganizationsList(): JSX.Element {
     // Focus stays put for anyone arrowing from the panel. That is the panel's
     // own navigation, and pulling the keyboard out to a row control would take
     // the operator off the record they are reading.
+    //
+    // Reading only: the arrow allow-list already turned every other trigger
+    // away, and the panel is not one, so a non-null fromTrigger here is the
+    // peeked row's. Named for the reader rather than to change the set.
     if (fromPeekedTrigger) setPeekTookTheKeyboard(true);
   };
 

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -6,7 +6,9 @@ import { organizationQuery } from "@/lib/adminQueries";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 
 // The row's own behavior lives here, so the slices that add a row menu, a
-// disable action and a trial extension all land in one file.
+// disable action and a trial extension all land in one file. The peek control
+// is a component, and a file that mixes a hook with components loses fast
+// refresh, so it sits in `PeekTrigger.tsx` instead.
 export function useOpenOrganization(): (org: AdminOrganization) => void {
   const navigate = useNavigate();
   const qc = useQueryClient();


### PR DESCRIPTION
Three pre-existing ways the organizations list left a keyboard operator without an answer while the peek panel was open, found while reviewing the peek trigger work rather than reported.

AGE-3206.

## What was wrong

**The panel answered keys meant for other controls.** The keydown handler above the table was allow-by-default. It bailed out only for a peek control belonging to some other row, so Arrow Down from the pager, or from a button inside the panel body, walked the panel to a record the operator was not on and called `preventDefault` on the way, eating the scroll they pressed the key for.

**The panel was unreachable after the first Tab.** At `tabindex="-1"` the focus it took on mount was the only focus it could get, because sequential navigation skips a `-1` node. One Tab to Close and record navigation was gone for the rest of the panel's life.

**The Columns menu did nothing an operator could see.** Peek overrides six columns while it is open: it hides five and forces Name on. A menu click on any of the six landed under the override, so the checkbox snapped back with no column, no refusal and no `aria-disabled` to say the action had been dropped. Unchecking Name was the worse half, because that write took effect **later**, when the peek closed and the column the row is anchored on disappeared at a moment the operator has no reason to connect to the click.

## What changed

The arrow keys and Escape are scoped separately, because they fail differently. Arrows reach the panel container and the peeked row's own control, and nothing else. Escape reaches the whole panel including the buttons in its body, because it has no scrolling of its own to lose and it dismisses whichever surface holds focus. The `defaultPrevented` guard stays ahead of both, so a tooltip or popover opened from inside the panel takes the first Escape rather than the panel closing underneath it.

The panel joins the tab order and keeps its focus ring.

The action bar reports a landed toggle and the page decides what to do with it, so the bar keeps no knowledge of peek. Toggling any overridden column closes the panel and applies the change in the same commit, and announces which way it went. One `PEEK_COLUMN_OVERRIDES` map is read by both the table's visibility and the menu's guard, so the two cannot disagree about the set. That is the actual fix for the Name half: the first guard named only the hidden constant and so answered only half the writes it could not satisfy.

## Verification

- `type-check`, `lint:oxlint`, `test` (120 passing in 8 files) and `build` all clean.
- A mutation sweep ran on the fixes, with three deliberate canaries that survived, so the harness is honest rather than silently green.
- The focus behaviour is pinned three ways: dropping the focus move, sending focus to the scroll box, and sending it to the panel each fail four tests. That assertion was **unfalsifiable in the first attempt** and rewriting it is why the sweep listed all three.

## One declared gap

The focus ring cannot be observed in this test environment. happy-dom does not lay out or paint, so the only available assertion is that a class string lacks `outline-none`, which pins the source rather than the behaviour and would report coverage it does not have. Reverting `outline-none` therefore survives the sweep, and this says so rather than papering over it with an assertion that cannot fail. Pinning it needs a browser-level check, which is not this slice.

## Stacked

Base is `walker/age-3189-peek-trigger` (#5287), not `main`.

`hygiene.yaml` filters on base `main`, so **the PR title lint, the changeset lint and the migration check do not run here.** Do not read the short check list as a pass. All three were verified by hand: every commit and this title carry a `fix:`/`chore:` prefix, `.changeset/admin-organizations-peek-keyboard.md` targets `admin` and describes user-facing behaviour, and there are no migrations in this diff. `pr.yaml` has no branch filter, so the tests and lint that do appear are real evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard handling and Columns menu behavior on the admin organizations list while peek is open. Before: the panel hijacked Arrow keys and Escape from unrelated controls, was unreachable via Tab, and the Columns menu silently dropped toggles for peek-overridden columns (with unchecking Name applying later). Now: Arrow keys only move peek from the panel container or the peeked row’s trigger; Escape closes from inside the panel (or the peeked trigger) but not from the pager; the panel is tabbable with a visible focus ring; and toggling any overridden column closes peek and applies immediately with an announcement.

- Key handling: allow-list per key; ArrowUp/Down accepted only from the panel container or the peeked trigger; Escape accepted from the peek subtree or the peeked trigger, ignored on the pager; guard on defaultPrevented so nested popovers take Escape first; closing marks the event prevented and returns focus to the row’s peek trigger.
- Focus: `PeekPanel` is tabIndex=0 with a visible ring and now accepts an optional ref so the list can distinguish the panel container from its contents.
- Columns: one `PEEK_COLUMN_OVERRIDES` map drives table visibility and menu guard (tests membership with Object.hasOwn); `TableActionBar` emits optional onColumnToggled(columnId, label) only when a toggle lands; the page closes peek and announces hide/show for overridden columns; keyboard stays on the Columns trigger; other `TableActionBar` consumers are unchanged unless they pass the callback.
- Tests pin key scopes, defaultPrevented marks, announcements, and focus paths; no data migrations. Linear: AGE-3206.

<sup>Written for commit 31852ca15ae8075fabc8a23432b612f76bc49a1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

