### PR TITLE
feat: add Stripe billing integration foundation

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -6,3 +6,7 @@
 # product_id_pro = "..."
 # meter_id_tool_calls = "..."
 # meter_id_servers = "..."
+
+# [stripe]
+# price_id_tum = "..."
+# meter_event_name = "tum"

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/speakeasy-api/openapi v1.24.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/stretchr/testify v1.11.1
+	github.com/stripe/stripe-go/v85 v85.0.1
 	github.com/superfly/fly-go v0.3.1
 	github.com/svix/svix-webhooks v1.93.0
 	github.com/testcontainers/testcontainers-go v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -731,6 +731,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stripe/stripe-go/v85 v85.0.1 h1:vlIo5VHrR9GkYneH5D9YGOPwNDRD6LW/THhtx9zNs6M=
+github.com/stripe/stripe-go/v85 v85.0.1/go.mod h1:5P+HGFenpWgak27T5Is6JMsmDfUC1yJnjhhmquz7kXw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/fly-go v0.3.1 h1:XWrxqQOpZhWFP0gpNgKFec1iXxOAwuW7dYWJW+hh8M8=

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -76,6 +76,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/polar"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	sv "github.com/speakeasy-api/gram/server/internal/thirdparty/svix"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/tracking"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
@@ -490,6 +491,7 @@ func newBillingProvider(
 	guardianPolicy *guardian.Policy,
 	redisClient *redis.Client,
 	posthogClient *posthog.Posthog,
+	stripeClient stripeclient.Client,
 	c *cli.Context,
 ) (billing.Repository, billing.Tracker, error) {
 	switch {
@@ -530,9 +532,46 @@ func newBillingProvider(
 		logger.WarnContext(ctx, "using stub billing client: polar not configured")
 		stub := billing.NewStubClient(logger, tracerProvider)
 		return stub, stub, nil
+	case stripeClient != nil:
+		logger.InfoContext(ctx, "using Stripe billing provider with legacy billing operations disabled")
+		unavailable := billing.NewUnavailableClient(logger)
+		return unavailable, tracking.New(unavailable, posthogClient, logger), nil
 	default:
 		return nil, nil, fmt.Errorf("billing provider is not configured")
 	}
+}
+
+func newStripeClient(
+	ctx context.Context,
+	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
+	c *cli.Context,
+) (stripeclient.Client, error) {
+	apiKey := c.String("stripe-api-key")
+	if !stripeclient.IsConfigured(apiKey) {
+		if c.String("environment") == "local" {
+			logger.WarnContext(ctx, "using stub Stripe client: Stripe not configured")
+			return stripeclient.NewStubClient(logger), nil
+		}
+
+		logger.InfoContext(ctx, "Stripe client not configured")
+		return nil, nil
+	}
+
+	catalog := stripeclient.Catalog{
+		PriceIDTUM:     c.String("stripe-price-id-tum"),
+		MeterEventName: c.String("stripe-meter-event-name"),
+	}
+	if err := catalog.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid Stripe catalog configuration: %w", err)
+	}
+
+	return stripeclient.NewClient(
+		guardianPolicy,
+		apiKey,
+		c.String("stripe-webhook-secret"),
+		catalog,
+	), nil
 }
 
 // workosClientOpts builds the ClientOpts threaded into every workos.NewClient

