### PR TITLE
feat: add ChatGPT Desktop as an MCP client

### DIFF
--- a/.changeset/chatgpt-desktop-mcp-client.md
+++ b/.changeset/chatgpt-desktop-mcp-client.md
@@ -1,0 +1,11 @@
+---
+"server": minor
+"dashboard": patch
+"cli": minor
+---
+
+Add ChatGPT Desktop as a first-class MCP client. The hosted install page now
+includes ChatGPT Desktop alongside Claude Desktop and Cursor, with instructions
+for Developer mode, custom connectors, and OAuth / Token / None authentication.
+`gram install chatgpt-desktop` prints the same steps. Dashboard copy and
+platform labels list ChatGPT Desktop with the other supported clients.

--- a/cli/internal/app/install.go
+++ b/cli/internal/app/install.go
@@ -51,6 +51,7 @@ func newInstallCommand() *cli.Command {
 		Name:  "install",
 		Usage: "Install Gram toolsets as MCP servers in various clients",
 		Subcommands: []*cli.Command{
+			newInstallChatGPTDesktopCommand(),
 			newInstallClaudeCodeCommand(),
 			newInstallClaudeDesktopCommand(),
 			newInstallCursorCommand(),

--- a/cli/internal/app/install_chatgpt_desktop.go
+++ b/cli/internal/app/install_chatgpt_desktop.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/cli/internal/app/logging"
+	"github.com/urfave/cli/v2"
+)
+
+func newInstallChatGPTDesktopCommand() *cli.Command {
+	return &cli.Command{
+		Name:   "chatgpt-desktop",
+		Usage:  "Print instructions for installing a Gram toolset in ChatGPT Desktop",
+		Flags:  baseInstallFlags,
+		Action: doInstallChatGPTDesktop,
+	}
+}
+
+func doInstallChatGPTDesktop(c *cli.Context) error {
+	ctx := c.Context
+	logger := logging.PullLogger(ctx)
+	info, err := resolveToolsetInfo(c)
+	if err != nil {
+		return fmt.Errorf("failed to resolve toolset info: %w", err)
+	}
+
+	logger.InfoContext(ctx, "prepared ChatGPT Desktop MCP install instructions",
+		slog.String("name", info.Name),
+		slog.String("url", info.URL))
+
+	fmt.Printf("\n✓ ChatGPT Desktop install details for '%s'\n", info.Name)
+	fmt.Printf("  MCP URL: %s\n", info.URL)
+	fmt.Printf("\nChatGPT Desktop accepts remote HTTPS MCP servers only. There is no local config file or deep link to write.\n")
+	fmt.Printf("\nNext steps:\n")
+	fmt.Printf("  1. Open ChatGPT Desktop → Settings and turn on Developer mode\n")
+	fmt.Printf("     (Settings → Security and login, or Apps & Connectors → Advanced settings)\n")
+	fmt.Printf("  2. Go to Settings → Apps & Connectors (or Plugins) and click Create\n")
+	fmt.Printf("  3. Paste the MCP URL above as the connector URL\n")
+	fmt.Printf("  4. Choose authentication: OAuth if the server requires sign-in, Token plus your Gram API key for private servers, or None for public servers\n")
+	fmt.Printf("     ChatGPT Token auth sends Authorization: Bearer. Extra custom headers are not supported.\n")
+	fmt.Printf("  5. Click Create, then enable the connector from the + menu in a new chat\n")
+
+	return nil
+}

--- a/client/dashboard/src/lib/formatPlatform.test.ts
+++ b/client/dashboard/src/lib/formatPlatform.test.ts
@@ -27,6 +27,8 @@ describe("formatPlatform", () => {
     expect(formatPlatform("CODEX_WEB")).toBe("Codex Web");
     expect(formatPlatform("chatgpt")).toBe("ChatGPT");
     expect(formatPlatform("ChatGPT")).toBe("ChatGPT");
+    expect(formatPlatform("chatgpt-desktop")).toBe("ChatGPT Desktop");
+    expect(formatPlatform("ChatGPT Desktop")).toBe("ChatGPT Desktop");
     expect(formatPlatform("chatgpt-work")).toBe("ChatGPT Work");
     expect(formatPlatform("opencode")).toBe("opencode");
     expect(formatPlatform("litellm")).toBe("LiteLLM");

--- a/client/dashboard/src/lib/formatPlatform.ts
+++ b/client/dashboard/src/lib/formatPlatform.ts
@@ -23,6 +23,7 @@ const PRODUCT_SURFACE_LABELS: Record<string, string> = {
   // compliance import — distinct surfaces from the Codex agent, split at
   // ingest by hook_source so they stay separable in the summaries.
   chatgpt: "ChatGPT",
+  "chatgpt-desktop": "ChatGPT Desktop",
   "chatgpt-work": "ChatGPT Work",
   opencode: "opencode",
   litellm: "LiteLLM",

--- a/client/dashboard/src/pages/mcp/BuiltInMCPDetailPage.tsx
+++ b/client/dashboard/src/pages/mcp/BuiltInMCPDetailPage.tsx
@@ -57,14 +57,14 @@ function BuiltInOverviewTab({ mcpUrl }: { mcpUrl: string }) {
     <Stack className="mb-4">
       <PageSection
         heading="Hosted URL"
-        description="The URL to connect to this MCP server from Claude Desktop, Cursor, or any MCP-compatible client."
+        description="The URL to connect to this MCP server from ChatGPT Desktop, Claude Desktop, Cursor, or any MCP-compatible client."
       >
         <CodeBlock className="mb-2">{mcpUrl}</CodeBlock>
       </PageSection>
 
       <PageSection
         heading="Install Page"
-        description="Share this page to give simple instructions for getting started with this MCP server in Cursor or Claude Desktop."
+        description="Share this page to give simple instructions for getting started with this MCP server in ChatGPT Desktop, Cursor, or Claude Desktop."
       >
         <div className="bg-muted/20 flex items-center gap-2 border p-2">
           <CodeBlock

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -340,7 +340,7 @@ function MCPOverview() {
       </Page.Section.Title>
       <Page.Section.Description>
         Pre-configured MCP servers provided by the platform for your project.
-        Connect from Claude Desktop, Cursor, or any MCP client.
+        Connect from ChatGPT Desktop, Claude Desktop, Cursor, or any MCP client.
       </Page.Section.Description>
       <Page.Section.Body>
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">

--- a/client/dashboard/src/pages/mcp/MCPEmptyState.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEmptyState.tsx
@@ -7,8 +7,8 @@ export function MCPEmptyState({ cta }: { cta?: React.ReactNode }): JSX.Element {
     <Page.Section>
       <Page.Section.Title>MCP Servers</Page.Section.Title>
       <Page.Section.Description className="max-w-2xl">
-        Hosted MCP servers expose your tools to Claude Desktop, Cursor, or any
-        MCP client.
+        Hosted MCP servers expose your tools to ChatGPT Desktop, Claude Desktop,
+        Cursor, or any MCP client.
       </Page.Section.Description>
       <Page.Section.Body>
         <div className="bg-muted/20 flex flex-col items-center justify-center border border-dashed px-8 py-16">

--- a/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
@@ -28,6 +28,7 @@ const SOURCE_ICONS: Record<string, string> = {
   cursor: "/icons/platforms/cursor.svg",
   codex: "/icons/platforms/openai.svg",
   chatgpt: "/icons/platforms/openai.svg",
+  "chatgpt-desktop": "/icons/platforms/openai.svg",
   "chatgpt-work": "/icons/platforms/openai.svg",
 };
 
@@ -49,6 +50,8 @@ function sourceLabel(source: string): string {
       return "Codex";
     case "chatgpt":
       return "ChatGPT";
+    case "chatgpt-desktop":
+      return "ChatGPT Desktop";
     case "chatgpt-work":
       return "ChatGPT Work";
     case "cowork":

--- a/client/dashboard/src/pages/toolsets/PromptsTab.tsx
+++ b/client/dashboard/src/pages/toolsets/PromptsTab.tsx
@@ -63,7 +63,7 @@ export function PromptsTabContent({
     return (
       <EmptyState
         heading="No prompts yet"
-        description="Prompt templates are ready-made prompts your MCP server offers to connected clients like Claude Desktop or Cursor, so users can start a common task without typing it out themselves."
+        description="Prompt templates are ready-made prompts your MCP server offers to connected clients like ChatGPT Desktop, Claude Desktop, or Cursor, so users can start a common task without typing it out themselves."
         nonEmptyProjectCTA={
           <RequireScope scope="mcp:write" level="component">
             <Stack gap={2} direction="horizontal">

--- a/server/internal/mcpmetadata/hosted_page.html.tmpl
+++ b/server/internal/mcpmetadata/hosted_page.html.tmpl
@@ -1196,6 +1196,90 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
         {{- end }}
       </div>
     </template>
+    <template
+      class="install-target-template"
+      data-install-target="chatgpt-desktop"
+    >
+      <div class="modal-content">
+        <h1>Instructions</h1>
+        <ol>
+          <li class="instruction-item">
+            In ChatGPT Desktop, open
+            <strong>Settings</strong> and turn on
+            <strong>Developer mode</strong> under
+            <strong>Security and login</strong>
+            (or
+            <strong>Apps &amp; Connectors &gt; Advanced settings</strong>,
+            depending on your app version). Developer mode is available on
+            Plus, Pro, Business, Enterprise, and Edu plans — not the free
+            tier.
+          </li>
+          <li class="instruction-item">
+            Go to
+            <strong>Settings &gt; Apps &amp; Connectors</strong>
+            (or <strong>Plugins</strong>) and click
+            <strong>Create</strong> or
+            <strong>Add custom connector</strong>.
+          </li>
+          <li class="instruction-item">
+            Enter a name for this server and paste the following URL as the
+            MCP server URL. ChatGPT accepts remote HTTPS endpoints only.
+            <div class="card code-container">
+              <button class="copy-button waiting">
+                <svg
+                  class="icon icon-copy"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy"></use>
+                </svg>
+                <svg
+                  class="icon icon-copy-success"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy-check"></use>
+                </svg>
+              </button>
+              <!-- prettier-ignore -->
+              <code class="code-snippet" data-scope-url-text>{{ .MCPURL }}</code>
+            </div>
+          </li>
+          {{- if .IsOAuth }}
+          <li class="instruction-item">
+            Set authentication to <strong>OAuth</strong>. ChatGPT will start
+            the sign-in flow when you create the connector.
+          </li>
+          {{- else if .SecurityInputs }}
+          <li class="instruction-item">
+            Set authentication to <strong>Token</strong> and paste your Gram
+            API key. ChatGPT sends it as an
+            <code>Authorization: Bearer</code> header. ChatGPT cannot set
+            additional custom HTTP headers, so extra headers such as
+            <code>Gram-Environment</code> are not sent.
+          </li>
+          {{- else }}
+          <li class="instruction-item">
+            Leave authentication as <strong>None</strong> unless this server
+            requires a token.
+          </li>
+          {{- end }}
+          <li class="instruction-item">
+            Click <strong>Create</strong>. In a new chat, open the
+            <strong>+</strong> menu and enable this connector so ChatGPT can
+            call its tools.
+          </li>
+        </ol>
+        <h2 class="modal-sub-heading">For Business &amp; Enterprise</h2>
+        <p>
+          Workspace admins may need to allow Developer mode or custom
+          connectors before members can add this server. ChatGPT Desktop and
+          ChatGPT web share the same connector list once you are signed in.
+        </p>
+      </div>
+    </template>
     <template class="install-target-template" data-install-target="codex-cli">
       <div class="modal-content">
         <h1>Instructions</h1>
@@ -1466,6 +1550,13 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                   >
                     Claude Desktop
                   </button>
+                  <button
+                    class="popover-button"
+                    data-install-method="modal"
+                    data-install-target="chatgpt-desktop"
+                  >
+                    ChatGPT Desktop
+                  </button>
                   <a
                     class="popover-button install-link"
                     href="{{ .VSCodeInstallLink }}"
@@ -1587,6 +1678,28 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                   />
                 </svg>
                 <span>Claude Desktop</span>
+              </div>
+            </div>
+            <div
+              tabindex="0"
+              class="card install-target"
+              data-install-method="modal"
+              data-install-target="chatgpt-desktop"
+            >
+              <div class="target">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="32"
+                  height="32"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M22.282 9.821a6 6 0 0 0-.516-4.91 6.05 6.05 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a6 6 0 0 0-3.998 2.9 6.05 6.05 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.05 6.05 0 0 0 6.515 2.9A6.06 6.06 0 0 0 13.26 24a6.06 6.06 0 0 0 5.772-4.206 6 6 0 0 0 3.997-2.9 6.06 6.06 0 0 0-.747-7.073M13.26 22.43a4.48 4.48 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.8.8 0 0 0 .392-.681v-6.737l2.02 1.168a.07.07 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494M3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.77.77 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646M2.34 7.896a4.5 4.5 0 0 1 2.366-1.973V11.6a.77.77 0 0 0 .388.677l5.815 3.354-2.02 1.168a.08.08 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855-5.833-3.387L15.119 7.2a.08.08 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667m2.01-3.023-.141-.085-4.774-2.782a.78.78 0 0 0-.785 0L9.409 9.23V6.897a.07.07 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.8.8 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5Z"
+                  />
+                </svg>
+                <span>ChatGPT Desktop</span>
               </div>
             </div>
             <a

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -974,6 +975,29 @@ func TestServeInstallPage_ClaudeDesktop_WithSecurityInputs(t *testing.T) {
 	assert.NotContains(t, body, "For Teams &amp; Enterprise", "should not render the Teams & Enterprise admin connector footer")
 }
 
+// installTargetTemplateHTML returns the inner HTML of the named
+// install-target <template>. The page also embeds mcp-remote in the Claude
+// Desktop modal and the raw-config snippet, so assertions that a client does
+// not use that workaround have to look at this section only.
+func installTargetTemplateHTML(t *testing.T, body, target string) string {
+	t.Helper()
+	marker := `data-install-target="` + target + `"`
+	searchFrom := 0
+	for {
+		rel := strings.Index(body[searchFrom:], marker)
+		require.GreaterOrEqual(t, rel, 0, "install target %s not found", target)
+		abs := searchFrom + rel
+		templateStart := strings.LastIndex(body[:abs], "<template")
+		require.GreaterOrEqual(t, templateStart, 0, "install target %s is not inside a template", target)
+		if strings.Contains(body[templateStart:abs], `class="install-target-template"`) {
+			endRel := strings.Index(body[abs:], "</template>")
+			require.GreaterOrEqual(t, endRel, 0, "install target %s template is unclosed", target)
+			return body[templateStart : abs+endRel]
+		}
+		searchFrom = abs + len(marker)
+	}
+}
+
 // TestServeInstallPage_ChatGPTDesktop_NoSecurityInputs verifies that a public
 // MCP server renders the ChatGPT Desktop custom-connector flow, including the
 // Business & Enterprise admin note and the None-auth instruction.
@@ -1018,13 +1042,15 @@ func TestServeInstallPage_ChatGPTDesktop_NoSecurityInputs(t *testing.T) {
 	body := rr.Body.String()
 	assert.Contains(t, body, `data-install-target="chatgpt-desktop"`, "should offer ChatGPT Desktop as an install target")
 	assert.Contains(t, body, "ChatGPT Desktop", "should label the ChatGPT Desktop install target")
-	assert.Contains(t, body, "Developer mode", "should tell users to enable Developer mode")
-	assert.Contains(t, body, "Add custom connector", "should render the custom connector step")
-	assert.Contains(t, body, "Leave authentication as <strong>None</strong>", "public servers should use None auth")
-	assert.Contains(t, body, "For Business &amp; Enterprise", "should render the Business & Enterprise admin note")
-	assert.NotContains(t, body, "Set authentication to <strong>Token</strong>", "public servers should not ask for Token auth")
-	assert.NotContains(t, body, "Set authentication to <strong>OAuth</strong>", "public servers should not ask for OAuth")
-	assert.NotContains(t, body, "mcp-remote", "ChatGPT Desktop cannot run local MCP proxies")
+
+	section := installTargetTemplateHTML(t, body, "chatgpt-desktop")
+	assert.Contains(t, section, "Developer mode", "should tell users to enable Developer mode")
+	assert.Contains(t, section, "Add custom connector", "should render the custom connector step")
+	assert.Contains(t, section, "Leave authentication as <strong>None</strong>", "public servers should use None auth")
+	assert.Contains(t, section, "For Business &amp; Enterprise", "should render the Business & Enterprise admin note")
+	assert.NotContains(t, section, "Set authentication to <strong>Token</strong>", "public servers should not ask for Token auth")
+	assert.NotContains(t, section, "Set authentication to <strong>OAuth</strong>", "public servers should not ask for OAuth")
+	assert.NotContains(t, section, "mcp-remote", "ChatGPT Desktop cannot run local MCP proxies")
 }
 
 // TestServeInstallPage_ChatGPTDesktop_WithSecurityInputs verifies that a
@@ -1063,13 +1089,15 @@ func TestServeInstallPage_ChatGPTDesktop_WithSecurityInputs(t *testing.T) {
 
 	body := rr.Body.String()
 	assert.Contains(t, body, `data-install-target="chatgpt-desktop"`, "should offer ChatGPT Desktop as an install target")
-	assert.Contains(t, body, "Set authentication to <strong>Token</strong>", "private servers should use Token auth")
-	assert.Contains(t, body, "Authorization: Bearer", "should explain how ChatGPT sends the token")
-	assert.Contains(t, body, "cannot set additional custom HTTP headers", "should explain the header limitation")
-	assert.Contains(t, body, "For Business &amp; Enterprise", "should still render the Business & Enterprise admin note")
-	assert.NotContains(t, body, "Leave authentication as <strong>None</strong>", "private servers should not suggest None auth")
-	assert.NotContains(t, body, "Set authentication to <strong>OAuth</strong>", "gram-key servers should not suggest OAuth")
-	assert.NotContains(t, body, "mcp-remote", "ChatGPT Desktop cannot run local MCP proxies")
+
+	section := installTargetTemplateHTML(t, body, "chatgpt-desktop")
+	assert.Contains(t, section, "Set authentication to <strong>Token</strong>", "private servers should use Token auth")
+	assert.Contains(t, section, "Authorization: Bearer", "should explain how ChatGPT sends the token")
+	assert.Contains(t, section, "additional custom HTTP headers", "should explain the header limitation")
+	assert.Contains(t, section, "For Business &amp; Enterprise", "should still render the Business & Enterprise admin note")
+	assert.NotContains(t, section, "Leave authentication as <strong>None</strong>", "private servers should not suggest None auth")
+	assert.NotContains(t, section, "Set authentication to <strong>OAuth</strong>", "gram-key servers should not suggest OAuth")
+	assert.NotContains(t, section, "mcp-remote", "ChatGPT Desktop cannot run local MCP proxies")
 }
 
 // TestServeInstallPage_ChatGPTDesktop_OAuth verifies that an OAuth-gated
@@ -1116,10 +1144,12 @@ func TestServeInstallPage_ChatGPTDesktop_OAuth(t *testing.T) {
 
 	body := rr.Body.String()
 	assert.Contains(t, body, `data-install-target="chatgpt-desktop"`, "should offer ChatGPT Desktop as an install target")
-	assert.Contains(t, body, "Set authentication to <strong>OAuth</strong>", "OAuth-gated servers should use OAuth")
-	assert.NotContains(t, body, "Set authentication to <strong>Token</strong>", "OAuth-gated servers should not ask for Token auth")
-	assert.NotContains(t, body, "Leave authentication as <strong>None</strong>", "OAuth-gated servers should not suggest None auth")
-	assert.NotContains(t, body, "GRAM_KEY", "OAuth-gated install must not ask for a Gram key")
+
+	section := installTargetTemplateHTML(t, body, "chatgpt-desktop")
+	assert.Contains(t, section, "Set authentication to <strong>OAuth</strong>", "OAuth-gated servers should use OAuth")
+	assert.NotContains(t, section, "Set authentication to <strong>Token</strong>", "OAuth-gated servers should not ask for Token auth")
+	assert.NotContains(t, section, "Leave authentication as <strong>None</strong>", "OAuth-gated servers should not suggest None auth")
+	assert.NotContains(t, section, "GRAM_KEY", "OAuth-gated install must not ask for a Gram key")
 }
 
 // TestServeInstallPage_PrivateWithGramOAuth_NoAuthorizationHeader regression-tests

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -974,6 +974,154 @@ func TestServeInstallPage_ClaudeDesktop_WithSecurityInputs(t *testing.T) {
 	assert.NotContains(t, body, "For Teams &amp; Enterprise", "should not render the Teams & Enterprise admin connector footer")
 }
 
+// TestServeInstallPage_ChatGPTDesktop_NoSecurityInputs verifies that a public
+// MCP server renders the ChatGPT Desktop custom-connector flow, including the
+// Business & Enterprise admin note and the None-auth instruction.
+func TestServeInstallPage_ChatGPTDesktop_NoSecurityInputs(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "chatgpt-desktop-public-" + uuid.New().String()[:8]
+	toolset, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Public ChatGPT Desktop Toolset",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("public toolset with no security inputs"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	err = toolsets_repo.New(testInstance.conn).SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true,
+		ID:          toolset.ID,
+		ProjectID:   toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(context.Background(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = testInstance.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.Contains(t, body, `data-install-target="chatgpt-desktop"`, "should offer ChatGPT Desktop as an install target")
+	assert.Contains(t, body, "ChatGPT Desktop", "should label the ChatGPT Desktop install target")
+	assert.Contains(t, body, "Developer mode", "should tell users to enable Developer mode")
+	assert.Contains(t, body, "Add custom connector", "should render the custom connector step")
+	assert.Contains(t, body, "Leave authentication as <strong>None</strong>", "public servers should use None auth")
+	assert.Contains(t, body, "For Business &amp; Enterprise", "should render the Business & Enterprise admin note")
+	assert.NotContains(t, body, "Set authentication to <strong>Token</strong>", "public servers should not ask for Token auth")
+	assert.NotContains(t, body, "Set authentication to <strong>OAuth</strong>", "public servers should not ask for OAuth")
+	assert.NotContains(t, body, "mcp-remote", "ChatGPT Desktop cannot run local MCP proxies")
+}
+
+// TestServeInstallPage_ChatGPTDesktop_WithSecurityInputs verifies that a
+// private Gram-key server tells ChatGPT Desktop users to use Token auth and
+// does not offer the mcp-remote workaround (ChatGPT is remote-HTTPS only).
+func TestServeInstallPage_ChatGPTDesktop_WithSecurityInputs(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "chatgpt-desktop-private-" + uuid.New().String()[:8]
+	_, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Private ChatGPT Desktop Toolset",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("private toolset producing security inputs via gram security mode"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = testInstance.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.Contains(t, body, `data-install-target="chatgpt-desktop"`, "should offer ChatGPT Desktop as an install target")
+	assert.Contains(t, body, "Set authentication to <strong>Token</strong>", "private servers should use Token auth")
+	assert.Contains(t, body, "Authorization: Bearer", "should explain how ChatGPT sends the token")
+	assert.Contains(t, body, "cannot set additional custom HTTP headers", "should explain the header limitation")
+	assert.Contains(t, body, "For Business &amp; Enterprise", "should still render the Business & Enterprise admin note")
+	assert.NotContains(t, body, "Leave authentication as <strong>None</strong>", "private servers should not suggest None auth")
+	assert.NotContains(t, body, "Set authentication to <strong>OAuth</strong>", "gram-key servers should not suggest OAuth")
+	assert.NotContains(t, body, "mcp-remote", "ChatGPT Desktop cannot run local MCP proxies")
+}
+
+// TestServeInstallPage_ChatGPTDesktop_OAuth verifies that an OAuth-gated
+// server tells ChatGPT Desktop users to choose OAuth rather than Token or None.
+func TestServeInstallPage_ChatGPTDesktop_OAuth(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "chatgpt-desktop-oauth-" + uuid.NewString()[:8]
+	toolset, err := ti.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "OAuth ChatGPT Desktop Toolset",
+		Slug:                   "chatgpt-desktop-oauth-ts-" + uuid.NewString()[:8],
+		Description:            conv.ToPGText("OAuth-gated toolset for ChatGPT Desktop install instructions"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText(mcpSlug),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	usi := createUserSessionIssuer(t, ctx, ti, *authCtx.ProjectID)
+
+	_, err = ti.toolsetRepo.UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: usi.ID, Valid: true},
+		Slug:                toolset.Slug,
+		ProjectID:           toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = ti.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.Contains(t, body, `data-install-target="chatgpt-desktop"`, "should offer ChatGPT Desktop as an install target")
+	assert.Contains(t, body, "Set authentication to <strong>OAuth</strong>", "OAuth-gated servers should use OAuth")
+	assert.NotContains(t, body, "Set authentication to <strong>Token</strong>", "OAuth-gated servers should not ask for Token auth")
+	assert.NotContains(t, body, "Leave authentication as <strong>None</strong>", "OAuth-gated servers should not suggest None auth")
+	assert.NotContains(t, body, "GRAM_KEY", "OAuth-gated install must not ask for a Gram key")
+}
+
 // TestServeInstallPage_PrivateWithGramOAuth_NoAuthorizationHeader regression-tests
 // AGE-1962: a private MCP server with a Gram OAuth proxy attached must not render
 // the GRAM_KEY Authorization header (or gram-environment) in the install snippets.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds ChatGPT Desktop as a first-class MCP client so operators can connect Gram-hosted servers the same way they already do for Claude Desktop and Cursor.

- Hosted MCP install page: ChatGPT Desktop card and “Add to Client” entry, with Developer mode + custom connector steps and auth that matches the server (OAuth, Token, or None). ChatGPT is remote-HTTPS only, so there is no `mcp-remote` workaround.
- CLI: `gram install chatgpt-desktop` prints the MCP URL and the same steps.
- Dashboard copy and `formatPlatform` now list ChatGPT Desktop alongside the other supported clients.

OAuth CIMD admission for ChatGPT connectors and ChatGPT conversation import via the Compliance API were already in place. This change is the missing connect path.

## Test plan

- [x] `mise run test:server ./internal/mcpmetadata/` — 59 tests, including public, Gram-key, and OAuth ChatGPT Desktop install-page flows
- [x] `aube run -F dashboard test -- src/lib/formatPlatform.test.ts` — ChatGPT Desktop label
- [x] `gram install chatgpt-desktop --mcp-url https://mcp.example.test/mcp/demo` prints the URL and next steps
- [x] `mise run lint:server`
- [ ] Open an MCP install page and confirm the ChatGPT Desktop card and modal render for a public server, a private Gram-key server, and an OAuth-gated server

Closes DNO-307.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-307](https://linear.app/speakeasy/issue/DNO-307/mcp-feat-support-chatgpt-desktop-app-as-mcp-client)

<div><a href="https://cursor.com/agents/bc-698b4782-31e9-4459-a553-2060e059ada3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-698b4782-31e9-4459-a553-2060e059ada3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ChatGPT Desktop as a first-class MCP client so operators can connect Gram-hosted servers like they do with Claude Desktop and Cursor. Previously unsupported; now the hosted install page, CLI, and dashboard guide setup for ChatGPT Desktop. ChatGPT Desktop only connects to remote HTTPS and cannot send custom headers, which blocks header-dependent private servers.

- Server: hosted install page adds a ChatGPT Desktop card and modal with conditional steps for OAuth, Token (`Authorization: Bearer`), or None; includes a Business/Enterprise note; no `mcp-remote` or local config.
- CLI: `gram install chatgpt-desktop` prints the MCP URL and step-by-step instructions.
- Dashboard: adds “ChatGPT Desktop” via `formatPlatform`, icon mapping, and copy updates.
- Tests: add public, Gram-key, and OAuth flows; scope assertions to the ChatGPT Desktop template to avoid false failures from `mcp-remote` content elsewhere; update platform label tests.

**Rollout notes**
- Requires Developer mode and a paid plan. Only remote HTTPS; no custom headers. Private servers that need extra headers (e.g., `Gram-Environment`) are unsupported in ChatGPT Desktop.
- No change to Claude Desktop or Cursor. Satisfies Linear DNO-307.

<sup>Written for commit a77cf435cb1fae1388a91d916abb51171308cb90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

