### PR TITLE
fix: quiet expected Temporal failures in workflow monitors

### DIFF
--- a/.changeset/quiet-temporal-failure-monitors.md
+++ b/.changeset/quiet-temporal-failure-monitors.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Quiet expected Temporal failures (timeouts, customer DNS gaps, rejected integration keys) so they stop paging failure monitors.

--- a/server/internal/background/activities/chat_resolutions/errors.go
+++ b/server/internal/background/activities/chat_resolutions/errors.go
@@ -24,10 +24,14 @@ const ErrTypeGenerationBumped = "ChatResolutionGenerationBumped"
 var ErrGenerationBumped = errors.New("chat generation bumped during analysis")
 
 func newGenerationBumpedError(pinned, current int32) error {
-	return temporal.NewNonRetryableApplicationError(
+	return temporal.NewApplicationErrorWithOptions(
 		fmt.Sprintf("chat generation bumped during analysis: pinned=%d current=%d", pinned, current),
 		ErrTypeGenerationBumped,
-		ErrGenerationBumped,
+		temporal.ApplicationErrorOptions{
+			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
+			Cause:        ErrGenerationBumped,
+		},
 	)
 }
 
@@ -50,10 +54,14 @@ func IsGenerationBumped(err error) bool {
 const ErrTypeInsufficientCredits = "ChatResolutionInsufficientCredits"
 
 func newInsufficientCreditsError(cause error) error {
-	return temporal.NewNonRetryableApplicationError(
+	return temporal.NewApplicationErrorWithOptions(
 		"insufficient openrouter credits",
 		ErrTypeInsufficientCredits,
-		cause,
+		temporal.ApplicationErrorOptions{
+			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
+			Cause:        cause,
+		},
 	)
 }
 
@@ -75,10 +83,14 @@ func IsInsufficientCredits(err error) bool {
 const ErrTypeInferenceDisabled = "ChatResolutionInferenceDisabled"
 
 func newInferenceDisabledError(cause error) error {
-	return temporal.NewNonRetryableApplicationError(
+	return temporal.NewApplicationErrorWithOptions(
 		"organization inference is disabled",
 		ErrTypeInferenceDisabled,
-		cause,
+		temporal.ApplicationErrorOptions{
+			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
+			Cause:        cause,
+		},
 	)
 }
 

--- a/server/internal/background/activities/chat_resolutions/errors_test.go
+++ b/server/internal/background/activities/chat_resolutions/errors_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
@@ -23,6 +25,25 @@ func TestIsInsufficientCredits_FromTemporalApplicationError(t *testing.T) {
 	original := fmt.Errorf("openrouter 402: %w", openrouter.ErrInsufficientCredits)
 	tempErr := newInsufficientCreditsError(original)
 	assert.True(t, IsInsufficientCredits(tempErr))
+}
+
+func TestExpectedChatResolutionErrorsAreBenign(t *testing.T) {
+	t.Parallel()
+
+	creditsErr := newInsufficientCreditsError(openrouter.ErrInsufficientCredits)
+	var creditsApp *temporal.ApplicationError
+	require.ErrorAs(t, creditsErr, &creditsApp)
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, creditsApp.Category())
+
+	disabledErr := newInferenceDisabledError(errors.New("key locked"))
+	var disabledApp *temporal.ApplicationError
+	require.ErrorAs(t, disabledErr, &disabledApp)
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, disabledApp.Category())
+
+	bumpedErr := newGenerationBumpedError(1, 2)
+	var bumpedApp *temporal.ApplicationError
+	require.ErrorAs(t, bumpedErr, &bumpedApp)
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, bumpedApp.Category())
 }
 
 func TestIsInsufficientCredits_OtherErrorsReturnFalse(t *testing.T) {

--- a/server/internal/background/activities/plugin_publisher.go
+++ b/server/internal/background/activities/plugin_publisher.go
@@ -106,7 +106,11 @@ func (p *PluginPublisher) PublishProject(ctx context.Context, input plugins.Publ
 			if se, ok := err.(interface{ String() string }); ok {
 				detail = se.String()
 			}
-			return nil, temporal.NewNonRetryableApplicationError(detail, ErrTypeGitHubRepoConflict, err)
+			return nil, temporal.NewApplicationErrorWithOptions(detail, ErrTypeGitHubRepoConflict, temporal.ApplicationErrorOptions{
+				NonRetryable: true,
+				Category:     temporal.ApplicationErrorCategoryBenign,
+				Cause:        err,
+			})
 		}
 		return nil, fmt.Errorf("publish plugin project: %w", err)
 	}

--- a/server/internal/background/activities/poll_ai_data.go
+++ b/server/internal/background/activities/poll_ai_data.go
@@ -328,9 +328,30 @@ func newPollFailureError(configID uuid.UUID, provider string, attempt int32, non
 
 	message := fmt.Sprintf("poll ai integration usage: provider=%s config=%s attempt=%d/%d: %s",
 		provider, configID, attempt, PollUsageMaxAttempts, cause)
+	category := temporal.ApplicationErrorCategoryUnspecified
+	if nonRetryable {
+		// Provider rejections (bad API key, unknown org) are customer-side
+		// configuration gaps. Marking them benign keeps Temporal's
+		// workflow_failed / activity_execution_failed counters and error
+		// spans out of failure alerts while the dashboard still records the
+		// failure and may auto-pause the schedule.
+		category = temporal.ApplicationErrorCategoryBenign
+	}
 	return temporal.NewApplicationErrorWithOptions(message, ErrTypeAIUsagePollFailed, temporal.ApplicationErrorOptions{
 		NonRetryable: nonRetryable,
+		Category:     category,
 		Cause:        cause,
 		Details:      []any{details},
 	})
+}
+
+// IsNonRetryableAIUsagePollFailure reports whether err is a provider-rejected
+// usage poll (bad API key, unknown org), including after Temporal has wrapped
+// it as it crossed the activity boundary.
+func IsNonRetryableAIUsagePollFailure(err error) bool {
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		return false
+	}
+	return appErr.Type() == ErrTypeAIUsagePollFailed && appErr.NonRetryable()
 }

--- a/server/internal/background/activities/poll_ai_data_test.go
+++ b/server/internal/background/activities/poll_ai_data_test.go
@@ -115,6 +115,8 @@ func TestNewPollFailureErrorCarriesStageAndProgressDetails(t *testing.T) {
 	require.ErrorAs(t, err, &appErr)
 	require.Equal(t, ErrTypeAIUsagePollFailed, appErr.Type())
 	require.False(t, appErr.NonRetryable())
+	require.Equal(t, temporal.ApplicationErrorCategoryUnspecified, appErr.Category())
+	require.False(t, IsNonRetryableAIUsagePollFailure(err))
 	require.Contains(t, appErr.Message(), "provider=anthropic_compliance")
 	require.Contains(t, appErr.Message(), fmt.Sprintf("attempt=5/%d", PollUsageMaxAttempts))
 
@@ -143,6 +145,8 @@ func TestNewPollFailureErrorMarksAuthFailuresNonRetryable(t *testing.T) {
 	var appErr *temporal.ApplicationError
 	require.ErrorAs(t, err, &appErr)
 	require.True(t, appErr.NonRetryable())
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, appErr.Category())
+	require.True(t, IsNonRetryableAIUsagePollFailure(err))
 
 	var details aiUsagePollFailureDetails
 	require.NoError(t, appErr.Details(&details))

--- a/server/internal/background/activities/process_deployment.go
+++ b/server/internal/background/activities/process_deployment.go
@@ -134,6 +134,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 	if errors.Is(err, oops.ErrPermanent) {
 		return temporal.NewApplicationErrorWithOptions("openapiv3 document was not processed successfully", "openapi_doc_error", temporal.ApplicationErrorOptions{
 			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
 			Cause:        err,
 		})
 	}
@@ -206,6 +207,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 		err = oops.E(oops.CodeUnexpected, err, "no tools were created for deployment").LogError(ctx, p.logger)
 		return temporal.NewApplicationErrorWithOptions("empty deployment was not expected", "deployment_error", temporal.ApplicationErrorOptions{
 			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
 			Cause:        err,
 		})
 	}

--- a/server/internal/background/activities/verify_custom_domain.go
+++ b/server/internal/background/activities/verify_custom_domain.go
@@ -34,11 +34,23 @@ import (
 const ErrTypeDNSNotFound = "CustomDomainDNSNotFound"
 
 func newDNSNotFoundError(cause error, missingHost string) error {
-	return temporal.NewNonRetryableApplicationError(
+	return temporal.NewApplicationErrorWithOptions(
 		fmt.Sprintf("DNS record not found for %s", missingHost),
 		ErrTypeDNSNotFound,
-		cause,
+		temporal.ApplicationErrorOptions{
+			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
+			Cause:        cause,
+		},
 	)
+}
+
+// IsDNSNotFound reports whether err originated from a missing DNS record
+// required for custom domain verification, including after Temporal has
+// wrapped it as it crossed the activity boundary.
+func IsDNSNotFound(err error) bool {
+	var appErr *temporal.ApplicationError
+	return errors.As(err, &appErr) && appErr.Type() == ErrTypeDNSNotFound
 }
 
 type VerifyCustomDomain struct {

--- a/server/internal/background/activities/verify_custom_domain_test.go
+++ b/server/internal/background/activities/verify_custom_domain_test.go
@@ -435,6 +435,8 @@ func TestVerifyCustomDomain_NXDOMAINOnCNAMEAndA(t *testing.T) {
 	require.ErrorAs(t, err, &appErr)
 	require.Equal(t, activities.ErrTypeDNSNotFound, appErr.Type())
 	require.True(t, appErr.NonRetryable(), "DNS-not-found should be non-retryable")
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, appErr.Category())
+	require.True(t, activities.IsDNSNotFound(err))
 	require.Contains(t, err.Error(), domain)
 }
 
@@ -464,6 +466,8 @@ func TestVerifyCustomDomain_NXDOMAINOnTXT(t *testing.T) {
 	require.ErrorAs(t, err, &appErr)
 	require.Equal(t, activities.ErrTypeDNSNotFound, appErr.Type())
 	require.True(t, appErr.NonRetryable(), "DNS-not-found should be non-retryable")
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, appErr.Category())
+	require.True(t, activities.IsDNSNotFound(err))
 	require.Contains(t, err.Error(), txtName)
 }
 

--- a/server/internal/background/ai_integration_usage_poller.go
+++ b/server/internal/background/ai_integration_usage_poller.go
@@ -146,6 +146,9 @@ func AIUsagePollerWorkflow(ctx workflow.Context, input string) error {
 
 	var a *Activities
 	if err := workflow.ExecuteActivity(ctx, a.PollAIData, input).Get(ctx, nil); err != nil {
+		if activities.IsNonRetryableAIUsagePollFailure(err) {
+			return asBenignWorkflowError(err)
+		}
 		return fmt.Errorf("poll and persist ai integration usage: %w", err)
 	}
 

--- a/server/internal/background/ai_integration_usage_poller_test.go
+++ b/server/internal/background/ai_integration_usage_poller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 
 	"github.com/speakeasy-api/gram/server/internal/aiintegrations"
@@ -305,6 +306,41 @@ func TestAIUsagePollerCoordinatorStartsIndependentWorkflowsForConfigSchedules(t 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	require.ElementsMatch(t, candidateSyncIDs(candidates), synced)
+}
+
+func TestAIUsagePollerWorkflow_NonRetryablePollIsBenign(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	syncID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	env.RegisterWorkflow(AIUsagePollerWorkflow)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ string) error {
+			return temporal.NewApplicationErrorWithOptions(
+				"cursor rejected the configured api key",
+				activities.ErrTypeAIUsagePollFailed,
+				temporal.ApplicationErrorOptions{
+					NonRetryable: true,
+					Category:     temporal.ApplicationErrorCategoryBenign,
+				},
+			)
+		},
+		activity.RegisterOptions{Name: "PollAIData"},
+	)
+
+	env.ExecuteWorkflow(AIUsagePollerWorkflow, syncID.String())
+
+	require.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	require.Error(t, err)
+
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, activities.ErrTypeAIUsagePollFailed, appErr.Type())
+	require.True(t, appErr.NonRetryable())
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, appErr.Category())
 }
 
 func candidateSyncIDs(candidates []aiintegrations.UsagePollCandidate) []string {

--- a/server/internal/background/benign.go
+++ b/server/internal/background/benign.go
@@ -1,0 +1,33 @@
+package background
+
+import (
+	"errors"
+
+	"go.temporal.io/sdk/temporal"
+)
+
+// asBenignWorkflowError returns a top-level ApplicationError with
+// CategoryBenign so Temporal's workflow_failed metric and OTel span status
+// stay quiet. Activity-caused errors arrive wrapped in *ActivityError (and
+// often fmt.Errorf), which the SDK's isBenignApplicationError type-assertion
+// does not unwrap — only a bare *ApplicationError at the workflow return
+// skips those counters.
+func asBenignWorkflowError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+	errType := ""
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) {
+		msg = appErr.Message()
+		errType = appErr.Type()
+	}
+
+	return temporal.NewApplicationErrorWithOptions(msg, errType, temporal.ApplicationErrorOptions{
+		NonRetryable: true,
+		Category:     temporal.ApplicationErrorCategoryBenign,
+		Cause:        err,
+	})
+}

