### PR TITLE
feat(admin): extend a running enterprise trial

### DIFF
--- a/.changeset/admin-extend-trial.md
+++ b/.changeset/admin-extend-trial.md
@@ -1,0 +1,23 @@
+---
+"server": patch
+---
+
+Platform admins can now give a customer more time on a running enterprise trial.
+Until now the trial end date was written once, when the trial was granted, and
+nothing anywhere could move it, so an operator who wanted to buy a customer
+another two weeks had no way to do it.
+
+The extension is added to the trial's current end date rather than to today, so
+"another two weeks" means two weeks on top of whatever the customer has left,
+and extending a trial that still has three weeks to run cannot accidentally
+shorten it. Extensions accumulate, and a single one is capped at a year.
+
+Only a running trial can be extended. A trial that has already converted to a
+contract, one that has been demoted, and one whose date has passed but that the
+expiry sweeper has not reached yet are all rejected with an error that leaves the
+date where it was, rather than quietly re-arming a trial that has already ended.
+Extending a trial changes the end date and nothing else: the organization's
+account type, its whitelist flag and the record of when the trial began all stay
+as they were.
+
+The admin dashboard row action follows.

--- a/.changeset/admin-extend-trial.md
+++ b/.changeset/admin-extend-trial.md
@@ -16,6 +16,9 @@ Only a running trial can be extended. A trial that has already converted to a
 contract, one that has been demoted, and one whose date has passed but that the
 expiry sweeper has not reached yet are all rejected with an error that leaves the
 date where it was, rather than quietly re-arming a trial that has already ended.
+An organization id that matches nothing is reported as not found, the same answer
+the disable and enable actions already give, so one mistyped id does not send an
+operator off to inspect a trial that was never the problem.
 Extending a trial changes the end date and nothing else: the organization's
 account type, its whitelist flag and the record of when the trial began all stay
 as they were.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -60176,6 +60176,22 @@ components:
       required:
         - ok
         - error
