### PR TITLE
feat: re-arm a demoted enterprise trial from the admin app

### DIFF
--- a/.changeset/admin-rearm-trial.md
+++ b/.changeset/admin-rearm-trial.md
@@ -1,0 +1,45 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Platform admins can now put a demoted enterprise trial back on. Until now the
+expiry sweeper's demotion was one-way: it dropped the organization to the free
+tier, put it back behind the book-a-demo gate and switched off its model
+provider keys. Only the keys could be undone, one at a time, through the
+existing admin action for enabling a key; the tier and the gate had no undo at
+all. An operator who wanted to give a customer a second run had no way to do it,
+and extending the trial was not the same thing, because an extension moves an
+end date and leaves the free tier exactly where the demotion left it.
+
+Re-arming restores all of it at once: the account type the trial grants, the
+whitelist flag, every model provider key the demotion switched off, and a fresh
+run of the length the operator asks for, capped at a year and counted from now. The end date is
+counted from now rather than added to the old one on purpose, because a demoted
+trial's end date is already in the past and adding to it could land in the past
+again, which would leave the sweeper free to demote the organization a second
+time within the hour.
+
+One caveat on the keys: this is the deployed behaviour. A local development
+stack has no OpenRouter account behind it, and its stand-in client accepts the
+refresh without doing anything, so a re-arm there reports success and restores
+the tier while both key rows stay switched off. Enabling a key locally has the
+same gap.
+
+The keys come back up before any of the database changes are committed. That
+ordering is the opposite of the demotion's, and it is deliberate: if the model
+provider refuses, the organization stays demoted and on the free tier, and the
+operator can retry. Any key that came back up before the refusal stays up, which
+is what makes the retry cheap. The alternative would advertise a running trial
+to a customer whose keys were still switched off.
+
+Only a demoted trial can be re-armed. A trial that is already running is
+rejected, so re-arm cannot be used as an extend that ignores the extension
+rules. An organization id that matches nothing is reported as not found, the
+same answer the disable, enable and extend actions already give, so a mistyped
+id does not send an operator off to inspect a trial that was never the problem.
+
+The activity log reads the new entry as "restarted enterprise trial", credited
+to the Speakeasy team rather than to the operator who ran it, which is the same
+label the log already gives a Speakeasy action inside a customer's
+organization. The admin dashboard row action follows.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -67950,6 +67950,22 @@ components:
       required:
         - group_value
         - points
+    RearmTrialRequestBody:
+      type: object
+      properties:
+        days:
+          type: integer
+          description: Number of days the re-armed trial runs for, counted from now.
+          format: int64
+          minimum: 1
+          maximum: 365
+        id:
+          type: string
+          description: Organization ID.
+          minLength: 1
+      required:
+        - id
+        - days
     RecordInstallIntentRequestBody:
       type: object
       properties:

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -181,12 +181,9 @@ func newAdminCommand() *cli.Command {
 			EnvVars:  []string{"GRAM_IDP_CLIENT_ID"},
 			Required: false,
 		},
-		// The three below are the server's own flags under the server's own
-		// names and environment variables, so a deployment that already runs
-		// gram-server needs no new secrets to re-arm a trial. The encryption
-		// key is the application-wide one, not admin-encryption-key: that key
-		// wraps admin session tokens, and openrouter_api_keys rows are sealed
-		// with this one.
+		// The server's own flag names and environment variables, so a deployment
+		// already running gram-server needs no new secrets. The encryption key
+		// is the application-wide one, not admin-encryption-key.
 		&cli.StringFlag{
 			Name:     "encryption-key",
 			Usage:    "Key for App level AES encryption/decryption",

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -181,6 +181,28 @@ func newAdminCommand() *cli.Command {
 			EnvVars:  []string{"GRAM_IDP_CLIENT_ID"},
 			Required: false,
 		},
+		// The three below are the server's own flags under the server's own
+		// names and environment variables, so a deployment that already runs
+		// gram-server needs no new secrets to re-arm a trial. The encryption
+		// key is the application-wide one, not admin-encryption-key: that key
+		// wraps admin session tokens, and openrouter_api_keys rows are sealed
+		// with this one.
+		&cli.StringFlag{
+			Name:     "encryption-key",
+			Usage:    "Key for App level AES encryption/decryption",
+			EnvVars:  []string{"GRAM_ENCRYPTION_KEY"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:    "openrouter-provisioning-key",
+			Usage:   "Provisioning key for OpenRouter to create new API keys for orgs - https://openrouter.ai/settings/provisioning-keys",
+			EnvVars: []string{"OPENROUTER_PROVISIONING_KEY"},
+		},
+		&cli.StringFlag{
+			Name:    "openrouter-dev-key",
+			Usage:   "Dev API key for OpenRouter (primarily for local development) - https://openrouter.ai/settings/keys",
+			EnvVars: []string{"OPENROUTER_DEV_KEY"},
+		},
 	}
 
 	return &cli.Command{
@@ -291,8 +313,9 @@ func newAdminCommand() *cli.Command {
 			mux.Use(admin.SessionMiddleware)
 
 			adminWorkOSClient := newAdminWorkOSOrganizationCreator(ctx, logger, guardianPolicy, c)
+			adminTrialKeyReviver := newAdminTrialKeyReviver(ctx, logger, tracerProvider, guardianPolicy, db, redisClient, c)
 
-			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient))
+			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminTrialKeyReviver))
 
 			srv := &http.Server{
 				Addr:              c.String("address"),

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -74,6 +74,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/polar"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
@@ -644,6 +645,57 @@ func newAdminWorkOSOrganizationCreator(ctx context.Context, logger *slog.Logger,
 		logger.WarnContext(ctx, "organization creation is unavailable: WorkOS not configured")
 		return orgprovision.Unavailable{}
 	}
+}
+
+// newAdminTrialKeyReviver builds the OpenRouter client the trial re-arm calls
+// to bring an organization's platform keys back up.
+//
+// It degrades rather than refusing to boot: every other admin endpoint works
+// without OpenRouter, and an admin server that will not start takes all of them
+// down over one unset secret. The condition is logged at Error on startup,
+// which is what makes it visible before an operator goes looking.
+//
+// openrouter.New ignores the tracer provider and the billing tracker it is
+// handed, and RefreshAPIKeyLimit never reaches the key refresher, so the nil
+// refresher here is the nil the streams process already passes.
+func newAdminTrialKeyReviver(
+	ctx context.Context,
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	guardianPolicy *guardian.Policy,
+	db *pgxpool.Pool,
+	redisClient *redis.Client,
+	c *cli.Context,
+) admin.TrialKeyReviver {
+	env := c.String("environment")
+	if env == "local" {
+		return openrouter.NewDevelopment(c.String("openrouter-dev-key"))
+	}
+
+	provisioningKey := c.String("openrouter-provisioning-key")
+	if provisioningKey == "" {
+		logger.ErrorContext(ctx, "trial re-arm is unavailable: no OpenRouter provisioning key configured")
+		return admin.TrialKeysUnavailable{}
+	}
+
+	encryptionClient, err := encryption.New(c.String("encryption-key"))
+	if err != nil {
+		logger.ErrorContext(ctx, "trial re-arm is unavailable: no usable encryption key configured", attr.SlogError(err))
+		return admin.TrialKeysUnavailable{}
+	}
+
+	return openrouter.New(
+		logger,
+		tracerProvider,
+		guardianPolicy,
+		db,
+		env,
+		provisioningKey,
+		nil,
+		productfeatures.NewClient(logger, tracerProvider, db, redisClient),
+		nil,
+		encryptionClient,
+	)
 }
 
 func newWorkOSClient(guardianPolicy *guardian.Policy, c *cli.Context) (client *workos.Client, workosAvailable bool, err error) {

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -647,17 +647,11 @@ func newAdminWorkOSOrganizationCreator(ctx context.Context, logger *slog.Logger,
 	}
 }
 
-// newAdminTrialKeyReviver builds the OpenRouter client the trial re-arm calls
-// to bring an organization's platform keys back up.
+// newAdminTrialKeyReviver builds the OpenRouter client the trial re-arm needs.
+// It degrades rather than refusing to boot, because every other admin endpoint
+// works without OpenRouter; the unavailable case is logged at Error on startup.
 //
