### PR TITLE
mig: add usage billing foundation

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -108,6 +108,13 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,
 
+  -- Stripe identity for PAYG organizations. NULL for organizations that have
+  -- not added a payment method through Stripe.
+  stripe_customer_id TEXT,
+  -- Current Stripe subscription. NULL after cancellation and replaced when
+  -- the organization subscribes again.
+  stripe_subscription_id TEXT,
+
   -- Contracted monthly "tokens under management" allowance. NULL means no
   -- contracted limit has been configured.
   tum_monthly_token_limit BIGINT,
@@ -131,6 +138,10 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
 
 CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_organization_id_key
 ON billing_metadata (organization_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_stripe_customer_id_key
+ON billing_metadata (stripe_customer_id)
+WHERE stripe_customer_id IS NOT NULL;
 
 COMMENT ON COLUMN billing_metadata.tunneled_mcp_server_limit IS 'Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.';
 
@@ -167,6 +178,59 @@ CREATE TABLE IF NOT EXISTS billing_cycle_usage (
 
 CREATE UNIQUE INDEX IF NOT EXISTS billing_cycle_usage_organization_id_cycle_start_key
 ON billing_cycle_usage (organization_id, cycle_start);
+
+-- Append-only mirror of TUM meter events reported to Stripe Billing. The
+-- upstream event identifier derives from the organization, cycle start, and
+-- sequence number, making sends idempotent and the ledger exactly replayable.
+CREATE TABLE IF NOT EXISTS stripe_meter_reports (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+
+  -- Cycle boundary from billing_cycle_usage at report time.
+  cycle_start timestamptz NOT NULL,
+  -- Monotonic sequence within an organization's billing cycle.
+  seq INT NOT NULL,
+  -- Tokens added by this report. The cycle's reported total is the sum of
+  -- these deltas.
+  delta_tokens BIGINT NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT stripe_meter_reports_pkey PRIMARY KEY (id),
+  CONSTRAINT stripe_meter_reports_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT stripe_meter_reports_delta_tokens_check CHECK (delta_tokens >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stripe_meter_reports_organization_id_cycle_start_seq_key
+ON stripe_meter_reports (organization_id, cycle_start, seq);
+
+-- Durable per-day OpenRouter spend per platform-managed key. Upstream history
+-- expires, so these rows are the permanent billing-grade record. key_type
+-- mirrors openrouter_api_keys but is deliberately not foreign-keyed so spend
+-- history survives key rotation and deletion.
+CREATE TABLE IF NOT EXISTS openrouter_spend_daily (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+
+  -- Billing reads 'chat' only; 'internal' spend is stored for observability.
+  -- Allowed values are validated in application code.
+  key_type TEXT NOT NULL DEFAULT 'chat',
+  -- UTC day the spend was attributed to upstream.
+  day DATE NOT NULL,
+  -- Fractional USD as reported by OpenRouter.
+  spend_usd NUMERIC(14, 6) NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT openrouter_spend_daily_pkey PRIMARY KEY (id),
+  CONSTRAINT openrouter_spend_daily_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT openrouter_spend_daily_spend_usd_check CHECK (spend_usd >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS openrouter_spend_daily_organization_id_key_type_day_key
+ON openrouter_spend_daily (organization_id, key_type, day);
 
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -315,6 +315,8 @@ type BillingCycleUsage struct {
 type BillingMetadatum struct {
 	ID                    uuid.UUID
 	OrganizationID        string
+	StripeCustomerID      pgtype.Text
+	StripeSubscriptionID  pgtype.Text
 	TumMonthlyTokenLimit  pgtype.Int8
 	AlertEmail            pgtype.Text
 	BillingCycleAnchorDay int32
@@ -1328,6 +1330,16 @@ type OpenrouterApiKey struct {
 	UpdatedAt      pgtype.Timestamptz
 	DeletedAt      pgtype.Timestamptz
 	Deleted        bool
+}
+
+type OpenrouterSpendDaily struct {
+	ID             uuid.UUID
+	OrganizationID string
+	KeyType        string
+	Day            pgtype.Date
+	SpendUsd       pgtype.Numeric
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
 }
 
 type OrganizationFeature struct {
@@ -2462,6 +2474,16 @@ type SpendRuleEvent struct {
 	WindowStart    pgtype.Timestamptz
 	WindowEnd      pgtype.Timestamptz
 	CreatedAt      pgtype.Timestamptz
+}
+
+type StripeMeterReport struct {
+	ID             uuid.UUID
+	OrganizationID string
+	CycleStart     pgtype.Timestamptz
+	Seq            int32
+	DeltaTokens    int64
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
 }
 
 // Durable record of a blocked tool call or prompt. One row per hook-time block decision, carrying the exact reason shown to the agent. Backs the durable /blocks/:id page and its thumbs feedback. The risk_results / risk_policies foreign keys are nullable enrichment links — the page renders from this row alone.

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -23,6 +23,8 @@ type BillingCycleUsage struct {
 type BillingMetadatum struct {
 	ID                    uuid.UUID
 	OrganizationID        string
+	StripeCustomerID      pgtype.Text
+	StripeSubscriptionID  pgtype.Text
 	TumMonthlyTokenLimit  pgtype.Int8
 	AlertEmail            pgtype.Text
 	BillingCycleAnchorDay int32

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getBillingMetadata = `-- name: GetBillingMetadata :one
-SELECT id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
+SELECT id, organization_id, stripe_customer_id, stripe_subscription_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 FROM billing_metadata
 WHERE organization_id = $1
 `
@@ -24,6 +24,8 @@ func (q *Queries) GetBillingMetadata(ctx context.Context, organizationID string)
 	err := row.Scan(
 		&i.ID,
 		&i.OrganizationID,
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
@@ -219,7 +221,7 @@ ON CONFLICT (organization_id) DO UPDATE SET
   -- field (dashboard TUM form, older SDKs) must not silently clear it.
   , tunneled_mcp_server_limit = COALESCE(EXCLUDED.tunneled_mcp_server_limit, billing_metadata.tunneled_mcp_server_limit)
   , updated_at = clock_timestamp()
-RETURNING id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
+RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 `
 
 type UpsertBillingMetadataParams struct {
@@ -242,6 +244,8 @@ func (q *Queries) UpsertBillingMetadata(ctx context.Context, arg UpsertBillingMe
 	err := row.Scan(
 		&i.ID,
 		&i.OrganizationID,
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,

--- a/server/migrations/20260814095831_payg-billing-foundation.sql
+++ b/server/migrations/20260814095831_payg-billing-foundation.sql
@@ -1,0 +1,36 @@
+-- atlas:txmode none
+
+-- Modify "billing_metadata" table
+ALTER TABLE "billing_metadata" ADD COLUMN "stripe_customer_id" text NULL, ADD COLUMN "stripe_subscription_id" text NULL;
+-- Create index "billing_metadata_stripe_customer_id_key" to table: "billing_metadata"
+CREATE UNIQUE INDEX CONCURRENTLY "billing_metadata_stripe_customer_id_key" ON "billing_metadata" ("stripe_customer_id") WHERE (stripe_customer_id IS NOT NULL);
+-- Create "openrouter_spend_daily" table
+CREATE TABLE "openrouter_spend_daily" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "key_type" text NOT NULL DEFAULT 'chat',
+  "day" date NOT NULL,
+  "spend_usd" numeric(14,6) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "openrouter_spend_daily_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "openrouter_spend_daily_spend_usd_check" CHECK (spend_usd >= (0)::numeric)
+);
+-- Create index "openrouter_spend_daily_organization_id_key_type_day_key" to table: "openrouter_spend_daily"
+CREATE UNIQUE INDEX "openrouter_spend_daily_organization_id_key_type_day_key" ON "openrouter_spend_daily" ("organization_id", "key_type", "day");
+-- Create "stripe_meter_reports" table
+CREATE TABLE "stripe_meter_reports" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "cycle_start" timestamptz NOT NULL,
+  "seq" integer NOT NULL,
+  "delta_tokens" bigint NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "stripe_meter_reports_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "stripe_meter_reports_delta_tokens_check" CHECK (delta_tokens >= 0)
+);
+-- Create index "stripe_meter_reports_organization_id_cycle_start_seq_key" to table: "stripe_meter_reports"
+CREATE UNIQUE INDEX "stripe_meter_reports_organization_id_cycle_start_seq_key" ON "stripe_meter_reports" ("organization_id", "cycle_start", "seq");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:apYXKwsBDd+VquEC87AF+rXYjCQGXtqSVbNBkad7hiE=
+h1:IfiHRfAvXar+DjF42FDlIFFsqyiq+7prEBiE61O2I20=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -340,3 +340,4 @@ h1:apYXKwsBDd+VquEC87AF+rXYjCQGXtqSVbNBkad7hiE=
 20260813140026_assistant-thread-events-trigger-instance-fkey-idx.sql h1:HOy5z8JXCh3rl8qfgYX7YXepyH8o4vezsEDruYeIT98=
 20260813150000_user-sessions-tool-selection.sql h1:6l17RI8mPHjZDTtBoUDL+EDSTouOLhTEhgWK0COmOz0=
 20260813230844_platform-mcp-onboarding-milestone-generation.sql h1:N9818ntJknuX+hIp9KZ0RGzCich+h0H2nIFmaXsSfkk=
+20260814095831_payg-billing-foundation.sql h1:++Wz/+C4L4CEUekUCe2U9I/+8AGT85XqQPSYeLRKVWU=


### PR DESCRIPTION
## Summary

- add Stripe customer and subscription identity to organization billing metadata
- add durable ledgers for Stripe meter reports and daily OpenRouter spend
- include the Atlas migration and required SQLc regeneration
- keep the new billing records organization-scoped with cascade cleanup, matching the approved billing data model and neighboring billing tables

Closes [DNO-833](https://linear.app/speakeasy/issue/DNO-833/feat-payg-billing-tables-stripe-identity-meter-report-ledger-daily)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
PAYG billing foundation for DNO-833: adds Stripe identity on org billing metadata and durable ledgers for Stripe meter events and daily OpenRouter spend. Previously we stored none of this; now we persist nullable Stripe customer/subscription IDs, an append-only meter-report ledger, and per-day spend to support accurate invoicing and reconciliation.

- Schema-only, expand-only migration; no backfill. Apply the DB migration; no app config changes.
- billing_metadata: add nullable stripe_customer_id and stripe_subscription_id; partial unique index on stripe_customer_id (created concurrently) for webhook reverse lookup.
- stripe_meter_reports: append-only, unique on (organization_id, cycle_start, seq); non-negative delta check; cascades on org delete.
- openrouter_spend_daily: unique on (organization_id, key_type, day); NUMERIC(14,6) USD; cascades on org delete.
- Regenerated models and repo queries now read/return the new Stripe fields; existing readers/writers remain compatible since fields are nullable.

<sup>Written for commit 19afbc97f1541a81d380e9eda2d67e46ad267214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