--- a/server/cmd/gram/deps_stripe_test.go
+++ b/server/cmd/gram/deps_stripe_test.go
@@ -1,0 +1,157 @@
+package gram
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+)
+
+func TestNewStripeClientLocalWithoutAPIKeyUsesStubBeforeCatalogValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := newStripeCLIContext(t, map[string]string{
+		"environment":             "local",
+		"stripe-api-key":          "unset",
+		"stripe-price-id-tum":     "partial-price",
+		"stripe-meter-event-name": "",
+	})
+
+	client, err := newStripeClient(
+		t.Context(),
+		testenv.NewLogger(t),
+		guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)),
+		ctx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.Equal(t, stripeclient.Catalog{}, client.Catalog())
+}
+
+func TestNewStripeClientRealClientValidatesCatalog(t *testing.T) {
+	t.Parallel()
+
+	ctx := newStripeCLIContext(t, map[string]string{
+		"environment":             "local",
+		"stripe-api-key":          "sk_test_placeholder",
+		"stripe-price-id-tum":     "partial-price",
+		"stripe-meter-event-name": "",
+	})
+
+	client, err := newStripeClient(
+		t.Context(),
+		testenv.NewLogger(t),
+		guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)),
+		ctx,
+	)
+	require.Nil(t, client)
+	require.ErrorContains(t, err, "invalid Stripe catalog configuration: missing meter event name")
+}
+
+func TestNewStripeClientNonLocalWithoutAPIKeyIsOptional(t *testing.T) {
+	t.Parallel()
+
+	ctx := newStripeCLIContext(t, map[string]string{
+		"environment":    "prod",
+		"stripe-api-key": "unset",
+	})
+
+	client, err := newStripeClient(
+		t.Context(),
+		testenv.NewLogger(t),
+		guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)),
+		ctx,
+	)
+	require.NoError(t, err)
+	require.Nil(t, client)
+}
+
+func TestNewStripeClientRealClientUsesCatalog(t *testing.T) {
+	t.Parallel()
+
+	ctx := newStripeCLIContext(t, map[string]string{
+		"environment":             "prod",
+		"stripe-api-key":          "sk_test_placeholder",
+		"stripe-webhook-secret":   "whsec_placeholder",
+		"stripe-price-id-tum":     "price_placeholder",
+		"stripe-meter-event-name": "tum",
+	})
+
+	client, err := newStripeClient(
+		t.Context(),
+		testenv.NewLogger(t),
+		guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)),
+		ctx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.Equal(t, stripeclient.Catalog{
+		PriceIDTUM:     "price_placeholder",
+		MeterEventName: "tum",
+	}, client.Catalog())
+}
+
+func TestNewBillingProviderAcceptsStripeWithoutPolar(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	ctx := newStripeCLIContext(t, map[string]string{
+		"environment": "prod",
+	})
+
+	repository, tracker, err := newBillingProvider(
+		t.Context(),
+		logger,
+		tracerProvider,
+		nil,
+		nil,
+		nil,
+		stripeclient.NewStubClient(logger),
+		ctx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, repository)
+	require.NotNil(t, tracker)
+
+	_, _, err = repository.GetCustomerTier(t.Context(), "org_placeholder")
+	require.ErrorContains(t, err, "legacy billing operations are unavailable")
+}
+
+func TestNewBillingProviderRejectsNonLocalWithoutProvider(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := newBillingProvider(
+		t.Context(),
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		nil,
+		nil,
+		nil,
+		nil,
+		newStripeCLIContext(t, map[string]string{"environment": "prod"}),
+	)
+	require.ErrorContains(t, err, "billing provider is not configured")
+}
+
+func newStripeCLIContext(t *testing.T, values map[string]string) *cli.Context {
+	t.Helper()
+
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String("environment", "", "")
+	set.String("stripe-api-key", "", "")
+	set.String("stripe-webhook-secret", "", "")
+	set.String("stripe-price-id-tum", "", "")
+	set.String("stripe-meter-event-name", "", "")
+	set.String("polar-api-key", "", "")
+	for key, value := range values {
+		require.NoError(t, set.Set(key, value))
+	}
+
+	return cli.NewContext(cli.NewApp(), set, nil)
+}

--- a/server/cmd/gram/flags_stripe_test.go
+++ b/server/cmd/gram/flags_stripe_test.go
@@ -1,0 +1,56 @@
+package gram
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+)
+
+func TestStripeFlagsAreAvailableInEveryServerProcess(t *testing.T) {
+	t.Parallel()
+
+	commands := map[string]*cli.Command{
+		"server":  newStartCommand(),
+		"worker":  newWorkerCommand(),
+		"streams": newStreamsCommand(),
+	}
+
+	for process, command := range commands {
+		t.Run(process, func(t *testing.T) {
+			t.Parallel()
+
+			apiKey := requireFlag(t, command.Flags, "stripe-api-key")
+			_, tomlSourceable := apiKey.(altsrc.FlagInputSourceExtension)
+			require.False(t, tomlSourceable, "Stripe API key must be env-only")
+
+			webhookSecret := requireFlag(t, command.Flags, "stripe-webhook-secret")
+			_, tomlSourceable = webhookSecret.(altsrc.FlagInputSourceExtension)
+			require.False(t, tomlSourceable, "Stripe webhook secret must be env-only")
+
+			priceID := requireFlag(t, command.Flags, "stripe-price-id-tum")
+			_, tomlSourceable = priceID.(altsrc.FlagInputSourceExtension)
+			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")
+			require.Contains(t, priceID.Names(), "stripe.price_id_tum")
+
+			meterEventName := requireFlag(t, command.Flags, "stripe-meter-event-name")
+			_, tomlSourceable = meterEventName.(altsrc.FlagInputSourceExtension)
+			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")
+			require.Contains(t, meterEventName.Names(), "stripe.meter_event_name")
+		})
+	}
+}
+
+func requireFlag(t *testing.T, flags []cli.Flag, name string) cli.Flag {
+	t.Helper()
+
+	for _, candidate := range flags {
+		if slices.Contains(candidate.Names(), name) {
+			return candidate
+		}
+	}
+	require.FailNow(t, "flag not found", name)
+	return nil
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -362,6 +362,28 @@ func newStartCommand() *cli.Command {
 			Required: false,
 		},
 		&cli.StringFlag{
+			Name:    "stripe-api-key",
+			Usage:   "The Stripe API key",
+			EnvVars: []string{"STRIPE_API_KEY"},
+		},
+		&cli.StringFlag{
+			Name:    "stripe-webhook-secret",
+			Usage:   "The Stripe webhook signing secret",
+			EnvVars: []string{"STRIPE_WEBHOOK_SECRET"},
+		},
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-price-id-tum",
+			Aliases: []string{"stripe.price_id_tum"},
+			Usage:   "The Stripe metered TUM price ID",
+			EnvVars: []string{"STRIPE_PRICE_ID_TUM"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-event-name",
+			Aliases: []string{"stripe.meter_event_name"},
+			Usage:   "The Stripe TUM meter event name",
+			EnvVars: []string{"STRIPE_METER_EVENT_NAME"},
+		}),
+		&cli.StringFlag{
 			Name:     "polar-api-key",
 			Usage:    "The polar API key",
 			EnvVars:  []string{"POLAR_API_KEY"},
@@ -591,7 +613,12 @@ func newStartCommand() *cli.Command {
 				backgroundWorkOSClient = workos.NewStubClient()
 			}
 
-			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, c)
+			stripeClient, err := newStripeClient(ctx, logger, guardianPolicy, c)
+			if err != nil {
+				return fmt.Errorf("failed to create Stripe client: %w", err)
+			}
+
+			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, stripeClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
@@ -105,6 +106,28 @@ func newStreamsCommand() *cli.Command {
 			Usage:   "Provisioning key for OpenRouter to create new API keys for orgs - https://openrouter.ai/settings/provisioning-keys",
 			EnvVars: []string{"OPENROUTER_PROVISIONING_KEY"},
 		},
