### PR TITLE
chore: isolate Blacksmith cache namespaces

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -201,6 +201,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment

--- a/.github/workflows/litellm-e2e.yml
+++ b/.github/workflows/litellm-e2e.yml
@@ -8,17 +8,18 @@ permissions:
 
 jobs:
   litellm-e2e:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2175,7 +2175,10 @@ jobs:
         with:
           install: true
           cache: true
-          cache_key_prefix: mise-blacksmith-v1
+          # This job only needs npx; avoid restoring the full ~606 MiB toolchain
+          # into a job with a five-minute timeout.
+          install_args: node
+          cache_key_prefix: mise-node-blacksmith-v1
           env: false
 
       - name: Run impeccable

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -259,7 +259,7 @@ jobs:
           # keep this job's cache separate from the full-install caches.
           install_args: yq
           cache: true
-          cache_key_prefix: mise-yq-v1
+          cache_key_prefix: mise-yq-blacksmith-v1
           env: false
 
       - id: "auth"
@@ -296,6 +296,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -461,6 +462,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -606,6 +608,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -747,6 +750,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Run ClickHouse migrations with golang-migrate
@@ -779,6 +783,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       # The ordering check needs both the checked-out head and the base commit
@@ -846,6 +851,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Lint PostgreSQL migrations
@@ -993,6 +999,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Fetch main branch
@@ -1055,6 +1062,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1151,6 +1159,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1217,6 +1226,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1272,6 +1282,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1326,6 +1337,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1369,6 +1381,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1433,6 +1446,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1476,6 +1490,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1517,6 +1532,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1700,6 +1716,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1757,6 +1774,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1803,6 +1821,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1848,6 +1867,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -1948,6 +1968,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -2094,6 +2115,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Prepare GitHub Actions environment
@@ -2153,6 +2175,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
 
       - name: Run impeccable

