### PR TITLE
feat(admin): filter the organizations list by sets of types and states

### DIFF
--- a/.changeset/admin-filter-organizations-by-sets.md
+++ b/.changeset/admin-filter-organizations-by-sets.md
@@ -1,0 +1,7 @@
+---
+"admin": patch
+---
+
+The admin organizations list now filters on sets rather than one value at a time: `account_types` takes several account types, `trial_states` takes any of running, ending soon, expired, demoted, converted or none, and `disabled_states` takes active, disabled or both. An empty set means no filter, except `disabled_states`, where an empty set still means active only. A value outside the known list matches nothing rather than failing the request, so an operator pasting a colleague's URL gets an empty table instead of an error. The total reported alongside the page counts the same filtered set, trial state included.
+
+This is an expand step. The single-valued `account_type` and the `include_disabled` boolean both still work: `account_type` joins `account_types` as one more member of the same set, and `disabled_states` overrides `include_disabled` when supplied. Keeping them lets the server ship before the dashboard changes. Retiring them is a separate contraction step.

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -339,8 +339,11 @@ var _ = Service("admin", func() {
 			security.AdminAuthPayload()
 
 			Attribute("q", String, "Search term applied to name and slug (case-insensitive substring).")
-			Attribute("account_type", String, "Filter by gram_account_type (e.g. free, pro, enterprise).")
-			Attribute("include_disabled", Boolean, "Include organizations with disabled_at set. Defaults to false.")
+			Attribute("account_type", String, "Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.")
+			Attribute("account_types", ArrayOf(String), "Match any of these gram_account_type values. Empty matches every account type. A value no organization carries matches nothing rather than failing the request.")
+			Attribute("trial_states", ArrayOf(String), "Match any of running, ending_soon, expired, demoted, converted or none. Empty matches every trial state. An unrecognised value matches nothing rather than failing the request.")
+			Attribute("disabled_states", ArrayOf(String), "Match any of active or disabled. Empty falls back to include_disabled. An unrecognised value matches nothing rather than failing the request.")
+			Attribute("include_disabled", Boolean, "Include organizations with disabled_at set. Defaults to false. Superseded by disabled_states, which overrides it outright when supplied.")
 			Attribute("cursor", String, "Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.")
 			Attribute("limit", Int, "Page size (default 50, max 100).")
 			Attribute("sort", String, "Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.")
@@ -355,6 +358,9 @@ var _ = Service("admin", func() {
 
 			Param("q")
 			Param("account_type")
+			Param("account_types")
+			Param("trial_states")
+			Param("disabled_states")
 			Param("include_disabled")
 			Param("cursor")
 			Param("limit")

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -238,9 +238,23 @@ type ListOrganizationsPayload struct {
 	AdminSessionToken *string
 	// Search term applied to name and slug (case-insensitive substring).
 	Q *string
-	// Filter by gram_account_type (e.g. free, pro, enterprise).
+	// Filter by a single gram_account_type (e.g. free, pro, enterprise).
+	// Superseded by account_types, which it joins as one more member of the same
+	// set.
 	AccountType *string
-	// Include organizations with disabled_at set. Defaults to false.
+	// Match any of these gram_account_type values. Empty matches every account
+	// type. A value no organization carries matches nothing rather than failing
+	// the request.
+	AccountTypes []string
+	// Match any of running, ending_soon, expired, demoted, converted or none.
+	// Empty matches every trial state. An unrecognised value matches nothing
+	// rather than failing the request.
+	TrialStates []string
+	// Match any of active or disabled. Empty falls back to include_disabled. An
+	// unrecognised value matches nothing rather than failing the request.
+	DisabledStates []string
+	// Include organizations with disabled_at set. Defaults to false. Superseded by
+	// disabled_states, which overrides it outright when supplied.
 	IncludeDisabled *bool
 	// Pagination cursor: id of the last item from the previous page. Ignored when
 	// sort or page is supplied.

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -202,7 +202,7 @@ func BuildListOrganizationProjectsPayload(adminListOrganizationProjectsOrganizat
 
 // BuildListOrganizationsPayload builds the payload for the admin
 // listOrganizations endpoint from CLI flags.
-func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrganizationsAccountType string, adminListOrganizationsIncludeDisabled string, adminListOrganizationsCursor string, adminListOrganizationsLimit string, adminListOrganizationsSort string, adminListOrganizationsDirection string, adminListOrganizationsPage string, adminListOrganizationsAdminSessionToken string) (*admin.ListOrganizationsPayload, error) {
+func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrganizationsAccountType string, adminListOrganizationsAccountTypes string, adminListOrganizationsTrialStates string, adminListOrganizationsDisabledStates string, adminListOrganizationsIncludeDisabled string, adminListOrganizationsCursor string, adminListOrganizationsLimit string, adminListOrganizationsSort string, adminListOrganizationsDirection string, adminListOrganizationsPage string, adminListOrganizationsAdminSessionToken string) (*admin.ListOrganizationsPayload, error) {
 	var err error
 	var q *string
 	{
@@ -214,6 +214,33 @@ func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrga
 	{
 		if adminListOrganizationsAccountType != "" {
 			accountType = &adminListOrganizationsAccountType
+		}
+	}
+	var accountTypes []string
+	{
+		if adminListOrganizationsAccountTypes != "" {
+			err = json.Unmarshal([]byte(adminListOrganizationsAccountTypes), &accountTypes)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for accountTypes, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"abc123\"\n   ]'")
+			}
+		}
+	}
+	var trialStates []string
+	{
+		if adminListOrganizationsTrialStates != "" {
+			err = json.Unmarshal([]byte(adminListOrganizationsTrialStates), &trialStates)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for trialStates, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"abc123\"\n   ]'")
+			}
+		}
+	}
+	var disabledStates []string
+	{
+		if adminListOrganizationsDisabledStates != "" {
+			err = json.Unmarshal([]byte(adminListOrganizationsDisabledStates), &disabledStates)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for disabledStates, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"abc123\"\n   ]'")
+			}
 		}
 	}
 	var includeDisabled *bool
@@ -278,6 +305,9 @@ func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrga
 	v := &admin.ListOrganizationsPayload{}
 	v.Q = q
 	v.AccountType = accountType
+	v.AccountTypes = accountTypes
+	v.TrialStates = trialStates
+	v.DisabledStates = disabledStates
 	v.IncludeDisabled = includeDisabled
 	v.Cursor = cursor
 	v.Limit = limit

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -1953,6 +1953,15 @@ func EncodeListOrganizationsRequest(encoder func(*http.Request) goahttp.Encoder)
 		if p.AccountType != nil {
 			values.Add("account_type", *p.AccountType)
 		}
+		for _, value := range p.AccountTypes {
+			values.Add("account_types", value)
+		}
+		for _, value := range p.TrialStates {
+			values.Add("trial_states", value)
+		}
+		for _, value := range p.DisabledStates {
+			values.Add("disabled_states", value)
+		}
 		if p.IncludeDisabled != nil {
 			values.Add("include_disabled", fmt.Sprintf("%v", *p.IncludeDisabled))
 		}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -1672,6 +1672,9 @@ func DecodeListOrganizationsRequest(mux goahttp.Muxer, decoder func(*http.Reques
 		var (
 			q                 *string
 			accountType       *string
+			accountTypes      []string
+			trialStates       []string
+			disabledStates    []string
 			includeDisabled   *bool
 			cursor            *string
 			limit             *int
@@ -1690,6 +1693,9 @@ func DecodeListOrganizationsRequest(mux goahttp.Muxer, decoder func(*http.Reques
 		if accountTypeRaw != "" {
 			accountType = &accountTypeRaw
 		}
+		accountTypes = qp["account_types"]
+		trialStates = qp["trial_states"]
+		disabledStates = qp["disabled_states"]
 		{
 			includeDisabledRaw := qp.Get("include_disabled")
 			if includeDisabledRaw != "" {
@@ -1741,7 +1747,7 @@ func DecodeListOrganizationsRequest(mux goahttp.Muxer, decoder func(*http.Reques
 		if err != nil {
 			return payload, err
 		}
-		payload = NewListOrganizationsPayload(q, accountType, includeDisabled, cursor, limit, sort, direction, page, adminSessionToken)
+		payload = NewListOrganizationsPayload(q, accountType, accountTypes, trialStates, disabledStates, includeDisabled, cursor, limit, sort, direction, page, adminSessionToken)
 		if payload.AdminSessionToken != nil {
 			if strings.Contains(*payload.AdminSessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -3353,10 +3353,13 @@ func NewListOrganizationProjectsPayload(organizationID string, adminSessionToken
 
 // NewListOrganizationsPayload builds a admin service listOrganizations
 // endpoint payload.
-func NewListOrganizationsPayload(q *string, accountType *string, includeDisabled *bool, cursor *string, limit *int, sort *string, direction *string, page *int, adminSessionToken *string) *admin.ListOrganizationsPayload {
+func NewListOrganizationsPayload(q *string, accountType *string, accountTypes []string, trialStates []string, disabledStates []string, includeDisabled *bool, cursor *string, limit *int, sort *string, direction *string, page *int, adminSessionToken *string) *admin.ListOrganizationsPayload {
 	v := &admin.ListOrganizationsPayload{}
 	v.Q = q
 	v.AccountType = accountType
+	v.AccountTypes = accountTypes
+	v.TrialStates = trialStates
+	v.DisabledStates = disabledStates
 	v.IncludeDisabled = includeDisabled
 	v.Cursor = cursor
 	v.Limit = limit

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -359,6 +359,9 @@ func ParseEndpoint(
 		adminListOrganizationsFlags                 = flag.NewFlagSet("list-organizations", flag.ExitOnError)
 		adminListOrganizationsQFlag                 = adminListOrganizationsFlags.String("q", "", "")
 		adminListOrganizationsAccountTypeFlag       = adminListOrganizationsFlags.String("account-type", "", "")
+		adminListOrganizationsAccountTypesFlag      = adminListOrganizationsFlags.String("account-types", "", "")
+		adminListOrganizationsTrialStatesFlag       = adminListOrganizationsFlags.String("trial-states", "", "")
+		adminListOrganizationsDisabledStatesFlag    = adminListOrganizationsFlags.String("disabled-states", "", "")
 		adminListOrganizationsIncludeDisabledFlag   = adminListOrganizationsFlags.String("include-disabled", "", "")
 		adminListOrganizationsCursorFlag            = adminListOrganizationsFlags.String("cursor", "", "")
 		adminListOrganizationsLimitFlag             = adminListOrganizationsFlags.String("limit", "", "")
@@ -6279,7 +6282,7 @@ func ParseEndpoint(
 				data, err = adminc.BuildListOrganizationProjectsPayload(*adminListOrganizationProjectsOrganizationIDFlag, *adminListOrganizationProjectsAdminSessionTokenFlag)
 			case "list-organizations":
 				endpoint = c.ListOrganizations()
-				data, err = adminc.BuildListOrganizationsPayload(*adminListOrganizationsQFlag, *adminListOrganizationsAccountTypeFlag, *adminListOrganizationsIncludeDisabledFlag, *adminListOrganizationsCursorFlag, *adminListOrganizationsLimitFlag, *adminListOrganizationsSortFlag, *adminListOrganizationsDirectionFlag, *adminListOrganizationsPageFlag, *adminListOrganizationsAdminSessionTokenFlag)
+				data, err = adminc.BuildListOrganizationsPayload(*adminListOrganizationsQFlag, *adminListOrganizationsAccountTypeFlag, *adminListOrganizationsAccountTypesFlag, *adminListOrganizationsTrialStatesFlag, *adminListOrganizationsDisabledStatesFlag, *adminListOrganizationsIncludeDisabledFlag, *adminListOrganizationsCursorFlag, *adminListOrganizationsLimitFlag, *adminListOrganizationsSortFlag, *adminListOrganizationsDirectionFlag, *adminListOrganizationsPageFlag, *adminListOrganizationsAdminSessionTokenFlag)
 			}
 		case "agent":
 			c := agentc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -8906,6 +8909,9 @@ func adminListOrganizationsUsage() {
 	fmt.Fprintf(os.Stderr, "%s [flags] admin list-organizations", os.Args[0])
 	fmt.Fprint(os.Stderr, " -q STRING")
 	fmt.Fprint(os.Stderr, " -account-type STRING")
+	fmt.Fprint(os.Stderr, " -account-types JSON")
+	fmt.Fprint(os.Stderr, " -trial-states JSON")
+	fmt.Fprint(os.Stderr, " -disabled-states JSON")
 	fmt.Fprint(os.Stderr, " -include-disabled BOOL")
 	fmt.Fprint(os.Stderr, " -cursor STRING")
 	fmt.Fprint(os.Stderr, " -limit INT")
@@ -8922,6 +8928,9 @@ func adminListOrganizationsUsage() {
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -q STRING: `)
 	fmt.Fprintln(os.Stderr, `    -account-type STRING: `)
+	fmt.Fprintln(os.Stderr, `    -account-types JSON: `)
+	fmt.Fprintln(os.Stderr, `    -trial-states JSON: `)
+	fmt.Fprintln(os.Stderr, `    -disabled-states JSON: `)
 	fmt.Fprintln(os.Stderr, `    -include-disabled BOOL: `)
 	fmt.Fprintln(os.Stderr, `    -cursor STRING: `)
 	fmt.Fprintln(os.Stderr, `    -limit INT: `)
@@ -8932,7 +8941,7 @@ func adminListOrganizationsUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin list-organizations --q \"abc123\" --account-type \"abc123\" --include-disabled false --cursor \"abc123\" --limit 1 --sort \"abc123\" --direction \"abc123\" --page 1 --admin-session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin list-organizations --q \"abc123\" --account-type \"abc123\" --account-types '[\n      \"abc123\"\n   ]' --trial-states '[\n      \"abc123\"\n   ]' --disabled-states '[\n      \"abc123\"\n   ]' --include-disabled false --cursor \"abc123\" --limit 1 --sort \"abc123\" --direction \"abc123\" --page 1 --admin-session-token \"abc123\"")
 }
 
 // agentUsage displays the usage of the agent command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -603,18 +603,45 @@ paths:
                     description: Search term applied to name and slug (case-insensitive substring).
                     type: string
                 - allowEmptyValue: true
-                  description: Filter by gram_account_type (e.g. free, pro, enterprise).
+                  description: Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.
                   in: query
                   name: account_type
                   schema:
-                    description: Filter by gram_account_type (e.g. free, pro, enterprise).
+                    description: Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.
                     type: string
                 - allowEmptyValue: true
-                  description: Include organizations with disabled_at set. Defaults to false.
+                  description: Match any of these gram_account_type values. Empty matches every account type. A value no organization carries matches nothing rather than failing the request.
+                  in: query
+                  name: account_types
+                  schema:
+                    description: Match any of these gram_account_type values. Empty matches every account type. A value no organization carries matches nothing rather than failing the request.
+                    items:
+                        type: string
+                    type: array
+                - allowEmptyValue: true
+                  description: Match any of running, ending_soon, expired, demoted, converted or none. Empty matches every trial state. An unrecognised value matches nothing rather than failing the request.
+                  in: query
+                  name: trial_states
+                  schema:
+                    description: Match any of running, ending_soon, expired, demoted, converted or none. Empty matches every trial state. An unrecognised value matches nothing rather than failing the request.
+                    items:
+                        type: string
+                    type: array
+                - allowEmptyValue: true
+                  description: Match any of active or disabled. Empty falls back to include_disabled. An unrecognised value matches nothing rather than failing the request.
+                  in: query
+                  name: disabled_states
+                  schema:
+                    description: Match any of active or disabled. Empty falls back to include_disabled. An unrecognised value matches nothing rather than failing the request.
+                    items:
+                        type: string
+                    type: array
+                - allowEmptyValue: true
+                  description: Include organizations with disabled_at set. Defaults to false. Superseded by disabled_states, which overrides it outright when supplied.
                   in: query
                   name: include_disabled
                   schema:
-                    description: Include organizations with disabled_at set. Defaults to false.
+                    description: Include organizations with disabled_at set. Defaults to false. Superseded by disabled_states, which overrides it outright when supplied.
                     type: boolean
                 - allowEmptyValue: true
                   description: 'Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.'

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -335,6 +335,34 @@ var listOrganizationsSortColumns = map[string]bool{
 	"trial_ends_at": true,
 }
 
+// listOrganizationsFilters resolves the two set filters the SQL takes from the
+// four the payload offers. The scalar account_type and the include_disabled
+// boolean predate the sets and stay live, because this endpoint keeps serving
+// the dashboard that is on main until AGE-3207 retires them.
+//
+// Unknown values pass straight through to match nothing. An organization can
+// carry an account type from outside the list the dashboard knows, and an
+// operator pasting a colleague's URL is owed an empty table rather than a 422.
+func listOrganizationsFilters(payload *gen.ListOrganizationsPayload) (accountTypes []string, disabledStates []string) {
+	// Union, not override: a caller supplying both asks for both.
+	accountTypes = payload.AccountTypes
+	if payload.AccountType != nil {
+		accountTypes = append(append([]string{}, accountTypes...), *payload.AccountType)
+	}
+
+	// disabled_states overrides the boolean outright. The boolean only picks the
+	// fallback, and these two literals are the arms of the CASE in both queries.
+	disabledStates = payload.DisabledStates
+	if len(disabledStates) == 0 {
+		disabledStates = []string{"active"}
+		if conv.PtrValOr(payload.IncludeDisabled, false) {
+			disabledStates = append(disabledStates, "disabled")
+		}
+	}
+
+	return accountTypes, disabledStates
+}
+
 func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrganizationsPayload) (*gen.AdminListOrganizationsResult, error) {
 	queries := repo.New(s.db)
 
@@ -379,15 +407,18 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 		fetchLimit = limit + 1
 	}
 
+	accountTypes, disabledStates := listOrganizationsFilters(payload)
+
 	rows, err := queries.AdminListOrganizations(ctx, repo.AdminListOrganizationsParams{
-		Q:               conv.PtrToPGText(payload.Q),
-		AccountType:     conv.PtrToPGText(payload.AccountType),
-		IncludeDisabled: conv.PtrValOr(payload.IncludeDisabled, false),
-		AfterID:         afterID,
-		SortBy:          sortBy,
-		SortDir:         sortDir,
-		PageOffset:      pageOffset,
-		PageLimit:       fetchLimit,
+		Q:              conv.PtrToPGText(payload.Q),
+		AccountTypes:   accountTypes,
+		TrialStates:    payload.TrialStates,
+		DisabledStates: disabledStates,
+		AfterID:        afterID,
+		SortBy:         sortBy,
+		SortDir:        sortDir,
+		PageOffset:     pageOffset,
+		PageLimit:      fetchLimit,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list organizations").LogError(ctx, s.logger)
@@ -397,9 +428,10 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 	// a count, and in cursor mode the page query has already discarded everything
 	// before the cursor.
 	total, err := queries.AdminCountOrganizations(ctx, repo.AdminCountOrganizationsParams{
-		Q:               conv.PtrToPGText(payload.Q),
-		AccountType:     conv.PtrToPGText(payload.AccountType),
-		IncludeDisabled: conv.PtrValOr(payload.IncludeDisabled, false),
+		Q:              conv.PtrToPGText(payload.Q),
+		AccountTypes:   accountTypes,
+		TrialStates:    payload.TrialStates,
+		DisabledStates: disabledStates,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "count organizations").LogError(ctx, s.logger)

--- a/server/internal/admin/listorganizationsfilters_test.go
+++ b/server/internal/admin/listorganizationsfilters_test.go
@@ -1,0 +1,316 @@
+package admin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+)
+
+const (
+	fltFreeNone      = "org_flt_free_none"
+	fltFreeRunning   = "org_flt_free_running"
+	fltFreeConverted = "org_flt_free_converted"
+	fltProEnding     = "org_flt_pro_ending"
+	fltProExpired    = "org_flt_pro_expired"
+	fltEntDemoted    = "org_flt_ent_demoted"
+	fltEntConverted  = "org_flt_ent_converted"
+	fltFreeWindowIn  = "org_flt_free_window_in"
+	fltFreeWindowOut = "org_flt_free_window_out"
+	fltFreeOff       = "org_flt_free_off"
+	fltProOffRunning = "org_flt_pro_off_running"
+)
+
+type filterFixture struct {
+	id          string
+	accountType string
+	// trial is nil for an organization that never trialled, which the ladder
+	// reports as "none".
+	trial      *trialFixture
+	trialState string
+	disabled   bool
+}
+
+// filterCorpus spreads account type, trial state and disabled state across
+// organizations so that no two of the three filters select the same rows. Every
+// trial state appears, converted and demoted appear on more than one row each so
+// that a count taken over the wrong state cannot land on the right number, and
+// two rows straddle the ending_soon boundary by an hour.
+func filterCorpus(now time.Time) []filterFixture {
+	demotedAt := now.Add(-72 * time.Hour)
+	convertedAt := now.Add(-96 * time.Hour)
+
+	return []filterFixture{
+		{id: fltFreeNone, accountType: "free", trialState: "none"},
+		{id: fltFreeRunning, accountType: "free", trialState: "running", trial: &trialFixture{endsAt: now.Add(30 * 24 * time.Hour)}},
+		{id: fltFreeConverted, accountType: "free", trialState: "converted", trial: &trialFixture{endsAt: now.Add(-10 * 24 * time.Hour), convertedAt: &convertedAt}},
+		{id: fltProEnding, accountType: "pro", trialState: "ending_soon", trial: &trialFixture{endsAt: now.Add(24 * time.Hour)}},
+		{id: fltProExpired, accountType: "pro", trialState: "expired", trial: &trialFixture{endsAt: now.Add(-24 * time.Hour)}},
+		{id: fltEntDemoted, accountType: "enterprise", trialState: "demoted", trial: &trialFixture{endsAt: now.Add(-10 * 24 * time.Hour), demotedAt: &demotedAt}},
+		{id: fltEntConverted, accountType: "enterprise", trialState: "converted", trial: &trialFixture{endsAt: now.Add(-10 * 24 * time.Hour), convertedAt: &convertedAt}},
+		{id: fltFreeWindowIn, accountType: "free", trialState: "ending_soon", trial: &trialFixture{endsAt: now.Add(endingSoonWindow - time.Hour)}},
+		{id: fltFreeWindowOut, accountType: "free", trialState: "running", trial: &trialFixture{endsAt: now.Add(endingSoonWindow + time.Hour)}},
+		{id: fltFreeOff, accountType: "free", trialState: "none", disabled: true},
+		{id: fltProOffRunning, accountType: "pro", trialState: "running", trial: &trialFixture{endsAt: now.Add(30 * 24 * time.Hour)}, disabled: true},
+	}
+}
+
+func seedFilterCorpus(t *testing.T, ctx context.Context, conn *pgxpool.Pool, corpus []filterFixture, disabledAt time.Time) {
+	t.Helper()
+
+	for _, f := range corpus {
+		org := orgFixture{id: f.id, name: "Org " + f.id, slug: f.id, accountType: f.accountType, whitelisted: true}
+		if f.disabled {
+			org.disabledAt = &disabledAt
+		}
+		seedOrg(t, ctx, conn, org)
+
+		if f.trial == nil {
+			continue
+		}
+
+		trial := *f.trial
+		trial.orgID = f.id
+		seedTrial(t, ctx, conn, trial)
+	}
+}
+
+func filterIDs(corpus []filterFixture, keep func(filterFixture) bool) []string {
+	out := make([]string, 0, len(corpus))
+	for _, f := range corpus {
+		if keep(f) {
+			out = append(out, f.id)
+		}
+	}
+	return out
+}
+
+// requireFilterMatches asserts both halves of the response. The total comes from
+// a second query with its own copy of the filter arms, so asserting the rows
+// alone would leave that copy untested.
+func requireFilterMatches(t *testing.T, ctx context.Context, svc *Service, payload *gen.ListOrganizationsPayload, wantIDs []string, label string) {
+	t.Helper()
+
+	res, err := svc.ListOrganizations(ctx, payload)
+	require.NoError(t, err, "listing organizations for %s", label)
+
+	got := make([]string, 0, len(res.Organizations))
+	for _, o := range res.Organizations {
+		got = append(got, o.ID)
+	}
+	require.ElementsMatch(t, wantIDs, got, "rows matched by %s", label)
+	require.Equal(t, int64(len(wantIDs)), res.Total, "total for %s", label)
+}
+
+func TestListOrganizations_SetFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	now := time.Now().UTC()
+	corpus := filterCorpus(now)
+	seedFilterCorpus(t, ctx, conn, corpus, now.Add(-24*time.Hour))
+
+	active := filterIDs(corpus, func(f filterFixture) bool { return !f.disabled })
+	all := filterIDs(corpus, func(filterFixture) bool { return true })
+
+	// Pin the corpus before filtering on it. A fixture whose trial dates do not
+	// produce the state its row claims would make every expectation below wrong
+	// in the same direction, and the filter tests would still pass.
+	t.Run("the corpus reports the trial states it claims", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{IncludeDisabled: ptrTo(true)})
+		require.NoError(t, err)
+		require.Len(t, res.Organizations, len(corpus))
+
+		byID := map[string]*gen.AdminOrganization{}
+		for _, o := range res.Organizations {
+			byID[o.ID] = o
+		}
+		for _, f := range corpus {
+			org := byID[f.id]
+			require.NotNil(t, org, "organization %s missing from the list", f.id)
+			require.NotNil(t, org.TrialState, "organization %s has no trial state", f.id)
+			require.Equal(t, f.trialState, *org.TrialState, "trial state for %s", f.id)
+		}
+	})
+
+	cases := []struct {
+		name    string
+		payload *gen.ListOrganizationsPayload
+		want    []string
+	}{
+		{
+			name:    "no filters keeps every active organization",
+			payload: &gen.ListOrganizationsPayload{},
+			want:    active,
+		},
+		{
+			name:    "account_types matches every listed type",
+			payload: &gen.ListOrganizationsPayload{AccountTypes: []string{"enterprise", "pro"}},
+			want:    []string{fltEntDemoted, fltEntConverted, fltProEnding, fltProExpired},
+		},
+		{
+			name:    "account_types ignores the order of the list",
+			payload: &gen.ListOrganizationsPayload{AccountTypes: []string{"pro", "enterprise"}},
+			want:    []string{fltEntDemoted, fltEntConverted, fltProEnding, fltProExpired},
+		},
+		{
+			name:    "an unknown account type alongside a known one keeps the known one",
+			payload: &gen.ListOrganizationsPayload{AccountTypes: []string{"platinum", "pro"}},
+			want:    []string{fltProEnding, fltProExpired},
+		},
+		{
+			name:    "the account_type scalar still filters on its own",
+			payload: &gen.ListOrganizationsPayload{AccountType: ptrTo("pro")},
+			want:    []string{fltProEnding, fltProExpired},
+		},
+		{
+			name:    "the account_type scalar joins the set rather than replacing it",
+			payload: &gen.ListOrganizationsPayload{AccountType: ptrTo("free"), AccountTypes: []string{"enterprise"}},
+			want:    []string{fltFreeNone, fltFreeRunning, fltFreeConverted, fltFreeWindowIn, fltFreeWindowOut, fltEntDemoted, fltEntConverted},
+		},
+		{
+			name:    "trial_states running spans the far side of the ending_soon boundary",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"running"}},
+			want:    []string{fltFreeRunning, fltFreeWindowOut},
+		},
+		{
+			name:    "trial_states ending_soon spans the near side of the boundary",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"ending_soon"}},
+			want:    []string{fltProEnding, fltFreeWindowIn},
+		},
+		{
+			name:    "trial_states matches every listed state",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"running", "ending_soon"}},
+			want:    []string{fltFreeRunning, fltFreeWindowOut, fltProEnding, fltFreeWindowIn},
+		},
+		{
+			name:    "trial_states none matches the organizations that never trialled",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"none"}},
+			want:    []string{fltFreeNone},
+		},
+		{
+			name:    "trial_states converted takes precedence over the trial end date",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"converted"}},
+			want:    []string{fltFreeConverted, fltEntConverted},
+		},
+		{
+			name:    "trial_states demoted takes precedence over the trial end date",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"demoted"}},
+			want:    []string{fltEntDemoted},
+		},
+		{
+			name:    "trial_states expired excludes trials that ended after converting or demoting",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"expired"}},
+			want:    []string{fltProExpired},
+		},
+		{
+			name:    "disabled_states disabled drops the active organizations",
+			payload: &gen.ListOrganizationsPayload{DisabledStates: []string{"disabled"}},
+			want:    []string{fltFreeOff, fltProOffRunning},
+		},
+		{
+			name:    "disabled_states with both members keeps everything",
+			payload: &gen.ListOrganizationsPayload{DisabledStates: []string{"active", "disabled"}},
+			want:    all,
+		},
+		{
+			name:    "include_disabled still widens on its own",
+			payload: &gen.ListOrganizationsPayload{IncludeDisabled: ptrTo(true)},
+			want:    all,
+		},
+		{
+			name:    "disabled_states overrides include_disabled",
+			payload: &gen.ListOrganizationsPayload{IncludeDisabled: ptrTo(true), DisabledStates: []string{"active"}},
+			want:    active,
+		},
+		{
+			name: "the three filters compose",
+			payload: &gen.ListOrganizationsPayload{
+				AccountTypes:   []string{"pro"},
+				TrialStates:    []string{"running"},
+				DisabledStates: []string{"disabled"},
+			},
+			want: []string{fltProOffRunning},
+		},
+		{
+			name:    "an unknown account type matches nothing without failing",
+			payload: &gen.ListOrganizationsPayload{AccountTypes: []string{"platinum"}},
+			want:    nil,
+		},
+		{
+			name:    "an unknown trial state matches nothing without failing",
+			payload: &gen.ListOrganizationsPayload{TrialStates: []string{"paused"}},
+			want:    nil,
+		},
+		{
+			name:    "an unknown disabled state matches nothing without failing",
+			payload: &gen.ListOrganizationsPayload{DisabledStates: []string{"archived"}},
+			want:    nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			requireFilterMatches(t, ctx, svc, c.payload, c.want, c.name)
+		})
+	}
+}
+
+// The filters have to survive the paging modes: the page query applies
+// trial_states outside the CTE that the cursor predicate sits in, and the count
+// query has no cursor predicate at all.
+func TestListOrganizations_SetFiltersSurvivePaging(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	now := time.Now().UTC()
+	corpus := filterCorpus(now)
+	seedFilterCorpus(t, ctx, conn, corpus, now.Add(-24*time.Hour))
+
+	filtered := &gen.ListOrganizationsPayload{
+		AccountTypes: []string{"free"},
+		TrialStates:  []string{"running", "ending_soon", "none"},
+		Limit:        ptrTo(2),
+	}
+
+	// Cursor mode. Walk the whole filtered set two rows at a time.
+	var walked []string
+	var cursor *string
+	for range len(corpus) {
+		payload := *filtered
+		payload.Cursor = cursor
+
+		res, err := svc.ListOrganizations(ctx, &payload)
+		require.NoError(t, err)
+		require.Equal(t, int64(4), res.Total, "the total counts the filtered set, not the page")
+
+		for _, o := range res.Organizations {
+			walked = append(walked, o.ID)
+		}
+		if res.NextCursor == nil {
+			break
+		}
+		cursor = res.NextCursor
+	}
+	require.ElementsMatch(t, []string{fltFreeNone, fltFreeRunning, fltFreeWindowIn, fltFreeWindowOut}, walked, "the cursor walk over a filtered set")
+
+	// Offset mode. The second page holds the remainder of the same set.
+	page2 := *filtered
+	page2.Sort = ptrTo("name")
+	page2.Page = ptrTo(2)
+
+	res, err := svc.ListOrganizations(ctx, &page2)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), res.Total)
+	require.Len(t, res.Organizations, 2)
+}

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -95,11 +95,18 @@ WITH filtered AS (
             OR om.id = sqlc.narg('q')::text
             OR om.workos_id = sqlc.narg('q')::text
         )
-        AND (sqlc.narg('account_type')::text IS NULL OR om.gram_account_type = sqlc.narg('account_type')::text)
-        AND (sqlc.arg('include_disabled')::boolean OR om.disabled_at IS NULL)
+        -- coalesce, not a bare cardinality: an absent filter reaches pgx as a nil
+        -- slice and encodes to a NULL array, and cardinality(NULL) is NULL, which
+        -- would drop every row instead of keeping every row.
+        AND (coalesce(cardinality(sqlc.arg('account_types')::text[]), 0) = 0 OR om.gram_account_type = ANY(sqlc.arg('account_types')::text[]))
+        -- No empty arm: the handler resolves an absent filter to {active}.
+        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY(sqlc.arg('disabled_states')::text[])
         AND (sqlc.narg('after_id')::text IS NULL OR om.id > sqlc.narg('after_id')::text)
 )
 SELECT * FROM filtered
+-- trial_state is computed in the CTE's select list, so it cannot be named in the
+-- CTE's own WHERE. Filtering out here keeps the ladder to one copy per query.
+WHERE coalesce(cardinality(sqlc.arg('trial_states')::text[]), 0) = 0 OR trial_state = ANY(sqlc.arg('trial_states')::text[])
 -- The sort key stays a bound parameter, never an interpolated column name, so no
 -- caller input reaches the parser. NULLS LAST is what keeps empty dates at the
 -- bottom under DESC, where Postgres would otherwise put them first; on the ASC
@@ -132,21 +139,36 @@ OFFSET sqlc.arg('page_offset')::bigint;
 -- row to carry a count at all. Keeping it out also leaves the page query free to
 -- terminate early on its index scan.
 --
--- The filter arms must stay identical to AdminListOrganizations. The trials join
--- is absent on purpose rather than by omission: organization_id is that table's
--- primary key, so the left join there cannot change how many rows match.
-SELECT count(*)::bigint
-FROM organization_metadata om
-WHERE
-    (
-        sqlc.narg('q')::text IS NULL
-        OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
-        OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
-        OR om.id = sqlc.narg('q')::text
-        OR om.workos_id = sqlc.narg('q')::text
-    )
-    AND (sqlc.narg('account_type')::text IS NULL OR om.gram_account_type = sqlc.narg('account_type')::text)
-    AND (sqlc.arg('include_disabled')::boolean OR om.disabled_at IS NULL);
+-- The filter arms must stay identical to AdminListOrganizations, trial_states
+-- included. That arm reads a column only the trials join can produce, so this
+-- query carries the join and the same CASE ladder. The join stays count-safe
+-- because organization_id is that table's primary key and cannot fan one
+-- organization out into several counted rows.
+WITH filtered AS (
+    SELECT
+        CASE
+            WHEN t.organization_id IS NULL THEN 'none'
+            WHEN t.converted_at IS NOT NULL THEN 'converted'
+            WHEN t.demoted_at IS NOT NULL THEN 'demoted'
+            WHEN t.ends_at <= now() THEN 'expired'
+            WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
+            ELSE 'running'
+        END::text AS trial_state
+    FROM organization_metadata om
+    LEFT JOIN trials t ON t.organization_id = om.id
+    WHERE
+        (
+            sqlc.narg('q')::text IS NULL
+            OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
+            OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
+            OR om.id = sqlc.narg('q')::text
+            OR om.workos_id = sqlc.narg('q')::text
+        )
+        AND (coalesce(cardinality(sqlc.arg('account_types')::text[]), 0) = 0 OR om.gram_account_type = ANY(sqlc.arg('account_types')::text[]))
+        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY(sqlc.arg('disabled_states')::text[])
+)
+SELECT count(*)::bigint FROM filtered
+WHERE coalesce(cardinality(sqlc.arg('trial_states')::text[]), 0) = 0 OR trial_state = ANY(sqlc.arg('trial_states')::text[]);
 
 -- name: AdminUpdateOrganization :exec
 -- Admin-only mutation. Both fields are optional — caller passes NULL to skip

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -13,24 +13,38 @@ import (
 )
 
 const adminCountOrganizations = `-- name: AdminCountOrganizations :one
-SELECT count(*)::bigint
-FROM organization_metadata om
-WHERE
-    (
-        $1::text IS NULL
-        OR om.name ILIKE '%' || $1::text || '%'
-        OR om.slug ILIKE '%' || $1::text || '%'
-        OR om.id = $1::text
-        OR om.workos_id = $1::text
-    )
-    AND ($2::text IS NULL OR om.gram_account_type = $2::text)
-    AND ($3::boolean OR om.disabled_at IS NULL)
+WITH filtered AS (
+    SELECT
+        CASE
+            WHEN t.organization_id IS NULL THEN 'none'
+            WHEN t.converted_at IS NOT NULL THEN 'converted'
+            WHEN t.demoted_at IS NOT NULL THEN 'demoted'
+            WHEN t.ends_at <= now() THEN 'expired'
+            WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
+            ELSE 'running'
+        END::text AS trial_state
+    FROM organization_metadata om
+    LEFT JOIN trials t ON t.organization_id = om.id
+    WHERE
+        (
+            $2::text IS NULL
+            OR om.name ILIKE '%' || $2::text || '%'
+            OR om.slug ILIKE '%' || $2::text || '%'
+            OR om.id = $2::text
+            OR om.workos_id = $2::text
+        )
+        AND (coalesce(cardinality($3::text[]), 0) = 0 OR om.gram_account_type = ANY($3::text[]))
+        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY($4::text[])
+)
+SELECT count(*)::bigint FROM filtered
+WHERE coalesce(cardinality($1::text[]), 0) = 0 OR trial_state = ANY($1::text[])
 `
 
 type AdminCountOrganizationsParams struct {
-	Q               pgtype.Text
-	AccountType     pgtype.Text
-	IncludeDisabled bool
+	TrialStates    []string
+	Q              pgtype.Text
+	AccountTypes   []string
+	DisabledStates []string
 }
 
 // The count cannot ride on the page query. That query carries the cursor
@@ -39,11 +53,18 @@ type AdminCountOrganizationsParams struct {
 // row to carry a count at all. Keeping it out also leaves the page query free to
 // terminate early on its index scan.
 //
-// The filter arms must stay identical to AdminListOrganizations. The trials join
-// is absent on purpose rather than by omission: organization_id is that table's
-// primary key, so the left join there cannot change how many rows match.
+// The filter arms must stay identical to AdminListOrganizations, trial_states
+// included. That arm reads a column only the trials join can produce, so this
+// query carries the join and the same CASE ladder. The join stays count-safe
+// because organization_id is that table's primary key and cannot fan one
+// organization out into several counted rows.
 func (q *Queries) AdminCountOrganizations(ctx context.Context, arg AdminCountOrganizationsParams) (int64, error) {
-	row := q.db.QueryRow(ctx, adminCountOrganizations, arg.Q, arg.AccountType, arg.IncludeDisabled)
+	row := q.db.QueryRow(ctx, adminCountOrganizations,
+		arg.TrialStates,
+		arg.Q,
+		arg.AccountTypes,
+		arg.DisabledStates,
+	)
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err
@@ -332,47 +353,53 @@ WITH filtered AS (
         -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
         -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
         (
-            $5::text IS NULL
-            OR om.name ILIKE '%' || $5::text || '%'
-            OR om.slug ILIKE '%' || $5::text || '%'
-            OR om.id = $5::text
-            OR om.workos_id = $5::text
+            $6::text IS NULL
+            OR om.name ILIKE '%' || $6::text || '%'
+            OR om.slug ILIKE '%' || $6::text || '%'
+            OR om.id = $6::text
+            OR om.workos_id = $6::text
         )
-        AND ($6::text IS NULL OR om.gram_account_type = $6::text)
-        AND ($7::boolean OR om.disabled_at IS NULL)
-        AND ($8::text IS NULL OR om.id > $8::text)
+        -- coalesce, not a bare cardinality: an absent filter reaches pgx as a nil
+        -- slice and encodes to a NULL array, and cardinality(NULL) is NULL, which
+        -- would drop every row instead of keeping every row.
+        AND (coalesce(cardinality($7::text[]), 0) = 0 OR om.gram_account_type = ANY($7::text[]))
+        -- No empty arm: the handler resolves an absent filter to {active}.
+        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY($8::text[])
+        AND ($9::text IS NULL OR om.id > $9::text)
 )
 SELECT id, name, slug, account_type, workos_id, whitelisted, disabled_at, free_trial_started_at, free_trial_ends_at, trial_state, trial_ends_at, created_at, updated_at, member_count FROM filtered
+WHERE coalesce(cardinality($1::text[]), 0) = 0 OR trial_state = ANY($1::text[])
 ORDER BY
-    CASE WHEN $1::text = 'name' AND $2::text = 'asc' THEN name END ASC NULLS LAST,
-    CASE WHEN $1::text = 'name' AND $2::text = 'desc' THEN name END DESC NULLS LAST,
-    CASE WHEN $1::text = 'slug' AND $2::text = 'asc' THEN slug END ASC NULLS LAST,
-    CASE WHEN $1::text = 'slug' AND $2::text = 'desc' THEN slug END DESC NULLS LAST,
-    CASE WHEN $1::text = 'account_type' AND $2::text = 'asc' THEN account_type END ASC NULLS LAST,
-    CASE WHEN $1::text = 'account_type' AND $2::text = 'desc' THEN account_type END DESC NULLS LAST,
-    CASE WHEN $1::text = 'member_count' AND $2::text = 'asc' THEN member_count END ASC NULLS LAST,
-    CASE WHEN $1::text = 'member_count' AND $2::text = 'desc' THEN member_count END DESC NULLS LAST,
-    CASE WHEN $1::text = 'created_at' AND $2::text = 'asc' THEN created_at END ASC NULLS LAST,
-    CASE WHEN $1::text = 'created_at' AND $2::text = 'desc' THEN created_at END DESC NULLS LAST,
-    CASE WHEN $1::text = 'disabled_at' AND $2::text = 'asc' THEN disabled_at END ASC NULLS LAST,
-    CASE WHEN $1::text = 'disabled_at' AND $2::text = 'desc' THEN disabled_at END DESC NULLS LAST,
-    CASE WHEN $1::text = 'trial_ends_at' AND $2::text = 'asc' THEN trial_ends_at END ASC NULLS LAST,
-    CASE WHEN $1::text = 'trial_ends_at' AND $2::text = 'desc' THEN trial_ends_at END DESC NULLS LAST,
+    CASE WHEN $2::text = 'name' AND $3::text = 'asc' THEN name END ASC NULLS LAST,
+    CASE WHEN $2::text = 'name' AND $3::text = 'desc' THEN name END DESC NULLS LAST,
+    CASE WHEN $2::text = 'slug' AND $3::text = 'asc' THEN slug END ASC NULLS LAST,
+    CASE WHEN $2::text = 'slug' AND $3::text = 'desc' THEN slug END DESC NULLS LAST,
+    CASE WHEN $2::text = 'account_type' AND $3::text = 'asc' THEN account_type END ASC NULLS LAST,
+    CASE WHEN $2::text = 'account_type' AND $3::text = 'desc' THEN account_type END DESC NULLS LAST,
+    CASE WHEN $2::text = 'member_count' AND $3::text = 'asc' THEN member_count END ASC NULLS LAST,
+    CASE WHEN $2::text = 'member_count' AND $3::text = 'desc' THEN member_count END DESC NULLS LAST,
+    CASE WHEN $2::text = 'created_at' AND $3::text = 'asc' THEN created_at END ASC NULLS LAST,
+    CASE WHEN $2::text = 'created_at' AND $3::text = 'desc' THEN created_at END DESC NULLS LAST,
+    CASE WHEN $2::text = 'disabled_at' AND $3::text = 'asc' THEN disabled_at END ASC NULLS LAST,
+    CASE WHEN $2::text = 'disabled_at' AND $3::text = 'desc' THEN disabled_at END DESC NULLS LAST,
+    CASE WHEN $2::text = 'trial_ends_at' AND $3::text = 'asc' THEN trial_ends_at END ASC NULLS LAST,
+    CASE WHEN $2::text = 'trial_ends_at' AND $3::text = 'desc' THEN trial_ends_at END DESC NULLS LAST,
     -- Without this tiebreaker rows that tie on the sort key can swap between calls, which drops or repeats rows across a page boundary.
     id ASC
-LIMIT $4::int
-OFFSET $3::bigint
+LIMIT $5::int
+OFFSET $4::bigint
 `
 
 type AdminListOrganizationsParams struct {
-	SortBy          string
-	SortDir         string
-	PageOffset      int64
-	PageLimit       int32
-	Q               pgtype.Text
-	AccountType     pgtype.Text
-	IncludeDisabled bool
-	AfterID         pgtype.Text
+	TrialStates    []string
+	SortBy         string
+	SortDir        string
+	PageOffset     int64
+	PageLimit      int32
+	Q              pgtype.Text
+	AccountTypes   []string
+	DisabledStates []string
+	AfterID        pgtype.Text
 }
 
 type AdminListOrganizationsRow struct {
@@ -395,6 +422,8 @@ type AdminListOrganizationsRow struct {
 // Two paging modes share this query. A caller that supplies no sort key gets the
 // cursor walk it always had: the sort ladder collapses to all-NULL and the
 // tiebreaker alone orders the rows. A caller that supplies one gets offset paging.
+// trial_state is computed in the CTE's select list, so it cannot be named in the
+// CTE's own WHERE. Filtering out here keeps the ladder to one copy per query.
 // The sort key stays a bound parameter, never an interpolated column name, so no
 // caller input reaches the parser. NULLS LAST is what keeps empty dates at the
 // bottom under DESC, where Postgres would otherwise put them first; on the ASC
@@ -402,13 +431,14 @@ type AdminListOrganizationsRow struct {
 // column read alike.
 func (q *Queries) AdminListOrganizations(ctx context.Context, arg AdminListOrganizationsParams) ([]AdminListOrganizationsRow, error) {
 	rows, err := q.db.Query(ctx, adminListOrganizations,
+		arg.TrialStates,
 		arg.SortBy,
 		arg.SortDir,
 		arg.PageOffset,
 		arg.PageLimit,
 		arg.Q,
-		arg.AccountType,
-		arg.IncludeDisabled,
+		arg.AccountTypes,
+		arg.DisabledStates,
 		arg.AfterID,
 	)
 	if err != nil {


### PR DESCRIPTION
The admin organizations list could filter on one account type and a disabled yes/no. An operator asking for "enterprise or pro", or for "trials running or ending soon", had to run several requests and merge the pages by hand.

This adds three repeated query parameters to `admin/organizations.list`:

| Parameter | Takes |
| --- | --- |
| `account_types` | any number of account types |
| `trial_states` | any of `running`, `ending_soon`, `expired`, `demoted`, `converted`, `none` |
| `disabled_states` | `active`, `disabled`, or both |

An empty set means no filter of that kind, except `disabled_states`, where empty still means active only. A value outside the known list matches nothing rather than failing the request: an organization can carry an account type the dashboard does not know, and an operator pasting a colleague's URL is owed an empty table rather than a 422.

## This is the expand step

`account_type` and `include_disabled` both still work. `account_type` joins `account_types` as one more member of the same set, and `disabled_states` overrides `include_disabled` when supplied. That is what lets this ship before the client half. Retiring the two scalars is a separate contraction step.

## The count query changed, and that is the risky part

`total` drives the pager, so the count query has to apply the same filters as the page query or the pager lies. `trial_states` reads a column only the `trials` join can produce, so the count query now carries that join and the same `CASE` ladder, both inside a CTE referenced once.

The old comment on that query said the join could not change how many rows match. That was true until `trial_states` made the join decide which rows count, so the comment is replaced rather than kept.

The join stays count-safe because `trials_pkey` is `PRIMARY KEY (organization_id)` (`server/database/schema.sql:101`), so it cannot fan one organization out into several counted rows.

## Two traps worth knowing about if you review the SQL

**An absent repeated parameter reaches pgx as a nil slice and encodes to a SQL `NULL` array.** A bare `cardinality($n) = 0` arm would then evaluate to `NULL` and silently drop every row. The `account_types` and `trial_states` arms use `coalesce(cardinality(...), 0) = 0`. The `disabled_states` arm deliberately has no empty arm, because the handler resolves an absent filter to `{active}` before the query ever sees it; that guard lives in Go rather than in SQL, which is a note for any future direct caller of the repo layer.

**`cardinality` rather than `array_length`,** because `cardinality('{}')` is 0 while `array_length('{}', 1)` is `NULL`.

## Tests

The filter predicates exist twice, once per query, and rows alone cannot tell the two copies apart. So every case asserts the reported total as well as the rows: deleting the trial-state predicate from the count query while leaving the page query intact now fails.

The corpus is built so a wrong answer cannot look right. Filters select disjoint row sets, `converted` and `demoted` carry more than one row each so a count over the wrong state cannot land on the right number, and two rows straddle the `ending_soon` boundary by an hour on either side.

A mutation sweep was run against it, including a deliberate equivalent-mutant canary (`count(*)` to `count(1)`) that survived as expected, which is what proves the sweep can report a survivor rather than killing everything.

## Reviewed before opening

An independent SQL review checked the NULL-array hazard on every arm in both queries, confirmed the two `WHERE` clauses are byte-identical once whitespace and comments are normalised, verified the primary-key claim, and checked the sqlc placeholder-to-field alignment by hand in `repo/queries.sql.go`. A separate scope and hygiene pass found no drive-by changes and nothing that should not be published.

## Client half

The dashboard side is a separate branch and a separate pull request, because this half is designed to merge first. AGE-3186.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds set-based filtering to the admin organizations list so operators can query “enterprise or pro” and “trials running or ending soon” in one request. Previously you could pass one `account_type` and `include_disabled`; now `account_types`, `trial_states`, and `disabled_states` accept repeated values, and the total uses the same filters as the page.

- Unknown values match nothing; an empty set means no filter (except `disabled_states`, which defaults to active and respects `include_disabled` when set).
- Backward compatible: `account_type` joins `account_types`; `disabled_states` overrides `include_disabled`.

**Review notes**
- API: Adds `account_types`, `trial_states`, `disabled_states` to `admin/organizations.list`; OpenAPI and HTTP client/server encoders updated; `gram` CLI gains `--account-types`, `--trial-states`, `--disabled-states` (JSON arrays).
- SQL: Count query now joins `trials` and computes `trial_state` in a CTE shared with the page query; filters are byte-identical across queries. Uses coalesce(cardinality(...), 0) to handle absent arrays; `disabled_states` default is resolved in Go (`server/internal/admin/impl.go`).
- Tests: `server/internal/admin/listorganizationsfilters_test.go` asserts both rows and totals and exercises cursor/offset paging.

**Rollout/migration**
- No required client changes; existing dashboard continues to work. Clients may begin sending the new repeated parameters at any time. For CLI, pass arrays as JSON (e.g., `--account-types '["pro","enterprise"]'`).
- Supports Linear AGE-3186; this is the server “expand” step and can merge before the dashboard PR.

<sup>Written for commit 3b98c4fb87249063430ce423b03b22374565326b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