--- a/server/internal/background/benign_test.go
+++ b/server/internal/background/benign_test.go
@@ -1,0 +1,42 @@
+package background
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/temporal"
+)
+
+func TestAsBenignWorkflowError_Nil(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, asBenignWorkflowError(nil))
+}
+
+func TestAsBenignWorkflowError_PreservesTypeAndMessage(t *testing.T) {
+	t.Parallel()
+
+	cause := temporal.NewApplicationErrorWithOptions(
+		"DNS record not found for example.com",
+		"CustomDomainDNSNotFound",
+		temporal.ApplicationErrorOptions{
+			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
+			Cause:        errors.New("no such host"),
+		},
+	)
+	wrapped := fmt.Errorf("failed to verify custom domain: %w", cause)
+
+	err := asBenignWorkflowError(wrapped)
+	require.Error(t, err)
+
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, "CustomDomainDNSNotFound", appErr.Type())
+	require.Equal(t, "DNS record not found for example.com", appErr.Message())
+	require.True(t, appErr.NonRetryable())
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, appErr.Category())
+	require.ErrorIs(t, err, cause)
+}

--- a/server/internal/background/custom_domain_reconcile_test.go
+++ b/server/internal/background/custom_domain_reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 
@@ -172,4 +173,43 @@ func TestCustomDomainRegistrationWorkflowUsesReconcileBridgeBudget(t *testing.T)
 	require.Equal(t, signalCustomDomainReconcileActivityMaximumAttempts, bridgeAttempts)
 	require.Greater(t, bridgeTimeout, 11*time.Minute)
 	require.LessOrEqual(t, bridgeTimeout, signalCustomDomainReconcileStartToCloseTimeout)