+		&cli.StringFlag{
+			Name:    "stripe-api-key",
+			Usage:   "The Stripe API key",
+			EnvVars: []string{"STRIPE_API_KEY"},
+		},
+		&cli.StringFlag{
+			Name:    "stripe-webhook-secret",
+			Usage:   "The Stripe webhook signing secret",
+			EnvVars: []string{"STRIPE_WEBHOOK_SECRET"},
+		},
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-price-id-tum",
+			Aliases: []string{"stripe.price_id_tum"},
+			Usage:   "The Stripe metered TUM price ID",
+			EnvVars: []string{"STRIPE_PRICE_ID_TUM"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-event-name",
+			Aliases: []string{"stripe.meter_event_name"},
+			Usage:   "The Stripe TUM meter event name",
+			EnvVars: []string{"STRIPE_METER_EVENT_NAME"},
+		}),
 		&cli.StringFlag{
 			Name:     "polar-api-key",
 			Usage:    "The polar API key",
@@ -289,7 +312,12 @@ func newStreamsCommand() *cli.Command {
 			}
 
 			productFeatures := productfeatures.NewClient(logger, tracerProvider, db, redisClient)
-			_, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, c)
+			stripeClient, err := newStripeClient(ctx, logger, guardianPolicy, c)
+			if err != nil {
+				return fmt.Errorf("failed to create Stripe client: %w", err)
+			}
+
+			_, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, stripeClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -201,6 +201,28 @@ func newWorkerCommand() *cli.Command {
 			Required: false,
 		},
 		&cli.StringFlag{
+			Name:    "stripe-api-key",
+			Usage:   "The Stripe API key",
+			EnvVars: []string{"STRIPE_API_KEY"},
+		},
+		&cli.StringFlag{
+			Name:    "stripe-webhook-secret",
+			Usage:   "The Stripe webhook signing secret",
+			EnvVars: []string{"STRIPE_WEBHOOK_SECRET"},
+		},
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-price-id-tum",
+			Aliases: []string{"stripe.price_id_tum"},
+			Usage:   "The Stripe metered TUM price ID",
+			EnvVars: []string{"STRIPE_PRICE_ID_TUM"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-event-name",
+			Aliases: []string{"stripe.meter_event_name"},
+			Usage:   "The Stripe TUM meter event name",
+			EnvVars: []string{"STRIPE_METER_EVENT_NAME"},
+		}),
+		&cli.StringFlag{
 			Name:     "polar-api-key",
 			Usage:    "The polar API key",
 			EnvVars:  []string{"POLAR_API_KEY"},
@@ -509,7 +531,12 @@ func newWorkerCommand() *cli.Command {
 				shutdownFuncs = append(shutdownFuncs, shutdown)
 			}
 
-			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, c)
+			stripeClient, err := newStripeClient(ctx, logger, guardianPolicy, c)
+			if err != nil {
+				return fmt.Errorf("failed to create Stripe client: %w", err)
+			}
+
+			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, stripeClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}

