### PR TITLE
fix: isolate Redis caches in tests

### DIFF
--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
@@ -158,7 +157,7 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 	}
 
 	authzProvisioner := authz.NewProvisioner(conn)
-	cacheSuffix := cache.Suffix("auth-" + t.Name() + "-" + uuid.NewString())
+	cacheSuffix := testenv.NewCacheSuffix(t, cache.Suffix("auth"))
 	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, wf, orgRepo.New(conn), usersRepo.New(conn), pylonClient, posthogClient, cacheSuffix)
 	sessionManager := sessions.NewManager(
 		logger, tracerProvider, conn, redisClient, cacheSuffix,

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
@@ -157,9 +158,10 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 	}
 
 	authzProvisioner := authz.NewProvisioner(conn)
-	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, wf, orgRepo.New(conn), usersRepo.New(conn), pylonClient, posthogClient, cache.SuffixNone)
+	cacheSuffix := cache.Suffix("auth-" + t.Name() + "-" + uuid.NewString())
+	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, wf, orgRepo.New(conn), usersRepo.New(conn), pylonClient, posthogClient, cacheSuffix)
 	sessionManager := sessions.NewManager(
-		logger, tracerProvider, conn, redisClient, cache.Suffix("gram-e2e"),
+		logger, tracerProvider, conn, redisClient, cacheSuffix,
 		idpClient, billingClient, resolver,
 	)
 

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -81,7 +81,7 @@ func NewManager(
 	return &Manager{
 		logger:       logger,
 		tracer:       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/auth/sessions"),
-		sessionCache: cache.NewTypedObjectCache[Session](logger.With(attr.SlogCacheNamespace("session")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
+		sessionCache: cache.NewTypedObjectCache[Session](logger.With(attr.SlogCacheNamespace("session")), cache.NewRedisCacheAdapter(redisClient), suffix),
 		idpClient:    idpClient,
 		orgRepo:      orgRepo.New(db),
 		billingRepo:  billingRepo,

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
@@ -179,7 +178,7 @@ func newTestAuthServiceWithWorkOSClient(t *testing.T, userInfo *MockUserInfo, wo
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	authzProvisioner := authz.NewProvisioner(conn)
-	cacheSuffix := cache.Suffix("auth-" + t.Name() + "-" + uuid.NewString())
+	cacheSuffix := testenv.NewCacheSuffix(t, cache.Suffix("auth"))
 	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, workosClient, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cacheSuffix)
 	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cacheSuffix, idpClient, billingClient, resolver)
 
@@ -246,7 +245,7 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	authzProvisioner := authz.NewProvisioner(conn)
-	cacheSuffix := cache.Suffix("auth-" + t.Name() + "-" + uuid.NewString())
+	cacheSuffix := testenv.NewCacheSuffix(t, cache.Suffix("auth"))
 	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, nil, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cacheSuffix)
 	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cacheSuffix, idpClient, billingClient, resolver)
 

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
@@ -178,8 +179,9 @@ func newTestAuthServiceWithWorkOSClient(t *testing.T, userInfo *MockUserInfo, wo
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	authzProvisioner := authz.NewProvisioner(conn)
-	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, workosClient, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cache.SuffixNone)
-	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cache.Suffix("gram-test"), idpClient, billingClient, resolver)
+	cacheSuffix := cache.Suffix("auth-" + t.Name() + "-" + uuid.NewString())
+	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, workosClient, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cacheSuffix)
+	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cacheSuffix, idpClient, billingClient, resolver)
 
 	authConfigs := auth.AuthConfigurations{
 		IDPBaseURL:        mockServer.URL,
@@ -244,8 +246,9 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	authzProvisioner := authz.NewProvisioner(conn)
-	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, nil, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cache.SuffixNone)
-	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cache.Suffix("gram-test"), idpClient, billingClient, resolver)
+	cacheSuffix := cache.Suffix("auth-" + t.Name() + "-" + uuid.NewString())
+	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, nil, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cacheSuffix)
+	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cacheSuffix, idpClient, billingClient, resolver)
 
 	authConfigs := auth.AuthConfigurations{
 		IDPBaseURL:        mockServer.URL,

--- a/server/internal/chat/setup_test.go
+++ b/server/internal/chat/setup_test.go
@@ -106,10 +106,7 @@ func newTestChatServiceWithOptions(t *testing.T, completionClient openrouter.Com
 	require.NoError(t, err)
 
 	billingClient := billing.NewStubClient(logger, tp)
-	// Use a unique suffix per test to isolate Redis cache entries when tests
-	// run in parallel and all use the same mockidp.MockUserID.
-	suffix := cache.Suffix("gram-local-" + uuid.NewString()[:8])
-	mgr := testenv.NewTestManager(t, logger, tp, conn, redisClient, suffix, billingClient)
+	mgr := testenv.NewTestManager(t, logger, tp, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	assetStorage := assetstest.NewTestBlobStore(t)

--- a/server/internal/litellm/setup_test.go
+++ b/server/internal/litellm/setup_test.go
@@ -107,7 +107,7 @@ func newRealTestServiceWithScannerFactory(t *testing.T, scannerFactory func(*pgx
 	redisClient, err := testInfra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 	billingClient := billing.NewStubClient(logger, tracerProvider)
-	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("litellm-test-"+uuid.NewString()), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("litellm-test"), billingClient)
 	ctx = authztest.InitAuthContext(t, ctx, conn, sessionManager)
 	chConn, err := testInfra.NewClickhouseClient(t)
 	require.NoError(t, err)

--- a/server/internal/testenv/auth.go
+++ b/server/internal/testenv/auth.go
@@ -34,6 +34,7 @@ import (
 // manager as the UserResolver, matching the production wiring in start.go.
 func NewTestManager(t *testing.T, logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, redisClient *redis.Client, suffix cache.Suffix, billingRepo billing.Repository) *sessions.Manager {
 	t.Helper()
+	suffix = cache.Suffix(fmt.Sprintf("%s-%s-%s", suffix, t.Name(), uuid.NewString()))
 
 	cfg := mockidp.NewConfig()
 	srv := httptest.NewServer(mockidp.Handler(cfg))

--- a/server/internal/testenv/auth.go
+++ b/server/internal/testenv/auth.go
@@ -34,7 +34,7 @@ import (
 // manager as the UserResolver, matching the production wiring in start.go.
 func NewTestManager(t *testing.T, logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, redisClient *redis.Client, suffix cache.Suffix, billingRepo billing.Repository) *sessions.Manager {
 	t.Helper()
-	suffix = cache.Suffix(fmt.Sprintf("%s-%s-%s", suffix, t.Name(), uuid.NewString()))
+	suffix = NewCacheSuffix(t, suffix)
 
 	cfg := mockidp.NewConfig()
 	srv := httptest.NewServer(mockidp.Handler(cfg))

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -16,10 +17,18 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	tracernoop "go.opentelemetry.io/otel/trace/noop"
 
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
+
+// NewCacheSuffix returns a cache suffix unique to this test invocation.
+func NewCacheSuffix(t *testing.T, base cache.Suffix) cache.Suffix {
+	t.Helper()
+
+	return cache.Suffix(string(base) + "-" + t.Name() + "-" + uuid.NewString())
+}
 
 func DefaultSiteURL(t *testing.T) *url.URL {
 	t.Helper()


### PR DESCRIPTION
## Summary

- isolate Redis-backed identity and session caches per test instance
- honor the cache suffix passed to the session manager
- apply unique cache namespaces centrally for server test managers

## Testing

- `mise exec -- go test ./server/internal/auth -run 'TestAuthorizeSession|TestE2E_Callback_IDPOrgSelectionSyncsMissingMembershipForExistingUser' -count=20`
- `mise exec -- go test ./server/internal/auth -count=2`
- `mise exec -- go test ./server/internal/agent ./server/internal/plugins -count=5`
- `mise lint:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates Redis-backed identity and session caches per test to eliminate cross-test pollution and flakiness. Previously tests reused fixed cache namespaces and `sessions.NewManager` hardcoded `cache.SuffixNone`; now `sessions.NewManager` honors the provided suffix and tests derive a per-test suffix.

- `sessions.NewManager` uses the passed suffix when creating `cache.NewTypedObjectCache` (was `cache.SuffixNone`).
- Adds `testenv.NewCacheSuffix(t, base)` to generate `base-<t.Name>-<uuid>`; `testenv.NewTestManager` applies it automatically.
- Auth, chat, and litellm tests pass a stable base suffix and rely on `NewTestManager`; auth tests pass the same per-test suffix to the identity resolver and session manager.
- No production behavior changes; only test cache namespaces change.

<sup>Written for commit 8d270b8c662908e199edfe5293b094697f929dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