+}
+
+func TestCustomDomainRegistrationWorkflow_DNSNotFoundIsBenign(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivityWithOptions(
+		func(context.Context, activities.VerifyCustomDomainArgs) error {
+			return temporal.NewApplicationErrorWithOptions(
+				"DNS record not found for missing.example.com",
+				activities.ErrTypeDNSNotFound,
+				temporal.ApplicationErrorOptions{
+					NonRetryable: true,
+					Category:     temporal.ApplicationErrorCategoryBenign,
+				},
+			)
+		},
+		activity.RegisterOptions{Name: "VerifyCustomDomain"},
+	)
+
+	env.ExecuteWorkflow(CustomDomainRegistrationWorkflow, CustomDomainRegistrationParams{
+		OrgID:           "test-organization",
+		Domain:          "missing.example.com",
+		CreatedBy:       urn.NewPrincipal(urn.PrincipalTypeUser, "test-user"),
+		CreatedByName:   nil,
+		ProvisionerKind: k8s.ProvisionerKindIngress,
+		IPAllowlist:     nil,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	require.Error(t, err)
+
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, activities.ErrTypeDNSNotFound, appErr.Type())
+	require.True(t, appErr.NonRetryable())
+	require.Equal(t, temporal.ApplicationErrorCategoryBenign, appErr.Category())
 }

--- a/server/internal/background/custom_domain_registration.go
+++ b/server/internal/background/custom_domain_registration.go
@@ -193,6 +193,10 @@ func CustomDomainRegistrationWorkflow(ctx workflow.Context, params CustomDomainR
 		},
 	).Get(ctx, nil)
 	if err != nil {
+		if activities.IsDNSNotFound(err) {
+			logger.Info("custom domain DNS not found, skipping verification retries", "error", err.Error(), "org_id", params.OrgID, "domain", params.Domain)
+			return asBenignWorkflowError(err)
+		}
 		logger.Error("failed to verify custom domain", "error", err.Error(), "org_id", params.OrgID, "domain", params.Domain)
 		return fmt.Errorf("failed to verify custom domain: %w", err)
 	}

