### PR TITLE
feat(dashboard): add welcome banner to org home

### DIFF
--- a/.changeset/org-home-welcome-banner.md
+++ b/.changeset/org-home-welcome-banner.md
@@ -1,0 +1,11 @@
+---
+"dashboard": patch
+---
+
+Org home now opens with a welcome banner offering three first moves: enter the
+demo org, get started in a project, or run the setup wizard. Admins only, and
+the header's "Finish setup" banner stands down while it shows. It appears for
+every admin for now; which orgs count as new is follow-up work.
+
+Below it, the project search, view toggle, and Add New move into the column they
+act on, and the two rails cap their height and scroll.

--- a/.changeset/org-home-welcome-banner.md
+++ b/.changeset/org-home-welcome-banner.md
@@ -3,9 +3,10 @@
 ---
 
 Org home now opens with a welcome banner offering three first moves: enter the
-demo org, get started in a project, or run the setup wizard. Admins only, and
-the header's "Finish setup" banner stands down while it shows. It appears for
-every admin for now; which orgs count as new is follow-up work.
+demo org, get started in a project, or start the enterprise rollout. The third
+card needs an enterprise admin; the other two are open to any member. The
+header's "Finish setup" banner stands down while the banner shows. It appears
+for everyone for now; which orgs count as new is follow-up work.
 
 Below it, the project search, view toggle, and Add New move into the column they
 act on, and the two rails cap their height and scroll.

--- a/client/dashboard/src/components/onboarding-banner.test.tsx
+++ b/client/dashboard/src/components/onboarding-banner.test.tsx
@@ -5,6 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const pathname = vi.hoisted(() => ({ current: "/acme" }));
 
 vi.mock("@/contexts/Sdk", () => ({ useSlugs: () => ({ orgSlug: "acme" }) }));
+vi.mock("@/hooks/useRBAC", () => ({
+  useRBAC: () => ({ hasScope: () => true }),
+}));
 vi.mock("react-router", () => ({
   useLocation: () => ({ pathname: pathname.current }),
 }));

