### PR TITLE
chore(authz): drop legacy role URN support

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -66886,7 +66886,7 @@ components:
           format: uuid
         principal_urn:
           type: string
-          description: Principal URN (e.g. role:engineering, user:id, or *).
+          description: Principal URN (e.g. role:organization:<uuid>, user:id, or *).
       required:
         - id
         - principal_urn

--- a/client/dashboard/src/pages/plugins/plugin-reach.test.ts
+++ b/client/dashboard/src/pages/plugins/plugin-reach.test.ts
@@ -87,25 +87,12 @@ describe("countPluginInstalls", () => {
     ).toBe(1);
   });
 
-  it("matches role assignments stored in the legacy role:<slug> form", () => {
-    const syncedUsers = [synced("member@corp.com")];
-    const members = [member("u1", "member@corp.com", ["role-eng"])];
-    expect(
-      countPluginInstalls(
-        [assignment("role:engineering")],
-        syncedUsers,
-        members,
-        [engineering],
-      ),
-    ).toBe(1);
-  });
-
   it("does not double-count a user matched by multiple assignments", () => {
     const syncedUsers = [synced("member@corp.com")];
     const members = [member("u1", "member@corp.com", ["role-eng"])];
     expect(
       countPluginInstalls(
-        [assignment("user:u1"), assignment("role:engineering")],
+        [assignment("user:u1"), assignment("role:organization:role-eng")],
         syncedUsers,
         members,
         [engineering],

--- a/client/dashboard/src/pages/plugins/plugin-reach.ts
+++ b/client/dashboard/src/pages/plugins/plugin-reach.ts
@@ -17,10 +17,7 @@ const ALL_USERS_PRINCIPAL = "user:all";
 //   user:all           → every synced identity that resolves to an org member
 //   email:<addr>       → the synced user with that email
 //   user:<id>          → the member with that id
-//   role:<...>         → every synced member holding that role, matched against
-//                        both the canonical role URN and the legacy role:<slug>
-//                        principal (the backend still honors both — see
-//                        newRolePrincipals / AGE-1954)
+//   role:<kind>:<uuid> → every synced member holding that role
 //
 // Marketplace installs (Claude/Cursor/Codex) ship every published plugin and
 // aren't attributed per plugin, so this count reflects device-agent reach only.
@@ -44,13 +41,9 @@ export function countPluginInstalls(
     (a) => a.principalUrn === ALL_USERS_PRINCIPAL,
   );
 
-  // A role assignment can be stored as either the canonical role principal URN
-  // or the legacy role:<slug> form, so index roles under both to match the
-  // agent's dual-principal role matching.
   const roleIdByUrn = new Map<string, string>();
   for (const role of roles) {
     if (role.principalUrn) roleIdByUrn.set(role.principalUrn, role.id);
-    if (role.slug) roleIdByUrn.set(`${ROLE_PREFIX}${role.slug}`, role.id);
   }
 
   const assignedEmails = new Set<string>();

--- a/client/dashboard/src/sdk/src/models/components/pluginassignment.ts
+++ b/client/dashboard/src/sdk/src/models/components/pluginassignment.ts
@@ -15,7 +15,7 @@ export type PluginAssignment = {
    */
   id: string;
   /**
-   * Principal URN (e.g. role:engineering, user:id, or *).
+   * Principal URN (e.g. role:organization:<uuid>, user:id, or *).
    */
   principalUrn: string;
 };

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -15,7 +15,7 @@ Org admin                     Gram                        GitHub repo (auto-mana
   │                             │                                │
   ├─ create plugin "AI Tools"   │                                │
   ├─ add 3 MCP servers          │                                │
-  ├─ assign to role:engineers ──► publishPlugins() ─────────────► push .claude-plugin/
+  ├─ assign to a role ──────────► publishPlugins() ─────────────► push .claude-plugin/
   │                             │   mint API keys                   .cursor-plugin/
   │                             │   generate ZIPs                   .codex-plugin/
   │                             │   store marketplace token         marketplace.json
@@ -32,7 +32,7 @@ Team member installs from Claude/Cursor/Codex marketplace
 **Assignments.** Plugins are assigned to principals using URN strings:
 
 - `*` — all users in the org
-- `role:engineers` — all members of a named role
+- `role:organization:<role-uuid>` — all members of an organization role
 - `user:<uuid>` — a specific user
 
 Assignments control who sees the plugin in their marketplace; RBAC (`mcp:connect` scope) still enforces access at the MCP entrypoint.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -26,17 +26,19 @@ Examples:
 
 ```text
 user:user_01abc
-role:admin
-role:member
-role:custom-builder
+role:global:00000000-0000-0000-0000-000000000001
+role:global:00000000-0000-0000-0000-000000000002
+role:organization:00000000-0000-0000-0000-000000000003
 ```
+
+Role principals use `role:<kind>:<role-uuid>`, where `kind` is `global` or `organization`. Role slugs such as `admin` remain display and lookup metadata; they are not principal identifiers.
 
 The current RBAC implementation supports `user` and `role` principals, but there is no hard limitation to those two. We can add other principal types as the model grows. For example, we expect to migrate the current API key system into RBAC eventually, which would introduce an `api_key` principal.
 
 A request's effective grants are normally loaded from both:
 
 - the authenticated user principal, such as `user:user_01abc`
-- the user's organization role principal, such as `role:admin` or `role:custom-builder`
+- the user's canonical role principal, such as `role:global:<role-uuid>` or `role:organization:<role-uuid>`
 
 This lets us give most access through roles while still allowing direct user grants when needed.
 
@@ -140,14 +142,14 @@ principal + scope + selector = grant
 Example:
 
 ```text
-role:member has project:read on project 018f...
+role:global:00000000-0000-0000-0000-000000000002 has project:read on project 018f...
 ```
 
 In database shape:
 
 ```json
 {
-  "principal_urn": "role:member",
+  "principal_urn": "role:global:00000000-0000-0000-0000-000000000002",
   "scope": "project:read",
   "selectors": {
     "resource_kind": "project",
@@ -385,9 +387,9 @@ org:admin
 Grants assign that vocabulary to principals:
 
 ```text
-role:admin has project:write on every project
-role:member has mcp:connect on every MCP server
-role:custom-support has mcp:connect on toolset_123, tool=search_docs
+role:global:00000000-0000-0000-0000-000000000001 has project:write on every project
+role:global:00000000-0000-0000-0000-000000000002 has mcp:connect on every MCP server
+role:organization:00000000-0000-0000-0000-000000000003 has mcp:connect on toolset_123, tool=search_docs
 ```
 
 The practical distinction is simple: add a grant when the permission already exists but another principal needs it. Add a scope only when the product needs a new kind of permission that should be independently assignable. Most changes should add or modify grants, not scopes.
@@ -475,7 +477,7 @@ The principal list usually contains the user and their role:
 
 ```text
 user:user_01abc
-role:member
+role:global:00000000-0000-0000-0000-000000000002
 ```
 
 The engine then evaluates checks in memory against the loaded grants.
@@ -752,7 +754,7 @@ Grant row:
 ```json
 {
   "organization_id": "org_123",
-  "principal_urn": "role:analyst",
+  "principal_urn": "role:organization:00000000-0000-0000-0000-000000000010",
   "scope": "project:read",
   "selectors": {
     "resource_kind": "project",
@@ -782,7 +784,7 @@ Grant row:
 
 ```json
 {
-  "principal_urn": "role:analyst",
+  "principal_urn": "role:organization:00000000-0000-0000-0000-000000000010",
   "scope": "project:read",
   "selectors": {
     "resource_kind": "project",
@@ -812,7 +814,7 @@ Grant row:
 
 ```json
 {
-  "principal_urn": "role:builder",
+  "principal_urn": "role:organization:00000000-0000-0000-0000-000000000011",
   "scope": "project:write",
   "selectors": {
     "resource_kind": "project",
@@ -842,7 +844,7 @@ Grant row:
 
 ```json
 {
-  "principal_urn": "role:agent-user",
+  "principal_urn": "role:organization:00000000-0000-0000-0000-000000000012",
   "scope": "mcp:connect",
   "selectors": {
     "resource_kind": "mcp",
@@ -870,7 +872,7 @@ Grant row:
 
 ```json
 {
-  "principal_urn": "role:agent-user",
+  "principal_urn": "role:organization:00000000-0000-0000-0000-000000000012",
   "scope": "mcp:connect",
   "selectors": {
     "resource_kind": "mcp",
@@ -907,7 +909,7 @@ Grant rows:
 ```json
 [
   {
-    "principal_urn": "role:analyst",
+    "principal_urn": "role:organization:00000000-0000-0000-0000-000000000010",
     "scope": "project:read",
     "selectors": {
       "resource_kind": "project",
@@ -915,7 +917,7 @@ Grant rows:
     }
   },
   {
-    "principal_urn": "role:analyst",
+    "principal_urn": "role:organization:00000000-0000-0000-0000-000000000010",
     "scope": "project:read",
     "selectors": {
       "resource_kind": "project",

--- a/server/cmd/workos-backfill/backfill.go
+++ b/server/cmd/workos-backfill/backfill.go
@@ -303,7 +303,7 @@ func backfillOrganizationRoles(ctx context.Context, logger *slog.Logger, dbtx pg
 		// slug, so mirror the event handler's principal exactly — a slug-based
 		// URN matches nothing and leaves the grants behind.
 		rolePrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+localRole.ID.String())
-		if err := authz.DeleteRoleGrants(ctx, repo, organizationID, localRole.WorkosSlug, rolePrincipal.String()); err != nil {
+		if err := authz.DeleteRoleGrants(ctx, repo, organizationID, rolePrincipal.String()); err != nil {
 			return fmt.Errorf("delete grants for organization role %q: %w", localRole.WorkosSlug, err)
 		}
 		logger.DebugContext(ctx, "soft-deleted WorkOS organization role missing from snapshot", attr.SlogAccessRoleSlug(localRole.WorkosSlug))

--- a/server/design/plugins/design.go
+++ b/server/design/plugins/design.go
@@ -478,7 +478,7 @@ var PluginAssignmentModel = Type("PluginAssignment", func() {
 		Description("Unique assignment identifier.")
 		Format(FormatUUID)
 	})
-	Attribute("principal_urn", String, "Principal URN (e.g. role:engineering, user:id, or *).")
+	Attribute("principal_urn", String, "Principal URN (e.g. role:organization:<uuid>, user:id, or *).")
 	Attribute("created_at", String, func() {
 		Format(FormatDateTime)
 	})

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -67109,7 +67109,7 @@ components:
                     format: uuid
                 principal_urn:
                     type: string
-                    description: Principal URN (e.g. role:engineering, user:id, or *).
+                    description: Principal URN (e.g. role:organization:<uuid>, user:id, or *).
             required:
                 - id
                 - principal_urn

--- a/server/gen/http/plugins/client/types.go
+++ b/server/gen/http/plugins/client/types.go
@@ -3344,7 +3344,7 @@ type PluginServerResponseBody struct {
 type PluginAssignmentResponseBody struct {
 	// Unique assignment identifier.
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
-	// Principal URN (e.g. role:engineering, user:id, or *).
+	// Principal URN (e.g. role:organization:<uuid>, user:id, or *).
 	PrincipalUrn *string `form:"principal_urn,omitempty" json:"principal_urn,omitempty" xml:"principal_urn,omitempty"`
 	CreatedAt    *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 }

--- a/server/gen/http/plugins/server/types.go
+++ b/server/gen/http/plugins/server/types.go
@@ -3344,7 +3344,7 @@ type PluginServerResponseBody struct {
 type PluginAssignmentResponseBody struct {
 	// Unique assignment identifier.
 	ID string `form:"id" json:"id" xml:"id"`
-	// Principal URN (e.g. role:engineering, user:id, or *).
+	// Principal URN (e.g. role:organization:<uuid>, user:id, or *).
 	PrincipalUrn string `form:"principal_urn" json:"principal_urn" xml:"principal_urn"`
 	CreatedAt    string `form:"created_at" json:"created_at" xml:"created_at"`
 }

--- a/server/gen/plugins/service.go
+++ b/server/gen/plugins/service.go
@@ -260,7 +260,7 @@ type Plugin struct {
 type PluginAssignment struct {
 	// Unique assignment identifier.
 	ID string
-	// Principal URN (e.g. role:engineering, user:id, or *).
+	// Principal URN (e.g. role:organization:<uuid>, user:id, or *).
 	PrincipalUrn string
 	CreatedAt    string
 }

--- a/server/internal/access/createrole_test.go
+++ b/server/internal/access/createrole_test.go
@@ -193,7 +193,6 @@ func TestService_CreateRole_ReactivatesDeletedSlug(t *testing.T) {
 
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_1", "Custom Builder", "org-custom-builder", "Old description"))
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+roleID), authz.ScopeRiskPolicyEvaluate, "policy-1")
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "org-custom-builder"), authz.ScopeMCPConnect, authz.WildcardResource)
 
 	deleted, err := accessrepo.New(ti.conn).MarkOrganizationRoleDeleted(ctx, accessrepo.MarkOrganizationRoleDeletedParams{
 		WorkosDeletedAt:   conv.ToPGTimestamptz(time.Now().UTC()),
@@ -204,7 +203,7 @@ func TestService_CreateRole_ReactivatesDeletedSlug(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), deleted)
 
-	err = authz.DeleteRoleGrants(ctx, accessrepo.New(ti.conn), authCtx.ActiveOrganizationID, "org-custom-builder", "role:organization:"+roleID)
+	err = authz.DeleteRoleGrants(ctx, accessrepo.New(ti.conn), authCtx.ActiveOrganizationID, "role:organization:"+roleID)
 	require.NoError(t, err)
 
 	ti.roles.On("CreateRole", mock.Anything, mockidp.MockOrgID, thirdpartyworkos.CreateRoleOpts{
@@ -238,9 +237,6 @@ func TestService_CreateRole_ReactivatesDeletedSlug(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, row.Deleted)
 	require.False(t, row.WorkosDeleted)
-
-	legacyGrants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "org-custom-builder"))
-	require.Empty(t, legacyGrants)
 
 	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+roleID))
 	require.Len(t, grants, 1)

--- a/server/internal/access/deleterole_test.go
+++ b/server/internal/access/deleterole_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestService_DeleteRole(t *testing.T) {
@@ -28,14 +27,15 @@ func TestService_DeleteRole(t *testing.T) {
 
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"))
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeMCPConnect, authz.WildcardResource)
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeRiskPolicyEvaluate, "policy-1")
+	rolePrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeProjectRead, "project-1")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeMCPConnect, authz.WildcardResource)
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeRiskPolicyEvaluate, "policy-1")
 
 	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: roleID})
 	require.NoError(t, err)
 
-	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"))
+	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal)
 	require.Empty(t, grants)
 
 	role, err := accessrepo.New(ti.conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
@@ -123,12 +123,13 @@ func TestService_DeleteRole_ReassignFailureDoesNotHaltDelete(t *testing.T) {
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "", mockMember(mockidp.MockOrgID, "membership_1", "user_1", "custom-builder"))
 	ti.roles.On("UpdateMemberRoles", mock.Anything, "membership_1", []string{authz.SystemRoleMember}).Return((*thirdpartyworkos.Member)(nil), errors.New("workos unavailable")).Times(3)
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+	rolePrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeProjectRead, "project-1")
 
 	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: roleID})
 	require.NoError(t, err)
 
-	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"))
+	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal)
 	require.Empty(t, grants)
 }
 
@@ -153,12 +154,13 @@ func TestService_DeleteRole_PartialReassignFailureContinuesDelete(t *testing.T) 
 	}, nil).Once()
 	ti.roles.On("UpdateMemberRoles", mock.Anything, "membership_2", []string{authz.SystemRoleMember}).Return((*thirdpartyworkos.Member)(nil), errors.New("workos unavailable")).Times(3)
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+	rolePrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeProjectRead, "project-1")
 
 	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: roleID})
 	require.NoError(t, err)
 
-	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"))
+	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal)
 	require.Empty(t, grants)
 }
 
@@ -194,12 +196,13 @@ func TestService_DeleteRole_WorkOSDeleteFailure(t *testing.T) {
 	require.NotNil(t, authCtx)
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"))
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(errors.New("workos unavailable")).Times(3)
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+	rolePrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeProjectRead, "project-1")
 
 	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: roleID})
 	require.NoError(t, err)
 
-	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"))
+	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal)
 	require.Empty(t, grants)
 }
 
@@ -215,7 +218,7 @@ func TestService_DeleteRole_AuditLog(t *testing.T) {
 
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_custom", "Audit Builder", "custom-builder", "Old description"))
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder"), authz.ScopeProjectRead, "project-1")
 
 	err = ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: roleID})
 	require.NoError(t, err)

--- a/server/internal/access/getrole_test.go
+++ b/server/internal/access/getrole_test.go
@@ -8,7 +8,6 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/access"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestService_GetRole(t *testing.T) {
@@ -29,9 +28,10 @@ func TestService_GetRole(t *testing.T) {
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", mockMember("", "membership_2", "user_2", "custom-builder"))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_3", mockMember("", "membership_3", "user_3", "admin"))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "", mockMember("", "membership_workos_only", "user_workos_only", "custom-builder"))
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeMCPConnect, authz.WildcardResource)
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeRiskPolicyEvaluate, "policy-1")
+	customRolePrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, customRolePrincipal, authz.ScopeProjectRead, "project-1")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, customRolePrincipal, authz.ScopeMCPConnect, authz.WildcardResource)
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, customRolePrincipal, authz.ScopeRiskPolicyEvaluate, "policy-1")
 
 	role, err := ti.service.GetRole(ctx, &gen.GetRolePayload{ID: customID})
 	require.NoError(t, err)

--- a/server/internal/access/listroles_test.go
+++ b/server/internal/access/listroles_test.go
@@ -8,7 +8,6 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/access"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestService_ListRoles(t *testing.T) {
@@ -29,11 +28,13 @@ func TestService_ListRoles(t *testing.T) {
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", mockMember("", "membership_2", "user_2", "custom-builder"))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_3", mockMember("", "membership_3", "user_3", "custom-builder"))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "", mockMember("", "membership_workos_only", "user_workos_only", "custom-builder"))
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "admin"), authz.ScopeOrgAdmin, authz.WildcardResource)
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-2")
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeMCPConnect, authz.WildcardResource)
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeRiskPolicyEvaluate, "policy-1")
+	adminPrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "admin")
+	customRolePrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, adminPrincipal, authz.ScopeOrgAdmin, authz.WildcardResource)
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, customRolePrincipal, authz.ScopeProjectRead, "project-1")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, customRolePrincipal, authz.ScopeProjectRead, "project-2")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, customRolePrincipal, authz.ScopeMCPConnect, authz.WildcardResource)
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, customRolePrincipal, authz.ScopeRiskPolicyEvaluate, "policy-1")
 
 	result, err := ti.service.ListRoles(ctx, &gen.ListRolesPayload{})
 	require.NoError(t, err)

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -46,7 +46,7 @@ func TestService_ListGrants(t *testing.T) {
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, authCtx.UserID, mockMember("", "membership_1", "workos_user_member", "custom-builder"))
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID), authz.ScopeProjectRead, "project_123")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID), authz.ScopeRiskPolicyEvaluate, "policy_123")
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeMCPConnect, "tool_456")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder"), authz.ScopeMCPConnect, "tool_456")
 
 	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
 	require.NoError(t, err)
@@ -74,8 +74,9 @@ func TestService_ListGrants_RoleGrants(t *testing.T) {
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, authCtx.UserID, "member@example.com", "Member User", "workos_user_member", "membership_1")
 	seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_custom", "Custom Builder", "custom-builder", ""))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, authCtx.UserID, mockMember("", "membership_1", "workos_user_member", "custom-builder"))
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project_123")
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeMCPConnect, "tool_456")
+	rolePrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeProjectRead, "project_123")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, rolePrincipal, authz.ScopeMCPConnect, "tool_456")
 
 	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
 	require.NoError(t, err)

--- a/server/internal/access/rbac_test.go
+++ b/server/internal/access/rbac_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestService_ListRoles_ForbiddenWithoutOrgReadGrant(t *testing.T) {
@@ -62,7 +61,7 @@ func TestService_GetRole_AllowsOrgReadGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgRead, Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID)})
 
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_custom", "Custom Builder", "custom-builder", "Can build selected resources"))
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder"), authz.ScopeProjectRead, "project-1")
 
 	role, err := ti.service.GetRole(ctx, &gen.GetRolePayload{ID: roleID})
 	require.NoError(t, err)
@@ -213,7 +212,7 @@ func TestService_DeleteRole_AllowsOrgAdminGrant(t *testing.T) {
 
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"))
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder"), authz.ScopeProjectRead, "project-1")
 
 	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: roleID})
 	require.NoError(t, err)

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -548,7 +548,7 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 		return localRole{}, oops.E(oops.CodeNotFound, nil, "role not found").LogError(ctx, r.logger)
 	}
 
-	if err := authz.DeleteRoleGrants(ctx, repo.New(tx), gramOrgID, currentRole.Slug, currentRole.PrincipalURN); err != nil {
+	if err := authz.DeleteRoleGrants(ctx, repo.New(tx), gramOrgID, currentRole.PrincipalURN); err != nil {
 		return localRole{}, oops.E(oops.CodeUnexpected, err, "delete grants for deleted role").LogError(ctx, r.logger)
 	}
 
@@ -1057,9 +1057,7 @@ func retryWorkOSError(err error) bool {
 
 // roleViewFromLocalRole converts a local role record into the public API role view and attaches local grants.
 func (r *RoleManager) roleViewFromLocalRole(ctx context.Context, organizationID string, role localRole) (*gen.Role, error) {
-	// Role grant reads intentionally include both canonical role URNs and
-	// legacy role slugs until old principal_grants rows are backfilled.
-	grants, err := authz.GrantsForRole(ctx, r.logger, r.db, organizationID, role.Slug, role.PrincipalURN)
+	grants, err := authz.GrantsForRole(ctx, r.logger, r.db, organizationID, role.PrincipalURN)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load role grants").LogError(ctx, r.logger)
 	}

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -198,6 +198,17 @@ func seedRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizatio
 	return row.ID.String()
 }
 
+func seededRolePrincipal(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, roleSlug string) urn.Principal {
+	t.Helper()
+
+	row, err := accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: organizationID,
+		WorkosSlug:     roleSlug,
+	})
+	require.NoError(t, err)
+	return urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+row.ID.String())
+}
+
 func seedGlobalRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, role workos.Role) string {
 	t.Helper()
 

--- a/server/internal/access/syncgrants_test.go
+++ b/server/internal/access/syncgrants_test.go
@@ -7,7 +7,6 @@ import (
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/authz"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestService_patchRoleGrants_preservesUnmentionedGrants(t *testing.T) {
@@ -18,11 +17,9 @@ func TestService_patchRoleGrants_preservesUnmentionedGrants(t *testing.T) {
 	roleSlug := "custom-audiences"
 	seedInternalOrganization(t, ctx, conn, organizationID)
 	rolePrincipal := seedInternalRole(t, ctx, conn, organizationID, roleSlug)
-	legacyRolePrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, roleSlug)
 
 	seedInternalGrant(t, ctx, conn, organizationID, rolePrincipal, string(authz.ScopeProjectRead), "project-old")
 	seedInternalGrant(t, ctx, conn, organizationID, rolePrincipal, string(authz.ScopeRiskPolicyEvaluate), "policy-canonical")
-	seedInternalGrant(t, ctx, conn, organizationID, legacyRolePrincipal, string(authz.ScopeRiskPolicyEvaluate), "policy-legacy")
 
 	_, err := authz.PatchRoleGrantsTx(ctx, conn, organizationID, roleSlug, rolePrincipal.String(), []*authz.RoleGrant{
 		{
@@ -59,12 +56,4 @@ func TestService_patchRoleGrants_preservesUnmentionedGrants(t *testing.T) {
 		{scope: string(authz.ScopeProjectWrite), resourceID: authz.WildcardResource},
 		{scope: string(authz.ScopeRiskPolicyEvaluate), resourceID: "policy-canonical"},
 	}, got)
-
-	legacyRows, err := accessrepo.New(conn).ListPrincipalGrantsByOrg(ctx, accessrepo.ListPrincipalGrantsByOrgParams{
-		OrganizationID: organizationID,
-		PrincipalUrn:   legacyRolePrincipal.String(),
-	})
-	require.NoError(t, err)
-	require.Len(t, legacyRows, 1)
-	require.Equal(t, string(authz.ScopeRiskPolicyEvaluate), legacyRows[0].Scope)
 }

--- a/server/internal/access/updaterole_test.go
+++ b/server/internal/access/updaterole_test.go
@@ -64,7 +64,7 @@ func TestService_UpdateRole(t *testing.T) {
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", mockMember(mockidp.MockOrgID, "membership_2", "user_2", authz.SystemRoleMember))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_3", mockMember(mockidp.MockOrgID, "membership_3", "user_3", "custom-builder"))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "", mockMember(mockidp.MockOrgID, "membership_workos_only", "user_workos_only", "custom-builder"))
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-old")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+roleID), authz.ScopeProjectRead, "project-old")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+roleID), authz.ScopeRiskPolicyEvaluate, "policy-1")
 	role, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
 		ID:          roleID,
@@ -360,7 +360,7 @@ func TestService_UpdateRole_AuditLog(t *testing.T) {
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", "user2@test.com", "User 2", "user_2", "membership_2")
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", mockMember(mockidp.MockOrgID, "membership_1", "user_1", "custom-builder"))
 	seedRoleAssignment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", mockMember(mockidp.MockOrgID, "membership_2", "user_2", "custom-builder"))
-	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-old")
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+roleID), authz.ScopeProjectRead, "project-old")
 
 	updated, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
 		ID:          roleID,

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -228,7 +228,7 @@ func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload
 	principals := []string{emailPrincipal.String(), urn.PrincipalWildcard}
 
 	// Resolve the reported email to an org member so user:<id>, user:all, and
-	// role:<...> assignments deliver too. A non-member (or unknown email) is not
+	// role:<kind>:<uuid> assignments deliver too. A non-member (or unknown email) is not
 	// an error: the caller still receives email- and wildcard-scoped plugins.
 	user, err := usersrepo.New(s.db).GetConnectedUserByEmail(ctx, usersrepo.GetConnectedUserByEmailParams{
 		Email:          email,

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -1338,7 +1338,7 @@ func TestE2E_Register_CreatesWorkOSOrg(t *testing.T) {
 		role, err := accessRepo.New(inst.conn).GetGlobalRoleBySlug(ctx, roleSlug)
 		require.NoError(t, err)
 		roleURN := "role:global:" + role.ID.String()
-		grants, err := authz.GrantsForRole(ctx, testenv.NewLogger(t), inst.conn, expectedGramOrgID, roleSlug, roleURN)
+		grants, err := authz.GrantsForRole(ctx, testenv.NewLogger(t), inst.conn, expectedGramOrgID, roleURN)
 		require.NoError(t, err)
 		require.Len(t, grants, len(authz.SystemRoleGrants[roleSlug]))
 	}

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -118,17 +118,13 @@ func SeedSystemRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, organizationID 
 			}
 		}
 
-		rp, err := loadRolePrincipals(ctx, dbtx, organizationID, roleSlug, "")
+		principal, err := loadRolePrincipal(ctx, dbtx, organizationID, roleSlug, "")
 		if err != nil {
 			return fmt.Errorf("resolve %s role principal: %w", roleSlug, err)
 		}
-		principalURNs, err := principalURNStrings(rp.MatchPrincipals)
-		if err != nil {
-			return fmt.Errorf("build %s role principals: %w", roleSlug, err)
-		}
 		existingGrants, err := q.GetPrincipalGrants(ctx, repo.GetPrincipalGrantsParams{
 			OrganizationID: organizationID,
-			PrincipalUrns:  principalURNs,
+			PrincipalUrns:  []string{principal.String()},
 		})
 		if err != nil {
 			return fmt.Errorf("list %s grants: %w", roleSlug, err)
@@ -141,7 +137,7 @@ func SeedSystemRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, organizationID 
 		if err != nil {
 			return fmt.Errorf("build %s grants: %w", roleSlug, err)
 		}
-		if err := rp.insertGrantsIfAbsent(ctx, q, organizationID, rows); err != nil {
+		if err := insertRoleGrantsIfAbsent(ctx, q, organizationID, roleSlug, principal, rows); err != nil {
 			return fmt.Errorf("seed %s grants: %w", roleSlug, err)
 		}
 	}
@@ -155,7 +151,7 @@ func PatchRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, orgID string, roleSl
 		return nil, fmt.Errorf("organization id is required")
 	}
 
-	rp, err := loadRolePrincipals(ctx, dbtx, orgID, roleSlug, rolePrincipalURN)
+	principal, err := loadRolePrincipal(ctx, dbtx, orgID, roleSlug, rolePrincipalURN)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +161,7 @@ func PatchRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, orgID string, roleSl
 	if err != nil {
 		return nil, err
 	}
-	if err := rp.deleteGrants(ctx, q, orgID, removeRows); err != nil {
+	if err := deletePrincipalGrants(ctx, q, orgID, principal, removeRows); err != nil {
 		return nil, err
 	}
 
@@ -173,17 +169,13 @@ func PatchRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, orgID string, roleSl
 	if err != nil {
 		return nil, err
 	}
-	if err := rp.upsertGrants(ctx, q, orgID, addRows); err != nil {
+	if err := upsertPrincipalGrants(ctx, q, orgID, principal, addRows); err != nil {
 		return nil, err
 	}
 
-	principalURNs, err := principalURNStrings(rp.MatchPrincipals)
-	if err != nil {
-		return nil, fmt.Errorf("build role principals: %w", err)
-	}
 	rows, err := q.GetPrincipalGrants(ctx, repo.GetPrincipalGrantsParams{
 		OrganizationID: orgID,
-		PrincipalUrns:  principalURNs,
+		PrincipalUrns:  []string{principal.String()},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list grants for role: %w", err)
@@ -244,22 +236,15 @@ func flattenRoleGrants(grants []*RoleGrant) ([]roleGrantRow, error) {
 	return rows, nil
 }
 
-func GrantsForRole(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, orgID string, roleSlug string, rolePrincipalURN string) ([]*ScopedGrant, error) {
-	// TODO(AGE-1954): remove dual-read after legacy role:<slug> grants are backfilled.
-	// During the role-principal migration, reads include both the canonical
-	// role:<kind>:<uuid> principal and the legacy role:<slug> principal.
-	rp, err := newRolePrincipals(roleSlug, rolePrincipalURN)
+func GrantsForRole(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, orgID string, rolePrincipalURN string) ([]*ScopedGrant, error) {
+	principal, err := parseRolePrincipalURN(rolePrincipalURN)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build role principals").LogError(ctx, logger)
-	}
-	principalURNs, err := principalURNStrings(rp.MatchPrincipals)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build role principals").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "parse role principal").LogError(ctx, logger)
 	}
 
 	rows, err := repo.New(db).GetPrincipalGrants(ctx, repo.GetPrincipalGrantsParams{
 		OrganizationID: orgID,
-		PrincipalUrns:  principalURNs,
+		PrincipalUrns:  []string{principal.String()},
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list grants for role").LogError(ctx, logger)

--- a/server/internal/authz/load_test.go
+++ b/server/internal/authz/load_test.go
@@ -49,7 +49,7 @@ func TestSeedSystemRoleGrantsBootstrapsGlobalRoles(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Admin", adminRole.WorkosName)
 
-	grants, err := GrantsForRole(ctx, testenv.NewLogger(t), conn, organizationID, SystemRoleAdmin, "role:global:"+adminRole.ID.String())
+	grants, err := GrantsForRole(ctx, testenv.NewLogger(t), conn, organizationID, "role:global:"+adminRole.ID.String())
 	require.NoError(t, err)
 	require.NotEmpty(t, grants)
 

--- a/server/internal/authz/principal.go
+++ b/server/internal/authz/principal.go
@@ -66,18 +66,16 @@ func ResolveUserPrincipals(ctx context.Context, db repo.DBTX, organizationID str
 	}
 
 	for _, role := range roleRows {
-		rp, err := newRolePrincipals(role.RoleSlug, role.PrincipalUrn)
+		principal, err := parseRolePrincipalURN(role.PrincipalUrn)
 		if err != nil {
 			return nil, err
 		}
-		for _, principal := range rp.MatchPrincipals {
-			key := principal.String()
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			principals = append(principals, principal)
+		key := principal.String()
+		if _, ok := seen[key]; ok {
+			continue
 		}
+		seen[key] = struct{}{}
+		principals = append(principals, principal)
 	}
 
 	return principals, nil
@@ -139,13 +137,20 @@ func ValidatePrincipal(ctx context.Context, db repo.DBTX, organizationID string,
 	return nil
 }
 
-func DeleteRoleGrants(ctx context.Context, q *repo.Queries, orgID, roleSlug, rolePrincipalURN string) error {
-	rp, err := newRolePrincipals(roleSlug, rolePrincipalURN)
+func DeleteRoleGrants(ctx context.Context, q *repo.Queries, orgID, rolePrincipalURN string) error {
+	principal, err := parseRolePrincipalURN(rolePrincipalURN)
 	if err != nil {
 		return err
 	}
 
-	return rp.deleteAllGrants(ctx, q, orgID)
+	if _, err := q.DeletePrincipalGrantsByPrincipal(ctx, repo.DeletePrincipalGrantsByPrincipalParams{
+		OrganizationID: orgID,
+		PrincipalUrn:   principal,
+	}); err != nil {
+		return fmt.Errorf("delete grants for %s: %w", principal.Label(), err)
+	}
+
+	return nil
 }
 
 // PatchPrincipalGrants applies exact grant additions and removals for one
@@ -163,7 +168,7 @@ func PatchPrincipalGrants(ctx context.Context, dbtx repo.DBTX, orgID string, pri
 		return err
 	}
 	q := repo.New(dbtx)
-	if err := deletePrincipalGrants(ctx, q, orgID, []urn.Principal{principal}, removeRows); err != nil {
+	if err := deletePrincipalGrants(ctx, q, orgID, principal, removeRows); err != nil {
 		return err
 	}
 
@@ -182,73 +187,39 @@ func AllUsersPrincipal() urn.Principal {
 	return urn.NewPrincipal(urn.PrincipalTypeUser, urn.AllUsersPrincipalID)
 }
 
-// rolePrincipals owns the canonical write principal and all principals that
-// may still match existing role grants. The WritePrincipal/MatchPrincipals
-// split exists only for the AGE-1954 role-principal migration: new writes use
-// WritePrincipal while reads/deletes still include legacy role:<slug> rows.
-type rolePrincipals struct {
-	Slug            string
-	WritePrincipal  urn.Principal
-	MatchPrincipals []urn.Principal
-}
-
-func loadRolePrincipals(ctx context.Context, dbtx repo.DBTX, orgID, roleSlug, rolePrincipalURN string) (rolePrincipals, error) {
-	if rolePrincipalURN != "" {
-		return newRolePrincipals(roleSlug, rolePrincipalURN)
-	}
-
-	role, err := repo.New(dbtx).GetActiveOrganizationRoleBySlug(ctx, repo.GetActiveOrganizationRoleBySlugParams{
-		OrganizationID: orgID,
-		WorkosSlug:     roleSlug,
-	})
-	if err != nil {
-		return rolePrincipals{}, fmt.Errorf("resolve role principal for %q: %w", roleSlug, err)
-	}
-
-	return newRolePrincipals(roleSlug, role.RoleUrn)
-}
-
-func newRolePrincipals(roleSlug, rolePrincipalURN string) (rolePrincipals, error) {
-	// TODO(AGE-1954): drop legacy role:<slug> principals after the role-principal backfill is complete.
-	writePrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, roleSlug)
-	matchPrincipals := make([]urn.Principal, 0, 2)
-
-	if rolePrincipalURN != "" {
-		principal, err := urn.ParsePrincipal(rolePrincipalURN)
-		if err != nil {
-			return rolePrincipals{}, fmt.Errorf("parse role principal urn %q: %w", rolePrincipalURN, err)
-		}
-		writePrincipal = principal
-		matchPrincipals = append(matchPrincipals, principal)
-	}
-
-	legacyPrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, roleSlug)
-	if rolePrincipalURN == "" || legacyPrincipal.String() != rolePrincipalURN {
-		matchPrincipals = append(matchPrincipals, legacyPrincipal)
-	}
-
-	return rolePrincipals{
-		Slug:            roleSlug,
-		WritePrincipal:  writePrincipal,
-		MatchPrincipals: matchPrincipals,
-	}, nil
-}
-
-func (rp rolePrincipals) deleteAllGrants(ctx context.Context, q *repo.Queries, orgID string) error {
-	for _, principal := range rp.MatchPrincipals {
-		if _, err := q.DeletePrincipalGrantsByPrincipal(ctx, repo.DeletePrincipalGrantsByPrincipalParams{
+func loadRolePrincipal(ctx context.Context, dbtx repo.DBTX, orgID, roleSlug, rolePrincipalURN string) (urn.Principal, error) {
+	if rolePrincipalURN == "" {
+		role, err := repo.New(dbtx).GetActiveOrganizationRoleBySlug(ctx, repo.GetActiveOrganizationRoleBySlugParams{
 			OrganizationID: orgID,
-			PrincipalUrn:   principal,
-		}); err != nil {
-			return fmt.Errorf("delete grants for role %q: %w", rp.Slug, err)
+			WorkosSlug:     roleSlug,
+		})
+		if err != nil {
+			return urn.Principal{}, fmt.Errorf("resolve role principal for %q: %w", roleSlug, err)
 		}
+		rolePrincipalURN = role.RoleUrn
 	}
 
-	return nil
+	return parseRolePrincipalURN(rolePrincipalURN)
 }
 
-func (rp rolePrincipals) upsertGrants(ctx context.Context, q *repo.Queries, orgID string, rows []roleGrantRow) error {
-	return upsertPrincipalGrants(ctx, q, orgID, rp.WritePrincipal, rows)
+func parseRolePrincipalURN(rolePrincipalURN string) (urn.Principal, error) {
+	principal, err := urn.ParsePrincipal(rolePrincipalURN)
+	if err != nil {
+		return urn.Principal{}, fmt.Errorf("parse role principal urn %q: %w", rolePrincipalURN, err)
+	}
+	if principal.Type != urn.PrincipalTypeRole {
+		return urn.Principal{}, fmt.Errorf("invalid role principal %q", rolePrincipalURN)
+	}
+
+	roleKind, rawRoleID, ok := strings.Cut(principal.ID, ":")
+	if !ok || (roleKind != "organization" && roleKind != "global") {
+		return urn.Principal{}, fmt.Errorf("invalid role principal %q", rolePrincipalURN)
+	}
+	if _, err := uuid.Parse(rawRoleID); err != nil {
+		return urn.Principal{}, fmt.Errorf("invalid role principal %q: %w", rolePrincipalURN, err)
+	}
+
+	return principal, nil
 }
 
 func upsertPrincipalGrants(ctx context.Context, q *repo.Queries, orgID string, principal urn.Principal, rows []roleGrantRow) error {
@@ -266,36 +237,30 @@ func upsertPrincipalGrants(ctx context.Context, q *repo.Queries, orgID string, p
 	return nil
 }
 
-func (rp rolePrincipals) insertGrantsIfAbsent(ctx context.Context, q *repo.Queries, orgID string, rows []roleGrantRow) error {
+func insertRoleGrantsIfAbsent(ctx context.Context, q *repo.Queries, orgID string, roleSlug string, principal urn.Principal, rows []roleGrantRow) error {
 	for _, row := range rows {
 		if _, err := q.InsertPrincipalGrantIfAbsent(ctx, repo.InsertPrincipalGrantIfAbsentParams{
 			OrganizationID: orgID,
-			PrincipalUrn:   rp.WritePrincipal,
+			PrincipalUrn:   principal,
 			Scope:          string(row.Scope),
 			Selectors:      row.SelectorRaw,
 		}); err != nil {
-			return fmt.Errorf("insert grant %q for role %q: %w", row.Scope, rp.Slug, err)
+			return fmt.Errorf("insert grant %q for role %q: %w", row.Scope, roleSlug, err)
 		}
 	}
 
 	return nil
 }
 
-func (rp rolePrincipals) deleteGrants(ctx context.Context, q *repo.Queries, orgID string, rows []roleGrantRow) error {
-	return deletePrincipalGrants(ctx, q, orgID, rp.MatchPrincipals, rows)
-}
-
-func deletePrincipalGrants(ctx context.Context, q *repo.Queries, orgID string, principals []urn.Principal, rows []roleGrantRow) error {
-	for _, principal := range principals {
-		for _, row := range rows {
-			if _, err := q.DeletePrincipalGrantByIdentity(ctx, repo.DeletePrincipalGrantByIdentityParams{
-				OrganizationID: orgID,
-				PrincipalUrn:   principal,
-				Scope:          string(row.Scope),
-				Selectors:      row.SelectorRaw,
-			}); err != nil {
-				return fmt.Errorf("delete grant %q for %s: %w", row.Scope, principal.Label(), err)
-			}
+func deletePrincipalGrants(ctx context.Context, q *repo.Queries, orgID string, principal urn.Principal, rows []roleGrantRow) error {
+	for _, row := range rows {
+		if _, err := q.DeletePrincipalGrantByIdentity(ctx, repo.DeletePrincipalGrantByIdentityParams{
+			OrganizationID: orgID,
+			PrincipalUrn:   principal,
+			Scope:          string(row.Scope),
+			Selectors:      row.SelectorRaw,
+		}); err != nil {
+			return fmt.Errorf("delete grant %q for %s: %w", row.Scope, principal.Label(), err)
 		}
 	}
 

--- a/server/internal/authz/principal.go
+++ b/server/internal/authz/principal.go
@@ -7,17 +7,18 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/speakeasy-api/gram/server/internal/access/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-// ErrPrincipalNotFound reports that a Gram user could not be resolved to an
-// active in-organization principal.
+// ErrPrincipalNotFound reports that a principal does not resolve to an active
+// target in the organization.
 var ErrPrincipalNotFound = errors.New("principal not found")
 
-// ErrPrincipalInvalid reports caller input that cannot be a concrete user
+// ErrPrincipalInvalid reports caller input that cannot identify a supported
 // principal.
 var ErrPrincipalInvalid = errors.New("principal invalid")
 
@@ -111,27 +112,30 @@ func ValidatePrincipal(ctx context.Context, db repo.DBTX, organizationID string,
 	case urn.PrincipalTypeRole:
 		roleKind, rawRoleID, ok := strings.Cut(principal.ID, ":")
 		if !ok {
-			return fmt.Errorf("invalid role principal %q", principal.String())
+			return fmt.Errorf("%w: role principal %q", ErrPrincipalInvalid, principal.String())
 		}
 		if roleKind != "organization" && roleKind != "global" {
-			return fmt.Errorf("invalid role principal %q", principal.String())
+			return fmt.Errorf("%w: role principal %q", ErrPrincipalInvalid, principal.String())
 		}
 		roleID, err := uuid.Parse(rawRoleID)
 		if err != nil {
-			return fmt.Errorf("invalid role principal %q: %w", principal.String(), err)
+			return fmt.Errorf("%w: role principal %q: %w", ErrPrincipalInvalid, principal.String(), err)
 		}
 		row, err := repo.New(db).GetOrganizationRoleByID(ctx, repo.GetOrganizationRoleByIDParams{
 			OrganizationID: organizationID,
 			ID:             roleID,
 		})
 		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("validate role principal %q: %w", principal.String(), ErrPrincipalNotFound)
+			}
 			return fmt.Errorf("validate role principal %q: %w", principal.String(), err)
 		}
 		if row.RoleUrn != principal.String() {
-			return fmt.Errorf("role principal %q does not match active role %q", principal.String(), row.RoleUrn)
+			return fmt.Errorf("%w: role principal %q does not match active role %q", ErrPrincipalInvalid, principal.String(), row.RoleUrn)
 		}
 	default:
-		return fmt.Errorf("unsupported principal type %q", principal.Type)
+		return fmt.Errorf("%w: unsupported principal type %q", ErrPrincipalInvalid, principal.Type)
 	}
 
 	return nil

--- a/server/internal/authz/principal_test.go
+++ b/server/internal/authz/principal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -145,7 +146,16 @@ func TestValidatePrincipal(t *testing.T) {
 	require.ErrorIs(t, err, ErrPrincipalNotFound)
 
 	err = ValidatePrincipal(ctx, conn, organizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "principal-validator"))
-	require.ErrorContains(t, err, "invalid role principal")
+	require.ErrorIs(t, err, ErrPrincipalInvalid)
+
+	err = ValidatePrincipal(ctx, conn, organizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+uuid.NewString()))
+	require.ErrorIs(t, err, ErrPrincipalNotFound)
+
+	conn.Close()
+	err = ValidatePrincipal(ctx, conn, organizationID, rolePrincipal)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrPrincipalInvalid)
+	require.NotErrorIs(t, err, ErrPrincipalNotFound)
 }
 
 func seedActiveOrganizationUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, userID string) {

--- a/server/internal/authz/principal_test.go
+++ b/server/internal/authz/principal_test.go
@@ -2,8 +2,6 @@ package authz
 
 import (
 	"context"
-	"slices"
-	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +27,8 @@ func TestResolveKnownUserPrincipals_resolvesUserAndRolesForOrgMember(t *testing.
 	seedActiveOrganizationUser(t, ctx, conn, organizationID, userID)
 	require.NoError(t, SeedSystemRoleGrants(ctx, conn, organizationID))
 	seedRoleAssignmentForUser(t, ctx, conn, organizationID, userID, SystemRoleMember)
+	memberRole, err := accessrepo.New(conn).GetGlobalRoleBySlug(ctx, SystemRoleMember)
+	require.NoError(t, err)
 
 	principals, err := ResolveUserPrincipals(ctx, conn, organizationID, userID)
 	require.NoError(t, err)
@@ -39,10 +39,30 @@ func TestResolveKnownUserPrincipals_resolvesUserAndRolesForOrgMember(t *testing.
 	}
 	require.Contains(t, principalURNs, urn.NewPrincipal(urn.PrincipalTypeUser, userID).String())
 	require.Contains(t, principalURNs, AllUsersPrincipal().String())
-	require.Contains(t, principalURNs, "role:member")
-	require.True(t, slices.ContainsFunc(principalURNs, func(principalURN string) bool {
-		return strings.HasPrefix(principalURN, "role:global:")
-	}))
+	require.Contains(t, principalURNs, "role:global:"+memberRole.ID.String())
+	require.NotContains(t, principalURNs, "role:member")
+}
+
+func TestParseRolePrincipalURN_requiresCanonicalRoleURN(t *testing.T) {
+	t.Parallel()
+
+	const roleID = "00000000-0000-0000-0000-000000000001"
+	for _, roleURN := range []string{"role:global:" + roleID, "role:organization:" + roleID} {
+		principal, err := parseRolePrincipalURN(roleURN)
+		require.NoError(t, err)
+		require.Equal(t, roleURN, principal.String())
+	}
+
+	for _, roleURN := range []string{
+		"role:member",
+		"role:organization:not-a-uuid",
+		"role:unknown:" + roleID,
+		"user:" + roleID,
+	} {
+		principal, err := parseRolePrincipalURN(roleURN)
+		require.Error(t, err)
+		require.Equal(t, urn.Principal{}, principal)
+	}
 }
 
 func TestResolveUserPrincipals_includesAllUsersWhenUserMissingOrNotInOrg(t *testing.T) {

--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -645,7 +645,7 @@ func handleRoleDeleted(ctx context.Context, logger *slog.Logger, dbtx database.D
 	}
 
 	rolePrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+existing.ID.String())
-	if err := authz.DeleteRoleGrants(ctx, repo, org.ID, payload.Slug, rolePrincipal.String()); err != nil {
+	if err := authz.DeleteRoleGrants(ctx, repo, org.ID, rolePrincipal.String()); err != nil {
 		return fmt.Errorf("delete grants for role %q: %w", payload.Slug, err)
 	}
 

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -886,7 +886,19 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleUpsertAndDelete(t *test
 	})
 	require.NoError(t, err)
 
-	rolePrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, slug)
+	now := time.Now().UTC()
+	seededRole, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    externalID,
+		WorkosSlug:        slug,
+		WorkosName:        "Billing Manager",
+		WorkosDescription: conv.ToPGTextEmpty(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: conv.ToPGTextEmpty("event_00SEED"),
+	})
+	require.NoError(t, err)
+	rolePrincipal, err := urn.ParsePrincipal(seededRole.RoleUrn)
+	require.NoError(t, err)
 	_, err = accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
 		OrganizationID: externalID,
 		PrincipalUrn:   rolePrincipal,

--- a/server/internal/plugins/audit_test.go
+++ b/server/internal/plugins/audit_test.go
@@ -228,7 +228,10 @@ func TestPluginsService_SetPluginAssignments_RecordsAuditEvent(t *testing.T) {
 	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginAssignmentsSet)
 	require.NoError(t, err)
 
-	urns := []string{"role:engineering", "role:gtm"}
+	urns := []string{
+		createTestRolePrincipal(t, ctx, ti, "engineering"),
+		createTestRolePrincipal(t, ctx, ti, "gtm"),
+	}
 	_, err = ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
 		PluginID:      plugin.ID,
 		PrincipalUrns: urns,
@@ -249,8 +252,8 @@ func TestPluginsService_SetPluginAssignments_RecordsAuditEvent(t *testing.T) {
 	got, ok := meta["principal_urns"].([]any)
 	require.True(t, ok)
 	require.Len(t, got, 2)
-	require.Equal(t, "role:engineering", got[0])
-	require.Equal(t, "role:gtm", got[1])
+	require.Equal(t, urns[0], got[0])
+	require.Equal(t, urns[1], got[1])
 }
 
 func TestPluginsService_PublishPlugins_RecordsAuditEvent(t *testing.T) {

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1109,6 +1109,7 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 
 	// Normalize and validate every principal URN through urn.ParsePrincipal so
 	// the typed wrapper is the single source of truth on what a principal is.
+	// Role assignments additionally require an active canonical role principal.
 	// The wildcard is a literal token (not a typed URN), so it takes a
 	// fast-path. Email IDs are lowercased here so the device-agent endpoint
 	// can match a lowercased lookup deterministically.
@@ -1126,6 +1127,11 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 			parsed, err := urn.ParsePrincipal(normalized)
 			if err != nil {
 				return nil, oops.E(oops.CodeBadRequest, err, "invalid principal URN: %s", raw)
+			}
+			if parsed.Type == urn.PrincipalTypeRole {
+				if err := authz.ValidatePrincipal(ctx, s.db, ac.ActiveOrganizationID, parsed); err != nil {
+					return nil, oops.E(oops.CodeBadRequest, err, "invalid role principal URN: %s", raw)
+				}
 			}
 			principalURN = parsed.String()
 		}

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1130,7 +1130,10 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 			}
 			if parsed.Type == urn.PrincipalTypeRole {
 				if err := authz.ValidatePrincipal(ctx, s.db, ac.ActiveOrganizationID, parsed); err != nil {
-					return nil, oops.E(oops.CodeBadRequest, err, "invalid role principal URN: %s", raw)
+					if errors.Is(err, authz.ErrPrincipalInvalid) || errors.Is(err, authz.ErrPrincipalNotFound) {
+						return nil, oops.E(oops.CodeBadRequest, err, "invalid role principal URN: %s", raw)
+					}
+					return nil, oops.E(oops.CodeUnexpected, err, "validate role principal URN: %s", raw).LogError(ctx, s.logger)
 				}
 			}
 			principalURN = parsed.String()

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -715,11 +715,13 @@ func TestPluginsService_SetPluginAssignments(t *testing.T) {
 
 	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Assignment Test"})
 	require.NoError(t, err)
+	engineeringRole := createTestRolePrincipal(t, ctx, ti, "engineering")
+	gtmRole := createTestRolePrincipal(t, ctx, ti, "gtm")
 
 	// Set initial assignments.
 	result, err := ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
 		PluginID:      plugin.ID,
-		PrincipalUrns: []string{"role:engineering", "role:gtm"},
+		PrincipalUrns: []string{engineeringRole, gtmRole},
 	})
 	require.NoError(t, err)
 	require.Len(t, result.Assignments, 2)
@@ -746,14 +748,15 @@ func TestPluginsService_SetPluginAssignments_NormalizesAndDeduplicatesPrincipalU
 
 	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Dedupe Assignment Test"})
 	require.NoError(t, err)
+	engineeringRole := createTestRolePrincipal(t, ctx, ti, "engineering")
 
 	result, err := ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
 		PluginID: plugin.ID,
 		PrincipalUrns: []string{
 			"email:Dev@Acme.Corp",
 			"email:dev@acme.corp",
-			"role:engineering",
-			"role:engineering",
+			engineeringRole,
+			engineeringRole,
 			"*",
 			"*",
 		},
@@ -761,7 +764,7 @@ func TestPluginsService_SetPluginAssignments_NormalizesAndDeduplicatesPrincipalU
 	require.NoError(t, err)
 	require.Len(t, result.Assignments, 3)
 	require.Equal(t, "email:dev@acme.corp", result.Assignments[0].PrincipalUrn)
-	require.Equal(t, "role:engineering", result.Assignments[1].PrincipalUrn)
+	require.Equal(t, engineeringRole, result.Assignments[1].PrincipalUrn)
 	require.Equal(t, "*", result.Assignments[2].PrincipalUrn)
 
 	fetched, err := ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: plugin.ID})
@@ -795,7 +798,26 @@ func TestPluginsService_SetPluginAssignments_InvalidURNReturnsBadRequest(t *test
 
 	_, err = ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
 		PluginID:      plugin.ID,
-		PrincipalUrns: []string{"role:engineering", "not a valid urn"},
+		PrincipalUrns: []string{"not a valid urn"},
+	})
+	require.Error(t, err)
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+}
+
+func TestPluginsService_SetPluginAssignments_LegacyRoleURNReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Legacy Role URN Validation"})
+	require.NoError(t, err)
+
+	_, err = ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
+		PluginID:      plugin.ID,
+		PrincipalUrns: []string{"role:engineering"},
 	})
 	require.Error(t, err)
 

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -826,6 +826,25 @@ func TestPluginsService_SetPluginAssignments_LegacyRoleURNReturnsBadRequest(t *t
 	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
 }
 
+func TestPluginsService_SetPluginAssignments_UnknownRoleURNReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Unknown Role URN Validation"})
+	require.NoError(t, err)
+
+	_, err = ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
+		PluginID:      plugin.ID,
+		PrincipalUrns: []string{"role:organization:" + uuid.NewString()},
+	})
+	require.Error(t, err)
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+}
+
 func TestPluginsService_DownloadPluginPackage(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/plugins/setup_test.go
+++ b/server/internal/plugins/setup_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -107,6 +108,26 @@ func newTestPluginsService(t *testing.T) (context.Context, *testInstance) {
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
+}
+
+func createTestRolePrincipal(t *testing.T, ctx context.Context, ti *testInstance, slug string) string {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	now := time.Now().UTC()
+	role, err := accessrepo.New(ti.conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    authCtx.ActiveOrganizationID,
+		WorkosSlug:        slug,
+		WorkosName:        slug,
+		WorkosDescription: conv.ToPGTextEmpty(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+
+	return role.RoleUrn
 }
 
 func newTestPluginsServiceWithGitHub(t *testing.T, ghClient plugins.GitHubPublisher) (context.Context, *testInstance) {


### PR DESCRIPTION
## Summary

- remove dual-read, dual-delete, and slug-principal compatibility from RBAC role grants
- require canonical `role:<kind>:<uuid>` principals for plugin role assignments
- remove dashboard matching for legacy role slug aliases
- update tests, RBAC documentation, and generated API documentation to use canonical role URNs

## Why

The existing data has been backfilled and validated, so the temporary compatibility layer is no longer needed. Keeping it allowed invalid `role:<slug>` principals to remain readable and accepted by plugin assignment writes.

## Impact

Role grants and plugin role assignments now use canonical role principals exclusively. This PR does not include a database migration.

## Validation

- `mise exec -- go test ./server/internal/authz ./server/internal/access ./server/internal/background/activities ./server/internal/plugins ./server/internal/auth ./server/internal/agent ./server/internal/productfeatures ./server/cmd/workos-backfill`
- `mise lint:server`
- `pnpm -F dashboard exec vitest run src/pages/plugins/plugin-reach.test.ts` (7 tests)
- `pnpm -F dashboard type-check`
- `git diff --check`

Linear: AGE-2583

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops legacy role:<slug> principals across RBAC and plugins; only canonical role:<kind>:<uuid> URNs are accepted, read, and written. Previously we dual-read/deleted slug aliases; now legacy inputs return 400 and leftover slug-backed grants are ignored. Addresses Linear AGE-2583.

**Changes**
- AuthZ: strict role principal parsing; `ResolveUserPrincipals` returns canonical roles only; `GrantsForRole(ctx, logger, db, orgID, rolePrincipalURN)` and `DeleteRoleGrants(ctx, q, orgID, rolePrincipalURN)` now accept only canonical role URNs; `ValidatePrincipal` distinguishes invalid vs not-found so callers return 400 for both.
- Plugins: `SetPluginAssignments` validates role URNs against active roles and rejects `role:<slug>` and unknown role IDs with 400; audit/tests updated.
- Dashboard/Docs/SDK: remove legacy role mapping; examples and `principal_urn` use `role:organization:<uuid>`; OpenAPI and `client/dashboard` SDK regenerated.
- WorkOS flows: backfill and role-delete paths delete grants by the canonical role principal only. No DB migration; any `role:<slug>` rows are ignored.

**Required actions**
- Use `role:global:<uuid>` or `role:organization:<uuid>` when constructing role principals everywhere.
- Update call sites to `GrantsForRole(ctx, logger, db, orgID, rolePrincipalURN)` and `DeleteRoleGrants(ctx, q, orgID, rolePrincipalURN)`.
- Stop sending `role:<slug>` to plugin assignment APIs; send canonical role URNs.

<sup>Written for commit 290f761bcc8dade79ec385e6334f0b16988eb536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