--- a/server/internal/background/interceptors/log.go
+++ b/server/internal/background/interceptors/log.go
@@ -2,6 +2,7 @@ package interceptors
 
 import (
 	"context"
+	"errors"
 
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"go.temporal.io/sdk/activity"
@@ -70,30 +71,48 @@ func (a *activityLogExecution) ExecuteActivity(ctx context.Context, in *intercep
 	return result, err
 }
 
-// logWorkflowResult downgrades benign Temporal sentinels (ContinueAsNew,
-// Canceled) to Info so they stay out of failure alerts and log noise.
+// logWorkflowResult downgrades Temporal control-flow and expected customer-side
+// errors to Info so they stay out of failure alerts and log noise.
 func logWorkflowResult(logger sdklog.Logger, err error) {
 	switch {
 	case err == nil:
 		logger.Info("workflow finished")
 	case workflow.IsContinueAsNewError(err):
 		logger.Info("workflow continuing as new")
-	case temporal.IsCanceledError(err):
+	case temporal.IsCanceledError(err) || errors.Is(err, context.Canceled):
 		logger.Info("workflow canceled")
+	case temporal.IsTimeoutError(err) || errors.Is(err, context.DeadlineExceeded):
+		logger.Info("workflow timed out")
+	case temporal.IsTerminatedError(err):
+		logger.Info("workflow terminated")
+	case isBenignApplicationError(err):
+		logger.Info("workflow finished with expected error", "error", err.Error())
 	default:
 		logger.Error("workflow failed", "error", err.Error())
 	}
 }
 
-// logActivityResult downgrades the Canceled sentinel (worker shutdown,
-// workflow timeout, caller cancel) to Info so it stays out of failure alerts.
+// logActivityResult downgrades Temporal control-flow and expected customer-side
+// errors to Info so they stay out of failure alerts.
 func logActivityResult(logger sdklog.Logger, err error) {
 	switch {
 	case err == nil:
 		logger.Info("activity finished")
-	case temporal.IsCanceledError(err):
+	case temporal.IsCanceledError(err) || errors.Is(err, context.Canceled):
 		logger.Info("activity canceled")
+	case temporal.IsTimeoutError(err) || errors.Is(err, context.DeadlineExceeded):
+		logger.Info("activity timed out")
+	case isBenignApplicationError(err):
+		logger.Info("activity finished with expected error", "error", err.Error())
 	default:
 		logger.Error("activity failed", "error", err.Error())
 	}
+}
+
+// isBenignApplicationError reports whether err is (or wraps) an ApplicationError
+// marked CategoryBenign. The SDK's own check type-asserts and misses wrappers;
+// errors.As is used so ActivityError/fmt.Errorf still match for logging.
+func isBenignApplicationError(err error) bool {
+	var appErr *temporal.ApplicationError
+	return errors.As(err, &appErr) && appErr.Category() == temporal.ApplicationErrorCategoryBenign
 }

--- a/server/internal/background/interceptors/log_test.go
+++ b/server/internal/background/interceptors/log_test.go
@@ -1,10 +1,13 @@
 package interceptors
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
 	sdklog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -73,6 +76,49 @@ func TestLogWorkflowResult_Canceled(t *testing.T) {
 	require.Equal(t, []capturedLog{{level: "info", message: "workflow canceled"}}, logger.calls)
 }
 
+func TestLogWorkflowResult_Timeout(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, temporal.NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil))
+
+	require.Equal(t, []capturedLog{{level: "info", message: "workflow timed out"}}, logger.calls)
+}
+
+func TestLogWorkflowResult_BenignApplicationError(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, temporal.NewApplicationErrorWithOptions(
+		"DNS record not found",
+		"CustomDomainDNSNotFound",
+		temporal.ApplicationErrorOptions{
+			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
+		},
+	))
+
+	require.Equal(t, []capturedLog{{level: "info", message: "workflow finished with expected error"}}, logger.calls)
+}
+
+func TestLogWorkflowResult_RegularApplicationError(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, temporal.NewApplicationError("infra exploded", "db"))
+
+	require.Equal(t, []capturedLog{{level: "error", message: "workflow failed"}}, logger.calls)
+}
+
+func TestLogWorkflowResult_WrappedCanceled(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, fmt.Errorf("verify custom domain: %w", temporal.NewCanceledError()))
+
+	require.Equal(t, []capturedLog{{level: "info", message: "workflow canceled"}}, logger.calls)
+}
+
 func TestLogActivityResult_Success(t *testing.T) {
 	t.Parallel()
 
@@ -98,4 +144,38 @@ func TestLogActivityResult_Canceled(t *testing.T) {
 	logActivityResult(logger, temporal.NewCanceledError())
 
 	require.Equal(t, []capturedLog{{level: "info", message: "activity canceled"}}, logger.calls)
+}
+
+func TestLogActivityResult_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logActivityResult(logger, context.Canceled)
+
+	require.Equal(t, []capturedLog{{level: "info", message: "activity canceled"}}, logger.calls)
+}
+
+func TestLogActivityResult_DeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logActivityResult(logger, context.DeadlineExceeded)
+
+	require.Equal(t, []capturedLog{{level: "info", message: "activity timed out"}}, logger.calls)
+}
+
+func TestLogActivityResult_BenignApplicationError(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logActivityResult(logger, temporal.NewApplicationErrorWithOptions(
+		"cursor rejected the configured api key",
+		"AIUsagePollFailed",
+		temporal.ApplicationErrorOptions{
+			NonRetryable: true,
+			Category:     temporal.ApplicationErrorCategoryBenign,
+		},
+	))
+
+	require.Equal(t, []capturedLog{{level: "info", message: "activity finished with expected error"}}, logger.calls)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://linear.app/speakeasy/issue/DNO-876/audit-temporal-failures-monitors-and-quiet-them

Recurring Temporal failures were paging oncall even when they were control flow or customer-side configuration gaps, not product bugs. This follows the AGE-2285 approach (ContinueAsNew / Canceled already logged at Info) and covers the remaining noisy cases.

**Fail less (and stay off `temporal_workflow_failed` / error spans)**

Temporal’s SDK only skips `workflow_failed` when the workflow returns a bare `*ApplicationError` with `CategoryBenign`. Activity errors arrive wrapped in `*ActivityError`, so wrapping with `fmt.Errorf` still increments the counter. Expected failures now return a top-level benign application error:

- Custom domain verification when DNS is NXDOMAIN
- AI usage polling when the provider rejects the configured key (401/403/404)

**Quiet the log interceptor**

`workflow failed` / `activity failed` error logs (and the APM spans they flip) were the other monitor input. The interceptor now logs at Info for:

- Timeouts (`TimeoutError`, `context.DeadlineExceeded`) — AGE-2285 treated these as cancels, but they are not
- Worker/activity cancel (`CanceledError`, `context.Canceled`)
- Workflow terminate
- `ApplicationError` with `CategoryBenign` (unwraps wrappers via `errors.As`)

**Mark expected activity errors as benign** so activity failure metrics and OTel error status stay quiet even when the parent workflow continues:

- Custom domain DNS not found
- Non-retryable AI usage poll (rejected key)
- Plugin GitHub repo conflict
- Chat-resolution generation bump, insufficient credits, inference disabled
- OpenAPI / empty-deployment processing errors (customer spec issues)

Infra failures (DB, Polar, unexpected DNS/network errors) still fail and still page.

## Test plan

- [x] Interceptor unit tests for timeout, cancel, deadline, benign vs regular application errors
- [x] Workflow tests: DNS-not-found and rejected AI poll return `CategoryBenign`
- [x] Activity tests: NXDOMAIN and non-retryable poll errors carry `CategoryBenign`
- [x] `mise run lint:server`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-876](https://linear.app/speakeasy/issue/DNO-876/audit-temporal-failures-monitors-and-quiet-them)

<div><a href="https://cursor.com/agents/bc-6e95091b-501d-4385-a571-3e9a8393cc5f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e95091b-501d-4385-a571-3e9a8393cc5f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiet expected Temporal failures so they stop paging failure monitors and flipping error spans. Previously, timeouts, cancels, and customer-side configuration errors incremented `workflow_failed`/`activity_failed` and logged at Error; now they return benign non-retryable ApplicationErrors or log at Info. Infra failures still fail and still page.

- Marked as benign: DNS not found during custom domain verification, non-retryable AI usage poll rejections (bad/unknown credentials), plugin GitHub repo conflict, OpenAPI/empty deployment errors, and chat resolution generation bumped/insufficient credits/inference disabled.
- Interceptor logs timeouts, cancels, termination, and benign ApplicationErrors at Info for workflows and activities; other errors remain Error.
- Workflows wrap expected activity failures with a top-level benign ApplicationError to avoid `workflow_failed` metrics.
- Added targeted tests for categorization and logging.

**Operational impact**

- Temporal failure monitors will page less for customer-side issues; dashboards still record failures and schedules may auto-pause.
- No API or config changes; no migration required.

Linear: DNO-876

<sup>Written for commit 440e0687afd2cc369f1773185fa6751611bb8b30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