--- a/server/internal/billing/unavailable.go
+++ b/server/internal/billing/unavailable.go
@@ -1,0 +1,106 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	gen "github.com/speakeasy-api/gram/server/gen/usage"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+var errLegacyBillingUnavailable = errors.New("legacy billing operations are unavailable with the Stripe provider")
+
+// UnavailableClient fails closed for Polar-shaped operations when Stripe is
+// the configured billing provider.
+type UnavailableClient struct {
+	logger  *slog.Logger
+	logOnce sync.Once
+}
+
+// NewUnavailableClient creates a fail-closed legacy billing client.
+func NewUnavailableClient(logger *slog.Logger) *UnavailableClient {
+	return &UnavailableClient{
+		logger:  logger.With(attr.SlogComponent("billing_unavailable")),
+		logOnce: sync.Once{},
+	}
+}
+
+var _ Repository = (*UnavailableClient)(nil)
+var _ Tracker = (*UnavailableClient)(nil)
+
+func (*UnavailableClient) GetCustomer(context.Context, string) (*Customer, error) {
+	return nil, errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) GetCustomerTier(context.Context, string) (*Tier, bool, error) {
+	return nil, false, errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) GetPeriodUsage(context.Context, string) (*gen.PeriodUsage, error) {
+	return nil, errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) GetStoredPeriodUsage(context.Context, string) (*gen.PeriodUsage, error) {
+	return nil, errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) CreateCheckout(context.Context, string, string, string) (string, error) {
+	return "", errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) CreateTopUpCheckout(context.Context, string, string, string) (string, error) {
+	return "", errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) IsTopUpProductID(string) bool {
+	return false
+}
+
+func (*UnavailableClient) CreateCustomerSession(context.Context, string) (string, error) {
+	return "", errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) AttachAssistantsBenefit(context.Context, string, string) (string, error) {
+	return "", errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) CancelSubscriptionAtPeriodEnd(context.Context, string) error {
+	return errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) GetUsageTiers(context.Context) (*gen.UsageTiers, error) {
+	return nil, errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) ValidateAndParseWebhookEvent(context.Context, []byte, http.Header) (*PolarWebhookPayload, error) {
+	return nil, errLegacyBillingUnavailable
+}
+
+func (*UnavailableClient) InvalidateBillingCustomerCaches(context.Context, string) error {
+	return errLegacyBillingUnavailable
+}
+
+func (c *UnavailableClient) TrackToolCallUsage(ctx context.Context, _ ToolCallUsageEvent) {
+	c.logUnavailable(ctx)
+}
+
+func (c *UnavailableClient) TrackPromptCallUsage(ctx context.Context, _ PromptCallUsageEvent) {
+	c.logUnavailable(ctx)
+}
+
+func (c *UnavailableClient) TrackModelUsage(ctx context.Context, _ ModelUsageEvent) {
+	c.logUnavailable(ctx)
+}
+
+func (c *UnavailableClient) TrackPlatformUsage(ctx context.Context, _ []PlatformUsageEvent) {
+	c.logUnavailable(ctx)
+}
+
+func (c *UnavailableClient) logUnavailable(ctx context.Context) {
+	c.logOnce.Do(func() {
+		c.logger.WarnContext(ctx, "legacy billing usage tracking is unavailable with the Stripe provider")
+	})
+}

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -1,0 +1,238 @@
+// Package stripe provides the narrow Stripe boundary used by PAYG billing.
+package stripe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	stripesdk "github.com/stripe/stripe-go/v85"
+	stripewebhook "github.com/stripe/stripe-go/v85/webhook"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+)
+
+const (
+	organizationIDMetadataKey   = "organization_id"
+	organizationSlugMetadataKey = "organization_slug"
+	meterCustomerPayloadKey     = "stripe_customer_id"
+	meterValuePayloadKey        = "value"
+)
+
+var errMissingIdempotencyKey = errors.New("idempotency key is required")
+
+// Catalog contains the Stripe object identifiers used by PAYG billing.
+type Catalog struct {
+	PriceIDTUM     string
+	MeterEventName string
+}
+
+// Validate checks that every required Stripe catalog value is configured.
+func (c Catalog) Validate() error {
+	if !IsConfigured(c.PriceIDTUM) {
+		return errors.New("missing TUM price id in catalog")
+	}
+	if !IsConfigured(c.MeterEventName) {
+		return errors.New("missing meter event name in catalog")
+	}
+	return nil
+}
+
+// IsConfigured reports whether a Stripe config value is present.
+func IsConfigured(value string) bool {
+	return value != "" && value != "unset"
+}
+
+// Client is the Stripe surface used by PAYG billing.
+type Client interface {
+	CreateCustomer(context.Context, CreateCustomerInput) (*Customer, error)
+	CreateMeterEvent(context.Context, CreateMeterEventInput) error
+	VerifyWebhook(payload []byte, signature string) (*WebhookEvent, error)
+	Catalog() Catalog
+}
+
+// CreateCustomerInput identifies the organization represented by a new Stripe customer.
+type CreateCustomerInput struct {
+	OrganizationID   string
+	OrganizationSlug string
+	IdempotencyKey   string
+}
+
+// Customer is the Stripe customer data needed by billing callers.
+type Customer struct {
+	ID string
+}
+
+// CreateMeterEventInput reports a TUM delta for one Stripe customer.
+type CreateMeterEventInput struct {
+	CustomerID     string
+	Value          int64
+	Timestamp      time.Time
+	IdempotencyKey string
+}
+
+// WebhookEvent is the verified Stripe event envelope consumed by webhook handlers.
+type WebhookEvent struct {
+	ID      string
+	Type    string
+	Created time.Time
+	Data    json.RawMessage
+}
+
+type stripeAPI interface {
+	createCustomer(context.Context, *stripesdk.CustomerCreateParams) (*stripesdk.Customer, error)
+	createMeterEvent(context.Context, *stripesdk.BillingMeterEventCreateParams) (*stripesdk.BillingMeterEvent, error)
+}
+
+type sdkAPI struct {
+	client *stripesdk.Client
+}
+
+func (s *sdkAPI) createCustomer(ctx context.Context, params *stripesdk.CustomerCreateParams) (*stripesdk.Customer, error) {
+	customer, err := s.client.V1Customers.Create(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe SDK create customer: %w", err)
+	}
+	return customer, nil
+}
+
+func (s *sdkAPI) createMeterEvent(ctx context.Context, params *stripesdk.BillingMeterEventCreateParams) (*stripesdk.BillingMeterEvent, error) {
+	event, err := s.client.V1BillingMeterEvents.Create(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe SDK create meter event: %w", err)
+	}
+	return event, nil
+}
+
+type client struct {
+	api           stripeAPI
+	catalog       Catalog
+	webhookSecret string
+}
+
+// NewClient creates a real Stripe client using the repository HTTP policy.
+func NewClient(guardianPolicy *guardian.Policy, apiKey, webhookSecret string, catalog Catalog) Client {
+	retries := guardian.DefaultRetryConfig()
+	retries.WaitMax = 10 * time.Second
+	retries.MaxAttempts = 1
+	httpClient := guardianPolicy.PooledClient(guardian.WithRetryConfig(retries))
+	httpClient.Timeout = 30 * time.Second
+
+	backendConfig := new(stripesdk.BackendConfig)
+	backendConfig.HTTPClient = httpClient
+	// Guardian owns retries so the two retry layers cannot amplify each other.
+	backendConfig.MaxNetworkRetries = stripesdk.Int64(0)
+	backends := stripesdk.NewBackendsWithConfig(backendConfig)
+	sdkClient := stripesdk.NewClient(apiKey, stripesdk.WithBackends(backends))
+
+	return &client{
+		api:           &sdkAPI{client: sdkClient},
+		catalog:       catalog,
+		webhookSecret: webhookSecret,
+	}
+}
+
+func (c *client) CreateCustomer(ctx context.Context, input CreateCustomerInput) (*Customer, error) {
+	if input.IdempotencyKey == "" {
+		return nil, errMissingIdempotencyKey
+	}
+
+	params := new(stripesdk.CustomerCreateParams)
+	params.Metadata = map[string]string{
+		organizationIDMetadataKey:   input.OrganizationID,
+		organizationSlugMetadataKey: input.OrganizationSlug,
+	}
+	params.SetIdempotencyKey(input.IdempotencyKey)
+
+	customer, err := c.api.createCustomer(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("create Stripe customer: %w", err)
+	}
+	return &Customer{ID: customer.ID}, nil
+}
+
+func (c *client) CreateMeterEvent(ctx context.Context, input CreateMeterEventInput) error {
+	if input.IdempotencyKey == "" {
+		return errMissingIdempotencyKey
+	}
+
+	params := new(stripesdk.BillingMeterEventCreateParams)
+	params.EventName = stripesdk.String(c.catalog.MeterEventName)
+	params.Identifier = stripesdk.String(input.IdempotencyKey)
+	params.Payload = map[string]string{
+		meterCustomerPayloadKey: input.CustomerID,
+		meterValuePayloadKey:    strconv.FormatInt(input.Value, 10),
+	}
+	if !input.Timestamp.IsZero() {
+		params.Timestamp = new(input.Timestamp.Unix())
+	}
+	params.SetIdempotencyKey(input.IdempotencyKey)
+
+	if _, err := c.api.createMeterEvent(ctx, params); err != nil {
+		return fmt.Errorf("create Stripe meter event: %w", err)
+	}
+	return nil
+}
+
+func (c *client) VerifyWebhook(payload []byte, signature string) (*WebhookEvent, error) {
+	if !IsConfigured(c.webhookSecret) {
+		return nil, errors.New("verify Stripe webhook: webhook secret is not configured")
+	}
+
+	event, err := stripewebhook.ConstructEvent(payload, signature, c.webhookSecret)
+	if err != nil {
+		return nil, fmt.Errorf("verify Stripe webhook: %w", err)
+	}
+	if event.APIVersion != stripesdk.APIVersion {
+		return nil, fmt.Errorf("verify Stripe webhook: expected API version %s, got %s", stripesdk.APIVersion, event.APIVersion)
+	}
+
+	var data json.RawMessage
+	if event.Data != nil {
+		data = event.Data.Raw
+	}
+	return &WebhookEvent{
+		ID:      event.ID,
+		Type:    string(event.Type),
+		Created: time.Unix(event.Created, 0),
+		Data:    data,
+	}, nil
+}
+
+func (c *client) Catalog() Catalog {
+	return c.catalog
+}
+
+type stubClient struct {
+	logger *slog.Logger
+}
+
+// NewStubClient returns a local no-op Stripe client.
+func NewStubClient(logger *slog.Logger) Client {
+	return &stubClient{logger: logger}
+}
+
+func (s *stubClient) CreateCustomer(ctx context.Context, _ CreateCustomerInput) (*Customer, error) {
+	s.logger.DebugContext(ctx, "stub Stripe customer creation skipped")
+	return &Customer{ID: "cus_local_stub"}, nil
+}
+
+func (s *stubClient) CreateMeterEvent(ctx context.Context, _ CreateMeterEventInput) error {
+	s.logger.DebugContext(ctx, "stub Stripe meter event skipped")
+	return nil
+}
+
+func (s *stubClient) VerifyWebhook(_ []byte, _ string) (*WebhookEvent, error) {
+	return nil, errors.New("verify Stripe webhook: Stripe is not configured")
+}
+
+func (s *stubClient) Catalog() Catalog {
+	return Catalog{
+		PriceIDTUM:     "",
+		MeterEventName: "",
+	}
+}

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -1,0 +1,284 @@
+package stripe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	stripesdk "github.com/stripe/stripe-go/v85"
+	stripewebhook "github.com/stripe/stripe-go/v85/webhook"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestCatalogValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		catalog Catalog
+		wantErr string
+	}{
+		{
+			name: "valid",
+			catalog: Catalog{
+				PriceIDTUM:     "price_test",
+				MeterEventName: "tum",
+			},
+		},
+		{
+			name:    "missing price",
+			catalog: Catalog{MeterEventName: "tum"},
+			wantErr: "missing TUM price id",
+		},
+		{
+			name:    "missing meter event name",
+			catalog: Catalog{PriceIDTUM: "price_test"},
+			wantErr: "missing meter event name",
+		},
+		{
+			name:    "unset price",
+			catalog: Catalog{PriceIDTUM: "unset", MeterEventName: "tum"},
+			wantErr: "missing TUM price id",
+		},
+		{
+			name:    "unset meter event name",
+			catalog: Catalog{PriceIDTUM: "price_test", MeterEventName: "unset"},
+			wantErr: "missing meter event name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.catalog.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestIsConfigured(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsConfigured(""))
+	require.False(t, IsConfigured("unset"))
+	require.True(t, IsConfigured("sk_test_placeholder"))
+}
+
+func TestSDKPinsExpectedAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "2026-03-25.dahlia", stripesdk.APIVersion)
+}
+
+type fakeStripeAPI struct {
+	customerParams   *stripesdk.CustomerCreateParams
+	meterEventParams *stripesdk.BillingMeterEventCreateParams
+	calls            int
+	err              error
+}
+
+func (f *fakeStripeAPI) createCustomer(_ context.Context, params *stripesdk.CustomerCreateParams) (*stripesdk.Customer, error) {
+	f.calls++
+	f.customerParams = params
+	return &stripesdk.Customer{ID: "cus_test"}, f.err
+}
+
+func (f *fakeStripeAPI) createMeterEvent(_ context.Context, params *stripesdk.BillingMeterEventCreateParams) (*stripesdk.BillingMeterEvent, error) {
+	f.calls++
+	f.meterEventParams = params
+	return &stripesdk.BillingMeterEvent{}, f.err
+}
+
+func TestCreateCustomerPropagatesIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	customer, err := c.CreateCustomer(t.Context(), CreateCustomerInput{
+		OrganizationID:   "<ORG_ID>",
+		OrganizationSlug: "the-customer",
+		IdempotencyKey:   "customer:<ORG_ID>",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "cus_test", customer.ID)
+	require.Equal(t, "customer:<ORG_ID>", stripesdk.StringValue(api.customerParams.IdempotencyKey))
+	require.Equal(t, "<ORG_ID>", api.customerParams.Metadata[organizationIDMetadataKey])
+	require.Equal(t, "the-customer", api.customerParams.Metadata[organizationSlugMetadataKey])
+}
+
+func TestCreateCustomerRejectsMissingIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{})
+	require.ErrorIs(t, err, errMissingIdempotencyKey)
+	require.Zero(t, api.calls)
+}
+
+func TestCreateMeterEventPropagatesIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{
+		api:     api,
+		catalog: Catalog{MeterEventName: "tum"},
+	}
+	timestamp := time.Date(2026, time.August, 14, 10, 0, 0, 0, time.UTC)
+
+	err := c.CreateMeterEvent(t.Context(), CreateMeterEventInput{
+		CustomerID:     "cus_test",
+		Value:          42,
+		Timestamp:      timestamp,
+		IdempotencyKey: "meter:<ORG_ID>:1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "meter:<ORG_ID>:1", stripesdk.StringValue(api.meterEventParams.IdempotencyKey))
+	require.Equal(t, "meter:<ORG_ID>:1", stripesdk.StringValue(api.meterEventParams.Identifier))
+	require.Equal(t, "tum", stripesdk.StringValue(api.meterEventParams.EventName))
+	require.Equal(t, "cus_test", api.meterEventParams.Payload[meterCustomerPayloadKey])
+	require.Equal(t, "42", api.meterEventParams.Payload[meterValuePayloadKey])
+	require.Equal(t, timestamp.Unix(), stripesdk.Int64Value(api.meterEventParams.Timestamp))
+}
+
+func TestCreateMeterEventRejectsMissingIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	err := c.CreateMeterEvent(t.Context(), CreateMeterEventInput{})
+	require.ErrorIs(t, err, errMissingIdempotencyKey)
+	require.Zero(t, api.calls)
+}
+
+func TestWritesWrapStripeErrors(t *testing.T) {
+	t.Parallel()
+
+	apiErr := errors.New("request failed")
+	api := &fakeStripeAPI{err: apiErr}
+	c := &client{api: api, catalog: Catalog{MeterEventName: "tum"}}
+
+	_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{IdempotencyKey: "customer"})
+	require.ErrorIs(t, err, apiErr)
+	require.ErrorContains(t, err, "create Stripe customer")
+
+	err = c.CreateMeterEvent(t.Context(), CreateMeterEventInput{IdempotencyKey: "meter"})
+	require.ErrorIs(t, err, apiErr)
+	require.ErrorContains(t, err, "create Stripe meter event")
+}
+
+func TestVerifyWebhook(t *testing.T) {
+	t.Parallel()
+
+	const secret = "whsec_test"
+	payload := webhookPayload(t, stripesdk.APIVersion)
+	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
+		Payload:   payload,
+		Secret:    secret,
+		Timestamp: time.Now(),
+	})
+	c := &client{webhookSecret: secret}
+
+	event, err := c.VerifyWebhook(signed.Payload, signed.Header)
+	require.NoError(t, err)
+	require.Equal(t, "evt_test", event.ID)
+	require.Equal(t, "invoice.created", event.Type)
+	require.JSONEq(t, `{"id":"in_test"}`, string(event.Data))
+}
+
+func TestVerifyWebhookRejectsInvalidSignature(t *testing.T) {
+	t.Parallel()
+
+	const secret = "whsec_test"
+	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
+		Payload: webhookPayload(t, stripesdk.APIVersion),
+		Secret:  secret,
+	})
+	c := &client{webhookSecret: secret}
+
+	_, err := c.VerifyWebhook(signed.Payload, signed.Header+"bad")
+	require.ErrorContains(t, err, "verify Stripe webhook")
+}
+
+func TestVerifyWebhookRejectsUnconfiguredSecret(t *testing.T) {
+	t.Parallel()
+
+	payload := webhookPayload(t, stripesdk.APIVersion)
+	for _, secret := range []string{"", "unset"} {
+		c := &client{webhookSecret: secret}
+		_, err := c.VerifyWebhook(payload, "")
+		require.ErrorContains(t, err, "webhook secret is not configured")
+	}
+}
+
+func TestVerifyWebhookRejectsReplayedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	const secret = "whsec_test"
+	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
+		Payload:   webhookPayload(t, stripesdk.APIVersion),
+		Secret:    secret,
+		Timestamp: time.Now().Add(-stripewebhook.DefaultTolerance - time.Second),
+	})
+	c := &client{webhookSecret: secret}
+
+	_, err := c.VerifyWebhook(signed.Payload, signed.Header)
+	require.ErrorContains(t, err, "timestamp wasn't within tolerance")
+}
+
+func TestVerifyWebhookRejectsWrongAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	const secret = "whsec_test"
+	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
+		Payload: webhookPayload(t, "2026-05-27.dahlia"),
+		Secret:  secret,
+	})
+	c := &client{webhookSecret: secret}
+
+	_, err := c.VerifyWebhook(signed.Payload, signed.Header)
+	require.ErrorContains(t, err, "expected API version "+stripesdk.APIVersion)
+}
+
+func TestStubClientIsSafeToCall(t *testing.T) {
+	t.Parallel()
+
+	c := NewStubClient(testenv.NewLogger(t))
+
+	customer, err := c.CreateCustomer(t.Context(), CreateCustomerInput{})
+	require.NoError(t, err)
+	require.Equal(t, "cus_local_stub", customer.ID)
+	require.NoError(t, c.CreateMeterEvent(t.Context(), CreateMeterEventInput{}))
+	require.Equal(t, Catalog{}, c.Catalog())
+	_, err = c.VerifyWebhook(nil, "")
+	require.Error(t, err)
+}
+
+func webhookPayload(t *testing.T, apiVersion string) []byte {
+	t.Helper()
+
+	payload, err := json.Marshal(map[string]any{
+		"id":          "evt_test",
+		"object":      "event",
+		"api_version": apiVersion,
+		"created":     time.Now().Unix(),
+		"type":        "invoice.created",
+		"data": map[string]any{
+			"object": map[string]any{"id": "in_test"},
+		},
+	})
+	require.NoError(t, err)
+	return payload
+}

