### PR TITLE
feat: pre-fill exclusion rule from starting Watchdog signal

### DIFF
--- a/client/dashboard/src/pages/security/exclusion-options.test.ts
+++ b/client/dashboard/src/pages/security/exclusion-options.test.ts
@@ -75,6 +75,27 @@ describe("exclusionOptions", () => {
     });
   });
 
+  it("offers a preset rule before any findings load", () => {
+    const options = exclusionOptions([], undefined, "pii.email_address");
+    expect(options.map((o) => o.value)).toEqual(["rule", "custom"]);
+    expect(options[0]?.fields).toMatchObject({
+      matchType: "rule_id",
+      matchValue: "pii.email_address",
+    });
+  });
+
+  it("lets the selection's shared rule win over a preset", () => {
+    const options = exclusionOptions(
+      [result({ ruleId: "generic-api-key" })],
+      undefined,
+      "pii.email_address",
+    );
+    expect(options.find((o) => o.value === "rule")?.fields).toMatchObject({
+      matchType: "rule_id",
+      matchValue: "generic-api-key",
+    });
+  });
+
   it("offers only custom when rows share neither rule nor source", () => {
     expect(
       values([

--- a/client/dashboard/src/pages/security/exclusion-options.ts
+++ b/client/dashboard/src/pages/security/exclusion-options.ts
@@ -66,13 +66,14 @@ function shared<K extends "ruleId" | "source">(
 // finding — its plaintext comes from the finding itself on the chat surfaces,
 // or from `exact` on the masked list pages, where the raw match never reaches
 // the browser until it is unmasked. Rule and source rules need every selected
-// row to agree on that field — except `signalRuleId`, which a signal-originated
-// create supplies directly: the Watchdog signal already names the rule, so the
-// rule option must not depend on evidence rows having loaded.
+// row to agree on that field — except `presetRuleId`, which an opener that
+// already knows the rule (the Watchdog signal drawer) supplies directly, so the
+// rule option doesn't depend on findings having loaded. The selection wins when
+// it determines a rule of its own.
 export function exclusionOptions(
   results: RiskResult[],
   exact?: ExactCandidate,
-  signalRuleId?: string,
+  presetRuleId?: string,
 ): ExclusionOption[] {
   const options: ExclusionOption[] = [];
 
@@ -92,7 +93,7 @@ export function exclusionOptions(
     });
   }
 
-  const ruleId = shared(results, "ruleId") ?? signalRuleId;
+  const ruleId = shared(results, "ruleId") ?? presetRuleId;
   if (ruleId) {
     options.push({
       value: "rule",

--- a/client/dashboard/src/pages/security/exclusion-options.ts
+++ b/client/dashboard/src/pages/security/exclusion-options.ts
@@ -66,10 +66,13 @@ function shared<K extends "ruleId" | "source">(
 // finding — its plaintext comes from the finding itself on the chat surfaces,
 // or from `exact` on the masked list pages, where the raw match never reaches
 // the browser until it is unmasked. Rule and source rules need every selected
-// row to agree on that field.
+// row to agree on that field — except `signalRuleId`, which a signal-originated
+// create supplies directly: the Watchdog signal already names the rule, so the
+// rule option must not depend on evidence rows having loaded.
 export function exclusionOptions(
   results: RiskResult[],
   exact?: ExactCandidate,
+  signalRuleId?: string,
 ): ExclusionOption[] {
   const options: ExclusionOption[] = [];
 
@@ -89,7 +92,7 @@ export function exclusionOptions(
     });
   }
 
-  const ruleId = shared(results, "ruleId");
+  const ruleId = shared(results, "ruleId") ?? signalRuleId;
   if (ruleId) {
     options.push({
       value: "rule",

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -24,7 +24,6 @@ import { useRiskSuggestExclusionMutation } from "@gram/client/react-query/riskSu
 import { useRiskUpdateExclusionMutation } from "@gram/client/react-query/riskUpdateExclusion.js";
 import type { RiskExclusion } from "@gram/client/models/components/riskexclusion.js";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
-import type { RiskSignal } from "@gram/client/models/components/risksignal.js";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/RadioGroup";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, Sparkles } from "lucide-react";
@@ -63,10 +62,11 @@ export type ExclusionSheetState =
        * picker; absent for the Exclusions tab / Policy Center buttons, which
        * have no finding and open straight onto the criteria box. */
       results?: RiskResult[];
-      /** The Watchdog signal the create was started from. Signals cluster on
-       * one rule, so this pre-fills the "Any <rule> finding" option — and
-       * makes it the default — even before any evidence rows have loaded. */
-      signal?: RiskSignal;
+      /** The detection rule the create is pre-targeted at, for an opener that
+       * knows it independently of the findings — a Watchdog signal clusters on
+       * one rule. Pre-fills the "Any <rule> finding" option and makes it the
+       * default, even before any evidence rows have loaded. */
+      presetRuleId?: string;
     }
   | { mode: "edit"; exclusion: RiskExclusion };
 
@@ -138,10 +138,7 @@ export function ExclusionEditor({
   const formKey =
     state.mode === "edit"
       ? `edit-${state.exclusion.id}`
-      : // The signal key participates so a signal-originated create remounts
-        // when the drawer switches signals even while both have no evidence
-        // rows loaded yet.
-        `create-${state.signal?.key ?? ""}-${(state.results ?? []).map((r) => r.id).join(",")}`;
+      : `create-${(state.results ?? []).map((r) => r.id).join(",")}`;
 
   return (
     <ExclusionForm
@@ -252,7 +249,7 @@ function ExclusionForm({
 }: ExclusionFormProps) {
   const editing = state.mode === "edit" ? state.exclusion : null;
   const results = state.mode === "create" ? (state.results ?? []) : [];
-  const signal = state.mode === "create" ? state.signal : undefined;
+  const presetRuleId = state.mode === "create" ? state.presetRuleId : undefined;
   const single = results.length === 1 ? results[0] : undefined;
 
   // Risk Events and Risk Overview null the raw match at the API boundary, so
@@ -271,14 +268,13 @@ function ExclusionForm({
 
   // Ready-made rules for the selection. Always at least ["custom"], so an
   // edit or a no-finding create renders no picker and opens on the DSL box.
-  // A signal supplies its rule directly, so the rule option is on offer even
-  // before evidence rows load.
-  const options = exclusionOptions(results, exact, signal?.ruleId);
+  // A pre-targeted rule is on offer even before any findings load.
+  const options = exclusionOptions(results, exact, presetRuleId);
   const [choice, setChoice] = useState<ExclusionOption["value"]>(() => {
-    // A signal-originated create defaults to the rule option: the flow began
-    // as "stop flagging this signal", which is the whole rule cluster, not
-    // any one matched value.
-    if (signal && options.some((o) => o.value === "rule")) return "rule";
+    // A pre-targeted create opens on the rule option: the flow began as "stop
+    // flagging this signal", which is the whole rule cluster, not any one
+    // matched value. The option is always present when the id is.
+    if (presetRuleId) return "rule";
     // A pending exact option is not savable yet, so never open on it —
     // selecting it is the gesture that fires the reveal.
     return (

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -138,7 +138,11 @@ export function ExclusionEditor({
   const formKey =
     state.mode === "edit"
       ? `edit-${state.exclusion.id}`
-      : `create-${(state.results ?? []).map((r) => r.id).join(",")}`;
+      : // Keyed by both inputs the form seeds from, so a host that swaps one
+        // create for another — a different rule with the same findings, or
+        // none on either side — rebuilds instead of keeping the old selection
+        // and draft.
+        `create-${state.presetRuleId ?? ""}-${(state.results ?? []).map((r) => r.id).join(",")}`;
 
   return (
     <ExclusionForm

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -24,6 +24,7 @@ import { useRiskSuggestExclusionMutation } from "@gram/client/react-query/riskSu
 import { useRiskUpdateExclusionMutation } from "@gram/client/react-query/riskUpdateExclusion.js";
 import type { RiskExclusion } from "@gram/client/models/components/riskexclusion.js";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
+import type { RiskSignal } from "@gram/client/models/components/risksignal.js";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/RadioGroup";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, Sparkles } from "lucide-react";
@@ -62,6 +63,10 @@ export type ExclusionSheetState =
        * picker; absent for the Exclusions tab / Policy Center buttons, which
        * have no finding and open straight onto the criteria box. */
       results?: RiskResult[];
+      /** The Watchdog signal the create was started from. Signals cluster on
+       * one rule, so this pre-fills the "Any <rule> finding" option — and
+       * makes it the default — even before any evidence rows have loaded. */
+      signal?: RiskSignal;
     }
   | { mode: "edit"; exclusion: RiskExclusion };
 
@@ -133,7 +138,10 @@ export function ExclusionEditor({
   const formKey =
     state.mode === "edit"
       ? `edit-${state.exclusion.id}`
-      : `create-${(state.results ?? []).map((r) => r.id).join(",")}`;
+      : // The signal key participates so a signal-originated create remounts
+        // when the drawer switches signals even while both have no evidence
+        // rows loaded yet.
+        `create-${state.signal?.key ?? ""}-${(state.results ?? []).map((r) => r.id).join(",")}`;
 
   return (
     <ExclusionForm
@@ -244,6 +252,7 @@ function ExclusionForm({
 }: ExclusionFormProps) {
   const editing = state.mode === "edit" ? state.exclusion : null;
   const results = state.mode === "create" ? (state.results ?? []) : [];
+  const signal = state.mode === "create" ? state.signal : undefined;
   const single = results.length === 1 ? results[0] : undefined;
 
   // Risk Events and Risk Overview null the raw match at the API boundary, so
@@ -262,13 +271,20 @@ function ExclusionForm({
 
   // Ready-made rules for the selection. Always at least ["custom"], so an
   // edit or a no-finding create renders no picker and opens on the DSL box.
-  const options = exclusionOptions(results, exact);
-  const [choice, setChoice] = useState<ExclusionOption["value"]>(
+  // A signal supplies its rule directly, so the rule option is on offer even
+  // before evidence rows load.
+  const options = exclusionOptions(results, exact, signal?.ruleId);
+  const [choice, setChoice] = useState<ExclusionOption["value"]>(() => {
+    // A signal-originated create defaults to the rule option: the flow began
+    // as "stop flagging this signal", which is the whole rule cluster, not
+    // any one matched value.
+    if (signal && options.some((o) => o.value === "rule")) return "rule";
     // A pending exact option is not savable yet, so never open on it —
     // selecting it is the gesture that fires the reveal.
-    () =>
-      options.find((o) => o.value !== "exact" || o.fields)?.value ?? "custom",
-  );
+    return (
+      options.find((o) => o.value !== "exact" || o.fields)?.value ?? "custom"
+    );
+  });
   const picked = options.find((o) => o.value === choice);
   // A finding-originated create is always global: "stop flagging this" means
   // everywhere, and the Scope select is there to narrow it.

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -17,7 +17,7 @@ import { useRiskListResults } from "@gram/client/react-query/riskListResults.js"
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { Loader2 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ExclusionEditor, type ExclusionSheetState } from "../exclusion-sheet";
 import {
@@ -245,8 +245,9 @@ export function SignalDrawer({
     if (!signal) return;
     // The signal itself carries the rule, so the sheet offers — and defaults
     // to — the "Any <rule> finding" option even before evidence rows load.
-    // Whatever evidence has arrived by now rides along for the exact-value
-    // option and the custom branch's findings context; opening before the
+    // Whatever evidence has arrived by now rides along for the custom branch's
+    // findings context — and, only where the rule has a lone evidence row, the
+    // exact-value option, which needs a single finding. Opening before the
     // query resolves makes this a rule-only create, since the snapshot
     // deliberately doesn't refill as rows land — that would rebuild the form
     // under an operator who is already typing.
@@ -272,21 +273,26 @@ export function SignalDrawer({
   // itself still runs to completion. Keyed by timestamps rather than Date
   // identity, and by signal key rather than the signal object, so neither an
   // equal window nor a list refetch discards a live collection.
+  //
+  // Both resets run before paint: a passive effect would let the swap commit
+  // first, painting one frame of the previous selection's dialog or editor
+  // under the new signal's name.
   const collectionToken = useRef(0);
   const windowFrom = window.from?.getTime();
   const windowTo = window.to?.getTime();
-  useEffect(() => {
+  useLayoutEffect(() => {
     collectionToken.current += 1;
     setPendingDismiss(null);
     setCollecting(false);
   }, [signal?.key, windowFrom, windowTo]);
 
   // Editor state follows the signal alone: an open editor would go on targeting
-  // the previous signal's rule, and the back-from-editor slide would replay for
-  // a signal whose editor was never opened. The window is deliberately absent —
-  // the rule and evidence the editor seeds from are unwindowed, so a date
-  // change must not discard a half-filled form.
-  useEffect(() => {
+  // the previous signal's rule (and keep the sheet's close affordance hidden),
+  // and the back-from-editor slide would replay for a signal whose editor was
+  // never opened. The window is deliberately absent — the rule and evidence the
+  // editor seeds from are unwindowed, so a date change must not discard a
+  // half-filled form.
+  useLayoutEffect(() => {
     setExclusionState(null);
     setReturningFromEditor(false);
   }, [signal?.key]);

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -245,8 +245,11 @@ export function SignalDrawer({
     if (!signal) return;
     // The signal itself carries the rule, so the sheet offers — and defaults
     // to — the "Any <rule> finding" option even before evidence rows load.
-    // Evidence rows still ride along for the exact-value option and the
-    // custom branch's findings context.
+    // Whatever evidence has arrived by now rides along for the exact-value
+    // option and the custom branch's findings context; opening before the
+    // query resolves makes this a rule-only create, since the snapshot
+    // deliberately doesn't refill as rows land — that would rebuild the form
+    // under an operator who is already typing.
     setExclusionState({
       mode: "create",
       results: evidence,
@@ -261,18 +264,23 @@ export function SignalDrawer({
     signal !== null && hasJudgeSource(signal.detectionSources);
 
   // Which signal is on screen is a URL param, so browser back/forward swaps it
-  // while the drawer stays mounted — and every piece of state here snapshots
+  // while the drawer stays mounted — and every piece of state here belongs to
   // the signal it was started from, so none of it may outlive a switch. An open
-  // exclusion editor would go on targeting the previous signal's rule, a
+  // exclusion editor would go on targeting the previous signal's rule; a
   // pending dismissal would clear the previous signal's findings under the new
-  // signal's name, and a collection still in flight must not open that dialog
-  // at all. Tracked by key rather than by the signal object so a list refetch's
-  // new identity doesn't discard live state; clearing on mount is a no-op.
+  // signal's name; a collection still in flight would leave the new signal's
+  // action spinning (and must not open that dialog at all — hence the key
+  // compare below); and the back-from-editor transition would replay for a
+  // signal whose editor was never opened. Tracked by key rather than by the
+  // signal object so a list refetch's new identity doesn't discard live state;
+  // clearing on mount is a no-op.
   const activeSignalKey = useRef<string | null>(null);
   useEffect(() => {
     activeSignalKey.current = signal?.key ?? null;
     setExclusionState(null);
     setPendingDismiss(null);
+    setCollecting(false);
+    setReturningFromEditor(false);
   }, [signal?.key]);
 
   const openSignalDismiss = async () => {
@@ -291,7 +299,10 @@ export function SignalDrawer({
       if (activeSignalKey.current !== requestKey) return;
       toast.error("Failed to load this signal's findings.");
     } finally {
-      setCollecting(false);
+      // Same guard: the switch already cleared the flag for the new signal, so
+      // a late-settling request must not clear it out from under a collection
+      // the operator started there.
+      if (activeSignalKey.current === requestKey) setCollecting(false);
     }
   };
 

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -243,11 +243,11 @@ export function SignalDrawer({
 
   const openSignalExclusion = () => {
     if (!signal) return;
-    // The sheet derives its ready-made rule options from the findings it is
-    // handed; the loaded evidence rows all share this signal's rule, so the
-    // "Any <rule> finding" option is on offer. Before evidence loads the
-    // sheet still opens, just without ready-made options.
-    setExclusionState({ mode: "create", results: evidence });
+    // The signal itself carries the rule, so the sheet offers — and defaults
+    // to — the "Any <rule> finding" option even before evidence rows load.
+    // Evidence rows still ride along for the exact-value option and the
+    // custom branch's findings context.
+    setExclusionState({ mode: "create", results: evidence, signal });
   };
 
   // Judge-backed signals get false-positive dismissal as the signal-level

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -263,29 +263,37 @@ export function SignalDrawer({
   const judgeSignal =
     signal !== null && hasJudgeSource(signal.detectionSources);
 
-  // Which signal is on screen is a URL param, so browser back/forward swaps it
-  // while the drawer stays mounted — and every piece of state here belongs to
-  // the signal it was started from, so none of it may outlive a switch. An open
-  // exclusion editor would go on targeting the previous signal's rule; a
-  // pending dismissal would clear the previous signal's findings under the new
-  // signal's name; a collection still in flight would leave the new signal's
-  // action spinning (and must not open that dialog at all — hence the key
-  // compare below); and the back-from-editor transition would replay for a
-  // signal whose editor was never opened. Tracked by key rather than by the
-  // signal object so a list refetch's new identity doesn't discard live state;
-  // clearing on mount is a no-op.
-  const activeSignalKey = useRef<string | null>(null);
+  // Signal and window both live in the URL, so back/forward can swap either
+  // while the drawer stays mounted, and a dismissal belongs to the pair it was
+  // started from: surfacing one after a swap would confirm the previous
+  // selection's findings under the new one's name, or leave its action
+  // spinning. Bumping the token makes an in-flight collection drop its result —
+  // and its spinner reset — rather than land on the new selection; the request
+  // itself still runs to completion. Keyed by timestamps rather than Date
+  // identity, and by signal key rather than the signal object, so neither an
+  // equal window nor a list refetch discards a live collection.
+  const collectionToken = useRef(0);
+  const windowFrom = window.from?.getTime();
+  const windowTo = window.to?.getTime();
   useEffect(() => {
-    activeSignalKey.current = signal?.key ?? null;
-    setExclusionState(null);
+    collectionToken.current += 1;
     setPendingDismiss(null);
     setCollecting(false);
+  }, [signal?.key, windowFrom, windowTo]);
+
+  // Editor state follows the signal alone: an open editor would go on targeting
+  // the previous signal's rule, and the back-from-editor slide would replay for
+  // a signal whose editor was never opened. The window is deliberately absent —
+  // the rule and evidence the editor seeds from are unwindowed, so a date
+  // change must not discard a half-filled form.
+  useEffect(() => {
+    setExclusionState(null);
     setReturningFromEditor(false);
   }, [signal?.key]);
 
   const openSignalDismiss = async () => {
     if (!signal) return;
-    const requestKey = signal.key;
+    const token = collectionToken.current;
     setCollecting(true);
     try {
       const results = await collectFindingsForRules(
@@ -293,16 +301,16 @@ export function SignalDrawer({
         [signal.ruleId],
         window,
       );
-      if (activeSignalKey.current !== requestKey) return;
+      if (collectionToken.current !== token) return;
       setPendingDismiss(results);
     } catch {
-      if (activeSignalKey.current !== requestKey) return;
+      if (collectionToken.current !== token) return;
       toast.error("Failed to load this signal's findings.");
     } finally {
-      // Same guard: the switch already cleared the flag for the new signal, so
-      // a late-settling request must not clear it out from under a collection
-      // the operator started there.
-      if (activeSignalKey.current === requestKey) setCollecting(false);
+      // Same guard: the switch already cleared the flag for the new selection,
+      // so a late-settling request must not clear it out from under a
+      // collection the operator started there.
+      if (collectionToken.current === token) setCollecting(false);
     }
   };
 

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -247,7 +247,11 @@ export function SignalDrawer({
     // to — the "Any <rule> finding" option even before evidence rows load.
     // Evidence rows still ride along for the exact-value option and the
     // custom branch's findings context.
-    setExclusionState({ mode: "create", results: evidence, signal });
+    setExclusionState({
+      mode: "create",
+      results: evidence,
+      presetRuleId: signal.ruleId,
+    });
   };
 
   // Judge-backed signals get false-positive dismissal as the signal-level
@@ -256,15 +260,20 @@ export function SignalDrawer({
   const judgeSignal =
     signal !== null && hasJudgeSource(signal.detectionSources);
 
-  // The drawer stays mounted across signal switches and closes, so a
-  // collection that was in flight when either happened must not open the
-  // confirm dialog with the previous signal's findings. The ref tracks the
-  // currently displayed signal; a finished collection only lands if it still
-  // matches.
+  // Which signal is on screen is a URL param, so browser back/forward swaps it
+  // while the drawer stays mounted — and every piece of state here snapshots
+  // the signal it was started from, so none of it may outlive a switch. An open
+  // exclusion editor would go on targeting the previous signal's rule, a
+  // pending dismissal would clear the previous signal's findings under the new
+  // signal's name, and a collection still in flight must not open that dialog
+  // at all. Tracked by key rather than by the signal object so a list refetch's
+  // new identity doesn't discard live state; clearing on mount is a no-op.
   const activeSignalKey = useRef<string | null>(null);
   useEffect(() => {
     activeSignalKey.current = signal?.key ?? null;
-  }, [signal]);
+    setExclusionState(null);
+    setPendingDismiss(null);
+  }, [signal?.key]);
 
   const openSignalDismiss = async () => {
     if (!signal) return;


### PR DESCRIPTION
## Summary

Starting an exclusion from a Watchdog signal derived its ready-made options only from the evidence rows the drawer had loaded. If evidence hadn't loaded yet (or the window had none), the editor opened on a bare "Write it myself" criteria box with no ready-made option and no context — even though the signal itself already names the rule to exclude.

Refs AIS-540.

## Changes

- `exclusionOptions` accepts an optional `signalRuleId`; the "Any \<rule\> finding" option derives from the shared evidence rule **or** the signal's rule, so it no longer depends on evidence rows having loaded.
- `ExclusionSheetState`'s create variant carries the originating `RiskSignal`. A signal-originated create now opens with the rule option pre-selected — the flow began as "stop flagging this signal" (the whole rule cluster), not one matched value. Other surfaces keep the existing first-savable default.
- The form remount key includes the signal key, so switching signals in the drawer resets the form even when neither signal has evidence rows loaded.
- The drawer's signal-level "Create exclusion rule" passes the signal through; the per-evidence-row "Exclude" is deliberately unchanged (its intent is that row's value, and the rule option already derives from the row).

## Verification

- `aube run -F dashboard type-check` — clean
- `aube run -F dashboard lint` — clean
- `aube run -F dashboard test` — 204 files, 1804 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-fills the exclusion editor with a Watchdog signal’s rule and prevents stale UI when the URL changes. Previously the “Any <rule> finding” option appeared only after evidence loaded and in‑flight collections could briefly render under a new signal/window; now the option is immediate and defaulted, and collections, toasts, and spinners drop on signal or window change before paint.

- exclusionOptions accepts an optional preset rule id; the “Any <rule> finding” option derives from shared evidence or the signal’s rule, and a shared selection rule overrides the preset.
- Create state carries a preset rule id and defaults the picker to the rule option for signal-originated creates; the form key includes the preset id to remount on rule/signal swap. Other entry points keep existing defaults.
- The drawer closes the exclusion editor on signal change (not window) and clears pending dismissal and collection/transition flags on signal or window change; a monotonic token drops late responses, error toasts, and spinner resets; resets run before paint to avoid a one‑frame flash of stale UI.
- Adds tests for offering a preset rule before findings load and for shared‑rule override.

Addresses AIS-540.

<sup>Written for commit e032a54498d0becfc6e4f3036eea64423a8bd287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

