### PR TITLE
mig: add Stripe webhook event receipts

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -145,6 +145,23 @@ WHERE stripe_customer_id IS NOT NULL;
 
 COMMENT ON COLUMN billing_metadata.tunneled_mcp_server_limit IS 'Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.';
 
+-- Durable completion receipts for accepted Stripe webhooks. A row commits
+-- atomically with the handler's database effects.
+CREATE TABLE IF NOT EXISTS stripe_webhook_receipts (
+  stripe_event_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT stripe_webhook_receipts_pkey PRIMARY KEY (stripe_event_id),
+  CONSTRAINT stripe_webhook_receipts_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS stripe_webhook_receipts_organization_id_idx
+ON stripe_webhook_receipts (organization_id);
+
 -- Durable per-billing-cycle "tokens under management" (TUM) snapshots for an
 -- organization. ClickHouse telemetry expires (telemetry_logs after 90 days,
 -- chat_token_summaries after 730 days), so rows here are the permanent record

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -155,8 +155,7 @@ CREATE TABLE IF NOT EXISTS stripe_webhook_receipts (
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
-  CONSTRAINT stripe_webhook_receipts_pkey PRIMARY KEY (stripe_event_id),
-  CONSTRAINT stripe_webhook_receipts_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+  CONSTRAINT stripe_webhook_receipts_pkey PRIMARY KEY (stripe_event_id)
 );
 
 CREATE INDEX IF NOT EXISTS stripe_webhook_receipts_organization_id_idx

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2486,6 +2486,14 @@ type StripeMeterReport struct {
 	UpdatedAt      pgtype.Timestamptz
 }
 
+type StripeWebhookReceipt struct {
+	StripeEventID  string
+	OrganizationID string
+	EventType      string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
 // Durable record of a blocked tool call or prompt. One row per hook-time block decision, carrying the exact reason shown to the agent. Backs the durable /blocks/:id page and its thumbs feedback. The risk_results / risk_policies foreign keys are nullable enrichment links — the page renders from this row alone.
 type ToolCallBlock struct {
 	ID             uuid.UUID

--- a/server/migrations/20260814124226_stripe-webhook-event-receipts.sql
+++ b/server/migrations/20260814124226_stripe-webhook-event-receipts.sql
@@ -1,0 +1,12 @@
+-- Create "stripe_webhook_receipts" table
+CREATE TABLE "stripe_webhook_receipts" (
+  "stripe_event_id" text NOT NULL,
+  "organization_id" text NOT NULL,
+  "event_type" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("stripe_event_id"),
+  CONSTRAINT "stripe_webhook_receipts_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "stripe_webhook_receipts_organization_id_idx" to table: "stripe_webhook_receipts"
+CREATE INDEX "stripe_webhook_receipts_organization_id_idx" ON "stripe_webhook_receipts" ("organization_id");

--- a/server/migrations/20260814152427_stripe-webhook-event-receipts.sql
+++ b/server/migrations/20260814152427_stripe-webhook-event-receipts.sql
@@ -5,8 +5,7 @@ CREATE TABLE "stripe_webhook_receipts" (
   "event_type" text NOT NULL,
   "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
   "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
-  PRIMARY KEY ("stripe_event_id"),
-  CONSTRAINT "stripe_webhook_receipts_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+  PRIMARY KEY ("stripe_event_id")
 );
 -- Create index "stripe_webhook_receipts_organization_id_idx" to table: "stripe_webhook_receipts"
 CREATE INDEX "stripe_webhook_receipts_organization_id_idx" ON "stripe_webhook_receipts" ("organization_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:k5RH1AztnTy+Mg5O46CGO3OyvKyO759p51m1mX/eiwE=
+h1:FPKKL9w+F2wNSd2gQXsMdSzzuuBwfXRScTFYmne5g50=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -341,4 +341,4 @@ h1:k5RH1AztnTy+Mg5O46CGO3OyvKyO759p51m1mX/eiwE=
 20260813150000_user-sessions-tool-selection.sql h1:6l17RI8mPHjZDTtBoUDL+EDSTouOLhTEhgWK0COmOz0=
 20260813230844_platform-mcp-onboarding-milestone-generation.sql h1:N9818ntJknuX+hIp9KZ0RGzCich+h0H2nIFmaXsSfkk=
 20260814095831_payg-billing-foundation.sql h1:++Wz/+C4L4CEUekUCe2U9I/+8AGT85XqQPSYeLRKVWU=
-20260814124226_stripe-webhook-event-receipts.sql h1:CxtpdYXr04Vp51Rj0oK2sU+Ryin2CEkENlzimG3T2bY=
+20260814152427_stripe-webhook-event-receipts.sql h1:DHqXglVOvTVASvRPZdwK5atcTJFIL1lo1lohJ8WPxSY=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:IfiHRfAvXar+DjF42FDlIFFsqyiq+7prEBiE61O2I20=
+h1:k5RH1AztnTy+Mg5O46CGO3OyvKyO759p51m1mX/eiwE=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -341,3 +341,4 @@ h1:IfiHRfAvXar+DjF42FDlIFFsqyiq+7prEBiE61O2I20=
 20260813150000_user-sessions-tool-selection.sql h1:6l17RI8mPHjZDTtBoUDL+EDSTouOLhTEhgWK0COmOz0=
 20260813230844_platform-mcp-onboarding-milestone-generation.sql h1:N9818ntJknuX+hIp9KZ0RGzCich+h0H2nIFmaXsSfkk=
 20260814095831_payg-billing-foundation.sql h1:++Wz/+C4L4CEUekUCe2U9I/+8AGT85XqQPSYeLRKVWU=
+20260814124226_stripe-webhook-event-receipts.sql h1:CxtpdYXr04Vp51Rj0oK2sU+Ryin2CEkENlzimG3T2bY=


### PR DESCRIPTION
## Summary

- add durable Stripe webhook completion receipts keyed by the global Stripe event ID
- retain organization and event type context without storing webhook payloads
- keep organization ownership as indexed metadata without coupling receipt lifecycle to the organization row

Linear: https://linear.app/speakeasy/issue/DNO-836

## Rollout

- schema-only migration; no backfill required
- insert the receipt in the same transaction as webhook side effects
- handle the `stripe_event_id` primary-key conflict as an already-processed event