--- a/client/dashboard/src/components/onboarding-banner.test.tsx
+++ b/client/dashboard/src/components/onboarding-banner.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const pathname = vi.hoisted(() => ({ current: "/acme" }));
+
+vi.mock("@/contexts/Sdk", () => ({ useSlugs: () => ({ orgSlug: "acme" }) }));
+vi.mock("react-router", () => ({
+  useLocation: () => ({ pathname: pathname.current }),
+}));
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({
+    setup: { Link: ({ children }: { children: ReactNode }) => <>{children}</> },
+  }),
+}));
+vi.mock("@/hooks/useOnboardingCta", () => ({
+  ONBOARDING_CTA_VT_CLASS: "",
+  ONBOARDING_CTA_CONTENT_VT_CLASS: "",
+  useOnboardingCta: () => ({
+    eligible: true,
+    dismissed: false,
+    dismiss: vi.fn(),
+  }),
+}));
+
+import { OnboardingBanner } from "./onboarding-banner.tsx";
+
+afterEach(cleanup);
+
+describe("OnboardingBanner", () => {
+  it("stands down on org home, where the welcome banner offers setup", () => {
+    pathname.current = "/acme";
+    render(<OnboardingBanner />);
+    expect(screen.queryByText("Finish setup")).toBeNull();
+  });
+
+  it("still shows on other org-level pages", () => {
+    pathname.current = "/acme/settings";
+    render(<OnboardingBanner />);
+    expect(screen.getByText("Finish setup")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/onboarding-banner.test.tsx
+++ b/client/dashboard/src/components/onboarding-banner.test.tsx
@@ -5,9 +5,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const pathname = vi.hoisted(() => ({ current: "/acme" }));
 
 vi.mock("@/contexts/Sdk", () => ({ useSlugs: () => ({ orgSlug: "acme" }) }));
-vi.mock("@/hooks/useRBAC", () => ({
-  useRBAC: () => ({ hasScope: () => true }),
-}));
 vi.mock("react-router", () => ({
   useLocation: () => ({ pathname: pathname.current }),
 }));

--- a/client/dashboard/src/components/onboarding-banner.tsx
+++ b/client/dashboard/src/components/onboarding-banner.tsx
@@ -6,6 +6,7 @@ import {
   useOnboardingCta,
 } from "@/hooks/useOnboardingCta";
 import { useSlugs } from "@/contexts/Sdk";
+import { useOrgWelcomeBanner } from "@/hooks/useOrgWelcomeBanner";
 import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
 import { ArrowRight, Wrench } from "lucide-react";
@@ -14,11 +15,15 @@ export function OnboardingBanner(): JSX.Element | null {
   const orgRoutes = useOrgRoutes();
   const { projectSlug } = useSlugs();
   const { eligible, dismissed, dismiss } = useOnboardingCta();
+  const { visible: welcomeBannerVisible } = useOrgWelcomeBanner();
 
   // Project-scoped routes (/:orgSlug/projects/:projectSlug/...) are too deep
   // in a specific workflow for an org-wide setup nudge — only show this on
   // org-level pages (home, org settings, etc).
   if (!eligible || dismissed || projectSlug) return null;
+
+  // The welcome banner's third card is this same wizard.
+  if (welcomeBannerVisible) return null;
 
   return (
     <div

--- a/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
+++ b/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
@@ -1,0 +1,19 @@
+import { useSlugs } from "@/contexts/Sdk";
+import { useLocation } from "react-router";
+
+/**
+ * Whether the org-home welcome banner is on screen. The header's "Finish
+ * setup" banner reads it too, so the two never show at once. Route-based for
+ * now; the real zero-data rule lands here.
+ */
+export function useOrgWelcomeBanner(): { visible: boolean } {
+  const { orgSlug, projectSlug } = useSlugs();
+  const { pathname } = useLocation();
+
+  const onOrgHome =
+    Boolean(orgSlug) &&
+    !projectSlug &&
+    pathname.replace(/\/+$/, "") === `/${orgSlug}`;
+
+  return { visible: onOrgHome };
+}

--- a/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
+++ b/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
@@ -1,5 +1,4 @@
 import { useSlugs } from "@/contexts/Sdk";
-import { useRBAC } from "@/hooks/useRBAC";
 import { useLocation } from "react-router";
 
 /**
@@ -7,18 +6,17 @@ import { useLocation } from "react-router";
  * setup" banner reads it too, so the two never show at once. Route-based for
  * now; the real zero-data rule lands here.
  *
- * Admins only: every first move it offers is an admin task. Non-admins get
- * their own card later.
+ * Every org member sees it: the demo org and the project it points at need no
+ * admin scope. The setup card inside the banner keeps its own gate.
  */
 export function useOrgWelcomeBanner(): { visible: boolean } {
   const { orgSlug, projectSlug } = useSlugs();
   const { pathname } = useLocation();
-  const { hasScope } = useRBAC();
 
   const onOrgHome =
     Boolean(orgSlug) &&
     !projectSlug &&
     pathname.replace(/\/+$/, "") === `/${orgSlug}`;
 
-  return { visible: onOrgHome && hasScope("org:admin") };
+  return { visible: onOrgHome };
 }

--- a/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
+++ b/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
@@ -1,19 +1,24 @@
 import { useSlugs } from "@/contexts/Sdk";
+import { useRBAC } from "@/hooks/useRBAC";
 import { useLocation } from "react-router";
 
 /**
  * Whether the org-home welcome banner is on screen. The header's "Finish
  * setup" banner reads it too, so the two never show at once. Route-based for
  * now; the real zero-data rule lands here.
+ *
+ * Admins only: every first move it offers is an admin task. Non-admins get
+ * their own card later.
  */
 export function useOrgWelcomeBanner(): { visible: boolean } {
   const { orgSlug, projectSlug } = useSlugs();
   const { pathname } = useLocation();
+  const { hasScope } = useRBAC();
 
   const onOrgHome =
     Boolean(orgSlug) &&
     !projectSlug &&
     pathname.replace(/\/+$/, "") === `/${orgSlug}`;
 
-  return { visible: onOrgHome };
+  return { visible: onOrgHome && hasScope("org:admin") };
 }

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -77,6 +77,8 @@ vi.mock("@/routes", () => ({
       Link: ({ children }: { children: ReactNode }) => <>{children}</>,
     },
     team: { goTo: vi.fn() },
+    // Used by the welcome banner's third route card.
+    setup: { href: () => "/acme/setup" },
   }),
 }));
 

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -106,6 +106,8 @@ vi.mock("react-router", () => ({
     <a {...props}>{children}</a>
   ),
   useNavigate: () => vi.fn(),
+  // Org root path, so the welcome banner's route check passes.
+  useLocation: () => ({ pathname: "/acme" }),
 }));
 vi.mock("@/components/ui/Dropdown", () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -81,8 +81,13 @@ vi.mock("@/routes", () => ({
       Link: ({ children }: { children: ReactNode }) => <>{children}</>,
     },
     team: { goTo: vi.fn() },
-    // Used by the welcome banner's third route card.
+    // Used by the welcome banner's route cards.
+    home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
+  }),
+  useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
+    exploreDemo: { href: () => "/explore-demo" },
+    home: { href: () => `/acme/projects/${projectSlug}` },
   }),
 }));
 

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -44,6 +44,10 @@ vi.mock("@/contexts/Auth", () => ({
     slug: "acme",
     projects: [{ id: "project-1", name: "Project One", slug: "project-one" }],
   }),
+  useSession: () => ({
+    rawGramAccountType: "enterprise",
+    hasActiveSubscription: true,
+  }),
 }));
 vi.mock("@/contexts/Sdk", () => ({
   useSdkClient: () => ({ projects: { create: vi.fn() } }),

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -90,7 +90,9 @@ export default function OrgHome(): JSX.Element {
       <Page.Header>
         <Page.Header.Breadcrumbs />
       </Page.Header>
-      <Page.Body>
+      {/* fullWidth + noPadding so the welcome banner can run edge to edge;
+          everything else re-applies the page column below. */}
+      <Page.Body fullWidth noPadding className="gap-0">
         <RequireScope
           scope={["org:read", "project:read", "org:admin"]}
           level="page"
@@ -281,9 +283,9 @@ function OrgHomeInner() {
 
   return (
     <>
-      <div className="flex flex-col gap-6">
-        <OrgWelcomeBanner />
+      <OrgWelcomeBanner />
 
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-8 pb-24">
         <div className="flex items-center gap-2">
           <SearchBar
             value={search}

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -285,7 +285,7 @@ function OrgHomeInner() {
     <>
       <OrgWelcomeBanner />
 
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-8 pt-12 pb-24">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-8 pt-8 pb-24">
         <div className="flex items-center gap-2">
           <SearchBar
             value={search}

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -286,29 +286,29 @@ function OrgHomeInner() {
       <OrgWelcomeBanner />
 
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-8 pt-8 pb-24">
-        <div className="flex items-center gap-2">
-          <SearchBar
-            value={search}
-            onChange={setSearch}
-            placeholder="Search projects..."
-            className="flex-1"
-          />
-          <ViewModeToggle value={viewMode} onChange={setViewMode} />
-          {canAdmin && (
-            <AddNewMenu
-              onCreateProject={() => setCreateDialogOpen(true)}
-              onInviteMember={() => orgRoutes.team.goTo()}
-              onManageRoles={() => orgRoutes.access.roles.goTo()}
-            />
-          )}
-        </div>
-
         {/* `items-start` so each column is only as tall as its content — the
             default stretch left the Projects card padded with dead space
             whenever the rail was taller, which is the common case for orgs
             with one or two projects. */}
         <div className="grid grid-cols-1 items-start gap-8 xl:grid-cols-[1fr_420px] 2xl:grid-cols-[1fr_500px]">
-          <main className="flex min-w-0 flex-col gap-3">
+          <main className="flex min-w-0 flex-col gap-6">
+            <div className="flex items-center gap-2">
+              <SearchBar
+                value={search}
+                onChange={setSearch}
+                placeholder="Search projects..."
+                className="flex-1"
+              />
+              <ViewModeToggle value={viewMode} onChange={setViewMode} />
+              {canAdmin && (
+                <AddNewMenu
+                  onCreateProject={() => setCreateDialogOpen(true)}
+                  onInviteMember={() => orgRoutes.team.goTo()}
+                  onManageRoles={() => orgRoutes.access.roles.goTo()}
+                />
+              )}
+            </div>
+
             {/* List rows run edge to edge; grid cards need the card's own
                 padding so they do not collide with its border. */}
             <Card.Dashboard
@@ -974,7 +974,7 @@ function RecentActivityCompact({ logs }: { logs: AuditLog[] }) {
           Activity will appear here as your team makes changes.
         </Text>
       ) : (
-        <ol className="divide-border divide-y">
+        <ol className="divide-border max-h-72 divide-y overflow-y-auto">
           {preview.map((log) => (
             <li
               key={log.id}
@@ -1060,7 +1060,7 @@ function RecentChallengesCompact() {
           No denied access attempts. Authorization checks are all passing.
         </Text>
       ) : (
-        <ol className="divide-border divide-y">
+        <ol className="divide-border max-h-72 divide-y overflow-y-auto">
           {buckets.map((bucket) => (
             <li key={bucket.id}>
               <CompactChallengeRow bucket={bucket} />

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -285,7 +285,7 @@ function OrgHomeInner() {
     <>
       <OrgWelcomeBanner />
 
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-8 pb-24">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-8 pt-12 pb-24">
         <div className="flex items-center gap-2">
           <SearchBar
             value={search}

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -30,6 +30,7 @@ import {
   getInitials,
   isDisplayableBucket,
 } from "@/pages/access/challengeHelpers";
+import { OrgWelcomeBanner } from "@/pages/org/OrgWelcomeBanner";
 import { useOrgRoutes } from "@/routes";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import type { AuditLog } from "@gram/client/models/components/auditlog.js";
@@ -281,6 +282,8 @@ function OrgHomeInner() {
   return (
     <>
       <div className="flex flex-col gap-6">
+        <OrgWelcomeBanner />
+
         <div className="flex items-center gap-2">
           <SearchBar
             value={search}

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -50,14 +50,14 @@ describe("OrgWelcomeBanner", () => {
 
     expect(hrefFor("Enter demo org")).toBe("/explore-demo");
     expect(hrefFor("Start using Speakeasy")).toBe("/acme/projects/alpha");
-    expect(hrefFor("Start setup wizard")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
   });
 
   it("drops the setup card when the org cannot run the wizard", () => {
     setupEligible.current = false;
     render(<OrgWelcomeBanner />);
 
-    expect(screen.queryByText("Start setup wizard")).toBeNull();
+    expect(screen.queryByText("Begin rollout")).toBeNull();
     expect(screen.getByText("Enter demo org")).toBeTruthy();
   });
 

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -4,11 +4,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const projects = vi.hoisted(() => ({
   current: [{ id: "p1", name: "Alpha", slug: "alpha" }],
 }));
+const setupEligible = vi.hoisted(() => ({ current: true }));
 
 vi.mock("@/contexts/Auth", () => ({
   useOrganization: () => ({ projects: projects.current }),
 }));
 vi.mock("@/contexts/Sdk", () => ({ useSlugs: () => ({ orgSlug: "acme" }) }));
+vi.mock("@/hooks/useOnboardingCta", () => ({
+  useOnboardingCta: () => ({ eligible: setupEligible.current }),
+}));
 vi.mock("@/hooks/useOrgWelcomeBanner", () => ({
   useOrgWelcomeBanner: () => ({ visible: true }),
 }));
@@ -30,6 +34,7 @@ afterEach(() => {
   cleanup();
   localStorage.clear();
   projects.current = [{ id: "p1", name: "Alpha", slug: "alpha" }];
+  setupEligible.current = true;
 });
 
 describe("OrgWelcomeBanner", () => {
@@ -39,6 +44,14 @@ describe("OrgWelcomeBanner", () => {
     expect(hrefFor("Enter demo org")).toBe("/explore-demo");
     expect(hrefFor("Start using Speakeasy")).toBe("/acme/projects/alpha");
     expect(hrefFor("Start setup wizard")).toBe("/acme/setup");
+  });
+
+  it("drops the setup card when the org cannot run the wizard", () => {
+    setupEligible.current = false;
+    render(<OrgWelcomeBanner />);
+
+    expect(screen.queryByText("Start setup wizard")).toBeNull();
+    expect(screen.getByText("Enter demo org")).toBeTruthy();
   });
 
   it("prefers the last-visited project, then default", () => {

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -9,15 +9,22 @@ const setupEligible = vi.hoisted(() => ({ current: true }));
 vi.mock("@/contexts/Auth", () => ({
   useOrganization: () => ({ projects: projects.current }),
 }));
-vi.mock("@/contexts/Sdk", () => ({ useSlugs: () => ({ orgSlug: "acme" }) }));
 vi.mock("@/hooks/useOnboardingCta", () => ({
   useOnboardingCta: () => ({ eligible: setupEligible.current }),
 }));
 vi.mock("@/hooks/useOrgWelcomeBanner", () => ({
   useOrgWelcomeBanner: () => ({ visible: true }),
 }));
+// Resolves the same paths the real hooks build for org "acme".
 vi.mock("@/routes", () => ({
-  useOrgRoutes: () => ({ setup: { href: () => "/acme/setup" } }),
+  useOrgRoutes: () => ({
+    home: { href: () => "/acme" },
+    setup: { href: () => "/acme/setup" },
+  }),
+  useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
+    exploreDemo: { href: () => "/explore-demo" },
+    home: { href: () => `/acme/projects/${projectSlug}` },
+  }),
 }));
 vi.mock("react-router", () => ({
   Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
@@ -52,6 +59,13 @@ describe("OrgWelcomeBanner", () => {
 
     expect(screen.queryByText("Start setup wizard")).toBeNull();
     expect(screen.getByText("Enter demo org")).toBeTruthy();
+  });
+
+  it("falls back to org home when the org has no projects", () => {
+    projects.current = [];
+    render(<OrgWelcomeBanner />);
+
+    expect(hrefFor("Start using Speakeasy")).toBe("/acme");
   });
 
   it("prefers the last-visited project, then default", () => {

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const projects = vi.hoisted(() => ({
+  current: [{ id: "p1", name: "Alpha", slug: "alpha" }],
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ projects: projects.current }),
+}));
+vi.mock("@/contexts/Sdk", () => ({ useSlugs: () => ({ orgSlug: "acme" }) }));
+vi.mock("@/hooks/useOrgWelcomeBanner", () => ({
+  useOrgWelcomeBanner: () => ({ visible: true }),
+}));
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({ setup: { href: () => "/acme/setup" } }),
+}));
+vi.mock("react-router", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+import { OrgWelcomeBanner } from "./OrgWelcomeBanner";
+
+const hrefFor = (cta: string) =>
+  screen.getByText(cta).closest("a")?.getAttribute("href");
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  projects.current = [{ id: "p1", name: "Alpha", slug: "alpha" }];
+});
+
+describe("OrgWelcomeBanner", () => {
+  it("points each route card at its destination", () => {
+    render(<OrgWelcomeBanner />);
+
+    expect(hrefFor("Enter demo org")).toBe("/explore-demo");
+    expect(hrefFor("Start using Speakeasy")).toBe("/acme/projects/alpha");
+    expect(hrefFor("Start setup wizard")).toBe("/acme/setup");
+  });
+
+  it("prefers the last-visited project, then default", () => {
+    projects.current = [
+      { id: "p1", name: "Alpha", slug: "alpha" },
+      { id: "p2", name: "Default", slug: "default" },
+    ];
+
+    render(<OrgWelcomeBanner />);
+    expect(hrefFor("Start using Speakeasy")).toBe("/acme/projects/default");
+
+    cleanup();
+    localStorage.setItem("preferredProject", "alpha");
+    render(<OrgWelcomeBanner />);
+    expect(hrefFor("Start using Speakeasy")).toBe("/acme/projects/alpha");
+  });
+});

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/components/brand-mesh";
 import { useOrganization } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
+import { useOrgWelcomeBanner } from "@/hooks/useOrgWelcomeBanner";
 import { getPreferredProject } from "@/lib/preferredProject";
 import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
@@ -16,26 +17,20 @@ type RouteCard = {
   cta: string;
   meta: string;
   to: string;
-  /** Draws the brand gradient edge and the "Recommended" tag. */
   recommended?: boolean;
 };
 
 /**
- * Zero-data welcome banner for org home: one hero and three mutually exclusive
- * first moves (demo org / start in a project / org setup wizard).
- *
- * Renders unconditionally for now — the visibility rule (which orgs count as
- * "new", and how the banner is dismissed) is still open, so nothing here reads
- * onboarding state yet.
+ * Zero-data welcome banner for org home: a hero over three first moves — demo
+ * org, start in a project, org setup wizard.
  */
-export function OrgWelcomeBanner(): JSX.Element {
+export function OrgWelcomeBanner(): JSX.Element | null {
   const organization = useOrganization();
   const { orgSlug } = useSlugs();
   const orgRoutes = useOrgRoutes();
+  const { visible } = useOrgWelcomeBanner();
 
-  // Same preference order as the overview prefetch below it on org home: last
-  // visited, else `default`, else whatever exists. A brand-new org always has
-  // `default`; the org-home fallback only covers the degenerate no-project case.
+  // Same preference order as the overview prefetch on org home.
   const startProject =
     getPreferredProject(organization.projects) ??
     organization.projects.find((project) => project.slug === "default") ??
@@ -71,10 +66,11 @@ export function OrgWelcomeBanner(): JSX.Element {
     },
   ];
 
+  if (!visible) return null;
+
   return (
     <section className="border-border border">
-      {/* Deep bottom padding leaves room for the cards to pull up into the
-          hero — the overlap is the point, so the mesh reads behind them. */}
+      {/* Deep bottom padding leaves room for the cards to overlap the hero. */}
       <div
         className={cn(
           BRAND_MESH_SURFACE_CLASS,
@@ -106,8 +102,6 @@ function RouteCardLink({ card }: { card: RouteCard }): JSX.Element {
       className="group bg-card border-border hover:border-foreground relative flex min-h-[250px] flex-col gap-3 border px-6.5 pt-7.5 pb-6.5 no-underline transition-colors hover:no-underline"
     >
       {card.recommended && (
-        // Pulled a pixel past each edge so the strip covers the card border
-        // rather than sitting inside it.
         <span
           aria-hidden="true"
           className="bg-gradient-primary absolute -top-px -right-px -left-px h-[3px]"

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -1,0 +1,149 @@
+import {
+  BRAND_MESH_SURFACE_CLASS,
+  BrandMeshLayers,
+} from "@/components/brand-mesh";
+import { useOrganization } from "@/contexts/Auth";
+import { useSlugs } from "@/contexts/Sdk";
+import { getPreferredProject } from "@/lib/preferredProject";
+import { cn } from "@/lib/utils";
+import { useOrgRoutes } from "@/routes";
+import { Link } from "react-router";
+
+type RouteCard = {
+  index: string;
+  title: string;
+  body: string;
+  cta: string;
+  meta: string;
+  to: string;
+  /** Draws the brand gradient edge and the "Recommended" tag. */
+  recommended?: boolean;
+};
+
+/**
+ * Zero-data welcome banner for org home: one hero and three mutually exclusive
+ * first moves (demo org / start in a project / org setup wizard).
+ *
+ * Renders unconditionally for now — the visibility rule (which orgs count as
+ * "new", and how the banner is dismissed) is still open, so nothing here reads
+ * onboarding state yet.
+ */
+export function OrgWelcomeBanner(): JSX.Element {
+  const organization = useOrganization();
+  const { orgSlug } = useSlugs();
+  const orgRoutes = useOrgRoutes();
+
+  // Same preference order as the overview prefetch below it on org home: last
+  // visited, else `default`, else whatever exists. A brand-new org always has
+  // `default`; the org-home fallback only covers the degenerate no-project case.
+  const startProject =
+    getPreferredProject(organization.projects) ??
+    organization.projects.find((project) => project.slug === "default") ??
+    organization.projects[0];
+
+  const cards: RouteCard[] = [
+    {
+      index: "01",
+      title: "Explore the demo org",
+      body: "A read-only organization with two weeks of simulated agent traffic, spend, and blocked calls.",
+      cta: "Enter demo org",
+      meta: "Read-only · simulated data",
+      to: "/explore-demo",
+    },
+    {
+      index: "02",
+      title: "Get started",
+      body: "Start getting your own data into the dashboard. Connect an MCP server, or set a policy and watch it block a call.",
+      cta: "Start using Speakeasy",
+      meta: "~5 minutes · your data",
+      to: startProject
+        ? `/${orgSlug}/projects/${startProject.slug}`
+        : `/${orgSlug}`,
+      recommended: true,
+    },
+    {
+      index: "03",
+      title: "Set up the organization",
+      body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
+      cta: "Start setup wizard",
+      meta: "5 steps · resumable",
+      to: orgRoutes.setup.href(),
+    },
+  ];
+
+  return (
+    <section className="border-border border">
+      {/* Deep bottom padding leaves room for the cards to pull up into the
+          hero — the overlap is the point, so the mesh reads behind them. */}
+      <div
+        className={cn(
+          BRAND_MESH_SURFACE_CLASS,
+          "flex flex-col gap-4 px-6 pt-10 pb-10 md:px-11 md:pt-11 md:pb-28",
+        )}
+      >
+        <BrandMeshLayers />
+        <span className="text-eyebrow">Welcome to Speakeasy</span>
+        <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] md:text-[60px]">
+          Choose your
+          <br />
+          first move
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 px-6 pb-6 md:-mt-20 md:grid-cols-3 md:px-11 md:pb-10">
+        {cards.map((card) => (
+          <RouteCardLink key={card.index} card={card} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RouteCardLink({ card }: { card: RouteCard }): JSX.Element {
+  return (
+    <Link
+      to={card.to}
+      className="group bg-card border-border hover:border-foreground relative flex min-h-[250px] flex-col gap-3 border px-6.5 pt-7.5 pb-6.5 no-underline transition-colors hover:no-underline"
+    >
+      {card.recommended && (
+        // Pulled a pixel past each edge so the strip covers the card border
+        // rather than sitting inside it.
+        <span
+          aria-hidden="true"
+          className="bg-gradient-primary absolute -top-px -right-px -left-px h-[3px]"
+        />
+      )}
+
+      <span className="flex items-center gap-2.5">
+        <span className="text-muted-foreground font-mono text-[11px] tracking-[0.06em]">
+          {card.index}
+        </span>
+        {card.recommended && (
+          <span className="border-foreground text-foreground border px-1.5 py-px font-mono text-[9px] tracking-[0.08em] uppercase">
+            Recommended
+          </span>
+        )}
+      </span>
+
+      <span className="text-foreground max-w-[22ch] text-[23px] leading-[1.2]">
+        {card.title}
+      </span>
+      <span className="text-muted-foreground text-[13px] leading-[1.6]">
+        {card.body}
+      </span>
+
+      <span className="text-foreground mt-auto flex items-center gap-2.5 font-mono text-[13px]">
+        {card.cta}
+        <span
+          aria-hidden="true"
+          className="text-muted-foreground transition-transform group-hover:translate-x-0.5"
+        >
+          →
+        </span>
+      </span>
+      <span className="text-muted-foreground font-mono text-[10.5px] tracking-[0.04em]">
+        {card.meta}
+      </span>
+    </Link>
+  );
+}

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/components/brand-mesh";
 import { useOrganization } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
+import { useOnboardingCta } from "@/hooks/useOnboardingCta";
 import { useOrgWelcomeBanner } from "@/hooks/useOrgWelcomeBanner";
 import { getPreferredProject } from "@/lib/preferredProject";
 import { cn } from "@/lib/utils";
@@ -32,6 +33,9 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   const { orgSlug } = useSlugs();
   const orgRoutes = useOrgRoutes();
   const { visible } = useOrgWelcomeBanner();
+  // Same gate as the header's "Finish setup" banner: the wizard is an
+  // enterprise org-admin surface.
+  const { eligible: canSetUpOrg } = useOnboardingCta();
 
   // Same preference order as the overview prefetch on org home.
   const startProject =
@@ -59,15 +63,18 @@ export function OrgWelcomeBanner(): JSX.Element | null {
         : `/${orgSlug}`,
       recommended: true,
     },
-    {
+  ];
+
+  if (canSetUpOrg) {
+    cards.push({
       index: "03",
       title: "Set up the organization",
       body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
       cta: "Start setup wizard",
       meta: "5 steps · resumable",
       to: orgRoutes.setup.href(),
-    },
-  ];
+    });
+  }
 
   if (!visible) return null;
 
@@ -81,11 +88,11 @@ export function OrgWelcomeBanner(): JSX.Element | null {
       <div
         className={cn(
           COLUMN_CLASS,
-          "flex flex-col gap-4 pt-10 pb-10 md:pt-11 md:pb-28",
+          "flex flex-col gap-4 pt-10 pb-10 lg:pt-12 lg:pb-28",
         )}
       >
         <span className="text-eyebrow">Welcome to Speakeasy</span>
-        <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] md:text-[60px]">
+        <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] lg:text-[60px]">
           Choose your
           <br />
           first move
@@ -95,8 +102,15 @@ export function OrgWelcomeBanner(): JSX.Element | null {
       {/* flow-root keeps the cards' negative margin from collapsing out
           through the band, which would drag the band up over the hero. */}
       <div className="bg-background/50 flow-root w-full border-border border-y">
-        <div className={cn(COLUMN_CLASS, "pb-6 md:pb-12")}>
-          <div className="grid grid-cols-1 gap-4 md:-mt-20 md:grid-cols-3">
+        <div className={cn(COLUMN_CLASS, "pt-8 lg:pt-0 pb-8")}>
+          {/* Stacked below lg, side by side above — 2 or 3 across depending
+              on whether the setup card is present. */}
+          <div
+            className={cn(
+              "grid grid-cols-1 gap-4 lg:-mt-20",
+              cards.length === 3 ? "lg:grid-cols-3" : "lg:grid-cols-2",
+            )}
+          >
             {cards.map((card) => (
               <RouteCardLink key={card.index} card={card} />
             ))}

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -68,9 +68,9 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   if (canSetUpOrg) {
     cards.push({
       index: "03",
-      title: "Set up the organization",
+      title: "Start enterprise rollout",
       body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
-      cta: "Start setup wizard",
+      cta: "Begin rollout",
       meta: "5 steps · resumable",
       to: orgRoutes.setup.href(),
     });

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -74,29 +74,28 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   return (
     // Section runs the full width of the content area; the column class below
     // keeps its contents aligned with the rest of the page.
-    <section className="border-muted dark:border-border/50 w-full border-b">
-      <div className={cn(BRAND_MESH_SURFACE_CLASS, "w-full")}>
-        <BrandMeshLayers />
-        {/* Deep bottom padding leaves room for the cards to overlap the hero. */}
-        <div
-          className={cn(
-            COLUMN_CLASS,
-            "flex flex-col gap-4 pt-10 pb-10 md:pt-11 md:pb-28",
-          )}
-        >
-          <span className="text-eyebrow">Welcome to Speakeasy</span>
-          <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] md:text-[60px]">
-            Choose your
-            <br />
-            first move
-          </h2>
-        </div>
+    <section className={cn(BRAND_MESH_SURFACE_CLASS, "w-full")}>
+      {/* Mesh spans the whole banner; the gray band below paints over it. */}
+      <BrandMeshLayers />
+      {/* Deep bottom padding leaves room for the cards to overlap the hero. */}
+      <div
+        className={cn(
+          COLUMN_CLASS,
+          "flex flex-col gap-4 pt-10 pb-10 md:pt-11 md:pb-28",
+        )}
+      >
+        <span className="text-eyebrow">Welcome to Speakeasy</span>
+        <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] md:text-[60px]">
+          Choose your
+          <br />
+          first move
+        </h2>
       </div>
 
       {/* flow-root keeps the cards' negative margin from collapsing out
           through the band, which would drag the band up over the hero. */}
-      <div className="bg-muted/20 flow-root w-full">
-        <div className={cn(COLUMN_CLASS, "pb-6 md:pb-10")}>
+      <div className="bg-background/50 flow-root w-full border-border border-y">
+        <div className={cn(COLUMN_CLASS, "pb-6 md:pb-12")}>
           <div className="grid grid-cols-1 gap-4 md:-mt-20 md:grid-cols-3">
             {cards.map((card) => (
               <RouteCardLink key={card.index} card={card} />
@@ -117,12 +116,12 @@ function RouteCardLink({ card }: { card: RouteCard }): JSX.Element {
       {card.recommended && (
         <span
           aria-hidden="true"
-          className="bg-gradient-primary absolute -top-px -right-px -left-px h-[3px]"
+          className="bg-gradient-primary absolute -top-px -right-px -left-px h-1"
         />
       )}
 
       <span className="flex items-center gap-2.5">
-        <span className="text-muted-foreground font-mono text-[11px] tracking-[0.06em]">
+        <span className="text-muted-foreground font-mono text-xs tracking-wider">
           {card.index}
         </span>
         {card.recommended && (

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -10,6 +10,9 @@ import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
 import { Link } from "react-router";
 
+// Matches the page column OrgHome applies to everything below the banner.
+const COLUMN_CLASS = "mx-auto w-full max-w-7xl px-8";
+
 type RouteCard = {
   index: string;
   title: string;
@@ -69,27 +72,37 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   if (!visible) return null;
 
   return (
-    <section className="border-border border">
-      {/* Deep bottom padding leaves room for the cards to overlap the hero. */}
-      <div
-        className={cn(
-          BRAND_MESH_SURFACE_CLASS,
-          "flex flex-col gap-4 px-6 pt-10 pb-10 md:px-11 md:pt-11 md:pb-28",
-        )}
-      >
+    // Section runs the full width of the content area; the column class below
+    // keeps its contents aligned with the rest of the page.
+    <section className="border-muted dark:border-border/50 w-full border-b">
+      <div className={cn(BRAND_MESH_SURFACE_CLASS, "w-full")}>
         <BrandMeshLayers />
-        <span className="text-eyebrow">Welcome to Speakeasy</span>
-        <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] md:text-[60px]">
-          Choose your
-          <br />
-          first move
-        </h2>
+        {/* Deep bottom padding leaves room for the cards to overlap the hero. */}
+        <div
+          className={cn(
+            COLUMN_CLASS,
+            "flex flex-col gap-4 pt-10 pb-10 md:pt-11 md:pb-28",
+          )}
+        >
+          <span className="text-eyebrow">Welcome to Speakeasy</span>
+          <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] md:text-[60px]">
+            Choose your
+            <br />
+            first move
+          </h2>
+        </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 px-6 pb-6 md:-mt-20 md:grid-cols-3 md:px-11 md:pb-10">
-        {cards.map((card) => (
-          <RouteCardLink key={card.index} card={card} />
-        ))}
+      {/* flow-root keeps the cards' negative margin from collapsing out
+          through the band, which would drag the band up over the hero. */}
+      <div className="bg-muted/20 flow-root w-full">
+        <div className={cn(COLUMN_CLASS, "pb-6 md:pb-10")}>
+          <div className="grid grid-cols-1 gap-4 md:-mt-20 md:grid-cols-3">
+            {cards.map((card) => (
+              <RouteCardLink key={card.index} card={card} />
+            ))}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -3,12 +3,11 @@ import {
   BrandMeshLayers,
 } from "@/components/brand-mesh";
 import { useOrganization } from "@/contexts/Auth";
-import { useSlugs } from "@/contexts/Sdk";
 import { useOnboardingCta } from "@/hooks/useOnboardingCta";
 import { useOrgWelcomeBanner } from "@/hooks/useOrgWelcomeBanner";
 import { getPreferredProject } from "@/lib/preferredProject";
 import { cn } from "@/lib/utils";
-import { useOrgRoutes } from "@/routes";
+import { useOrgRoutes, useRoutes } from "@/routes";
 import { Link } from "react-router";
 
 // Matches the page column OrgHome applies to everything below the banner.
@@ -30,7 +29,6 @@ type RouteCard = {
  */
 export function OrgWelcomeBanner(): JSX.Element | null {
   const organization = useOrganization();
-  const { orgSlug } = useSlugs();
   const orgRoutes = useOrgRoutes();
   const { visible } = useOrgWelcomeBanner();
   // Same gate as the header's "Finish setup" banner: the wizard is an
@@ -43,6 +41,10 @@ export function OrgWelcomeBanner(): JSX.Element | null {
     organization.projects.find((project) => project.slug === "default") ??
     organization.projects[0];
 
+  // Org home has no project slug of its own, so the project routes resolve
+  // against the project card 02 points at.
+  const projectRoutes = useRoutes({ projectSlug: startProject?.slug });
+
   const cards: RouteCard[] = [
     {
       index: "01",
@@ -50,7 +52,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
       body: "A read-only organization with two weeks of simulated agent traffic, spend, and blocked calls.",
       cta: "Enter demo org",
       meta: "Read-only · simulated data",
-      to: "/explore-demo",
+      to: projectRoutes.exploreDemo.href(),
     },
     {
       index: "02",
@@ -58,9 +60,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
       body: "Start getting your own data into the dashboard. Connect an MCP server, or set a policy and watch it block a call.",
       cta: "Start using Speakeasy",
       meta: "~5 minutes · your data",
-      to: startProject
-        ? `/${orgSlug}/projects/${startProject.slug}`
-        : `/${orgSlug}`,
+      to: startProject ? projectRoutes.home.href() : orgRoutes.home.href(),
       recommended: true,
     },
   ];


### PR DESCRIPTION
## Summary

- Adds `OrgWelcomeBanner` to org home: a full-bleed brand-mesh hero over three "first move" route cards — explore the demo org, get started in a project, and start the enterprise rollout. Copy and layout follow the AGE-3102 design handoff.
- Reuses `BrandMeshLayers`, which already matches the handoff's chroma wash and grain and is theme-aware, so the banner needs no palette of its own. The card band is a translucent surface over that gradient and the cards hang up into the hero.
- Card 02 resolves to whichever project the dashboard would send you to anyway — last visited, then `default`, then first in the list, and org home if the org has no projects. All three destinations come from the route table rather than hand-built paths.
- Open to any org member. The demo org and the project card 02 points at need no admin scope, so a member gets those two; card 03 keeps the existing enterprise + admin gate and simply isn't there otherwise, with the grid falling back to two columns. Cards stack below `lg`.
- While the banner shows, the header's "Finish setup" banner stands down — the banner's third card is that same wizard. Both read one flag (`useOrgWelcomeBanner`) so they can't disagree. On org home the card is the entry point; "Finish setup" is unchanged on every other org page, as is the sidebar resume button that appears once it's dismissed.
- Below the banner: search, view toggle, and Add New move into the column they act on, directly above the project list, instead of spanning the full page width as page-level controls. The two rails cap at `max-h-72` and scroll rather than stretching their cards.

## Scope

Org home only. The project-home journeys — the other half of AGE-3102 — ship separately.

The banner currently shows on org home for **everyone**; it does not yet read org state, so it never goes away on its own. Which orgs count as new lands behind the same flag in AGE-3240, and the "Finish setup" suppression follows it with no further change. Dismissal is deliberately not part of this.

<img width="2164" height="1336" alt="image" src="https://github.com/user-attachments/assets/612ec78c-1667-415d-929d-b88de3826933" />

## Test plan

Checked in code and covered by tests:

- [x] Card 03 present only for an enterprise admin, and the grid falls to two columns without it
- [x] Card 02 resolves last-visited → `default` → first project → org home when the org has none
- [x] Banner confined to org home, so "Finish setup" is untouched on every other org page
- [x] `tsc -p tsconfig.app.json --noEmit`, `lint:format`, `lint:oxlint`
- [x] `vitest run src/pages/org src/components/onboarding-banner.test.tsx` — 32 passing

Needs a browser:

- [x] Banner renders full bleed, hero and cards align with the column below
- [x] Light and dark, and below `lg` where the cards stack
- [x] Right rail lists scroll rather than stretching their cards
- [x] Member (non-admin) sees two cards across, no "Finish setup" in the header

