### PR TITLE
feat(admin): filter the organizations list by type, trial state and status

### DIFF
--- a/.changeset/admin-organizations-filters.md
+++ b/.changeset/admin-organizations-filters.md
@@ -1,0 +1,34 @@
+---
+"admin": patch
+---
+
+Let a platform admin narrow the organizations list by account type, trial state
+and status, picking as many values in each as they need.
+
+The toolbar carries one control per group. Any of them opens the same sheet, on
+the group that was pressed, and each group is a multi-select: Type takes any of
+free, pro and enterprise, Trial takes any of the six states the rows show, and
+Status takes active, disabled or both. An empty group is a default rather than
+an empty result, and each control says its own: all types, all trial states,
+active only.
+
+The trial options read from the same map the trial badge on the row renders, so
+the filter and the rows it returns cannot say different words for one state.
+
+Nothing reaches the table until the operator applies. Picking three values
+otherwise costs three requests and shows two lists nobody asked for on the way
+to the one they did. Escape closes the sheet, discards the edit and puts the
+keyboard back on the control it opened from. Clear all resets every filter and
+leaves the search term alone: the term is not a filter this sheet holds.
+
+The chosen filters live in the URL, so an operator can paste the view they are
+looking at and get the same rows back. Applying returns to the first page and
+keeps the sort. Values are ordered as the pickers offer them and deduplicated,
+so two operators who chose the same filter in a different order send one request
+and share one cache entry. An account type from outside the offered list is kept
+rather than dropped, because dropping it would widen a link's view while the
+control still read "all types".
+
+The request now sends `account_types`, `trial_states` and `disabled_states`, each
+repeated once per chosen value, in place of the single `account_type` and the
+`include_disabled` flag.

--- a/.changeset/admin-organizations-write-actions.md
+++ b/.changeset/admin-organizations-write-actions.md
@@ -1,0 +1,27 @@
+---
+"admin": patch
+---
+
+Let a platform admin disable an organization, re-enable it, and extend its
+enterprise trial without leaving the organizations list.
+
+Every row carries a menu with those actions, and the peek panel repeats them as
+buttons in its footer, so the operator acts on the record they are already
+reading. The menu offers Disable or Re-enable, never both: which one it shows
+follows the row, so a record disabled a moment ago offers the way back
+immediately. Extend trial is offered only for a trial the server will extend,
+which is one that is running or ending soon.
+
+Disabling asks for a confirmation first, because it takes Gram away from every
+member of the organization until it is re-enabled. Re-enabling does not: it
+gives access back, and a second press costs a request and nothing else.
+
+Extending asks for a day count, starting at 14. The days are added to the date
+the trial ends on now rather than to today, so extending it early does not
+shorten it. A count outside 1 to 365 is refused in the dialog, with the reason,
+before a request the server would reject leaves the browser.
+
+The list repaints from what the write answered, with no second request behind
+it, so the row and the panel show the new state as soon as it lands. A write
+that failed says why: inside the dialog it failed in, and through the same
+polite region the list already announces the peek with.

--- a/.changeset/admin-organizations-write-actions.md
+++ b/.changeset/admin-organizations-write-actions.md
@@ -9,8 +9,9 @@ Every row carries a menu with those actions, and the peek panel repeats them as
 buttons in its footer, so the operator acts on the record they are already
 reading. The menu offers Disable or Re-enable, never both: which one it shows
 follows the row, so a record disabled a moment ago offers the way back
-immediately. Extend trial is offered only for a trial the server will extend,
-which is one that is running or ending soon.
+immediately. Extend trial is offered only for a trial that is running or ending
+soon, and never for a disabled organization, whose trial runs on while every
+member is locked out.
 
 Disabling asks for a confirmation first, because it takes Gram away from every
 member of the organization until it is re-enabled. Re-enabling does not: it
@@ -22,6 +23,11 @@ shorten it. A count outside 1 to 365 is refused in the dialog, with the reason,
 before a request the server would reject leaves the browser.
 
 The list repaints from what the write answered, with no second request behind
-it, so the row and the panel show the new state as soon as it lands. A write
-that failed says why: inside the dialog it failed in, and through the same
-polite region the list already announces the peek with.
+it, so the row and the panel show the new state as soon as it lands.
+
+A write that failed says why. A write made from a dialog reports inside that
+dialog. Re-enable has no dialog, so its failure raises a message above the list
+that stays until it is dismissed or the next write succeeds. Every outcome also
+goes through the polite region the list already announces the peek with, and the
+keyboard returns to the control that opened the dialog rather than to the top of
+the page.

--- a/.changeset/admin-organizations-write-actions.md
+++ b/.changeset/admin-organizations-write-actions.md
@@ -23,7 +23,10 @@ shorten it. A count outside 1 to 365 is refused in the dialog, with the reason,
 before a request the server would reject leaves the browser.
 
 The list repaints from what the write answered, with no second request behind
-it, so the row and the panel show the new state as soon as it lands.
+it, so the row and the panel show the new state as soon as it lands. A read
+already in flight when the operator acts is dropped rather than left to finish,
+because it answers with the row as it was and would put that back over the
+write.
 
 A write that failed says why. A write made from a dialog reports inside that
 dialog. Re-enable has no dialog, so its failure raises a message above the list

--- a/client/admin/package.json
+++ b/client/admin/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-table": "9.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "catalog:",
     "radix-ui": "^1.6.0",
     "react": "^19.2.8",

--- a/client/admin/src/components/Trial.tsx
+++ b/client/admin/src/components/Trial.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "react";
 import { Badge } from "@/components/ui/badge";
 import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization, TrialState } from "@/lib/gramAdminApi";