+    ExtendTrialRequestBody:
+      type: object
+      properties:
+        days:
+          type: integer
+          description: Number of days to add to the trial's current end date.
+          format: int64
+          minimum: 1
+          maximum: 365
+        id:
+          type: string
+          description: Organization ID.
+          minLength: 1
+      required:
+        - id
+        - days
     ExternalCredentialSummary:
       type: object
       properties:

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -390,7 +390,7 @@ var _ = Service("admin", func() {
 		Payload(func() {
 			security.AdminAuthPayload()
 
-			Attribute("q", String, "Search term applied to name and slug (case-insensitive substring).")
+			Attribute("q", String, "Search term. Matches name and slug as a case-insensitive substring, and organization id and WorkOS id exactly.")
 			Attribute("account_type", String, "Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.")
 			Attribute("account_types", ArrayOf(String), "Match any of these gram_account_type values. Empty matches every account type. A value no organization carries matches nothing rather than failing the request.")
 			Attribute("trial_states", ArrayOf(String), "Match any of running, ending_soon, expired, demoted, converted or none. Empty matches every trial state. An unrecognised value matches nothing rather than failing the request.")
@@ -424,5 +424,34 @@ var _ = Service("admin", func() {
 
 		shared.CursorPagination()
 		Meta("openapi:operationId", "adminListOrganizations")
+	})
+
+	// Declared last on purpose. Goa names response body types after their
+	// position in this block, so inserting a method in the middle renames every
+	// generated type below it and buries the real change in positional churn.
+	Method("extendTrial", func() {
+		Description("Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("id", "days")
+
+			Attribute("id", String, "Organization ID.", func() {
+				MinLength(1)
+			})
+			Attribute("days", Int, "Number of days to add to the trial's current end date.", func() {
+				Minimum(constants.MinTrialExtensionDays)
+				Maximum(constants.MaxTrialExtensionDays)
+			})
+		})
+
+		Result(AdminOrganization)
+
+		HTTP(func() {
+			POST("/admin/trial.extend")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminExtendTrial")
 	})
 })

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -390,7 +390,7 @@ var _ = Service("admin", func() {
 		Payload(func() {
 			security.AdminAuthPayload()
 
-			Attribute("q", String, "Search term. Matches name and slug as a case-insensitive substring, and organization id and WorkOS id exactly.")
+			Attribute("q", String, "Search term applied to name and slug (case-insensitive substring).")
 			Attribute("account_type", String, "Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.")
 			Attribute("account_types", ArrayOf(String), "Match any of these gram_account_type values. Empty matches every account type. A value no organization carries matches nothing rather than failing the request.")
 			Attribute("trial_states", ArrayOf(String), "Match any of running, ending_soon, expired, demoted, converted or none. Empty matches every trial state. An unrecognised value matches nothing rather than failing the request.")

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -426,9 +426,18 @@ var _ = Service("admin", func() {
 		Meta("openapi:operationId", "adminListOrganizations")
 	})
 
-	// Declared last on purpose. Goa names response body types after their
-	// position in this block, so inserting a method in the middle renames every
-	// generated type below it and buries the real change in positional churn.
+	// Appended rather than inserted mid-block, and that is a diff-size choice
+	// and nothing more. Generated type names come from the method name, so
+	// position cannot rename anything; appending only keeps goa from reordering
+	// the declarations below it. Measured on this change, appending cost 19
+	// deleted lines under server/gen where the disable and enable slice's
+	// mid-block insert churned 3777 lines of types.go.
+	//
+	// The one positional effect that is real is the one disableOrganization
+	// above documents: the OpenAPI emitter deduplicates structurally identical
+	// request bodies and names the shared schema after whichever method it met
+	// first. This payload's {id, days} shape is unique, so it needs no
+	// openapi:typename.
 	Method("extendTrial", func() {
 		Description("Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.")
 

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -26,10 +26,11 @@ type Client struct {
 	ListOrganizationMembersEndpoint  goa.Endpoint
 	ListOrganizationProjectsEndpoint goa.Endpoint
 	ListOrganizationsEndpoint        goa.Endpoint
+	ExtendTrialEndpoint              goa.Endpoint
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
@@ -42,6 +43,7 @@ func NewClient(login, callback, logout, getProject, updateOrganization, disableO
 		ListOrganizationMembersEndpoint:  listOrganizationMembers,
 		ListOrganizationProjectsEndpoint: listOrganizationProjects,
 		ListOrganizationsEndpoint:        listOrganizations,
+		ExtendTrialEndpoint:              extendTrial,
 	}
 }
 
@@ -287,4 +289,26 @@ func (c *Client) ListOrganizations(ctx context.Context, p *ListOrganizationsPayl
 		return
 	}
 	return ires.(*AdminListOrganizationsResult), nil
+}
+
+// ExtendTrial calls the "extendTrial" endpoint of the "admin" service.
+// ExtendTrial may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) ExtendTrial(ctx context.Context, p *ExtendTrialPayload) (res *AdminOrganization, err error) {
+	var ires any
+	ires, err = c.ExtendTrialEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminOrganization), nil
 }

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -27,6 +27,7 @@ type Endpoints struct {
 	ListOrganizationMembers  goa.Endpoint
 	ListOrganizationProjects goa.Endpoint
 	ListOrganizations        goa.Endpoint
+	ExtendTrial              goa.Endpoint
 }
 
 // NewEndpoints wraps the methods of the "admin" service with endpoints.
@@ -45,6 +46,7 @@ func NewEndpoints(s Service) *Endpoints {
 		ListOrganizationMembers:  NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
 		ListOrganizationProjects: NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
 		ListOrganizations:        NewListOrganizationsEndpoint(s, a.APIKeyAuth),
+		ExtendTrial:              NewExtendTrialEndpoint(s, a.APIKeyAuth),
 	}
 }
 
@@ -61,6 +63,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.ListOrganizationMembers = m(e.ListOrganizationMembers)
 	e.ListOrganizationProjects = m(e.ListOrganizationProjects)
 	e.ListOrganizations = m(e.ListOrganizations)
+	e.ExtendTrial = m(e.ExtendTrial)
 }
 
 // NewLoginEndpoint returns an endpoint function that calls the method "login"
@@ -271,5 +274,28 @@ func NewListOrganizationsEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFun
 			return nil, err
 		}
 		return s.ListOrganizations(ctx, p)
+	}
+}
+
+// NewExtendTrialEndpoint returns an endpoint function that calls the method
+// "extendTrial" of service "admin".
+func NewExtendTrialEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*ExtendTrialPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.ExtendTrial(ctx, p)
 	}
 }

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -43,6 +43,10 @@ type Service interface {
 	ListOrganizationProjects(context.Context, *ListOrganizationProjectsPayload) (res *AdminListOrganizationProjectsResult, err error)
 	// Lists organizations for admin operations with optional search and filters.
 	ListOrganizations(context.Context, *ListOrganizationsPayload) (res *AdminListOrganizationsResult, err error)
+	// Extends a running enterprise trial by adding days to its current end date.
+	// Only a running trial can be extended: one that has converted, has been
+	// demoted, or has already expired is rejected rather than re-armed.
+	ExtendTrial(context.Context, *ExtendTrialPayload) (res *AdminOrganization, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.
@@ -65,7 +69,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [11]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations"}
+var MethodNames = [12]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial"}
 
 // AdminListOrganizationMembersResult is the result type of the admin service
 // listOrganizationMembers method.
@@ -224,6 +228,16 @@ type EnableOrganizationPayload struct {
 	ID string
 }
 
+// ExtendTrialPayload is the payload type of the admin service extendTrial
+// method.
+type ExtendTrialPayload struct {
+	AdminSessionToken *string
+	// Organization ID.
+	ID string
+	// Number of days to add to the trial's current end date.
+	Days int
+}
+
 // GetOrganizationPayload is the payload type of the admin service
 // getOrganization method.
 type GetOrganizationPayload struct {
@@ -259,7 +273,8 @@ type ListOrganizationProjectsPayload struct {
 // listOrganizations method.
 type ListOrganizationsPayload struct {
 	AdminSessionToken *string
-	// Search term applied to name and slug (case-insensitive substring).
+	// Search term. Matches name and slug as a case-insensitive substring, and
+	// organization id and WorkOS id exactly.
 	Q *string
 	// Filter by a single gram_account_type (e.g. free, pro, enterprise).
 	// Superseded by account_types, which it joins as one more member of the same

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -273,8 +273,7 @@ type ListOrganizationProjectsPayload struct {
 // listOrganizations method.
 type ListOrganizationsPayload struct {
 	AdminSessionToken *string
-	// Search term. Matches name and slug as a case-insensitive substring, and
-	// organization id and WorkOS id exactly.
+	// Search term applied to name and slug (case-insensitive substring).
 	Q *string
 	// Filter by a single gram_account_type (e.g. free, pro, enterprise).
 	// Superseded by account_types, which it joins as one more member of the same

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -382,3 +382,41 @@ func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrga
 
 	return v, nil
 }
+
+// BuildExtendTrialPayload builds the payload for the admin extendTrial
+// endpoint from CLI flags.
+func BuildExtendTrialPayload(adminExtendTrialBody string, adminExtendTrialAdminSessionToken string) (*admin.ExtendTrialPayload, error) {
+	var err error
+	var body ExtendTrialRequestBody
+	{
+		err = json.Unmarshal([]byte(adminExtendTrialBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"days\": 2,\n      \"id\": \"aa\"\n   }'")
+		}
+		if utf8.RuneCountInString(body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", body.ID, utf8.RuneCountInString(body.ID), 1, true))
+		}
+		if body.Days < 1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", body.Days, 1, true))
+		}
+		if body.Days > 365 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", body.Days, 365, false))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminExtendTrialAdminSessionToken != "" {
+			adminSessionToken = &adminExtendTrialAdminSessionToken
+		}
+	}
+	v := &admin.ExtendTrialPayload{
+		ID:   body.ID,
+		Days: body.Days,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -59,6 +59,10 @@ type Client struct {
 	// listOrganizations endpoint.
 	ListOrganizationsDoer goahttp.Doer
 
+	// ExtendTrial Doer is the HTTP client used to make requests to the extendTrial
+	// endpoint.
+	ExtendTrialDoer goahttp.Doer
+
 	// RestoreResponseBody controls whether the response bodies are reset after
 	// decoding so they can be read again.
 	RestoreResponseBody bool
@@ -90,6 +94,7 @@ func NewClient(
 		ListOrganizationMembersDoer:  doer,
 		ListOrganizationProjectsDoer: doer,
 		ListOrganizationsDoer:        doer,
+		ExtendTrialDoer:              doer,
 		RestoreResponseBody:          restoreBody,
 		scheme:                       scheme,
 		host:                         host,
@@ -357,6 +362,30 @@ func (c *Client) ListOrganizations() goa.Endpoint {
 		resp, err := c.ListOrganizationsDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "listOrganizations", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// ExtendTrial returns an endpoint that makes HTTP requests to the admin
+// service extendTrial server.
+func (c *Client) ExtendTrial() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeExtendTrialRequest(c.encoder)
+		decodeResponse = DecodeExtendTrialResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildExtendTrialRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.ExtendTrialDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "extendTrial", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -2653,6 +2653,240 @@ func DecodeListOrganizationsResponse(decoder func(*http.Response) goahttp.Decode
 	}
 }
 
+// BuildExtendTrialRequest instantiates a HTTP request object with method and
+// path set to call the "admin" service "extendTrial" endpoint
+func (c *Client) BuildExtendTrialRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: ExtendTrialAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "extendTrial", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeExtendTrialRequest returns an encoder for requests sent to the admin
+// extendTrial server.
+func EncodeExtendTrialRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.ExtendTrialPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "extendTrial", "*admin.ExtendTrialPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewExtendTrialRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "extendTrial", err)
+		}
+		return nil
+	}
+}
+
+// DecodeExtendTrialResponse returns a decoder for responses returned by the
+// admin extendTrial endpoint. restoreBody controls whether the response body
+// should be restored after having been read.
+// DecodeExtendTrialResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeExtendTrialResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body ExtendTrialResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			res := NewExtendTrialAdminOrganizationOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body ExtendTrialUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body ExtendTrialForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body ExtendTrialBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body ExtendTrialNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body ExtendTrialConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body ExtendTrialUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body ExtendTrialInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body ExtendTrialInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+				}
+				err = ValidateExtendTrialInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+				}
+				return nil, NewExtendTrialInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body ExtendTrialUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+				}
+				err = ValidateExtendTrialUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+				}
+				return nil, NewExtendTrialUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "extendTrial", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body ExtendTrialGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "extendTrial", err)
+			}
+			err = ValidateExtendTrialGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "extendTrial", err)
+			}
+			return nil, NewExtendTrialGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "extendTrial", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // unmarshalAdminOrganizationMemberResponseBodyToAdminAdminOrganizationMember
 // builds a value of type *admin.AdminOrganizationMember from a value of type
 // *AdminOrganizationMemberResponseBody.

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -61,3 +61,8 @@ func ListOrganizationProjectsAdminPath() string {
 func ListOrganizationsAdminPath() string {
 	return "/admin/organizations.list"
 }
+
+// ExtendTrialAdminPath returns the URL path to the admin service extendTrial HTTP endpoint.
+func ExtendTrialAdminPath() string {
+	return "/admin/trial.extend"
+}

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -37,6 +37,15 @@ type EnableOrganizationRequestBody struct {
 	ID string `form:"id" json:"id" xml:"id"`
 }
 
+// ExtendTrialRequestBody is the type of the "admin" service "extendTrial"
+// endpoint HTTP request body.
+type ExtendTrialRequestBody struct {
+	// Organization ID.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Number of days to add to the trial's current end date.
+	Days int `form:"days" json:"days" xml:"days"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -227,6 +236,40 @@ type ListOrganizationsResponseBody struct {
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
 	// Number of organizations matching the filters, before paging.
 	Total *int64 `form:"total,omitempty" json:"total,omitempty" xml:"total,omitempty"`
+}
+
+// ExtendTrialResponseBody is the type of the "admin" service "extendTrial"
+// endpoint HTTP response body.
+type ExtendTrialResponseBody struct {
+	// The ID of the organization
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// The name of the organization
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// The slug of the organization
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount *int `form:"member_count,omitempty" json:"member_count,omitempty" xml:"member_count,omitempty"`
+	// The creation date of the organization.
+	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
+	// The last update date of the organization.
+	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -2247,6 +2290,187 @@ type ListOrganizationsGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// ExtendTrialUnauthorizedResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "unauthorized" error.
+type ExtendTrialUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialForbiddenResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "forbidden" error.
+type ExtendTrialForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialBadRequestResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "bad_request" error.
+type ExtendTrialBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialNotFoundResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "not_found" error.
+type ExtendTrialNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialConflictResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "conflict" error.
+type ExtendTrialConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialUnsupportedMediaResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "unsupported_media" error.
+type ExtendTrialUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialInvalidResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "invalid" error.
+type ExtendTrialInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialInvariantViolationResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "invariant_violation"
+// error.
+type ExtendTrialInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialUnexpectedResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "unexpected" error.
+type ExtendTrialUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ExtendTrialGatewayErrorResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "gateway_error" error.
+type ExtendTrialGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -2335,6 +2559,16 @@ func NewDisableOrganizationRequestBody(p *admin.DisableOrganizationPayload) *Dis
 func NewEnableOrganizationRequestBody(p *admin.EnableOrganizationPayload) *EnableOrganizationRequestBody {
 	body := &EnableOrganizationRequestBody{
 		ID: p.ID,
+	}
+	return body
+}
+
+// NewExtendTrialRequestBody builds the HTTP request body from the payload of
+// the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialRequestBody(p *admin.ExtendTrialPayload) *ExtendTrialRequestBody {
+	body := &ExtendTrialRequestBody{
+		ID:   p.ID,
+		Days: p.Days,
 	}
 	return body
 }
@@ -4162,6 +4396,179 @@ func NewListOrganizationsGatewayError(body *ListOrganizationsGatewayErrorRespons
 	return v
 }
 
+// NewExtendTrialAdminOrganizationOK builds a "admin" service "extendTrial"
+// endpoint result from a HTTP "OK" response.
+func NewExtendTrialAdminOrganizationOK(body *ExtendTrialResponseBody) *admin.AdminOrganization {
+	v := &admin.AdminOrganization{
+		ID:                 *body.ID,
+		Name:               *body.Name,
+		Slug:               *body.Slug,
+		AccountType:        *body.AccountType,
+		WorkosID:           body.WorkosID,
+		Whitelisted:        *body.Whitelisted,
+		DisabledAt:         body.DisabledAt,
+		FreeTrialStartedAt: body.FreeTrialStartedAt,
+		FreeTrialEndsAt:    body.FreeTrialEndsAt,
+		TrialState:         body.TrialState,
+		TrialEndsAt:        body.TrialEndsAt,
+		MemberCount:        *body.MemberCount,
+		CreatedAt:          *body.CreatedAt,
+		UpdatedAt:          *body.UpdatedAt,
+	}
+
+	return v
+}
+
+// NewExtendTrialUnauthorized builds a admin service extendTrial endpoint
+// unauthorized error.
+func NewExtendTrialUnauthorized(body *ExtendTrialUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialForbidden builds a admin service extendTrial endpoint
+// forbidden error.
+func NewExtendTrialForbidden(body *ExtendTrialForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialBadRequest builds a admin service extendTrial endpoint
+// bad_request error.
+func NewExtendTrialBadRequest(body *ExtendTrialBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialNotFound builds a admin service extendTrial endpoint not_found
+// error.
+func NewExtendTrialNotFound(body *ExtendTrialNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialConflict builds a admin service extendTrial endpoint conflict
+// error.
+func NewExtendTrialConflict(body *ExtendTrialConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialUnsupportedMedia builds a admin service extendTrial endpoint
+// unsupported_media error.
+func NewExtendTrialUnsupportedMedia(body *ExtendTrialUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialInvalid builds a admin service extendTrial endpoint invalid
+// error.
+func NewExtendTrialInvalid(body *ExtendTrialInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialInvariantViolation builds a admin service extendTrial endpoint
+// invariant_violation error.
+func NewExtendTrialInvariantViolation(body *ExtendTrialInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialUnexpected builds a admin service extendTrial endpoint
+// unexpected error.
+func NewExtendTrialUnexpected(body *ExtendTrialUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewExtendTrialGatewayError builds a admin service extendTrial endpoint
+// gateway_error error.
+func NewExtendTrialGatewayError(body *ExtendTrialGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // ValidateGetProjectResponseBody runs the validations defined on
 // GetProjectResponseBody
 func ValidateGetProjectResponseBody(body *GetProjectResponseBody) (err error) {
@@ -4469,6 +4876,59 @@ func ValidateListOrganizationsResponseBody(body *ListOrganizationsResponseBody) 
 				err = goa.MergeErrors(err, err2)
 			}
 		}
+	}
+	return
+}
+
+// ValidateExtendTrialResponseBody runs the validations defined on
+// ExtendTrialResponseBody
+func ValidateExtendTrialResponseBody(body *ExtendTrialResponseBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.Slug == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if body.Whitelisted == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("whitelisted", "body"))
+	}
+	if body.MemberCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("member_count", "body"))
+	}
+	if body.CreatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
+	}
+	if body.UpdatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	if body.DisabledAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.disabled_at", *body.DisabledAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialStartedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_started_at", *body.FreeTrialStartedAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_ends_at", *body.FreeTrialEndsAt, goa.FormatDateTime))
+	}
+	if body.TrialState != nil {
+		if !(*body.TrialState == "none" || *body.TrialState == "running" || *body.TrialState == "ending_soon" || *body.TrialState == "expired" || *body.TrialState == "demoted" || *body.TrialState == "converted") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.trial_state", *body.TrialState, []any{"none", "running", "ending_soon", "expired", "demoted", "converted"}))
+		}
+	}
+	if body.TrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_ends_at", *body.TrialEndsAt, goa.FormatDateTime))
+	}
+	if body.CreatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
+	}
+	if body.UpdatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
 	}
 	return
 }
@@ -7096,6 +7556,246 @@ func ValidateListOrganizationsUnexpectedResponseBody(body *ListOrganizationsUnex
 // ValidateListOrganizationsGatewayErrorResponseBody runs the validations
 // defined on listOrganizations_gateway_error_response_body
 func ValidateListOrganizationsGatewayErrorResponseBody(body *ListOrganizationsGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialUnauthorizedResponseBody runs the validations defined on
+// extendTrial_unauthorized_response_body
+func ValidateExtendTrialUnauthorizedResponseBody(body *ExtendTrialUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialForbiddenResponseBody runs the validations defined on
+// extendTrial_forbidden_response_body
+func ValidateExtendTrialForbiddenResponseBody(body *ExtendTrialForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialBadRequestResponseBody runs the validations defined on
+// extendTrial_bad_request_response_body
+func ValidateExtendTrialBadRequestResponseBody(body *ExtendTrialBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialNotFoundResponseBody runs the validations defined on
+// extendTrial_not_found_response_body
+func ValidateExtendTrialNotFoundResponseBody(body *ExtendTrialNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialConflictResponseBody runs the validations defined on
+// extendTrial_conflict_response_body
+func ValidateExtendTrialConflictResponseBody(body *ExtendTrialConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialUnsupportedMediaResponseBody runs the validations defined
+// on extendTrial_unsupported_media_response_body
+func ValidateExtendTrialUnsupportedMediaResponseBody(body *ExtendTrialUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialInvalidResponseBody runs the validations defined on
+// extendTrial_invalid_response_body
+func ValidateExtendTrialInvalidResponseBody(body *ExtendTrialInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialInvariantViolationResponseBody runs the validations
+// defined on extendTrial_invariant_violation_response_body
+func ValidateExtendTrialInvariantViolationResponseBody(body *ExtendTrialInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialUnexpectedResponseBody runs the validations defined on
+// extendTrial_unexpected_response_body
+func ValidateExtendTrialUnexpectedResponseBody(body *ExtendTrialUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateExtendTrialGatewayErrorResponseBody runs the validations defined on
+// extendTrial_gateway_error_response_body
+func ValidateExtendTrialGatewayErrorResponseBody(body *ExtendTrialGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -2342,6 +2342,219 @@ func EncodeListOrganizationsError(encoder func(context.Context, http.ResponseWri
 	}
 }
 
+// EncodeExtendTrialResponse returns an encoder for responses returned by the
+// admin extendTrial endpoint.
+func EncodeExtendTrialResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminOrganization)
+		enc := encoder(ctx, w)
+		body := NewExtendTrialResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeExtendTrialRequest returns a decoder for requests sent to the admin
+// extendTrial endpoint.
+func DecodeExtendTrialRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.ExtendTrialPayload, error) {
+	return func(r *http.Request) (*admin.ExtendTrialPayload, error) {
+		var payload *admin.ExtendTrialPayload
+		var (
+			body ExtendTrialRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateExtendTrialRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewExtendTrialPayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeExtendTrialError returns an encoder for errors returned by the
+// extendTrial admin endpoint.
+func EncodeExtendTrialError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewExtendTrialGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // marshalAdminAdminOrganizationMemberToAdminOrganizationMemberResponseBody
 // builds a value of type *AdminOrganizationMemberResponseBody from a value of
 // type *admin.AdminOrganizationMember.

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -61,3 +61,8 @@ func ListOrganizationProjectsAdminPath() string {
 func ListOrganizationsAdminPath() string {
 	return "/admin/organizations.list"
 }
+
+// ExtendTrialAdminPath returns the URL path to the admin service extendTrial HTTP endpoint.
+func ExtendTrialAdminPath() string {
+	return "/admin/trial.extend"
+}

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	ListOrganizationMembers  http.Handler
 	ListOrganizationProjects http.Handler
 	ListOrganizations        http.Handler
+	ExtendTrial              http.Handler
 }
 
 // MountPoint holds information about the mounted endpoints.
@@ -70,6 +71,7 @@ func New(
 			{"ListOrganizationMembers", "GET", "/admin/organization.members"},
 			{"ListOrganizationProjects", "GET", "/admin/organization.projects"},
 			{"ListOrganizations", "GET", "/admin/organizations.list"},
+			{"ExtendTrial", "POST", "/admin/trial.extend"},
 		},
 		Login:                    NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
 		Callback:                 NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
@@ -82,6 +84,7 @@ func New(
 		ListOrganizationMembers:  NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizationProjects: NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizations:        NewListOrganizationsHandler(e.ListOrganizations, mux, decoder, encoder, errhandler, formatter),
+		ExtendTrial:              NewExtendTrialHandler(e.ExtendTrial, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 
@@ -101,6 +104,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.ListOrganizationMembers = m(s.ListOrganizationMembers)
 	s.ListOrganizationProjects = m(s.ListOrganizationProjects)
 	s.ListOrganizations = m(s.ListOrganizations)
+	s.ExtendTrial = m(s.ExtendTrial)
 }
 
 // MethodNames returns the methods served.
@@ -119,6 +123,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountListOrganizationMembersHandler(mux, h.ListOrganizationMembers)
 	MountListOrganizationProjectsHandler(mux, h.ListOrganizationProjects)
 	MountListOrganizationsHandler(mux, h.ListOrganizations)
+	MountExtendTrialHandler(mux, h.ExtendTrial)
 }
 
 // Mount configures the mux to serve the admin endpoints.
@@ -688,6 +693,59 @@ func NewListOrganizationsHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "listOrganizations")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountExtendTrialHandler configures the mux to serve the "admin" service
+// "extendTrial" endpoint.
+func MountExtendTrialHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/trial.extend", f)
+}
+
+// NewExtendTrialHandler creates a HTTP handler which loads the HTTP request
+// and calls the "admin" service "extendTrial" endpoint.
+func NewExtendTrialHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeExtendTrialRequest(mux, decoder)
+		encodeResponse = EncodeExtendTrialResponse(encoder)
+		encodeError    = EncodeExtendTrialError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "extendTrial")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -39,6 +39,15 @@ type EnableOrganizationRequestBody struct {
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 }
 
+// ExtendTrialRequestBody is the type of the "admin" service "extendTrial"
+// endpoint HTTP request body.
+type ExtendTrialRequestBody struct {
+	// Organization ID.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Number of days to add to the trial's current end date.
+	Days *int `form:"days,omitempty" json:"days,omitempty" xml:"days,omitempty"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -229,6 +238,40 @@ type ListOrganizationsResponseBody struct {
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
 	// Number of organizations matching the filters, before paging.
 	Total int64 `form:"total" json:"total" xml:"total"`
+}
+
+// ExtendTrialResponseBody is the type of the "admin" service "extendTrial"
+// endpoint HTTP response body.
+type ExtendTrialResponseBody struct {
+	// The ID of the organization
+	ID string `form:"id" json:"id" xml:"id"`
+	// The name of the organization
+	Name string `form:"name" json:"name" xml:"name"`
+	// The slug of the organization
+	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted bool `form:"whitelisted" json:"whitelisted" xml:"whitelisted"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount int `form:"member_count" json:"member_count" xml:"member_count"`
+	// The creation date of the organization.
+	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
+	// The last update date of the organization.
+	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -2249,6 +2292,187 @@ type ListOrganizationsGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// ExtendTrialUnauthorizedResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "unauthorized" error.
+type ExtendTrialUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialForbiddenResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "forbidden" error.
+type ExtendTrialForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialBadRequestResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "bad_request" error.
+type ExtendTrialBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialNotFoundResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "not_found" error.
+type ExtendTrialNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialConflictResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "conflict" error.
+type ExtendTrialConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialUnsupportedMediaResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "unsupported_media" error.
+type ExtendTrialUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialInvalidResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "invalid" error.
+type ExtendTrialInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialInvariantViolationResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "invariant_violation"
+// error.
+type ExtendTrialInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialUnexpectedResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "unexpected" error.
+type ExtendTrialUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ExtendTrialGatewayErrorResponseBody is the type of the "admin" service
+// "extendTrial" endpoint HTTP response body for the "gateway_error" error.
+type ExtendTrialGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -2478,6 +2702,28 @@ func NewListOrganizationsResponseBody(res *admin.AdminListOrganizationsResult) *
 		}
 	} else {
 		body.Organizations = []*AdminOrganizationResponseBody{}
+	}
+	return body
+}
+
+// NewExtendTrialResponseBody builds the HTTP response body from the result of
+// the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialResponseBody(res *admin.AdminOrganization) *ExtendTrialResponseBody {
+	body := &ExtendTrialResponseBody{
+		ID:                 res.ID,
+		Name:               res.Name,
+		Slug:               res.Slug,
+		AccountType:        res.AccountType,
+		WorkosID:           res.WorkosID,
+		Whitelisted:        res.Whitelisted,
+		DisabledAt:         res.DisabledAt,
+		FreeTrialStartedAt: res.FreeTrialStartedAt,
+		FreeTrialEndsAt:    res.FreeTrialEndsAt,
+		TrialState:         res.TrialState,
+		TrialEndsAt:        res.TrialEndsAt,
+		MemberCount:        res.MemberCount,
+		CreatedAt:          res.CreatedAt,
+		UpdatedAt:          res.UpdatedAt,
 	}
 	return body
 }
@@ -4051,6 +4297,146 @@ func NewListOrganizationsGatewayErrorResponseBody(res *goa.ServiceError) *ListOr
 	return body
 }
 
+// NewExtendTrialUnauthorizedResponseBody builds the HTTP response body from
+// the result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialUnauthorizedResponseBody(res *goa.ServiceError) *ExtendTrialUnauthorizedResponseBody {
+	body := &ExtendTrialUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialForbiddenResponseBody builds the HTTP response body from the
+// result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialForbiddenResponseBody(res *goa.ServiceError) *ExtendTrialForbiddenResponseBody {
+	body := &ExtendTrialForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialBadRequestResponseBody builds the HTTP response body from the
+// result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialBadRequestResponseBody(res *goa.ServiceError) *ExtendTrialBadRequestResponseBody {
+	body := &ExtendTrialBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialNotFoundResponseBody builds the HTTP response body from the
+// result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialNotFoundResponseBody(res *goa.ServiceError) *ExtendTrialNotFoundResponseBody {
+	body := &ExtendTrialNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialConflictResponseBody builds the HTTP response body from the
+// result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialConflictResponseBody(res *goa.ServiceError) *ExtendTrialConflictResponseBody {
+	body := &ExtendTrialConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialUnsupportedMediaResponseBody builds the HTTP response body
+// from the result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialUnsupportedMediaResponseBody(res *goa.ServiceError) *ExtendTrialUnsupportedMediaResponseBody {
+	body := &ExtendTrialUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialInvalidResponseBody builds the HTTP response body from the
+// result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialInvalidResponseBody(res *goa.ServiceError) *ExtendTrialInvalidResponseBody {
+	body := &ExtendTrialInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialInvariantViolationResponseBody builds the HTTP response body
+// from the result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialInvariantViolationResponseBody(res *goa.ServiceError) *ExtendTrialInvariantViolationResponseBody {
+	body := &ExtendTrialInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialUnexpectedResponseBody builds the HTTP response body from the
+// result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialUnexpectedResponseBody(res *goa.ServiceError) *ExtendTrialUnexpectedResponseBody {
+	body := &ExtendTrialUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewExtendTrialGatewayErrorResponseBody builds the HTTP response body from
+// the result of the "extendTrial" endpoint of the "admin" service.
+func NewExtendTrialGatewayErrorResponseBody(res *goa.ServiceError) *ExtendTrialGatewayErrorResponseBody {
+	body := &ExtendTrialGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewLoginPayload builds a admin service login endpoint payload.
 func NewLoginPayload(returnTo *string, prompt *string) *admin.LoginPayload {
 	v := &admin.LoginPayload{}
@@ -4174,6 +4560,17 @@ func NewListOrganizationsPayload(q *string, accountType *string, accountTypes []
 	return v
 }
 
+// NewExtendTrialPayload builds a admin service extendTrial endpoint payload.
+func NewExtendTrialPayload(body *ExtendTrialRequestBody, adminSessionToken *string) *admin.ExtendTrialPayload {
+	v := &admin.ExtendTrialPayload{
+		ID:   *body.ID,
+		Days: *body.Days,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
 // ValidateUpdateOrganizationRequestBody runs the validations defined on
 // UpdateOrganizationRequestBody
 func ValidateUpdateOrganizationRequestBody(body *UpdateOrganizationRequestBody) (err error) {
@@ -4206,6 +4603,33 @@ func ValidateEnableOrganizationRequestBody(body *EnableOrganizationRequestBody) 
 	if body.ID != nil {
 		if utf8.RuneCountInString(*body.ID) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
+		}
+	}
+	return
+}
+
+// ValidateExtendTrialRequestBody runs the validations defined on
+// ExtendTrialRequestBody
+func ValidateExtendTrialRequestBody(body *ExtendTrialRequestBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Days == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("days", "body"))
+	}
+	if body.ID != nil {
+		if utf8.RuneCountInString(*body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
+		}
+	}
+	if body.Days != nil {
+		if *body.Days < 1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", *body.Days, 1, true))
+		}
+	}
+	if body.Days != nil {
+		if *body.Days > 365 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", *body.Days, 365, false))
 		}
 	}
 	return

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -97,7 +97,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|upsert-shadow-mcp-inventory-policy-bypass|delete-shadow-mcp-inventory-policy-bypass|block-shadow-mcp-inventory-server|unblock-shadow-mcp-inventory-server|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations)",
+		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -377,6 +377,10 @@ func ParseEndpoint(
 		adminListOrganizationsDirectionFlag         = adminListOrganizationsFlags.String("direction", "", "")
 		adminListOrganizationsPageFlag              = adminListOrganizationsFlags.String("page", "", "")
 		adminListOrganizationsAdminSessionTokenFlag = adminListOrganizationsFlags.String("admin-session-token", "", "")
+
+		adminExtendTrialFlags                 = flag.NewFlagSet("extend-trial", flag.ExitOnError)
+		adminExtendTrialBodyFlag              = adminExtendTrialFlags.String("body", "REQUIRED", "")
+		adminExtendTrialAdminSessionTokenFlag = adminExtendTrialFlags.String("admin-session-token", "", "")
 
 		agentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
 
@@ -3383,6 +3387,7 @@ func ParseEndpoint(
 	adminListOrganizationMembersFlags.Usage = adminListOrganizationMembersUsage
 	adminListOrganizationProjectsFlags.Usage = adminListOrganizationProjectsUsage
 	adminListOrganizationsFlags.Usage = adminListOrganizationsUsage
+	adminExtendTrialFlags.Usage = adminExtendTrialUsage
 
 	agentFlags.Usage = agentUsage
 	agentGetPluginsFlags.Usage = agentGetPluginsUsage
@@ -4331,6 +4336,9 @@ func ParseEndpoint(
 
 			case "list-organizations":
 				epf = adminListOrganizationsFlags
+
+			case "extend-trial":
+				epf = adminExtendTrialFlags
 
 			}
 
@@ -6305,6 +6313,9 @@ func ParseEndpoint(
 			case "list-organizations":
 				endpoint = c.ListOrganizations()
 				data, err = adminc.BuildListOrganizationsPayload(*adminListOrganizationsQFlag, *adminListOrganizationsAccountTypeFlag, *adminListOrganizationsAccountTypesFlag, *adminListOrganizationsTrialStatesFlag, *adminListOrganizationsDisabledStatesFlag, *adminListOrganizationsIncludeDisabledFlag, *adminListOrganizationsCursorFlag, *adminListOrganizationsLimitFlag, *adminListOrganizationsSortFlag, *adminListOrganizationsDirectionFlag, *adminListOrganizationsPageFlag, *adminListOrganizationsAdminSessionTokenFlag)
+			case "extend-trial":
+				endpoint = c.ExtendTrial()
+				data, err = adminc.BuildExtendTrialPayload(*adminExtendTrialBodyFlag, *adminExtendTrialAdminSessionTokenFlag)
 			}
 		case "agent":
 			c := agentc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -8760,6 +8771,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    list-organization-members: Lists members of an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organization-projects: Lists projects belonging to an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organizations: Lists organizations for admin operations with optional search and filters.`)
+	fmt.Fprintln(os.Stderr, `    extend-trial: Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
 	fmt.Fprintf(os.Stderr, "    %s admin COMMAND --help\n", os.Args[0])
@@ -9006,6 +9018,26 @@ func adminListOrganizationsUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin list-organizations --q \"abc123\" --account-type \"abc123\" --account-types '[\n      \"abc123\"\n   ]' --trial-states '[\n      \"abc123\"\n   ]' --disabled-states '[\n      \"abc123\"\n   ]' --include-disabled false --cursor \"abc123\" --limit 1 --sort \"abc123\" --direction \"abc123\" --page 1 --admin-session-token \"abc123\"")
+}
+
+func adminExtendTrialUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin extend-trial", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin extend-trial --body '{\n      \"days\": 2,\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
 }
 
 // agentUsage displays the usage of the agent command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -748,11 +748,11 @@ paths:
             operationId: adminListOrganizations
             parameters:
                 - allowEmptyValue: true
-                  description: Search term. Matches name and slug as a case-insensitive substring, and organization id and WorkOS id exactly.
+                  description: Search term applied to name and slug (case-insensitive substring).
                   in: query
                   name: q
                   schema:
-                    description: Search term. Matches name and slug as a case-insensitive substring, and organization id and WorkOS id exactly.
+                    description: Search term applied to name and slug (case-insensitive substring).
                     type: string
                 - allowEmptyValue: true
                   description: Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -748,11 +748,11 @@ paths:
             operationId: adminListOrganizations
             parameters:
                 - allowEmptyValue: true
-                  description: Search term applied to name and slug (case-insensitive substring).
+                  description: Search term. Matches name and slug as a case-insensitive substring, and organization id and WorkOS id exactly.
                   in: query
                   name: q
                   schema:
-                    description: Search term applied to name and slug (case-insensitive substring).
+                    description: Search term. Matches name and slug as a case-insensitive substring, and organization id and WorkOS id exactly.
                     type: string
                 - allowEmptyValue: true
                   description: Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.
@@ -929,6 +929,82 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/AdminProjectDetail'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
+    /admin/trial.extend:
+        post:
+            tags:
+                - admin
+            summary: extendTrial admin
+            description: 'Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.'
+            operationId: adminExtendTrial
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ExtendTrialRequestBody'
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminOrganization'
                 "400":
                     description: 'bad_request: request is invalid'
                     content:
@@ -60603,6 +60679,22 @@ components:
             required:
                 - ok
                 - error
+        ExtendTrialRequestBody:
+            type: object
+            properties:
+                days:
+                    type: integer
+                    description: Number of days to add to the trial's current end date.
+                    format: int64
+                    minimum: 1
+                    maximum: 365
+                id:
+                    type: string
+                    description: Organization ID.
+                    minLength: 1
+            required:
+                - id
+                - days
         ExternalCredentialSummary:
             type: object
             properties:

--- a/server/internal/admin/extendtrial_test.go
+++ b/server/internal/admin/extendtrial_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
@@ -158,6 +160,10 @@ func TestExtendTrial_OnlyARunningTrialCanBeExtended(t *testing.T) {
 	}
 }
 
+// TestExtendTrial_OrganizationWithNoTrialRow is one half of the pair that pins
+// the two causes of a zero-row update apart. This organization exists, so the
+// answer is a conflict; TestExtendTrial_UnknownAndMalformedOrganizationIDs
+// covers the other half, where it does not and the answer is not-found.
 func TestExtendTrial_OrganizationWithNoTrialRow(t *testing.T) {
 	t.Parallel()
 
@@ -174,12 +180,20 @@ func TestExtendTrial_OrganizationWithNoTrialRow(t *testing.T) {
 	require.Error(t, err, "a rejected extension must not create a trial row")
 }
 
+// TestExtendTrial_UnknownAndMalformedOrganizationIDs is the other half of that
+// pair. Every id here names an organization that does not exist, so every one
+// is not-found rather than conflict: an operator who pastes one bad id must get
+// the same answer from extend that disable and enable already give them, or the
+// second story sends them to inspect a trial when the fault is their clipboard.
 func TestExtendTrial_UnknownAndMalformedOrganizationIDs(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn := newTestAdminService(t)
 
-	// A running trial that must survive every rejected call below.
+	// A running trial that must survive every rejected call below. Its slug is
+	// one of the ids tried, which pins that the lookup resolves ids only: a
+	// slug is not a way in here, and matching one must not turn the answer into
+	// a conflict about that organization's perfectly healthy trial.
 	seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_bystander", name: "Bystander", slug: "ext-bystander", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_bystander", endsAt: seededEndsAt})
@@ -187,10 +201,10 @@ func TestExtendTrial_UnknownAndMalformedOrganizationIDs(t *testing.T) {
 
 	// The empty id is rejected as a 400 at the HTTP boundary by MinLength(1),
 	// which a direct service call does not run; the service-level contract for
-	// an id that matches nothing is the same conflict as any other.
+	// it is the same not-found as any other id that matches no organization.
 	for _, id := range []string{"org_ext_does_not_exist", "", "ext-bystander", "not a valid id"} {
 		_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: id, Days: 3})
-		requireOopsCode(t, err, oops.CodeConflict)
+		requireOopsCode(t, err, oops.CodeNotFound)
 	}
 
 	after := readTrial(t, ctx, conn, "org_ext_bystander")
@@ -220,6 +234,19 @@ func TestExtendTrial_DayCountBounds(t *testing.T) {
 
 		{name: "one past the maximum", days: constants.MaxTrialExtensionDays + 1, wantErr: true},
 		{name: "far past the maximum", days: 100000, wantErr: true},
+
+		// These two pin that the bounds check runs on the wide payload.Days and
+		// that the int32 narrowing stays below it. Only a non-HTTP caller can
+		// reach the service with a day count this large, which is the caller the
+		// handler's own check exists for.
+		//
+		// The second is the one that matters. 1<<32 + 1 narrows to exactly 1, a
+		// value inside the bounds, so a handler that narrowed before checking
+		// would accept it and quietly extend by a day. The first narrows to
+		// MinInt32 and is rejected either way; it is here so the pair reads as
+		// the boundary it is.
+		{name: "int32 overflow to a negative", days: math.MaxInt32 + 1, wantErr: true},
+		{name: "int32 overflow to a valid day count", days: math.MaxUint32 + 2, wantErr: true},
 	}
 
 	for _, tc := range cases {
@@ -314,6 +341,55 @@ func TestExtendTrial_TouchesOnlyTheTargetRow(t *testing.T) {
 	neighbourAfter := readTrial(t, ctx, conn, "org_ext_neighbour")
 	require.Equal(t, neighbourBefore.EndsAt.Time, neighbourAfter.EndsAt.Time, "extending must not spill onto other trials")
 	require.Equal(t, neighbourBefore.UpdatedAt.Time, neighbourAfter.UpdatedAt.Time)
+}
+
+// TestExtendTrialRequestBody_DesignBoundsAreEnforced pins the other copy of the
+// bounds. Every other test here calls svc.ExtendTrial directly, which skips the
+// generated request decoder, so for the only caller production actually has —
+// an HTTP request — none of them touch the validation that runs first. Deleting
+// Minimum, Maximum and MinLength(1) from the design would leave the rest of this
+// file green.
+//
+// It needs no database, because the generated validator is a pure function.
+func TestExtendTrialRequestBody_DesignBoundsAreEnforced(t *testing.T) {
+	t.Parallel()
+
+	id := "org_ext_validate"
+	minDays := constants.MinTrialExtensionDays
+	maxDays := constants.MaxTrialExtensionDays
+
+	cases := []struct {
+		name    string
+		id      *string
+		days    *int
+		wantErr bool
+	}{
+		// Every field is a pointer in the generated body, so the table has to
+		// distinguish "absent" from "present and invalid".
+		{name: "at the minimum", id: &id, days: &minDays},
+		{name: "at the maximum", id: &id, days: &maxDays},
+
+		{name: "below the minimum", id: &id, days: new(minDays - 1), wantErr: true},
+		{name: "above the maximum", id: &id, days: new(maxDays + 1), wantErr: true},
+		{name: "negative", id: &id, days: new(-1), wantErr: true},
+
+		{name: "empty id", id: new(""), days: &minDays, wantErr: true},
+		{name: "missing id", id: nil, days: &minDays, wantErr: true},
+		{name: "missing days", id: &id, days: nil, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := srv.ValidateExtendTrialRequestBody(&srv.ExtendTrialRequestBody{ID: tc.id, Days: tc.days})
+			if tc.wantErr {
+				require.Error(t, err, "the request decoder must reject this before the handler runs")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestExtendTrial_ExtensionsAccumulate(t *testing.T) {

--- a/server/internal/admin/extendtrial_test.go
+++ b/server/internal/admin/extendtrial_test.go
@@ -1,0 +1,340 @@
+package admin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+// readTrial reads the trials row straight from the database. Going through the
+// API instead would only ever show ends_at, and this slice has to prove that
+// four other columns did not move.
+func readTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string) trialsRepo.Trial {
+	t.Helper()
+
+	row, err := trialsRepo.New(conn).GetTrial(ctx, orgID)
+	require.NoError(t, err)
+	return row
+}
+
+func TestExtendTrial_MovesEndsAtByExactlyTheGivenDays(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// The seeded end date is deliberately not a multiple of the extension, and
+	// is far from both now() and the fixture's created_at (30 days back). An
+	// implementation that added the interval to the wrong base would land on a
+	// different date rather than accidentally on the right one:
+	//
+	//   correct              now + 10d + 3d = now + 13d
+	//   added to now()       now + 3d
+	//   added to created_at  now - 27d
+	seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext", name: "Ext Co", slug: "ext-co", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext", endsAt: seededEndsAt})
+	before := readTrial(t, ctx, conn, "org_ext")
+
+	res, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext", Days: 3})
+	require.NoError(t, err)
+	require.Equal(t, "org_ext", res.ID, "the response must describe the organization that was written")
+
+	after := readTrial(t, ctx, conn, "org_ext")
+	require.Equal(t, 3*24*time.Hour, after.EndsAt.Time.Sub(before.EndsAt.Time),
+		"ends_at must move by exactly the days asked for, from its previous value: was %s, now %s", before.EndsAt.Time, after.EndsAt.Time)
+
+	// Everything else on the row is either the record of how the trial began or
+	// the record of how it ended, and an extension is neither.
+	require.Equal(t, before.Tier, after.Tier)
+	require.Equal(t, before.CreatedAt.Time, after.CreatedAt.Time, "extending must not restamp created_at")
+	require.False(t, after.ConvertedAt.Valid, "extending must not convert the trial")
+	require.False(t, after.DemotedAt.Valid, "extending must not demote the trial")
+	require.True(t, after.UpdatedAt.Time.After(before.UpdatedAt.Time),
+		"extending must move updated_at: was %s, now %s", before.UpdatedAt.Time, after.UpdatedAt.Time)
+
+	// The new date reaches the operator through all three surfaces.
+	require.NotNil(t, res.TrialEndsAt)
+	fromResponse, err := time.Parse(time.RFC3339, *res.TrialEndsAt)
+	require.NoError(t, err)
+	require.WithinDuration(t, after.EndsAt.Time, fromResponse, time.Second, "the response must carry the new end date")
+
+	detail, err := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: "org_ext"})
+	require.NoError(t, err)
+	require.NotNil(t, detail.TrialEndsAt)
+	require.Equal(t, *res.TrialEndsAt, *detail.TrialEndsAt, "the detail endpoint must agree with the write")
+	require.Equal(t, "running", *detail.TrialState)
+
+	list, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{})
+	require.NoError(t, err)
+	require.Len(t, list.Organizations, 1)
+	require.NotNil(t, list.Organizations[0].TrialEndsAt)
+	require.Equal(t, *res.TrialEndsAt, *list.Organizations[0].TrialEndsAt, "the list endpoint must agree with the write")
+}
+
+// TestExtendTrial_OnlyARunningTrialCanBeExtended walks the whole state space of
+// the guard rather than a sample of it. converted_at and demoted_at are each
+// null or not-null, and ends_at is each side of now, which is eight rows; only
+// the one where all three are satisfied may move. Seeding one polarity of a
+// nullable column makes half of its mutations unreachable, exactly as seeding
+// one polarity of a boolean does.
+func TestExtendTrial_OnlyARunningTrialCanBeExtended(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	now := time.Now().UTC()
+	convertedAt := now.Add(-96 * time.Hour)
+	demotedAt := now.Add(-72 * time.Hour)
+
+	cases := []struct {
+		name      string
+		orgID     string
+		expired   bool
+		converted bool
+		demoted   bool
+		wantMove  bool
+	}{
+		{name: "running", orgID: "org_ext_running", wantMove: true},
+
+		// The row the sweeper has not reached yet. It still reads as armed:
+		// both stamps are null and only the date says otherwise.
+		{name: "expired not yet demoted", orgID: "org_ext_expired", expired: true},
+
+		{name: "converted", orgID: "org_ext_converted", converted: true},
+		{name: "converted and expired", orgID: "org_ext_converted_expired", converted: true, expired: true},
+		{name: "demoted", orgID: "org_ext_demoted", demoted: true},
+		{name: "demoted and expired", orgID: "org_ext_demoted_expired", demoted: true, expired: true},
+		{name: "converted after demotion", orgID: "org_ext_both", converted: true, demoted: true},
+		{name: "converted after demotion and expired", orgID: "org_ext_both_expired", converted: true, demoted: true, expired: true},
+	}
+
+	for _, tc := range cases {
+		endsAt := now.Add(10 * 24 * time.Hour)
+		if tc.expired {
+			endsAt = now.Add(-10 * 24 * time.Hour)
+		}
+		f := trialFixture{orgID: tc.orgID, endsAt: endsAt}
+		if tc.converted {
+			f.convertedAt = &convertedAt
+		}
+		if tc.demoted {
+			f.demotedAt = &demotedAt
+		}
+
+		seedOrg(t, ctx, conn, orgFixture{id: tc.orgID, name: tc.orgID, slug: tc.orgID, accountType: "enterprise", whitelisted: true})
+		seedTrial(t, ctx, conn, f)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Safe to run alongside the other cases: each owns its own
+			// organization, and the assertions read that row alone.
+			t.Parallel()
+
+			before := readTrial(t, ctx, conn, tc.orgID)
+
+			_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: tc.orgID, Days: 3})
+
+			after := readTrial(t, ctx, conn, tc.orgID)
+			if tc.wantMove {
+				require.NoError(t, err)
+				require.Equal(t, 3*24*time.Hour, after.EndsAt.Time.Sub(before.EndsAt.Time))
+				return
+			}
+
+			requireOopsCode(t, err, oops.CodeConflict)
+			require.Equal(t, before.EndsAt.Time, after.EndsAt.Time,
+				"a trial that is not running must not move: was %s, now %s", before.EndsAt.Time, after.EndsAt.Time)
+			require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time, "a rejected extension must not touch updated_at")
+		})
+	}
+}
+
+func TestExtendTrial_OrganizationWithNoTrialRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_no_trial", name: "No Trial", slug: "no-trial", whitelisted: true})
+
+	_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_no_trial", Days: 3})
+	requireOopsCode(t, err, oops.CodeConflict)
+
+	// Extend moves an end date; it must never be a way to arm a trial that was
+	// never granted, which is the auth flow's job.
+	_, err = trialsRepo.New(conn).GetTrial(ctx, "org_ext_no_trial")
+	require.Error(t, err, "a rejected extension must not create a trial row")
+}
+
+func TestExtendTrial_UnknownAndMalformedOrganizationIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// A running trial that must survive every rejected call below.
+	seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_bystander", name: "Bystander", slug: "ext-bystander", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_bystander", endsAt: seededEndsAt})
+	before := readTrial(t, ctx, conn, "org_ext_bystander")
+
+	// The empty id is rejected as a 400 at the HTTP boundary by MinLength(1),
+	// which a direct service call does not run; the service-level contract for
+	// an id that matches nothing is the same conflict as any other.
+	for _, id := range []string{"org_ext_does_not_exist", "", "ext-bystander", "not a valid id"} {
+		_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: id, Days: 3})
+		requireOopsCode(t, err, oops.CodeConflict)
+	}
+
+	after := readTrial(t, ctx, conn, "org_ext_bystander")
+	require.Equal(t, before.EndsAt.Time, after.EndsAt.Time, "an unmatched id must not extend anything")
+	require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+}
+
+func TestExtendTrial_DayCountBounds(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	cases := []struct {
+		name    string
+		days    int
+		wantErr bool
+	}{
+		// A negative count would shorten a trial through an endpoint named
+		// extend, and zero would report success having moved nothing but
+		// updated_at.
+		{name: "large negative", days: -365, wantErr: true},
+		{name: "minus one", days: -1, wantErr: true},
+		{name: "zero", days: 0, wantErr: true},
+
+		{name: "minimum", days: constants.MinTrialExtensionDays},
+		{name: "maximum", days: constants.MaxTrialExtensionDays},
+
+		{name: "one past the maximum", days: constants.MaxTrialExtensionDays + 1, wantErr: true},
+		{name: "far past the maximum", days: 100000, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID := "org_ext_bound_" + tc.name
+			seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+			seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, whitelisted: true})
+			seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: seededEndsAt})
+			before := readTrial(t, ctx, conn, orgID)
+
+			_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: orgID, Days: tc.days})
+
+			after := readTrial(t, ctx, conn, orgID)
+			if tc.wantErr {
+				requireOopsCode(t, err, oops.CodeInvalid)
+				require.Equal(t, before.EndsAt.Time, after.EndsAt.Time,
+					"a rejected day count must not move ends_at: was %s, now %s", before.EndsAt.Time, after.EndsAt.Time)
+				require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, time.Duration(tc.days)*24*time.Hour, after.EndsAt.Time.Sub(before.EndsAt.Time))
+		})
+	}
+}
+
+// TestExtendTrial_LeavesTheOrganizationTierAlone is the regression the scope of
+// this slice turns on. Demotion drops gram_account_type to free and clears
+// whitelisted; extending must do neither, in either polarity, or an operator
+// buying a customer more time would take their access away instead.
+func TestExtendTrial_LeavesTheOrganizationTierAlone(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	cases := []struct {
+		accountType string
+		whitelisted bool
+	}{
+		{accountType: "enterprise", whitelisted: true},
+		{accountType: "enterprise", whitelisted: false},
+		{accountType: "free", whitelisted: true},
+		{accountType: "pro", whitelisted: false},
+	}
+
+	for _, tc := range cases {
+		orgID := "org_ext_tier_" + tc.accountType
+		if tc.whitelisted {
+			orgID += "_wl"
+		}
+
+		seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+		seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: tc.accountType, whitelisted: tc.whitelisted})
+		seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: seededEndsAt})
+
+		_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: orgID, Days: 3})
+		require.NoError(t, err)
+
+		// The extension must really have landed, or the assertions below hold
+		// for the uninteresting reason that nothing happened at all.
+		after := readTrial(t, ctx, conn, orgID)
+		require.WithinDuration(t, seededEndsAt.Add(3*24*time.Hour), after.EndsAt.Time, time.Second)
+
+		state := readOrgState(t, ctx, conn, orgID)
+		require.Equal(t, tc.accountType, state.GramAccountType, "extending must leave gram_account_type at %s on %s", tc.accountType, orgID)
+		require.Equal(t, tc.whitelisted, state.Whitelisted, "extending must leave whitelisted at %v on %s", tc.whitelisted, orgID)
+		require.False(t, state.DisabledAt.Valid, "extending must not disable the organization")
+	}
+}
+
+func TestExtendTrial_TouchesOnlyTheTargetRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// The neighbour's end date differs from the target's, so a write that
+	// spilled onto it would be visible as a move rather than hidden by the two
+	// rows happening to agree.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_target", name: "Target", slug: "ext-target", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_target", endsAt: time.Now().UTC().Add(10 * 24 * time.Hour)})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_neighbour", name: "Neighbour", slug: "ext-neighbour", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_neighbour", endsAt: time.Now().UTC().Add(21 * 24 * time.Hour)})
+
+	neighbourBefore := readTrial(t, ctx, conn, "org_ext_neighbour")
+
+	_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_target", Days: 3})
+	require.NoError(t, err)
+
+	neighbourAfter := readTrial(t, ctx, conn, "org_ext_neighbour")
+	require.Equal(t, neighbourBefore.EndsAt.Time, neighbourAfter.EndsAt.Time, "extending must not spill onto other trials")
+	require.Equal(t, neighbourBefore.UpdatedAt.Time, neighbourAfter.UpdatedAt.Time)
+}
+
+func TestExtendTrial_ExtensionsAccumulate(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// Two extensions of different sizes: adding to the current end date rather
+	// than to now() is what makes the second one land on the sum. The sizes
+	// differ so that a mutation which used the first count twice, or the second
+	// twice, would miss.
+	seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_twice", name: "Twice", slug: "ext-twice", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_twice", endsAt: seededEndsAt})
+
+	_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_twice", Days: 3})
+	require.NoError(t, err)
+	_, err = svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_twice", Days: 5})
+	require.NoError(t, err)
+
+	after := readTrial(t, ctx, conn, "org_ext_twice")
+	require.WithinDuration(t, seededEndsAt.Add(8*24*time.Hour), after.EndsAt.Time, time.Second,
+		"a second extension must build on the first")
+}

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -25,11 +25,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/admin/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 type Service struct {
@@ -561,6 +563,35 @@ func (s *Service) EnableOrganization(ctx context.Context, payload *gen.EnableOrg
 	}
 
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enable")
+}
+
+func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPayload) (*gen.AdminOrganization, error) {
+	// The design bounds this too, but that validation is generated into the
+	// request decoder and only runs at the HTTP boundary. Repeating it here is
+	// what stops a negative day count from shortening a trial through an
+	// endpoint named extend if a future caller reaches the service another way.
+	if payload.Days < constants.MinTrialExtensionDays || payload.Days > constants.MaxTrialExtensionDays {
+		return nil, oops.E(oops.CodeInvalid, nil, "days must be between %d and %d", constants.MinTrialExtensionDays, constants.MaxTrialExtensionDays)
+	}
+
+	rows, err := trialsRepo.New(s.db).ExtendTrial(ctx, trialsRepo.ExtendTrialParams{
+		OrganizationID: payload.ID,
+		ExtendByDays:   int32(payload.Days),
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "extend trial").LogError(ctx, s.logger)
+	}
+	// Zero rows cannot say which of the four guards rejected the row, and the
+	// operator does not need to know: converted, demoted, expired and never
+	// created all mean the same thing here. Conflict rather than not-found,
+	// because the organization usually does exist and it is its trial's state
+	// that blocks the write. failed_precondition would read better still, but
+	// the admin service does not declare it, so it would leave as a 500.
+	if rows == 0 {
+		return nil, oops.E(oops.CodeConflict, nil, "organization has no running enterprise trial to extend")
+	}
+
+	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial extension")
 }
 
 // readOrganizationAfterWrite returns the organization a write just landed on.

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -570,6 +570,12 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 	// request decoder and only runs at the HTTP boundary. Repeating it here is
 	// what stops a negative day count from shortening a trial through an
 	// endpoint named extend if a future caller reaches the service another way.
+	//
+	// The check must stay on the wide payload.Days and the int32 narrowing must
+	// stay below it. Narrowing first would let 1<<32 + 1 truncate to 1 and
+	// quietly extend by a day, and a non-HTTP caller is the only one who can
+	// pass a day count that large at all. TestExtendTrial_DayCountBounds pins
+	// this order.
 	if payload.Days < constants.MinTrialExtensionDays || payload.Days > constants.MaxTrialExtensionDays {
 		return nil, oops.E(oops.CodeInvalid, nil, "days must be between %d and %d", constants.MinTrialExtensionDays, constants.MaxTrialExtensionDays)
 	}
@@ -581,13 +587,34 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "extend trial").LogError(ctx, s.logger)
 	}
-	// Zero rows cannot say which of the four guards rejected the row, and the
-	// operator does not need to know: converted, demoted, expired and never
-	// created all mean the same thing here. Conflict rather than not-found,
-	// because the organization usually does exist and it is its trial's state
-	// that blocks the write. failed_precondition would read better still, but
-	// the admin service does not declare it, so it would leave as a 500.
+	// Zero rows has two causes that mean different things to the operator, and
+	// only the second is a conflict: the organization does not exist at all, or
+	// it exists and its trial cannot be extended. Disable and enable both answer
+	// not-found for an id that matches nothing, so an operator who pastes one bad
+	// id must not be told to go and look at a trial by this endpoint alone.
+	//
+	// The lookup is on the failure path only, so the happy path still costs one
+	// write and one read.
 	if rows == 0 {
+		_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
+			ID:        payload.ID,
+			AllowSlug: false,
+		})
+		switch {
+		case errors.Is(lookupErr, pgx.ErrNoRows):
+			return nil, oops.C(oops.CodeNotFound)
+		case lookupErr != nil:
+			// Falling through to the conflict here would report a trial state we
+			// never managed to read.
+			return nil, oops.E(oops.CodeUnexpected, lookupErr, "look up organization after unextended trial").LogError(ctx, s.logger)
+		}
+
+		// The organization exists, so it is the trial that blocks the write:
+		// converted, demoted, expired, or never granted. Which one is not the
+		// operator's business, and arming a trial that was never granted is the
+		// auth flow's job rather than this endpoint's. failed_precondition would
+		// read better than conflict, but the admin service does not declare it,
+		// so it would leave as a 500.
 		return nil, oops.E(oops.CodeConflict, nil, "organization has no running enterprise trial to extend")
 	}
 

--- a/server/internal/constants/trials.go
+++ b/server/internal/constants/trials.go
@@ -1,0 +1,11 @@
+package constants
+
+// MinTrialExtensionDays is the smallest extension an operator can apply. Zero
+// would report success while moving nothing but updated_at, and a negative
+// value would shorten the trial through an endpoint named extend.
+const MinTrialExtensionDays = 1
+
+// MaxTrialExtensionDays caps a single extension at a year, because a trial that
+// runs longer than that is a contract rather than a trial, and the bound also
+// keeps the ends_at arithmetic far away from what timestamptz can hold.
+const MaxTrialExtensionDays = 365

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -204,7 +204,10 @@ WHERE id = @id;
 -- the reference points for "did this write stamp the moment of the action":
 -- comparing a stamp against them keeps the comparison inside the database
 -- clock, which the test host's clock can drift from.
-SELECT disabled_at, workos_last_event_id, whitelisted, created_at, updated_at
+-- gram_account_type and whitelisted are the two columns trial demotion drops,
+-- so a write that only extends a trial has to leave both exactly where it found
+-- them.
+SELECT disabled_at, workos_last_event_id, whitelisted, gram_account_type, created_at, updated_at
 FROM organization_metadata
 WHERE id = @id;
 

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -396,7 +396,7 @@ func (q *Queries) GetDeviceIntegrationSyncPushDigests(ctx context.Context, devic
 }
 
 const getOrganizationMetadataStateFixture = `-- name: GetOrganizationMetadataStateFixture :one
-SELECT disabled_at, workos_last_event_id, whitelisted, created_at, updated_at
+SELECT disabled_at, workos_last_event_id, whitelisted, gram_account_type, created_at, updated_at
 FROM organization_metadata
 WHERE id = $1
 `
@@ -405,6 +405,7 @@ type GetOrganizationMetadataStateFixtureRow struct {
 	DisabledAt        pgtype.Timestamptz
 	WorkosLastEventID pgtype.Text
 	Whitelisted       bool
+	GramAccountType   string
 	CreatedAt         pgtype.Timestamptz
 	UpdatedAt         pgtype.Timestamptz
 }
@@ -417,6 +418,9 @@ type GetOrganizationMetadataStateFixtureRow struct {
 // the reference points for "did this write stamp the moment of the action":
 // comparing a stamp against them keeps the comparison inside the database
 // clock, which the test host's clock can drift from.
+// gram_account_type and whitelisted are the two columns trial demotion drops,
+// so a write that only extends a trial has to leave both exactly where it found
+// them.
 func (q *Queries) GetOrganizationMetadataStateFixture(ctx context.Context, id string) (GetOrganizationMetadataStateFixtureRow, error) {
 	row := q.db.QueryRow(ctx, getOrganizationMetadataStateFixture, id)
 	var i GetOrganizationMetadataStateFixtureRow
@@ -424,6 +428,7 @@ func (q *Queries) GetOrganizationMetadataStateFixture(ctx context.Context, id st
 		&i.DisabledAt,
 		&i.WorkosLastEventID,
 		&i.Whitelisted,
+		&i.GramAccountType,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -73,13 +73,49 @@ RETURNING *;
 -- on top of whatever the trial has left, and adding to now would silently
 -- shorten a trial that still had three weeks to run.
 --
--- Only a running trial can be extended, and the three conditions that define
--- running are here rather than in the handler so the database enforces them.
--- Zero rows means the trial converted, was demoted, has already expired, or was
--- never created. Extending a demoted trial is deliberately not the same as
--- re-arming it: demotion also disabled the organization's model provider keys
--- and nothing in this repository can re-enable them, so clearing demoted_at
--- would advertise a running trial whose keys stay dead (AGE-3208).
+-- make_interval(days => N) on a timestamptz is calendar-day arithmetic evaluated
+-- in the session TimeZone, so it is 23 hours across a spring-forward rather than
+-- 24. Calendar days are the right semantics for "another two weeks", and every
+-- session here is UTC in any case: the database container defaults to Etc/UTC and
+-- GRAM_DATABASE_URL sets no TimeZone. That is what makes the exact 24-hour
+-- assertions in the tests sound, and a deployment that ever sets a non-UTC
+-- session TimeZone has to revisit them.
+--
+-- Only a running trial can be extended, and the conditions that define running
+-- are here rather than in the handler so the database enforces them. Zero rows
+-- means either that the trial cannot be extended or that the organization does
+-- not exist at all; the two share a row count but not an operator action, so the
+-- handler tells them apart with a follow-up read rather than merging them.
+--
+-- The three conditions are not equally load-bearing today, and it is worth
+-- saying which is which:
+--
+--   * converted_at IS NULL is load-bearing. A mid-trial conversion leaves ends_at
+--     in the future, so nothing else would reject it.
+--   * ends_at > clock_timestamp() is load-bearing. It is the ordinary case.
+--   * demoted_at IS NULL is forward-looking. MarkTrialDemoted only demotes an
+--     already-expired trial and nothing moves ends_at forward afterwards, so in
+--     every state the application can currently reach it is subsumed by the
+--     ends_at condition. It is kept as defence against a future re-arm path.
+--
+-- Extending a demoted trial is deliberately not the same as re-arming it:
+-- demotion also disabled the organization's model provider keys and nothing in
+-- this repository can re-enable them, so clearing demoted_at would advertise a
+-- running trial whose keys stay dead (AGE-3208).
+--
+-- Two things this query deliberately does not check:
+--
+--   * tier. The error message and the API description both say enterprise, and
+--     enterprise is the only tier the application writes, so the claim holds
+--     today. schema.sql anticipates further tiers, and the first one that arrives
+--     must revisit this query and that wording together, because this statement
+--     would otherwise extend it while reporting an enterprise trial.
+--   * organization_metadata.disabled_at. A disabled organization can still be
+--     extended, on purpose. Disabled and trial state are independent axes: an
+--     operator who disables an organization while investigating and re-enables it
+--     afterwards should not have silently lost the ability to extend in between,
+--     and a trial that keeps expiring during the investigation punishes the
+--     investigation.
 UPDATE trials
 SET ends_at = ends_at + make_interval(days => @extend_by_days::int),
     updated_at = clock_timestamp()

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -67,6 +67,27 @@ WHERE organization_id = @organization_id
   AND demoted_at IS NULL
 RETURNING *;
 
+-- name: ExtendTrial :execrows
+-- Operator-initiated extension. The interval is added to the existing ends_at
+-- rather than to the current time: "give them another two weeks" means two weeks
+-- on top of whatever the trial has left, and adding to now would silently
+-- shorten a trial that still had three weeks to run.
+--
+-- Only a running trial can be extended, and the three conditions that define
+-- running are here rather than in the handler so the database enforces them.
+-- Zero rows means the trial converted, was demoted, has already expired, or was
+-- never created. Extending a demoted trial is deliberately not the same as
+-- re-arming it: demotion also disabled the organization's model provider keys
+-- and nothing in this repository can re-enable them, so clearing demoted_at
+-- would advertise a running trial whose keys stay dead (AGE-3208).
+UPDATE trials
+SET ends_at = ends_at + make_interval(days => @extend_by_days::int),
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND converted_at IS NULL
+  AND demoted_at IS NULL
+  AND ends_at > clock_timestamp();
+
 -- name: DemoteOrganizationToFree :one
 -- Drops the organization to the free tier and back behind the dashboard
 -- book-a-demo gate. Returns the pre-update account type.

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -82,13 +82,49 @@ type ExtendTrialParams struct {
 // on top of whatever the trial has left, and adding to now would silently
 // shorten a trial that still had three weeks to run.
 //
-// Only a running trial can be extended, and the three conditions that define
-// running are here rather than in the handler so the database enforces them.
-// Zero rows means the trial converted, was demoted, has already expired, or was
-// never created. Extending a demoted trial is deliberately not the same as
-// re-arming it: demotion also disabled the organization's model provider keys
-// and nothing in this repository can re-enable them, so clearing demoted_at
-// would advertise a running trial whose keys stay dead (AGE-3208).
+// make_interval(days => N) on a timestamptz is calendar-day arithmetic evaluated
+// in the session TimeZone, so it is 23 hours across a spring-forward rather than
+// 24. Calendar days are the right semantics for "another two weeks", and every
+// session here is UTC in any case: the database container defaults to Etc/UTC and
+// GRAM_DATABASE_URL sets no TimeZone. That is what makes the exact 24-hour
+// assertions in the tests sound, and a deployment that ever sets a non-UTC
+// session TimeZone has to revisit them.
+//
+// Only a running trial can be extended, and the conditions that define running
+// are here rather than in the handler so the database enforces them. Zero rows
+// means either that the trial cannot be extended or that the organization does
+// not exist at all; the two share a row count but not an operator action, so the
+// handler tells them apart with a follow-up read rather than merging them.
+//
+// The three conditions are not equally load-bearing today, and it is worth
+// saying which is which:
+//
+//   - converted_at IS NULL is load-bearing. A mid-trial conversion leaves ends_at
+//     in the future, so nothing else would reject it.
+//   - ends_at > clock_timestamp() is load-bearing. It is the ordinary case.
+//   - demoted_at IS NULL is forward-looking. MarkTrialDemoted only demotes an
+//     already-expired trial and nothing moves ends_at forward afterwards, so in
+//     every state the application can currently reach it is subsumed by the
+//     ends_at condition. It is kept as defence against a future re-arm path.
+//
+// Extending a demoted trial is deliberately not the same as re-arming it:
+// demotion also disabled the organization's model provider keys and nothing in
+// this repository can re-enable them, so clearing demoted_at would advertise a
+// running trial whose keys stay dead (AGE-3208).
+//
+// Two things this query deliberately does not check:
+//
+//   - tier. The error message and the API description both say enterprise, and
+//     enterprise is the only tier the application writes, so the claim holds
+//     today. schema.sql anticipates further tiers, and the first one that arrives
+//     must revisit this query and that wording together, because this statement
+//     would otherwise extend it while reporting an enterprise trial.
+//   - organization_metadata.disabled_at. A disabled organization can still be
+//     extended, on purpose. Disabled and trial state are independent axes: an
+//     operator who disables an organization while investigating and re-enables it
+//     afterwards should not have silently lost the ability to extend in between,
+//     and a trial that keeps expiring during the investigation punishes the
+//     investigation.
 func (q *Queries) ExtendTrial(ctx context.Context, arg ExtendTrialParams) (int64, error) {
 	result, err := q.db.Exec(ctx, extendTrial, arg.ExtendByDays, arg.OrganizationID)
 	if err != nil {

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -62,6 +62,41 @@ func (q *Queries) DemoteOrganizationToFree(ctx context.Context, organizationID s
 	return i, err
 }
 
+const extendTrial = `-- name: ExtendTrial :execrows
+UPDATE trials
+SET ends_at = ends_at + make_interval(days => $1::int),
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND converted_at IS NULL
+  AND demoted_at IS NULL
+  AND ends_at > clock_timestamp()
+`
+
+type ExtendTrialParams struct {
+	ExtendByDays   int32
+	OrganizationID string
+}
+
+// Operator-initiated extension. The interval is added to the existing ends_at
+// rather than to the current time: "give them another two weeks" means two weeks
+// on top of whatever the trial has left, and adding to now would silently
+// shorten a trial that still had three weeks to run.
+//
+// Only a running trial can be extended, and the three conditions that define
+// running are here rather than in the handler so the database enforces them.
+// Zero rows means the trial converted, was demoted, has already expired, or was
+// never created. Extending a demoted trial is deliberately not the same as
+// re-arming it: demotion also disabled the organization's model provider keys
+// and nothing in this repository can re-enable them, so clearing demoted_at
+// would advertise a running trial whose keys stay dead (AGE-3208).
+func (q *Queries) ExtendTrial(ctx context.Context, arg ExtendTrialParams) (int64, error) {
+	result, err := q.db.Exec(ctx, extendTrial, arg.ExtendByDays, arg.OrganizationID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getActiveTrial = `-- name: GetActiveTrial :one
 SELECT organization_id, created_at, ends_at
 FROM trials


### PR DESCRIPTION
A platform admin can now give a customer more time on a running enterprise trial. Until now the end date was written once, when the trial was granted, and nothing anywhere could move it.

AGE-3191. Server half; the dashboard row action follows.

## Behaviour

`POST /admin/trial.extend` adds N days, bounded to 1..365 per call.

**The interval is added to the trial's current end date, not to today.** "Another two weeks" means two weeks on top of whatever the customer has left, so extending a trial that still has three weeks to run cannot silently shorten it. Extensions accumulate.

**Only a running trial can be extended,** and the three conditions that define running live in the query rather than the handler, so the database enforces them. A converted trial, a demoted one, and one whose date has passed but that the expiry sweeper has not reached yet are all rejected with the date left where it was. Extending is deliberately not a way to arm a trial that was never granted, which is the auth flow's job.

**An organization id that matches nothing answers 404,** the same answer disable and enable already give. Merging it into the conflict meant one mistyped id got two different stories from two buttons in the same session, and the second sent the operator to inspect a trial that was never the problem. The lookup that distinguishes them runs on the zero-row path only, so the happy path still costs one write and one read.

A trial that exists but cannot be extended answers 409. `failed_precondition` would read better, but the admin service does not declare it, so it would leave as a 500.

## Notable decisions

**A demoted trial is not re-armed by an extension.** Demotion also disabled the organization's model provider keys, and nothing in this repository can re-enable them, so clearing `demoted_at` would advertise a running trial whose keys stay dead. Filed as AGE-3208.

**Disabled organizations stay extendable.** Disabled and trial state are independent axes, and an operator who disables an organization while investigating should not silently lose the ability to extend it in between. Recorded in the query comment rather than left implicit.

**`tier` is deliberately unchecked** while `enterprise` is the only tier the application writes. The comment says so, and says that a second tier must revisit this query and the error message.

**The bounds check must stay on the wide `payload.Days`,** with the `int32` narrowing below it. Narrowing first would let `1<<32 + 1` truncate to `1` and quietly extend by a day. A test pins that order.

## Verification

Generators reproduce the committed output with zero drift, `gen:sdk --check` is up to date, and build, lint and gofmt are clean. Suite is 83 passing.

A 17-mutant sweep killed 16, each by a named test, with two canaries surviving as designed. **One survivor is recorded rather than hidden:** deleting the failed-lookup arm is not detected, because reaching it needs the update to match zero rows and the follow-up read to fail, which is fault injection between two statements. The arm is kept and left uncovered on purpose.

`TestExtendTrialRequestBody_DesignBoundsAreEnforced` is new and covers the design's own `Minimum`, `Maximum` and `MinLength(1)`. Every other test calls the service directly, so those declarations could previously be deleted with the whole suite still green.

## One correction worth flagging to reviewers

A comment in `design.go` claimed Goa names response body types by position, so inserting a method mid-block renames everything below it. **That is false and the comment is fixed.** Moving the whole method from last to first changes ten generated files and leaves all 717 generated Go type names byte-identical, because names come from the method name. The genuinely positional effect is the OpenAPI deduplication of structurally identical request bodies, which the neighbouring `disableOrganization` comment already documents correctly and which is why disable and enable need `openapi:typename`. Appending the method is now described as what it is, a diff-size choice.

## Follow-ups filed, not in this PR

- **AGE-3212**: an extension writes no audit event, while arming and demoting both do. Not a regression, since the admin service audits nothing at all, but extending is the one admin write whose effect leaves no trace in the resulting state.
- **AGE-3208**: re-arming a demoted trial needs the provider keys re-enabled first.

## Stacked

Base is `walker/age-3190-disable-server` (#5290), not `main`.

`hygiene.yaml` filters on base `main`, so **the PR title lint, the changeset lint and the migration check do not run here.** Do not read the short check list as a pass. All three were verified by hand: the title and both commits carry `feat:`/`fix:` prefixes, `.changeset/admin-extend-trial.md` targets `server` and describes user-facing behaviour, and there are no migrations or schema changes in this diff. `pr.yaml` has no branch filter, so the tests and lint that do appear are real evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend running enterprise trials via the admin API so platform admins can add 1–365 days to the current end date. Previously the end date was immutable; now extensions accumulate and add to the existing `ends_at` to avoid shortening active trials.

- New endpoint: POST `/admin/trial.extend` with `{ id, days }`. Adds days to the current `ends_at`; extensions accumulate; bounds enforced at 1–365.
- Only running trials can be extended. Converted, demoted, or already-expired trials return 409 with no mutation. Unknown organization IDs return 404. Orgs that exist but have no trial row return 409.
- Demoted trials are not re-armed by extension; disabled organizations remain extendable; no audit event is emitted. Follow-ups: AGE-3208 (re-arming + provider key re-enable), AGE-3212 (audit event).
- Guards live in SQL so the database enforces “running”; behavior is documented in OpenAPI and generated `admin` HTTP/client code. No schema changes.
- Implements the server half of Linear AGE-3191.

<sup>Written for commit c8e554678210885b4d108912ceb137705e9a20fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