-// It degrades rather than refusing to boot: every other admin endpoint works
-// without OpenRouter, and an admin server that will not start takes all of them
-// down over one unset secret. The condition is logged at Error on startup,
-// which is what makes it visible before an operator goes looking.
-//
-// openrouter.New ignores the tracer provider and the billing tracker it is
-// handed, and RefreshAPIKeyLimit never reaches the key refresher, so the nil
-// refresher here is the nil the streams process already passes.
+// The nil arguments are a billing tracker and a key refresher, neither reached.
 func newAdminTrialKeyReviver(
 	ctx context.Context,
 	logger *slog.Logger,

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -436,8 +436,8 @@ var _ = Service("admin", func() {
 	// The one positional effect that is real is the one disableOrganization
 	// above documents: the OpenAPI emitter deduplicates structurally identical
 	// request bodies and names the shared schema after whichever method it met
-	// first. This payload's {id, days} shape is unique, so it needs no
-	// openapi:typename.
+	// first. rearmTrial below shares this {id, days} shape and carries the
+	// explicit typename, so this one keeps the generated name.
 	Method("extendTrial", func() {
 		Description("Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.")
 
@@ -500,6 +500,7 @@ var _ = Service("admin", func() {
 		Meta("openapi:operationId", "adminCreateOrganization")
 	})
 
+	// Appended, not inserted: see the note above extendTrial. New methods go last.
 	Method("rearmTrial", func() {
 		Description("Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.")
 
@@ -507,18 +508,13 @@ var _ = Service("admin", func() {
 			security.AdminAuthPayload()
 			Required("id", "days")
 
-			// Structurally identical to extendTrial's body, and the OpenAPI
-			// emitter deduplicates request bodies by shape and keeps the first
-			// name it registered. Without this the schema would come out named
-			// after extend, so an operator reading the spec would see re-arm
-			// documented as an extension.
+			// Shares extendTrial's body shape, and the OpenAPI emitter names a
+			// deduplicated schema after the first method it met.
 			Meta("openapi:typename", "RearmTrialRequestBody")
 
 			Attribute("id", String, "Organization ID.", func() {
 				MinLength(1)
 			})
-			// Counted from now rather than added to the trial's current end
-			// date, which is always in the past on a demoted trial.
 			Attribute("days", Int, "Number of days the re-armed trial runs for, counted from now.", func() {
 				Minimum(constants.MinTrialRearmDays)
 				Maximum(constants.MaxTrialRearmDays)

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -499,4 +499,39 @@ var _ = Service("admin", func() {
 
 		Meta("openapi:operationId", "adminCreateOrganization")
 	})
+
+	Method("rearmTrial", func() {
+		Description("Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("id", "days")
+
+			// Structurally identical to extendTrial's body, and the OpenAPI
+			// emitter deduplicates request bodies by shape and keeps the first
+			// name it registered. Without this the schema would come out named
+			// after extend, so an operator reading the spec would see re-arm
+			// documented as an extension.
+			Meta("openapi:typename", "RearmTrialRequestBody")
+
+			Attribute("id", String, "Organization ID.", func() {
+				MinLength(1)
+			})
+			// Counted from now rather than added to the trial's current end
+			// date, which is always in the past on a demoted trial.
+			Attribute("days", Int, "Number of days the re-armed trial runs for, counted from now.", func() {
+				Minimum(constants.MinTrialRearmDays)
+				Maximum(constants.MaxTrialRearmDays)
+			})
+		})
+
+		Result(AdminOrganization)
+
+		HTTP(func() {
+			POST("/admin/trial.rearm")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminRearmTrial")
+	})
 })

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -28,10 +28,11 @@ type Client struct {
 	ListOrganizationsEndpoint        goa.Endpoint
 	ExtendTrialEndpoint              goa.Endpoint
 	CreateOrganizationEndpoint       goa.Endpoint
+	RearmTrialEndpoint               goa.Endpoint
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
@@ -46,6 +47,7 @@ func NewClient(login, callback, logout, getProject, updateOrganization, disableO
 		ListOrganizationsEndpoint:        listOrganizations,
 		ExtendTrialEndpoint:              extendTrial,
 		CreateOrganizationEndpoint:       createOrganization,
+		RearmTrialEndpoint:               rearmTrial,
 	}
 }
 
@@ -332,6 +334,28 @@ func (c *Client) ExtendTrial(ctx context.Context, p *ExtendTrialPayload) (res *A
 func (c *Client) CreateOrganization(ctx context.Context, p *CreateOrganizationPayload) (res *AdminOrganization, err error) {
 	var ires any
 	ires, err = c.CreateOrganizationEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminOrganization), nil
+}
+
+// RearmTrial calls the "rearmTrial" endpoint of the "admin" service.
+// RearmTrial may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) RearmTrial(ctx context.Context, p *RearmTrialPayload) (res *AdminOrganization, err error) {
+	var ires any
+	ires, err = c.RearmTrialEndpoint(ctx, p)
 	if err != nil {
 		return
 	}

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -29,6 +29,7 @@ type Endpoints struct {
 	ListOrganizations        goa.Endpoint
 	ExtendTrial              goa.Endpoint
 	CreateOrganization       goa.Endpoint
+	RearmTrial               goa.Endpoint
 }
 
 // NewEndpoints wraps the methods of the "admin" service with endpoints.
@@ -49,6 +50,7 @@ func NewEndpoints(s Service) *Endpoints {
 		ListOrganizations:        NewListOrganizationsEndpoint(s, a.APIKeyAuth),
 		ExtendTrial:              NewExtendTrialEndpoint(s, a.APIKeyAuth),
 		CreateOrganization:       NewCreateOrganizationEndpoint(s, a.APIKeyAuth),
+		RearmTrial:               NewRearmTrialEndpoint(s, a.APIKeyAuth),
 	}
 }
 
@@ -67,6 +69,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.ListOrganizations = m(e.ListOrganizations)
 	e.ExtendTrial = m(e.ExtendTrial)
 	e.CreateOrganization = m(e.CreateOrganization)
+	e.RearmTrial = m(e.RearmTrial)
 }
 
 // NewLoginEndpoint returns an endpoint function that calls the method "login"
@@ -323,5 +326,28 @@ func NewCreateOrganizationEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFu
 			return nil, err
 		}
 		return s.CreateOrganization(ctx, p)
+	}
+}
+
+// NewRearmTrialEndpoint returns an endpoint function that calls the method
+// "rearmTrial" of service "admin".
+func NewRearmTrialEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*RearmTrialPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.RearmTrial(ctx, p)
 	}
 }

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -53,6 +53,11 @@ type Service interface {
 	// the WorkOS organization webhook: the Gram ID is derived from the WorkOS ID,
 	// so both writers converge on one row.
 	CreateOrganization(context.Context, *CreateOrganizationPayload) (res *AdminOrganization, err error)
+	// Puts a demoted enterprise trial back on: restores the organization's account
+	// type and whitelist flag, revives its model provider keys, and gives the
+	// trial a fresh run of the given length counted from now. Only a demoted trial
+	// can be re-armed; one that has converted or is already running is rejected.
+	RearmTrial(context.Context, *RearmTrialPayload) (res *AdminOrganization, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.
@@ -75,7 +80,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [13]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization"}
+var MethodNames = [14]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial"}
 
 // AdminListOrganizationMembersResult is the result type of the admin service
 // listOrganizationMembers method.
@@ -348,6 +353,15 @@ type LoginResult struct {
 type LogoutPayload struct {
 	// The session cookie value to clear for logging out
 	SessionID *string
+}
+
+// RearmTrialPayload is the payload type of the admin service rearmTrial method.
+type RearmTrialPayload struct {
+	AdminSessionToken *string
+	// Organization ID.
+	ID string
+	// Number of days the re-armed trial runs for, counted from now.
+	Days int
 }
 
 // UpdateOrganizationPayload is the payload type of the admin service

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -451,3 +451,41 @@ func BuildCreateOrganizationPayload(adminCreateOrganizationBody string, adminCre
 
 	return v, nil
 }
+
+// BuildRearmTrialPayload builds the payload for the admin rearmTrial endpoint
+// from CLI flags.
+func BuildRearmTrialPayload(adminRearmTrialBody string, adminRearmTrialAdminSessionToken string) (*admin.RearmTrialPayload, error) {
+	var err error
+	var body RearmTrialRequestBody
+	{
+		err = json.Unmarshal([]byte(adminRearmTrialBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"days\": 2,\n      \"id\": \"aa\"\n   }'")
+		}
+		if utf8.RuneCountInString(body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", body.ID, utf8.RuneCountInString(body.ID), 1, true))
+		}
+		if body.Days < 1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", body.Days, 1, true))
+		}
+		if body.Days > 365 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", body.Days, 365, false))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminRearmTrialAdminSessionToken != "" {
+			adminSessionToken = &adminRearmTrialAdminSessionToken
+		}
+	}
+	v := &admin.RearmTrialPayload{
+		ID:   body.ID,
+		Days: body.Days,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -67,6 +67,10 @@ type Client struct {
 	// createOrganization endpoint.
 	CreateOrganizationDoer goahttp.Doer
 
+	// RearmTrial Doer is the HTTP client used to make requests to the rearmTrial
+	// endpoint.
+	RearmTrialDoer goahttp.Doer
+
 	// RestoreResponseBody controls whether the response bodies are reset after
 	// decoding so they can be read again.
 	RestoreResponseBody bool
@@ -100,6 +104,7 @@ func NewClient(
 		ListOrganizationsDoer:        doer,
 		ExtendTrialDoer:              doer,
 		CreateOrganizationDoer:       doer,
+		RearmTrialDoer:               doer,
 		RestoreResponseBody:          restoreBody,
 		scheme:                       scheme,
 		host:                         host,
@@ -415,6 +420,30 @@ func (c *Client) CreateOrganization() goa.Endpoint {
 		resp, err := c.CreateOrganizationDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "createOrganization", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// RearmTrial returns an endpoint that makes HTTP requests to the admin service
+// rearmTrial server.
+func (c *Client) RearmTrial() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeRearmTrialRequest(c.encoder)
+		decodeResponse = DecodeRearmTrialResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildRearmTrialRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.RearmTrialDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "rearmTrial", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -3121,6 +3121,240 @@ func DecodeCreateOrganizationResponse(decoder func(*http.Response) goahttp.Decod
 	}
 }
 
+// BuildRearmTrialRequest instantiates a HTTP request object with method and
+// path set to call the "admin" service "rearmTrial" endpoint
+func (c *Client) BuildRearmTrialRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: RearmTrialAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "rearmTrial", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeRearmTrialRequest returns an encoder for requests sent to the admin
+// rearmTrial server.
+func EncodeRearmTrialRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.RearmTrialPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "rearmTrial", "*admin.RearmTrialPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewRearmTrialRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "rearmTrial", err)
+		}
+		return nil
+	}
+}
+
+// DecodeRearmTrialResponse returns a decoder for responses returned by the
+// admin rearmTrial endpoint. restoreBody controls whether the response body
+// should be restored after having been read.
+// DecodeRearmTrialResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeRearmTrialResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body RearmTrialResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			res := NewRearmTrialAdminOrganizationOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body RearmTrialUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body RearmTrialForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body RearmTrialBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body RearmTrialNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body RearmTrialConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body RearmTrialUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body RearmTrialInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body RearmTrialInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+				}
+				err = ValidateRearmTrialInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+				}
+				return nil, NewRearmTrialInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body RearmTrialUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+				}
+				err = ValidateRearmTrialUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+				}
+				return nil, NewRearmTrialUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "rearmTrial", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body RearmTrialGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "rearmTrial", err)
+			}
+			err = ValidateRearmTrialGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "rearmTrial", err)
+			}
+			return nil, NewRearmTrialGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "rearmTrial", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // unmarshalAdminOrganizationMemberResponseBodyToAdminAdminOrganizationMember
 // builds a value of type *admin.AdminOrganizationMember from a value of type
 // *AdminOrganizationMemberResponseBody.

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -71,3 +71,8 @@ func ExtendTrialAdminPath() string {
 func CreateOrganizationAdminPath() string {
 	return "/admin/organization.create"
 }
+
+// RearmTrialAdminPath returns the URL path to the admin service rearmTrial HTTP endpoint.
+func RearmTrialAdminPath() string {
+	return "/admin/trial.rearm"
+}

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -53,6 +53,15 @@ type CreateOrganizationRequestBody struct {
 	Name string `form:"name" json:"name" xml:"name"`
 }
 
+// RearmTrialRequestBody is the type of the "admin" service "rearmTrial"
+// endpoint HTTP request body.
+type RearmTrialRequestBody struct {
+	// Organization ID.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Number of days the re-armed trial runs for, counted from now.
+	Days int `form:"days" json:"days" xml:"days"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -282,6 +291,40 @@ type ExtendTrialResponseBody struct {
 // CreateOrganizationResponseBody is the type of the "admin" service
 // "createOrganization" endpoint HTTP response body.
 type CreateOrganizationResponseBody struct {
+	// The ID of the organization
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// The name of the organization
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// The slug of the organization
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount *int `form:"member_count,omitempty" json:"member_count,omitempty" xml:"member_count,omitempty"`
+	// The creation date of the organization.
+	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
+	// The last update date of the organization.
+	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
+}
+
+// RearmTrialResponseBody is the type of the "admin" service "rearmTrial"
+// endpoint HTTP response body.
+type RearmTrialResponseBody struct {
 	// The ID of the organization
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 	// The name of the organization
@@ -2696,6 +2739,186 @@ type CreateOrganizationGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// RearmTrialUnauthorizedResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "unauthorized" error.
+type RearmTrialUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialForbiddenResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "forbidden" error.
+type RearmTrialForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialBadRequestResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "bad_request" error.
+type RearmTrialBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialNotFoundResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "not_found" error.
+type RearmTrialNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialConflictResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "conflict" error.
+type RearmTrialConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialUnsupportedMediaResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "unsupported_media" error.
+type RearmTrialUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialInvalidResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "invalid" error.
+type RearmTrialInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialInvariantViolationResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "invariant_violation" error.
+type RearmTrialInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialUnexpectedResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "unexpected" error.
+type RearmTrialUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RearmTrialGatewayErrorResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "gateway_error" error.
+type RearmTrialGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -2803,6 +3026,16 @@ func NewExtendTrialRequestBody(p *admin.ExtendTrialPayload) *ExtendTrialRequestB
 func NewCreateOrganizationRequestBody(p *admin.CreateOrganizationPayload) *CreateOrganizationRequestBody {
 	body := &CreateOrganizationRequestBody{
 		Name: p.Name,
+	}
+	return body
+}
+
+// NewRearmTrialRequestBody builds the HTTP request body from the payload of
+// the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialRequestBody(p *admin.RearmTrialPayload) *RearmTrialRequestBody {
+	body := &RearmTrialRequestBody{
+		ID:   p.ID,
+		Days: p.Days,
 	}
 	return body
 }
@@ -4976,6 +5209,179 @@ func NewCreateOrganizationGatewayError(body *CreateOrganizationGatewayErrorRespo
 	return v
 }
 
+// NewRearmTrialAdminOrganizationOK builds a "admin" service "rearmTrial"
+// endpoint result from a HTTP "OK" response.
+func NewRearmTrialAdminOrganizationOK(body *RearmTrialResponseBody) *admin.AdminOrganization {
+	v := &admin.AdminOrganization{
+		ID:                 *body.ID,
+		Name:               *body.Name,
+		Slug:               *body.Slug,
+		AccountType:        *body.AccountType,
+		WorkosID:           body.WorkosID,
+		Whitelisted:        *body.Whitelisted,
+		DisabledAt:         body.DisabledAt,
+		FreeTrialStartedAt: body.FreeTrialStartedAt,
+		FreeTrialEndsAt:    body.FreeTrialEndsAt,
+		TrialState:         body.TrialState,
+		TrialEndsAt:        body.TrialEndsAt,
+		MemberCount:        *body.MemberCount,
+		CreatedAt:          *body.CreatedAt,
+		UpdatedAt:          *body.UpdatedAt,
+	}
+
+	return v
+}
+
+// NewRearmTrialUnauthorized builds a admin service rearmTrial endpoint
+// unauthorized error.
+func NewRearmTrialUnauthorized(body *RearmTrialUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialForbidden builds a admin service rearmTrial endpoint forbidden
+// error.
+func NewRearmTrialForbidden(body *RearmTrialForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialBadRequest builds a admin service rearmTrial endpoint
+// bad_request error.
+func NewRearmTrialBadRequest(body *RearmTrialBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialNotFound builds a admin service rearmTrial endpoint not_found
+// error.
+func NewRearmTrialNotFound(body *RearmTrialNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialConflict builds a admin service rearmTrial endpoint conflict
+// error.
+func NewRearmTrialConflict(body *RearmTrialConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialUnsupportedMedia builds a admin service rearmTrial endpoint
+// unsupported_media error.
+func NewRearmTrialUnsupportedMedia(body *RearmTrialUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialInvalid builds a admin service rearmTrial endpoint invalid
+// error.
+func NewRearmTrialInvalid(body *RearmTrialInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialInvariantViolation builds a admin service rearmTrial endpoint
+// invariant_violation error.
+func NewRearmTrialInvariantViolation(body *RearmTrialInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialUnexpected builds a admin service rearmTrial endpoint
+// unexpected error.
+func NewRearmTrialUnexpected(body *RearmTrialUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewRearmTrialGatewayError builds a admin service rearmTrial endpoint
+// gateway_error error.
+func NewRearmTrialGatewayError(body *RearmTrialGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // ValidateGetProjectResponseBody runs the validations defined on
 // GetProjectResponseBody
 func ValidateGetProjectResponseBody(body *GetProjectResponseBody) (err error) {
@@ -5343,6 +5749,59 @@ func ValidateExtendTrialResponseBody(body *ExtendTrialResponseBody) (err error) 
 // ValidateCreateOrganizationResponseBody runs the validations defined on
 // CreateOrganizationResponseBody
 func ValidateCreateOrganizationResponseBody(body *CreateOrganizationResponseBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.Slug == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if body.Whitelisted == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("whitelisted", "body"))
+	}
+	if body.MemberCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("member_count", "body"))
+	}
+	if body.CreatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
+	}
+	if body.UpdatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	if body.DisabledAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.disabled_at", *body.DisabledAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialStartedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_started_at", *body.FreeTrialStartedAt, goa.FormatDateTime))
+	}
+	if body.FreeTrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.free_trial_ends_at", *body.FreeTrialEndsAt, goa.FormatDateTime))
+	}
+	if body.TrialState != nil {
+		if !(*body.TrialState == "none" || *body.TrialState == "running" || *body.TrialState == "ending_soon" || *body.TrialState == "expired" || *body.TrialState == "demoted" || *body.TrialState == "converted") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.trial_state", *body.TrialState, []any{"none", "running", "ending_soon", "expired", "demoted", "converted"}))
+		}
+	}
+	if body.TrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_ends_at", *body.TrialEndsAt, goa.FormatDateTime))
+	}
+	if body.CreatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
+	}
+	if body.UpdatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
+	}
+	return
+}
+
+// ValidateRearmTrialResponseBody runs the validations defined on
+// RearmTrialResponseBody
+func ValidateRearmTrialResponseBody(body *RearmTrialResponseBody) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}
@@ -8496,6 +8955,246 @@ func ValidateCreateOrganizationUnexpectedResponseBody(body *CreateOrganizationUn
 // ValidateCreateOrganizationGatewayErrorResponseBody runs the validations
 // defined on createOrganization_gateway_error_response_body
 func ValidateCreateOrganizationGatewayErrorResponseBody(body *CreateOrganizationGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialUnauthorizedResponseBody runs the validations defined on
+// rearmTrial_unauthorized_response_body
+func ValidateRearmTrialUnauthorizedResponseBody(body *RearmTrialUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialForbiddenResponseBody runs the validations defined on
+// rearmTrial_forbidden_response_body
+func ValidateRearmTrialForbiddenResponseBody(body *RearmTrialForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialBadRequestResponseBody runs the validations defined on
+// rearmTrial_bad_request_response_body
+func ValidateRearmTrialBadRequestResponseBody(body *RearmTrialBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialNotFoundResponseBody runs the validations defined on
+// rearmTrial_not_found_response_body
+func ValidateRearmTrialNotFoundResponseBody(body *RearmTrialNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialConflictResponseBody runs the validations defined on
+// rearmTrial_conflict_response_body
+func ValidateRearmTrialConflictResponseBody(body *RearmTrialConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialUnsupportedMediaResponseBody runs the validations defined
+// on rearmTrial_unsupported_media_response_body
+func ValidateRearmTrialUnsupportedMediaResponseBody(body *RearmTrialUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialInvalidResponseBody runs the validations defined on
+// rearmTrial_invalid_response_body
+func ValidateRearmTrialInvalidResponseBody(body *RearmTrialInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialInvariantViolationResponseBody runs the validations
+// defined on rearmTrial_invariant_violation_response_body
+func ValidateRearmTrialInvariantViolationResponseBody(body *RearmTrialInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialUnexpectedResponseBody runs the validations defined on
+// rearmTrial_unexpected_response_body
+func ValidateRearmTrialUnexpectedResponseBody(body *RearmTrialUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRearmTrialGatewayErrorResponseBody runs the validations defined on
+// rearmTrial_gateway_error_response_body
+func ValidateRearmTrialGatewayErrorResponseBody(body *RearmTrialGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -2768,6 +2768,219 @@ func EncodeCreateOrganizationError(encoder func(context.Context, http.ResponseWr
 	}
 }
 
+// EncodeRearmTrialResponse returns an encoder for responses returned by the
+// admin rearmTrial endpoint.
+func EncodeRearmTrialResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminOrganization)
+		enc := encoder(ctx, w)
+		body := NewRearmTrialResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeRearmTrialRequest returns a decoder for requests sent to the admin
+// rearmTrial endpoint.
+func DecodeRearmTrialRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.RearmTrialPayload, error) {
+	return func(r *http.Request) (*admin.RearmTrialPayload, error) {
+		var payload *admin.RearmTrialPayload
+		var (
+			body RearmTrialRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateRearmTrialRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewRearmTrialPayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeRearmTrialError returns an encoder for errors returned by the
+// rearmTrial admin endpoint.
+func EncodeRearmTrialError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRearmTrialGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // marshalAdminAdminOrganizationMemberToAdminOrganizationMemberResponseBody
 // builds a value of type *AdminOrganizationMemberResponseBody from a value of
 // type *admin.AdminOrganizationMember.

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -71,3 +71,8 @@ func ExtendTrialAdminPath() string {
 func CreateOrganizationAdminPath() string {
 	return "/admin/organization.create"
 }
+
+// RearmTrialAdminPath returns the URL path to the admin service rearmTrial HTTP endpoint.
+func RearmTrialAdminPath() string {
+	return "/admin/trial.rearm"
+}

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	ListOrganizations        http.Handler
 	ExtendTrial              http.Handler
 	CreateOrganization       http.Handler
+	RearmTrial               http.Handler
 }
 
 // MountPoint holds information about the mounted endpoints.
@@ -74,6 +75,7 @@ func New(
 			{"ListOrganizations", "GET", "/admin/organizations.list"},
 			{"ExtendTrial", "POST", "/admin/trial.extend"},
 			{"CreateOrganization", "POST", "/admin/organization.create"},
+			{"RearmTrial", "POST", "/admin/trial.rearm"},
 		},
 		Login:                    NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
 		Callback:                 NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
@@ -88,6 +90,7 @@ func New(
 		ListOrganizations:        NewListOrganizationsHandler(e.ListOrganizations, mux, decoder, encoder, errhandler, formatter),
 		ExtendTrial:              NewExtendTrialHandler(e.ExtendTrial, mux, decoder, encoder, errhandler, formatter),
 		CreateOrganization:       NewCreateOrganizationHandler(e.CreateOrganization, mux, decoder, encoder, errhandler, formatter),
+		RearmTrial:               NewRearmTrialHandler(e.RearmTrial, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 
@@ -109,6 +112,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.ListOrganizations = m(s.ListOrganizations)
 	s.ExtendTrial = m(s.ExtendTrial)
 	s.CreateOrganization = m(s.CreateOrganization)
+	s.RearmTrial = m(s.RearmTrial)
 }
 
 // MethodNames returns the methods served.
@@ -129,6 +133,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountListOrganizationsHandler(mux, h.ListOrganizations)
 	MountExtendTrialHandler(mux, h.ExtendTrial)
 	MountCreateOrganizationHandler(mux, h.CreateOrganization)
+	MountRearmTrialHandler(mux, h.RearmTrial)
 }
 
 // Mount configures the mux to serve the admin endpoints.
@@ -804,6 +809,59 @@ func NewCreateOrganizationHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "createOrganization")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountRearmTrialHandler configures the mux to serve the "admin" service
+// "rearmTrial" endpoint.
+func MountRearmTrialHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/trial.rearm", f)
+}
+
+// NewRearmTrialHandler creates a HTTP handler which loads the HTTP request and
+// calls the "admin" service "rearmTrial" endpoint.
+func NewRearmTrialHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeRearmTrialRequest(mux, decoder)
+		encodeResponse = EncodeRearmTrialResponse(encoder)
+		encodeError    = EncodeRearmTrialError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "rearmTrial")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -55,6 +55,15 @@ type CreateOrganizationRequestBody struct {
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 }
 
+// RearmTrialRequestBody is the type of the "admin" service "rearmTrial"
+// endpoint HTTP request body.
+type RearmTrialRequestBody struct {
+	// Organization ID.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Number of days the re-armed trial runs for, counted from now.
+	Days *int `form:"days,omitempty" json:"days,omitempty" xml:"days,omitempty"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -284,6 +293,40 @@ type ExtendTrialResponseBody struct {
 // CreateOrganizationResponseBody is the type of the "admin" service
 // "createOrganization" endpoint HTTP response body.
 type CreateOrganizationResponseBody struct {
+	// The ID of the organization
+	ID string `form:"id" json:"id" xml:"id"`
+	// The name of the organization
+	Name string `form:"name" json:"name" xml:"name"`
+	// The slug of the organization
+	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted bool `form:"whitelisted" json:"whitelisted" xml:"whitelisted"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// The time at which the free trial started.
+	FreeTrialStartedAt *string `form:"free_trial_started_at,omitempty" json:"free_trial_started_at,omitempty" xml:"free_trial_started_at,omitempty"`
+	// The time at which the free trial ends.
+	FreeTrialEndsAt *string `form:"free_trial_ends_at,omitempty" json:"free_trial_ends_at,omitempty" xml:"free_trial_ends_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount int `form:"member_count" json:"member_count" xml:"member_count"`
+	// The creation date of the organization.
+	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
+	// The last update date of the organization.
+	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
+}
+
+// RearmTrialResponseBody is the type of the "admin" service "rearmTrial"
+// endpoint HTTP response body.
+type RearmTrialResponseBody struct {
 	// The ID of the organization
 	ID string `form:"id" json:"id" xml:"id"`
 	// The name of the organization
@@ -2698,6 +2741,186 @@ type CreateOrganizationGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// RearmTrialUnauthorizedResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "unauthorized" error.
+type RearmTrialUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialForbiddenResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "forbidden" error.
+type RearmTrialForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialBadRequestResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "bad_request" error.
+type RearmTrialBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialNotFoundResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "not_found" error.
+type RearmTrialNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialConflictResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "conflict" error.
+type RearmTrialConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialUnsupportedMediaResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "unsupported_media" error.
+type RearmTrialUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialInvalidResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "invalid" error.
+type RearmTrialInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialInvariantViolationResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "invariant_violation" error.
+type RearmTrialInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialUnexpectedResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "unexpected" error.
+type RearmTrialUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RearmTrialGatewayErrorResponseBody is the type of the "admin" service
+// "rearmTrial" endpoint HTTP response body for the "gateway_error" error.
+type RearmTrialGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -2957,6 +3180,28 @@ func NewExtendTrialResponseBody(res *admin.AdminOrganization) *ExtendTrialRespon
 // result of the "createOrganization" endpoint of the "admin" service.
 func NewCreateOrganizationResponseBody(res *admin.AdminOrganization) *CreateOrganizationResponseBody {
 	body := &CreateOrganizationResponseBody{
+		ID:                 res.ID,
+		Name:               res.Name,
+		Slug:               res.Slug,
+		AccountType:        res.AccountType,
+		WorkosID:           res.WorkosID,
+		Whitelisted:        res.Whitelisted,
+		DisabledAt:         res.DisabledAt,
+		FreeTrialStartedAt: res.FreeTrialStartedAt,
+		FreeTrialEndsAt:    res.FreeTrialEndsAt,
+		TrialState:         res.TrialState,
+		TrialEndsAt:        res.TrialEndsAt,
+		MemberCount:        res.MemberCount,
+		CreatedAt:          res.CreatedAt,
+		UpdatedAt:          res.UpdatedAt,
+	}
+	return body
+}
+
+// NewRearmTrialResponseBody builds the HTTP response body from the result of
+// the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialResponseBody(res *admin.AdminOrganization) *RearmTrialResponseBody {
+	body := &RearmTrialResponseBody{
 		ID:                 res.ID,
 		Name:               res.Name,
 		Slug:               res.Slug,
@@ -4826,6 +5071,146 @@ func NewCreateOrganizationGatewayErrorResponseBody(res *goa.ServiceError) *Creat
 	return body
 }
 
+// NewRearmTrialUnauthorizedResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialUnauthorizedResponseBody(res *goa.ServiceError) *RearmTrialUnauthorizedResponseBody {
+	body := &RearmTrialUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialForbiddenResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialForbiddenResponseBody(res *goa.ServiceError) *RearmTrialForbiddenResponseBody {
+	body := &RearmTrialForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialBadRequestResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialBadRequestResponseBody(res *goa.ServiceError) *RearmTrialBadRequestResponseBody {
+	body := &RearmTrialBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialNotFoundResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialNotFoundResponseBody(res *goa.ServiceError) *RearmTrialNotFoundResponseBody {
+	body := &RearmTrialNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialConflictResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialConflictResponseBody(res *goa.ServiceError) *RearmTrialConflictResponseBody {
+	body := &RearmTrialConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialUnsupportedMediaResponseBody builds the HTTP response body from
+// the result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialUnsupportedMediaResponseBody(res *goa.ServiceError) *RearmTrialUnsupportedMediaResponseBody {
+	body := &RearmTrialUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialInvalidResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialInvalidResponseBody(res *goa.ServiceError) *RearmTrialInvalidResponseBody {
+	body := &RearmTrialInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialInvariantViolationResponseBody builds the HTTP response body
+// from the result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialInvariantViolationResponseBody(res *goa.ServiceError) *RearmTrialInvariantViolationResponseBody {
+	body := &RearmTrialInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialUnexpectedResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialUnexpectedResponseBody(res *goa.ServiceError) *RearmTrialUnexpectedResponseBody {
+	body := &RearmTrialUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRearmTrialGatewayErrorResponseBody builds the HTTP response body from the
+// result of the "rearmTrial" endpoint of the "admin" service.
+func NewRearmTrialGatewayErrorResponseBody(res *goa.ServiceError) *RearmTrialGatewayErrorResponseBody {
+	body := &RearmTrialGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewLoginPayload builds a admin service login endpoint payload.
 func NewLoginPayload(returnTo *string, prompt *string) *admin.LoginPayload {
 	v := &admin.LoginPayload{}
@@ -4971,6 +5356,17 @@ func NewCreateOrganizationPayload(body *CreateOrganizationRequestBody, adminSess
 	return v
 }
 
+// NewRearmTrialPayload builds a admin service rearmTrial endpoint payload.
+func NewRearmTrialPayload(body *RearmTrialRequestBody, adminSessionToken *string) *admin.RearmTrialPayload {
+	v := &admin.RearmTrialPayload{
+		ID:   *body.ID,
+		Days: *body.Days,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
 // ValidateUpdateOrganizationRequestBody runs the validations defined on
 // UpdateOrganizationRequestBody
 func ValidateUpdateOrganizationRequestBody(body *UpdateOrganizationRequestBody) (err error) {
@@ -5044,6 +5440,33 @@ func ValidateCreateOrganizationRequestBody(body *CreateOrganizationRequestBody) 
 	if body.Name != nil {
 		if utf8.RuneCountInString(*body.Name) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.name", *body.Name, utf8.RuneCountInString(*body.Name), 1, true))
+		}
+	}
+	return
+}
+
+// ValidateRearmTrialRequestBody runs the validations defined on
+// RearmTrialRequestBody
+func ValidateRearmTrialRequestBody(body *RearmTrialRequestBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Days == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("days", "body"))
+	}
+	if body.ID != nil {
+		if utf8.RuneCountInString(*body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
+		}
+	}
+	if body.Days != nil {
+		if *body.Days < 1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", *body.Days, 1, true))
+		}
+	}
+	if body.Days != nil {
+		if *body.Days > 365 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("body.days", *body.Days, 365, false))
 		}
 	}
 	return

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -97,7 +97,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|upsert-shadow-mcp-inventory-policy-bypass|delete-shadow-mcp-inventory-policy-bypass|block-shadow-mcp-inventory-server|unblock-shadow-mcp-inventory-server|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization)",
+		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -385,6 +385,10 @@ func ParseEndpoint(
 		adminCreateOrganizationFlags                 = flag.NewFlagSet("create-organization", flag.ExitOnError)
 		adminCreateOrganizationBodyFlag              = adminCreateOrganizationFlags.String("body", "REQUIRED", "")
 		adminCreateOrganizationAdminSessionTokenFlag = adminCreateOrganizationFlags.String("admin-session-token", "", "")
+
+		adminRearmTrialFlags                 = flag.NewFlagSet("rearm-trial", flag.ExitOnError)
+		adminRearmTrialBodyFlag              = adminRearmTrialFlags.String("body", "REQUIRED", "")
+		adminRearmTrialAdminSessionTokenFlag = adminRearmTrialFlags.String("admin-session-token", "", "")
 
 		agentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
 
@@ -3393,6 +3397,7 @@ func ParseEndpoint(
 	adminListOrganizationsFlags.Usage = adminListOrganizationsUsage
 	adminExtendTrialFlags.Usage = adminExtendTrialUsage
 	adminCreateOrganizationFlags.Usage = adminCreateOrganizationUsage
+	adminRearmTrialFlags.Usage = adminRearmTrialUsage
 
 	agentFlags.Usage = agentUsage
 	agentGetPluginsFlags.Usage = agentGetPluginsUsage
@@ -4347,6 +4352,9 @@ func ParseEndpoint(
 
 			case "create-organization":
 				epf = adminCreateOrganizationFlags
+
+			case "rearm-trial":
+				epf = adminRearmTrialFlags
 
 			}
 
@@ -6327,6 +6335,9 @@ func ParseEndpoint(
 			case "create-organization":
 				endpoint = c.CreateOrganization()
 				data, err = adminc.BuildCreateOrganizationPayload(*adminCreateOrganizationBodyFlag, *adminCreateOrganizationAdminSessionTokenFlag)
+			case "rearm-trial":
+				endpoint = c.RearmTrial()
+				data, err = adminc.BuildRearmTrialPayload(*adminRearmTrialBodyFlag, *adminRearmTrialAdminSessionTokenFlag)
 			}
 		case "agent":
 			c := agentc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -8784,6 +8795,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    list-organizations: Lists organizations for admin operations with optional search and filters.`)
 	fmt.Fprintln(os.Stderr, `    extend-trial: Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.`)
 	fmt.Fprintln(os.Stderr, `    create-organization: Creates an organization in WorkOS and in Gram, so an operator does not have to leave the admin app for the WorkOS dashboard. The organization starts with no members, is not whitelisted, and gets no trial. Idempotent against the WorkOS organization webhook: the Gram ID is derived from the WorkOS ID, so both writers converge on one row.`)
+	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
 	fmt.Fprintf(os.Stderr, "    %s admin COMMAND --help\n", os.Args[0])
@@ -9070,6 +9082,26 @@ func adminCreateOrganizationUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin create-organization --body '{\n      \"name\": \"aa\"\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminRearmTrialUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin rearm-trial", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin rearm-trial --body '{\n      \"days\": 2,\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
 }
 
 // agentUsage displays the usage of the agent command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1137,6 +1137,82 @@ paths:
                                 $ref: '#/components/schemas/Error'
             security:
                 - admin_auth_header_Authorization: []
+    /admin/trial.rearm:
+        post:
+            tags:
+                - admin
+            summary: rearmTrial admin
+            description: 'Puts a demoted enterprise trial back on: restores the organization''s account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.'
+            operationId: adminRearmTrial
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RearmTrialRequestBody'
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminOrganization'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /rpc/access.blockShadowMCPInventoryServer:
         post:
             description: Block a Shadow MCP server URL under an allow-by-default (allow_all) blocking policy by adding a risk_policy:block grant.
@@ -68526,6 +68602,22 @@ components:
             required:
                 - group_value
                 - points
+        RearmTrialRequestBody:
+            type: object
+            properties:
+                days:
+                    type: integer
+                    description: Number of days the re-armed trial runs for, counted from now.
+                    format: int64
+                    minimum: 1
+                    maximum: 365
+                id:
+                    type: string
+                    description: Organization ID.
+                    minLength: 1
+            required:
+                - id
+                - days
         RecordInstallIntentRequestBody:
             type: object
             properties:

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -59,28 +59,20 @@ type Service struct {
 	// CreateOrganization reports rather than working around.
 	workos orgprovision.WorkOSOrganizationCreator
 
-	// openRouter brings an organization's platform keys back up when a demoted
-	// trial is re-armed.
 	openRouter TrialKeyReviver
 
 	audit *audit.Logger
 }
 
 // TrialKeyReviver is the one method of openrouter.Provisioner a re-arm needs.
-// The doc comment on the interface names it the reinstatement path: a key that
-// DisableAPIKey turned off comes back enabled, upstream and locally.
 type TrialKeyReviver interface {
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
 }
 
-// ErrKeyRevivalUnavailable reports a deployment that cannot reach OpenRouter,
-// which RearmTrial answers below 500 so its explanation reaches the operator.
+// ErrKeyRevivalUnavailable reports a deployment that cannot reach OpenRouter.
 var ErrKeyRevivalUnavailable = errors.New("no usable OpenRouter configuration")
 
-// TrialKeysUnavailable stands in for the OpenRouter client where one cannot be
-// built, so the admin server still boots: every endpoint that needs no
-// OpenRouter still works, and the one that does says so rather than panicking
-// on a nil interface.
+// TrialKeysUnavailable lets the admin server boot without OpenRouter.
 type TrialKeysUnavailable struct{}
 
 func (TrialKeysUnavailable) RefreshAPIKeyLimit(context.Context, string, openrouter.KeyType, *int) (int, error) {
@@ -799,23 +791,13 @@ func (s *Service) CreateOrganization(ctx context.Context, payload *gen.CreateOrg
 
 // RearmTrial puts a demoted enterprise trial back on.
 //
-// The keys come back up before the database restore commits, which is
-// deliberately not the demotion's ordering mirrored. The demotion takes the
-// keys down first and commits the account-type write after, because a rollback
-// there leaves an organization reading as enterprise with a dead key and the
-// next sweep finishes the job. Mirrored, that would leave a failed re-arm
-// reading as a running trial whose keys are dead, which is the one state this
-// endpoint exists to prevent.
-//
-// So a partial failure here leaves the organization still demoted and still
-// free, with keys that are alive again. Nothing advertises a trial that is not
-// running, and a retry is safe because reviving an already-live key is a no-op.
-// Do not "fix" this to match the demotion.
+// The keys come back up before the restore commits, deliberately not mirroring
+// the demotion's ordering: a partial failure must leave the organization
+// demoted with live keys, never a running trial with dead ones.
 func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload) (*gen.AdminOrganization, error) {
-	// Defence in depth against a non-HTTP caller, for the reason ExtendTrial
-	// gives: the design's bounds are generated into the request decoder alone.
-	// The check stays on the wide payload.Days and the int32 narrowing stays
-	// below it, or 1<<32 + 1 would truncate into range.
+	// Defence in depth against a non-HTTP caller: the design's bounds are
+	// generated into the request decoder alone. Keep this on the wide
+	// payload.Days, above the int32 narrowing, or 1<<32 + 1 truncates into range.
 	if payload.Days < constants.MinTrialRearmDays || payload.Days > constants.MaxTrialRearmDays {
 		return nil, oops.E(oops.CodeInvalid, nil, "days must be between %d and %d", constants.MinTrialRearmDays, constants.MaxTrialRearmDays)
 	}
@@ -858,10 +840,8 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	if err := s.audit.LogOrganizationEnterpriseTrialRearmed(ctx, tx, audit.LogOrganizationEnterpriseTrialRearmedEvent{
 		OrganizationID: payload.ID,
 		Actor:          actor,
-		// The customer reads this feed, so they get the collective staff label
-		// rather than the operator's email. adminActor says why the read-side
-		// mask cannot do it for us. The subject on Actor above is the
-		// accountability record and stays.
+		// The customer reads this feed, so the entry carries the team label
+		// rather than the operator's email. adminActor says why.
 		ActorDisplayName: conv.PtrEmpty(audit.SpeakeasyTeamActorLabel),
 		ActorSlug:        nil,
 		OrganizationName: organization.Name,
@@ -878,9 +858,7 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 
 	s.recapRevivedKeys(ctx, logger, payload.ID, uncapped)
 
-	// Which operator did it, recorded where only Speakeasy reads it. The audit
-	// entry carries the OIDC subject and the team label, so this log is the one
-	// place the two are tied together.
+	// Speakeasy-only, and the only place the email meets the entry's subject.
 	logger.InfoContext(ctx, "re-armed enterprise trial",
 		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
 	)
@@ -889,10 +867,7 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 }
 
 // rejectRearm turns a zero-row re-arm into the error the operator should act
-// on. It is ExtendTrial's disambiguation, on purpose and separately: an
-// operator who pastes one wrong id must be told the organization does not
-// exist, not sent to go and look at a trial. The two are kept apart rather than
-// shared because extend's semantics are out of this slice's scope.
+// on: a pasted wrong id must report a missing organization, not a trial state.
 func (s *Service) rejectRearm(ctx context.Context, logger *slog.Logger, organizationID string) error {
 	_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
 		ID:        organizationID,
@@ -902,39 +877,22 @@ func (s *Service) rejectRearm(ctx context.Context, logger *slog.Logger, organiza
 	case errors.Is(lookupErr, pgx.ErrNoRows):
 		return oops.C(oops.CodeNotFound)
 	case lookupErr != nil:
-		// Falling through to the conflict here would report a trial state we
-		// never managed to read.
+		// Falling through would report a trial state we never managed to read.
 		return oops.E(oops.CodeUnexpected, lookupErr, "look up organization after unrearmed trial").LogError(ctx, logger)
 	}
 
-	// The organization exists, so it is the trial that blocks the write: never
-	// granted, converted, or still running. Which one is not the operator's
-	// business, and arming a trial that was never granted is the auth flow's
-	// job rather than this endpoint's.
+	// Which of the three reasons applies is not the operator's business.
 	return oops.E(oops.CodeConflict, nil, "organization has no demoted enterprise trial to re-arm")
 }
 
-// reviveTrialKeys brings every platform key the organization holds back up.
+// reviveTrialKeys brings every platform key the organization holds back up, and
+// returns the types revived at a pre-commit ceiling, for recapRevivedKeys.
 //
-// Both key types, because the demotion loops openrouter.AllKeyTypes and a
-// re-arm that took only chat back up would leave the organization on a running
-// trial with its internal completions still dead.
+// Shaped like openrouterkeys.EnableKey rather than the demotion's blind loop:
+// DisableAPIKey no-ops on a missing key row, RefreshAPIKeyLimit errors on one.
 //
-// Shaped like openrouterkeys.EnableKey rather than like the demotion's
-// unconditional loop, and the difference is not cosmetic: DisableAPIKey no-ops
-// on an organization that has no key row of a type, but RefreshAPIKeyLimit
-// errors on one. An organization that never ran an internal completion has no
-// internal key, so the demotion's shape here would fail most re-arms outright.
-//
-// Every read and write in here runs on the pool rather than on the caller's
-// transaction, because RefreshAPIKeyLimit writes on the pool itself. That is
-// what makes a revived key survive the rollback of a re-arm that fails later,
-// which is the safe direction: a live key on a demoted organization costs
-// nothing, since the free tier's credit gate still binds.
-//
-// The key types it returns are the ones it could only revive at a ceiling
-// resolved from the pre-commit world. recapRevivedKeys finishes those off once
-// the restore has committed.
+// It runs on the pool, not the caller's transaction, so a revived key survives
+// a later rollback. That is the safe direction.
 func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, organizationID string) ([]openrouter.KeyType, error) {
 	keys := orrepo.New(s.db)
 
@@ -957,19 +915,10 @@ func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, orga
 		}
 
 		// The ceiling recorded on the row, not the policy default: a trial key
-		// is minted well below that default, and resetting to it would hand the
-		// organization a larger allowance than its trial ever had.
+		// is minted well below that default.
 		//
-		// A row with no recorded ceiling gets the default instead, because
-		// conv.PtrEmpty answers nil for a zero and RefreshAPIKeyLimit falls
-		// back to defaultLimitForOrg on a nil limit. Which default it lands on
-		// is worth stating: defaultLimitForOrg reads on the pool, so it runs
-		// before this transaction commits the restore and sees the
-		// organization as free with no active trial. It therefore returns the
-		// free-tier allowance rather than the trial's, which is the price of
-		// reviving the keys first. Only a row minted before the ceiling column
-		// existed can reach it, and recapRevivedKeys corrects that row once the
-		// restore has committed, so the type is recorded here.
+		// A zero becomes a nil limit, which RefreshAPIKeyLimit resolves on the
+		// pool: pre-commit that reads free. recapRevivedKeys fixes those after.
 		if row.MonthlyCredits == 0 {
 			uncapped = append(uncapped, keyType)
 		}
@@ -977,21 +926,13 @@ func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, orga
 		_, err = s.openRouter.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
 		switch {
 		case errors.Is(err, ErrKeyRevivalUnavailable):
-			// CodeInvalid and not CodeGatewayError:
-			// server/design/shared/errors.go maps
-			// gateway_error to 502 and the admin app trusts a response body
-			// only below 500, so this explanation would never arrive. It is
-			// worth arriving, because it names a deployment setting to fix
-			// rather than a call to retry. It names both settings because the
-			// handler cannot tell which one is missing: deps.go substitutes
-			// the same stand-in for an absent provisioning key and for an
-			// encryption key that will not parse, and logs which at startup.
+			// CodeInvalid and not CodeGatewayError: the admin app trusts a
+			// response body only below 500, and this names a deployment setting
+			// to fix rather than a call to retry.
 			return nil, oops.E(oops.CodeInvalid, err, "this server cannot revive model provider keys: it is missing either the OpenRouter provisioning key or a usable encryption key. The server log says which at startup")
 		case err != nil:
-			// A gateway error and not an unexpected one: this is OpenRouter
-			// refusing, and the operator's action is to retry rather than to
-			// read a stack trace. Both map above 500, so neither carries its
-			// message to the admin app; the detail belongs in the log.
+			// OpenRouter refusing: the operator's action is to retry, not to
+			// read a stack trace.
 			return nil, oops.E(oops.CodeGatewayError, err, "revive openrouter %s key", keyType).LogError(ctx, logger)
 		}
 	}
@@ -1000,21 +941,11 @@ func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, orga
 }
 
 // recapRevivedKeys puts the trial's own ceiling on the keys reviveTrialKeys
-// could only revive at the free-tier one.
+// could only revive at the free-tier one. It must run after the commit, because
+// RefreshAPIKeyLimit resolves a nil limit from the pool.
 //
-// It runs after the commit and only then, because that is the whole point: the
-// ceiling RefreshAPIKeyLimit resolves for a nil limit comes from
-// defaultLimitForOrg, which reads the organization and its trial on the pool.
-// Before the commit it sees a free organization with no running trial; after
-// it, the trial the re-arm just restored. Nothing else corrects this on any
-// schedule, so leaving it to a later refresh would strand the organization on
-// the free-tier allowance for the whole re-armed run.
-//
-// A failure here is logged and swallowed. The re-arm itself is committed and
-// durable by this point, so answering the operator with an error would report a
-// trial as unarmed that is in fact running. The organization is left with a
-// live key and too small an allowance, which the platform-admin key page
-// already has an action to correct.
+// A failure is logged and swallowed: the re-arm is already durable, so an error
+// here would report an armed trial as unarmed.
 func (s *Service) recapRevivedKeys(ctx context.Context, logger *slog.Logger, organizationID string, keyTypes []openrouter.KeyType) {
 	for _, keyType := range keyTypes {
 		if _, err := s.openRouter.RefreshAPIKeyLimit(ctx, organizationID, keyType, nil); err != nil {
@@ -1026,20 +957,13 @@ func (s *Service) recapRevivedKeys(ctx context.Context, logger *slog.Logger, org
 	}
 }
 
-// adminActor identifies the operator behind an admin-app write for the audit
-// log. An admin session carries an OIDC subject and an email rather than a Gram
-// user id, so the subject is what the principal is built from. A call that
-// arrives without a session records the same system actor the demotion sweeper
-// uses, because an entry naming an unknown operator beats no entry at all.
+// adminActor identifies the operator behind an admin-app write. An admin session
+// carries an OIDC subject rather than a Gram user id, and a call without one
+// records the system actor the demotion sweeper uses.
 //
-// The returned email is for the structured log only. It must not become the
-// entry's display name: these entries are written against the customer's
-// organization and surface in that customer's own audit feed, so a Speakeasy
-// operator's email would be handed to them. auditapi already masks staff
-// identities on read, but it cannot mask this one, because it recognises staff
-// by matching the actor id against a Gram user and an OIDC subject is not one.
-// The caller applies audit.SpeakeasyTeamActorLabel at write time instead, which
-// is the same string that mask produces.
+// The returned email is for the structured log only, never the entry's display
+// name: these entries surface in the customer's own feed, and auditapi's
+// read-side mask cannot recognise an OIDC subject as staff.
 func adminActor(ctx context.Context) (actor urn.Principal, operatorEmail *string) {
 	authCtx, ok := contextvalues.GetAdminAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.OIDCSubject == "" {

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -24,6 +24,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
 	"github.com/speakeasy-api/gram/server/internal/admin/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/orgslug"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -37,7 +38,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/organizations/orgprovision"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type Service struct {
@@ -54,6 +58,33 @@ type Service struct {
 	// no WorkOS configuration get orgprovision.Unavailable, whose failure
 	// CreateOrganization reports rather than working around.
 	workos orgprovision.WorkOSOrganizationCreator
+
+	// openRouter brings an organization's platform keys back up when a demoted
+	// trial is re-armed.
+	openRouter TrialKeyReviver
+
+	audit *audit.Logger
+}
+
+// TrialKeyReviver is the one method of openrouter.Provisioner a re-arm needs.
+// The doc comment on the interface names it the reinstatement path: a key that
+// DisableAPIKey turned off comes back enabled, upstream and locally.
+type TrialKeyReviver interface {
+	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
+}
+
+// ErrKeyRevivalUnavailable reports a deployment that cannot reach OpenRouter,
+// which RearmTrial answers below 500 so its explanation reaches the operator.
+var ErrKeyRevivalUnavailable = errors.New("no usable OpenRouter configuration")
+
+// TrialKeysUnavailable stands in for the OpenRouter client where one cannot be
+// built, so the admin server still boots: every endpoint that needs no
+// OpenRouter still works, and the one that does says so rather than panicking
+// on a nil interface.
+type TrialKeysUnavailable struct{}
+
+func (TrialKeysUnavailable) RefreshAPIKeyLimit(context.Context, string, openrouter.KeyType, *int) (int, error) {
+	return 0, ErrKeyRevivalUnavailable
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -68,6 +99,7 @@ func NewService(
 	encryptionClient *encryption.Client,
 	allowedOrigins []string,
 	workosClient orgprovision.WorkOSOrganizationCreator,
+	openRouter TrialKeyReviver,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("admin"))
 
@@ -89,6 +121,8 @@ func NewService(
 		verifier:       NewVerifier(logger, sessionStore, oidcClient),
 		allowedOrigins: allowedOrigins,
 		workos:         workosClient,
+		openRouter:     openRouter,
+		audit:          audit.NewLogger(),
 		loginStates: cache.NewTypedObjectCache[LoginState](
 			logger.With(attr.SlogCacheNamespace("admin_login_state")),
 			cache.NewRedisCacheAdapter(redisClient),
@@ -761,6 +795,258 @@ func (s *Service) CreateOrganization(ctx context.Context, payload *gen.CreateOrg
 	}
 
 	return s.readOrganizationAfterWrite(ctx, org.ID, "fetch organization after create")
+}
+
+// RearmTrial puts a demoted enterprise trial back on.
+//
+// The keys come back up before the database restore commits, which is
+// deliberately not the demotion's ordering mirrored. The demotion takes the
+// keys down first and commits the account-type write after, because a rollback
+// there leaves an organization reading as enterprise with a dead key and the
+// next sweep finishes the job. Mirrored, that would leave a failed re-arm
+// reading as a running trial whose keys are dead, which is the one state this
+// endpoint exists to prevent.
+//
+// So a partial failure here leaves the organization still demoted and still
+// free, with keys that are alive again. Nothing advertises a trial that is not
+// running, and a retry is safe because reviving an already-live key is a no-op.
+// Do not "fix" this to match the demotion.
+func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload) (*gen.AdminOrganization, error) {
+	// Defence in depth against a non-HTTP caller, for the reason ExtendTrial
+	// gives: the design's bounds are generated into the request decoder alone.
+	// The check stays on the wide payload.Days and the int32 narrowing stays
+	// below it, or 1<<32 + 1 would truncate into range.
+	if payload.Days < constants.MinTrialRearmDays || payload.Days > constants.MaxTrialRearmDays {
+		return nil, oops.E(oops.CodeInvalid, nil, "days must be between %d and %d", constants.MinTrialRearmDays, constants.MaxTrialRearmDays)
+	}
+
+	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin trial re-arm transaction").LogError(ctx, logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	trials := trialsRepo.New(tx)
+
+	rearmed, err := trials.RearmTrial(ctx, trialsRepo.RearmTrialParams{
+		OrganizationID: payload.ID,
+		RearmForDays:   int32(payload.Days),
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, s.rejectRearm(ctx, logger, payload.ID)
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "re-arm trial").LogError(ctx, logger)
+	}
+
+	uncapped, err := s.reviveTrialKeys(ctx, logger, payload.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	organization, err := trials.RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{
+		OrganizationID: payload.ID,
+		AccountType:    rearmed.Tier,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "restore organization from trial").LogError(ctx, logger)
+	}
+
+	actor, operatorEmail := adminActor(ctx)
+	if err := s.audit.LogOrganizationEnterpriseTrialRearmed(ctx, tx, audit.LogOrganizationEnterpriseTrialRearmedEvent{
+		OrganizationID: payload.ID,
+		Actor:          actor,
+		// The customer reads this feed, so they get the collective staff label
+		// rather than the operator's email. adminActor says why the read-side
+		// mask cannot do it for us. The subject on Actor above is the
+		// accountability record and stays.
+		ActorDisplayName: conv.PtrEmpty(audit.SpeakeasyTeamActorLabel),
+		ActorSlug:        nil,
+		OrganizationName: organization.Name,
+		OrganizationSlug: organization.Slug,
+		AccountType:      rearmed.Tier,
+		TrialEndsAt:      rearmed.EndsAt.Time,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log trial re-arm").LogError(ctx, logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit trial re-arm").LogError(ctx, logger)
+	}
+
+	s.recapRevivedKeys(ctx, logger, payload.ID, uncapped)
+
+	// Which operator did it, recorded where only Speakeasy reads it. The audit
+	// entry carries the OIDC subject and the team label, so this log is the one
+	// place the two are tied together.
+	logger.InfoContext(ctx, "re-armed enterprise trial",
+		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
+	)
+
+	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial re-arm")
+}
+
+// rejectRearm turns a zero-row re-arm into the error the operator should act
+// on. It is ExtendTrial's disambiguation, on purpose and separately: an
+// operator who pastes one wrong id must be told the organization does not
+// exist, not sent to go and look at a trial. The two are kept apart rather than
+// shared because extend's semantics are out of this slice's scope.
+func (s *Service) rejectRearm(ctx context.Context, logger *slog.Logger, organizationID string) error {
+	_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
+		ID:        organizationID,
+		AllowSlug: false,
+	})
+	switch {
+	case errors.Is(lookupErr, pgx.ErrNoRows):
+		return oops.C(oops.CodeNotFound)
+	case lookupErr != nil:
+		// Falling through to the conflict here would report a trial state we
+		// never managed to read.
+		return oops.E(oops.CodeUnexpected, lookupErr, "look up organization after unrearmed trial").LogError(ctx, logger)
+	}
+
+	// The organization exists, so it is the trial that blocks the write: never
+	// granted, converted, or still running. Which one is not the operator's
+	// business, and arming a trial that was never granted is the auth flow's
+	// job rather than this endpoint's.
+	return oops.E(oops.CodeConflict, nil, "organization has no demoted enterprise trial to re-arm")
+}
+
+// reviveTrialKeys brings every platform key the organization holds back up.
+//
+// Both key types, because the demotion loops openrouter.AllKeyTypes and a
+// re-arm that took only chat back up would leave the organization on a running
+// trial with its internal completions still dead.
+//
+// Shaped like openrouterkeys.EnableKey rather than like the demotion's
+// unconditional loop, and the difference is not cosmetic: DisableAPIKey no-ops
+// on an organization that has no key row of a type, but RefreshAPIKeyLimit
+// errors on one. An organization that never ran an internal completion has no
+// internal key, so the demotion's shape here would fail most re-arms outright.
+//
+// Every read and write in here runs on the pool rather than on the caller's
+// transaction, because RefreshAPIKeyLimit writes on the pool itself. That is
+// what makes a revived key survive the rollback of a re-arm that fails later,
+// which is the safe direction: a live key on a demoted organization costs
+// nothing, since the free tier's credit gate still binds.
+//
+// The key types it returns are the ones it could only revive at a ceiling
+// resolved from the pre-commit world. recapRevivedKeys finishes those off once
+// the restore has committed.
+func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, organizationID string) ([]openrouter.KeyType, error) {
+	keys := orrepo.New(s.db)
+
+	var uncapped []openrouter.KeyType
+
+	for _, keyType := range openrouter.AllKeyTypes {
+		row, err := keys.GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{
+			OrganizationID: organizationID,
+			KeyType:        string(keyType),
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			continue
+		case err != nil:
+			return nil, oops.E(oops.CodeUnexpected, err, "read openrouter %s key", keyType).LogError(ctx, logger)
+		}
+
+		if !row.Disabled {
+			continue
+		}
+
+		// The ceiling recorded on the row, not the policy default: a trial key
+		// is minted well below that default, and resetting to it would hand the
+		// organization a larger allowance than its trial ever had.
+		//
+		// A row with no recorded ceiling gets the default instead, because
+		// conv.PtrEmpty answers nil for a zero and RefreshAPIKeyLimit falls
+		// back to defaultLimitForOrg on a nil limit. Which default it lands on
+		// is worth stating: defaultLimitForOrg reads on the pool, so it runs
+		// before this transaction commits the restore and sees the
+		// organization as free with no active trial. It therefore returns the
+		// free-tier allowance rather than the trial's, which is the price of
+		// reviving the keys first. Only a row minted before the ceiling column
+		// existed can reach it, and recapRevivedKeys corrects that row once the
+		// restore has committed, so the type is recorded here.
+		if row.MonthlyCredits == 0 {
+			uncapped = append(uncapped, keyType)
+		}
+		limit := conv.PtrEmpty(int(row.MonthlyCredits))
+		_, err = s.openRouter.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
+		switch {
+		case errors.Is(err, ErrKeyRevivalUnavailable):
+			// CodeInvalid and not CodeGatewayError:
+			// server/design/shared/errors.go maps
+			// gateway_error to 502 and the admin app trusts a response body
+			// only below 500, so this explanation would never arrive. It is
+			// worth arriving, because it names a deployment setting to fix
+			// rather than a call to retry. It names both settings because the
+			// handler cannot tell which one is missing: deps.go substitutes
+			// the same stand-in for an absent provisioning key and for an
+			// encryption key that will not parse, and logs which at startup.
+			return nil, oops.E(oops.CodeInvalid, err, "this server cannot revive model provider keys: it is missing either the OpenRouter provisioning key or a usable encryption key. The server log says which at startup")
+		case err != nil:
+			// A gateway error and not an unexpected one: this is OpenRouter
+			// refusing, and the operator's action is to retry rather than to
+			// read a stack trace. Both map above 500, so neither carries its
+			// message to the admin app; the detail belongs in the log.
+			return nil, oops.E(oops.CodeGatewayError, err, "revive openrouter %s key", keyType).LogError(ctx, logger)
+		}
+	}
+
+	return uncapped, nil
+}
+
+// recapRevivedKeys puts the trial's own ceiling on the keys reviveTrialKeys
+// could only revive at the free-tier one.
+//
+// It runs after the commit and only then, because that is the whole point: the
+// ceiling RefreshAPIKeyLimit resolves for a nil limit comes from
+// defaultLimitForOrg, which reads the organization and its trial on the pool.
+// Before the commit it sees a free organization with no running trial; after
+// it, the trial the re-arm just restored. Nothing else corrects this on any
+// schedule, so leaving it to a later refresh would strand the organization on
+// the free-tier allowance for the whole re-armed run.
+//
+// A failure here is logged and swallowed. The re-arm itself is committed and
+// durable by this point, so answering the operator with an error would report a
+// trial as unarmed that is in fact running. The organization is left with a
+// live key and too small an allowance, which the platform-admin key page
+// already has an action to correct.
+func (s *Service) recapRevivedKeys(ctx context.Context, logger *slog.Logger, organizationID string, keyTypes []openrouter.KeyType) {
+	for _, keyType := range keyTypes {
+		if _, err := s.openRouter.RefreshAPIKeyLimit(ctx, organizationID, keyType, nil); err != nil {
+			logger.ErrorContext(ctx, "re-armed trial key kept the free-tier allowance: refresh it from the platform admin key page",
+				attr.SlogError(err),
+				attr.SlogOpenRouterKeyType(string(keyType)),
+			)
+		}
+	}
+}
+
+// adminActor identifies the operator behind an admin-app write for the audit
+// log. An admin session carries an OIDC subject and an email rather than a Gram
+// user id, so the subject is what the principal is built from. A call that
+// arrives without a session records the same system actor the demotion sweeper
+// uses, because an entry naming an unknown operator beats no entry at all.
+//
+// The returned email is for the structured log only. It must not become the
+// entry's display name: these entries are written against the customer's
+// organization and surface in that customer's own audit feed, so a Speakeasy
+// operator's email would be handed to them. auditapi already masks staff
+// identities on read, but it cannot mask this one, because it recognises staff
+// by matching the actor id against a Gram user and an OIDC subject is not one.
+// The caller applies audit.SpeakeasyTeamActorLabel at write time instead, which
+// is the same string that mask produces.
+func adminActor(ctx context.Context) (actor urn.Principal, operatorEmail *string) {
+	authCtx, ok := contextvalues.GetAdminAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.OIDCSubject == "" {
+		return urn.NewPrincipal(urn.PrincipalTypeUser, "system"), nil
+	}
+
+	return urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.OIDCSubject), conv.PtrEmpty(authCtx.Email)
 }
 
 // readOrganizationAfterWrite returns the organization a write just landed on.

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -326,7 +326,11 @@ func TestListOrganizations_FullPageWithFilterEndsTheWalk(t *testing.T) {
 }
 
 type trialFixture struct {
-	orgID       string
+	orgID string
+	// tier defaults to enterprise, which is the only tier the application
+	// writes today. The re-arm tests set it to something else to pin that the
+	// restored account type is read from the row rather than hardcoded.
+	tier        string
 	endsAt      time.Time
 	convertedAt *time.Time
 	demotedAt   *time.Time
@@ -335,8 +339,13 @@ type trialFixture struct {
 func seedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, f trialFixture) {
 	t.Helper()
 
+	if f.tier == "" {
+		f.tier = "enterprise"
+	}
+
 	err := trialsRepo.New(conn).InsertTrialFixture(ctx, trialsRepo.InsertTrialFixtureParams{
 		OrganizationID: f.orgID,
+		Tier:           f.tier,
 		CreatedAt:      conv.ToPGTimestamptz(time.Now().UTC().Add(-30 * 24 * time.Hour)),
 		EndsAt:         conv.ToPGTimestamptz(f.endsAt),
 		ConvertedAt:    conv.PtrToPGTimestamptz(f.convertedAt),

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -327,9 +327,7 @@ func TestListOrganizations_FullPageWithFilterEndsTheWalk(t *testing.T) {
 
 type trialFixture struct {
 	orgID string
-	// tier defaults to enterprise, which is the only tier the application
-	// writes today. The re-arm tests set it to something else to pin that the
-	// restored account type is read from the row rather than hardcoded.
+	// tier defaults to enterprise, the only tier the application writes today.
 	tier        string
 	endsAt      time.Time
 	convertedAt *time.Time

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -29,16 +29,8 @@ import (
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
-// keyRevival is one call the handler made to bring a key back up, together with
-// what the database looked like from outside the handler's transaction at the
-// moment it made it.
-//
-// The two "seen" fields are the whole point of the fake. D2 puts the revival
-// before the restore commits, and the only way to observe an ordering from a
-// test is to look at the world at the instant the middle step runs. These reads
-// go through the pool rather than the handler's transaction, so they see
-// committed state alone: an implementation that committed the restore first
-// would show enterprise and a cleared demotion here.
+// keyRevival is one call the handler made, with what the database looked like
+// from outside its transaction then. The "seen" fields read through the pool.
 type keyRevival struct {
 	orgID   string
 	keyType openrouter.KeyType
@@ -48,9 +40,7 @@ type keyRevival struct {
 	demotedSeen     bool
 }
 
-// rearmProvisioner stands in for OpenRouter. It records each revival, mirrors
-// the real client's local effect by clearing the row's disabled flag, and can
-// be made to fail on one key type so a partial failure is testable.
+// rearmProvisioner stands in for OpenRouter and can be made to fail on one key.
 type rearmProvisioner struct {
 	conn *pgxpool.Pool
 
@@ -58,9 +48,7 @@ type rearmProvisioner struct {
 	revivals []keyRevival
 
 	failOn openrouter.KeyType
-	// failAfter suppresses the failure for the first n calls, which is how a
-	// test reaches the post-commit recap: failing the revival instead aborts
-	// the handler long before it.
+	// failAfter is how a test reaches the post-commit recap.
 	failAfter int
 	failWith  error
 }
@@ -88,9 +76,7 @@ func (p *rearmProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string,
 		return 0, p.failWith
 	}
 
-	// What the real RefreshAPIKeyLimit does locally: the reinstatement is the
-	// point, so a fake that skipped it would let a test claim the keys came
-	// back up when nothing wrote that down.
+	// What the real RefreshAPIKeyLimit does locally.
 	if p.conn != nil {
 		if _, err := orrepo.New(p.conn).UpdateOpenRouterKey(ctx, orrepo.UpdateOpenRouterKeyParams{
 			OrganizationID: orgID,
@@ -106,12 +92,7 @@ func (p *rearmProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string,
 	return conv.PtrValOr(limit, 0), nil
 }
 
-// revivedLimits is which key types the handler asked for and the ceiling it
-// passed for each. It is a map rather than the call sequence on purpose:
-// reviving internal before chat is behaviourally identical, so an assertion on
-// the order would fail a change that broke nothing. The pointer is kept because
-// a nil ceiling is not the same request as a zero one: nil asks
-// RefreshAPIKeyLimit for the policy default.
+// A nil ceiling is not a zero one: nil asks for the policy default.
 func (p *rearmProvisioner) revivedLimits() map[openrouter.KeyType]*int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -124,10 +105,8 @@ func (p *rearmProvisioner) revivedLimits() map[openrouter.KeyType]*int {
 	return limits
 }
 
-// readRearmState is the observation the fake makes mid-flight, so it cannot use
-// the require-based helpers the tests use: a failed read here would abort the
-// handler's own goroutine rather than fail an assertion. It answers with zero
-// values instead and lets the caller's assertions report the mismatch.
+// readRearmState runs inside the handler's own goroutine, so it cannot use the
+// require helpers: it answers zero values and lets the caller's assertions fail.
 func readRearmState(ctx context.Context, conn *pgxpool.Pool, orgID string) (accountType string, demoted bool) {
 	org, err := testrepo.New(conn).GetOrganizationMetadataStateFixture(ctx, orgID)
 	if err != nil {
@@ -151,8 +130,6 @@ func newTestAdminServiceWithOpenRouter(t *testing.T, provisioner TrialKeyReviver
 	return ctx, svc, conn
 }
 
-// newRearmService is the common case: a fake wired to the same database the
-// handler writes to, so its ordering observations are real.
 func newRearmService(t *testing.T) (context.Context, *Service, *pgxpool.Pool, *rearmProvisioner) {
 	t.Helper()
 
@@ -203,22 +180,15 @@ func readOpenRouterKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, or
 	return row
 }
 
-// seedDemotedTrial leaves the organization exactly where the demotion sweeper
-// leaves it: free tier, whitelist cleared, trial stamped demoted with an
-// ends_at in the past, both platform keys disabled with different ceilings.
-//
-// The two ceilings differ so that a revival which passed the wrong row's limit,
-// or the policy default, is visible rather than hidden by the two agreeing.
+// seedDemotedTrial leaves the organization where the demotion sweeper leaves it.
+// The two key ceilings differ so a revival that passed the wrong one is visible.
 func seedDemotedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, tier string) time.Time {
 	t.Helper()
 
 	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
 	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
 
-	// All three of id, name and slug differ. The slug does so that a test can
-	// try it and see it rejected; the name does so that an assertion on a
-	// display name proves the name reached it rather than passing on a fixture
-	// where the id would have done just as well.
+	// id, name and slug all differ, so an assertion on one cannot pass on another.
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID + " Name", slug: orgID + "-slug", accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tier, endsAt: endsAt, demotedAt: &demotedAt})
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
@@ -239,10 +209,6 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "org_rearm", res.ID)
 
-	// Every key type the demotion disables comes back up, each with its own
-	// recorded ceiling rather than the other's or the policy default. Reviving
-	// chat alone is the bug this slice most plausibly ships: it leaves the
-	// organization on a running trial with its internal completions dead.
 	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
 	require.Equal(t, map[openrouter.KeyType]*int{
 		openrouter.KeyTypeChat:     conv.PtrEmpty(50),
@@ -251,9 +217,7 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm", openrouter.KeyTypeChat).Disabled)
 	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm", openrouter.KeyTypeInternal).Disabled)
 
-	// The organization comes back at the tier its trial grants, and off the
-	// book-a-demo gate. Demotion cleared both; the signup arming path only ever
-	// writes the first, so a re-arm that replayed it would leave the second.
+	// Demotion cleared both; the signup arming path only ever writes the first.
 	state := readOrgState(t, ctx, conn, "org_rearm")
 	require.Equal(t, "enterprise", state.GramAccountType)
 	require.True(t, state.Whitelisted, "a re-armed organization must be whitelisted again")
@@ -263,17 +227,12 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.False(t, after.ConvertedAt.Valid)
 	require.WithinDuration(t, time.Now().UTC().Add(14*24*time.Hour), after.EndsAt.Time, time.Minute)
 
-	// Both rows record when they were touched. The rejection tests assert that
-	// updated_at holds still; without this the pair is satisfied by a statement
-	// that never stamps it at all. The comparison stays inside the database
-	// clock, which the test host's can drift from.
+	// The rejection tests assert updated_at holds still; this is the other half.
 	require.True(t, after.UpdatedAt.Time.After(beforeTrial.UpdatedAt.Time),
 		"a re-arm must stamp the trial's updated_at: was %s, now %s", beforeTrial.UpdatedAt.Time, after.UpdatedAt.Time)
 	require.True(t, state.UpdatedAt.Time.After(beforeOrg.UpdatedAt.Time),
 		"restoring the organization must stamp its updated_at: was %s, now %s", beforeOrg.UpdatedAt.Time, state.UpdatedAt.Time)
 
-	// All three read surfaces agree, and the organization reads as running
-	// rather than expired.
 	require.NotNil(t, res.TrialEndsAt)
 	detail, err := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: "org_rearm"})
 	require.NoError(t, err)
@@ -282,16 +241,9 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.Equal(t, "enterprise", detail.AccountType)
 }
 
-// TestRearmTrial_MovesEndsAtIntoTheFuture is the test for the one place this
-// slice goes beyond "clear demoted_at".
-//
-// MarkTrialDemoted only ever demotes a trial whose ends_at has already passed,
-// so a re-arm that cleared the stamp and left the date alone would put the row
-// straight back into ListExpiredTrials and the next sweep would undo the whole
-// thing. Nor could an operator rescue it with extend, which requires
-// ends_at > now. The trial here ended 100 days ago, so a date computed from the
-// old ends_at rather than from now is still in the past and every assertion
-// below fails.
+// MarkTrialDemoted only demotes an already-past ends_at, so a re-arm that
+// cleared the stamp and left the date would be re-demoted on the next sweep.
+// The trial here ended 100 days ago, so a date computed from it is still past.
 func TestRearmTrial_MovesEndsAtIntoTheFuture(t *testing.T) {
 	t.Parallel()
 
@@ -312,26 +264,16 @@ func TestRearmTrial_MovesEndsAtIntoTheFuture(t *testing.T) {
 	require.WithinDuration(t, time.Now().UTC().Add(3*24*time.Hour), after.EndsAt.Time, time.Minute,
 		"the new end date is counted from now, not added to the old one")
 
-	// The load-bearing consequence, asserted against the sweeper's own query
-	// rather than restated as a date comparison.
 	expired, err := trialsRepo.New(conn).ListExpiredTrials(ctx)
 	require.NoError(t, err)
 	require.NotContains(t, expired, orgID, "a re-armed trial must not be due for demotion again")
 
-	// And the operator can extend it afterwards, which a trial left in the past
-	// could never be.
 	_, err = svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: orgID, Days: 5})
 	require.NoError(t, err, "a re-armed trial must be extendable")
 }
 
-// TestRearmTrial_RevivesKeysBeforeTheRestoreCommits pins D2's ordering, which
-// is deliberately not the demotion's mirror image.
-//
-// The fake reads through the pool, so it sees only committed state. While the
-// handler's transaction is open the organization must still read free and the
-// trial must still read demoted. An implementation that committed the restore
-// first, or that revived the keys after the commit, would show the restored
-// values here.
+// The fake reads through the pool, so while the handler's transaction is open
+// the organization must still read free and the trial must still read demoted.
 func TestRearmTrial_RevivesKeysBeforeTheRestoreCommits(t *testing.T) {
 	t.Parallel()
 
@@ -350,13 +292,7 @@ func TestRearmTrial_RevivesKeysBeforeTheRestoreCommits(t *testing.T) {
 	}
 }
 
-// TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted is the other
-// half of D2: what a partial failure actually leaves behind.
-//
-// The failure lands on the second key type, so the first is already back up
-// when the handler gives up. That is the safe direction. Nothing advertises a
-// trial that is not running, the organization is still free and still demoted,
-// and a retry is safe because reviving a live key is a no-op.
+// The failure lands on the second key type, so the first is already back up.
 func TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted(t *testing.T) {
 	t.Parallel()
 
@@ -376,8 +312,6 @@ func TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted(t *testing.T) 
 	require.NoError(t, err)
 
 	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_fail", Days: 14})
-	// An upstream refusal is a gateway error: the operator retries, and the
-	// detail belongs in the log rather than in their face.
 	requireOopsCode(t, err, oops.CodeGatewayError)
 
 	after := readTrial(t, ctx, conn, "org_rearm_fail")
@@ -392,23 +326,13 @@ func TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, auditsBefore, auditsAfter, "a failed re-arm must not claim one happened")
 
-	// The key that did come back up stays up through the rollback, because the
-	// revival never joined the handler's transaction.
 	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm_fail", openrouter.KeyTypeChat).Disabled,
 		"a revived key must survive the rollback, which is what makes a retry cheap")
 	require.True(t, readOpenRouterKey(t, ctx, conn, "org_rearm_fail", openrouter.KeyTypeInternal).Disabled)
 }
 
-// TestRearmTrial_OnlyADemotedTrialCanBeRearmed walks the whole state space of
-// the guard rather than a sample of it, the way the extend tests do.
-// converted_at and demoted_at are each null or not-null and ends_at is each
-// side of now, which is eight rows; only the two that are demoted and not
-// converted may move.
-//
-// The demoted-and-not-expired row cannot be reached by the application today,
-// since MarkTrialDemoted only demotes an expired trial. It is here because the
-// query deliberately does not test ends_at, and a row that stops being
-// unreachable must not silently change behaviour.
+// Walks the guard's whole eight-row state space. The demoted-and-not-expired
+// row is unreachable today, and is here because the query does not test ends_at.
 func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
 	t.Parallel()
 
@@ -429,9 +353,7 @@ func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
 		{name: "demoted and expired", orgID: "org_re_demoted_expired", demoted: true, expired: true, wantRearm: true},
 		{name: "demoted", orgID: "org_re_demoted", demoted: true, wantRearm: true},
 
-		// A signed customer must never be dragged back onto a trial, and a
-		// conversion can land after a demotion, so converted_at is not implied
-		// by demoted_at being null.
+		// A conversion can land after a demotion, so this is not implied.
 		{name: "converted after demotion", orgID: "org_re_both", converted: true, demoted: true},
 		{name: "converted after demotion and expired", orgID: "org_re_both_expired", converted: true, demoted: true, expired: true},
 
@@ -460,8 +382,6 @@ func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Safe alongside the other cases: each owns its own organization
-			// and the assertions read that row alone.
 			t.Parallel()
 
 			before := readTrial(t, ctx, conn, tc.orgID)
@@ -483,9 +403,7 @@ func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
 			require.Equal(t, before.ConvertedAt.Time, after.ConvertedAt.Time)
 			require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time, "a rejected re-arm must not touch updated_at")
 
-			// The rejection has to leave the organization alone too, or a
-			// converted customer would be whitelisted by a call that reported
-			// failure.
+			// A rejection must not whitelist a converted customer.
 			state := readOrgState(t, ctx, conn, tc.orgID)
 			require.Equal(t, "free", state.GramAccountType)
 			require.False(t, state.Whitelisted)
@@ -493,16 +411,8 @@ func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
 	}
 }
 
-// TestRearmTrial_ARejectedRearmRevivesNoKeys is the acceptance criterion the
-// state-space test above cannot reach: none of its organizations has a key row,
-// so nothing there notices which side of the guard the revival runs on.
-//
-// The revival deliberately happens before the database work commits (D2), which
-// means the guard has to be evaluated first. It is, because RearmTrial runs the
-// UPDATE and only calls reviveTrialKeys once a row has moved. Hoisting the
-// revival above that UPDATE breaks nothing else in the suite, and would switch a
-// converted customer's model provider keys back on before answering 409. The
-// keys are not transactional, so nothing would take them down again.
+// The state-space test above has no key rows. Hoisting the revival above the
+// UPDATE would switch a converted customer's keys on before answering 409.
 func TestRearmTrial_ARejectedRearmRevivesNoKeys(t *testing.T) {
 	t.Parallel()
 
@@ -512,11 +422,7 @@ func TestRearmTrial_ARejectedRearmRevivesNoKeys(t *testing.T) {
 	convertedAt := now.Add(-96 * time.Hour)
 	demotedAt := now.Add(-72 * time.Hour)
 
-	// Both organizations carry the full set of disabled keys the demotion
-	// leaves behind, which is what makes an early revival observable. For the
-	// running trial that is not a state the application reaches, and it is the
-	// point: the assertion has to be able to see a revival on every rejection,
-	// not only on the ones whose keys happen to be down.
+	// Including the running trial, which is not a state the application reaches.
 	seedRejectedRearm := func(orgID string, f trialFixture) {
 		t.Helper()
 
@@ -535,16 +441,12 @@ func TestRearmTrial_ARejectedRearmRevivesNoKeys(t *testing.T) {
 		orgID string
 		want  oops.Code
 	}{
-		// A signed customer. Reviving their keys here is the one that costs
-		// money on an account that is meant to be off the trial.
 		{name: "converted after demotion", orgID: "org_rearm_reject_converted", want: oops.CodeConflict},
 		{name: "running trial", orgID: "org_rearm_reject_running", want: oops.CodeConflict},
 		{name: "unknown organization", orgID: "org_rearm_reject_missing", want: oops.CodeNotFound},
 	}
 
-	// One case per iteration rather than per subtest, because the assertion is
-	// about the fake's whole history and a parallel subtest would read it while
-	// its siblings were still writing.
+	// Not subtests: a parallel sibling would still be writing the fake's history.
 	for _, tc := range cases {
 		_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: tc.orgID, Days: 14})
 		requireOopsCode(t, err, tc.want)
@@ -560,10 +462,7 @@ func TestRearmTrial_ARejectedRearmRevivesNoKeys(t *testing.T) {
 	}
 }
 
-// TestRearmTrial_RestoresTheTierTheTrialGrants pins that the account type comes
-// from the row rather than from a literal. Enterprise is the only tier the
-// application writes today, so a hardcoded 'enterprise' passes every other test
-// in this file.
+// A hardcoded 'enterprise' account type passes every other test in this file.
 func TestRearmTrial_RestoresTheTierTheTrialGrants(t *testing.T) {
 	t.Parallel()
 
@@ -579,18 +478,14 @@ func TestRearmTrial_RestoresTheTierTheTrialGrants(t *testing.T) {
 	require.True(t, state.Whitelisted)
 }
 
-// TestRearmTrial_UnknownAndMalformedOrganizationIDs and
-// TestRearmTrial_OrganizationWithNoTrialRow are the pair that keeps the two
-// causes of a zero-row update apart. An operator who pastes one wrong id must
-// be told the organization does not exist rather than sent to inspect a trial.
+// This and TestRearmTrial_OrganizationWithNoTrialRow keep the two causes of a
+// zero-row update apart: a wrong id reports a missing organization, not a trial.
 func TestRearmTrial_UnknownAndMalformedOrganizationIDs(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn, _ := newRearmService(t)
 
-	// A demoted trial that must survive every rejected call. Its slug is one of
-	// the ids tried, which pins that the lookup resolves ids only: matching a
-	// slug must not turn the answer into a conflict about this organization.
+	// Its slug is one of the ids tried below: the lookup must resolve ids only.
 	seedDemotedTrial(t, ctx, conn, "org_rearm_bystander", "enterprise")
 	before := readTrial(t, ctx, conn, "org_rearm_bystander")
 
@@ -615,8 +510,7 @@ func TestRearmTrial_OrganizationWithNoTrialRow(t *testing.T) {
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_no_trial", Days: 14})
 	requireOopsCode(t, err, oops.CodeConflict)
 
-	// Re-arm restarts a trial that exists; it must never be a way to grant one,
-	// which is the auth flow's job.
+	// Re-arm must never be a way to grant a trial; that is the auth flow's job.
 	_, err = trialsRepo.New(conn).GetTrial(ctx, "org_rearm_no_trial")
 	require.Error(t, err, "a rejected re-arm must not create a trial row")
 
@@ -625,11 +519,8 @@ func TestRearmTrial_OrganizationWithNoTrialRow(t *testing.T) {
 	require.False(t, state.Whitelisted)
 }
 
-// TestRearmTrial_OrganizationWithNoKeysSucceeds is the trap the demotion's own
-// shape would have walked into. DisableAPIKey no-ops on an organization that
-// has no key row of a type, but RefreshAPIKeyLimit errors on one, so an
-// unconditional loop over AllKeyTypes would fail every re-arm of an
-// organization that never ran a completion of that kind.
+// DisableAPIKey no-ops on a missing key row but RefreshAPIKeyLimit errors on
+// one, so the demotion's unconditional loop would fail this re-arm outright.
 func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	t.Parallel()
 
@@ -641,8 +532,6 @@ func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
 
-	// Only the chat key exists, so the internal one has to be skipped rather
-	// than refreshed.
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
@@ -657,14 +546,8 @@ func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	require.True(t, state.Whitelisted)
 }
 
-// TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds is the other half of
-// the missing-key case, and it is the half that distinguishes skipping an
-// absent key from stopping at one.
-//
-// The sibling test omits the internal key, which is the last of AllKeyTypes, so
-// an implementation that gave up on the first missing row would still pass it.
-// Here the missing row is the first one, so a re-arm that stopped there would
-// leave the organization's internal completions dead on a running trial.
+// The sibling test omits the last of AllKeyTypes, so an implementation that
+// stopped at the first missing row would still pass it. Here it is the first.
 func TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds(t *testing.T) {
 	t.Parallel()
 
@@ -686,9 +569,7 @@ func TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds(t *testing.T) {
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)
 }
 
-// TestRearmTrial_AlreadyEnabledKeyIsLeftAlone keeps the re-arm idempotent
-// against the upstream. A key that is already live needs no round trip, which
-// is what makes retrying a half-failed re-arm cheap.
+// A live key needs no round trip, which is what makes retrying a re-arm cheap.
 func TestRearmTrial_AlreadyEnabledKeyIsLeftAlone(t *testing.T) {
 	t.Parallel()
 
@@ -712,21 +593,9 @@ func TestRearmTrial_AlreadyEnabledKeyIsLeftAlone(t *testing.T) {
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)
 }
 
-// TestRearmTrial_ZeroCeilingKeyIsRecappedAfterTheRestoreCommits pins the one
-// case where reviving before the commit costs something.
-//
-// A key minted before the ceiling column existed records no ceiling, so its
-// revival has none to pass and RefreshAPIKeyLimit has to resolve one. Resolved
-// while the restore is still uncommitted, it reads a free organization with no
-// running trial and answers with the free tier's allowance, not the trial's.
-// Nothing corrects that on a schedule: the only automatic refresh in the
-// codebase runs off a Polar subscription webhook that a re-arm does not send.
-// So the handler asks again once the restore has committed, and it is that
-// second answer the organization keeps for the run.
-//
-// The assertions are on the state the fake saw at each call rather than on the
-// call count alone, because the count alone would pass an implementation that
-// asked twice before committing, which resolves the same wrong allowance twice.
+// A key minted before the ceiling column existed records none, so its revival
+// resolves one from the pool: pre-commit that reads a free organization and
+// answers the free-tier allowance. Nothing else corrects it on a schedule.
 func TestRearmTrial_ZeroCeilingKeyIsRecappedAfterTheRestoreCommits(t *testing.T) {
 	t.Parallel()
 
@@ -752,9 +621,7 @@ func TestRearmTrial_ZeroCeilingKeyIsRecappedAfterTheRestoreCommits(t *testing.T)
 		internal = append(internal, r)
 	}
 
-	// The key that already carried a ceiling is asked once and passed it. A
-	// second ask for that row would be a wasted upstream call, and worse, would
-	// overwrite a trial ceiling that had been raised by hand.
+	// A second ask for this row would overwrite a ceiling raised by hand.
 	require.Len(t, internal, 1, "a key with a recorded ceiling must not be asked twice")
 	require.Equal(t, conv.PtrEmpty(37), internal[0].limit)
 
@@ -770,10 +637,7 @@ func TestRearmTrial_ZeroCeilingKeyIsRecappedAfterTheRestoreCommits(t *testing.T)
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).Disabled)
 }
 
-// TestRearmTrial_RecapFailureStillReportsSuccess covers the half of the recap
-// that must not propagate. By the time it runs the re-arm is committed, so an
-// error answer would tell the operator a running trial is not armed and invite
-// a retry that has nothing left to do.
+// The re-arm is already committed, so an error here would misreport it.
 func TestRearmTrial_RecapFailureStillReportsSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -786,8 +650,7 @@ func TestRearmTrial_RecapFailureStillReportsSuccess(t *testing.T) {
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 0, disabled: true})
 
-	// Failing every call would also fail the revival and never reach the recap,
-	// so the fake is armed only once the revival is behind us.
+	// Failing every call would abort at the revival and never reach the recap.
 	provisioner.failAfter = 1
 	provisioner.failWith = errors.New("openrouter is down")
 
@@ -795,10 +658,7 @@ func TestRearmTrial_RecapFailureStillReportsSuccess(t *testing.T) {
 	require.NoError(t, err, "a failed recap must not report the committed re-arm as failed")
 	require.Equal(t, orgID, res.ID)
 
-	// Without this the test would pass on an implementation that never recaps
-	// at all: a re-arm that skips the second ask also returns no error and also
-	// leaves the rows below correct. The failure has to have been reached and
-	// swallowed, not avoided.
+	// Without this the test passes on an implementation that never recaps.
 	require.Len(t, provisioner.revivals, 2, "the recap must have been attempted")
 	failed := provisioner.revivals[1]
 	require.Nil(t, failed.limit)
@@ -816,9 +676,6 @@ func TestRearmTrial_WritesAnAuditEntry(t *testing.T) {
 	ctx, svc, conn, _ := newRearmService(t)
 	seedDemotedTrial(t, ctx, conn, "org_rearm_audit", "enterprise")
 
-	// An entry that cannot name the operator is most of the reason for keeping
-	// it, so the call carries a session the way the admin transport delivers
-	// one.
 	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{
 		SessionID:   "session-rearm-audit",
 		Email:       "operator@example.test",
@@ -841,17 +698,13 @@ func TestRearmTrial_WritesAnAuditEntry(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "organization", entry.SubjectType)
 
-	// The fixture gives the organization an id, a name and a slug that all
-	// differ, so these two pin that the entry carries the organization's own
-	// name and slug rather than whichever string was closest to hand.
+	// id, name and slug all differ in the fixture, so these pin the right one.
 	require.Equal(t, "org_rearm_audit Name", entry.SubjectDisplay)
 	require.Equal(t, "org_rearm_audit-slug", entry.SubjectSlug)
 	require.NotNil(t, entry.ActorDisplayName, "the entry must name who re-armed the trial")
 	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
 
-	// The restored tier is on the entry because the demotion's entry is the
-	// only record of the tier it overwrote, and a reader comparing the two
-	// learns whether the organization got back what it had.
+	// Comparing this with the demotion's entry shows whether the tier came back.
 	var metadata struct {
 		AccountType string    `json:"account_type"`
 		TrialEndsAt time.Time `json:"trial_ends_at"`
@@ -859,14 +712,10 @@ func TestRearmTrial_WritesAnAuditEntry(t *testing.T) {
 	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
 	require.Equal(t, "enterprise", metadata.AccountType)
 
-	// The date on the entry is the one the database wrote, not one the handler
-	// recomputed from a second clock afterwards.
+	// The date the database wrote, not one recomputed from a second clock.
 	require.WithinDuration(t, readTrial(t, ctx, conn, "org_rearm_audit").EndsAt.Time, metadata.TrialEndsAt, 0)
 
-	// The entry leaves on the trial lifecycle event, the one the arming and
-	// demotion entries already use. A consumer subscribed to that event is
-	// exactly who wants to hear that a demoted trial came back, and sending it
-	// under any other event type would deliver it to nobody.
+	// The trial lifecycle event; any other would deliver this to nobody.
 	_, err = audittestrepo.New(conn).GetLatestOutboxPayloadByOrg(ctx, audittestrepo.GetLatestOutboxPayloadByOrgParams{
 		OrganizationID: "org_rearm_audit",
 		EventType:      string(events.OrganizationEnterpriseTrialV1.EventType()),
@@ -895,26 +744,18 @@ func TestRearmTrial_AuditEntryNamesTheTeamAndNotTheOperator(t *testing.T) {
 	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
 	require.NoError(t, err)
 
-	// The customer reads this feed. A Speakeasy action carries the collective
-	// label there, the same one auditapi applies on read to a staff member it
-	// recognises. The read-side mask cannot reach this entry, because it
-	// matches an actor id against a Gram user and an admin session has an OIDC
-	// subject instead, so the write side is what has to get it right.
+	// The customer reads this feed, so a Speakeasy action carries the collective
+	// label. The read-side mask cannot reach this entry: it matches an actor id
+	// against a Gram user, and an admin session has an OIDC subject instead.
 	require.NotNil(t, entry.ActorDisplayName)
 	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
 
-	// Masking the display name must not cost the accountability record. The
-	// authoritative actor on the row is still the operator's OIDC subject,
-	// which is what ties the entry to the person through the identity provider
-	// and the server log. Without this, an entry that named nobody at all would
-	// satisfy the assertion above.
+	// Without this, an entry naming nobody at all would satisfy the one above.
 	require.Equal(t, "oidc-subject-rearm-actor", entry.ActorID,
 		"the entry must still record which operator acted, in the field the customer's feed does not render")
 	require.Equal(t, "user", entry.ActorType)
 
-	// And the operator's email appears nowhere else in the entry either. The
-	// subject is opaque, so it is not the email in another shape, and the email
-	// itself stays in the server log where only Speakeasy reads it.
+	// The subject is opaque, so it is not the email in another shape.
 	for name, field := range map[string]string{
 		"actor display name": conv.PtrValOr(entry.ActorDisplayName, ""),
 		"actor id":           entry.ActorID,
@@ -938,8 +779,7 @@ func TestRearmTrial_DayCountBounds(t *testing.T) {
 		days    int
 		wantErr bool
 	}{
-		// A zero or negative count would re-arm a trial that is already over,
-		// which is a demotion dressed up as a reinstatement.
+		// A zero or negative count would re-arm a trial that is already over.
 		{name: "large negative", days: -365, wantErr: true},
 		{name: "minus one", days: -1, wantErr: true},
 		{name: "zero", days: 0, wantErr: true},
@@ -950,12 +790,8 @@ func TestRearmTrial_DayCountBounds(t *testing.T) {
 		{name: "one past the maximum", days: constants.MaxTrialRearmDays + 1, wantErr: true},
 		{name: "far past the maximum", days: 100000, wantErr: true},
 
-		// These pin that the bounds check runs on the wide payload.Days and
-		// that the int32 narrowing stays below it. The second is the one that
-		// matters: 1<<32 + 1 narrows to exactly 1, a value inside the bounds,
-		// so a handler that narrowed first would accept it and re-arm for a
-		// day. Only a non-HTTP caller can reach the service with a count this
-		// large, which is the caller the handler's own check exists for.
+		// 1<<32 + 1 narrows to exactly 1, so a handler that narrowed before
+		// checking would accept it and re-arm for a day.
 		{name: "int32 overflow to a negative", days: math.MaxInt32 + 1, wantErr: true},
 		{name: "int32 overflow to a valid day count", days: math.MaxUint32 + 2, wantErr: true},
 	}
@@ -984,11 +820,8 @@ func TestRearmTrial_DayCountBounds(t *testing.T) {
 	}
 }
 
-// TestRearmTrialRequestBody_DesignBoundsAreEnforced pins the other copy of the
-// bounds. Every other test here calls svc.RearmTrial directly, which skips the
-// generated request decoder, so for the only caller production has none of them
-// touch the validation that runs first. Deleting Minimum, Maximum and
-// MinLength(1) from the design would leave the rest of this file green.
+// The other copy of the bounds. Every other test calls svc.RearmTrial directly,
+// so deleting Minimum, Maximum or MinLength(1) leaves all of them green.
 func TestRearmTrialRequestBody_DesignBoundsAreEnforced(t *testing.T) {
 	t.Parallel()
 
@@ -1028,11 +861,8 @@ func TestRearmTrialRequestBody_DesignBoundsAreEnforced(t *testing.T) {
 	}
 }
 
-// TestRearmTrial_WithoutOpenRouterConfiguration answers below 500 on purpose.
-// server/design/shared/errors.go maps gateway_error and unexpected alike to a
-// 5xx, and the admin app trusts a response body only below 500, so an operator
-// hitting an unconfigured deployment would otherwise see a bare status line
-// instead of the setting they have to fix.
+// Below 500 on purpose: the admin app trusts a response body only below 500,
+// and this one names the deployment setting the operator has to fix.
 func TestRearmTrial_WithoutOpenRouterConfiguration(t *testing.T) {
 	t.Parallel()
 
@@ -1074,10 +904,8 @@ func TestRearmTrial_TouchesOnlyTheTargetRow(t *testing.T) {
 	require.True(t, readOpenRouterKey(t, ctx, conn, "org_rearm_neighbour", openrouter.KeyTypeChat).Disabled)
 }
 
-// TestRearmTrial_IsIdempotentAcrossARetry covers the shape a half-failed
-// re-arm actually leaves for the operator: they press the button again. The
-// second call must be rejected as a conflict rather than silently granting a
-// second fresh window, which would let a re-arm be used as an unbounded extend.
+// A half-failed re-arm ends with the operator pressing the button again. The
+// second call must be a conflict, or re-arm becomes an unbounded extend.
 func TestRearmTrial_IsIdempotentAcrossARetry(t *testing.T) {
 	t.Parallel()
 
@@ -1102,9 +930,7 @@ func TestRearmTrial_RestoresADisabledOrganizationsTrialWithoutEnablingIt(t *test
 
 	ctx, svc, conn, _ := newRearmService(t)
 
-	// Disabled and trial state are independent axes, exactly as they are for
-	// extend: an operator investigating an organization must not have to choose
-	// between keeping it disabled and keeping its trial alive.
+	// Disabled and trial state are independent axes, as they are for extend.
 	orgID := "org_rearm_disabled"
 	disabledAt := time.Now().UTC().Add(-time.Hour)
 	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
@@ -1121,10 +947,8 @@ func TestRearmTrial_RestoresADisabledOrganizationsTrialWithoutEnablingIt(t *test
 	require.True(t, state.DisabledAt.Valid, "re-arming a trial must not enable a disabled organization")
 }
 
-// TestRearmTrial_SurvivesTheSweeperReachingTheOrganizationFirst is the
-// interleaving the re-arm shares a row lock with. It is written as a sequence
-// rather than as concurrency because the lock makes the two serialize anyway;
-// what matters is that neither order leaves the organization half restored.
+// A sequence, not concurrency: neither order may leave the organization half
+// restored.
 func TestRearmTrial_SurvivesTheSweeperReachingTheOrganizationFirst(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -1,0 +1,1147 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+// keyRevival is one call the handler made to bring a key back up, together with
+// what the database looked like from outside the handler's transaction at the
+// moment it made it.
+//
+// The two "seen" fields are the whole point of the fake. D2 puts the revival
+// before the restore commits, and the only way to observe an ordering from a
+// test is to look at the world at the instant the middle step runs. These reads
+// go through the pool rather than the handler's transaction, so they see
+// committed state alone: an implementation that committed the restore first
+// would show enterprise and a cleared demotion here.
+type keyRevival struct {
+	orgID   string
+	keyType openrouter.KeyType
+	limit   *int
+
+	accountTypeSeen string
+	demotedSeen     bool
+}
+
+// rearmProvisioner stands in for OpenRouter. It records each revival, mirrors
+// the real client's local effect by clearing the row's disabled flag, and can
+// be made to fail on one key type so a partial failure is testable.
+type rearmProvisioner struct {
+	conn *pgxpool.Pool
+
+	mu       sync.Mutex
+	revivals []keyRevival
+
+	failOn openrouter.KeyType
+	// failAfter suppresses the failure for the first n calls, which is how a
+	// test reaches the post-commit recap: failing the revival instead aborts
+	// the handler long before it.
+	failAfter int
+	failWith  error
+}
+
+var _ TrialKeyReviver = (*rearmProvisioner)(nil)
+
+func (p *rearmProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error) {
+	accountType, demoted := "", false
+	if p.conn != nil {
+		accountType, demoted = readRearmState(ctx, p.conn, orgID)
+	}
+
+	p.mu.Lock()
+	p.revivals = append(p.revivals, keyRevival{
+		orgID:           orgID,
+		keyType:         keyType,
+		limit:           limit,
+		accountTypeSeen: accountType,
+		demotedSeen:     demoted,
+	})
+	calls := len(p.revivals)
+	p.mu.Unlock()
+
+	if p.failWith != nil && calls > p.failAfter && (p.failOn == "" || p.failOn == keyType) {
+		return 0, p.failWith
+	}
+
+	// What the real RefreshAPIKeyLimit does locally: the reinstatement is the
+	// point, so a fake that skipped it would let a test claim the keys came
+	// back up when nothing wrote that down.
+	if p.conn != nil {
+		if _, err := orrepo.New(p.conn).UpdateOpenRouterKey(ctx, orrepo.UpdateOpenRouterKeyParams{
+			OrganizationID: orgID,
+			KeyType:        string(keyType),
+			MonthlyCredits: int64(conv.PtrValOr(limit, 0)),
+			KeyHash:        "hash-" + orgID + "-" + string(keyType),
+			Reinstate:      true,
+		}); err != nil {
+			return 0, fmt.Errorf("reinstate %s key: %w", keyType, err)
+		}
+	}
+
+	return conv.PtrValOr(limit, 0), nil
+}
+
+// revivedLimits is which key types the handler asked for and the ceiling it
+// passed for each. It is a map rather than the call sequence on purpose:
+// reviving internal before chat is behaviourally identical, so an assertion on
+// the order would fail a change that broke nothing. The pointer is kept because
+// a nil ceiling is not the same request as a zero one: nil asks
+// RefreshAPIKeyLimit for the policy default.
+func (p *rearmProvisioner) revivedLimits() map[openrouter.KeyType]*int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	limits := make(map[openrouter.KeyType]*int, len(p.revivals))
+	for _, r := range p.revivals {
+		limits[r.keyType] = r.limit
+	}
+
+	return limits
+}
+
+// readRearmState is the observation the fake makes mid-flight, so it cannot use
+// the require-based helpers the tests use: a failed read here would abort the
+// handler's own goroutine rather than fail an assertion. It answers with zero
+// values instead and lets the caller's assertions report the mismatch.
+func readRearmState(ctx context.Context, conn *pgxpool.Pool, orgID string) (accountType string, demoted bool) {
+	org, err := testrepo.New(conn).GetOrganizationMetadataStateFixture(ctx, orgID)
+	if err != nil {
+		return "", false
+	}
+
+	trial, err := trialsRepo.New(conn).GetTrial(ctx, orgID)
+	if err != nil {
+		return org.GramAccountType, false
+	}
+
+	return org.GramAccountType, trial.DemotedAt.Valid
+}
+
+func newTestAdminServiceWithOpenRouter(t *testing.T, provisioner TrialKeyReviver) (context.Context, *Service, *pgxpool.Pool) {
+	t.Helper()
+
+	ctx, svc, conn := newTestAdminService(t)
+	svc.openRouter = provisioner
+
+	return ctx, svc, conn
+}
+
+// newRearmService is the common case: a fake wired to the same database the
+// handler writes to, so its ordering observations are real.
+func newRearmService(t *testing.T) (context.Context, *Service, *pgxpool.Pool, *rearmProvisioner) {
+	t.Helper()
+
+	ctx, svc, conn := newTestAdminService(t)
+	provisioner := &rearmProvisioner{conn: conn, mu: sync.Mutex{}, revivals: nil, failOn: "", failAfter: 0, failWith: nil}
+	svc.openRouter = provisioner
+
+	return ctx, svc, conn, provisioner
+}
+
+type keyFixture struct {
+	keyType        openrouter.KeyType
+	monthlyCredits int64
+	disabled       bool
+}
+
+func seedOpenRouterKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, f keyFixture) {
+	t.Helper()
+
+	keys := orrepo.New(conn)
+	_, err := keys.CreateOpenRouterAPIKey(ctx, orrepo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(f.keyType),
+		Key:            conv.ToPGText("sk-test-" + orgID + "-" + string(f.keyType)),
+		KeyEncrypted:   conv.ToPGText(""),
+		KeyHash:        "hash-" + orgID + "-" + string(f.keyType),
+		MonthlyCredits: f.monthlyCredits,
+	})
+	require.NoError(t, err)
+
+	if f.disabled {
+		require.NoError(t, keys.DisableOpenRouterAPIKey(ctx, orrepo.DisableOpenRouterAPIKeyParams{
+			OrganizationID: orgID,
+			KeyType:        string(f.keyType),
+		}))
+	}
+}
+
+func readOpenRouterKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, keyType openrouter.KeyType) orrepo.OpenrouterApiKey {
+	t.Helper()
+
+	row, err := orrepo.New(conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+	})
+	require.NoError(t, err)
+
+	return row
+}
+
+// seedDemotedTrial leaves the organization exactly where the demotion sweeper
+// leaves it: free tier, whitelist cleared, trial stamped demoted with an
+// ends_at in the past, both platform keys disabled with different ceilings.
+//
+// The two ceilings differ so that a revival which passed the wrong row's limit,
+// or the policy default, is visible rather than hidden by the two agreeing.
+func seedDemotedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, tier string) time.Time {
+	t.Helper()
+
+	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
+
+	// All three of id, name and slug differ. The slug does so that a test can
+	// try it and see it rejected; the name does so that an assertion on a
+	// display name proves the name reached it rather than passing on a fixture
+	// where the id would have done just as well.
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID + " Name", slug: orgID + "-slug", accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tier, endsAt: endsAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
+
+	return endsAt
+}
+
+func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+	seedDemotedTrial(t, ctx, conn, "org_rearm", "enterprise")
+	beforeTrial := readTrial(t, ctx, conn, "org_rearm")
+	beforeOrg := readOrgState(t, ctx, conn, "org_rearm")
+
+	res, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm", Days: 14})
+	require.NoError(t, err)
+	require.Equal(t, "org_rearm", res.ID)
+
+	// Every key type the demotion disables comes back up, each with its own
+	// recorded ceiling rather than the other's or the policy default. Reviving
+	// chat alone is the bug this slice most plausibly ships: it leaves the
+	// organization on a running trial with its internal completions dead.
+	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
+	require.Equal(t, map[openrouter.KeyType]*int{
+		openrouter.KeyTypeChat:     conv.PtrEmpty(50),
+		openrouter.KeyTypeInternal: conv.PtrEmpty(37),
+	}, provisioner.revivedLimits(), "every key type the demotion disables must come back up on its own ceiling")
+	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm", openrouter.KeyTypeChat).Disabled)
+	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm", openrouter.KeyTypeInternal).Disabled)
+
+	// The organization comes back at the tier its trial grants, and off the
+	// book-a-demo gate. Demotion cleared both; the signup arming path only ever
+	// writes the first, so a re-arm that replayed it would leave the second.
+	state := readOrgState(t, ctx, conn, "org_rearm")
+	require.Equal(t, "enterprise", state.GramAccountType)
+	require.True(t, state.Whitelisted, "a re-armed organization must be whitelisted again")
+
+	after := readTrial(t, ctx, conn, "org_rearm")
+	require.False(t, after.DemotedAt.Valid, "re-arming must clear demoted_at")
+	require.False(t, after.ConvertedAt.Valid)
+	require.WithinDuration(t, time.Now().UTC().Add(14*24*time.Hour), after.EndsAt.Time, time.Minute)
+
+	// Both rows record when they were touched. The rejection tests assert that
+	// updated_at holds still; without this the pair is satisfied by a statement
+	// that never stamps it at all. The comparison stays inside the database
+	// clock, which the test host's can drift from.
+	require.True(t, after.UpdatedAt.Time.After(beforeTrial.UpdatedAt.Time),
+		"a re-arm must stamp the trial's updated_at: was %s, now %s", beforeTrial.UpdatedAt.Time, after.UpdatedAt.Time)
+	require.True(t, state.UpdatedAt.Time.After(beforeOrg.UpdatedAt.Time),
+		"restoring the organization must stamp its updated_at: was %s, now %s", beforeOrg.UpdatedAt.Time, state.UpdatedAt.Time)
+
+	// All three read surfaces agree, and the organization reads as running
+	// rather than expired.
+	require.NotNil(t, res.TrialEndsAt)
+	detail, err := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: "org_rearm"})
+	require.NoError(t, err)
+	require.Equal(t, "running", *detail.TrialState)
+	require.Equal(t, *res.TrialEndsAt, *detail.TrialEndsAt)
+	require.Equal(t, "enterprise", detail.AccountType)
+}
+
+// TestRearmTrial_MovesEndsAtIntoTheFuture is the test for the one place this
+// slice goes beyond "clear demoted_at".
+//
+// MarkTrialDemoted only ever demotes a trial whose ends_at has already passed,
+// so a re-arm that cleared the stamp and left the date alone would put the row
+// straight back into ListExpiredTrials and the next sweep would undo the whole
+// thing. Nor could an operator rescue it with extend, which requires
+// ends_at > now. The trial here ended 100 days ago, so a date computed from the
+// old ends_at rather than from now is still in the past and every assertion
+// below fails.
+func TestRearmTrial_MovesEndsAtIntoTheFuture(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+
+	orgID := "org_rearm_stale"
+	longExpired := time.Now().UTC().Add(-100 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-99 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: longExpired, demotedAt: &demotedAt})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 3})
+	require.NoError(t, err)
+
+	after := readTrial(t, ctx, conn, orgID)
+	require.True(t, after.EndsAt.Time.After(time.Now().UTC()),
+		"a re-armed trial must end in the future or the next sweep demotes it again: ends %s", after.EndsAt.Time)
+	require.WithinDuration(t, time.Now().UTC().Add(3*24*time.Hour), after.EndsAt.Time, time.Minute,
+		"the new end date is counted from now, not added to the old one")
+
+	// The load-bearing consequence, asserted against the sweeper's own query
+	// rather than restated as a date comparison.
+	expired, err := trialsRepo.New(conn).ListExpiredTrials(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, expired, orgID, "a re-armed trial must not be due for demotion again")
+
+	// And the operator can extend it afterwards, which a trial left in the past
+	// could never be.
+	_, err = svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: orgID, Days: 5})
+	require.NoError(t, err, "a re-armed trial must be extendable")
+}
+
+// TestRearmTrial_RevivesKeysBeforeTheRestoreCommits pins D2's ordering, which
+// is deliberately not the demotion's mirror image.
+//
+// The fake reads through the pool, so it sees only committed state. While the
+// handler's transaction is open the organization must still read free and the
+// trial must still read demoted. An implementation that committed the restore
+// first, or that revived the keys after the commit, would show the restored
+// values here.
+func TestRearmTrial_RevivesKeysBeforeTheRestoreCommits(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+	seedDemotedTrial(t, ctx, conn, "org_rearm_order", "enterprise")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_order", Days: 14})
+	require.NoError(t, err)
+
+	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
+	for _, revival := range provisioner.revivals {
+		require.Equal(t, "free", revival.accountTypeSeen,
+			"the %s key must come back up before the restore commits, or a failure leaves a running trial with dead keys", revival.keyType)
+		require.True(t, revival.demotedSeen,
+			"the %s key must come back up while the trial still reads demoted", revival.keyType)
+	}
+}
+
+// TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted is the other
+// half of D2: what a partial failure actually leaves behind.
+//
+// The failure lands on the second key type, so the first is already back up
+// when the handler gives up. That is the safe direction. Nothing advertises a
+// trial that is not running, the organization is still free and still demoted,
+// and a retry is safe because reviving a live key is a no-op.
+func TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	provisioner := &rearmProvisioner{
+		conn:      conn,
+		mu:        sync.Mutex{},
+		revivals:  nil,
+		failOn:    openrouter.KeyTypeInternal,
+		failAfter: 0,
+		failWith:  errors.New("openrouter is down"),
+	}
+	svc.openRouter = provisioner
+
+	seededEndsAt := seedDemotedTrial(t, ctx, conn, "org_rearm_fail", "enterprise")
+	auditsBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_fail", Days: 14})
+	// An upstream refusal is a gateway error: the operator retries, and the
+	// detail belongs in the log rather than in their face.
+	requireOopsCode(t, err, oops.CodeGatewayError)
+
+	after := readTrial(t, ctx, conn, "org_rearm_fail")
+	require.True(t, after.DemotedAt.Valid, "a failed re-arm must leave the trial demoted")
+	require.WithinDuration(t, seededEndsAt, after.EndsAt.Time, time.Second, "a failed re-arm must not move ends_at")
+
+	state := readOrgState(t, ctx, conn, "org_rearm_fail")
+	require.Equal(t, "free", state.GramAccountType, "a failed re-arm must not restore the account type")
+	require.False(t, state.Whitelisted)
+
+	auditsAfter, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	require.Equal(t, auditsBefore, auditsAfter, "a failed re-arm must not claim one happened")
+
+	// The key that did come back up stays up through the rollback, because the
+	// revival never joined the handler's transaction.
+	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm_fail", openrouter.KeyTypeChat).Disabled,
+		"a revived key must survive the rollback, which is what makes a retry cheap")
+	require.True(t, readOpenRouterKey(t, ctx, conn, "org_rearm_fail", openrouter.KeyTypeInternal).Disabled)
+}
+
+// TestRearmTrial_OnlyADemotedTrialCanBeRearmed walks the whole state space of
+// the guard rather than a sample of it, the way the extend tests do.
+// converted_at and demoted_at are each null or not-null and ends_at is each
+// side of now, which is eight rows; only the two that are demoted and not
+// converted may move.
+//
+// The demoted-and-not-expired row cannot be reached by the application today,
+// since MarkTrialDemoted only demotes an expired trial. It is here because the
+// query deliberately does not test ends_at, and a row that stops being
+// unreachable must not silently change behaviour.
+func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+
+	now := time.Now().UTC()
+	convertedAt := now.Add(-96 * time.Hour)
+	demotedAt := now.Add(-72 * time.Hour)
+
+	cases := []struct {
+		name      string
+		orgID     string
+		expired   bool
+		converted bool
+		demoted   bool
+		wantRearm bool
+	}{
+		{name: "demoted and expired", orgID: "org_re_demoted_expired", demoted: true, expired: true, wantRearm: true},
+		{name: "demoted", orgID: "org_re_demoted", demoted: true, wantRearm: true},
+
+		// A signed customer must never be dragged back onto a trial, and a
+		// conversion can land after a demotion, so converted_at is not implied
+		// by demoted_at being null.
+		{name: "converted after demotion", orgID: "org_re_both", converted: true, demoted: true},
+		{name: "converted after demotion and expired", orgID: "org_re_both_expired", converted: true, demoted: true, expired: true},
+
+		{name: "running", orgID: "org_re_running"},
+		{name: "expired not yet demoted", orgID: "org_re_expired", expired: true},
+		{name: "converted", orgID: "org_re_converted", converted: true},
+		{name: "converted and expired", orgID: "org_re_converted_expired", converted: true, expired: true},
+	}
+
+	for _, tc := range cases {
+		endsAt := now.Add(10 * 24 * time.Hour)
+		if tc.expired {
+			endsAt = now.Add(-10 * 24 * time.Hour)
+		}
+		f := trialFixture{orgID: tc.orgID, endsAt: endsAt}
+		if tc.converted {
+			f.convertedAt = &convertedAt
+		}
+		if tc.demoted {
+			f.demotedAt = &demotedAt
+		}
+
+		seedOrg(t, ctx, conn, orgFixture{id: tc.orgID, name: tc.orgID, slug: tc.orgID, accountType: "free", whitelisted: false})
+		seedTrial(t, ctx, conn, f)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Safe alongside the other cases: each owns its own organization
+			// and the assertions read that row alone.
+			t.Parallel()
+
+			before := readTrial(t, ctx, conn, tc.orgID)
+
+			_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: tc.orgID, Days: 14})
+
+			after := readTrial(t, ctx, conn, tc.orgID)
+			if tc.wantRearm {
+				require.NoError(t, err)
+				require.False(t, after.DemotedAt.Valid)
+				require.True(t, after.EndsAt.Time.After(now))
+				return
+			}
+
+			requireOopsCode(t, err, oops.CodeConflict)
+			require.Equal(t, before.EndsAt.Time, after.EndsAt.Time,
+				"a trial that is not demoted must not be re-armed: ends_at was %s, now %s", before.EndsAt.Time, after.EndsAt.Time)
+			require.Equal(t, before.DemotedAt.Time, after.DemotedAt.Time)
+			require.Equal(t, before.ConvertedAt.Time, after.ConvertedAt.Time)
+			require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time, "a rejected re-arm must not touch updated_at")
+
+			// The rejection has to leave the organization alone too, or a
+			// converted customer would be whitelisted by a call that reported
+			// failure.
+			state := readOrgState(t, ctx, conn, tc.orgID)
+			require.Equal(t, "free", state.GramAccountType)
+			require.False(t, state.Whitelisted)
+		})
+	}
+}
+
+// TestRearmTrial_ARejectedRearmRevivesNoKeys is the acceptance criterion the
+// state-space test above cannot reach: none of its organizations has a key row,
+// so nothing there notices which side of the guard the revival runs on.
+//
+// The revival deliberately happens before the database work commits (D2), which
+// means the guard has to be evaluated first. It is, because RearmTrial runs the
+// UPDATE and only calls reviveTrialKeys once a row has moved. Hoisting the
+// revival above that UPDATE breaks nothing else in the suite, and would switch a
+// converted customer's model provider keys back on before answering 409. The
+// keys are not transactional, so nothing would take them down again.
+func TestRearmTrial_ARejectedRearmRevivesNoKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+
+	now := time.Now().UTC()
+	convertedAt := now.Add(-96 * time.Hour)
+	demotedAt := now.Add(-72 * time.Hour)
+
+	// Both organizations carry the full set of disabled keys the demotion
+	// leaves behind, which is what makes an early revival observable. For the
+	// running trial that is not a state the application reaches, and it is the
+	// point: the assertion has to be able to see a revival on every rejection,
+	// not only on the ones whose keys happen to be down.
+	seedRejectedRearm := func(orgID string, f trialFixture) {
+		t.Helper()
+
+		f.orgID = orgID
+		seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID + " Name", slug: orgID + "-slug", accountType: "free", whitelisted: false})
+		seedTrial(t, ctx, conn, f)
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
+	}
+
+	seedRejectedRearm("org_rearm_reject_converted", trialFixture{endsAt: now.Add(-10 * 24 * time.Hour), convertedAt: &convertedAt, demotedAt: &demotedAt})
+	seedRejectedRearm("org_rearm_reject_running", trialFixture{endsAt: now.Add(10 * 24 * time.Hour)})
+
+	cases := []struct {
+		name  string
+		orgID string
+		want  oops.Code
+	}{
+		// A signed customer. Reviving their keys here is the one that costs
+		// money on an account that is meant to be off the trial.
+		{name: "converted after demotion", orgID: "org_rearm_reject_converted", want: oops.CodeConflict},
+		{name: "running trial", orgID: "org_rearm_reject_running", want: oops.CodeConflict},
+		{name: "unknown organization", orgID: "org_rearm_reject_missing", want: oops.CodeNotFound},
+	}
+
+	// One case per iteration rather than per subtest, because the assertion is
+	// about the fake's whole history and a parallel subtest would read it while
+	// its siblings were still writing.
+	for _, tc := range cases {
+		_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: tc.orgID, Days: 14})
+		requireOopsCode(t, err, tc.want)
+		require.Empty(t, provisioner.revivedLimits(),
+			"re-arming %s was rejected, so it must not have touched any model provider key", tc.name)
+	}
+
+	for _, orgID := range []string{"org_rearm_reject_converted", "org_rearm_reject_running"} {
+		for _, keyType := range openrouter.AllKeyTypes {
+			require.True(t, readOpenRouterKey(t, ctx, conn, orgID, keyType).Disabled,
+				"%s must still have its %s key switched off after a rejected re-arm", orgID, keyType)
+		}
+	}
+}
+
+// TestRearmTrial_RestoresTheTierTheTrialGrants pins that the account type comes
+// from the row rather than from a literal. Enterprise is the only tier the
+// application writes today, so a hardcoded 'enterprise' passes every other test
+// in this file.
+func TestRearmTrial_RestoresTheTierTheTrialGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	seedDemotedTrial(t, ctx, conn, "org_rearm_tier", "pro")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_tier", Days: 14})
+	require.NoError(t, err)
+
+	state := readOrgState(t, ctx, conn, "org_rearm_tier")
+	require.Equal(t, "pro", state.GramAccountType,
+		"the restored account type must be the trial's tier, not a hardcoded enterprise")
+	require.True(t, state.Whitelisted)
+}
+
+// TestRearmTrial_UnknownAndMalformedOrganizationIDs and
+// TestRearmTrial_OrganizationWithNoTrialRow are the pair that keeps the two
+// causes of a zero-row update apart. An operator who pastes one wrong id must
+// be told the organization does not exist rather than sent to inspect a trial.
+func TestRearmTrial_UnknownAndMalformedOrganizationIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+
+	// A demoted trial that must survive every rejected call. Its slug is one of
+	// the ids tried, which pins that the lookup resolves ids only: matching a
+	// slug must not turn the answer into a conflict about this organization.
+	seedDemotedTrial(t, ctx, conn, "org_rearm_bystander", "enterprise")
+	before := readTrial(t, ctx, conn, "org_rearm_bystander")
+
+	for _, id := range []string{"org_rearm_missing", "", "org_rearm_bystander-slug", "not a valid id"} {
+		_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: id, Days: 14})
+		requireOopsCode(t, err, oops.CodeNotFound)
+	}
+
+	after := readTrial(t, ctx, conn, "org_rearm_bystander")
+	require.True(t, after.DemotedAt.Valid, "an unmatched id must not re-arm anything")
+	require.Equal(t, before.EndsAt.Time, after.EndsAt.Time)
+	require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+}
+
+func TestRearmTrial_OrganizationWithNoTrialRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_rearm_no_trial", name: "No Trial", slug: "no-trial-rearm", accountType: "free"})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_no_trial", Days: 14})
+	requireOopsCode(t, err, oops.CodeConflict)
+
+	// Re-arm restarts a trial that exists; it must never be a way to grant one,
+	// which is the auth flow's job.
+	_, err = trialsRepo.New(conn).GetTrial(ctx, "org_rearm_no_trial")
+	require.Error(t, err, "a rejected re-arm must not create a trial row")
+
+	state := readOrgState(t, ctx, conn, "org_rearm_no_trial")
+	require.Equal(t, "free", state.GramAccountType)
+	require.False(t, state.Whitelisted)
+}
+
+// TestRearmTrial_OrganizationWithNoKeysSucceeds is the trap the demotion's own
+// shape would have walked into. DisableAPIKey no-ops on an organization that
+// has no key row of a type, but RefreshAPIKeyLimit errors on one, so an
+// unconditional loop over AllKeyTypes would fail every re-arm of an
+// organization that never ran a completion of that kind.
+func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+
+	orgID := "org_rearm_nokeys"
+	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+
+	// Only the chat key exists, so the internal one has to be skipped rather
+	// than refreshed.
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err, "an organization with no key of a type must still be re-armable")
+
+	//nolint:exhaustive // the absent key type is the assertion: it must not appear
+	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeChat: conv.PtrEmpty(50)}, provisioner.revivedLimits(),
+		"a key type the organization has no row for must not be refreshed")
+
+	state := readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "enterprise", state.GramAccountType)
+	require.True(t, state.Whitelisted)
+}
+
+// TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds is the other half of
+// the missing-key case, and it is the half that distinguishes skipping an
+// absent key from stopping at one.
+//
+// The sibling test omits the internal key, which is the last of AllKeyTypes, so
+// an implementation that gave up on the first missing row would still pass it.
+// Here the missing row is the first one, so a re-arm that stopped there would
+// leave the organization's internal completions dead on a running trial.
+func TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+
+	orgID := "org_rearm_internal_only"
+	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+
+	//nolint:exhaustive // the absent key type is the assertion: it must not appear
+	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(),
+		"a key that follows an absent one must still come back up")
+	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)
+}
+
+// TestRearmTrial_AlreadyEnabledKeyIsLeftAlone keeps the re-arm idempotent
+// against the upstream. A key that is already live needs no round trip, which
+// is what makes retrying a half-failed re-arm cheap.
+func TestRearmTrial_AlreadyEnabledKeyIsLeftAlone(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+
+	orgID := "org_rearm_partial"
+	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: false})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+
+	//nolint:exhaustive // the omitted key type is the assertion: it was already live
+	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(),
+		"an already-enabled key needs no upstream round trip")
+	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).Disabled)
+	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)
+}
+
+// TestRearmTrial_ZeroCeilingKeyIsRecappedAfterTheRestoreCommits pins the one
+// case where reviving before the commit costs something.
+//
+// A key minted before the ceiling column existed records no ceiling, so its
+// revival has none to pass and RefreshAPIKeyLimit has to resolve one. Resolved
+// while the restore is still uncommitted, it reads a free organization with no
+// running trial and answers with the free tier's allowance, not the trial's.
+// Nothing corrects that on a schedule: the only automatic refresh in the
+// codebase runs off a Polar subscription webhook that a re-arm does not send.
+// So the handler asks again once the restore has committed, and it is that
+// second answer the organization keeps for the run.
+//
+// The assertions are on the state the fake saw at each call rather than on the
+// call count alone, because the count alone would pass an implementation that
+// asked twice before committing, which resolves the same wrong allowance twice.
+func TestRearmTrial_ZeroCeilingKeyIsRecappedAfterTheRestoreCommits(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+
+	orgID := "org_rearm_zero_ceiling"
+	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 0, disabled: true})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+
+	var chat, internal []keyRevival
+	for _, r := range provisioner.revivals {
+		if r.keyType == openrouter.KeyTypeChat {
+			chat = append(chat, r)
+			continue
+		}
+		internal = append(internal, r)
+	}
+
+	// The key that already carried a ceiling is asked once and passed it. A
+	// second ask for that row would be a wasted upstream call, and worse, would
+	// overwrite a trial ceiling that had been raised by hand.
+	require.Len(t, internal, 1, "a key with a recorded ceiling must not be asked twice")
+	require.Equal(t, conv.PtrEmpty(37), internal[0].limit)
+
+	require.Len(t, chat, 2, "a key with no recorded ceiling must be asked again after the commit")
+	require.Nil(t, chat[0].limit, "the first ask has no ceiling to pass")
+	require.Equal(t, "free", chat[0].accountTypeSeen, "the first ask runs before the restore commits")
+	require.True(t, chat[0].demotedSeen)
+
+	require.Nil(t, chat[1].limit, "the second ask resolves the ceiling rather than passing the stale one")
+	require.Equal(t, "enterprise", chat[1].accountTypeSeen, "the second ask must see the committed restore, or it resolves the same free-tier ceiling again")
+	require.False(t, chat[1].demotedSeen, "the second ask must see the trial running, or defaultLimitForOrg misses it")
+
+	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).Disabled)
+}
+
+// TestRearmTrial_RecapFailureStillReportsSuccess covers the half of the recap
+// that must not propagate. By the time it runs the re-arm is committed, so an
+// error answer would tell the operator a running trial is not armed and invite
+// a retry that has nothing left to do.
+func TestRearmTrial_RecapFailureStillReportsSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+
+	orgID := "org_rearm_recap_fails"
+	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 0, disabled: true})
+
+	// Failing every call would also fail the revival and never reach the recap,
+	// so the fake is armed only once the revival is behind us.
+	provisioner.failAfter = 1
+	provisioner.failWith = errors.New("openrouter is down")
+
+	res, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err, "a failed recap must not report the committed re-arm as failed")
+	require.Equal(t, orgID, res.ID)
+
+	// Without this the test would pass on an implementation that never recaps
+	// at all: a re-arm that skips the second ask also returns no error and also
+	// leaves the rows below correct. The failure has to have been reached and
+	// swallowed, not avoided.
+	require.Len(t, provisioner.revivals, 2, "the recap must have been attempted")
+	failed := provisioner.revivals[1]
+	require.Nil(t, failed.limit)
+	require.Equal(t, "enterprise", failed.accountTypeSeen, "the swallowed failure must be the post-commit ask")
+
+	state := readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "enterprise", state.GramAccountType)
+	require.True(t, state.Whitelisted)
+	require.False(t, readTrial(t, ctx, conn, orgID).DemotedAt.Valid)
+}
+
+func TestRearmTrial_WritesAnAuditEntry(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	seedDemotedTrial(t, ctx, conn, "org_rearm_audit", "enterprise")
+
+	// An entry that cannot name the operator is most of the reason for keeping
+	// it, so the call carries a session the way the admin transport delivers
+	// one.
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{
+		SessionID:   "session-rearm-audit",
+		Email:       "operator@example.test",
+		OIDCSubject: "oidc-subject-rearm-audit",
+		Name:        "Test Operator",
+		HD:          "example.test",
+	})
+
+	before, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_audit", Days: 14})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	require.Equal(t, "organization", entry.SubjectType)
+
+	// The fixture gives the organization an id, a name and a slug that all
+	// differ, so these two pin that the entry carries the organization's own
+	// name and slug rather than whichever string was closest to hand.
+	require.Equal(t, "org_rearm_audit Name", entry.SubjectDisplay)
+	require.Equal(t, "org_rearm_audit-slug", entry.SubjectSlug)
+	require.NotNil(t, entry.ActorDisplayName, "the entry must name who re-armed the trial")
+	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
+
+	// The restored tier is on the entry because the demotion's entry is the
+	// only record of the tier it overwrote, and a reader comparing the two
+	// learns whether the organization got back what it had.
+	var metadata struct {
+		AccountType string    `json:"account_type"`
+		TrialEndsAt time.Time `json:"trial_ends_at"`
+	}
+	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
+	require.Equal(t, "enterprise", metadata.AccountType)
+
+	// The date on the entry is the one the database wrote, not one the handler
+	// recomputed from a second clock afterwards.
+	require.WithinDuration(t, readTrial(t, ctx, conn, "org_rearm_audit").EndsAt.Time, metadata.TrialEndsAt, 0)
+
+	// The entry leaves on the trial lifecycle event, the one the arming and
+	// demotion entries already use. A consumer subscribed to that event is
+	// exactly who wants to hear that a demoted trial came back, and sending it
+	// under any other event type would deliver it to nobody.
+	_, err = audittestrepo.New(conn).GetLatestOutboxPayloadByOrg(ctx, audittestrepo.GetLatestOutboxPayloadByOrgParams{
+		OrganizationID: "org_rearm_audit",
+		EventType:      string(events.OrganizationEnterpriseTrialV1.EventType()),
+	})
+	require.NoError(t, err, "a re-arm must enqueue an outbox entry on the enterprise trial event")
+}
+
+func TestRearmTrial_AuditEntryNamesTheTeamAndNotTheOperator(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	seedDemotedTrial(t, ctx, conn, "org_rearm_actor", "enterprise")
+
+	const operatorEmail = "operator@example.test"
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{
+		SessionID:   "session-rearm-actor",
+		Email:       operatorEmail,
+		OIDCSubject: "oidc-subject-rearm-actor",
+		Name:        "Test Operator",
+		HD:          "example.test",
+	})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_actor", Days: 14})
+	require.NoError(t, err)
+
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+
+	// The customer reads this feed. A Speakeasy action carries the collective
+	// label there, the same one auditapi applies on read to a staff member it
+	// recognises. The read-side mask cannot reach this entry, because it
+	// matches an actor id against a Gram user and an admin session has an OIDC
+	// subject instead, so the write side is what has to get it right.
+	require.NotNil(t, entry.ActorDisplayName)
+	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
+
+	// Masking the display name must not cost the accountability record. The
+	// authoritative actor on the row is still the operator's OIDC subject,
+	// which is what ties the entry to the person through the identity provider
+	// and the server log. Without this, an entry that named nobody at all would
+	// satisfy the assertion above.
+	require.Equal(t, "oidc-subject-rearm-actor", entry.ActorID,
+		"the entry must still record which operator acted, in the field the customer's feed does not render")
+	require.Equal(t, "user", entry.ActorType)
+
+	// And the operator's email appears nowhere else in the entry either. The
+	// subject is opaque, so it is not the email in another shape, and the email
+	// itself stays in the server log where only Speakeasy reads it.
+	for name, field := range map[string]string{
+		"actor display name": conv.PtrValOr(entry.ActorDisplayName, ""),
+		"actor id":           entry.ActorID,
+		"subject display":    entry.SubjectDisplay,
+		"subject slug":       entry.SubjectSlug,
+		"metadata":           string(entry.Metadata),
+		"before snapshot":    string(entry.BeforeSnapshot),
+		"after snapshot":     string(entry.AfterSnapshot),
+	} {
+		require.NotContains(t, field, operatorEmail, "the operator's email must not reach the customer's audit feed through the %s", name)
+	}
+}
+
+func TestRearmTrial_DayCountBounds(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+
+	cases := []struct {
+		name    string
+		days    int
+		wantErr bool
+	}{
+		// A zero or negative count would re-arm a trial that is already over,
+		// which is a demotion dressed up as a reinstatement.
+		{name: "large negative", days: -365, wantErr: true},
+		{name: "minus one", days: -1, wantErr: true},
+		{name: "zero", days: 0, wantErr: true},
+
+		{name: "minimum", days: constants.MinTrialRearmDays},
+		{name: "maximum", days: constants.MaxTrialRearmDays},
+
+		{name: "one past the maximum", days: constants.MaxTrialRearmDays + 1, wantErr: true},
+		{name: "far past the maximum", days: 100000, wantErr: true},
+
+		// These pin that the bounds check runs on the wide payload.Days and
+		// that the int32 narrowing stays below it. The second is the one that
+		// matters: 1<<32 + 1 narrows to exactly 1, a value inside the bounds,
+		// so a handler that narrowed first would accept it and re-arm for a
+		// day. Only a non-HTTP caller can reach the service with a count this
+		// large, which is the caller the handler's own check exists for.
+		{name: "int32 overflow to a negative", days: math.MaxInt32 + 1, wantErr: true},
+		{name: "int32 overflow to a valid day count", days: math.MaxUint32 + 2, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID := "org_rearm_bound_" + tc.name
+			seededEndsAt := seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+
+			_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: tc.days})
+
+			after := readTrial(t, ctx, conn, orgID)
+			if tc.wantErr {
+				requireOopsCode(t, err, oops.CodeInvalid)
+				require.True(t, after.DemotedAt.Valid, "a rejected day count must leave the trial demoted")
+				require.WithinDuration(t, seededEndsAt, after.EndsAt.Time, time.Second)
+				require.Equal(t, "free", readOrgState(t, ctx, conn, orgID).GramAccountType)
+				return
+			}
+
+			require.NoError(t, err)
+			require.WithinDuration(t, time.Now().UTC().Add(time.Duration(tc.days)*24*time.Hour), after.EndsAt.Time, time.Minute)
+		})
+	}
+}
+
+// TestRearmTrialRequestBody_DesignBoundsAreEnforced pins the other copy of the
+// bounds. Every other test here calls svc.RearmTrial directly, which skips the
+// generated request decoder, so for the only caller production has none of them
+// touch the validation that runs first. Deleting Minimum, Maximum and
+// MinLength(1) from the design would leave the rest of this file green.
+func TestRearmTrialRequestBody_DesignBoundsAreEnforced(t *testing.T) {
+	t.Parallel()
+
+	id := "org_rearm_validate"
+	minDays := constants.MinTrialRearmDays
+	maxDays := constants.MaxTrialRearmDays
+
+	cases := []struct {
+		name    string
+		id      *string
+		days    *int
+		wantErr bool
+	}{
+		{name: "at the minimum", id: &id, days: &minDays},
+		{name: "at the maximum", id: &id, days: &maxDays},
+
+		{name: "below the minimum", id: &id, days: new(minDays - 1), wantErr: true},
+		{name: "above the maximum", id: &id, days: new(maxDays + 1), wantErr: true},
+		{name: "negative", id: &id, days: new(-1), wantErr: true},
+
+		{name: "empty id", id: new(""), days: &minDays, wantErr: true},
+		{name: "missing id", id: nil, days: &minDays, wantErr: true},
+		{name: "missing days", id: &id, days: nil, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := srv.ValidateRearmTrialRequestBody(&srv.RearmTrialRequestBody{ID: tc.id, Days: tc.days})
+			if tc.wantErr {
+				require.Error(t, err, "the request decoder must reject this before the handler runs")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestRearmTrial_WithoutOpenRouterConfiguration answers below 500 on purpose.
+// server/design/shared/errors.go maps gateway_error and unexpected alike to a
+// 5xx, and the admin app trusts a response body only below 500, so an operator
+// hitting an unconfigured deployment would otherwise see a bare status line
+// instead of the setting they have to fix.
+func TestRearmTrial_WithoutOpenRouterConfiguration(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminServiceWithOpenRouter(t, TrialKeysUnavailable{})
+	seedDemotedTrial(t, ctx, conn, "org_rearm_unconfigured", "enterprise")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_unconfigured", Days: 14})
+	requireOopsCode(t, err, oops.CodeInvalid)
+
+	require.True(t, readTrial(t, ctx, conn, "org_rearm_unconfigured").DemotedAt.Valid,
+		"a re-arm that could not revive the keys must leave the trial demoted")
+	require.Equal(t, "free", readOrgState(t, ctx, conn, "org_rearm_unconfigured").GramAccountType)
+}
+
+func TestRearmTrial_TouchesOnlyTheTargetRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+
+	seedDemotedTrial(t, ctx, conn, "org_rearm_target", "enterprise")
+	seedDemotedTrial(t, ctx, conn, "org_rearm_neighbour", "enterprise")
+	neighbourBefore := readTrial(t, ctx, conn, "org_rearm_neighbour")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_target", Days: 14})
+	require.NoError(t, err)
+
+	neighbourAfter := readTrial(t, ctx, conn, "org_rearm_neighbour")
+	require.True(t, neighbourAfter.DemotedAt.Valid, "re-arming must not spill onto other trials")
+	require.Equal(t, neighbourBefore.EndsAt.Time, neighbourAfter.EndsAt.Time)
+	require.Equal(t, neighbourBefore.UpdatedAt.Time, neighbourAfter.UpdatedAt.Time)
+
+	neighbourState := readOrgState(t, ctx, conn, "org_rearm_neighbour")
+	require.Equal(t, "free", neighbourState.GramAccountType)
+	require.False(t, neighbourState.Whitelisted)
+
+	for _, revival := range provisioner.revivals {
+		require.Equal(t, "org_rearm_target", revival.orgID, "only the target organization's keys may be revived")
+	}
+	require.True(t, readOpenRouterKey(t, ctx, conn, "org_rearm_neighbour", openrouter.KeyTypeChat).Disabled)
+}
+
+// TestRearmTrial_IsIdempotentAcrossARetry covers the shape a half-failed
+// re-arm actually leaves for the operator: they press the button again. The
+// second call must be rejected as a conflict rather than silently granting a
+// second fresh window, which would let a re-arm be used as an unbounded extend.
+func TestRearmTrial_IsIdempotentAcrossARetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	seedDemotedTrial(t, ctx, conn, "org_rearm_twice", "enterprise")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_twice", Days: 14})
+	require.NoError(t, err)
+	first := readTrial(t, ctx, conn, "org_rearm_twice")
+
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_twice", Days: 365})
+	requireOopsCode(t, err, oops.CodeConflict)
+
+	second := readTrial(t, ctx, conn, "org_rearm_twice")
+	require.Equal(t, first.EndsAt.Time, second.EndsAt.Time,
+		"a second re-arm must not move a trial that is already running")
+	require.Equal(t, first.UpdatedAt.Time, second.UpdatedAt.Time)
+}
+
+func TestRearmTrial_RestoresADisabledOrganizationsTrialWithoutEnablingIt(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+
+	// Disabled and trial state are independent axes, exactly as they are for
+	// extend: an operator investigating an organization must not have to choose
+	// between keeping it disabled and keeping its trial alive.
+	orgID := "org_rearm_disabled"
+	disabledAt := time.Now().UTC().Add(-time.Hour)
+	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", disabledAt: &disabledAt})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+
+	state := readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "enterprise", state.GramAccountType)
+	require.True(t, state.Whitelisted)
+	require.True(t, state.DisabledAt.Valid, "re-arming a trial must not enable a disabled organization")
+}
+
+// TestRearmTrial_SurvivesTheSweeperReachingTheOrganizationFirst is the
+// interleaving the re-arm shares a row lock with. It is written as a sequence
+// rather than as concurrency because the lock makes the two serialize anyway;
+// what matters is that neither order leaves the organization half restored.
+func TestRearmTrial_SurvivesTheSweeperReachingTheOrganizationFirst(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	seedDemotedTrial(t, ctx, conn, "org_rearm_sweep", "enterprise")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_sweep", Days: 14})
+	require.NoError(t, err)
+
+	// The sweeper's own selection query, run after the re-arm committed.
+	expired, err := trialsRepo.New(conn).ListExpiredTrials(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, expired, "org_rearm_sweep")
+
+	// And its write, which must find nothing to do.
+	_, err = trialsRepo.New(conn).MarkTrialDemoted(ctx, "org_rearm_sweep")
+	require.Error(t, err, "a sweep arriving after a re-arm must demote nothing")
+
+	require.True(t, readOrgState(t, ctx, conn, "org_rearm_sweep").Whitelisted)
+}

--- a/server/internal/admin/setup_test.go
+++ b/server/internal/admin/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/organizations/orgprovision"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -49,6 +50,7 @@ func newTestAdminService(t *testing.T) (context.Context, *Service, *pgxpool.Pool
 	svc := &Service{
 		logger: logger,
 		db:     conn,
+		audit:  audit.NewLogger(),
 	}
 
 	return ctx, svc, conn

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -89,6 +89,7 @@ func TestService_Info(t *testing.T) {
 
 		require.NoError(t, trialsRepo.New(instance.conn).InsertTrialFixture(ctx, trialsRepo.InsertTrialFixtureParams{
 			OrganizationID: organizationID,
+			Tier:           "enterprise",
 			CreatedAt:      conv.ToPGTimestamptz(createdAt),
 			EndsAt:         conv.ToPGTimestamptz(endsAt),
 			ConvertedAt:    conv.PtrToPGTimestamptz(convertedAt),

--- a/server/internal/constants/trials.go
+++ b/server/internal/constants/trials.go
@@ -9,3 +9,13 @@ const MinTrialExtensionDays = 1
 // runs longer than that is a contract rather than a trial, and the bound also
 // keeps the ends_at arithmetic far away from what timestamptz can hold.
 const MaxTrialExtensionDays = 365
+
+// MinTrialRearmDays and MaxTrialRearmDays bound the runway a re-arm grants. A
+// re-arm counts its days from now rather than from the trial's old end date, so
+// the two operations bound different arithmetic, but the reasons for both ends
+// of the range are the extension's reasons unchanged. They are written as
+// aliases so a future divergence is a deliberate edit rather than a silent one.
+const (
+	MinTrialRearmDays = MinTrialExtensionDays
+	MaxTrialRearmDays = MaxTrialExtensionDays
+)

--- a/server/internal/constants/trials.go
+++ b/server/internal/constants/trials.go
@@ -10,11 +10,8 @@ const MinTrialExtensionDays = 1
 // keeps the ends_at arithmetic far away from what timestamptz can hold.
 const MaxTrialExtensionDays = 365
 
-// MinTrialRearmDays and MaxTrialRearmDays bound the runway a re-arm grants. A
-// re-arm counts its days from now rather than from the trial's old end date, so
-// the two operations bound different arithmetic, but the reasons for both ends
-// of the range are the extension's reasons unchanged. They are written as
-// aliases so a future divergence is a deliberate edit rather than a silent one.
+// MinTrialRearmDays and MaxTrialRearmDays bound the runway a re-arm grants.
+// Aliases, so a divergence from the extension bounds has to be a deliberate edit.
 const (
 	MinTrialRearmDays = MinTrialExtensionDays
 	MaxTrialRearmDays = MaxTrialExtensionDays

--- a/server/internal/thirdparty/openrouter/trial_credits_test.go
+++ b/server/internal/thirdparty/openrouter/trial_credits_test.go
@@ -168,6 +168,7 @@ func insertTrial(t *testing.T, conn *pgxpool.Pool, orgID string, endsAt time.Tim
 
 	require.NoError(t, trialsRepo.New(conn).InsertTrialFixture(t.Context(), trialsRepo.InsertTrialFixtureParams{
 		OrganizationID: orgID,
+		Tier:           "enterprise",
 		CreatedAt:      conv.ToPGTimestamptz(time.Now().UTC().Add(-24 * time.Hour)),
 		EndsAt:         conv.ToPGTimestamptz(endsAt),
 		ConvertedAt:    conv.PtrToPGTimestamptz(convertedAt),

--- a/server/internal/trialemails/service_test.go
+++ b/server/internal/trialemails/service_test.go
@@ -230,6 +230,7 @@ func newTestServiceWithTrial(t *testing.T, active bool) (context.Context, *testI
 	}))
 	require.NoError(t, trialsrepo.New(conn).InsertTrialFixture(ctx, trialsrepo.InsertTrialFixtureParams{
 		OrganizationID: organizationID,
+		Tier:           "enterprise",
 		CreatedAt:      conv.ToPGTimestamptz(createdAt),
 		EndsAt:         conv.ToPGTimestamptz(endsAt),
 		ConvertedAt:    conv.PtrToPGTimestamptz(nil),

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -28,11 +28,13 @@ WHERE organization_id = @organization_id
   AND converted_at IS NULL;
 
 -- name: InsertTrialFixture :exec
--- Test-only fixture for exercising active trial lifecycle states.
+-- Test-only fixture for exercising active trial lifecycle states. tier is a
+-- parameter rather than the literal enterprise it once was, so a test can pin
+-- that a re-arm restores the tier the trial grants rather than a hardcoded one.
 INSERT INTO trials (organization_id, tier, created_at, ends_at, converted_at, demoted_at)
 VALUES (
     @organization_id,
-    'enterprise',
+    @tier,
     @created_at,
     @ends_at,
     sqlc.narg('converted_at')::timestamptz,
@@ -93,15 +95,23 @@ RETURNING *;
 --   * converted_at IS NULL is load-bearing. A mid-trial conversion leaves ends_at
 --     in the future, so nothing else would reject it.
 --   * ends_at > clock_timestamp() is load-bearing. It is the ordinary case.
---   * demoted_at IS NULL is forward-looking. MarkTrialDemoted only demotes an
---     already-expired trial and nothing moves ends_at forward afterwards, so in
---     every state the application can currently reach it is subsumed by the
---     ends_at condition. It is kept as defence against a future re-arm path.
+--   * demoted_at IS NULL is not load-bearing. It is defence in depth, and
+--     AGE-3208 did not change that. No writer produces a row where demoted_at is
+--     set and ends_at is in the future, so the ends_at condition already rejects
+--     every demoted row this query can meet. MarkTrialDemoted only demotes an
+--     already-expired trial; this query cannot move a demoted row forward
+--     because it excludes one; the arming path inserts a null stamp; and
+--     RearmTrial below clears demoted_at and moves ends_at in the same UPDATE,
+--     so it never leaves the two disagreeing either. Only InsertTrialFixture can
+--     build that row, which is why the tests walk the state space rather than
+--     trusting the reachable half of it.
 --
--- Extending a demoted trial is deliberately not the same as re-arming it:
--- demotion also disabled the organization's model provider keys and nothing in
--- this repository can re-enable them, so clearing demoted_at would advertise a
--- running trial whose keys stay dead (AGE-3208).
+-- Extending a demoted trial is deliberately not the same as re-arming it. A
+-- re-arm has to revive the organization's model provider keys and restore the
+-- account type and whitelist flag that demotion overwrote, all of which
+-- RearmTrial and its handler do and none of which belong in a query that moves
+-- an end date. Clearing demoted_at here alone would advertise a running trial
+-- whose keys stay dead (AGE-3208).
 --
 -- Two things this query deliberately does not check:
 --
@@ -123,6 +133,86 @@ WHERE organization_id = @organization_id
   AND converted_at IS NULL
   AND demoted_at IS NULL
   AND ends_at > clock_timestamp();
+
+-- name: RearmTrial :one
+-- Operator-initiated reinstatement of a demoted trial. Returns the tier the
+-- trial grants, which the handler writes back onto the organization. The
+-- demotion's audit entry does record the account type it overwrote, in its
+-- previous_account_type metadata, but that is a fact about one past moment
+-- rather than a statement of what the organization is owed: other paths write
+-- gram_account_type between the demotion and the re-arm, mv.DescribeOrganization
+-- on every auth with a Polar customer tier for one, and none of them revise that
+-- entry. Reading it back would also mean finding the right entry in the whole
+-- feed and parsing its metadata. The trial's own tier is the durable answer, and
+-- it moves when the trial's terms move.
+--
+-- The new end date comes back with the tier so the audit entry records the date
+-- the database actually wrote rather than one recomputed from a second clock.
+--
+-- ends_at moves to a fresh window measured from now rather than being left
+-- where it was. Leaving it alone is not an option: MarkTrialDemoted only ever
+-- demotes a trial whose ends_at is already in the past, so a re-arm that
+-- cleared demoted_at and nothing else would put the row straight back into
+-- ListExpiredTrials, and the next sweep would demote it and take the keys down
+-- again. Nor could the operator rescue it with ExtendTrial afterwards, because
+-- that query requires ends_at > clock_timestamp(), which such a row fails.
+-- Adding to the old ends_at has the same defect: it is in the past by an
+-- unknown amount, so the sum can still land in the past.
+--
+-- Only a demoted trial can be re-armed, and the conditions are here rather than
+-- in the handler for ExtendTrial's reason: the database enforces them. The two
+-- are not equally load-bearing:
+--
+--   * demoted_at IS NOT NULL decides every outcome this query has today. It is
+--     what rejects a running trial, and so what keeps this from being a second,
+--     weaker extend that ignores the bounds on the current end date.
+--   * converted_at IS NULL protects nothing today, because nothing sets the
+--     column. MarkTrialConverted has no production caller; only tests and
+--     InsertTrialFixture write converted_at, so no reachable row can be both
+--     demoted and converted. The condition is written for the conversion path
+--     that will call it, and it is not implied by the other one: a trial can
+--     convert after it was demoted, and on that day this is what stops a signed
+--     customer being dragged back onto a trial. Until then it is a stated
+--     intention, not a guard.
+--
+-- Nothing checks tier, for the reason ExtendTrial gives, and nothing checks
+-- organization_metadata.disabled_at, also for the reason ExtendTrial gives.
+--
+-- A re-arm and a concurrent sweep cannot both take effect, and no lock ordering
+-- is involved. The two statements have disjoint predicates on demoted_at, each
+-- re-evaluated against the snapshot its own statement takes: while this
+-- transaction is open and uncommitted, MarkTrialDemoted still sees the old row
+-- version with demoted_at set, fails its demoted_at IS NULL condition and
+-- updates nothing, so it never waits on the row this holds. Afterwards the
+-- moved ends_at is what protects the re-arm: a sweep arriving once this commits
+-- passes demoted_at IS NULL but fails ends_at < clock_timestamp(). That is a
+-- second reason ends_at has to move, on top of the sweep that would otherwise
+-- fire on the very next tick.
+UPDATE trials
+SET demoted_at = NULL,
+    ends_at = clock_timestamp() + make_interval(days => @rearm_for_days::int),
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND demoted_at IS NOT NULL
+  AND converted_at IS NULL
+RETURNING tier, ends_at;
+
+-- name: RestoreOrganizationFromTrial :one
+-- Undoes DemoteOrganizationToFree's two writes. whitelisted is restored
+-- unconditionally rather than left alone, because demotion cleared it and the
+-- signup arming path never sets it: that path runs on an organization that was
+-- whitelisted already, so replaying it would leave a re-armed organization on
+-- the enterprise tier and still behind the book-a-demo gate.
+--
+-- The account type is a parameter rather than a literal so it comes from the
+-- trial's tier. A literal would be right only for as long as enterprise is the
+-- only tier written, and schema.sql already anticipates others.
+UPDATE organization_metadata
+SET gram_account_type = @account_type,
+    whitelisted = TRUE,
+    updated_at = clock_timestamp()
+WHERE id = @organization_id
+RETURNING name, slug;
 
 -- name: DemoteOrganizationToFree :one
 -- Drops the organization to the free tier and back behind the dashboard

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -28,9 +28,7 @@ WHERE organization_id = @organization_id
   AND converted_at IS NULL;
 
 -- name: InsertTrialFixture :exec
--- Test-only fixture for exercising active trial lifecycle states. tier is a
--- parameter rather than the literal enterprise it once was, so a test can pin
--- that a re-arm restores the tier the trial grants rather than a hardcoded one.
+-- Test-only fixture for exercising active trial lifecycle states.
 INSERT INTO trials (organization_id, tier, created_at, ends_at, converted_at, demoted_at)
 VALUES (
     @organization_id,
@@ -95,23 +93,11 @@ RETURNING *;
 --   * converted_at IS NULL is load-bearing. A mid-trial conversion leaves ends_at
 --     in the future, so nothing else would reject it.
 --   * ends_at > clock_timestamp() is load-bearing. It is the ordinary case.
---   * demoted_at IS NULL is not load-bearing. It is defence in depth, and
---     AGE-3208 did not change that. No writer produces a row where demoted_at is
---     set and ends_at is in the future, so the ends_at condition already rejects
---     every demoted row this query can meet. MarkTrialDemoted only demotes an
---     already-expired trial; this query cannot move a demoted row forward
---     because it excludes one; the arming path inserts a null stamp; and
---     RearmTrial below clears demoted_at and moves ends_at in the same UPDATE,
---     so it never leaves the two disagreeing either. Only InsertTrialFixture can
---     build that row, which is why the tests walk the state space rather than
---     trusting the reachable half of it.
+--   * demoted_at IS NULL is defence in depth: no writer leaves demoted_at set
+--     with ends_at in the future.
 --
--- Extending a demoted trial is deliberately not the same as re-arming it. A
--- re-arm has to revive the organization's model provider keys and restore the
--- account type and whitelist flag that demotion overwrote, all of which
--- RearmTrial and its handler do and none of which belong in a query that moves
--- an end date. Clearing demoted_at here alone would advertise a running trial
--- whose keys stay dead (AGE-3208).
+-- Extending a demoted trial is not re-arming it: a re-arm also revives the
+-- model provider keys and restores the account type. See RearmTrial.
 --
 -- Two things this query deliberately does not check:
 --
@@ -136,58 +122,14 @@ WHERE organization_id = @organization_id
 
 -- name: RearmTrial :one
 -- Operator-initiated reinstatement of a demoted trial. Returns the tier the
--- trial grants, which the handler writes back onto the organization. The
--- demotion's audit entry does record the account type it overwrote, in its
--- previous_account_type metadata, but that is a fact about one past moment
--- rather than a statement of what the organization is owed: other paths write
--- gram_account_type between the demotion and the re-arm, mv.DescribeOrganization
--- on every auth with a Polar customer tier for one, and none of them revise that
--- entry. Reading it back would also mean finding the right entry in the whole
--- feed and parsing its metadata. The trial's own tier is the durable answer, and
--- it moves when the trial's terms move.
+-- trial grants, which the handler writes back onto the organization.
 --
--- The new end date comes back with the tier so the audit entry records the date
--- the database actually wrote rather than one recomputed from a second clock.
+-- ends_at moves to a window measured from now, not left where it is:
+-- MarkTrialDemoted only demotes an already-past ends_at, so clearing demoted_at
+-- alone leaves a row the next sweep demotes again.
 --
--- ends_at moves to a fresh window measured from now rather than being left
--- where it was. Leaving it alone is not an option: MarkTrialDemoted only ever
--- demotes a trial whose ends_at is already in the past, so a re-arm that
--- cleared demoted_at and nothing else would put the row straight back into
--- ListExpiredTrials, and the next sweep would demote it and take the keys down
--- again. Nor could the operator rescue it with ExtendTrial afterwards, because
--- that query requires ends_at > clock_timestamp(), which such a row fails.
--- Adding to the old ends_at has the same defect: it is in the past by an
--- unknown amount, so the sum can still land in the past.
---
--- Only a demoted trial can be re-armed, and the conditions are here rather than
--- in the handler for ExtendTrial's reason: the database enforces them. The two
--- are not equally load-bearing:
---
---   * demoted_at IS NOT NULL decides every outcome this query has today. It is
---     what rejects a running trial, and so what keeps this from being a second,
---     weaker extend that ignores the bounds on the current end date.
---   * converted_at IS NULL protects nothing today, because nothing sets the
---     column. MarkTrialConverted has no production caller; only tests and
---     InsertTrialFixture write converted_at, so no reachable row can be both
---     demoted and converted. The condition is written for the conversion path
---     that will call it, and it is not implied by the other one: a trial can
---     convert after it was demoted, and on that day this is what stops a signed
---     customer being dragged back onto a trial. Until then it is a stated
---     intention, not a guard.
---
--- Nothing checks tier, for the reason ExtendTrial gives, and nothing checks
--- organization_metadata.disabled_at, also for the reason ExtendTrial gives.
---
--- A re-arm and a concurrent sweep cannot both take effect, and no lock ordering
--- is involved. The two statements have disjoint predicates on demoted_at, each
--- re-evaluated against the snapshot its own statement takes: while this
--- transaction is open and uncommitted, MarkTrialDemoted still sees the old row
--- version with demoted_at set, fails its demoted_at IS NULL condition and
--- updates nothing, so it never waits on the row this holds. Afterwards the
--- moved ends_at is what protects the re-arm: a sweep arriving once this commits
--- passes demoted_at IS NULL but fails ends_at < clock_timestamp(). That is a
--- second reason ends_at has to move, on top of the sweep that would otherwise
--- fire on the very next tick.
+-- converted_at IS NULL guards nothing today, because MarkTrialConverted has no
+-- production caller. It is written for the conversion path that will (AGE-3218).
 UPDATE trials
 SET demoted_at = NULL,
     ends_at = clock_timestamp() + make_interval(days => @rearm_for_days::int),
@@ -198,15 +140,9 @@ WHERE organization_id = @organization_id
 RETURNING tier, ends_at;
 
 -- name: RestoreOrganizationFromTrial :one
--- Undoes DemoteOrganizationToFree's two writes. whitelisted is restored
--- unconditionally rather than left alone, because demotion cleared it and the
--- signup arming path never sets it: that path runs on an organization that was
--- whitelisted already, so replaying it would leave a re-armed organization on
--- the enterprise tier and still behind the book-a-demo gate.
---
--- The account type is a parameter rather than a literal so it comes from the
--- trial's tier. A literal would be right only for as long as enterprise is the
--- only tier written, and schema.sql already anticipates others.
+-- Undoes DemoteOrganizationToFree's two writes. whitelisted is set
+-- unconditionally because demotion cleared it and the signup arming path never
+-- writes it, so replaying that path would leave the book-a-demo gate up.
 UPDATE organization_metadata
 SET gram_account_type = @account_type,
     whitelisted = TRUE,

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -102,23 +102,11 @@ type ExtendTrialParams struct {
 //   - converted_at IS NULL is load-bearing. A mid-trial conversion leaves ends_at
 //     in the future, so nothing else would reject it.
 //   - ends_at > clock_timestamp() is load-bearing. It is the ordinary case.
-//   - demoted_at IS NULL is not load-bearing. It is defence in depth, and
-//     AGE-3208 did not change that. No writer produces a row where demoted_at is
-//     set and ends_at is in the future, so the ends_at condition already rejects
-//     every demoted row this query can meet. MarkTrialDemoted only demotes an
-//     already-expired trial; this query cannot move a demoted row forward
-//     because it excludes one; the arming path inserts a null stamp; and
-//     RearmTrial below clears demoted_at and moves ends_at in the same UPDATE,
-//     so it never leaves the two disagreeing either. Only InsertTrialFixture can
-//     build that row, which is why the tests walk the state space rather than
-//     trusting the reachable half of it.
+//   - demoted_at IS NULL is defence in depth: no writer leaves demoted_at set
+//     with ends_at in the future.
 //
-// Extending a demoted trial is deliberately not the same as re-arming it. A
-// re-arm has to revive the organization's model provider keys and restore the
-// account type and whitelist flag that demotion overwrote, all of which
-// RearmTrial and its handler do and none of which belong in a query that moves
-// an end date. Clearing demoted_at here alone would advertise a running trial
-// whose keys stay dead (AGE-3208).
+// Extending a demoted trial is not re-arming it: a re-arm also revives the
+// model provider keys and restores the account type. See RearmTrial.
 //
 // Two things this query deliberately does not check:
 //
@@ -229,9 +217,7 @@ type InsertTrialFixtureParams struct {
 	DemotedAt      pgtype.Timestamptz
 }
 
-// Test-only fixture for exercising active trial lifecycle states. tier is a
-// parameter rather than the literal enterprise it once was, so a test can pin
-// that a re-arm restores the tier the trial grants rather than a hardcoded one.
+// Test-only fixture for exercising active trial lifecycle states.
 func (q *Queries) InsertTrialFixture(ctx context.Context, arg InsertTrialFixtureParams) error {
 	_, err := q.db.Exec(ctx, insertTrialFixture,
 		arg.OrganizationID,
@@ -340,58 +326,14 @@ type RearmTrialRow struct {
 }
 
 // Operator-initiated reinstatement of a demoted trial. Returns the tier the
-// trial grants, which the handler writes back onto the organization. The
-// demotion's audit entry does record the account type it overwrote, in its
-// previous_account_type metadata, but that is a fact about one past moment
-// rather than a statement of what the organization is owed: other paths write
-// gram_account_type between the demotion and the re-arm, mv.DescribeOrganization
-// on every auth with a Polar customer tier for one, and none of them revise that
-// entry. Reading it back would also mean finding the right entry in the whole
-// feed and parsing its metadata. The trial's own tier is the durable answer, and
-// it moves when the trial's terms move.
+// trial grants, which the handler writes back onto the organization.
 //
-// The new end date comes back with the tier so the audit entry records the date
-// the database actually wrote rather than one recomputed from a second clock.
+// ends_at moves to a window measured from now, not left where it is:
+// MarkTrialDemoted only demotes an already-past ends_at, so clearing demoted_at
+// alone leaves a row the next sweep demotes again.
 //
-// ends_at moves to a fresh window measured from now rather than being left
-// where it was. Leaving it alone is not an option: MarkTrialDemoted only ever
-// demotes a trial whose ends_at is already in the past, so a re-arm that
-// cleared demoted_at and nothing else would put the row straight back into
-// ListExpiredTrials, and the next sweep would demote it and take the keys down
-// again. Nor could the operator rescue it with ExtendTrial afterwards, because
-// that query requires ends_at > clock_timestamp(), which such a row fails.
-// Adding to the old ends_at has the same defect: it is in the past by an
-// unknown amount, so the sum can still land in the past.
-//
-// Only a demoted trial can be re-armed, and the conditions are here rather than
-// in the handler for ExtendTrial's reason: the database enforces them. The two
-// are not equally load-bearing:
-//
-//   - demoted_at IS NOT NULL decides every outcome this query has today. It is
-//     what rejects a running trial, and so what keeps this from being a second,
-//     weaker extend that ignores the bounds on the current end date.
-//   - converted_at IS NULL protects nothing today, because nothing sets the
-//     column. MarkTrialConverted has no production caller; only tests and
-//     InsertTrialFixture write converted_at, so no reachable row can be both
-//     demoted and converted. The condition is written for the conversion path
-//     that will call it, and it is not implied by the other one: a trial can
-//     convert after it was demoted, and on that day this is what stops a signed
-//     customer being dragged back onto a trial. Until then it is a stated
-//     intention, not a guard.
-//
-// Nothing checks tier, for the reason ExtendTrial gives, and nothing checks
-// organization_metadata.disabled_at, also for the reason ExtendTrial gives.
-//
-// A re-arm and a concurrent sweep cannot both take effect, and no lock ordering
-// is involved. The two statements have disjoint predicates on demoted_at, each
-// re-evaluated against the snapshot its own statement takes: while this
-// transaction is open and uncommitted, MarkTrialDemoted still sees the old row
-// version with demoted_at set, fails its demoted_at IS NULL condition and
-// updates nothing, so it never waits on the row this holds. Afterwards the
-// moved ends_at is what protects the re-arm: a sweep arriving once this commits
-// passes demoted_at IS NULL but fails ends_at < clock_timestamp(). That is a
-// second reason ends_at has to move, on top of the sweep that would otherwise
-// fire on the very next tick.
+// converted_at IS NULL guards nothing today, because MarkTrialConverted has no
+// production caller. It is written for the conversion path that will (AGE-3218).
 func (q *Queries) RearmTrial(ctx context.Context, arg RearmTrialParams) (RearmTrialRow, error) {
 	row := q.db.QueryRow(ctx, rearmTrial, arg.RearmForDays, arg.OrganizationID)
 	var i RearmTrialRow
@@ -418,15 +360,9 @@ type RestoreOrganizationFromTrialRow struct {
 	Slug string
 }
 
-// Undoes DemoteOrganizationToFree's two writes. whitelisted is restored
-// unconditionally rather than left alone, because demotion cleared it and the
-// signup arming path never sets it: that path runs on an organization that was
-// whitelisted already, so replaying it would leave a re-armed organization on
-// the enterprise tier and still behind the book-a-demo gate.
-//
-// The account type is a parameter rather than a literal so it comes from the
-// trial's tier. A literal would be right only for as long as enterprise is the
-// only tier written, and schema.sql already anticipates others.
+// Undoes DemoteOrganizationToFree's two writes. whitelisted is set
+// unconditionally because demotion cleared it and the signup arming path never
+// writes it, so replaying that path would leave the book-a-demo gate up.
 func (q *Queries) RestoreOrganizationFromTrial(ctx context.Context, arg RestoreOrganizationFromTrialParams) (RestoreOrganizationFromTrialRow, error) {
 	row := q.db.QueryRow(ctx, restoreOrganizationFromTrial, arg.AccountType, arg.OrganizationID)
 	var i RestoreOrganizationFromTrialRow

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -102,15 +102,23 @@ type ExtendTrialParams struct {
 //   - converted_at IS NULL is load-bearing. A mid-trial conversion leaves ends_at
 //     in the future, so nothing else would reject it.
 //   - ends_at > clock_timestamp() is load-bearing. It is the ordinary case.
-//   - demoted_at IS NULL is forward-looking. MarkTrialDemoted only demotes an
-//     already-expired trial and nothing moves ends_at forward afterwards, so in
-//     every state the application can currently reach it is subsumed by the
-//     ends_at condition. It is kept as defence against a future re-arm path.
+//   - demoted_at IS NULL is not load-bearing. It is defence in depth, and
+//     AGE-3208 did not change that. No writer produces a row where demoted_at is
+//     set and ends_at is in the future, so the ends_at condition already rejects
+//     every demoted row this query can meet. MarkTrialDemoted only demotes an
+//     already-expired trial; this query cannot move a demoted row forward
+//     because it excludes one; the arming path inserts a null stamp; and
+//     RearmTrial below clears demoted_at and moves ends_at in the same UPDATE,
+//     so it never leaves the two disagreeing either. Only InsertTrialFixture can
+//     build that row, which is why the tests walk the state space rather than
+//     trusting the reachable half of it.
 //
-// Extending a demoted trial is deliberately not the same as re-arming it:
-// demotion also disabled the organization's model provider keys and nothing in
-// this repository can re-enable them, so clearing demoted_at would advertise a
-// running trial whose keys stay dead (AGE-3208).
+// Extending a demoted trial is deliberately not the same as re-arming it. A
+// re-arm has to revive the organization's model provider keys and restore the
+// account type and whitelist flag that demotion overwrote, all of which
+// RearmTrial and its handler do and none of which belong in a query that moves
+// an end date. Clearing demoted_at here alone would advertise a running trial
+// whose keys stay dead (AGE-3208).
 //
 // Two things this query deliberately does not check:
 //
@@ -204,26 +212,30 @@ const insertTrialFixture = `-- name: InsertTrialFixture :exec
 INSERT INTO trials (organization_id, tier, created_at, ends_at, converted_at, demoted_at)
 VALUES (
     $1,
-    'enterprise',
     $2,
     $3,
-    $4::timestamptz,
-    $5::timestamptz
+    $4,
+    $5::timestamptz,
+    $6::timestamptz
 )
 `
 
 type InsertTrialFixtureParams struct {
 	OrganizationID string
+	Tier           string
 	CreatedAt      pgtype.Timestamptz
 	EndsAt         pgtype.Timestamptz
 	ConvertedAt    pgtype.Timestamptz
 	DemotedAt      pgtype.Timestamptz
 }
 
-// Test-only fixture for exercising active trial lifecycle states.
+// Test-only fixture for exercising active trial lifecycle states. tier is a
+// parameter rather than the literal enterprise it once was, so a test can pin
+// that a re-arm restores the tier the trial grants rather than a hardcoded one.
 func (q *Queries) InsertTrialFixture(ctx context.Context, arg InsertTrialFixtureParams) error {
 	_, err := q.db.Exec(ctx, insertTrialFixture,
 		arg.OrganizationID,
+		arg.Tier,
 		arg.CreatedAt,
 		arg.EndsAt,
 		arg.ConvertedAt,
@@ -303,5 +315,121 @@ func (q *Queries) MarkTrialDemoted(ctx context.Context, organizationID string) (
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
+	return i, err
+}
+
+const rearmTrial = `-- name: RearmTrial :one
+UPDATE trials
+SET demoted_at = NULL,
+    ends_at = clock_timestamp() + make_interval(days => $1::int),
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND demoted_at IS NOT NULL
+  AND converted_at IS NULL
+RETURNING tier, ends_at
+`
+
+type RearmTrialParams struct {
+	RearmForDays   int32
+	OrganizationID string
+}
+
+type RearmTrialRow struct {
+	Tier   string
+	EndsAt pgtype.Timestamptz
+}
+
+// Operator-initiated reinstatement of a demoted trial. Returns the tier the
+// trial grants, which the handler writes back onto the organization. The
+// demotion's audit entry does record the account type it overwrote, in its
+// previous_account_type metadata, but that is a fact about one past moment
+// rather than a statement of what the organization is owed: other paths write
+// gram_account_type between the demotion and the re-arm, mv.DescribeOrganization
+// on every auth with a Polar customer tier for one, and none of them revise that
+// entry. Reading it back would also mean finding the right entry in the whole
+// feed and parsing its metadata. The trial's own tier is the durable answer, and
+// it moves when the trial's terms move.
+//
+// The new end date comes back with the tier so the audit entry records the date
+// the database actually wrote rather than one recomputed from a second clock.
+//
+// ends_at moves to a fresh window measured from now rather than being left
+// where it was. Leaving it alone is not an option: MarkTrialDemoted only ever
+// demotes a trial whose ends_at is already in the past, so a re-arm that
+// cleared demoted_at and nothing else would put the row straight back into
+// ListExpiredTrials, and the next sweep would demote it and take the keys down
+// again. Nor could the operator rescue it with ExtendTrial afterwards, because
+// that query requires ends_at > clock_timestamp(), which such a row fails.
+// Adding to the old ends_at has the same defect: it is in the past by an
+// unknown amount, so the sum can still land in the past.
+//
+// Only a demoted trial can be re-armed, and the conditions are here rather than
+// in the handler for ExtendTrial's reason: the database enforces them. The two
+// are not equally load-bearing:
+//
+//   - demoted_at IS NOT NULL decides every outcome this query has today. It is
+//     what rejects a running trial, and so what keeps this from being a second,
+//     weaker extend that ignores the bounds on the current end date.
+//   - converted_at IS NULL protects nothing today, because nothing sets the
+//     column. MarkTrialConverted has no production caller; only tests and
+//     InsertTrialFixture write converted_at, so no reachable row can be both
+//     demoted and converted. The condition is written for the conversion path
+//     that will call it, and it is not implied by the other one: a trial can
+//     convert after it was demoted, and on that day this is what stops a signed
+//     customer being dragged back onto a trial. Until then it is a stated
+//     intention, not a guard.
+//
+// Nothing checks tier, for the reason ExtendTrial gives, and nothing checks
+// organization_metadata.disabled_at, also for the reason ExtendTrial gives.
+//
+// A re-arm and a concurrent sweep cannot both take effect, and no lock ordering
+// is involved. The two statements have disjoint predicates on demoted_at, each
+// re-evaluated against the snapshot its own statement takes: while this
+// transaction is open and uncommitted, MarkTrialDemoted still sees the old row
+// version with demoted_at set, fails its demoted_at IS NULL condition and
+// updates nothing, so it never waits on the row this holds. Afterwards the
+// moved ends_at is what protects the re-arm: a sweep arriving once this commits
+// passes demoted_at IS NULL but fails ends_at < clock_timestamp(). That is a
+// second reason ends_at has to move, on top of the sweep that would otherwise
+// fire on the very next tick.
+func (q *Queries) RearmTrial(ctx context.Context, arg RearmTrialParams) (RearmTrialRow, error) {
+	row := q.db.QueryRow(ctx, rearmTrial, arg.RearmForDays, arg.OrganizationID)
+	var i RearmTrialRow
+	err := row.Scan(&i.Tier, &i.EndsAt)
+	return i, err
+}
+
+const restoreOrganizationFromTrial = `-- name: RestoreOrganizationFromTrial :one
+UPDATE organization_metadata
+SET gram_account_type = $1,
+    whitelisted = TRUE,
+    updated_at = clock_timestamp()
+WHERE id = $2
+RETURNING name, slug
+`
+
+type RestoreOrganizationFromTrialParams struct {
+	AccountType    string
+	OrganizationID string
+}
+
+type RestoreOrganizationFromTrialRow struct {
+	Name string
+	Slug string
+}
+
+// Undoes DemoteOrganizationToFree's two writes. whitelisted is restored
+// unconditionally rather than left alone, because demotion cleared it and the
+// signup arming path never sets it: that path runs on an organization that was
+// whitelisted already, so replaying it would leave a re-armed organization on
+// the enterprise tier and still behind the book-a-demo gate.
+//
+// The account type is a parameter rather than a literal so it comes from the
+// trial's tier. A literal would be right only for as long as enterprise is the
+// only tier written, and schema.sql already anticipates others.
+func (q *Queries) RestoreOrganizationFromTrial(ctx context.Context, arg RestoreOrganizationFromTrialParams) (RestoreOrganizationFromTrialRow, error) {
+	row := q.db.QueryRow(ctx, restoreOrganizationFromTrial, arg.AccountType, arg.OrganizationID)
+	var i RestoreOrganizationFromTrialRow
+	err := row.Scan(&i.Name, &i.Slug)
 	return i, err
 }


### PR DESCRIPTION
Platform admins can put a demoted enterprise trial back on, and the organization comes back with working model provider keys rather than reading as a running trial whose keys are dead.

Server half of AGE-3208. The dashboard row action is a separate slice.

## This PR was split, and it is based on #5327 rather than on main

The audit-log half of this change now lives in #5327: the
`organization:enterprise_trial_rearmed` action, the writer that records it, the
phrase the dashboard renders, and the `SpeakeasyTeamActorLabel` extraction. This
PR is the admin API half and sits on top of it.

It no longer sits on #5297. Nothing here needed create-organization; the two
were stacked only because both edit `server/design/admin/design.go` and the
generated tree beneath it. #5297 is now a sibling on `main` and is untouched by
the split.

**Because this PR is based on a branch rather than on `main`, `hygiene.yaml`
does not run on it.** The PR title lint, the changeset lint and the migration
check are all skipped here, so a short check list on this PR is not the same as
a pass. #5327 is based on `main` and gets the full set. The changeset for this
half is `.changeset/admin-rearm-trial.md` and it is present.

Two comments were reworded where they referenced create-organization code that
is no longer in this PR's tree. No behaviour changed in the split.

## The ticket was written around a blocker that does not exist

AGE-3208 said there was no way to re-enable a disabled OpenRouter key, and treated that as the reason the slice could not be built. That was false when written, and the ticket has been corrected in place.

`RefreshAPIKeyLimit` is the reinstatement path, and the provisioner interface says so in its own doc comment. `Service.EnableKey` already wrapped it for the admin surface, with a test, and had landed the day before the ticket was filed. The search that produced the claim looked for a method named `EnableAPIKey`. Nothing carries that name.

**The same claim had been copied into a code comment**, where it was the stated reason two operations were kept separate. It is deleted here.

## What this adds

`POST /admin/trial.rearm`. In one transaction it clears `demoted_at`, moves `ends_at` to a fresh run counted from now, restores the account type the trial grants along with the whitelist flag, and writes an audit entry.

**Both OpenRouter key types come back up before any of that commits.** That ordering is deliberately *not* the demotion's mirror image. The demotion disables keys first so that a rollback leaves an organization reading as enterprise with a dead key, which the next sweep finishes. Inverted, the same shape would leave a partial failure reading as a **running trial with dead keys**, which is what the acceptance criteria forbid. Revive-first means a failure leaves the organization still demoted and still free, with live keys, which advertises nothing false and retries cheaply because the enable path no-ops on an already-enabled key.

Two departures from my own brief, both of which the builder argued and both of which I verified before accepting:

1. **The `days` payload is not in the brief, and without it the endpoint is dead on arrival.** `MarkTrialDemoted` only demotes a trial whose `ends_at` is already past, so clearing `demoted_at` alone puts the row straight back into `ListExpiredTrials` for the next hourly sweep, and `ExtendTrial` cannot rescue it because it requires `ends_at > clock_timestamp()`.
2. **Key revival does not mirror the demotion's blind loop.** `DisableAPIKey` no-ops on a missing key row; `RefreshAPIKeyLimit` **errors** on one. A mirrored loop would fail every re-arm of an organization that never ran an internal completion.

## Review round before this opened

Three reviewers, on correctness, on tests and mutation coverage, and on scope and API contract. Four things they found are fixed here.

**A customer-visible data leak.** This is the first audit write from the admin binary: `LogOrganizationEnterpriseTrialRearmed` is the only audit call in all of `server/internal/admin`. The first cut recorded the **operator's email address** on an entry scoped to the **customer's** organization. The staff mask in `auditapi` exists to prevent exactly that and cannot fire, because it matches actor ids against Gram user ids and an admin session supplies an OIDC subject. The entry now credits the collective staff label, which is what a customer already sees for every other staff action, and the operator's email goes to the structured log. The label has one definition rather than two copies of a user-visible string.

**Three false comments, one of them newly introduced.** The comment block above `ExtendTrial` had asserted the non-existent blocker; the first fix for it then overclaimed in the *opposite* direction, calling the `demoted_at IS NULL` condition load-bearing when no reachable row has `demoted_at` set with a future `ends_at`. A third claimed row-lock serialization that does not happen: a re-arm holding the lock does not block a concurrent sweep, which returns no rows in under a millisecond because its predicate does not match the row version its snapshot sees. What actually separates them is disjoint predicates per statement snapshot plus the moved end date.

**Two real gaps in the tests**, both now pinned and both verified non-vacuous against the mutation each exists to kill:

- Moving key revival **above** the guard query used to survive, so nothing pinned that a *rejected* re-arm revives no keys. That is the guarantee the ordering exists to give.
- Skip-absent and stop-early were indistinguishable, because the only key-absent test omitted the last element of `AllKeyTypes`.

## What changed after this opened

Four more commits, from cubic's round. One of them is behaviour, not tidying, so read it rather than the label.

**A re-armed key was getting the free tier's spending ceiling instead of the trial's.** A key row that records no ceiling of its own passes none on, so `RefreshAPIKeyLimit` resolves one itself, and it resolves it on the pool. Run before the restore commits, that read sees a free organization with no running trial and answers **5** rather than the trial's **50**. The comment claimed a later refresh corrects it. Nothing does: the only automatic refresh runs off a subscription webhook a re-arm never sends, and the other two callers are an operator action and a Temporal activity. The organization would have kept the free-tier allowance for the whole re-armed run.

Key revival now reports which types it could only revive at a pre-commit ceiling, and the handler asks again for those after the commit. That second ask is logged and swallowed rather than returned, because the re-arm is durable by then and an error would report a running trial as unarmed. The test pins that the swallowed failure was **reached**, not avoided: an implementation that never recaps at all would otherwise pass it.

The other three are a typo in a flag description this branch adds, the webhook catalog description now naming re-arm alongside armed and demoted, and the test above.

## Two follow-ups filed, deliberately not fixed here

- **AGE-3218.** `trials.converted_at` has **no production writer**, so the `converted_at IS NULL` guard on both this endpoint and the already-merged `ExtendTrial` protects nothing. A changeset sentence claiming that protection has been removed rather than shipped. Making the guard real changes endpoint semantics and interacts with the zero-row disambiguation, so it is its own ticket.
- **AGE-3219.** `openrouter_api_keys.disabled` records no reason, so a re-arm cannot tell a sweeper's demotion from a platform admin's deliberate lockdown of a leaked key, and silently reverses the second. Fixing it needs a new column.

One open question is on the ticket for Walker: whether platform-admin actions should be attributable to the *individual* operator in a customer-facing feed, which would need the mask taught about OIDC subjects.

## Known gaps, stated rather than hidden

On a local stack the development provisioner accepts the refresh without doing anything, so a re-arm reports success and leaves both key rows disabled. Enabling a key locally has the same gap. The changeset says so.

A sweep that fails after disabling keys leaves a state neither re-arm nor extend can fix, because their predicates disagree about it. It self-heals within the hour when the next sweep re-demotes, and it predates this change.

## Checks

**This is a stacked pull request, on `walker/age-3194-create-org` (#5297).** `hygiene.yaml` filters `branches: [main]`, so the **PR title lint, the changeset lint and the migration check do not run**. A short check list here is not a clean bill of health. I verified those three by hand: the title carries an allowed prefix, the changeset targets real packages and describes user-visible behaviour, and there is no migration. `pr.yaml` has no branch filter, so the tests and lint that do run are real evidence.

Gates run against the committed tree, with `HEAD` printed before and after to prove no drift: Go tests over `admin`, `trials`, `openrouterkeys`, `auditapi` and `audit`; `build:server`; `lint:server`; the `client/dashboard` audit-action guard test; and dashboard `type-check`. All exit 0, and re-run in full on the head above after the four post-open commits. `trials` carries no test files of its own; its behaviour is exercised through `admin`.

That guard test is why one client file is in the diff. It parses every `Action` constant out of `server/internal/audit/*.go` **at test time** and asserts the TypeScript list matches, so adding a Go constant breaks a package this slice otherwise never touches. Every gate on the first cut was a Go gate, and all of them passed while the branch was red.

No migration. No customer identifiers anywhere in the diff or this description.

