### PR TITLE
feat: allow risk policies to be paused without deleting

### DIFF
--- a/.changeset/pause-risk-policies.md
+++ b/.changeset/pause-risk-policies.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Allow risk policies to be disabled and re-enabled from Policy Center and the policy detail page, so operators can pause enforcement without deleting the policy.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/Dropdown";
 import { Stack } from "@/components/ui/Stack";
@@ -44,6 +45,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import {
+  Fragment,
   useState,
   useCallback,
   useEffect,
@@ -98,6 +100,11 @@ import {
 } from "./policy-delete-dialog";
 import { SeverityBadge } from "./risk-ui";
 import { policySummary } from "./policy-summary";
+import { policyEnabledActionLabel } from "./policy-enabled";
+import {
+  togglePolicyEnabledVariables,
+  useTogglePolicyEnabled,
+} from "./use-toggle-policy-enabled";
 
 /** Per-policy config for the Non-Corporate Accounts category: the list of
  *  email domains treated as corporate. Rendered inside the category's
@@ -499,7 +506,14 @@ function PolicyNameCell({ row }: { row: PolicyRow }): JSX.Element {
   return (
     <span className="flex min-w-0 flex-col gap-0.5 py-0.5">
       <span className="flex min-w-0 items-center gap-1.5 font-medium">
-        <span className="truncate">{row.policy.name}</span>
+        <span
+          className={cn(
+            "truncate",
+            !row.policy.enabled && "text-muted-foreground",
+          )}
+        >
+          {row.policy.name}
+        </span>
         {row.kind === "prompt" && (
           <SimpleTooltip tooltip="Prompt-based policy">
             <Sparkles
@@ -605,6 +619,14 @@ function PolicyCenterContent() {
     },
   });
 
+  const toggleEnabledMutation = useTogglePolicyEnabled();
+
+  const handleToggleEnabled = (row: PolicyRow) => {
+    toggleEnabledMutation.mutate(
+      togglePolicyEnabledVariables(row.policy.id, !row.policy.enabled),
+    );
+  };
+
   // Redirect a deep-linked policy to its detail page once its data has loaded.
   // Guarded by a ref so it fires once per id (not on every policies re-fetch),
   // and marks unknown ids handled so a stale id doesn't retry every render.
@@ -642,8 +664,16 @@ function PolicyCenterContent() {
         ]
       : []),
     {
+      label: policyEnabledActionLabel(row.policy.enabled),
+      disabled: toggleEnabledMutation.isPending,
+      onClick: () => {
+        setTimeout(() => handleToggleEnabled(row), 0);
+      },
+    },
+    {
       label: "Delete",
       destructive: true,
+      separatorBefore: true,
       onClick: () => {
         setTimeout(() => handleDelete(row), 0);
       },
@@ -653,6 +683,16 @@ function PolicyCenterContent() {
   const confirmDelete = () => {
     if (!policyToDelete) return;
     deleteMutation.mutate({ request: { id: policyToDelete.policy.id } });
+  };
+
+  const confirmDisableInstead = () => {
+    if (!policyToDelete) return;
+    toggleEnabledMutation.mutate(
+      togglePolicyEnabledVariables(policyToDelete.policy.id, false),
+      {
+        onSuccess: () => setPolicyToDelete(null),
+      },
+    );
   };
 
   // Empty state for the Policies tab only. It must NOT short-circuit the whole
@@ -714,7 +754,8 @@ function PolicyCenterContent() {
   const insightsContext = [
     "Page: Policy Center.",
     `Total policies: ${policyRows.length}.`,
-    `Policy actions: ${policyRows.map((r) => `${r.policy.name} (${r.policy.action})`).join(", ") || "none"}.`,
+    `Active policies: ${policyRows.filter((r) => r.policy.enabled).length}.`,
+    `Policy actions: ${policyRows.map((r) => `${r.policy.name} (${r.policy.action}${r.policy.enabled ? "" : ", inactive"})`).join(", ") || "none"}.`,
     "Available risk tools: listRiskPolicies, getRiskPolicy, getRiskPolicyStatus, listRiskResultsForAgent (finding-level with match redaction), listRiskResultsByChat, listShadowMCPApprovals.",
     "Never echo match_redacted values verbatim. Refer to findings by rule_id and source.",
   ].join(" ");
@@ -734,6 +775,27 @@ function PolicyCenterContent() {
         <span className="inline-flex">
           <ActionBadge action={(row.policy.action as PolicyAction) ?? "flag"} />
         </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      width: "0.5fr",
+      render: (row) => (
+        <div onClick={(e) => e.stopPropagation()}>
+          <Switch
+            checked={row.policy.enabled}
+            disabled={toggleEnabledMutation.isPending}
+            onCheckedChange={(checked) =>
+              toggleEnabledMutation.mutate(
+                togglePolicyEnabledVariables(row.policy.id, checked),
+              )
+            }
+            aria-label={
+              row.policy.enabled ? "Disable policy" : "Enable policy"
+            }
+          />
+        </div>
       ),
     },
     {
@@ -821,17 +883,20 @@ function PolicyCenterContent() {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {policyActions(row).map((action) => (
-                <DropdownMenuItem
-                  key={action.label}
-                  className={cn(
-                    "cursor-pointer",
-                    action.destructive &&
-                      "text-destructive focus:text-destructive",
-                  )}
-                  onSelect={() => action.onClick()}
-                >
-                  {action.label}
-                </DropdownMenuItem>
+                <Fragment key={action.label}>
+                  {action.separatorBefore ? <DropdownMenuSeparator /> : null}
+                  <DropdownMenuItem
+                    disabled={action.disabled}
+                    className={cn(
+                      "cursor-pointer",
+                      action.destructive &&
+                        "text-destructive focus:text-destructive",
+                    )}
+                    onSelect={() => action.onClick()}
+                  >
+                    {action.label}
+                  </DropdownMenuItem>
+                </Fragment>
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
@@ -962,6 +1027,12 @@ function PolicyCenterContent() {
               </code>{" "}
               policy will be permanently deleted.
             </Text>
+            {policyToDelete?.policy.enabled ? (
+              <Text variant="body">
+                To stop scanning without losing this policy, disable it
+                instead.
+              </Text>
+            ) : null}
             {policyDeleteImpactText && (
               <Text variant="body">{policyDeleteImpactText}</Text>
             )}
@@ -987,10 +1058,23 @@ function PolicyCenterContent() {
               >
                 Cancel
               </Button>
+              {policyToDelete?.policy.enabled ? (
+                <Button
+                  variant="secondary"
+                  onClick={confirmDisableInstead}
+                  disabled={
+                    deleteMutation.isPending || toggleEnabledMutation.isPending
+                  }
+                >
+                  Disable instead
+                </Button>
+              ) : null}
               <Button
                 variant="destructive-primary"
                 onClick={confirmDelete}
-                disabled={deleteMutation.isPending}
+                disabled={
+                  deleteMutation.isPending || toggleEnabledMutation.isPending
+                }
               >
                 Delete Policy
               </Button>

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -691,15 +691,10 @@ function PolicyCenterContent() {
 
   const confirmDisableInstead = () => {
     if (!policyToDelete) return;
+    const row = policyToDelete;
+    setPolicyToDelete(null);
     toggleEnabledMutation.mutate(
-      togglePolicyEnabledVariables(
-        policyToDelete.policy.id,
-        policyToDelete.policy.name,
-        false,
-      ),
-      {
-        onSuccess: () => setPolicyToDelete(null),
-      },
+      togglePolicyEnabledVariables(row.policy.id, row.policy.name, false),
     );
   };
 

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -623,7 +623,11 @@ function PolicyCenterContent() {
 
   const handleToggleEnabled = (row: PolicyRow) => {
     toggleEnabledMutation.mutate(
-      togglePolicyEnabledVariables(row.policy.id, !row.policy.enabled),
+      togglePolicyEnabledVariables(
+        row.policy.id,
+        row.policy.name,
+        !row.policy.enabled,
+      ),
     );
   };
 
@@ -688,7 +692,11 @@ function PolicyCenterContent() {
   const confirmDisableInstead = () => {
     if (!policyToDelete) return;
     toggleEnabledMutation.mutate(
-      togglePolicyEnabledVariables(policyToDelete.policy.id, false),
+      togglePolicyEnabledVariables(
+        policyToDelete.policy.id,
+        policyToDelete.policy.name,
+        false,
+      ),
       {
         onSuccess: () => setPolicyToDelete(null),
       },
@@ -788,12 +796,14 @@ function PolicyCenterContent() {
             disabled={toggleEnabledMutation.isPending}
             onCheckedChange={(checked) =>
               toggleEnabledMutation.mutate(
-                togglePolicyEnabledVariables(row.policy.id, checked),
+                togglePolicyEnabledVariables(
+                  row.policy.id,
+                  row.policy.name,
+                  checked,
+                ),
               )
             }
-            aria-label={
-              row.policy.enabled ? "Disable policy" : "Enable policy"
-            }
+            aria-label={row.policy.enabled ? "Disable policy" : "Enable policy"}
           />
         </div>
       ),
@@ -1029,8 +1039,7 @@ function PolicyCenterContent() {
             </Text>
             {policyToDelete?.policy.enabled ? (
               <Text variant="body">
-                To stop scanning without losing this policy, disable it
-                instead.
+                To stop scanning without losing this policy, disable it instead.
               </Text>
             ) : null}
             {policyDeleteImpactText && (

--- a/client/dashboard/src/pages/security/PolicyDetail.shadow-mcp.test.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.shadow-mcp.test.tsx
@@ -2,7 +2,7 @@ import { useSdkClient } from "@/contexts/Sdk";
 import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
 import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Children, isValidElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { shadowMCPPolicyInventoryQueryKey } from "@/components/shadow-mcp/useShadowMCPPolicyInventory";
@@ -19,6 +19,10 @@ const mocks = vi.hoisted(() => ({
   kind: null as string | null,
   category: null as string | null,
   detectorSelections: [] as Array<{ category: string; selected: boolean }>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 vi.mock("@/contexts/Auth", () => ({
@@ -313,6 +317,47 @@ describe("StandardPolicyEditor cached Shadow MCP inventory", () => {
         "https://sketchy.example.com/mcp",
       ]);
       expect(mocks.modeRenders.at(-1)).toBe("block");
+    });
+  });
+});
+
+describe("StandardPolicyEditor policy pause", () => {
+  beforeEach(() => {
+    mocks.saveDisabledRenders.length = 0;
+    mocks.selectionRenders.length = 0;
+    mocks.modeRenders.length = 0;
+    mocks.step = "action";
+    mocks.kind = null;
+    mocks.category = null;
+    mocks.detectorSelections.length = 0;
+    vi.clearAllMocks();
+    vi.mocked(useSdkClient).mockReturnValue({
+      access: { listShadowMCPInventory: vi.fn() },
+    } as unknown as ReturnType<typeof useSdkClient>);
+  });
+
+  it("shows Inactive and an enable switch when the policy is disabled", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <StandardPolicyEditor
+            policy={{ ...blockingPolicyWithDirtyDraftName(), enabled: false }}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("Inactive")).toBeTruthy();
+    const toggle = screen.getByRole("switch", { name: "Enable policy" });
+    fireEvent.click(toggle);
+    expect(mocks.mutateUpdate).toHaveBeenCalledWith({
+      request: {
+        updateRiskPolicyRequestBody: { id: "policy-1", enabled: true },
+      },
     });
   });
 });

--- a/client/dashboard/src/pages/security/PolicyDetail.shadow-mcp.test.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.shadow-mcp.test.tsx
@@ -356,7 +356,11 @@ describe("StandardPolicyEditor policy pause", () => {
     fireEvent.click(toggle);
     expect(mocks.mutateUpdate).toHaveBeenCalledWith({
       request: {
-        updateRiskPolicyRequestBody: { id: "policy-1", enabled: true },
+        updateRiskPolicyRequestBody: {
+          id: "policy-1",
+          name: "Original name",
+          enabled: true,
+        },
       },
     });
   });

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -106,6 +106,11 @@ import {
 } from "./PolicyCenter";
 import { DetectorCard } from "./DetectorCard";
 import { builtInRuleDisabledReason } from "./policy-built-in-rule-exclusivity";
+import { policyStatusLabel } from "./policy-enabled";
+import {
+  togglePolicyEnabledVariables,
+  useTogglePolicyEnabled,
+} from "./use-toggle-policy-enabled";
 import {
   ALL_CATEGORIES,
   AVAILABLE_CATEGORIES,
@@ -530,6 +535,7 @@ function PolicyHeader({
   const isCreate = policy === null;
   const routes = useRoutes();
   const [editingName, setEditingName] = useState(false);
+  const toggleEnabledMutation = useTogglePolicyEnabled();
 
   return (
     <Stack
@@ -575,11 +581,30 @@ function PolicyHeader({
               <Pencil className="text-muted-foreground h-4 w-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
             </button>
           )}
-          {policy ? <StatusBadge /> : null}
+          {policy ? (
+            <>
+              <StatusBadge enabled={policy.enabled} />
+              <Switch
+                checked={policy.enabled}
+                disabled={saving || toggleEnabledMutation.isPending}
+                onCheckedChange={(checked) =>
+                  toggleEnabledMutation.mutate(
+                    togglePolicyEnabledVariables(policy.id, checked),
+                  )
+                }
+                aria-label={
+                  policy.enabled ? "Disable policy" : "Enable policy"
+                }
+              />
+            </>
+          ) : null}
         </Stack>
         {policy ? (
           <Text small muted>
             Version {policy.version} · {kindLabel}
+            {policy.enabled
+              ? null
+              : " · Inactive — new messages are not scanned"}
           </Text>
         ) : (
           <Text small muted>
@@ -631,8 +656,12 @@ function CreateButton({
   );
 }
 
-function StatusBadge(): JSX.Element {
-  return <Badge variant="success">Enforcing</Badge>;
+function StatusBadge({ enabled }: { enabled: boolean }): JSX.Element {
+  return (
+    <Badge variant={enabled ? "success" : "neutral"}>
+      {policyStatusLabel(enabled)}
+    </Badge>
+  );
 }
 
 // Vertical section header — title stacked over subtext with breathing room.
@@ -789,7 +818,6 @@ function PromptPolicyEditor({
         updateRiskPolicyRequestBody: {
           id: policy.id,
           name: name.trim() || policy.name,
-          enabled: true,
           prompt,
           modelConfig: {
             model: model || undefined,
@@ -3771,7 +3799,6 @@ export function StandardPolicyEditor({
           updateRiskPolicyRequestBody: {
             id: policy.id,
             name: name.trim() || policy.name,
-            enabled: true,
             sources,
             presidioEntities,
             promptInjectionRules,

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -589,12 +589,14 @@ function PolicyHeader({
                 disabled={saving || toggleEnabledMutation.isPending}
                 onCheckedChange={(checked) =>
                   toggleEnabledMutation.mutate(
-                    togglePolicyEnabledVariables(policy.id, checked),
+                    togglePolicyEnabledVariables(
+                      policy.id,
+                      policy.name,
+                      checked,
+                    ),
                   )
                 }
-                aria-label={
-                  policy.enabled ? "Disable policy" : "Enable policy"
-                }
+                aria-label={policy.enabled ? "Disable policy" : "Enable policy"}
               />
             </>
           ) : null}

--- a/client/dashboard/src/pages/security/policy-enabled.test.ts
+++ b/client/dashboard/src/pages/security/policy-enabled.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  policyEnabledActionLabel,
+  policyStatusLabel,
+} from "./policy-enabled";
+
+describe("policyEnabledActionLabel", () => {
+  it("offers Disable while the policy is enforcing", () => {
+    expect(policyEnabledActionLabel(true)).toBe("Disable");
+  });
+
+  it("offers Enable while the policy is inactive", () => {
+    expect(policyEnabledActionLabel(false)).toBe("Enable");
+  });
+});
+
+describe("policyStatusLabel", () => {
+  it("labels an enabled policy as Enforcing", () => {
+    expect(policyStatusLabel(true)).toBe("Enforcing");
+  });
+
+  it("labels a disabled policy as Inactive", () => {
+    expect(policyStatusLabel(false)).toBe("Inactive");
+  });
+});

--- a/client/dashboard/src/pages/security/policy-enabled.test.ts
+++ b/client/dashboard/src/pages/security/policy-enabled.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  policyEnabledActionLabel,
-  policyStatusLabel,
-} from "./policy-enabled";
+import { policyEnabledActionLabel, policyStatusLabel } from "./policy-enabled";
 
 describe("policyEnabledActionLabel", () => {
   it("offers Disable while the policy is enforcing", () => {

--- a/client/dashboard/src/pages/security/policy-enabled.ts
+++ b/client/dashboard/src/pages/security/policy-enabled.ts
@@ -1,0 +1,9 @@
+export function policyEnabledActionLabel(
+  enabled: boolean,
+): "Disable" | "Enable" {
+  return enabled ? "Disable" : "Enable";
+}
+
+export function policyStatusLabel(enabled: boolean): "Enforcing" | "Inactive" {
+  return enabled ? "Enforcing" : "Inactive";
+}

--- a/client/dashboard/src/pages/security/use-toggle-policy-enabled.test.ts
+++ b/client/dashboard/src/pages/security/use-toggle-policy-enabled.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { togglePolicyEnabledVariables } from "./use-toggle-policy-enabled";
+
+describe("togglePolicyEnabledVariables", () => {
+  it("sends only the policy id and enabled flag", () => {
+    expect(togglePolicyEnabledVariables("policy-1", false)).toEqual({
+      request: {
+        updateRiskPolicyRequestBody: { id: "policy-1", enabled: false },
+      },
+    });
+    expect(togglePolicyEnabledVariables("policy-1", true)).toEqual({
+      request: {
+        updateRiskPolicyRequestBody: { id: "policy-1", enabled: true },
+      },
+    });
+  });
+});

--- a/client/dashboard/src/pages/security/use-toggle-policy-enabled.test.ts
+++ b/client/dashboard/src/pages/security/use-toggle-policy-enabled.test.ts
@@ -2,15 +2,27 @@ import { describe, expect, it } from "vitest";
 import { togglePolicyEnabledVariables } from "./use-toggle-policy-enabled";
 
 describe("togglePolicyEnabledVariables", () => {
-  it("sends only the policy id and enabled flag", () => {
-    expect(togglePolicyEnabledVariables("policy-1", false)).toEqual({
+  it("sends the policy id, name, and enabled flag", () => {
+    expect(
+      togglePolicyEnabledVariables("policy-1", "Secrets Flagger", false),
+    ).toEqual({
       request: {
-        updateRiskPolicyRequestBody: { id: "policy-1", enabled: false },
+        updateRiskPolicyRequestBody: {
+          id: "policy-1",
+          name: "Secrets Flagger",
+          enabled: false,
+        },
       },
     });
-    expect(togglePolicyEnabledVariables("policy-1", true)).toEqual({
+    expect(
+      togglePolicyEnabledVariables("policy-1", "Secrets Flagger", true),
+    ).toEqual({
       request: {
-        updateRiskPolicyRequestBody: { id: "policy-1", enabled: true },
+        updateRiskPolicyRequestBody: {
+          id: "policy-1",
+          name: "Secrets Flagger",
+          enabled: true,
+        },
       },
     });
   });

--- a/client/dashboard/src/pages/security/use-toggle-policy-enabled.ts
+++ b/client/dashboard/src/pages/security/use-toggle-policy-enabled.ts
@@ -1,0 +1,38 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { invalidateAllRiskListPolicies } from "@gram/client/react-query/riskListPolicies.js";
+import { invalidateAllRiskOverview } from "@gram/client/react-query/riskOverview.js";
+import { invalidateAllRiskPoliciesGet } from "@gram/client/react-query/riskPoliciesGet.js";
+import { invalidateAllRiskPoliciesStatus } from "@gram/client/react-query/riskPoliciesStatus.js";
+import { useRiskPoliciesUpdateMutation } from "@gram/client/react-query/riskPoliciesUpdate.js";
+
+export function togglePolicyEnabledVariables(id: string, enabled: boolean) {
+  return {
+    request: {
+      updateRiskPolicyRequestBody: { id, enabled },
+    },
+  };
+}
+
+export function useTogglePolicyEnabled() {
+  const queryClient = useQueryClient();
+  return useRiskPoliciesUpdateMutation({
+    onSuccess: (policy) => {
+      void invalidateAllRiskListPolicies(queryClient);
+      void invalidateAllRiskPoliciesGet(queryClient);
+      void invalidateAllRiskPoliciesStatus(queryClient);
+      void invalidateAllRiskOverview(queryClient);
+      toast.success(
+        policy.enabled
+          ? "Policy enabled. New messages will be scanned."
+          : "Policy disabled. New messages will not be scanned.",
+      );
+    },
+    onError: (err) =>
+      toast.error(
+        err instanceof Error && err.message
+          ? err.message
+          : "Failed to update policy.",
+      ),
+  });
+}

--- a/client/dashboard/src/pages/security/use-toggle-policy-enabled.ts
+++ b/client/dashboard/src/pages/security/use-toggle-policy-enabled.ts
@@ -4,17 +4,26 @@ import { invalidateAllRiskListPolicies } from "@gram/client/react-query/riskList
 import { invalidateAllRiskOverview } from "@gram/client/react-query/riskOverview.js";
 import { invalidateAllRiskPoliciesGet } from "@gram/client/react-query/riskPoliciesGet.js";
 import { invalidateAllRiskPoliciesStatus } from "@gram/client/react-query/riskPoliciesStatus.js";
-import { useRiskPoliciesUpdateMutation } from "@gram/client/react-query/riskPoliciesUpdate.js";
+import {
+  useRiskPoliciesUpdateMutation,
+  type RiskPoliciesUpdateMutationVariables,
+} from "@gram/client/react-query/riskPoliciesUpdate.js";
 
-export function togglePolicyEnabledVariables(id: string, enabled: boolean) {
+export function togglePolicyEnabledVariables(
+  id: string,
+  name: string,
+  enabled: boolean,
+): RiskPoliciesUpdateMutationVariables {
   return {
     request: {
-      updateRiskPolicyRequestBody: { id, enabled },
+      updateRiskPolicyRequestBody: { id, name, enabled },
     },
   };
 }
 
-export function useTogglePolicyEnabled() {
+export function useTogglePolicyEnabled(): ReturnType<
+  typeof useRiskPoliciesUpdateMutation
+> {
   const queryClient = useQueryClient();
   return useRiskPoliciesUpdateMutation({
     onSuccess: (policy) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Risk policies already had an `enabled` flag on the server (scanners skip disabled policies; historical findings remain). The dashboard never exposed it: create/save always sent `enabled: true`, and the only way off a policy was delete.

This adds pause/resume in the UI so operators can temporarily stop enforcement without losing the policy.

## Changes

- **Policy Center:** Status switch on each row, Disable/Enable in the row menu, and a **Disable instead** action on the delete confirmation dialog.
- **Policy detail:** Status badge reflects Enforcing vs Inactive, with a switch next to it. Saving a policy no longer forces it back to enabled.
- Choosing **Disable instead** closes the confirmation immediately; success/error toasts still report the result.
- Existing overview and risk-events surfaces already handle inactive policies; those are unchanged.

Fixes AIS-554.

## Demo

<a href="https://cursor.com/agents/bc-2e0d43bb-3582-4d74-9365-5c0603466296/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpause_risk_policy_demo.webm"><img src="https://cursor.com/artifacts/c/art-84c4f90c-ca43-4406-a418-cd1cda2626e5" alt="pause_risk_policy_demo.webm" /></a>

What it shows:
1. Status switch turns a policy off; toast confirms new messages will not be scanned.
2. Delete confirmation offers **Disable instead**; the policy stays in the list, inactive.

![Policy Center Status column with switches](https://cursor.com/artifacts/c/art-658e6b92-b8be-4c72-95c6-4af385b00ee9)
![Disabled policy muted in the list](https://cursor.com/artifacts/c/art-382fb0ed-b141-428f-aa9e-3074433d1996)
![Delete dialog with Disable instead](https://cursor.com/artifacts/c/art-411be4fe-7cf4-41e5-b438-102e99966ef8)
![Policy detail Inactive badge and switch](https://cursor.com/artifacts/c/art-4b0915f7-b497-4df5-a58e-00a35dc88823)

## Test plan

- [x] Disable a policy from the Policy Center switch; list shows inactive (muted name, switch off) and the database `enabled` flag is false.
- [x] Re-enable from the Policy Center switch and from the policy detail header; badge returns to Enforcing.
- [x] Open delete confirmation on an active policy and choose **Disable instead**; policy remains in the list, disabled.
- [x] Policy detail shows Inactive badge, Enable switch, and “Inactive — new messages are not scanned.”
- [ ] Edit and save a disabled policy; confirm it stays disabled (save omits `enabled`).
- [ ] Confirm scanners skip disabled policies for new messages (existing server behavior).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-554](https://linear.app/speakeasy/issue/AIS-554/feedback-allow-risk-policies-to-be-paused-or-disabled)

<div><a href="https://cursor.com/agents/bc-2e0d43bb-3582-4d74-9365-5c0603466296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e0d43bb-3582-4d74-9365-5c0603466296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow operators to pause and resume risk policies without deleting them. Previously, saving a policy always re-enabled it; now disabling stops scanning new messages while historical findings remain.

- UI: Policy Center adds a Status switch and an Enable/Disable row action; the delete dialog offers Disable instead and closes immediately; disabled policies render muted. Policy Detail shows an Enforcing/Inactive badge with a toggle. Saving a policy no longer forces it back to enabled.
- Behavior/Data: Disabled policies remain visible and display “Inactive — new messages are not scanned.” `useTogglePolicyEnabled` updates the existing `enabled` flag by sending id, name, and enabled, invalidates risk caches, and surfaces success/error toasts; no API or schema changes.

Satisfies Linear AIS-554.

<sup>Written for commit f50e48f5a03ba028390b1b7a81c22be2e29e1ac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