--- a/server/internal/thirdparty/tracking/impl.go
+++ b/server/internal/thirdparty/tracking/impl.go
@@ -6,28 +6,27 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
-	"github.com/speakeasy-api/gram/server/internal/thirdparty/polar"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 )
 
 type Composite struct {
-	polar   *polar.Client
+	billing billing.Tracker
 	posthog *posthog.Posthog
 	logger  *slog.Logger
 }
 
 var _ billing.Tracker = (*Composite)(nil)
 
-func New(polar *polar.Client, posthog *posthog.Posthog, logger *slog.Logger) *Composite {
+func New(billingTracker billing.Tracker, posthog *posthog.Posthog, logger *slog.Logger) *Composite {
 	return &Composite{
-		polar:   polar,
+		billing: billingTracker,
 		posthog: posthog,
 		logger:  logger.With(attr.SlogComponent("usage_tracker")),
 	}
 }
 
 func (c *Composite) TrackModelUsage(ctx context.Context, event billing.ModelUsageEvent) {
-	c.polar.TrackModelUsage(ctx, event)
+	c.billing.TrackModelUsage(ctx, event)
 
 	properties := map[string]any{
 		"organization_id":         event.OrganizationID,
@@ -55,7 +54,7 @@ func (c *Composite) TrackModelUsage(ctx context.Context, event billing.ModelUsag
 }
 
 func (c *Composite) TrackToolCallUsage(ctx context.Context, event billing.ToolCallUsageEvent) {
-	c.polar.TrackToolCallUsage(ctx, event)
+	c.billing.TrackToolCallUsage(ctx, event)
 
 	properties := map[string]any{
 		"organization_id":      event.OrganizationID,
@@ -111,7 +110,7 @@ func (c *Composite) TrackToolCallUsage(ctx context.Context, event billing.ToolCa
 }
 
 func (c *Composite) TrackPromptCallUsage(ctx context.Context, event billing.PromptCallUsageEvent) {
-	c.polar.TrackPromptCallUsage(ctx, event)
+	c.billing.TrackPromptCallUsage(ctx, event)
 
 	properties := map[string]any{
 		"organization_id":      event.OrganizationID,
@@ -157,7 +156,7 @@ func (c *Composite) TrackPromptCallUsage(ctx context.Context, event billing.Prom
 }
 
 func (c *Composite) TrackPlatformUsage(ctx context.Context, events []billing.PlatformUsageEvent) {
-	c.polar.TrackPlatformUsage(ctx, events)
+	c.billing.TrackPlatformUsage(ctx, events)
 }
 
 // for product metrics we create our own heuristic to estimate tool call success


### PR DESCRIPTION
## Summary

- add a narrow Stripe client with exact API-version and idempotency guarantees
- validate Stripe catalog configuration while preserving local stub behavior
- wire env-only secrets and TOML catalog flags across server processes

[Linear issue](https://linear.app/speakeasy/issue/DNO-834)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a narrow Stripe client and config plumbing for PAYG billing. Previously Stripe was unsupported; now an optional client initializes at startup with a pinned API version and idempotent writes. Selecting Stripe disables legacy Polar-shaped billing operations. Foundation for DNO-834.

- Introduces `server/internal/thirdparty/stripe` using `github.com/stripe/stripe-go/v85` (API version `2026-03-25.dahlia`); all writes require an idempotency key (also used as the meter event Identifier); webhook verifier enforces signature and API version.
- Adds flags to `server`, `worker`, and `streams`: `stripe-api-key`, `stripe-webhook-secret` (env-only); `stripe-price-id-tum`, `stripe-meter-event-name` (TOML-sourceable as `stripe.price_id_tum`, `stripe.meter_event_name`). `config.template.toml` includes `[stripe]` placeholders.
- Startup behavior: with `STRIPE_API_KEY` set, a partial `[stripe]` catalog fails startup; in local without `STRIPE_API_KEY`, a no-op stub is selected and the catalog is not validated; in non-local without `STRIPE_API_KEY`, Stripe remains unconfigured and startup continues (startup still fails if no billing provider is configured).
- Billing selection: when a Stripe client is present, use a fail-closed `UnavailableClient` for legacy repository methods and route usage tracking through the provider-agnostic tracker; Polar-shaped operations will error and usage tracking logs a once-per-process warning.
- To enable Stripe outside local: set `STRIPE_API_KEY` and `STRIPE_WEBHOOK_SECRET`; define `[stripe]` with `price_id_tum` and `meter_event_name`.

<sup>Written for commit cdbbe54c00638dce930f3fecd9dff814183f0ab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