+import { TRIAL_LABELS } from "@/lib/trialLabels";
 import { fmtDateShort } from "@/lib/utils";
 
 type TrialDisplay = {
@@ -23,11 +24,31 @@ type TrialDisplay = {
 // `TRIAL_STATES` at runtime, so a seventh state fails a test even if this
 // annotation is edited away.
 const TRIAL_DISPLAY: Record<Exclude<TrialState, "none">, TrialDisplay> = {
-  running: { label: "Running", tone: "neutral", showsEndDate: true },
-  ending_soon: { label: "Ending soon", tone: "warning", showsEndDate: true },
-  expired: { label: "Expired", tone: "destructive", showsEndDate: false },
-  demoted: { label: "Demoted", tone: "destructive", showsEndDate: false },
-  converted: { label: "Converted", tone: "success", showsEndDate: false },
+  running: {
+    label: TRIAL_LABELS.running,
+    tone: "neutral",
+    showsEndDate: true,
+  },
+  ending_soon: {
+    label: TRIAL_LABELS.ending_soon,
+    tone: "warning",
+    showsEndDate: true,
+  },
+  expired: {
+    label: TRIAL_LABELS.expired,
+    tone: "destructive",
+    showsEndDate: false,
+  },
+  demoted: {
+    label: TRIAL_LABELS.demoted,
+    tone: "destructive",
+    showsEndDate: false,
+  },
+  converted: {
+    label: TRIAL_LABELS.converted,
+    tone: "success",
+    showsEndDate: false,
+  },
 };
 
 // Indexed as a plain string record on purpose. The server can start sending a
@@ -63,7 +84,7 @@ export function Trial({ org }: { org: AdminOrganization }): JSX.Element {
       <span className="text-muted-foreground text-sm">
         <span aria-hidden="true">-</span>
         <span className="sr-only">
-          {unrecognised ? "Trial state not recognised" : "No trial"}
+          {unrecognised ? "Trial state not recognised" : TRIAL_LABELS.none}
         </span>
       </span>
     );

--- a/client/admin/src/components/ui/command.tsx
+++ b/client/admin/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/client/admin/src/components/ui/popover.tsx
+++ b/client/admin/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+};

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -169,7 +169,7 @@ describe("writeOrganizationToCache", () => {
     // Asked before the write, and still open when the write comes back.
     const inFlight = qc.prefetchQuery({ ...page, queryFn: () => stale });
 
-    await cancelOrganizationFetches(qc, DISABLED.id);
+    await cancelOrganizationFetches(qc);
     writeOrganizationToCache(qc, DISABLED);
 
     // The stale answer arrives late, carrying the row in its pre-write state.
@@ -178,5 +178,31 @@ describe("writeOrganizationToCache", () => {
 
     const after = qc.getQueryData<ListOrganizationsResult>(page.queryKey);
     expect(after?.organizations[0]).toEqual(DISABLED);
+  });
+
+  // The entry the operator actually opened. The row links by slug wherever an
+  // organization has one, so the detail read in flight is keyed by slug, and
+  // the slug is not known when the write starts. Cancelling the id alone would
+  // leave this one free to answer late and put the record back as it was.
+  it("survives a detail read in flight under the slug, not the id", async () => {
+    const qc = new QueryClient();
+    const detail = organizationQuery(DISABLED.slug);
+
+    let land: (result: AdminOrganization) => void = () => {};
+    const stale = new Promise<AdminOrganization>((resolve) => {
+      land = resolve;
+    });
+
+    const inFlight = qc.prefetchQuery({ ...detail, queryFn: () => stale });
+
+    await cancelOrganizationFetches(qc);
+    writeOrganizationToCache(qc, DISABLED);
+
+    land(LIVE);
+    await inFlight;
+
+    expect(qc.getQueryData(detail.queryKey)?.disabled_at).toBe(
+      DISABLED.disabled_at,
+    );
   });
 });

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -10,11 +10,14 @@ import type {
   ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
 
+// The slug is never the id. A fixture that spells them the same lets a lookup
+// by slug pass every assertion written for a lookup by id, and the two are
+// separate cache entries with separate consequences.
 function org(id: string): AdminOrganization {
   return {
     id,
     name: id,
-    slug: id,
+    slug: `slug-for-${id}`,
     account_type: "free",
     whitelisted: false,
     member_count: 1,
@@ -72,8 +75,6 @@ describe("organizationQuery", () => {
 // nothing refetches behind it, so an entry this function misses is a surface
 // still showing the state the operator just changed.
 describe("writeOrganizationToCache", () => {
-  // The slug is not the id. The two are separate cache entries, and a record
-  // whose slug reads like its id would let one assertion pass for both.
   const LIVE: AdminOrganization = { ...org("org-a"), slug: "placeholder-a" };
   const DISABLED: AdminOrganization = {
     ...LIVE,
@@ -115,6 +116,23 @@ describe("writeOrganizationToCache", () => {
     // The rest of the page is the page, not just its rows. A cursor dropped
     // here strands the operator on whichever page they had reached.
     expect(after?.next_cursor).toBe("cursor_page_two");
+  });
+
+  // The row is found by id, and by nothing else. A cached page is as old as the
+  // fetch behind it, so it can hold a record whose slug has since been changed
+  // from another surface; a writer matching on the slug would miss that row and
+  // leave the state the operator just changed on the page.
+  it("finds the row whose slug has moved on since the page was fetched", () => {
+    const qc = new QueryClient();
+    const page = organizationsListQuery({ q: "x" });
+    qc.setQueryData(page.queryKey, {
+      organizations: [{ ...LIVE, slug: "placeholder-a-as-it-was" }],
+    });
+
+    writeOrganizationToCache(qc, DISABLED);
+
+    const after = qc.getQueryData<ListOrganizationsResult>(page.queryKey);
+    expect(after?.organizations[0]).toEqual(DISABLED);
   });
 
   it("leaves a page that never held the record exactly as it was", () => {

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
-import { organizationQuery, organizationsListQuery } from "@/lib/adminQueries";
-import type { AdminOrganization } from "@/lib/gramAdminApi";
+import {
+  organizationQuery,
+  organizationsListQuery,
+  writeOrganizationToCache,
+} from "@/lib/adminQueries";
+import type {
+  AdminOrganization,
+  ListOrganizationsResult,
+} from "@/lib/gramAdminApi";
 
 function org(id: string): AdminOrganization {
   return {
@@ -58,5 +65,70 @@ describe("organizationQuery", () => {
   // an admin reads and acts on.
   it("leaves a seeded record open to a refetch", () => {
     expect(organizationQuery("org-a").staleTime).toBeUndefined();
+  });
+});
+
+// What a write puts back. The list and the peek panel repaint from this and
+// nothing refetches behind it, so an entry this function misses is a surface
+// still showing the state the operator just changed.
+describe("writeOrganizationToCache", () => {
+  // The slug is not the id. The two are separate cache entries, and a record
+  // whose slug reads like its id would let one assertion pass for both.
+  const LIVE: AdminOrganization = { ...org("org-a"), slug: "placeholder-a" };
+  const DISABLED: AdminOrganization = {
+    ...LIVE,
+    disabled_at: "2026-08-01T00:00:00Z",
+  };
+
+  it("answers the detail route by id and by slug", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(organizationQuery("org-a").queryKey, LIVE);
+    // The row links by slug, so this is the entry the operator opens after
+    // acting on the row, and it is a different entry from the one above.
+    qc.setQueryData(organizationQuery(DISABLED.slug).queryKey, LIVE);
+
+    writeOrganizationToCache(qc, DISABLED);
+
+    expect(
+      qc.getQueryData(organizationQuery("org-a").queryKey)?.disabled_at,
+    ).toBe(DISABLED.disabled_at);
+    expect(
+      qc.getQueryData(organizationQuery(DISABLED.slug).queryKey)?.disabled_at,
+    ).toBe(DISABLED.disabled_at);
+  });
+
+  it("replaces the record on every page that holds it, and only that record", () => {
+    const qc = new QueryClient();
+    const page = organizationsListQuery({ q: "x" });
+    qc.setQueryData(page.queryKey, {
+      organizations: [org("org-b"), LIVE],
+      next_cursor: "cursor_page_two",
+    });
+
+    writeOrganizationToCache(qc, DISABLED);
+
+    const after = qc.getQueryData<ListOrganizationsResult>(page.queryKey);
+    expect(after?.organizations.map((row) => row.disabled_at)).toEqual([
+      undefined,
+      DISABLED.disabled_at,
+    ]);
+    // The rest of the page is the page, not just its rows. A cursor dropped
+    // here strands the operator on whichever page they had reached.
+    expect(after?.next_cursor).toBe("cursor_page_two");
+  });
+
+  it("leaves a page that never held the record exactly as it was", () => {
+    const qc = new QueryClient();
+    const page = organizationsListQuery({ q: "other" });
+    const before: ListOrganizationsResult = { organizations: [org("org-b")] };
+    qc.setQueryData(page.queryKey, before);
+
+    writeOrganizationToCache(qc, DISABLED);
+
+    // Untouched down to the reference. React Query keeps the old object where
+    // the new one is deeply equal, so this holds whether the page was skipped
+    // or rebuilt from rows that had not changed; what it rules out is a write
+    // that lands on a page the record is not on.
+    expect(qc.getQueryData(page.queryKey)).toBe(before);
   });
 });

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
 import {
+  cancelOrganizationFetches,
   organizationQuery,
   organizationsListQuery,
   writeOrganizationToCache,
@@ -148,5 +149,34 @@ describe("writeOrganizationToCache", () => {
     // or rebuilt from rows that had not changed; what it rules out is a write
     // that lands on a page the record is not on.
     expect(qc.getQueryData(page.queryKey)).toBe(before);
+  });
+
+  // The write is only as good as the reads it outlives. A list fetch that was
+  // already open when the operator acted answers with the row as it was, and
+  // React Query commits that answer whenever it arrives, so without the cancel
+  // it lands on top of the write and the organization reads as though nothing
+  // happened.
+  it("survives a read that was already in flight when it landed", async () => {
+    const qc = new QueryClient();
+    const page = organizationsListQuery();
+    qc.setQueryData(page.queryKey, { organizations: [LIVE] });
+
+    let land: (result: ListOrganizationsResult) => void = () => {};
+    const stale = new Promise<ListOrganizationsResult>((resolve) => {
+      land = resolve;
+    });
+
+    // Asked before the write, and still open when the write comes back.
+    const inFlight = qc.prefetchQuery({ ...page, queryFn: () => stale });
+
+    await cancelOrganizationFetches(qc, DISABLED.id);
+    writeOrganizationToCache(qc, DISABLED);
+
+    // The stale answer arrives late, carrying the row in its pre-write state.
+    land({ organizations: [LIVE] });
+    await inFlight;
+
+    const after = qc.getQueryData<ListOrganizationsResult>(page.queryKey);
+    expect(after?.organizations[0]).toEqual(DISABLED);
   });
 });

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -98,6 +98,12 @@ export function organizationMembersQuery(
 // be the alternative, and the list is cursor-paged and filtered: refetching it
 // can move the row out from under the operator who just acted on it.
 //
+// One consequence, accepted rather than overlooked: the default list request
+// omits include_disabled, so a row that has just been disabled keeps its place
+// on a page whose filter no longer describes it, until something else fetches
+// that page. The alternative is dropping the row from under the operator the
+// moment they act on it, which is worse.
+//
 // It lives beside the keys rather than at a call site for the reason at the top
 // of this file: a key spelled out by hand is how a write updates the server and
 // leaves the table showing the old row.
@@ -110,9 +116,12 @@ export function writeOrganizationToCache(
   if (org.slug) qc.setQueryData(organizationQuery(org.slug).queryKey, org);
 
   // Every filter and every page, because the operator can act on a row from any
-  // of them and the rest stay in the cache behind it. The record is replaced
-  // where it appears and the page is left alone where it does not, so a list
-  // that never held it keeps its identity and does not re-render.
+  // of them and the rest stay in the cache behind it.
+  //
+  // The early return saves the rebuild on a page the record is not on. It is
+  // an allocation, not a correctness property: React Query hands back the old
+  // reference for a deeply equal result either way, so a page that never held
+  // the record keeps its identity with or without this.
   qc.setQueriesData<ListOrganizationsResult>(
     { queryKey: organizationsListQuery().queryKey },
     (previous) => {

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -4,7 +4,11 @@
 // written once. A key spelled out at a call site is the usual cause of a
 // mutation that updates the server and leaves the table showing the old row.
 
-import { queryOptions, type QueryKey } from "@tanstack/react-query";
+import {
+  queryOptions,
+  type QueryClient,
+  type QueryKey,
+} from "@tanstack/react-query";
 import {
   getOrganization,
   getProject,
@@ -87,6 +91,42 @@ export function organizationMembersQuery(
     queryKey: ["gram-admin-organization-members", organizationID] as const,
     queryFn: () => listOrganizationMembers(organizationID),
   });
+}
+
+// Every admin write answers with the organization in its new state, so the
+// caches that hold that record are written from the response. A refetch would
+// be the alternative, and the list is cursor-paged and filtered: refetching it
+// can move the row out from under the operator who just acted on it.
+//
+// It lives beside the keys rather than at a call site for the reason at the top
+// of this file: a key spelled out by hand is how a write updates the server and
+// leaves the table showing the old row.
+export function writeOrganizationToCache(
+  qc: QueryClient,
+  org: AdminOrganization,
+): void {
+  // The detail route takes either, and each is its own entry.
+  qc.setQueryData(organizationQuery(org.id).queryKey, org);
+  if (org.slug) qc.setQueryData(organizationQuery(org.slug).queryKey, org);
+
+  // Every filter and every page, because the operator can act on a row from any
+  // of them and the rest stay in the cache behind it. The record is replaced
+  // where it appears and the page is left alone where it does not, so a list
+  // that never held it keeps its identity and does not re-render.
+  qc.setQueriesData<ListOrganizationsResult>(
+    { queryKey: organizationsListQuery().queryKey },
+    (previous) => {
+      if (!previous?.organizations.some((row) => row.id === org.id)) {
+        return previous;
+      }
+      return {
+        ...previous,
+        organizations: previous.organizations.map((row) =>
+          row.id === org.id ? org : row,
+        ),
+      };
+    },
+  );
 }
 
 export function projectQuery(

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -133,10 +133,11 @@ export function cancelOrganizationFetches(qc: QueryClient): Promise<void> {
 // can move the row out from under the operator who just acted on it.
 //
 // One consequence, accepted rather than overlooked: the default list request
-// omits include_disabled, so a row that has just been disabled keeps its place
-// on a page whose filter no longer describes it, until something else fetches
-// that page. The alternative is dropping the row from under the operator the
-// moment they act on it, which is worse.
+// sends no disabled_states, which asks for active organizations only, so a row
+// that has just been disabled keeps its place on a page whose filter no longer
+// describes it, until something else fetches that page. The alternative is
+// dropping the row from under the operator the moment they act on it, which is
+// worse.
 //
 // It lives beside the keys rather than at a call site for the reason at the top
 // of this file: a key spelled out by hand is how a write updates the server and

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -93,6 +93,29 @@ export function organizationMembersQuery(
   });
 }
 
+// Called before a write goes out, because a read already in flight outlives it.
+// React Query commits whatever a request answers whenever it lands, so a list
+// fetch that started before the write returns the row in its old state
+// afterwards and undoes what the write just put in the cache. The row then
+// reads as though the write never happened, until something fetches that page
+// again.
+//
+// That window is ordinary rather than exotic: the list query sets no staleTime,
+// so returning to the tab starts a refetch, and the operator's next press lands
+// while it is still open.
+//
+// Cancelling rather than awaiting, because the answer is already stale: it was
+// asked before the write the operator just made.
+export function cancelOrganizationFetches(
+  qc: QueryClient,
+  id: string,
+): Promise<void> {
+  return Promise.all([
+    qc.cancelQueries({ queryKey: organizationsListQuery().queryKey }),
+    qc.cancelQueries({ queryKey: organizationQuery(id).queryKey }),
+  ]).then(() => undefined);
+}
+
 // Every admin write answers with the organization in its new state, so the
 // caches that hold that record are written from the response. A refetch would
 // be the alternative, and the list is cursor-paged and filtered: refetching it

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -60,11 +60,16 @@ export function organizationsListQuery(
   });
 }
 
+// Named once, because the detail entry is reached two ways. The route takes an
+// id or a slug and each is its own entry, so this is the only thing the two
+// have in common and the only way to name both at once.
+const ORGANIZATION_KEY = "gram-admin-organization";
+
 export function organizationQuery(
   idOrSlug: string,
 ): AdminQuery<AdminOrganization, readonly ["gram-admin-organization", string]> {
   return queryOptions({
-    queryKey: ["gram-admin-organization", idOrSlug] as const,
+    queryKey: [ORGANIZATION_KEY, idOrSlug] as const,
     queryFn: () => getOrganization(idOrSlug),
   });
 }
@@ -106,13 +111,19 @@ export function organizationMembersQuery(
 //
 // Cancelling rather than awaiting, because the answer is already stale: it was
 // asked before the write the operator just made.
-export function cancelOrganizationFetches(
-  qc: QueryClient,
-  id: string,
-): Promise<void> {
+export function cancelOrganizationFetches(qc: QueryClient): Promise<void> {
   return Promise.all([
     qc.cancelQueries({ queryKey: organizationsListQuery().queryKey }),
-    qc.cancelQueries({ queryKey: organizationQuery(id).queryKey }),
+    // The whole detail key rather than one organization's, and that is the
+    // point rather than laziness. `writeOrganizationToCache` writes the record
+    // under its id and under its slug, the row links by slug wherever there is
+    // one, and the slug is not known here: it arrives with the response the
+    // write has not made yet. Cancelling the id alone would leave the entry the
+    // operator actually opened free to answer late and put the record back.
+    //
+    // Cancelling another organization's detail fetch costs that page a refetch
+    // and nothing else, and only one detail query is ever in flight from here.
+    qc.cancelQueries({ queryKey: [ORGANIZATION_KEY] }),
   ]).then(() => undefined);
 }
 

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -6,6 +6,8 @@ import {
   errorMessage,
   extendTrial,
   logout,
+  MAX_TRIAL_EXTENSION_DAYS,
+  MIN_TRIAL_EXTENSION_DAYS,
   toSearchParams,
   type AdminOrganization,
 } from "@/lib/gramAdminApi";
@@ -88,6 +90,7 @@ describe("the organization write endpoints", () => {
   function requestOf(fetch: ReturnType<typeof vi.fn>): {
     path: unknown;
     method: unknown;
+    contentType: string | null;
     body: unknown;
   } {
     const call = fetch.mock.calls.at(-1);
@@ -98,12 +101,30 @@ describe("the organization write endpoints", () => {
     return {
       path: call?.[0],
       method: init?.method,
+      // Read through Headers, because gramAdminRequest normalises whatever it
+      // was handed and adds an Accept of its own. Asserted at all because a
+      // POST that drops it is answered with a 415, and a 415 is not observable
+      // from the client suite: nothing else here would change.
+      contentType: new Headers(init?.headers).get("Content-Type"),
       body: typeof body === "string" ? (JSON.parse(body) as unknown) : body,
     };
   }
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  // The two ends of the range the server takes, written out rather than
+  // derived. Every other bounds test in this repository reads these constants
+  // for its expectation, so moving one moves the whole suite with it and the
+  // browser starts refusing day counts the server would have taken.
+  //
+  // They must equal MinTrialExtensionDays and MaxTrialExtensionDays in
+  // server/internal/constants/trials.go. Nothing ties the two files together
+  // and nothing can: the admin API is stripped from both generated SDKs.
+  it("mirrors the server's day-count bounds exactly", () => {
+    expect(MIN_TRIAL_EXTENSION_DAYS).toBe(1);
+    expect(MAX_TRIAL_EXTENSION_DAYS).toBe(365);
   });
 
   it("posts the id to the disable path", async () => {
@@ -114,6 +135,7 @@ describe("the organization write endpoints", () => {
     expect(requestOf(fetch)).toEqual({
       path: "/admin/organization.disable",
       method: "POST",
+      contentType: "application/json",
       body: { id: ORG.id },
     });
   });
@@ -126,6 +148,7 @@ describe("the organization write endpoints", () => {
     expect(requestOf(fetch)).toEqual({
       path: "/admin/organization.enable",
       method: "POST",
+      contentType: "application/json",
       body: { id: ORG.id },
     });
   });
@@ -138,6 +161,7 @@ describe("the organization write endpoints", () => {
     expect(requestOf(fetch)).toEqual({
       path: "/admin/trial.extend",
       method: "POST",
+      contentType: "application/json",
       body: { id: ORG.id, days: 30 },
     });
   });

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -5,6 +5,7 @@ import {
   enableOrganization,
   errorMessage,
   extendTrial,
+  listOrganizations,
   logout,
   MAX_TRIAL_EXTENSION_DAYS,
   MIN_TRIAL_EXTENSION_DAYS,
@@ -31,6 +32,54 @@ describe("toSearchParams", () => {
   it("encodes a value that needs escaping", () => {
     const qs = toSearchParams({ q: "a b&c" });
     expect(qs.toString()).toBe("q=a+b%26c");
+  });
+});
+
+// The whole URL, not the params object, because a set the server reads as a set
+// has to arrive as one key per value. A comma-joined `account_types=free,pro`
+// parses on the server as a single account type named "free,pro", which matches
+// no organization: the browser would show an empty list and no error.
+describe("listOrganizations", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("repeats a key per value of each filter", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ organizations: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    await listOrganizations({
+      q: "acme",
+      account_types: ["free", "pro"],
+      trial_states: ["running", "ending_soon"],
+      disabled_states: ["active", "disabled"],
+    });
+
+    expect(fetch.mock.calls.at(-1)?.[0]).toBe(
+      "/admin/organizations.list?q=acme" +
+        "&account_types=free&account_types=pro" +
+        "&trial_states=running&trial_states=ending_soon" +
+        "&disabled_states=active&disabled_states=disabled",
+    );
+  });
+
+  it("asks for the unfiltered list with no query string at all", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ organizations: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    await listOrganizations({ account_types: [], trial_states: [] });
+
+    expect(fetch.mock.calls.at(-1)?.[0]).toBe("/admin/organizations.list");
   });
 });
 

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   GramAdminError,
+  disableOrganization,
+  enableOrganization,
   errorMessage,
+  extendTrial,
   logout,
   toSearchParams,
+  type AdminOrganization,
 } from "@/lib/gramAdminApi";
 
 describe("toSearchParams", () => {
@@ -52,6 +56,117 @@ describe("errorMessage", () => {
   it("falls back to the status line when the body carries no message", () => {
     const e = new GramAdminError(404, null, "gram admin 404 Not Found");
     expect(errorMessage(e)).toBe("gram admin 404 Not Found");
+  });
+});
+
+// The admin API is stripped from both generated SDKs, so nothing checks these
+// paths against the design. A test naming each one is the only thing between a
+// disable that enables and a review that reads two identical-looking calls.
+describe("the organization write endpoints", () => {
+  const ORG = {
+    id: "org_placeholder_one",
+    name: "Placeholder One",
+    slug: "placeholder-one",
+    account_type: "enterprise",
+    whitelisted: false,
+    member_count: 1,
+    created_at: "2026-01-02T00:00:00Z",
+    updated_at: "2026-01-07T00:00:00Z",
+  } satisfies AdminOrganization;
+
+  function stubFetch(): ReturnType<typeof vi.fn> {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(ORG), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    return fetch;
+  }
+
+  function requestOf(fetch: ReturnType<typeof vi.fn>): {
+    path: unknown;
+    method: unknown;
+    body: unknown;
+  } {
+    const call = fetch.mock.calls.at(-1);
+    const init = call?.[1] as RequestInit | undefined;
+    // A body these calls did not serialize is left as it is, so the assertion
+    // reads the shape it was handed rather than "[object Object]".
+    const body = init?.body;
+    return {
+      path: call?.[0],
+      method: init?.method,
+      body: typeof body === "string" ? (JSON.parse(body) as unknown) : body,
+    };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the id to the disable path", async () => {
+    const fetch = stubFetch();
+
+    await expect(disableOrganization({ id: ORG.id })).resolves.toEqual(ORG);
+
+    expect(requestOf(fetch)).toEqual({
+      path: "/admin/organization.disable",
+      method: "POST",
+      body: { id: ORG.id },
+    });
+  });
+
+  it("posts the id to the enable path", async () => {
+    const fetch = stubFetch();
+
+    await expect(enableOrganization({ id: ORG.id })).resolves.toEqual(ORG);
+
+    expect(requestOf(fetch)).toEqual({
+      path: "/admin/organization.enable",
+      method: "POST",
+      body: { id: ORG.id },
+    });
+  });
+
+  it("posts the id and the day count to the trial path", async () => {
+    const fetch = stubFetch();
+
+    await expect(extendTrial({ id: ORG.id, days: 30 })).resolves.toEqual(ORG);
+
+    expect(requestOf(fetch)).toEqual({
+      path: "/admin/trial.extend",
+      method: "POST",
+      body: { id: ORG.id, days: 30 },
+    });
+  });
+
+  // The 409 the server answers when a trial has converted, been demoted or
+  // already expired. The body carries the sentence the operator has to read,
+  // and it only survives if the call goes through gramAdminFetch.
+  it("carries the conflict the server sends back", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            name: "conflict",
+            message: "organization has no running enterprise trial to extend",
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const failure = await extendTrial({ id: ORG.id, days: 30 }).catch(
+      (e: unknown) => e,
+    );
+
+    expect(failure).toBeInstanceOf(GramAdminError);
+    expect(errorMessage(failure)).toBe(
+      "organization has no running enterprise trial to extend",
+    );
   });
 });
 

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -228,10 +228,19 @@ export type ListOrganizationsResult = {
   next_cursor?: string;
 };
 
+// Each filter is a repeated parameter the server reads as a set, and an absent
+// one means no filter of that kind: no account_types is every type, no
+// trial_states is every state, no disabled_states is active organizations only.
+//
+// The scalar `account_type` and the `include_disabled` flag these replaced are
+// still accepted by the server, so its half of this change can merge first.
+// Nothing here sends them, and nothing should: two ways to say the same filter
+// is how the browser and the server end up disagreeing about what is on.
 export type ListOrganizationsParams = {
   q?: string;
-  account_type?: string;
-  include_disabled?: boolean;
+  account_types?: string[];
+  trial_states?: string[];
+  disabled_states?: string[];
   cursor?: string;
   limit?: number;
 };

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -288,6 +288,57 @@ export function updateOrganization(
   });
 }
 
+export type OrganizationRequest = {
+  id: string;
+};
+
+// Both answer the organization in its new state, so a caller updates its cache
+// from the response rather than reading the record back.
+export function disableOrganization(
+  body: OrganizationRequest,
+): Promise<AdminOrganization> {
+  return gramAdminFetch<AdminOrganization>("/admin/organization.disable", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function enableOrganization(
+  body: OrganizationRequest,
+): Promise<AdminOrganization> {
+  return gramAdminFetch<AdminOrganization>("/admin/organization.enable", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// The server's own bounds, mirrored so a value it would reject never leaves the
+// browser. See MinTrialExtensionDays and MaxTrialExtensionDays in
+// server/internal/constants/trials.go: zero moves nothing but updated_at, a
+// negative shortens a trial through an endpoint named extend, and a year is
+// where a trial becomes a contract.
+export const MIN_TRIAL_EXTENSION_DAYS = 1;
+export const MAX_TRIAL_EXTENSION_DAYS = 365;
+
+export type ExtendTrialRequest = {
+  id: string;
+  days: number;
+};
+
+// The days are added to the trial's current end date, not to today, so an
+// extension applied early does not shorten the trial.
+export function extendTrial(
+  body: ExtendTrialRequest,
+): Promise<AdminOrganization> {
+  return gramAdminFetch<AdminOrganization>("/admin/trial.extend", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 export type AdminProject = {
   id: string;
   name: string;

--- a/client/admin/src/lib/organizationFilters.ts
+++ b/client/admin/src/lib/organizationFilters.ts
@@ -1,0 +1,193 @@
+// The vocabulary of the organizations list's filters: the groups an operator
+// picks from, and the rules that turn a chosen set into the URL.
+//
+// It sits in `lib` rather than beside the sheet because the route's search
+// schema reads it too, and the sheet is rendered by a page the route imports.
+// A group declared in the sheet would close that circle, and a circular import
+// leaves whichever module evaluates second holding an undefined constant.
+
+import { ACCOUNT_TYPE_OPTIONS, isAccountType } from "@/lib/accountTypes";
+import { TRIAL_STATES, type TrialState } from "@/lib/gramAdminApi";
+import { TRIAL_LABELS } from "@/lib/trialLabels";
+
+// Whether an organization is switched off. Declared here rather than in the
+// API module because the server has no enum for it: it derives the state from
+// `disabled_at`, and these two words are the whole of what `disabled_states`
+// accepts.
+export const DISABLED_STATES = ["active", "disabled"] as const;
+
+export type DisabledState = (typeof DISABLED_STATES)[number];
+
+export const FILTER_GROUP_KEYS = ["type", "trial", "disabled"] as const;
+
+export type FilterGroupKey = (typeof FILTER_GROUP_KEYS)[number];
+
+/** One list of chosen values per group, in the order the pickers offer them. */
+export type FilterSelection = Record<FilterGroupKey, string[]>;
+
+export const NO_FILTERS: FilterSelection = {
+  type: [],
+  trial: [],
+  disabled: [],
+};
+
+export type FilterOption = { value: string; label: string };
+
+export type FilterGroup = {
+  key: FilterGroupKey;
+  label: string;
+  // What the group filters on when nothing is chosen. Not every default is
+  // "everything", and an operator cannot be expected to know which is which,
+  // so each group says its own.
+  emptyLabel: string;
+  options: FilterOption[];
+};
+
+// "Status", rather than the "disabled" the parameter is named for: a group
+// headed Disabled whose first option is Active reads as a contradiction.
+const DISABLED_LABELS: Record<DisabledState, string> = {
+  active: "Active",
+  disabled: "Disabled",
+};
+
+// The order here is the order the URL, the request and the cache key put a
+// chosen set into, because everything below sorts back into it.
+export const FILTER_GROUPS: FilterGroup[] = [
+  {
+    key: "type",
+    label: "Type",
+    emptyLabel: "All types",
+    options: ACCOUNT_TYPE_OPTIONS.map((value) => ({ value, label: value })),
+  },
+  {
+    key: "trial",
+    label: "Trial",
+    emptyLabel: "All trial states",
+    // TRIAL_LABELS is the map the Trial cell renders its badge from, so the
+    // filter and the rows it returns cannot say different words for one state.
+    options: TRIAL_STATES.map((value) => ({
+      value,
+      label: TRIAL_LABELS[value],
+    })),
+  },
+  {
+    key: "disabled",
+    label: "Status",
+    emptyLabel: "Active only",
+    options: DISABLED_STATES.map((value) => ({
+      value,
+      label: DISABLED_LABELS[value],
+    })),
+  },
+];
+
+/**
+ * What a group's control says it is filtering on. The one chosen value is
+ * named rather than counted, because "1 selected" makes an operator open the
+ * sheet to learn what they already decided.
+ */
+export function filterSummary(
+  group: FilterGroup,
+  chosen: string[],
+  options: FilterOption[] = group.options,
+): string {
+  if (chosen.length === 0) return group.emptyLabel;
+  const only = chosen[0];
+  if (chosen.length === 1 && only !== undefined) {
+    return options.find((option) => option.value === only)?.label ?? only;
+  }
+  return `${chosen.length} selected`;
+}
+
+/**
+ * The options a group offers, given what is already chosen. Only the account
+ * types can differ from the declared list: an organization can carry a type
+ * from outside it, so a link that filters on one has to show that value as a
+ * chosen option rather than drop it and read as unfiltered.
+ */
+export function optionsFor(
+  group: FilterGroup,
+  chosen: string[],
+): FilterOption[] {
+  const declared = new Set(group.options.map((option) => option.value));
+  const extra = chosen
+    .filter((value) => !declared.has(value))
+    .map((value) => ({ value, label: value }));
+  return extra.length > 0 ? [...group.options, ...extra] : group.options;
+}
+
+/**
+ * Kept in the options' order rather than the order the operator clicked, so
+ * the URL a chosen set produces does not depend on the path taken to it.
+ */
+export function toggleFilter(
+  chosen: string[],
+  value: string,
+  options: FilterOption[],
+): string[] {
+  const next = new Set(chosen);
+  if (!next.delete(value)) next.add(value);
+  return options.map((option) => option.value).filter((item) => next.has(item));
+}
+
+// Ordered by the list the picker offers rather than by the order a link
+// happened to name, and deduplicated. Two operators who chose the same filter
+// in a different order then send the same request, which is the same cache
+// entry and the same pager signature.
+function inOptionOrder<T extends string>(
+  chosen: string[],
+  options: readonly T[],
+): T[] {
+  const wanted = new Set(chosen);
+  return options.filter((option) => wanted.has(option));
+}
+
+/**
+ * Unlike the two below, an unrecognised value is kept. `ACCOUNT_TYPE_OPTIONS`
+ * is the list the picker offers, not the list the column can hold. Dropping a
+ * value from outside it would widen a link's view without saying so, and leave
+ * the picker reading "all types" while the rows were still filtered.
+ */
+export function accountTypes(chosen: string[]): string[] | undefined {
+  const known = inOptionOrder(chosen, ACCOUNT_TYPE_OPTIONS);
+  const rest = [...new Set(chosen.filter((item) => !isAccountType(item)))];
+  const all = [...known, ...rest];
+  return all.length > 0 ? all : undefined;
+}
+
+/**
+ * A state the server does not derive is dropped. Unlike an account type it can
+ * match no row at all, so keeping it would empty a list whose control claimed
+ * the state was on.
+ */
+export function trialStates(chosen: string[]): TrialState[] | undefined {
+  const kept = inOptionOrder(chosen, TRIAL_STATES);
+  return kept.length > 0 ? kept : undefined;
+}
+
+export function disabledStates(chosen: string[]): DisabledState[] | undefined {
+  const kept = inOptionOrder(chosen, DISABLED_STATES);
+  return kept.length > 0 ? kept : undefined;
+}
+
+/** The three params a chosen set puts in the URL. */
+export type FilterSearch = {
+  type?: string[];
+  trial?: TrialState[];
+  disabled?: DisabledState[];
+};
+
+/**
+ * A chosen set as the URL states it.
+ *
+ * Written through the same three readers a pasted link goes through, so a
+ * control cannot put a value in the URL that a reload would refuse: the view
+ * an operator sends is the view they are looking at.
+ */
+export function filtersToSearch(filters: FilterSelection): FilterSearch {
+  return {
+    type: accountTypes(filters.type),
+    trial: trialStates(filters.trial),
+    disabled: disabledStates(filters.disabled),
+  };
+}

--- a/client/admin/src/lib/trialLabels.ts
+++ b/client/admin/src/lib/trialLabels.ts
@@ -1,0 +1,16 @@
+import type { TrialState } from "@/lib/gramAdminApi";
+
+// The one wording for each state. The badge on the row and the option that
+// filters the list for that state both read from here, so the filter and the
+// rows it returns cannot say different words for the same thing.
+//
+// `none` is included because it is a state an operator filters on, even though
+// the cell renders it as a dash rather than a badge.
+export const TRIAL_LABELS: Record<TrialState, string> = {
+  none: "No trial",
+  running: "Running",
+  ending_soon: "Ending soon",
+  expired: "Expired",
+  demoted: "Demoted",
+  converted: "Converted",
+};

--- a/client/admin/src/pages/organizations/FilterSheet.tsx
+++ b/client/admin/src/pages/organizations/FilterSheet.tsx
@@ -1,0 +1,225 @@
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import { useId, useRef, useState, type JSX, type Ref } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  FILTER_GROUPS,
+  filterSummary,
+  NO_FILTERS,
+  optionsFor,
+  toggleFilter,
+  type FilterGroup,
+  type FilterGroupKey,
+  type FilterOption,
+  type FilterSelection,
+} from "@/lib/organizationFilters";
+import { cn } from "@/lib/utils";
+
+/**
+ * Every filter this list carries, in one sheet.
+ *
+ * The edit is a draft: nothing reaches the URL, and so nothing reaches the
+ * request, until the operator applies it. An admin narrowing a view by three
+ * clicks would otherwise send three requests and read two lists they never
+ * asked for on the way to the one they did.
+ */
+export function FilterSheet({
+  value,
+  openGroup,
+  onOpenChange,
+  onApply,
+  onReturnFocus,
+}: {
+  value: FilterSelection;
+  // Which group the operator asked for, and null when the sheet is closed. The
+  // sheet opens with that group's picker focused, so the trigger they pressed
+  // is the control they land on.
+  openGroup: FilterGroupKey | null;
+  onOpenChange: (open: boolean) => void;
+  onApply: (next: FilterSelection) => void;
+  // Called instead of Radix's own restore, which returns the keyboard to
+  // whatever held it when the sheet opened. A click does not focus a button in
+  // every browser, so that is not reliably the trigger.
+  onReturnFocus: () => void;
+}): JSX.Element {
+  const open = openGroup !== null;
+  const [draft, setDraft] = useState(value);
+  const [lastOpened, setLastOpened] = useState(openGroup);
+
+  // Seeded while rendering rather than in an effect, so a picker never paints
+  // the previous edit for a frame. Opening is the only moment the draft follows
+  // the URL: while the sheet is open the draft belongs to the operator, and a
+  // navigation landing underneath must not move it.
+  if (openGroup !== lastOpened) {
+    setLastOpened(openGroup);
+    if (open) setDraft(value);
+  }
+
+  const pickers = useRef<Partial<Record<FilterGroupKey, HTMLButtonElement>>>(
+    {},
+  );
+
+  const apply = (next: FilterSelection): void => {
+    onApply(next);
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        className="w-full gap-0 sm:max-w-md"
+        onOpenAutoFocus={(event) => {
+          if (!openGroup) return;
+          const picker = pickers.current[openGroup];
+          if (!picker) return;
+          event.preventDefault();
+          picker.focus();
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          onReturnFocus();
+        }}
+      >
+        <SheetHeader>
+          <SheetTitle>Filters</SheetTitle>
+          <SheetDescription>
+            Nothing in the table changes until you apply.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="grid gap-4 p-4">
+          {FILTER_GROUPS.map((group) => (
+            <FilterPicker
+              key={group.key}
+              group={group}
+              chosen={draft[group.key]}
+              // Taken from the value the sheet opened on, not from the draft:
+              // an unrecognised type unchecked mid-edit has to stay on screen,
+              // or the operator cannot change their mind.
+              options={optionsFor(group, value[group.key])}
+              onChange={(next) =>
+                setDraft((previous) => ({ ...previous, [group.key]: next }))
+              }
+              ref={(node) => {
+                if (node) pickers.current[group.key] = node;
+              }}
+            />
+          ))}
+        </div>
+
+        <SheetFooter className="flex-row justify-end">
+          {/* Clears the filters and nothing else. The search term is not a
+              filter this sheet holds, and an operator who reset the filters has
+              not asked to type their term again. */}
+          <Button variant="ghost" onClick={() => apply(NO_FILTERS)}>
+            Clear all
+          </Button>
+          <Button onClick={() => apply(draft)}>Apply</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function FilterPicker({
+  group,
+  chosen,
+  options,
+  onChange,
+  ref,
+}: {
+  group: FilterGroup;
+  chosen: string[];
+  options: FilterOption[];
+  onChange: (next: string[]) => void;
+  ref: Ref<HTMLButtonElement>;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  return (
+    <div className="grid gap-1.5">
+      <span id={`${id}-label`} className="font-medium text-sm">
+        {group.label}
+      </span>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            ref={ref}
+            id={id}
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            // The group's name and the trigger's own text, which is the state
+            // of the group. A screen reader then announces both, the way a
+            // select announces its label and its value.
+            aria-labelledby={`${id}-label ${id}`}
+            className="w-full justify-between font-normal"
+          >
+            <span
+              className={cn(chosen.length === 0 && "text-muted-foreground")}
+            >
+              {filterSummary(group, chosen, options)}
+            </span>
+            <ChevronsUpDownIcon className="opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-(--radix-popover-trigger-width) p-0"
+          align="start"
+        >
+          <Command>
+            <CommandInput placeholder={`Filter ${group.label.toLowerCase()}`} />
+            <CommandList aria-multiselectable="true">
+              <CommandEmpty>No match.</CommandEmpty>
+              <CommandGroup>
+                {options.map((option) => {
+                  const selected = chosen.includes(option.value);
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      value={option.value}
+                      // The label as well, so typing what is on screen finds
+                      // the option: "ending" has to reach `ending_soon`.
+                      keywords={[option.label]}
+                      aria-checked={selected}
+                      onSelect={() =>
+                        onChange(toggleFilter(chosen, option.value, options))
+                      }
+                    >
+                      <CheckIcon
+                        className={cn(selected ? "opacity-100" : "opacity-0")}
+                      />
+                      {option.label}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/client/admin/src/pages/organizations/OrganizationActions.test.tsx
+++ b/client/admin/src/pages/organizations/OrganizationActions.test.tsx
@@ -17,7 +17,21 @@ import {
 } from "@/lib/gramAdminApi";
 import { renderWithApp } from "@/test/harness";
 
-import { AnnounceProvider, OrganizationActions } from "./OrganizationActions";
+import {
+  OrganizationActions,
+  WriteReportProvider,
+} from "./OrganizationActions";
+
+// One note for whoever writes the next test here. A synchronous read straight
+// after `await act(...)` misses TanStack Query's pending state: its notify
+// manager schedules on a macrotask, so `expect(button.textContent).toBe(
+// "Disabling...")` on the line after the click reads the state from before the
+// mutation started and passes for the wrong reason. Every assertion about a
+// write in flight below goes through `findBy*` or `waitFor` for that reason.
+//
+// The same applies to focus after a dialog closes: Radix's FocusScope restores
+// it from a `setTimeout(..., 0)`, so it has not moved yet when the close
+// returns.
 
 const mocks = vi.hoisted(() => ({
   disableOrganization:
@@ -69,12 +83,14 @@ const EXTENDABLE: (TrialState | undefined)[] = ["running", "ending_soon"];
 const DEFAULT_DAYS = "14";
 
 const announce = vi.fn<(text: string) => void>();
+const showFailure = vi.fn<(text: string | null) => void>();
+const REPORTER = { announce, showFailure };
 
 async function renderMenu(org: AdminOrganization = ORG): Promise<HTMLElement> {
   await renderWithApp(
-    <AnnounceProvider value={announce}>
+    <WriteReportProvider value={REPORTER}>
       <OrganizationActions org={org} layout="menu" />
-    </AnnounceProvider>,
+    </WriteReportProvider>,
   );
   const trigger = screen.getByRole("button", {
     name: `Actions for ${org.name}`,
@@ -90,9 +106,9 @@ async function renderMenu(org: AdminOrganization = ORG): Promise<HTMLElement> {
 
 async function renderFooter(org: AdminOrganization = ORG): Promise<void> {
   await renderWithApp(
-    <AnnounceProvider value={announce}>
+    <WriteReportProvider value={REPORTER}>
       <OrganizationActions org={org} layout="footer" />
-    </AnnounceProvider>,
+    </WriteReportProvider>,
   );
 }
 
@@ -104,6 +120,19 @@ function menuItems(): string[] {
 
 function dialog(): HTMLElement {
   return screen.getByRole("dialog");
+}
+
+// The node, not the role. Radix takes the portal out of the accessibility tree
+// while it works out whether a dismiss is allowed, so `queryByRole("dialog")`
+// answers null for a dialog that is still on the page and refusing to close.
+function dialogNode(): HTMLElement | null {
+  return document.querySelector("[data-slot='dialog-content']");
+}
+
+function overlay(): HTMLElement {
+  const node = document.querySelector("[data-slot='dialog-overlay']");
+  if (!(node instanceof HTMLElement)) throw new Error("no dialog overlay");
+  return node;
 }
 
 function dayInput(): HTMLInputElement {
@@ -140,6 +169,7 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 
 beforeEach(() => {
   announce.mockReset();
+  showFailure.mockReset();
   mocks.disableOrganization.mockReset();
   mocks.disableOrganization.mockResolvedValue({
     ...ORG,
@@ -169,7 +199,9 @@ describe("the row menu", () => {
   it("offers Re-enable, and not Disable, for a disabled organization", async () => {
     await renderMenu(DISABLED_ORG);
 
-    expect(menuItems()).toEqual(["Re-enable", "Extend trial"]);
+    // Re-enable alone. The record is on a running trial, and the walk below
+    // says why the trial is not extendable while the organization is off.
+    expect(menuItems()).toEqual(["Re-enable"]);
   });
 
   it.each([...TRIAL_STATES, undefined])(
@@ -185,6 +217,19 @@ describe("the row menu", () => {
       expect(menuItems().includes("Extend trial")).toBe(
         EXTENDABLE.includes(state),
       );
+    },
+  );
+
+  it.each([...TRIAL_STATES, undefined])(
+    "keeps Extend trial off a disabled organization on the %s trial",
+    async (state) => {
+      await renderMenu({ ...DISABLED_ORG, trial_state: state });
+
+      // The server would take this request: nothing in the extend handler
+      // reads disabled_at, and the trial goes on running while every member is
+      // locked out. Offering it anyway is offering to buy more of a trial
+      // nobody can use.
+      expect(menuItems().includes("Extend trial")).toBe(false);
     },
   );
 
@@ -239,6 +284,9 @@ describe("the row menu", () => {
     expect(mocks.enableOrganization).toHaveBeenCalledWith({ id: ORG.id });
     expect(screen.queryByRole("dialog")).toBeNull();
     expect(announce).toHaveBeenCalledWith(`${ORG.name} is enabled.`);
+    // A write that succeeded clears the banner an earlier one left behind:
+    // the operator has just been told the current state of this record.
+    expect(showFailure).toHaveBeenCalledWith(null);
   });
 });
 
@@ -296,6 +344,88 @@ describe("the extend trial dialog", () => {
       }
     },
   );
+
+  it("says so again when the same value is refused twice", async () => {
+    await renderMenu();
+    await openExtendDialog();
+
+    await submitDays("0");
+    await submitDays("0");
+
+    // Nothing on screen moves on the second press: the state is already
+    // rejected and the text is a constant, so the alert is not re-inserted and
+    // a role="alert" announces only what is inserted or changed. The live
+    // region is what carries the second refusal, which is why this path
+    // announces rather than relying on the node.
+    expect(announce).toHaveBeenCalledTimes(2);
+    expect(announce).toHaveBeenNthCalledWith(
+      2,
+      `Could not extend the trial for ${ORG.name}: Enter a whole number of days between ${MIN_TRIAL_EXTENSION_DAYS} and ${MAX_TRIAL_EXTENSION_DAYS}.`,
+    );
+    expect(mocks.extendTrial).not.toHaveBeenCalled();
+  });
+
+  it("points the day count at the message under it", async () => {
+    await renderMenu();
+    await openExtendDialog();
+
+    await submitDays("0");
+
+    // aria-invalid says the value is wrong. Only this says what would make it
+    // right, to a user who has moved back to the field and cannot see the line
+    // beneath it.
+    const alert = await screen.findByRole("alert");
+    expect(alert.id).toBeTruthy();
+    expect(dayInput().getAttribute("aria-describedby")).toBe(alert.id);
+  });
+
+  it("stops calling a corrected value out of bounds", async () => {
+    const held = deferred<AdminOrganization>();
+    await renderMenu();
+    await openExtendDialog();
+    await submitDays("0");
+    expect(await screen.findByRole("alert")).toBeTruthy();
+
+    mocks.extendTrial.mockReturnValue(held.promise);
+    await submitDays("30");
+
+    // While the corrected request is still in flight, which is the only moment
+    // it is visible: success unmounts the dialog. The field would otherwise
+    // sit there marked invalid, under a bounds message, while its own request
+    // runs.
+    await screen.findByRole("button", { name: "Extending..." });
+    expect(dayInput().getAttribute("aria-invalid")).toBe("false");
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    await act(async () => {
+      held.resolve({ ...ORG, trial_ends_at: "2026-05-20T00:00:00Z" });
+    });
+  });
+
+  it("shows the bounds alone when a refusal follows a server failure", async () => {
+    mocks.extendTrial.mockRejectedValue(
+      new GramAdminError(
+        409,
+        { name: "conflict", message: "organization has no running trial" },
+        "gram admin 409 Conflict",
+      ),
+    );
+    await renderMenu();
+    await openExtendDialog();
+    await submitDays("30");
+    expect(await screen.findByRole("alert")).toBeTruthy();
+
+    await submitDays("0");
+
+    // One alert, not two. The failed request and the refused value are both
+    // true, and showing both gives the operator two reasons with nothing
+    // saying which one the next press answers.
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.textContent).toContain(
+      `between ${MIN_TRIAL_EXTENSION_DAYS} and ${MAX_TRIAL_EXTENSION_DAYS}`,
+    );
+  });
 
   it("keeps the dialog open and names the conflict the server answered", async () => {
     mocks.extendTrial.mockRejectedValue(
@@ -408,6 +538,60 @@ describe("a rejected write", () => {
     );
   });
 
+  it("opens the next confirmation without the last one's failure", async () => {
+    mocks.disableOrganization.mockRejectedValue(
+      new GramAdminError(404, null, "gram admin 404 Not Found"),
+    );
+    const trigger = await renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+    expect(await screen.findByRole("alert")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(dialogNode()).toBeNull();
+    });
+    fireEvent.pointerDown(trigger, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+
+    // The same rule the extend dialog follows. The failure belonged to the
+    // attempt the operator abandoned, and reporting it here reports a request
+    // this confirmation has not made.
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("gives a re-enable failure the sentence the server sent", async () => {
+    mocks.enableOrganization.mockRejectedValue(
+      new GramAdminError(
+        409,
+        { name: "conflict", message: "organization is not disabled" },
+        "gram admin 409 Conflict",
+      ),
+    );
+    await renderMenu(DISABLED_ORG);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Re-enable" }));
+    });
+
+    // A 4xx body carries a sentence the operator can act on, and the status
+    // line does not. The 5xx case below is the other half of that rule, and
+    // only the two together tell the message apart from the status line.
+    const text = `Could not re-enable ${ORG.name}: organization is not disabled`;
+    expect(announce).toHaveBeenCalledWith(text);
+    // Shown as well as spoken. This is the one write with no dialog, so
+    // without the banner the whole account of the failure is inside sr-only.
+    expect(showFailure).toHaveBeenCalledWith(text);
+  });
+
   it("reports a re-enable that failed, which has no dialog to report in", async () => {
     mocks.enableOrganization.mockRejectedValue(
       new GramAdminError(
@@ -430,6 +614,206 @@ describe("a rejected write", () => {
   });
 });
 
+// Radix hard-codes its close behaviour: onCloseAutoFocus cancels FocusScope's
+// restore of the previously focused element and focuses the DialogTrigger
+// instead. These dialogs have no trigger, so without a restore of their own
+// every one of these paths ends with the keyboard on document.body, at the top
+// of the page, after an action the operator took on one row of a long table.
+describe("the keyboard when a dialog closes", () => {
+  it("goes back to the row menu trigger when the write succeeds", async () => {
+    const trigger = await renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  // The four ways out that are not the write itself. Each is its own Radix
+  // path, and each one used to end on the body.
+  it.each([
+    [
+      "Escape",
+      (): void => {
+        fireEvent.keyDown(document, { key: "Escape" });
+      },
+    ],
+    [
+      "Cancel",
+      (): void => {
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      },
+    ],
+    [
+      "the backdrop",
+      (): void => {
+        fireEvent.pointerDown(overlay(), {
+          button: 0,
+          ctrlKey: false,
+          pointerType: "mouse",
+        });
+        fireEvent.click(overlay(), { button: 0, ctrlKey: false });
+      },
+    ],
+    [
+      "the X",
+      (): void => {
+        fireEvent.click(screen.getByRole("button", { name: "Close" }));
+      },
+    ],
+  ] as [string, () => void][])(
+    "goes back to the row menu trigger when %s closes the dialog",
+    async (_path, close) => {
+      const trigger = await renderMenu();
+      fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+      await screen.findByRole("dialog");
+
+      await act(async () => {
+        close();
+      });
+
+      await waitFor(() => {
+        expect(dialogNode()).toBeNull();
+      });
+      await waitFor(() => {
+        expect(document.activeElement).toBe(trigger);
+      });
+      expect(mocks.disableOrganization).not.toHaveBeenCalled();
+    },
+  );
+
+  it("goes back to the peek footer control the dialog opened from", async () => {
+    await renderFooter();
+    const button = screen.getByRole("button", { name: `Disable ${ORG.name}` });
+    fireEvent.click(button);
+    await screen.findByRole("dialog");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(button);
+    });
+  });
+});
+
+describe("a write in flight", () => {
+  // Cancel carries `disabled` while the write runs, so Escape and the overlay
+  // are the only ways in and the guard on onOpenChange is the only thing
+  // holding them off.
+  it("cannot be dismissed out of the disable confirmation", async () => {
+    const held = deferred<AdminOrganization>();
+    mocks.disableOrganization.mockReturnValue(held.promise);
+    await renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+    await screen.findByRole("button", { name: "Disabling..." });
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+
+    // The answer decides what the row says next. A dialog dismissed mid-write
+    // leaves the operator with no account of how their action ended.
+    expect(dialogNode()).not.toBeNull();
+
+    await act(async () => {
+      held.resolve({ ...ORG, disabled_at: "2026-08-01T00:00:00Z" });
+    });
+    await waitFor(() => {
+      expect(dialogNode()).toBeNull();
+    });
+  });
+
+  it("cannot be dismissed out of the extend dialog", async () => {
+    const held = deferred<AdminOrganization>();
+    mocks.extendTrial.mockReturnValue(held.promise);
+    await renderMenu();
+    await openExtendDialog();
+    await submitDays("30");
+    await screen.findByRole("button", { name: "Extending..." });
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+
+    expect(dialogNode()).not.toBeNull();
+
+    await act(async () => {
+      held.resolve({ ...ORG, trial_ends_at: "2026-05-20T00:00:00Z" });
+    });
+    await waitFor(() => {
+      expect(dialogNode()).toBeNull();
+    });
+  });
+
+  it("marks the row menu trigger busy rather than disabling it", async () => {
+    const held = deferred<AdminOrganization>();
+    mocks.disableOrganization.mockReturnValue(held.promise);
+    const trigger = await renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+
+    // Read off the node: an open modal takes the rest of the page out of the
+    // accessibility tree, so the trigger cannot be found by role from here.
+    await waitFor(() => {
+      expect(trigger.getAttribute("aria-busy")).toBe("true");
+    });
+    expect(trigger.hasAttribute("disabled")).toBe(false);
+
+    await act(async () => {
+      held.resolve({ ...ORG, disabled_at: "2026-08-01T00:00:00Z" });
+    });
+    await waitFor(() => {
+      expect(trigger.getAttribute("aria-busy")).toBe("false");
+    });
+  });
+
+  it("marks both peek footer controls busy rather than disabling them", async () => {
+    const held = deferred<AdminOrganization>();
+    mocks.extendTrial.mockReturnValue(held.promise);
+    await renderFooter();
+    const disable = screen.getByRole("button", { name: `Disable ${ORG.name}` });
+    const extend = screen.getByRole("button", {
+      name: `Extend trial for ${ORG.name}`,
+    });
+
+    fireEvent.click(extend);
+    await screen.findByRole("dialog");
+    await submitDays("30");
+
+    // Both, not just the one that started it. A control that goes dead under
+    // the operator's hand is the thing this design exists to avoid, and the
+    // write is the record's, not the button's.
+    await waitFor(() => {
+      expect(extend.getAttribute("aria-busy")).toBe("true");
+    });
+    expect(disable.getAttribute("aria-busy")).toBe("true");
+    expect(extend.hasAttribute("disabled")).toBe(false);
+    expect(disable.hasAttribute("disabled")).toBe(false);
+
+    await act(async () => {
+      held.resolve({ ...ORG, trial_ends_at: "2026-05-20T00:00:00Z" });
+    });
+    await waitFor(() => {
+      expect(extend.getAttribute("aria-busy")).toBe("false");
+    });
+  });
+});
+
 describe("the peek panel footer", () => {
   it("offers the same three actions as buttons rather than a menu", async () => {
     await renderFooter();
@@ -437,28 +821,42 @@ describe("the peek panel footer", () => {
     expect(
       screen.queryByRole("button", { name: `Actions for ${ORG.name}` }),
     ).toBeNull();
-    expect(screen.getByRole("button", { name: "Disable" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Extend trial" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Re-enable" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: `Disable ${ORG.name}` }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: `Extend trial for ${ORG.name}` }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: `Re-enable ${ORG.name}` }),
+    ).toBeNull();
   });
 
   it("shows Re-enable for a disabled organization", async () => {
     await renderFooter(DISABLED_ORG);
 
-    expect(screen.getByRole("button", { name: "Re-enable" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: `Re-enable ${ORG.name}` }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: `Disable ${ORG.name}` }),
+    ).toBeNull();
   });
 
   it("hides Extend trial for a trial the server would refuse", async () => {
     await renderFooter({ ...ORG, trial_state: "converted" });
 
-    expect(screen.queryByRole("button", { name: "Extend trial" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: `Extend trial for ${ORG.name}` }),
+    ).toBeNull();
   });
 
   it("confirms before it disables, the same as the row menu does", async () => {
     await renderFooter();
 
-    fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: `Disable ${ORG.name}` }),
+    );
 
     await screen.findByRole("dialog");
     expect(mocks.disableOrganization).not.toHaveBeenCalled();
@@ -468,7 +866,9 @@ describe("the peek panel footer", () => {
     const held = deferred<AdminOrganization>();
     mocks.enableOrganization.mockReturnValue(held.promise);
     await renderFooter(DISABLED_ORG);
-    const button = screen.getByRole("button", { name: "Re-enable" });
+    const button = screen.getByRole("button", {
+      name: `Re-enable ${ORG.name}`,
+    });
 
     fireEvent.click(button);
 

--- a/client/admin/src/pages/organizations/OrganizationActions.test.tsx
+++ b/client/admin/src/pages/organizations/OrganizationActions.test.tsx
@@ -1,0 +1,492 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GramAdminError,
+  MAX_TRIAL_EXTENSION_DAYS,
+  MIN_TRIAL_EXTENSION_DAYS,
+  TRIAL_STATES,
+  type AdminOrganization,
+  type TrialState,
+} from "@/lib/gramAdminApi";
+import { renderWithApp } from "@/test/harness";
+
+import { AnnounceProvider, OrganizationActions } from "./OrganizationActions";
+
+const mocks = vi.hoisted(() => ({
+  disableOrganization:
+    vi.fn<(body: { id: string }) => Promise<AdminOrganization>>(),
+  enableOrganization:
+    vi.fn<(body: { id: string }) => Promise<AdminOrganization>>(),
+  extendTrial:
+    vi.fn<(body: { id: string; days: number }) => Promise<AdminOrganization>>(),
+}));
+
+// The three writes only. errorMessage stays real, because what the operator is
+// told about a failure is the subject of several of these tests.
+vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
+  return {
+    ...actual,
+    disableOrganization: mocks.disableOrganization,
+    enableOrganization: mocks.enableOrganization,
+    extendTrial: mocks.extendTrial,
+  };
+});
+
+// Live, and trialling: the record that offers Disable and Extend. Every case
+// below that needs another state derives it from this one, so a field a test
+// does not name is the same field in every test.
+const ORG: AdminOrganization = {
+  id: "org_placeholder_one",
+  name: "Placeholder One",
+  slug: "placeholder-one",
+  account_type: "enterprise",
+  whitelisted: false,
+  trial_state: "running",
+  trial_ends_at: "2026-05-06T00:00:00Z",
+  member_count: 3,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-07T00:00:00Z",
+};
+
+const DISABLED_ORG: AdminOrganization = {
+  ...ORG,
+  disabled_at: "2026-03-04T00:00:00Z",
+};
+
+// The two states the server will extend. Written out rather than imported from
+// the module under test: importing the set would move this expectation along
+// with the rule it is meant to hold in place.
+const EXTENDABLE: (TrialState | undefined)[] = ["running", "ending_soon"];
+
+const DEFAULT_DAYS = "14";
+
+const announce = vi.fn<(text: string) => void>();
+
+async function renderMenu(org: AdminOrganization = ORG): Promise<HTMLElement> {
+  await renderWithApp(
+    <AnnounceProvider value={announce}>
+      <OrganizationActions org={org} layout="menu" />
+    </AnnounceProvider>,
+  );
+  const trigger = screen.getByRole("button", {
+    name: `Actions for ${org.name}`,
+  });
+  // A Radix menu opens on pointerdown, not on click.
+  fireEvent.pointerDown(trigger, {
+    button: 0,
+    ctrlKey: false,
+    pointerType: "mouse",
+  });
+  return trigger;
+}
+
+async function renderFooter(org: AdminOrganization = ORG): Promise<void> {
+  await renderWithApp(
+    <AnnounceProvider value={announce}>
+      <OrganizationActions org={org} layout="footer" />
+    </AnnounceProvider>,
+  );
+}
+
+function menuItems(): string[] {
+  return screen
+    .queryAllByRole("menuitem")
+    .map((item) => item.textContent ?? "");
+}
+
+function dialog(): HTMLElement {
+  return screen.getByRole("dialog");
+}
+
+function dayInput(): HTMLInputElement {
+  const input = screen.getByLabelText("Days");
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error("the day count is not an input");
+  }
+  return input;
+}
+
+// The dialog opens from a menu item, and the menu takes a moment to unmount
+// itself around the state change that opens it.
+async function openExtendDialog(): Promise<void> {
+  fireEvent.click(screen.getByRole("menuitem", { name: "Extend trial" }));
+  await screen.findByRole("dialog");
+}
+
+async function submitDays(value: string): Promise<void> {
+  fireEvent.change(dayInput(), { target: { value } });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Extend" }));
+  });
+}
+
+// A write held open, so a test can read the page while the request is in
+// flight and settle it when it chooses.
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  announce.mockReset();
+  mocks.disableOrganization.mockReset();
+  mocks.disableOrganization.mockResolvedValue({
+    ...ORG,
+    disabled_at: "2026-08-01T00:00:00Z",
+  });
+  mocks.enableOrganization.mockReset();
+  mocks.enableOrganization.mockResolvedValue(ORG);
+  mocks.extendTrial.mockReset();
+  mocks.extendTrial.mockResolvedValue({
+    ...ORG,
+    trial_ends_at: "2026-05-20T00:00:00Z",
+  });
+});
+
+afterEach(cleanup);
+
+describe("the row menu", () => {
+  it("offers Disable, and not Re-enable, for a live organization", async () => {
+    await renderMenu();
+
+    // Exactly one of the two. Both at once would be a menu offering to undo
+    // something that has not happened, and the operator has no way to tell
+    // which one the record is in.
+    expect(menuItems()).toEqual(["Disable", "Extend trial"]);
+  });
+
+  it("offers Re-enable, and not Disable, for a disabled organization", async () => {
+    await renderMenu(DISABLED_ORG);
+
+    expect(menuItems()).toEqual(["Re-enable", "Extend trial"]);
+  });
+
+  it.each([...TRIAL_STATES, undefined])(
+    "offers Extend trial for the %s trial only where the server would take it",
+    async (state) => {
+      await renderMenu({ ...ORG, trial_state: state });
+
+      // Every state the server can send, walked at runtime. The server refuses
+      // converted, demoted and expired with a conflict, and an organization
+      // with no trial has no end date to add days to, so offering the action
+      // there is offering a request that cannot succeed. A seventh state fails
+      // here as well as in the build.
+      expect(menuItems().includes("Extend trial")).toBe(
+        EXTENDABLE.includes(state),
+      );
+    },
+  );
+
+  it("waits for the confirmation before it disables anything", async () => {
+    await renderMenu();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+
+    await screen.findByRole("dialog");
+    // The whole point of the confirmation. Disabling cuts a customer off, and
+    // this menu sits one row away from four others.
+    expect(mocks.disableOrganization).not.toHaveBeenCalled();
+    expect(dialog().textContent).toContain(`Disable ${ORG.name}?`);
+  });
+
+  it("sends nothing when the operator cancels the confirmation", async () => {
+    await renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(mocks.disableOrganization).not.toHaveBeenCalled();
+  });
+
+  it("disables the organization once the operator confirms", async () => {
+    await renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+
+    expect(mocks.disableOrganization).toHaveBeenCalledWith({ id: ORG.id });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(announce).toHaveBeenCalledWith(`${ORG.name} is disabled.`);
+  });
+
+  it("re-enables without a confirmation, because nothing is lost", async () => {
+    await renderMenu(DISABLED_ORG);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Re-enable" }));
+    });
+
+    expect(mocks.enableOrganization).toHaveBeenCalledWith({ id: ORG.id });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(announce).toHaveBeenCalledWith(`${ORG.name} is enabled.`);
+  });
+});
+
+describe("the extend trial dialog", () => {
+  it("starts on the trial length the rest of the system assumes", async () => {
+    await renderMenu();
+    await openExtendDialog();
+
+    expect(dayInput().value).toBe(DEFAULT_DAYS);
+  });
+
+  it("extends by the day count the operator typed", async () => {
+    await renderMenu();
+    await openExtendDialog();
+
+    await submitDays("30");
+
+    expect(mocks.extendTrial).toHaveBeenCalledWith({ id: ORG.id, days: 30 });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(announce).toHaveBeenCalledWith(
+      `${ORG.name} trial extended by 30 days.`,
+    );
+  });
+
+  // Both edges and both sides of each. The server takes 1 to 365 inclusive, so
+  // a bound written as an exclusive comparison passes a one-sided test.
+  it.each([
+    [String(MIN_TRIAL_EXTENSION_DAYS - 1), false],
+    [String(MIN_TRIAL_EXTENSION_DAYS), true],
+    [String(MAX_TRIAL_EXTENSION_DAYS), true],
+    [String(MAX_TRIAL_EXTENSION_DAYS + 1), false],
+    ["-7", false],
+    ["1.5", false],
+    ["", false],
+  ] as [string, boolean][])(
+    "sends %s to the server only where the server would take it",
+    async (value, sent) => {
+      await renderMenu();
+      await openExtendDialog();
+
+      await submitDays(value);
+
+      expect(mocks.extendTrial).toHaveBeenCalledTimes(sent ? 1 : 0);
+      if (!sent) {
+        // Refused, and said so. A request the server is certain to reject is
+        // worse than no request, and a dialog that swallows the press is
+        // worse than either.
+        expect((await screen.findByRole("alert")).textContent).toContain(
+          `between ${MIN_TRIAL_EXTENSION_DAYS} and ${MAX_TRIAL_EXTENSION_DAYS}`,
+        );
+        expect(dayInput().getAttribute("aria-invalid")).toBe("true");
+        expect(screen.getByRole("dialog")).toBeTruthy();
+      }
+    },
+  );
+
+  it("keeps the dialog open and names the conflict the server answered", async () => {
+    mocks.extendTrial.mockRejectedValue(
+      new GramAdminError(
+        409,
+        {
+          name: "conflict",
+          message: "organization has no running enterprise trial to extend",
+        },
+        "gram admin 409 Conflict",
+      ),
+    );
+    await renderMenu();
+    await openExtendDialog();
+
+    await submitDays("30");
+
+    // A modal takes the page's live region out of the accessibility tree, so
+    // the dialog carries its own account of the failure.
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "organization has no running enterprise trial to extend",
+    );
+    expect(announce).toHaveBeenCalledWith(
+      `Could not extend the trial for ${ORG.name}: organization has no running enterprise trial to extend`,
+    );
+  });
+
+  it("opens the next attempt without the last one's failure", async () => {
+    mocks.extendTrial.mockRejectedValue(
+      new GramAdminError(404, null, "gram admin 404 Not Found"),
+    );
+    await renderMenu();
+    await openExtendDialog();
+    await submitDays("30");
+    expect(await screen.findByRole("alert")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: `Actions for ${ORG.name}` }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    await openExtendDialog();
+
+    // The failure belonged to the attempt the operator abandoned. Opening the
+    // dialog on it would report a request this one has not made.
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(dayInput().value).toBe(DEFAULT_DAYS);
+  });
+
+  it("holds the operator out of the dialog while the write is in flight", async () => {
+    const held = deferred<AdminOrganization>();
+    mocks.extendTrial.mockReturnValue(held.promise);
+    await renderMenu();
+    await openExtendDialog();
+
+    await submitDays("30");
+
+    const submit = await screen.findByRole("button", { name: "Extending..." });
+    expect(submit.hasAttribute("disabled")).toBe(true);
+    expect(dayInput().hasAttribute("disabled")).toBe(true);
+
+    await act(async () => {
+      held.resolve({ ...ORG, trial_ends_at: "2026-05-20T00:00:00Z" });
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(mocks.extendTrial).toHaveBeenCalledTimes(1);
+  });
+
+  it("says one day rather than 1 days", async () => {
+    await renderMenu();
+    await openExtendDialog();
+
+    await submitDays("1");
+
+    expect(announce).toHaveBeenCalledWith(
+      `${ORG.name} trial extended by 1 day.`,
+    );
+  });
+});
+
+describe("a rejected write", () => {
+  it("leaves the confirmation open, holding the reason", async () => {
+    mocks.disableOrganization.mockRejectedValue(
+      new GramAdminError(
+        404,
+        { name: "not_found", message: "organization not found" },
+        "gram admin 404 Not Found",
+      ),
+    );
+    await renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "organization not found",
+    );
+    expect(announce).toHaveBeenCalledWith(
+      `Could not disable ${ORG.name}: organization not found`,
+    );
+  });
+
+  it("reports a re-enable that failed, which has no dialog to report in", async () => {
+    mocks.enableOrganization.mockRejectedValue(
+      new GramAdminError(
+        500,
+        { name: "internal", message: "enable" },
+        "gram admin 500 Internal Server Error",
+      ),
+    );
+    await renderMenu(DISABLED_ORG);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Re-enable" }));
+    });
+
+    // The status line, not the body: a 5xx body carries the handler's verb
+    // phrase, and "enable" is not a sentence an operator can act on.
+    expect(announce).toHaveBeenCalledWith(
+      `Could not re-enable ${ORG.name}: gram admin 500 Internal Server Error`,
+    );
+  });
+});
+
+describe("the peek panel footer", () => {
+  it("offers the same three actions as buttons rather than a menu", async () => {
+    await renderFooter();
+
+    expect(
+      screen.queryByRole("button", { name: `Actions for ${ORG.name}` }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Disable" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Extend trial" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Re-enable" })).toBeNull();
+  });
+
+  it("shows Re-enable for a disabled organization", async () => {
+    await renderFooter(DISABLED_ORG);
+
+    expect(screen.getByRole("button", { name: "Re-enable" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+  });
+
+  it("hides Extend trial for a trial the server would refuse", async () => {
+    await renderFooter({ ...ORG, trial_state: "converted" });
+
+    expect(screen.queryByRole("button", { name: "Extend trial" })).toBeNull();
+  });
+
+  it("confirms before it disables, the same as the row menu does", async () => {
+    await renderFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+
+    await screen.findByRole("dialog");
+    expect(mocks.disableOrganization).not.toHaveBeenCalled();
+  });
+
+  it("stays live while a write is in flight rather than going disabled", async () => {
+    const held = deferred<AdminOrganization>();
+    mocks.enableOrganization.mockReturnValue(held.promise);
+    await renderFooter(DISABLED_ORG);
+    const button = screen.getByRole("button", { name: "Re-enable" });
+
+    fireEvent.click(button);
+
+    // Disabling the control the operator just pressed drops the keyboard onto
+    // the document body. The busy state rides on aria-busy instead, and the
+    // accessible name does not move, so a screen reader is not told the
+    // control was replaced.
+    await waitFor(() => {
+      expect(button.getAttribute("aria-busy")).toBe("true");
+    });
+    expect(button.hasAttribute("disabled")).toBe(false);
+    expect(button.textContent).toBe("Re-enable");
+
+    await act(async () => {
+      held.resolve(ORG);
+    });
+    await waitFor(() => {
+      expect(button.getAttribute("aria-busy")).toBe("false");
+    });
+  });
+});

--- a/client/admin/src/pages/organizations/OrganizationActions.tsx
+++ b/client/admin/src/pages/organizations/OrganizationActions.tsx
@@ -1,0 +1,428 @@
+import { MoreHorizontalIcon } from "lucide-react";
+import {
+  createContext,
+  useContext,
+  useId,
+  useState,
+  type FormEvent,
+  type JSX,
+  type ReactNode,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  errorMessage,
+  MAX_TRIAL_EXTENSION_DAYS,
+  MIN_TRIAL_EXTENSION_DAYS,
+  type AdminOrganization,
+} from "@/lib/gramAdminApi";
+
+import {
+  canExtendTrial,
+  useDisableOrganization,
+  useEnableOrganization,
+  useExtendTrial,
+} from "./rowActions";
+
+// The trial length the rest of the system assumes, so the operator extending a
+// trial by the usual amount types nothing.
+const DEFAULT_EXTENSION_DAYS = 14;
+
+const BOUNDS_HINT = `Enter a whole number of days between ${MIN_TRIAL_EXTENSION_DAYS} and ${MAX_TRIAL_EXTENSION_DAYS}.`;
+
+/**
+ * The list owns the only live region on the page, and these controls are drawn
+ * inside table cells the list cannot pass props to, so the announcer reaches
+ * them through context the way the peek controls do.
+ *
+ * The default is a no-op rather than a throw: the peek panel renders these
+ * actions too and it is mounted on its own in tests.
+ */
+const AnnounceContext = createContext<(text: string) => void>(() => {});
+
+export function AnnounceProvider({
+  value,
+  children,
+}: {
+  value: (text: string) => void;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <AnnounceContext.Provider value={value}>
+      {children}
+    </AnnounceContext.Provider>
+  );
+}
+
+type OpenDialog = "disable" | "extend";
+
+/**
+ * Disable, re-enable and extend, in the row menu and in the peek panel footer.
+ *
+ * One component for both surfaces, because they are the same three actions
+ * against the same record: two implementations would be two answers to
+ * "can this trial be extended" and two confirmations to keep in step.
+ */
+export function OrganizationActions({
+  org,
+  layout,
+}: {
+  org: AdminOrganization;
+  layout: "menu" | "footer";
+}): JSX.Element {
+  const announce = useContext(AnnounceContext);
+  const [open, setOpen] = useState<OpenDialog>();
+
+  // Held here rather than in the dialogs. A dialog unmounts as it closes, and
+  // the write it started has to keep its cache update and its announcement.
+  const disable = useDisableOrganization();
+  const enable = useEnableOrganization();
+  const extend = useExtendTrial();
+
+  const isDisabled = Boolean(org.disabled_at);
+  const busy = disable.isPending || enable.isPending || extend.isPending;
+
+  const openDialog = (dialog: OpenDialog): void => {
+    // A failure the operator cancelled out of is not one the next attempt
+    // should open holding.
+    disable.reset();
+    extend.reset();
+    setOpen(dialog);
+  };
+
+  const runDisable = (): void => {
+    disable.mutate(org.id, {
+      onSuccess: () => {
+        setOpen(undefined);
+        announce(`${org.name} is disabled.`);
+      },
+      // The dialog stays open and carries the same failure, because that is
+      // where the operator is looking.
+      onError: (error) =>
+        announce(`Could not disable ${org.name}: ${errorMessage(error)}`),
+    });
+  };
+
+  const runEnable = (): void => {
+    enable.mutate(org.id, {
+      onSuccess: () => announce(`${org.name} is enabled.`),
+      onError: (error) =>
+        announce(`Could not re-enable ${org.name}: ${errorMessage(error)}`),
+    });
+  };
+
+  const runExtend = (days: number): void => {
+    extend.mutate(
+      { id: org.id, days },
+      {
+        onSuccess: () => {
+          setOpen(undefined);
+          announce(`${org.name} trial extended by ${dayCount(days)}.`);
+        },
+        onError: (error) =>
+          announce(
+            `Could not extend the trial for ${org.name}: ${errorMessage(error)}`,
+          ),
+      },
+    );
+  };
+
+  const dialogs = (
+    <>
+      {open === "disable" && (
+        <ConfirmDisable
+          org={org}
+          pending={disable.isPending}
+          failure={disable.error}
+          onCancel={() => setOpen(undefined)}
+          onConfirm={runDisable}
+        />
+      )}
+      {open === "extend" && (
+        <ExtendTrial
+          org={org}
+          pending={extend.isPending}
+          failure={extend.error}
+          onCancel={() => setOpen(undefined)}
+          onSubmit={runExtend}
+        />
+      )}
+    </>
+  );
+
+  // Everything this component draws is inside a table row that opens the
+  // organization when it is clicked, and a portal's events travel up the React
+  // tree rather than the DOM: a menu item, a dialog body and the dialog's own
+  // backdrop all reach that handler from a portal at the end of the document.
+  // None of them is a click on the row. `contents` keeps the box itself out of
+  // both layouts.
+  const contain = (children: ReactNode): JSX.Element => (
+    <div className="contents" onClick={(event) => event.stopPropagation()}>
+      {children}
+    </div>
+  );
+
+  if (layout === "footer") {
+    return contain(
+      <>
+        {/* Live while a write is in flight, and marked busy instead. Disabling
+            the control the operator just pressed drops the keyboard onto the
+            body, and re-enabling is idempotent, so a second press costs a
+            request and nothing else. */}
+        {isDisabled ? (
+          <Button
+            variant="outline"
+            size="xs"
+            aria-busy={busy}
+            onClick={runEnable}
+          >
+            Re-enable
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            size="xs"
+            aria-busy={busy}
+            onClick={() => openDialog("disable")}
+          >
+            Disable
+          </Button>
+        )}
+        {canExtendTrial(org) && (
+          <Button
+            variant="outline"
+            size="xs"
+            aria-busy={busy}
+            onClick={() => openDialog("extend")}
+          >
+            Extend trial
+          </Button>
+        )}
+        {dialogs}
+      </>,
+    );
+  }
+
+  return contain(
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          {/* Named for the record, because a table full of identical "Actions"
+              buttons tells a screen reader nothing about which row it is on. */}
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label={`Actions for ${org.name}`}
+            aria-busy={busy}
+          >
+            <MoreHorizontalIcon />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {isDisabled ? (
+            <DropdownMenuItem onSelect={runEnable}>Re-enable</DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              variant="destructive"
+              // Opens the confirmation. The write waits for it: disabling cuts
+              // a customer off, and this menu sits one row away from four
+              // others.
+              onSelect={() => openDialog("disable")}
+            >
+              Disable
+            </DropdownMenuItem>
+          )}
+          {canExtendTrial(org) && (
+            <DropdownMenuItem onSelect={() => openDialog("extend")}>
+              Extend trial
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {dialogs}
+    </>,
+  );
+}
+
+function dayCount(days: number): string {
+  return `${days} ${days === 1 ? "day" : "days"}`;
+}
+
+// A modal takes the rest of the page out of the accessibility tree, the live
+// region included, so a failure the operator is looking at needs its own.
+function Failure({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <p role="alert" className="text-destructive text-sm">
+      {children}
+    </p>
+  );
+}
+
+function ConfirmDisable({
+  org,
+  pending,
+  failure,
+  onCancel,
+  onConfirm,
+}: {
+  org: AdminOrganization;
+  pending: boolean;
+  failure: Error | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+}): JSX.Element {
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        // Not while the write is in flight: the answer decides what the row
+        // says next, and dismissing the dialog would leave the operator with
+        // no account of how it ended.
+        if (!next && !pending) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disable {org.name}?</DialogTitle>
+          <DialogDescription>
+            Every member loses access to Gram until the organization is
+            re-enabled.
+          </DialogDescription>
+        </DialogHeader>
+        {failure && <Failure>{errorMessage(failure)}</Failure>}
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={pending}
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={pending}
+            onClick={onConfirm}
+          >
+            {pending ? "Disabling..." : "Disable"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ExtendTrial({
+  org,
+  pending,
+  failure,
+  onCancel,
+  onSubmit,
+}: {
+  org: AdminOrganization;
+  pending: boolean;
+  failure: Error | null;
+  onCancel: () => void;
+  onSubmit: (days: number) => void;
+}): JSX.Element {
+  const [days, setDays] = useState(String(DEFAULT_EXTENSION_DAYS));
+  const [rejected, setRejected] = useState(false);
+  const fieldID = useId();
+
+  const submit = (event: FormEvent): void => {
+    event.preventDefault();
+    const parsed = Number(days);
+    // The server's own bounds, refused here so a request that cannot succeed
+    // never leaves the browser. A whole number, because the interval the
+    // server adds is a count of days.
+    if (
+      !Number.isInteger(parsed) ||
+      parsed < MIN_TRIAL_EXTENSION_DAYS ||
+      parsed > MAX_TRIAL_EXTENSION_DAYS
+    ) {
+      setRejected(true);
+      return;
+    }
+    setRejected(false);
+    onSubmit(parsed);
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next && !pending) onCancel();
+      }}
+    >
+      <DialogContent>
+        {/* noValidate, so a day count outside the bounds is refused in one
+            place and reported in one voice. The browser's own bubble says
+            something different in every browser, disappears on the next key
+            and is not part of the accessibility tree. */}
+        <form noValidate onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>Extend the trial for {org.name}?</DialogTitle>
+            {/* Radix points the dialog's description at this, so the bounds
+                are announced with the title rather than only after a refusal. */}
+            <DialogDescription>
+              The days are added to the date the trial ends on now, not to
+              today. {BOUNDS_HINT}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="my-4 flex items-center gap-2">
+            <label htmlFor={fieldID} className="text-sm">
+              Days
+            </label>
+            <Input
+              id={fieldID}
+              type="number"
+              min={MIN_TRIAL_EXTENSION_DAYS}
+              max={MAX_TRIAL_EXTENSION_DAYS}
+              step={1}
+              value={days}
+              disabled={pending}
+              aria-invalid={rejected}
+              onChange={(event) => setDays(event.target.value)}
+              className="w-24"
+            />
+          </div>
+
+          {rejected && <Failure>{BOUNDS_HINT}</Failure>}
+          {!rejected && failure && <Failure>{errorMessage(failure)}</Failure>}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={pending}
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={pending}>
+              {pending ? "Extending..." : "Extend"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/admin/src/pages/organizations/OrganizationActions.tsx
+++ b/client/admin/src/pages/organizations/OrganizationActions.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useContext,
   useId,
+  useRef,
   useState,
   type FormEvent,
   type JSX,
@@ -46,26 +47,42 @@ const DEFAULT_EXTENSION_DAYS = 14;
 const BOUNDS_HINT = `Enter a whole number of days between ${MIN_TRIAL_EXTENSION_DAYS} and ${MAX_TRIAL_EXTENSION_DAYS}.`;
 
 /**
- * The list owns the only live region on the page, and these controls are drawn
- * inside table cells the list cannot pass props to, so the announcer reaches
- * them through context the way the peek controls do.
+ * How these controls report a write.
+ *
+ * The list owns both surfaces a write can report on, the live region and the
+ * failure banner, and these controls are drawn inside table cells the list
+ * cannot pass props to, so they reach them through context the way the peek
+ * controls do.
  *
  * The default is a no-op rather than a throw: the peek panel renders these
  * actions too and it is mounted on its own in tests.
  */
-const AnnounceContext = createContext<(text: string) => void>(() => {});
+export type WriteReporter = {
+  // Speaks. Every write ends in one of these, whether it succeeded or not.
+  announce: (text: string) => void;
+  // Shows, and only for a failure with no dialog of its own to report in.
+  // `null` clears whatever is showing.
+  showFailure: (text: string | null) => void;
+};
 
-export function AnnounceProvider({
+const NO_REPORTER: WriteReporter = {
+  announce: () => {},
+  showFailure: () => {},
+};
+
+const WriteReportContext = createContext<WriteReporter>(NO_REPORTER);
+
+export function WriteReportProvider({
   value,
   children,
 }: {
-  value: (text: string) => void;
+  value: WriteReporter;
   children: ReactNode;
 }): JSX.Element {
   return (
-    <AnnounceContext.Provider value={value}>
+    <WriteReportContext.Provider value={value}>
       {children}
-    </AnnounceContext.Provider>
+    </WriteReportContext.Provider>
   );
 }
 
@@ -85,7 +102,7 @@ export function OrganizationActions({
   org: AdminOrganization;
   layout: "menu" | "footer";
 }): JSX.Element {
-  const announce = useContext(AnnounceContext);
+  const { announce, showFailure } = useContext(WriteReportContext);
   const [open, setOpen] = useState<OpenDialog>();
 
   // Held here rather than in the dialogs. A dialog unmounts as it closes, and
@@ -97,7 +114,20 @@ export function OrganizationActions({
   const isDisabled = Boolean(org.disabled_at);
   const busy = disable.isPending || enable.isPending || extend.isPending;
 
-  const openDialog = (dialog: OpenDialog): void => {
+  const menuTrigger = useRef<HTMLButtonElement>(null);
+
+  // Where the keyboard goes when a dialog closes. Radix restores focus to a
+  // `DialogTrigger`, and these dialogs have none: its `onCloseAutoFocus`
+  // cancels FocusScope's own restore and then focuses `triggerRef.current`,
+  // which is null here, so without this every close drops the keyboard onto
+  // `document.body`. The control that opened the dialog is still mounted on
+  // all six exit paths, the peek footer button being the same node after the
+  // write it started, so one handler covers success, Escape, Cancel, the
+  // backdrop and the X.
+  const openedFrom = useRef<HTMLElement | null>(null);
+
+  const openDialog = (dialog: OpenDialog, from: HTMLElement | null): void => {
+    openedFrom.current = from;
     // A failure the operator cancelled out of is not one the next attempt
     // should open holding.
     disable.reset();
@@ -105,10 +135,20 @@ export function OrganizationActions({
     setOpen(dialog);
   };
 
+  const restoreFocus = (event: Event): void => {
+    const control = openedFrom.current;
+    // A control that has left the page is not somewhere to put the keyboard.
+    // Radix's own restore is no better in that case, so this leaves it alone.
+    if (!control?.isConnected) return;
+    event.preventDefault();
+    control.focus();
+  };
+
   const runDisable = (): void => {
     disable.mutate(org.id, {
       onSuccess: () => {
         setOpen(undefined);
+        showFailure(null);
         announce(`${org.name} is disabled.`);
       },
       // The dialog stays open and carries the same failure, because that is
@@ -120,9 +160,18 @@ export function OrganizationActions({
 
   const runEnable = (): void => {
     enable.mutate(org.id, {
-      onSuccess: () => announce(`${org.name} is enabled.`),
-      onError: (error) =>
-        announce(`Could not re-enable ${org.name}: ${errorMessage(error)}`),
+      onSuccess: () => {
+        showFailure(null);
+        announce(`${org.name} is enabled.`);
+      },
+      // The one write with no dialog, so its failure is shown as well as
+      // spoken. Without the banner the only account of it on the page is
+      // inside a region no sighted operator reads.
+      onError: (error) => {
+        const text = `Could not re-enable ${org.name}: ${errorMessage(error)}`;
+        announce(text);
+        showFailure(text);
+      },
     });
   };
 
@@ -132,6 +181,7 @@ export function OrganizationActions({
       {
         onSuccess: () => {
           setOpen(undefined);
+          showFailure(null);
           announce(`${org.name} trial extended by ${dayCount(days)}.`);
         },
         onError: (error) =>
@@ -150,6 +200,7 @@ export function OrganizationActions({
           pending={disable.isPending}
           failure={disable.error}
           onCancel={() => setOpen(undefined)}
+          onCloseAutoFocus={restoreFocus}
           onConfirm={runDisable}
         />
       )}
@@ -159,6 +210,7 @@ export function OrganizationActions({
           pending={extend.isPending}
           failure={extend.error}
           onCancel={() => setOpen(undefined)}
+          onCloseAutoFocus={restoreFocus}
           onSubmit={runExtend}
         />
       )}
@@ -180,7 +232,12 @@ export function OrganizationActions({
   if (layout === "footer") {
     return contain(
       <>
-        {/* Live while a write is in flight, and marked busy instead. Disabling
+        {/* Named for the record, the same way the row menu trigger is. The
+            panel's own name is the constant "Organization peek" and it swaps
+            records under itself, so a bare "Disable" reaches a screen reader
+            with nothing saying which organization it acts on.
+
+            Live while a write is in flight, and marked busy instead. Disabling
             the control the operator just pressed drops the keyboard onto the
             body, and re-enabling is idempotent, so a second press costs a
             request and nothing else. */}
@@ -188,6 +245,7 @@ export function OrganizationActions({
           <Button
             variant="outline"
             size="xs"
+            aria-label={`Re-enable ${org.name}`}
             aria-busy={busy}
             onClick={runEnable}
           >
@@ -197,8 +255,9 @@ export function OrganizationActions({
           <Button
             variant="outline"
             size="xs"
+            aria-label={`Disable ${org.name}`}
             aria-busy={busy}
-            onClick={() => openDialog("disable")}
+            onClick={(event) => openDialog("disable", event.currentTarget)}
           >
             Disable
           </Button>
@@ -207,8 +266,9 @@ export function OrganizationActions({
           <Button
             variant="outline"
             size="xs"
+            aria-label={`Extend trial for ${org.name}`}
             aria-busy={busy}
-            onClick={() => openDialog("extend")}
+            onClick={(event) => openDialog("extend", event.currentTarget)}
           >
             Extend trial
           </Button>
@@ -225,6 +285,7 @@ export function OrganizationActions({
           {/* Named for the record, because a table full of identical "Actions"
               buttons tells a screen reader nothing about which row it is on. */}
           <Button
+            ref={menuTrigger}
             variant="ghost"
             size="icon-xs"
             aria-label={`Actions for ${org.name}`}
@@ -242,13 +303,20 @@ export function OrganizationActions({
               // Opens the confirmation. The write waits for it: disabling cuts
               // a customer off, and this menu sits one row away from four
               // others.
-              onSelect={() => openDialog("disable")}
+              //
+              // The trigger, not the item this fires on: the menu closes with
+              // the dialog opening and takes the item down with it, and the
+              // dialog has to give the keyboard back to something still on the
+              // page.
+              onSelect={() => openDialog("disable", menuTrigger.current)}
             >
               Disable
             </DropdownMenuItem>
           )}
           {canExtendTrial(org) && (
-            <DropdownMenuItem onSelect={() => openDialog("extend")}>
+            <DropdownMenuItem
+              onSelect={() => openDialog("extend", menuTrigger.current)}
+            >
               Extend trial
             </DropdownMenuItem>
           )}
@@ -265,9 +333,15 @@ function dayCount(days: number): string {
 
 // A modal takes the rest of the page out of the accessibility tree, the live
 // region included, so a failure the operator is looking at needs its own.
-function Failure({ children }: { children: ReactNode }): JSX.Element {
+function Failure({
+  id,
+  children,
+}: {
+  id?: string;
+  children: ReactNode;
+}): JSX.Element {
   return (
-    <p role="alert" className="text-destructive text-sm">
+    <p id={id} role="alert" className="text-destructive text-sm">
       {children}
     </p>
   );
@@ -278,12 +352,14 @@ function ConfirmDisable({
   pending,
   failure,
   onCancel,
+  onCloseAutoFocus,
   onConfirm,
 }: {
   org: AdminOrganization;
   pending: boolean;
   failure: Error | null;
   onCancel: () => void;
+  onCloseAutoFocus: (event: Event) => void;
   onConfirm: () => void;
 }): JSX.Element {
   return (
@@ -296,7 +372,7 @@ function ConfirmDisable({
         if (!next && !pending) onCancel();
       }}
     >
-      <DialogContent>
+      <DialogContent onCloseAutoFocus={onCloseAutoFocus}>
         <DialogHeader>
           <DialogTitle>Disable {org.name}?</DialogTitle>
           <DialogDescription>
@@ -333,17 +409,21 @@ function ExtendTrial({
   pending,
   failure,
   onCancel,
+  onCloseAutoFocus,
   onSubmit,
 }: {
   org: AdminOrganization;
   pending: boolean;
   failure: Error | null;
   onCancel: () => void;
+  onCloseAutoFocus: (event: Event) => void;
   onSubmit: (days: number) => void;
 }): JSX.Element {
+  const { announce } = useContext(WriteReportContext);
   const [days, setDays] = useState(String(DEFAULT_EXTENSION_DAYS));
   const [rejected, setRejected] = useState(false);
   const fieldID = useId();
+  const messageID = useId();
 
   const submit = (event: FormEvent): void => {
     event.preventDefault();
@@ -357,6 +437,12 @@ function ExtendTrial({
       parsed > MAX_TRIAL_EXTENSION_DAYS
     ) {
       setRejected(true);
+      // Spoken as well as shown, because showing it a second time shows
+      // nothing: the state and the text are both unchanged, so the same press
+      // repeated leaves the DOM untouched and a `role="alert"` announces only
+      // what is inserted or changed. The live region alternates a zero-width
+      // space, so it speaks every time.
+      announce(`Could not extend the trial for ${org.name}: ${BOUNDS_HINT}`);
       return;
     }
     setRejected(false);
@@ -370,7 +456,7 @@ function ExtendTrial({
         if (!next && !pending) onCancel();
       }}
     >
-      <DialogContent>
+      <DialogContent onCloseAutoFocus={onCloseAutoFocus}>
         {/* noValidate, so a day count outside the bounds is refused in one
             place and reported in one voice. The browser's own bubble says
             something different in every browser, disappears on the next key
@@ -399,13 +485,24 @@ function ExtendTrial({
               value={days}
               disabled={pending}
               aria-invalid={rejected}
+              // Pointed at whichever message is under the field. Without it a
+              // user who tabs back to the input is told it is invalid and not
+              // what would make it valid: the bounds are in the dialog
+              // description and in the alert, and neither is the field's.
+              aria-describedby={rejected || failure ? messageID : undefined}
               onChange={(event) => setDays(event.target.value)}
               className="w-24"
             />
           </div>
 
-          {rejected && <Failure>{BOUNDS_HINT}</Failure>}
-          {!rejected && failure && <Failure>{errorMessage(failure)}</Failure>}
+          {/* One at a time. The bounds refusal is the newer of the two and it
+              is about the value now in the field, so a stale server failure
+              underneath it would give the operator two reasons and no way to
+              tell which one the next press answers. */}
+          {rejected && <Failure id={messageID}>{BOUNDS_HINT}</Failure>}
+          {!rejected && failure && (
+            <Failure id={messageID}>{errorMessage(failure)}</Failure>
+          )}
 
           <DialogFooter>
             <Button

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -16,6 +16,8 @@ import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 import { cn, fmtDateShort } from "@/lib/utils";
 
+import { OrganizationActions } from "./OrganizationActions";
+
 const COPY_CONFIRM_MS = 1500;
 
 // One panel is on the page at a time, so a constant is enough and the row's
@@ -162,8 +164,12 @@ export function PeekPanel({
       </div>
 
       <Separator />
-      {/* Empty on purpose: reserved so later actions do not move the grid. */}
-      <div className="flex min-h-8 items-center gap-2 p-4" />
+      {/* Plain buttons, not a menu: this footer sits inside the subtree the
+          list watches for Escape and the arrow keys, and a menu would answer
+          Escape before the panel it is drawn in. */}
+      <div className="flex min-h-8 items-center gap-2 p-4">
+        <OrganizationActions org={org} layout="footer" />
+      </div>
     </aside>
   );
 }

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -1,12 +1,13 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { Column, RowData } from "@tanstack/react-table";
 import { SearchIcon } from "lucide-react";
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 
 import type {
   DataTableFeatures,
   DataTableInstance,
 } from "@/components/data-table";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -16,15 +17,17 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ACCOUNT_TYPE_OPTIONS, isAccountType } from "@/lib/accountTypes";
+  FILTER_GROUPS,
+  filterSummary,
+  filtersToSearch,
+  optionsFor,
+  type FilterGroupKey,
+  type FilterSelection,
+} from "@/lib/organizationFilters";
 import { cn } from "@/lib/utils";
 import type { OrganizationsSearch } from "@/routes/organizations.index";
+
+import { FilterSheet } from "./FilterSheet";
 
 const ROUTE_ID = "/organizations/";
 const SEARCH_DEBOUNCE_MS = 300;
@@ -74,17 +77,38 @@ export function Toolbar(): JSX.Element {
     return () => clearTimeout(timer);
   }, [draft, committed, navigate]);
 
-  const applyFilter = (patch: Partial<OrganizationsSearch>): void => {
+  // Which group the sheet is showing, and null when it is closed.
+  const [openGroup, setOpenGroup] = useState<FilterGroupKey | null>(null);
+  const triggers = useRef<Partial<Record<FilterGroupKey, HTMLButtonElement>>>(
+    {},
+  );
+  // The trigger the sheet has to give the keyboard back to. A ref rather than
+  // `openGroup`, because the sheet asks for it as it unmounts: by then the
+  // state that opened it has already been cleared.
+  const openedFrom = useRef<FilterGroupKey | null>(null);
+
+  const filters: FilterSelection = {
+    type: search.type ?? [],
+    trial: search.trial ?? [],
+    disabled: search.disabled ?? [],
+  };
+
+  const applyFilters = (next: FilterSelection): void => {
     void navigate({
       search: (prev: OrganizationsSearch) => ({
         ...prev,
-        ...patch,
+        ...filtersToSearch(next),
+        // Page 1. The rows a page-two cursor points at were counted under the
+        // filters that minted it.
         page: undefined,
       }),
     });
   };
 
-  const selectedType = search.type ?? "";
+  const openFilters = (group: FilterGroupKey): void => {
+    openedFrom.current = group;
+    setOpenGroup(group);
+  };
 
   return (
     <div className="mb-2 flex items-center gap-2">
@@ -98,36 +122,47 @@ export function Toolbar(): JSX.Element {
           className="w-full py-1.5 pr-2 pl-8"
         />
       </div>
-      <Select
-        value={selectedType || "all"}
-        onValueChange={(value) =>
-          applyFilter({ type: isAccountType(value) ? value : undefined })
-        }
-      >
-        <SelectTrigger
-          aria-label="Account type"
-          className="h-auto w-auto px-2 py-1.5"
-        >
-          <SelectValue placeholder="All types" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All types</SelectItem>
-          {ACCOUNT_TYPE_OPTIONS.map((t) => (
-            <SelectItem key={t} value={t}>
-              {t}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <Button
-        variant={search.disabled ? "default" : "ghost"}
-        size="xs"
-        onClick={() =>
-          applyFilter({ disabled: search.disabled ? undefined : true })
-        }
-      >
-        {search.disabled ? "Hide disabled" : "Show disabled"}
-      </Button>
+
+      {/* One trigger per group, all opening the same sheet. The group is the
+          unit an operator thinks in, and a single Filters button would make
+          them find the group again inside the sheet. */}
+      {FILTER_GROUPS.map((group) => {
+        const chosen = filters[group.key];
+        return (
+          <Button
+            key={group.key}
+            ref={(node) => {
+              if (node) triggers.current[group.key] = node;
+            }}
+            variant={chosen.length > 0 ? "secondary" : "ghost"}
+            size="xs"
+            // The count is the whole visible signal, and a count does not say
+            // what it counts. The name a screen reader announces says it.
+            aria-label={`${group.label} filter: ${filterSummary(
+              group,
+              chosen,
+              optionsFor(group, chosen),
+            )}`}
+            onClick={() => openFilters(group.key)}
+          >
+            {group.label}
+            {chosen.length > 0 && <Badge>{chosen.length}</Badge>}
+          </Button>
+        );
+      })}
+
+      <FilterSheet
+        value={filters}
+        openGroup={openGroup}
+        onOpenChange={(open) => {
+          if (!open) setOpenGroup(null);
+        }}
+        onApply={applyFilters}
+        onReturnFocus={() => {
+          const group = openedFrom.current;
+          if (group) triggers.current[group]?.focus();
+        }}
+      />
     </div>
   );
 }

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -8,6 +8,7 @@ import { badgeTone } from "@/lib/badgeTone";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 import { cn, fmtDateShort } from "@/lib/utils";
 
+import { OrganizationActions } from "./OrganizationActions";
 import { PeekTrigger } from "./PeekTrigger";
 
 const column = createColumnHelper<DataTableFeatures, AdminOrganization>();
@@ -26,6 +27,21 @@ export const ORG_COLUMNS = column.columns([
     // Hiding the control would put peek back out of reach of the keyboard.
     enableHiding: false,
     cell: ({ row }) => <PeekTrigger org={row.original} />,
+  }),
+  // Beside peek rather than trailing the row, for the reason above: the row
+  // menu is the control an operator reaches for while peek is open, and it is
+  // the five hidden columns' width away from where it was if it sits last.
+  //
+  // Deliberately in neither PEEK_HIDDEN_COLUMNS nor PEEK_COLUMN_OVERRIDES: an
+  // open peek is no reason to take the other rows' actions away, and hiding a
+  // control the Columns menu cannot bring back would strand it.
+  column.display({
+    id: "actions",
+    header: "Actions",
+    // Hiding the menu would put disable, re-enable and extend out of reach for
+    // the whole list, and the peek panel's copy of them covers one record.
+    enableHiding: false,
+    cell: ({ row }) => <OrganizationActions org={row.original} layout="menu" />,
   }),
   column.accessor("name", {
     header: "Name",

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -621,6 +621,48 @@ describe("organizations list", () => {
     expect(picker("Type").textContent).toContain("All types");
   });
 
+  it("holds the list open so a second value can be picked off it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openFilters("Type");
+    // The trigger is clicked once and only once. Every other test here goes
+    // through `chooseFilter`, which reopens a closed list, so a picker that
+    // shut itself on each choice would pass all of them: the operator would be
+    // reopening the list for every value, and nothing would say so.
+    fireEvent.click(picker("Type"));
+    fireEvent.click(await screen.findByRole("option", { name: "enterprise" }));
+
+    expect(picker("Type").getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(screen.getByRole("option", { name: "free" }));
+    expect(picker("Type").getAttribute("aria-expanded")).toBe("true");
+
+    applyFilters();
+    await waitFor(() => {
+      expect(lastListParams().account_types).toEqual(["free", "enterprise"]);
+    });
+  });
+
+  it("gives the keyboard back to the trigger after applying", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await waitFor(() => {
+      expect(mocks.listOrganizations).toHaveBeenCalled();
+    });
+
+    await openFilters("Trial");
+    await chooseFilter("Trial", "Expired");
+    applyFilters();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    // Escape is not the only way out of the sheet. Applying unmounts the same
+    // subtree, and must not leave the keyboard on it either.
+    expect(document.activeElement).toBe(filterTrigger("Trial"));
+    await waitFor(() => {
+      expect(lastListParams().trial_states).toEqual(["expired"]);
+    });
+  });
+
   it("clears every filter and leaves the search term alone", async () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: urlFor({

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -23,10 +23,11 @@ import {
   type Mock,
 } from "vitest";
 
-import type {
-  AdminOrganization,
-  ListOrganizationsParams,
-  ListOrganizationsResult,
+import {
+  GramAdminError,
+  type AdminOrganization,
+  type ListOrganizationsParams,
+  type ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
 import { useState, type JSX } from "react";
 
@@ -50,6 +51,12 @@ const mocks = vi.hoisted(() => ({
   getOrganization: vi.fn(),
   listOrganizationProjects: vi.fn(),
   listOrganizationMembers: vi.fn(),
+  disableOrganization:
+    vi.fn<(body: { id: string }) => Promise<AdminOrganization>>(),
+  enableOrganization:
+    vi.fn<(body: { id: string }) => Promise<AdminOrganization>>(),
+  extendTrial:
+    vi.fn<(body: { id: string; days: number }) => Promise<AdminOrganization>>(),
 }));
 
 // Only the endpoints this page's route tree reaches are replaced. The rest of
@@ -65,6 +72,9 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     getOrganization: mocks.getOrganization,
     listOrganizationProjects: mocks.listOrganizationProjects,
     listOrganizationMembers: mocks.listOrganizationMembers,
+    disableOrganization: mocks.disableOrganization,
+    enableOrganization: mocks.enableOrganization,
+    extendTrial: mocks.extendTrial,
   };
 });
 
@@ -123,6 +133,24 @@ const NEXT_PAGE_ORG: AdminOrganization = {
 
 const [FIRST_ORG, SECOND_ORG] = ORGS;
 if (!FIRST_ORG || !SECOND_ORG) throw new Error("ORGS needs two rows");
+
+// The first row is disabled and its trial is running; the second is live and
+// never trialled. Between them every action has a row that offers it and a row
+// that does not.
+if (!FIRST_ORG.disabled_at || SECOND_ORG.disabled_at) {
+  throw new Error("the fixture needs one disabled row and one live row");
+}
+
+// What each write answers with, dated apart from anything the fixture already
+// carries so a row that failed to repaint cannot read as one that did.
+const DISABLED_AT = "2026-08-01T00:00:00Z";
+const EXTENDED_TRIAL_END = "2026-05-20T00:00:00Z";
+
+function orgByID(id: string): AdminOrganization {
+  const org = ORGS.find((row) => row.id === id);
+  if (!org) throw new Error(`no fixture organization with id ${id}`);
+  return org;
+}
 
 // The columns render a date through toLocaleDateString, so the expected text
 // has to come out of the same formatter. Reading the field off the fixture is
@@ -268,6 +296,21 @@ beforeEach(() => {
   mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
   mocks.listOrganizationMembers.mockReset();
   mocks.listOrganizationMembers.mockResolvedValue({ members: [] });
+  // Each write answers with the record in its new state, which is what the
+  // list repaints from. Answered off the id in the request, so a test can act
+  // on either row and still be given that row back.
+  mocks.disableOrganization.mockReset();
+  mocks.disableOrganization.mockImplementation(({ id }) =>
+    Promise.resolve({ ...orgByID(id), disabled_at: DISABLED_AT }),
+  );
+  mocks.enableOrganization.mockReset();
+  mocks.enableOrganization.mockImplementation(({ id }) =>
+    Promise.resolve({ ...orgByID(id), disabled_at: undefined }),
+  );
+  mocks.extendTrial.mockReset();
+  mocks.extendTrial.mockImplementation(({ id }) =>
+    Promise.resolve({ ...orgByID(id), trial_ends_at: EXTENDED_TRIAL_END }),
+  );
 });
 
 afterEach(cleanup);
@@ -532,6 +575,7 @@ describe("organizations list", () => {
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
       "Peek",
+      "Actions",
       "Name",
       "Slug",
       "Type",
@@ -547,6 +591,8 @@ describe("organizations list", () => {
         .map((cell) => cell.textContent),
     ).toEqual([
       // The peek control carries an icon and its name is on the button.
+      "",
+      // So does the row menu, for the same reason.
       "",
       FIRST_ORG.name,
       FIRST_ORG.slug,
@@ -608,10 +654,11 @@ describe("organizations list", () => {
     });
 
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    // Past the peek control and the name link, so the click lands on the row
-    // body rather than on something that handles it first.
-    const [, , slugCell] = within(rowFor(link)).getAllByRole("cell");
-    if (!slugCell) throw new Error("the row needs a third cell");
+    // Past the two controls and the name link, so the click lands on the row
+    // body rather than on something that handles it first. Named by its header
+    // rather than counted, because a control column added beside the others
+    // would otherwise slide this onto a cell that answers the click itself.
+    const slugCell = cellUnder(rowFor(link), "Slug");
 
     fireEvent.click(slugCell);
 
@@ -689,7 +736,7 @@ describe("organizations list peek", () => {
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Peek", "Name", "Slug", "Type"]);
+    ).toEqual(["Peek", "Actions", "Name", "Slug", "Type"]);
   });
 
   it("takes the trial column down with the rest while it is open", async () => {
@@ -811,7 +858,7 @@ describe("organizations list peek", () => {
     await peekOn(FIRST_ORG.name);
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Peek", "Name", "Type"]);
+    ).toEqual(["Peek", "Actions", "Name", "Type"]);
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
@@ -819,6 +866,7 @@ describe("organizations list peek", () => {
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
       "Peek",
+      "Actions",
       "Name",
       "Type",
       "Members",
@@ -845,7 +893,7 @@ describe("organizations list peek", () => {
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Peek", "Name", "Slug", "Type"]);
+    ).toEqual(["Peek", "Actions", "Name", "Slug", "Type"]);
     expect(screen.getByRole("link", { name: FIRST_ORG.name })).toBeTruthy();
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
@@ -910,6 +958,7 @@ describe("organizations list peek", () => {
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
       "Peek",
+      "Actions",
       "Name",
       "Slug",
       "Type",
@@ -1407,8 +1456,7 @@ describe("organizations list peek", () => {
     });
 
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
-    const [, , slugCell] = within(rowFor(link)).getAllByRole("cell");
-    if (!slugCell) throw new Error("the row needs a third cell");
+    const slugCell = cellUnder(rowFor(link), "Slug");
 
     // The gesture is gone: browsers read Alt-click on an anchor as "save
     // link", and the row's own handler carries no branch for it any more.
@@ -1688,22 +1736,305 @@ describe("organizations list peek", () => {
   });
 });
 
+describe("organizations list write actions", () => {
+  // The second row: live, so it is the one that offers Disable, and it is not
+  // the row the detail mocks answer for.
+  const LIVE = SECOND_ORG;
+
+  async function openRowMenu(name: string): Promise<HTMLElement> {
+    const trigger = await screen.findByRole("button", {
+      name: `Actions for ${name}`,
+    });
+    openOn(trigger);
+    return trigger;
+  }
+
+  async function confirmDisable(): Promise<void> {
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    });
+  }
+
+  it("repaints the row out of the answer rather than asking for the list again", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: LIVE.name });
+    expect(cellUnder(rowFor(link), "Disabled").textContent).toBe("-");
+
+    await openRowMenu(LIVE.name);
+    await confirmDisable();
+
+    await waitFor(() => {
+      expect(cellUnder(rowFor(link), "Disabled").textContent).toBe(
+        shortDate(DISABLED_AT),
+      );
+    });
+    // One request, the one that drew the page. The answer already carries the
+    // record in its new state, so a refetch behind it is a second round trip
+    // for a row that is already right, and the list flickers through the
+    // loading state on the way.
+    expect(mocks.listOrganizations).toHaveBeenCalledTimes(1);
+    // The row that was written, and no other. A cache update keyed on the
+    // wrong thing repaints every row with one record.
+    const other = screen.getByRole("link", { name: FIRST_ORG.name });
+    expect(cellUnder(rowFor(other), "Disabled").textContent).toBe(
+      shortDate(FIRST_ORG.disabled_at ?? ""),
+    );
+  });
+
+  it("stays on the list while the operator works the menu it opened from a row", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    await openRowMenu(LIVE.name);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    const dialog = await screen.findByRole("dialog");
+
+    // The row opens the organization when it is clicked, and both of these are
+    // drawn in a portal at the end of the document: nowhere near the row in the
+    // DOM, and directly under it in the React tree the click travels up. The
+    // operator reading a confirmation has not asked to leave the list, and
+    // leaving would take the confirmation with it.
+    fireEvent.click(within(dialog).getByText(`Disable ${LIVE.name}?`));
+    const backdrop = document.querySelector('[data-slot="dialog-overlay"]');
+    if (!backdrop) throw new Error("the dialog has no backdrop");
+    fireEvent.click(backdrop);
+
+    expect(router.state.location.pathname).toBe("/organizations");
+    expect(mocks.disableOrganization).not.toHaveBeenCalled();
+  });
+
+  it("offers the opposite action after each write, twice running", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openRowMenu(LIVE.name);
+    await confirmDisable();
+
+    // The row now carries a disabled record, so the menu has to have swapped
+    // the two entries. Twice, because the state the second write leaves is the
+    // state the first one started from: a menu that reads its answer from the
+    // record the page loaded with, rather than from the row it is drawn on,
+    // passes this once and fails on the way back.
+    await openRowMenu(LIVE.name);
+    expect(screen.queryByRole("menuitem", { name: "Disable" })).toBeNull();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Re-enable" }));
+    });
+
+    await openRowMenu(LIVE.name);
+    expect(screen.queryByRole("menuitem", { name: "Re-enable" })).toBeNull();
+    await confirmDisable();
+
+    expect(mocks.disableOrganization).toHaveBeenCalledTimes(2);
+    expect(mocks.enableOrganization).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the row as it was when the server refuses the write", async () => {
+    mocks.disableOrganization.mockRejectedValue(
+      new GramAdminError(
+        409,
+        { name: "conflict", message: "organization is already disabled" },
+        "gram admin 409 Conflict",
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: LIVE.name });
+
+    await openRowMenu(LIVE.name);
+    await confirmDisable();
+
+    // The dialog is still up, holding the reason, and the operator is the one
+    // who decides when to leave it.
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    // The row is drawn from the answer, and there was no answer. A row that
+    // repaints off the request instead shows the operator a state the server
+    // never reached, and the list is the only place they would notice.
+    const link = screen.getByRole("link", { name: LIVE.name });
+    expect(cellUnder(rowFor(link), "Disabled").textContent).toBe("-");
+    expect(announcement()).toBe(
+      `Could not disable ${LIVE.name}: organization is already disabled`,
+    );
+  });
+
+  it("reports the write through the one region the list already speaks from", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openRowMenu(LIVE.name);
+    await confirmDisable();
+
+    // The same polite region the peek announces through, rather than a second
+    // one shipped with the row menu. A row menu is not a surface an operator
+    // can read a result off: the dialog closes and the cell that changed is
+    // eight columns away.
+    await waitFor(() => {
+      expect(announcement()).toBe(`${LIVE.name} is disabled.`);
+    });
+  });
+
+  it("will not let the Columns menu take the row menu away", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    openOn(screen.getByRole("button", { name: "Columns" }));
+    const item = screen.getByRole("menuitemcheckbox", { name: "Actions" });
+    fireEvent.click(item);
+
+    // Hiding this column puts disable, re-enable and extend out of reach for
+    // every row at once, and the operator has no route back except the column
+    // they just hid.
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    expect(item.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.keyDown(item, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: "Actions" }),
+      ).toBeTruthy();
+    });
+    expect(
+      await screen.findByRole("button", { name: `Actions for ${LIVE.name}` }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the actions column while the peek is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    // Peek takes five columns down to make room for the panel. This one stays:
+    // the panel covers one record, and the reason to reach for another row's
+    // menu does not go away because a panel is open beside it.
+    expect(screen.getByRole("columnheader", { name: "Actions" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: `Actions for ${LIVE.name}` }),
+    ).toBeTruthy();
+  });
+
+  it("extends the trial from the panel and repaints the panel with the answer", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    fireEvent.click(
+      within(peekPanel()).getByRole("button", { name: "Extend trial" }),
+    );
+    await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Extend" }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    // The default day count, sent without the operator typing anything.
+    expect(mocks.extendTrial).toHaveBeenCalledWith({
+      id: FIRST_ORG.id,
+      days: 14,
+    });
+    // The panel is drawn from the row it is peeking at, so it repaints from the
+    // same cache write the row does. Reading the old date here is the operator
+    // being shown the trial they just extended, unextended.
+    expect(peekPanel().textContent).toContain(shortDate(EXTENDED_TRIAL_END));
+    expect(announcement()).toBe(`${FIRST_ORG.name} trial extended by 14 days.`);
+  });
+
+  it("re-enables from the panel without a dialog in the way", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+    const panel = within(peekPanel());
+
+    await act(async () => {
+      fireEvent.click(panel.getByRole("button", { name: "Re-enable" }));
+    });
+
+    expect(mocks.enableOrganization).toHaveBeenCalledWith({
+      id: FIRST_ORG.id,
+    });
+    expect(
+      within(peekPanel()).getByRole("button", { name: "Disable" }),
+    ).toBeTruthy();
+    // The panel stays. Nothing about the record left the list, and closing it
+    // would take the operator off the row they are working.
+    expect(peekPanel()).toBeTruthy();
+  });
+
+  it("leaves the arrow keys to the day count typed inside the peek", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
+    await peekOn(FIRST_ORG.name);
+
+    fireEvent.click(
+      within(peekPanel()).getByRole("button", { name: "Extend trial" }),
+    );
+    await screen.findByRole("dialog");
+
+    // The dialog is drawn in a portal and rendered inside the panel's subtree,
+    // so its keys reach the list's handler through React even though the node
+    // is outside the panel. A number input steps its value on the arrow keys,
+    // and an operator holding ArrowUp to reach 30 days is not asking the list
+    // to walk the peek down the page underneath them.
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    screen.getByLabelText("Days").dispatchEvent(event);
+
+    // Read off the row rather than through a role query: an open modal takes
+    // the table out of the accessibility tree.
+    expect(isPeeked(first)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("closes the dialog on Escape and leaves the peek open behind it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    fireEvent.click(
+      within(peekPanel()).getByRole("button", { name: "Extend trial" }),
+    );
+    await screen.findByRole("dialog");
+
+    fireEvent.keyDown(screen.getByLabelText("Days"), { key: "Escape" });
+
+    // One surface per press. Escape inside the panel body closes the peek, and
+    // this key is inside the panel's React subtree, so two separate things
+    // keep the panel: the dialog answers the key first and marks it, and the
+    // panel reads containment off the DOM, where the portal is nowhere near
+    // it. Losing either one alone is survivable; losing both closes the panel
+    // out from under a dialog the operator was reading.
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(peekPanel()).toBeTruthy();
+    expect(mocks.extendTrial).not.toHaveBeenCalled();
+  });
+});
+
 // The bar takes a table, so the last-column case is reachable here by handing
 // it a two column table rather than by clicking seven items shut through a
 // menu that closes each time.
 describe("TableActionBar", () => {
-  // Sliced, so the array carries the element type useTable asks for. Two data
-  // columns for the cases about the bar's own two rules, and the peek column
-  // beside one of them for the case where an unhideable column is in the count.
-  const MENU_COLUMNS = ORG_COLUMNS.slice(1, 3);
-  const WITH_PEEK_COLUMN = ORG_COLUMNS.slice(0, 2);
-
-  // Destructured off the tuple rather than off the slice, which widens each
+  // Destructured off the tuple rather than off a slice, which widens each
   // element back to a bare column definition.
-  const [PEEK, FIRST, SECOND, THIRD] = ORG_COLUMNS;
-  if (!PEEK || !FIRST || !SECOND || !THIRD) {
-    throw new Error("ORG_COLUMNS needs four columns");
+  const [PEEK, ACTIONS, FIRST, SECOND, THIRD] = ORG_COLUMNS;
+  if (!PEEK || !ACTIONS || !FIRST || !SECOND || !THIRD) {
+    throw new Error("ORG_COLUMNS needs five columns");
   }
+
+  // Sliced, so the array carries the element type useTable asks for. Two data
+  // columns for the cases about the bar's own two rules, and each control
+  // column beside one of them for the cases where a column that cannot be
+  // hidden is in the count.
+  const MENU_COLUMNS = ORG_COLUMNS.slice(2, 4);
+  const WITH_PEEK_COLUMN: typeof MENU_COLUMNS = [PEEK, FIRST];
+  const WITH_ACTIONS_COLUMN: typeof MENU_COLUMNS = [ACTIONS, FIRST];
 
   // An accessor column takes its id from its key unless it names one, and that
   // id is what the visibility state is keyed by.
@@ -1868,6 +2199,21 @@ describe("TableActionBar", () => {
     // The peek column is locked too, by its own opt-out rather than by this
     // rule, so the operator cannot reach the same state from the other side.
     expect(itemFor(PEEK.header).getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("stops the operator hiding the last data column beside the row menu", () => {
+    // The same case as above, from the column that arrived after the rule. A
+    // second column that opts out of hiding is a second way to make the count
+    // wrong, and a guard that counts every visible column instead of every
+    // hideable one now needs two data columns before it lets go of one.
+    const { onVisibilityChange } = openColumnsMenu({}, WITH_ACTIONS_COLUMN);
+
+    const item = itemFor(FIRST.header);
+    fireEvent.click(item);
+
+    expect(onVisibilityChange).not.toHaveBeenCalled();
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    expect(itemFor(ACTIONS.header).getAttribute("aria-disabled")).toBe("true");
   });
 
   it("locks a column that opts out of hiding", () => {

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -116,6 +116,21 @@ const ORGS: AdminOrganization[] = [
     created_at: "2026-06-08T00:00:00Z",
     updated_at: "2026-06-09T00:00:00Z",
   },
+  // Live, and mid-trial. Extend trial is offered on this row and on no other:
+  // the first row's trial is running too, but the organization is disabled and
+  // a disabled organization is not offered more of a trial nobody can use.
+  {
+    id: "org_placeholder_four",
+    name: "Placeholder Four",
+    slug: "placeholder-four",
+    account_type: "enterprise",
+    whitelisted: false,
+    trial_state: "ending_soon",
+    trial_ends_at: "2026-05-06T00:00:00Z",
+    member_count: 5,
+    created_at: "2026-04-02T00:00:00Z",
+    updated_at: "2026-04-07T00:00:00Z",
+  },
 ];
 
 // A page the cursor leads to. Nothing it holds appears on the first page, so a
@@ -131,8 +146,10 @@ const NEXT_PAGE_ORG: AdminOrganization = {
   updated_at: "2026-07-11T00:00:00Z",
 };
 
-const [FIRST_ORG, SECOND_ORG] = ORGS;
-if (!FIRST_ORG || !SECOND_ORG) throw new Error("ORGS needs two rows");
+const [FIRST_ORG, SECOND_ORG, TRIALLING_ORG] = ORGS;
+if (!FIRST_ORG || !SECOND_ORG || !TRIALLING_ORG) {
+  throw new Error("ORGS needs three rows");
+}
 
 // The first row is disabled and its trial is running; the second is live and
 // never trialled. Between them every action has a row that offers it and a row
@@ -786,9 +803,16 @@ describe("organizations list peek", () => {
     );
     expect(isPeeked(first)).toBe(false);
 
+    // On to the last row, and then nowhere: paging replaces the row nodes the
+    // anchor depends on, so the walk stops rather than following the pager.
     fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
     expect(
-      within(peekPanel()).getByRole("heading", { name: SECOND_ORG.name }),
+      within(peekPanel()).getByRole("heading", { name: TRIALLING_ORG.name }),
+    ).toBeTruthy();
+
+    fireEvent.keyDown(peekPanel(), { key: "ArrowDown" });
+    expect(
+      within(peekPanel()).getByRole("heading", { name: TRIALLING_ORG.name }),
     ).toBeTruthy();
   });
 
@@ -1878,6 +1902,104 @@ describe("organizations list write actions", () => {
     });
   });
 
+  it("shows a re-enable that failed, and not only to a screen reader", async () => {
+    mocks.enableOrganization.mockRejectedValue(
+      new GramAdminError(
+        409,
+        { name: "conflict", message: "organization is not disabled" },
+        "gram admin 409 Conflict",
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openRowMenu(FIRST_ORG.name);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Re-enable" }));
+    });
+
+    // Re-enable is the one action with no dialog, so without this the whole
+    // account of the failure on the page is a sentence inside sr-only: the row
+    // does not change, and the banner above it covers the list query alone. A
+    // sighted operator presses Re-enable, sees nothing happen, and is told
+    // nothing about why.
+    const failure = `Could not re-enable ${FIRST_ORG.name}: organization is not disabled`;
+    const banner = await screen.findByRole("alert");
+    expect(banner.textContent).toContain(failure);
+    expect(banner.className).not.toContain("sr-only");
+    expect(announcement()).toBe(failure);
+
+    // Dismissible, because it is the operator's page and this is not a modal.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss the failure" }),
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("takes the failure down when the next write succeeds", async () => {
+    mocks.enableOrganization.mockRejectedValueOnce(
+      new GramAdminError(404, null, "gram admin 404 Not Found"),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openRowMenu(FIRST_ORG.name);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Re-enable" }));
+    });
+    expect(await screen.findByRole("alert")).toBeTruthy();
+
+    await openRowMenu(FIRST_ORG.name);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("menuitem", { name: "Re-enable" }));
+    });
+
+    // The operator has just been told the current state of this record, so a
+    // banner about the attempt before it is describing a page that has moved
+    // on.
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+  });
+
+  it("keeps the live region reachable while a dialog is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openRowMenu(LIVE.name);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await screen.findByRole("dialog");
+
+    // An open Radix modal hides the rest of the page with aria-hidden, and the
+    // one exemption that package makes is for elements carrying aria-live by
+    // name. Everything else goes, which is what this asserts against: the
+    // table is gone from the tree and the region is not.
+    expect(liveRegion()).toBeTruthy();
+    expect(screen.queryByRole("link", { name: LIVE.name })).toBeNull();
+  });
+
+  it("speaks the same refusal twice when the operator presses through it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await openRowMenu(TRIALLING_ORG.name);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Extend trial" }));
+    await screen.findByRole("dialog");
+
+    const days = screen.getByLabelText("Days");
+    fireEvent.change(days, { target: { value: "0" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Extend" }));
+    });
+    const first = liveRegion().textContent;
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Extend" }));
+    });
+
+    // Word for word the same sentence, and the region still changed: the
+    // zero-width space alternates, so the second refusal reaches the
+    // accessibility tree as a change rather than as silence. Nothing on screen
+    // moves on that press, which is the whole reason this path announces.
+    expect(announcement()).toContain("between 1 and 365");
+    expect(liveRegion().textContent).not.toBe(first);
+    expect(mocks.extendTrial).not.toHaveBeenCalled();
+  });
+
   it("will not let the Columns menu take the row menu away", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     await screen.findByRole("link", { name: FIRST_ORG.name });
@@ -1919,10 +2041,12 @@ describe("organizations list write actions", () => {
 
   it("extends the trial from the panel and repaints the panel with the answer", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    await peekOn(FIRST_ORG.name);
+    await peekOn(TRIALLING_ORG.name);
 
     fireEvent.click(
-      within(peekPanel()).getByRole("button", { name: "Extend trial" }),
+      within(peekPanel()).getByRole("button", {
+        name: `Extend trial for ${TRIALLING_ORG.name}`,
+      }),
     );
     await screen.findByRole("dialog");
     await act(async () => {
@@ -1934,14 +2058,16 @@ describe("organizations list write actions", () => {
     });
     // The default day count, sent without the operator typing anything.
     expect(mocks.extendTrial).toHaveBeenCalledWith({
-      id: FIRST_ORG.id,
+      id: TRIALLING_ORG.id,
       days: 14,
     });
     // The panel is drawn from the row it is peeking at, so it repaints from the
     // same cache write the row does. Reading the old date here is the operator
     // being shown the trial they just extended, unextended.
     expect(peekPanel().textContent).toContain(shortDate(EXTENDED_TRIAL_END));
-    expect(announcement()).toBe(`${FIRST_ORG.name} trial extended by 14 days.`);
+    expect(announcement()).toBe(
+      `${TRIALLING_ORG.name} trial extended by 14 days.`,
+    );
   });
 
   it("re-enables from the panel without a dialog in the way", async () => {
@@ -1950,54 +2076,102 @@ describe("organizations list write actions", () => {
     const panel = within(peekPanel());
 
     await act(async () => {
-      fireEvent.click(panel.getByRole("button", { name: "Re-enable" }));
+      fireEvent.click(
+        panel.getByRole("button", { name: `Re-enable ${FIRST_ORG.name}` }),
+      );
     });
 
     expect(mocks.enableOrganization).toHaveBeenCalledWith({
       id: FIRST_ORG.id,
     });
+    // Named for the record it acts on, and it is the record that changed
+    // rather than the panel: the panel's own name is a constant, and it swaps
+    // records under itself on the arrow keys.
     expect(
-      within(peekPanel()).getByRole("button", { name: "Disable" }),
+      within(peekPanel()).getByRole("button", {
+        name: `Disable ${FIRST_ORG.name}`,
+      }),
     ).toBeTruthy();
     // The panel stays. Nothing about the record left the list, and closing it
     // would take the operator off the row they are working.
     expect(peekPanel()).toBeTruthy();
   });
 
+  it("gives the keyboard back to the panel control the dialog opened from", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(TRIALLING_ORG.name);
+    const extend = within(peekPanel()).getByRole("button", {
+      name: `Extend trial for ${TRIALLING_ORG.name}`,
+    });
+
+    fireEvent.click(extend);
+    await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Extend" }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    // The same node, through the write: the record changed underneath it and
+    // React kept the element. Radix would have focused a DialogTrigger that
+    // does not exist here and left the keyboard on the document body, at the
+    // top of the page, with the panel still open beside it.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(extend);
+    });
+  });
+
   it("leaves the arrow keys to the day count typed inside the peek", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    const first = await screen.findByRole("link", { name: FIRST_ORG.name });
-    await peekOn(FIRST_ORG.name);
+    const peeked = await screen.findByRole("link", {
+      name: TRIALLING_ORG.name,
+    });
+    await peekOn(TRIALLING_ORG.name);
 
     fireEvent.click(
-      within(peekPanel()).getByRole("button", { name: "Extend trial" }),
+      within(peekPanel()).getByRole("button", {
+        name: `Extend trial for ${TRIALLING_ORG.name}`,
+      }),
     );
     await screen.findByRole("dialog");
 
+    // A spinner, which is the premise of everything below: the arrow keys have
+    // something to do inside this field only because it steps its own value,
+    // and the bounds are on the control as well as in the check behind it.
+    // happy-dom does not step a number input on ArrowUp or ArrowDown, so the
+    // attributes are assertable here and the stepping is not.
+    const days = screen.getByLabelText("Days");
+    expect(days.getAttribute("type")).toBe("number");
+    expect(days.getAttribute("min")).toBe("1");
+    expect(days.getAttribute("max")).toBe("365");
+    expect(days.getAttribute("step")).toBe("1");
+
     // The dialog is drawn in a portal and rendered inside the panel's subtree,
     // so its keys reach the list's handler through React even though the node
-    // is outside the panel. A number input steps its value on the arrow keys,
-    // and an operator holding ArrowUp to reach 30 days is not asking the list
-    // to walk the peek down the page underneath them.
+    // is outside the panel. An operator holding ArrowUp to reach 30 days is not
+    // asking the list to walk the peek down the page underneath them.
     const event = new KeyboardEvent("keydown", {
       key: "ArrowDown",
       bubbles: true,
       cancelable: true,
     });
-    screen.getByLabelText("Days").dispatchEvent(event);
+    days.dispatchEvent(event);
 
     // Read off the row rather than through a role query: an open modal takes
     // the table out of the accessibility tree.
-    expect(isPeeked(first)).toBe(true);
+    expect(isPeeked(peeked)).toBe(true);
     expect(event.defaultPrevented).toBe(false);
   });
 
   it("closes the dialog on Escape and leaves the peek open behind it", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
-    await peekOn(FIRST_ORG.name);
+    await peekOn(TRIALLING_ORG.name);
 
     fireEvent.click(
-      within(peekPanel()).getByRole("button", { name: "Extend trial" }),
+      within(peekPanel()).getByRole("button", {
+        name: `Extend trial for ${TRIALLING_ORG.name}`,
+      }),
     );
     await screen.findByRole("dialog");
 

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -712,6 +712,50 @@ describe("organizations list", () => {
     expect(option.getAttribute("aria-checked")).toBe("true");
   });
 
+  // These two assert the request rather than the parsed search, because the
+  // empty string has to be gone by the time anything is sent, and asserting the
+  // schema's output would pass while it survived one step further on.
+  //
+  // The hazard is specific to the type group. `trialStates` and
+  // `disabledStates` drop whatever they do not recognise, so an empty string
+  // reaching them is harmless. `accountTypes` deliberately keeps an
+  // unrecognised value, so an empty one would be sent as an account type, and
+  // the server matches no organization against it: a blank table under a
+  // control still reading "All types".
+  it("sends no filter for a group a link left empty", async () => {
+    // `?type=` is not the empty list the schema already drops. It arrives as an
+    // empty string, and `text()` normalising to undefined is the only thing
+    // between it and the request.
+    await renderRouteTree(routeTree, {
+      initialPath: "/organizations?type=&trial=&disabled=",
+    });
+
+    await waitFor(() => {
+      expect(mocks.listOrganizations).toHaveBeenCalled();
+    });
+    const params = lastListParams();
+    expect(params.account_types).toBeUndefined();
+    expect(params.trial_states).toBeUndefined();
+    expect(params.disabled_states).toBeUndefined();
+    expect(filterTrigger("Type").getAttribute("aria-label")).toContain(
+      "All types",
+    );
+  });
+
+  it("sends no filter for a group a link filled with whitespace", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: "/organizations?type=%20&trial=%20&disabled=%20",
+    });
+
+    await waitFor(() => {
+      expect(mocks.listOrganizations).toHaveBeenCalled();
+    });
+    const params = lastListParams();
+    expect(params.account_types).toBeUndefined();
+    expect(params.trial_states).toBeUndefined();
+    expect(params.disabled_states).toBeUndefined();
+  });
+
   it("opens on the group the operator asked for", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -25,10 +25,12 @@ import {
 
 import {
   GramAdminError,
+  TRIAL_STATES,
   type AdminOrganization,
   type ListOrganizationsParams,
   type ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
+import { TRIAL_LABELS } from "@/lib/trialLabels";
 import { useState, type JSX } from "react";
 
 import { routeTree } from "@/routeTree.gen";
@@ -209,6 +211,43 @@ async function withFakeTimers(
 // lets an assertion name the value the way the schema declares it.
 function currentSearch(router: AnyRouter): string {
   return decodeURIComponent(router.state.location.searchStr);
+}
+
+// The three triggers above the table. Found by the state a screen reader is
+// told, because the visible label is the group's name and a bare count.
+function filterTrigger(group: string): HTMLElement {
+  return screen.getByRole("button", { name: new RegExp(`^${group} filter:`) });
+}
+
+// Focused before the click, because a click does not focus a button in every
+// browser and the sheet hands the keyboard back to the trigger that opened it.
+async function openFilters(group: string): Promise<HTMLElement> {
+  const trigger = filterTrigger(group);
+  trigger.focus();
+  fireEvent.click(trigger);
+  await screen.findByRole("dialog");
+  return trigger;
+}
+
+// A picker inside the sheet. Its accessible name is the group's heading
+// followed by its own text, which is what the group is filtering on.
+function picker(group: string): HTMLElement {
+  return screen.getByRole("combobox", { name: new RegExp(`^${group}`) });
+}
+
+// Radix opens a popover on click, unlike the menu and the select below. A
+// choice does not close it, because the group takes more than one, so a second
+// call must not toggle the open list shut.
+async function chooseFilter(group: string, option: string): Promise<void> {
+  const trigger = picker(group);
+  if (trigger.getAttribute("aria-expanded") !== "true") {
+    fireEvent.click(trigger);
+  }
+  fireEvent.click(await screen.findByRole("option", { name: option }));
+}
+
+function applyFilters(): void {
+  fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 }
 
 // A Radix menu and a Radix select both open on pointerdown, not on click.
@@ -481,56 +520,240 @@ describe("organizations list", () => {
 
   it("shows the filters a reloaded URL carries", async () => {
     await renderRouteTree(routeTree, {
-      initialPath: urlFor({ type: "pro", disabled: true }),
+      initialPath: urlFor({
+        type: ["pro"],
+        trial: ["running", "expired"],
+        disabled: ["active", "disabled"],
+      }),
     });
 
-    expect(screen.getByLabelText("Account type").textContent).toContain("pro");
-    expect(screen.getByRole("button", { name: "Hide disabled" })).toBeTruthy();
+    // The one chosen value is named; more than one is counted, because the
+    // trigger has a row of controls to share.
+    expect(filterTrigger("Type").getAttribute("aria-label")).toContain("pro");
+    expect(filterTrigger("Trial").getAttribute("aria-label")).toContain(
+      "2 selected",
+    );
 
     await waitFor(() => {
       expect(mocks.listOrganizations).toHaveBeenCalled();
     });
-    expect(lastListParams().account_type).toBe("pro");
-    expect(lastListParams().include_disabled).toBe(true);
+    expect(lastListParams()).toMatchObject({
+      account_types: ["pro"],
+      trial_states: ["running", "expired"],
+      disabled_states: ["active", "disabled"],
+    });
+
+    await openFilters("Type");
+    expect(picker("Type").textContent).toContain("pro");
   });
 
-  it("writes the filter controls back to the URL", async () => {
+  it("sends every value of a group the operator picked", async () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
     });
 
-    openOn(screen.getByLabelText("Account type"));
-    fireEvent.click(await screen.findByRole("option", { name: "enterprise" }));
+    await openFilters("Type");
+    // Picked in the other order, so the assertion below is about the order the
+    // schema settles on rather than the order they were clicked. Two operators
+    // choosing the same filter must produce one request and one cache entry.
+    await chooseFilter("Type", "enterprise");
+    await chooseFilter("Type", "free");
+    applyFilters();
 
     await waitFor(() => {
-      expect(currentSearch(router)).toContain("type=enterprise");
+      expect(lastListParams().account_types).toEqual(["free", "enterprise"]);
     });
-
-    fireEvent.click(screen.getByRole("button", { name: "Show disabled" }));
-
-    await waitFor(() => {
-      expect(currentSearch(router)).toContain("disabled=true");
-    });
-    expect(currentSearch(router)).toContain("type=enterprise");
+    expect(currentSearch(router)).toContain('type=["free","enterprise"]');
   });
 
-  it("clears the account type filter back to every type", async () => {
+  it("holds the table still until the operator applies", async () => {
     const { router } = await renderRouteTree(routeTree, {
-      initialPath: urlFor({ type: "pro" }),
+      initialPath: "/organizations",
+    });
+    await waitFor(() => {
+      expect(mocks.listOrganizations).toHaveBeenCalled();
+    });
+    const before = mocks.listOrganizations.mock.calls.length;
+
+    await openFilters("Trial");
+    await chooseFilter("Trial", "Running");
+    await chooseFilter("Trial", "Expired");
+
+    // Three requests and two lists nobody asked for, if the edit went straight
+    // to the URL.
+    expect(mocks.listOrganizations.mock.calls.length).toBe(before);
+    expect(currentSearch(router)).toBe("");
+
+    applyFilters();
+
+    await waitFor(() => {
+      expect(lastListParams().trial_states).toEqual(["running", "expired"]);
+    });
+  });
+
+  it("discards the edit when the operator presses Escape", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+    await waitFor(() => {
+      expect(mocks.listOrganizations).toHaveBeenCalled();
+    });
+
+    const trigger = await openFilters("Type");
+    await chooseFilter("Type", "enterprise");
+
+    // The open picker is a dismiss layer of its own and takes the first
+    // Escape. The sheet takes the second.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(currentSearch(router)).toBe("");
+    expect(lastListParams().account_types).toBeUndefined();
+    // Closing must not strand the keyboard on a subtree that has unmounted.
+    expect(document.activeElement).toBe(trigger);
+
+    // Discarded, not merely unapplied: the edit is gone when the sheet is
+    // opened again.
+    await openFilters("Type");
+    expect(picker("Type").textContent).toContain("All types");
+  });
+
+  it("clears every filter and leaves the search term alone", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: urlFor({
+        q: "acme",
+        type: ["pro"],
+        disabled: ["disabled"],
+      }),
+    });
+    await waitFor(() => {
+      expect(lastListParams().account_types).toEqual(["pro"]);
+    });
+
+    await openFilters("Status");
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+
+    await waitFor(() => {
+      expect(lastListParams().account_types).toBeUndefined();
+    });
+    expect(lastListParams().disabled_states).toBeUndefined();
+    // The term is not a filter this sheet holds. An operator who cleared the
+    // filters has not asked to type it again.
+    expect(lastListParams().q).toBe("acme");
+    expect(currentSearch(router)).toContain("q=acme");
+    expect(
+      (screen.getByLabelText("Search organizations") as HTMLInputElement).value,
+    ).toBe("acme");
+  });
+
+  it("keeps an account type the picker does not offer", async () => {
+    // ACCOUNT_TYPE_OPTIONS is the list the picker offers, not the list the
+    // column can hold. Dropping a value from outside it would widen the view a
+    // link carries while the control read "all types".
+    await renderRouteTree(routeTree, {
+      initialPath: urlFor({ type: ["startup"] }),
     });
 
     await waitFor(() => {
-      expect(lastListParams().account_type).toBe("pro");
+      expect(lastListParams().account_types).toEqual(["startup"]);
     });
+    expect(filterTrigger("Type").getAttribute("aria-label")).toContain(
+      "startup",
+    );
 
-    openOn(screen.getByLabelText("Account type"));
-    fireEvent.click(await screen.findByRole("option", { name: "All types" }));
+    await openFilters("Type");
+    fireEvent.click(picker("Type"));
+    const option = await screen.findByRole("option", { name: "startup" });
+    expect(option.getAttribute("aria-checked")).toBe("true");
+  });
 
-    // "All types" is the only route back to an unfiltered list.
+  it("opens on the group the operator asked for", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openFilters("Trial");
+
+    // The sheet holds three pickers. Landing on the first would make the
+    // operator walk to the one they pressed.
     await waitFor(() => {
-      expect(lastListParams().account_type).toBeUndefined();
+      expect(document.activeElement).toBe(picker("Trial"));
     });
-    expect(currentSearch(router)).not.toContain("type=");
+  });
+
+  it("offers the trial states under the words the rows carry", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await openFilters("Trial");
+    fireEvent.click(picker("Trial"));
+
+    // TRIAL_LABELS is the map the Trial cell renders its badge from, so a
+    // filter that spelled a state its own way would fail here.
+    const options = await screen.findAllByRole("option");
+    expect(options.map((option) => option.textContent)).toEqual(
+      TRIAL_STATES.map((state) => TRIAL_LABELS[state]),
+    );
+  });
+
+  it("keeps the sort when a filter is applied", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: urlFor({ sort: "name", dir: "asc" }),
+    });
+
+    await openFilters("Status");
+    await chooseFilter("Status", "Disabled");
+    applyFilters();
+
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+    const url = currentSearch(router);
+    expect(url).toContain("sort=name");
+    expect(url).toContain("dir=asc");
+  });
+
+  it("returns to the first page when a filter is applied", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: urlFor({ page: 3 }),
+    });
+
+    await openFilters("Status");
+    await chooseFilter("Status", "Disabled");
+    applyFilters();
+
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+    // Page three of the old filter set is not page three of the new one, and
+    // an operator who narrowed a list expects its first rows.
+    expect(currentSearch(router)).not.toContain("page");
+  });
+
+  it("keeps an unrecognised type on offer after the operator unchecks it", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: urlFor({ type: ["startup"] }),
+    });
+    await waitFor(() => {
+      expect(lastListParams().account_types).toEqual(["startup"]);
+    });
+
+    await openFilters("Type");
+    // Unchecked, the value has nothing left to derive the option from. Taking
+    // the options off the draft would drop it out of the list here, and the
+    // operator could not change their mind without editing the URL by hand.
+    await chooseFilter("Type", "startup");
+    expect(
+      (await screen.findByRole("option", { name: "startup" })).getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("false");
+
+    await chooseFilter("Type", "startup");
+    applyFilters();
+    await waitFor(() => {
+      expect(lastListParams().account_types).toEqual(["startup"]);
+    });
   });
 
   it("sends a pasted term without the whitespace around it", async () => {
@@ -561,10 +784,12 @@ describe("organizations list", () => {
       expect(lastListParams().cursor).toBe("cursor_page_two");
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Show disabled" }));
+    await openFilters("Status");
+    await chooseFilter("Status", "Disabled");
+    applyFilters();
 
     await waitFor(() => {
-      expect(lastListParams().include_disabled).toBe(true);
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
     });
     // The cursor was minted by the previous filter set and points into a
     // different result set.
@@ -2414,13 +2639,50 @@ describe("TableActionBar", () => {
 // value below is the whole object the route sees.
 describe("organizationsSearchSchema", () => {
   const cases: [string, Record<string, unknown>, OrganizationsSearch][] = [
-    ["reads a hand-written type", { type: "free" }, { type: "free" }],
-    ["drops a type the API does not accept", { type: "startup" }, {}],
+    ["reads a hand-written type", { type: "free" }, { type: ["free"] }],
     [
-      "drops a list, which the request cannot honour",
+      "keeps a type the picker does not offer",
+      { type: "startup" },
+      { type: ["startup"] },
+    ],
+    [
+      "reads a list of types",
       { type: ["pro", "enterprise"] },
+      { type: ["pro", "enterprise"] },
+    ],
+    [
+      "sorts a chosen set into the picker's order",
+      { type: ["enterprise", "free"] },
+      { type: ["free", "enterprise"] },
+    ],
+    ["drops a type named twice", { type: ["pro", "pro"] }, { type: ["pro"] }],
+    [
+      "keeps an unrecognised type after the ones the picker offers",
+      { type: ["startup", "pro"] },
+      { type: ["pro", "startup"] },
+    ],
+    ["drops an empty list of types", { type: [] }, {}],
+    [
+      "sorts trial states into the order the picker offers them",
+      { trial: ["expired", "running"] },
+      { trial: ["running", "expired"] },
+    ],
+    [
+      "drops a trial state the server does not derive",
+      { trial: ["hibernating"] },
       {},
     ],
+    [
+      "reads a status the picker offers",
+      { disabled: ["disabled"] },
+      { disabled: ["disabled"] },
+    ],
+    [
+      "reads the flag this list used to carry as both statuses",
+      { disabled: true },
+      { disabled: ["active", "disabled"] },
+    ],
+    ["drops a status outside the two", { disabled: ["retired"] }, {}],
     ["reads an all-digit term the router coerced", { q: 123 }, { q: "123" }],
     ["reads a boolean term the router coerced", { q: true }, { q: "true" }],
     ["reads a null term the router coerced", { q: null }, { q: "null" }],
@@ -2429,8 +2691,7 @@ describe("organizationsSearchSchema", () => {
     ["trims the term a pasted link carries", { q: "  acme  " }, { q: "acme" }],
     ["reads a direction in the union", { dir: "desc" }, { dir: "desc" }],
     ["drops a direction outside the union", { dir: "sideways" }, {}],
-    ["keeps the disabled flag", { disabled: true }, { disabled: true }],
-    ["drops the disabled flag when it is off", { disabled: false }, {}],
+    ["drops the old disabled flag when it is off", { disabled: false }, {}],
     ["drops page 1, which is the default", { page: 1 }, {}],
     ["drops a page below 1", { page: 0 }, {}],
     ["drops a page between two whole ones", { page: 2.5 }, {}],

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -23,7 +23,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { ORG_COLUMNS } from "./columns";
-import { AnnounceProvider } from "./OrganizationActions";
+import { WriteReportProvider } from "./OrganizationActions";
 import { PeekPanel } from "./PeekPanel";
 import { PEEK_TRIGGER_SELECTOR, PeekProvider } from "./PeekTrigger";
 import { useOpenOrganization } from "./rowActions";
@@ -107,9 +107,24 @@ export function OrganizationsList(): JSX.Element {
   // that follows the peek to the next row's control.
   const [peekTookTheKeyboard, setPeekTookTheKeyboard] = useState(false);
 
+  // A write that failed with no dialog of its own to report in. Re-enable is
+  // the only one, and without this the whole account of it on the page is a
+  // sentence inside `sr-only`: the row is unchanged, the banner above covers
+  // the list query alone, and a sighted operator presses Re-enable, sees
+  // nothing happen and is told nothing about why.
+  const [writeFailure, setWriteFailure] = useState<string | null>(null);
+
   const announce = useCallback((text: string): void => {
     setAnnouncement((previous) => ({ text, count: previous.count + 1 }));
   }, []);
+
+  // One object, memoised: it is a context value, and a fresh one on every
+  // render would re-render every row's actions on every keystroke in the
+  // filter box.
+  const writeReporter = useMemo(
+    () => ({ announce, showFailure: setWriteFailure }),
+    [announce],
+  );
 
   // One object is the source of both the request and the signature below. Two
   // hand-written lists drift: a slice that adds a filter to the request would
@@ -364,11 +379,35 @@ export function OrganizationsList(): JSX.Element {
           </div>
         )}
 
+        {/* A write that has no dialog to fail in reports here, where it can be
+            read as well as heard, and stays until it is dismissed or a later
+            write succeeds. */}
+        {writeFailure && (
+          <div
+            role="alert"
+            className="mb-2 flex items-start justify-between gap-2 rounded-md border border-destructive/40 px-3 py-2 text-destructive text-sm"
+          >
+            <span>{writeFailure}</span>
+            <Button
+              variant="ghost"
+              size="xs"
+              aria-label="Dismiss the failure"
+              onClick={() => setWriteFailure(null)}
+            >
+              Dismiss
+            </Button>
+          </div>
+        )}
+
         {/* The only thing that speaks when the arrow keys swap the record under
             a panel that already holds the focus.
 
-            `aria-live` is written out as well as implied by the role: a few
-            screen readers only honour the attribute. The zero-width space
+            `aria-live` is written out as well as implied by the role, and it is
+            load-bearing rather than belt and braces: an open Radix modal hides
+            the rest of the page with `aria-hidden`, and the one exemption that
+            package makes is for elements carrying this attribute by name.
+            Without it the region goes down with the app container and a write
+            that fails behind a dialog is announced to nobody. The zero-width
             alternates with the count so that a sentence set twice running
             still reaches the accessibility tree as a change. It is not
             announced, and it is not rendered anywhere a sighted operator
@@ -381,7 +420,7 @@ export function OrganizationsList(): JSX.Element {
         {/* Both providers wrap the panel as well as the table: the row menu and
             the panel footer are the same actions, and they report through the
             one region above. */}
-        <AnnounceProvider value={announce}>
+        <WriteReportProvider value={writeReporter}>
           <PeekProvider value={peekControls}>
             {/* Stretch, so the panel takes its height from the row. */}
             <div
@@ -472,7 +511,7 @@ export function OrganizationsList(): JSX.Element {
               ) : null}
             </div>
           </PeekProvider>
-        </AnnounceProvider>
+        </WriteReportProvider>
       </section>
     </div>
   );

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { ORG_COLUMNS } from "./columns";
+import { AnnounceProvider } from "./OrganizationActions";
 import { PeekPanel } from "./PeekPanel";
 import { PEEK_TRIGGER_SELECTOR, PeekProvider } from "./PeekTrigger";
 import { useOpenOrganization } from "./rowActions";
@@ -377,93 +378,101 @@ export function OrganizationsList(): JSX.Element {
           {announcement.count % 2 === 1 ? ZERO_WIDTH_SPACE : ""}
         </div>
 
-        <PeekProvider value={peekControls}>
-          {/* Stretch, so the panel takes its height from the row. */}
-          <div className="flex min-h-0 flex-1 gap-4" onKeyDown={handleKeyDown}>
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-              <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
-                <TableActionBar
-                  table={table}
-                  onColumnToggled={handleColumnToggled}
-                />
+        {/* Both providers wrap the panel as well as the table: the row menu and
+            the panel footer are the same actions, and they report through the
+            one region above. */}
+        <AnnounceProvider value={announce}>
+          <PeekProvider value={peekControls}>
+            {/* Stretch, so the panel takes its height from the row. */}
+            <div
+              className="flex min-h-0 flex-1 gap-4"
+              onKeyDown={handleKeyDown}
+            >
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                <div className="flex min-h-0 flex-1 flex-col rounded-lg border">
+                  <TableActionBar
+                    table={table}
+                    onColumnToggled={handleColumnToggled}
+                  />
 
-                <div
-                  ref={scrollBox}
-                  // Named, because this is where the keyboard lands when the
-                  // peeked record leaves the list with the panel holding the
-                  // focus. An unnamed div would put the operator somewhere
-                  // their screen reader cannot describe.
-                  role="region"
-                  aria-label="Organizations table"
-                  // Programmatic only: -1 takes the box out of the tab order
-                  // and still lets that rescue focus it. The focus ring stays,
-                  // because nothing else on screen moves when focus arrives
-                  // here and the ring is the only sign that it did.
-                  tabIndex={-1}
-                  className={cn(
-                    "min-h-0 flex-1 overflow-auto",
-                    isPlaceholderData && "opacity-60",
-                  )}
-                >
-                  <Table>
-                    <Table.Header table={table} />
-                    <Table.Body>
-                      {rows.length === 0 ? (
-                        <Table.NoResultsMessage>
-                          <span className="text-muted-foreground text-sm">
-                            {emptyStateMessage(isLoading, isError)}
-                          </span>
-                        </Table.NoResultsMessage>
-                      ) : (
-                        rows.map((row) => {
-                          const isPeeked = row.id === peekedId;
-                          return (
-                            <Table.Row
-                              key={row.id}
-                              row={row}
-                              ref={isPeeked ? peekedRow : undefined}
-                              className={cn(isPeeked && "bg-muted")}
-                              onClick={openOrganization}
-                            />
-                          );
-                        })
-                      )}
-                    </Table.Body>
-                  </Table>
+                  <div
+                    ref={scrollBox}
+                    // Named, because this is where the keyboard lands when the
+                    // peeked record leaves the list with the panel holding the
+                    // focus. An unnamed div would put the operator somewhere
+                    // their screen reader cannot describe.
+                    role="region"
+                    aria-label="Organizations table"
+                    // Programmatic only: -1 takes the box out of the tab order
+                    // and still lets that rescue focus it. The focus ring stays,
+                    // because nothing else on screen moves when focus arrives
+                    // here and the ring is the only sign that it did.
+                    tabIndex={-1}
+                    className={cn(
+                      "min-h-0 flex-1 overflow-auto",
+                      isPlaceholderData && "opacity-60",
+                    )}
+                  >
+                    <Table>
+                      <Table.Header table={table} />
+                      <Table.Body>
+                        {rows.length === 0 ? (
+                          <Table.NoResultsMessage>
+                            <span className="text-muted-foreground text-sm">
+                              {emptyStateMessage(isLoading, isError)}
+                            </span>
+                          </Table.NoResultsMessage>
+                        ) : (
+                          rows.map((row) => {
+                            const isPeeked = row.id === peekedId;
+                            return (
+                              <Table.Row
+                                key={row.id}
+                                row={row}
+                                ref={isPeeked ? peekedRow : undefined}
+                                className={cn(isPeeked && "bg-muted")}
+                                onClick={openOrganization}
+                              />
+                            );
+                          })
+                        )}
+                      </Table.Body>
+                    </Table>
+                  </div>
+                </div>
+
+                {/* Inside the table's column, so it does not run under the panel. */}
+                <div className="mt-3 flex items-center justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    disabled={isPlaceholderData || pager.stack.length === 0}
+                    onClick={goPrev}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    disabled={isPlaceholderData || !data?.next_cursor}
+                    onClick={goNext}
+                  >
+                    Next
+                  </Button>
                 </div>
               </div>
 
-              {/* Inside the table's column, so it does not run under the panel. */}
-              <div className="mt-3 flex items-center justify-end gap-2">
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  disabled={isPlaceholderData || pager.stack.length === 0}
-                  onClick={goPrev}
-                >
-                  Previous
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  disabled={isPlaceholderData || !data?.next_cursor}
-                  onClick={goNext}
-                >
-                  Next
-                </Button>
-              </div>
+              {peeked ? (
+                <PeekPanel
+                  ref={peekPanel}
+                  org={peeked.original}
+                  onClose={closePeek}
+                  className="w-100 shrink-0"
+                />
+              ) : null}
             </div>
-
-            {peeked ? (
-              <PeekPanel
-                ref={peekPanel}
-                org={peeked.original}
-                onClose={closePeek}
-                className="w-100 shrink-0"
-              />
-            ) : null}
-          </div>
-        </PeekProvider>
+          </PeekProvider>
+        </AnnounceProvider>
       </section>
     </div>
   );

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -133,8 +133,9 @@ export function OrganizationsList(): JSX.Element {
   // Every value arrives validated, so nothing is normalised a second time here.
   const listParams: ListOrganizationsParams = {
     q: search.q,
-    account_type: search.type,
-    include_disabled: search.disabled,
+    account_types: search.type,
+    trial_states: search.trial,
+    disabled_states: search.disabled,
   };
 
   // omitUnset, not the raw object: the signature has to call a param unset

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import {
+  cancelOrganizationFetches,
   organizationQuery,
   writeOrganizationToCache,
 } from "@/lib/adminQueries";
@@ -76,10 +77,15 @@ type OrganizationWrite<TVariables> = UseMutationResult<
 // All three writes answer with the organization in its new state and all three
 // put it in the cache the same way, so the list and the peek repaint from the
 // response with no refetch behind them.
+//
+// All three drop the reads already in flight first. React Query awaits
+// `onMutate` before it sends the request, so the stale fetch is cancelled
+// before the write leaves rather than racing it home.
 export function useDisableOrganization(): OrganizationWrite<string> {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => disableOrganization({ id }),
+    onMutate: (id) => cancelOrganizationFetches(qc, id),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
   });
 }
@@ -88,6 +94,7 @@ export function useEnableOrganization(): OrganizationWrite<string> {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => enableOrganization({ id }),
+    onMutate: (id) => cancelOrganizationFetches(qc, id),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
   });
 }
@@ -98,6 +105,7 @@ export function useExtendTrial(): OrganizationWrite<ExtendTrialRequest> {
     // Wrapped, so the body is the only argument the client is handed: the
     // mutation passes its own context as a second one.
     mutationFn: (body: ExtendTrialRequest) => extendTrial(body),
+    onMutate: (body) => cancelOrganizationFetches(qc, body.id),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
   });
 }

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -85,7 +85,7 @@ export function useDisableOrganization(): OrganizationWrite<string> {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => disableOrganization({ id }),
-    onMutate: (id) => cancelOrganizationFetches(qc, id),
+    onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
   });
 }
@@ -94,7 +94,7 @@ export function useEnableOrganization(): OrganizationWrite<string> {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => enableOrganization({ id }),
-    onMutate: (id) => cancelOrganizationFetches(qc, id),
+    onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
   });
 }
@@ -105,7 +105,7 @@ export function useExtendTrial(): OrganizationWrite<ExtendTrialRequest> {
     // Wrapped, so the body is the only argument the client is handed: the
     // mutation passes its own context as a second one.
     mutationFn: (body: ExtendTrialRequest) => extendTrial(body),
-    onMutate: (body) => cancelOrganizationFetches(qc, body.id),
+    onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
   });
 }

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -53,8 +53,15 @@ const EXTENDABLE_TRIAL_STATES: ReadonlySet<TrialState> = new Set([
   "ending_soon",
 ]);
 
+// Not for a disabled organization, whatever its trial says. The server would
+// take the request: nothing there reads disabled_at, and the trial goes on
+// running while every member is locked out. That is the reason to leave the
+// action off. Buying more of a trial nobody can use is an offer the product
+// cannot honour, and re-enabling is one press away for an operator who means
+// to make it real.
 export function canExtendTrial(org: AdminOrganization): boolean {
   return (
+    !org.disabled_at &&
     org.trial_state !== undefined &&
     EXTENDABLE_TRIAL_STATES.has(org.trial_state)
   );

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -1,14 +1,29 @@
-import { useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
-import { organizationQuery } from "@/lib/adminQueries";
-import type { AdminOrganization } from "@/lib/gramAdminApi";
+import {
+  organizationQuery,
+  writeOrganizationToCache,
+} from "@/lib/adminQueries";
+import {
+  disableOrganization,
+  enableOrganization,
+  extendTrial,
+  type AdminOrganization,
+  type ExtendTrialRequest,
+  type TrialState,
+} from "@/lib/gramAdminApi";
 
 // The row's own behavior lives here, so the slices that add a row menu, a
 // disable action and a trial extension all land in one file. The peek control
 // is a component, and a file that mixes a hook with components loses fast
-// refresh, so it sits in `PeekTrigger.tsx` instead.
+// refresh, so it sits in `PeekTrigger.tsx` instead. The controls these hooks
+// drive sit in `OrganizationActions.tsx` for the same reason.
 export function useOpenOrganization(): (org: AdminOrganization) => void {
   const navigate = useNavigate();
   const qc = useQueryClient();
@@ -25,4 +40,57 @@ export function useOpenOrganization(): (org: AdminOrganization) => void {
     },
     [navigate, qc],
   );
+}
+
+// The two states the server will extend. Everything else is refused there:
+// converted, demoted and expired are all rejected with a conflict, and an
+// organization with no trial has no end date to add days to. Offering the
+// action for one of those would be offering a request that cannot succeed.
+//
+// A set rather than a disjunction, so the states are data a test can walk.
+const EXTENDABLE_TRIAL_STATES: ReadonlySet<TrialState> = new Set([
+  "running",
+  "ending_soon",
+]);
+
+export function canExtendTrial(org: AdminOrganization): boolean {
+  return (
+    org.trial_state !== undefined &&
+    EXTENDABLE_TRIAL_STATES.has(org.trial_state)
+  );
+}
+
+type OrganizationWrite<TVariables> = UseMutationResult<
+  AdminOrganization,
+  Error,
+  TVariables
+>;
+
+// All three writes answer with the organization in its new state and all three
+// put it in the cache the same way, so the list and the peek repaint from the
+// response with no refetch behind them.
+export function useDisableOrganization(): OrganizationWrite<string> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => disableOrganization({ id }),
+    onSuccess: (org) => writeOrganizationToCache(qc, org),
+  });
+}
+
+export function useEnableOrganization(): OrganizationWrite<string> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => enableOrganization({ id }),
+    onSuccess: (org) => writeOrganizationToCache(qc, org),
+  });
+}
+
+export function useExtendTrial(): OrganizationWrite<ExtendTrialRequest> {
+  const qc = useQueryClient();
+  return useMutation({
+    // Wrapped, so the body is the only argument the client is handed: the
+    // mutation passes its own context as a second one.
+    mutationFn: (body: ExtendTrialRequest) => extendTrial(body),
+    onSuccess: (org) => writeOrganizationToCache(qc, org),
+  });
 }

--- a/client/admin/src/routes/organizations.index.tsx
+++ b/client/admin/src/routes/organizations.index.tsx
@@ -61,9 +61,7 @@ function text(value: unknown): string | undefined {
 // the second, so both are read as a set of one or more.
 function values(value: unknown): string[] {
   const items = Array.isArray(value) ? (value as unknown[]) : [value];
-  return items
-    .map(text)
-    .filter((item): item is string => item !== undefined && item !== "");
+  return items.map(text).filter((item): item is string => item !== undefined);
 }
 
 // `?disabled=true` is the parameter this list used to carry, and it meant

--- a/client/admin/src/routes/organizations.index.tsx
+++ b/client/admin/src/routes/organizations.index.tsx
@@ -1,6 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { isAccountType, type AccountType } from "@/lib/accountTypes";
+import {
+  accountTypes,
+  disabledStates,
+  DISABLED_STATES,
+  trialStates,
+  type DisabledState,
+} from "@/lib/organizationFilters";
+import { type TrialState } from "@/lib/gramAdminApi";
 import { OrganizationsList } from "@/pages/organizations/index";
 
 /**
@@ -14,13 +21,14 @@ import { OrganizationsList } from "@/pages/organizations/index";
  *
  * A param is absent from the URL whenever it holds its default. That keeps a
  * shared link down to what the operator actually changed, and it is why every
- * field is optional.
+ * field is optional. An empty list is a default, so it is absent too: the three
+ * filters below are either a non-empty set or nothing at all.
  */
 export type OrganizationsSearch = {
   q?: string;
-  type?: AccountType;
-  trial?: string;
-  disabled?: boolean;
+  type?: string[];
+  trial?: TrialState[];
+  disabled?: DisabledState[];
   sort?: string;
   dir?: "asc" | "desc";
   /** 1-based. Declared, not yet wired: the list API is still cursor-paged. */
@@ -47,20 +55,23 @@ function text(value: unknown): string | undefined {
   return undefined;
 }
 
-// Anything outside the accepted list is dropped, so the URL, the control and
-// the request agree that no type filter is on. Keeping an unknown value would
-// filter the rows while the control read empty.
-//
-// One value rather than a list: the API takes a single account_type and the
-// control offers a single choice, so a list would let a link advertise more
-// than the request sends.
-function accountType(value: unknown): AccountType | undefined {
-  const item = text(value);
-  return isAccountType(item) ? item : undefined;
+// A filter is a set, and the router hands it over as a list only when the link
+// was written as one: `?type=["free","pro"]` arrives as an array and `?type=pro`
+// as a bare string. A person typing a single value into the address bar writes
+// the second, so both are read as a set of one or more.
+function values(value: unknown): string[] {
+  const items = Array.isArray(value) ? (value as unknown[]) : [value];
+  return items
+    .map(text)
+    .filter((item): item is string => item !== undefined && item !== "");
 }
 
-function flag(value: unknown): true | undefined {
-  return value === true || value === "true" ? true : undefined;
+// `?disabled=true` is the parameter this list used to carry, and it meant
+// "disabled organizations as well as active ones". A bookmark holding it has to
+// keep showing both, or the link quietly narrows to this filter's default.
+function statuses(value: unknown): DisabledState[] | undefined {
+  if (value === true || value === "true") return [...DISABLED_STATES];
+  return disabledStates(values(value));
 }
 
 function direction(value: unknown): "asc" | "desc" | undefined {
@@ -80,9 +91,9 @@ export function organizationsSearchSchema(
 ): OrganizationsSearch {
   return {
     q: text(search["q"]),
-    type: accountType(search["type"]),
-    trial: text(search["trial"]),
-    disabled: flag(search["disabled"]),
+    type: accountTypes(values(search["type"])),
+    trial: trialStates(values(search["trial"])),
+    disabled: statuses(search["disabled"]),
     sort: text(search["sort"]),
     dir: direction(search["dir"]),
     page: pageNumber(search["page"]),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react:
         specifier: 'catalog:'
         version: 1.28.0(react@19.2.8)


### PR DESCRIPTION
A platform admin could narrow the organizations list by one account type and a disabled yes/no. Asking for "enterprise or pro", or for "trials running or ending soon", meant several passes over the list and merging the pages by eye.

This adds one sheet that holds every filter the list carries, with a multi-select per group.

![The filter sheet](https://gist.githubusercontent.com/walker-tx/105d1748786b09b834e517ebf86c6f15/raw/filters-toolbar.png)

![Picking filters and applying](https://gist.githubusercontent.com/walker-tx/105d1748786b09b834e517ebf86c6f15/raw/demo.gif)

**The rows do not narrow in the recording.** It was captured against the local server, which is the pre-change API. The server half is a separate pull request and merges first.

## What it does

The toolbar carries one control per group, and any of them opens the same sheet on the group that was pressed. Type takes any of free, pro and enterprise. Trial takes any of the six states the rows already show. Status takes active, disabled or both.

An empty group is a default rather than an empty result, and each control says its own default: all types, all trial states, active only.

Nothing reaches the table until the operator applies. Picking three values otherwise costs three requests and shows two lists nobody asked for on the way to the one they did. Escape closes the sheet, discards the edit and puts the keyboard back on the control it opened from. Clear all resets every filter and leaves the search term alone, because the term is not a filter this sheet holds.

## The URL is the view

The chosen filters live in the URL, so an operator can paste what they are looking at and get the same rows back. Applying returns to the first page and keeps the sort.

Values are ordered as the pickers offer them and deduplicated, so two operators who chose the same filter in a different order send one request and share one cache entry.

**An account type from outside the offered list is kept rather than dropped.** Dropping it would widen the view a pasted link produces while the control still read "all types", which is the one failure mode an operator cannot see.

## One source for the trial words

The trial options read from the same map the trial badge on the row renders. The filter and the rows it returns therefore cannot say different words for one state.

## The request

`account_types`, `trial_states` and `disabled_states`, each repeated once per chosen value, in place of the single `account_type` and the `include_disabled` flag.

Empty arrays are dropped before the request is built, so an empty group sends no parameter at all rather than `?disabled_states=`. That matters: an empty-string member would reach the server as a value outside the known list and return an empty table. Two independent guards close it, one in the route's `values()` and one in `omitUnset`, and both are asserted.

## Two new stock components

`components/ui/command.tsx` and `components/ui/popover.tsx` are added from the shadcn registry unmodified. No existing file under `components/ui/` is touched.

## Tests

11 files, 265 tests. The additions assert the behaviours a passing test could otherwise fake:

- The picker stays open across two choices off the same list. The old helper reopened a closed picker, so every multi-select test would have passed even if the list shut on each choice.
- Focus returns to the opening control on **both** exits, Escape and Apply, because both unmount the same subtree through the same handler.
- The applied URL is asserted, not just the rendered chips, so an ordering or dedup regression fails.

## Checks that do not run on this pull request

The base is `walker/age-3211-write-actions-client`, not `main`. Only `hygiene.yaml` filters on base `main`, so on a stacked pull request the **PR title lint, the changeset lint and the migration check do not run**. Read the short check list accordingly. All three were verified by hand: the title carries a `feat:` prefix, `.changeset/admin-organizations-filters.md` targets `admin` and describes the user-facing behaviour, and there is no migration in this diff.

The test and lint suite does run, and is real evidence.

## Server half

`account_types`, `trial_states` and `disabled_states` are added by a separate pull request on a separate branch, which is designed to merge first. `account_type` and `include_disabled` both still work there, so the two halves can land in either order without a broken window. AGE-3186.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter the admin organizations list by Type, Trial, and Status in one multi‑select sheet. Previously Type was single‑select and Status a toggle; now each group is multi‑select with explicit Apply, URL‑backed sets, and no mid‑edit refetches.

- Toolbar: one trigger per group with a count badge; opening focuses that group’s picker. Pickers stay open across multiple choices. Apply resets to page 1 and keeps the sort; Escape or Apply restores focus to the opening trigger. Clear all resets filters but keeps the search term.
- URL and parsing: sets are ordered and deduped; unknown account types are kept so pasted links don’t widen. Empty or whitespace‑only filter params (for example `?type=`) are ignored before the request. Legacy `disabled=true` in a link maps to both statuses.
- API and rollout: requests now send repeated `account_types`, `trial_states`, and `disabled_states`. Absence means unfiltered type/trial and “active only” for status. The server still accepts the old `account_type` and `include_disabled`; deploy server support for the arrays before or with this client.
- Copy: trial labels come from one `TRIAL_LABELS` map shared by the filter and row badges.
- Dependencies: add `cmdk` and stock `components/ui/command.tsx` and `components/ui/popover.tsx`. Tests assert repeated params, URL shape, empty‑param handling, picker open state, and focus restore on both exits.

Satisfies Linear AGE-3186.

<sup>Written for commit f7374c34c2d8fe5381b42af3439a492c779ab7ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