--- a/.github/workflows/release-hooks.yaml
+++ b/.github/workflows/release-hooks.yaml
@@ -39,12 +39,12 @@ jobs:
     # version, a signed build, and a pin pull request on an identical binary,
     # so the closure decides.
     name: Decide whether to release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       release: ${{ steps.decide.outputs.release }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
         with:
           fetch-depth: 0
       - name: Setup Mise
@@ -52,6 +52,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-blacksmith-v1
           env: false
       - name: Decide
         id: decide

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,9 @@ jobs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     env:
       GRAM_GIT_SHA: "${{ github.sha }}"
+      # npm trusted publishing requires this GitHub-hosted job, so keep its
+      # cache keys separate from the Blacksmith-backed CI namespace.
+      CACHE_NAMESPACE: github-v1
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,6 +37,7 @@ jobs:
         with:
           install: true
           cache: true
+          cache_key_prefix: mise-github-v1
           env: false
 
       - name: Prepare GitHub Actions environment

--- a/.mise-tasks/github/pre-cache.mts
+++ b/.mise-tasks/github/pre-cache.mts
@@ -18,9 +18,35 @@ if (!process.env["GITHUB_ENV"]) {
 
 const env = process.env["GITHUB_ENV"];
 
+// Blacksmith transparently handles actions/cache on its runners, but a
+// GitHub-hosted workflow can populate the same default-branch key in GitHub's
+// backend. Keep the namespaces distinct so an exact GitHub-backed hit cannot
+// prevent a colocated entry from being populated on Blacksmith.
+const configuredCacheNamespace = process.env["CACHE_NAMESPACE"];
+
+if (
+  process.env["RUNNER_ENVIRONMENT"] === "github-hosted" &&
+  !configuredCacheNamespace
+) {
+  console.error(
+    "CACHE_NAMESPACE must be set explicitly on GitHub-hosted runners",
+  );
+  process.exit(1);
+}
+
+const cacheNamespace = configuredCacheNamespace || "blacksmith-v1";
+
+if (!/^[A-Za-z0-9._-]+$/.test(cacheNamespace)) {
+  console.error(
+    "CACHE_NAMESPACE may only contain letters, numbers, dots, underscores, and hyphens",
+  );
+  process.exit(1);
+}
+
 async function setupGoCaching() {
   const goBuildCache = execSync("go env GOCACHE", { encoding: "utf8" }).trim();
   const goModCache = execSync("go env GOMODCACHE", { encoding: "utf8" }).trim();
+  const goVersion = execSync("go env GOVERSION", { encoding: "utf8" }).trim();
 
   await fs.appendFile(env, `GOCACHE=${goBuildCache}\n`);
   await fs.appendFile(env, `GOMODCACHE=${goModCache}\n`);
@@ -38,9 +64,8 @@ async function setupGoCaching() {
 
   const goModHash = hash.digest("hex");
 
-  const version = 1; // Increment this if you need to bust the cache
-  const cacheKey = `${version}-${os}-${arch}-${goModHash}`;
-  const partialKey = `${version}-${os}-${arch}-`;
+  const cacheKey = `${cacheNamespace}-${os}-${arch}-${goVersion}-${goModHash}`;
+  const partialKey = `${cacheNamespace}-${os}-${arch}-${goVersion}-`;
   await fs.appendFile(env, `GH_CACHE_GO_KEY=go-${cacheKey}\n`);
   await fs.appendFile(env, `GH_CACHE_GO_KEY_PARTIAL=go-${partialKey}\n`);
 
@@ -72,9 +97,8 @@ async function setupUVCaching() {
 
   const uvHash = hash.digest("hex");
 
-  const version = 1; // Increment this if you need to bust the cache
-  const cacheKey = `${version}-${os}-${arch}-uv${uvVersion}-${uvHash}`;
-  const partialKey = `${version}-${os}-${arch}-uv${uvVersion}-`;
+  const cacheKey = `${cacheNamespace}-${os}-${arch}-uv${uvVersion}-${uvHash}`;
+  const partialKey = `${cacheNamespace}-${os}-${arch}-uv${uvVersion}-`;
   await fs.appendFile(env, `GH_CACHE_UV_KEY=uv-${cacheKey}\n`);
   await fs.appendFile(env, `GH_CACHE_UV_KEY_PARTIAL=uv-${partialKey}\n`);
 
@@ -107,9 +131,8 @@ async function setupAubeCaching() {
 
   const lockfileHash = hash.digest("hex");
 
-  const version = 1; // Increment this if you need to bust the cache
-  const cacheKey = `${version}-${os}-${arch}-aube${aubeMajorVersion}-${lockfileHash}`;
-  const partialKey = `${version}-${os}-${arch}-aube${aubeMajorVersion}-`;
+  const cacheKey = `${cacheNamespace}-${os}-${arch}-aube${aubeMajorVersion}-${lockfileHash}`;
+  const partialKey = `${cacheNamespace}-${os}-${arch}-aube${aubeMajorVersion}-`;
   await fs.appendFile(env, `GH_CACHE_AUBE_KEY=aube-${cacheKey}\n`);
   await fs.appendFile(env, `GH_CACHE_AUBE_KEY_PARTIAL=aube-${partialKey}\n`);
 

--- a/.mise-tasks/github/pre-cache.mts
+++ b/.mise-tasks/github/pre-cache.mts
@@ -64,8 +64,9 @@ async function setupGoCaching() {
 
   const goModHash = hash.digest("hex");
 
-  const cacheKey = `${cacheNamespace}-${os}-${arch}-${goVersion}-${goModHash}`;
-  const partialKey = `${cacheNamespace}-${os}-${arch}-${goVersion}-`;
+  const version = 1; // Increment this to bust the Go cache
+  const cacheKey = `${cacheNamespace}-${version}-${os}-${arch}-${goVersion}-${goModHash}`;
+  const partialKey = `${cacheNamespace}-${version}-${os}-${arch}-${goVersion}-`;
   await fs.appendFile(env, `GH_CACHE_GO_KEY=go-${cacheKey}\n`);
   await fs.appendFile(env, `GH_CACHE_GO_KEY_PARTIAL=go-${partialKey}\n`);
 
@@ -97,8 +98,9 @@ async function setupUVCaching() {
 
   const uvHash = hash.digest("hex");
 
-  const cacheKey = `${cacheNamespace}-${os}-${arch}-uv${uvVersion}-${uvHash}`;
-  const partialKey = `${cacheNamespace}-${os}-${arch}-uv${uvVersion}-`;
+  const version = 1; // Increment this to bust the uv cache
+  const cacheKey = `${cacheNamespace}-${version}-${os}-${arch}-uv${uvVersion}-${uvHash}`;
+  const partialKey = `${cacheNamespace}-${version}-${os}-${arch}-uv${uvVersion}-`;
   await fs.appendFile(env, `GH_CACHE_UV_KEY=uv-${cacheKey}\n`);
   await fs.appendFile(env, `GH_CACHE_UV_KEY_PARTIAL=uv-${partialKey}\n`);
 
@@ -131,8 +133,9 @@ async function setupAubeCaching() {
 
   const lockfileHash = hash.digest("hex");
 
-  const cacheKey = `${cacheNamespace}-${os}-${arch}-aube${aubeMajorVersion}-${lockfileHash}`;
-  const partialKey = `${cacheNamespace}-${os}-${arch}-aube${aubeMajorVersion}-`;
+  const version = 1; // Increment this to bust the aube cache
+  const cacheKey = `${cacheNamespace}-${version}-${os}-${arch}-aube${aubeMajorVersion}-${lockfileHash}`;
+  const partialKey = `${cacheNamespace}-${version}-${os}-${arch}-aube${aubeMajorVersion}-`;
   await fs.appendFile(env, `GH_CACHE_AUBE_KEY=aube-${cacheKey}\n`);
   await fs.appendFile(env, `GH_CACHE_AUBE_KEY_PARTIAL=aube-${partialKey}\n`);
 

--- a/.mise-tasks/lint/webhooks-server.sh
+++ b/.mise-tasks/lint/webhooks-server.sh
@@ -13,7 +13,7 @@ BASE="${usage_base:-origin/main}"
 if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
   BREAKING=$(openapi-changes report --no-logo \
     "${BASE}:${CATALOG}" "${CATALOG}" 2>/dev/null \
-    | jq '[.reportSummary | to_entries[] | .value.breakingChanges] | add // 0')
+    | jq 'if type != "object" then error("unexpected report output") else [((.reportSummary // {}) | to_entries[]) | .value.breakingChanges] | add // 0 end')
 
   if [ "${BREAKING:-0}" -gt 0 ]; then
     openapi-changes markdown-report --no-logo \


### PR DESCRIPTION
## Summary

- isolate mise, Go, uv, and aube caches by runner provider so GitHub-hosted jobs cannot populate keys consumed by Blacksmith jobs
- move the remaining cache-bearing LiteLLM and release-hook gate jobs onto Blacksmith runners
- retain upstream `actions/cache`, which Blacksmith transparently redirects to its colocated cache backend; do not adopt the archived `useblacksmith/cache` fork
- give the five-minute UI scan a dedicated Node-only mise cache instead of restoring the full 606 MiB CI toolchain
- fail fast when a GitHub-hosted job omits its explicit cache namespace, validate namespace syntax, and scope Go caches by toolchain version
- retain independently bumpable `version` values for the Go, uv, and aube cache families

## Investigation

The timed-out [Detect UI anti-patterns job](https://github.com/speakeasy-api/gram/actions/runs/31799593851/job/94764323512) exact-hit a 635,453,710-byte `mise-v1` entry but restored it at about 1.8 MiB/s. After 286 seconds it had downloaded only 79.2%, and the five-minute job timeout cancelled the step.

The cache API and logs also showed a concrete provider-collision risk: the GitHub-hosted [Release job](https://github.com/speakeasy-api/gram/actions/runs/31788415571/job/94729504507) created the same `mise-v1` key on `main`. The new provider-specific keys remove that ambiguity and prevent either backend from exact-hitting entries created by the other provider.

[Blacksmith's current guidance](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions) is to keep using upstream `actions/cache`; its runners route those calls to the Blacksmith cache service automatically. The migration therefore separates provider namespaces instead of replacing the action.

CI also narrowed the remaining performance issue: the new `mise-blacksmith-v1` entry is absent from GitHub's cache API, proving the provider-isolated entry is in Blacksmith. Its first 606 MiB warm restore reached only 5.5 MiB/s, showing that slowdown was in the Blacksmith cache path at that time rather than another GitHub-cache hit. A later current-head run restored the 77 MiB Node-only entry at 150 MiB/s, confirming the colocated path recovered; the smaller job-specific cache also removes the timeout risk if backend throughput degrades again.

## Validation

- [Current-head `ci:full` run](https://github.com/speakeasy-api/gram/actions/runs/31820225209) — 34 jobs passed, two intentionally skipped, CI Gate passed
- warm target-only rerun — passed
- `mise run test:ci` — 9/9 passed
- `GITHUB_ACTIONS=true mise run lint:webhooks-server --base HEAD` — passed identical-catalog edge case exposed by `ci:full`
- `hk fix`, workflow YAML parsing, Prettier checks, and `git diff --check` — passed
- exercised generated Go/uv/aube keys with an isolated namespace, including Go-version scoping
- exercised failure paths for a missing GitHub-hosted namespace, invalid namespace characters, and malformed webhook reports
- adversarial review with `clink claude-fable-5` — READY, no remaining actionable findings after fixes and repeated re-review

## CI cache timing

The namespace and Go-key changes intentionally made the first full-toolchain run cold. The dedicated Node-only key then had its own one-time cold population before the warm measurement.

| Measurement | Cache size | Setup Mise | Effective throughput | Delta vs failed baseline |
| --- | ---: | ---: | ---: | ---: |
| [Failed baseline](https://github.com/speakeasy-api/gram/actions/runs/31799593851/job/94764323512) | ~606 MiB | timed out after 286 s at 79.2% | ~1.8 MiB/s | — |
| [Provider-isolated full cache, cold](https://github.com/speakeasy-api/gram/actions/runs/31803303875/job/94776134005) | ~606 MiB | 89 s | cache miss | 68.9% less time |
| [Provider-isolated full cache, warm](https://github.com/speakeasy-api/gram/actions/runs/31804188626/job/94779017163) | ~606 MiB | 115 s | 5.5 MiB/s | 59.8% less time; 3.1x throughput |
| [Node-only cache, cold](https://github.com/speakeasy-api/gram/actions/runs/31805033446/job/94781955699) | ~77 MiB | 37 s, including save | 11.0 MiB/s upload | 87.1% less time |
| [Node-only cache, first warm](https://github.com/speakeasy-api/gram/actions/runs/31805033446/job/94787640368) | ~77 MiB | 10 s | 10.9 MiB/s | 96.5% less time; 6.1x throughput |
| [Node-only cache, current head](https://github.com/speakeasy-api/gram/actions/runs/31820225209/job/94831425500) | ~77 MiB | **2 s** | **150 MiB/s** | **99.3% less time; 83.3x throughput** |
