### PR TITLE
feat: activate PAYG from completed Stripe checkout

### DIFF
--- a/.changeset/activate-payg-checkout.md
+++ b/.changeset/activate-payg-checkout.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Activate pay-as-you-go billing atomically when Stripe confirms a completed checkout, including replay-safe webhook processing, subscription ownership validation, trial conversion, and entitlement setup for organizations without a prior trial.

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -81,6 +81,7 @@ export const AUDIT_ACTIONS = [
   "organization:enterprise_trial_rearmed",
   "organization:hooks_fail_open_disabled",
   "organization:hooks_fail_open_enabled",
+  "organization:payg_activated",
   "organization:webhooks_disabled",
   "organization:webhooks_enabled",
   "organization_invitation:create",
@@ -379,6 +380,8 @@ export function staticActionPhrase(action: AuditAction): string {
       return "extended enterprise trial";
     case "organization:enterprise_trial_rearmed":
       return "restarted enterprise trial";
+    case "organization:payg_activated":
+      return "activated pay-as-you-go billing for";
 
     case "organization_invitation:create":
       return "invited";

--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -102,7 +102,7 @@ flowchart LR
   s_gram_risk_v1_prompt_policy_analyzer --> c20
   c21[\"📥<br/>server/cmd/gram/streams.go<br/>new"\]:::go
   s_gram_telemetry_v1_noop --> c21
-  c22[\"📥<br/>server/cmd/gram/streams.go<br/>svixRelayHandler"\]:::go
+  c22[\"📥<br/>server/cmd/gram/streams.go<br/>webhookEventHandler"\]:::go
   s_gram_webhooks_v1_svix_relay --> c22
 ```
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1451,7 +1451,7 @@ func newStartCommand() *cli.Command {
 			chat.Attach(mux, chatService)
 			variations.Attach(mux, variations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			customdomains.Attach(mux, customdomains.NewService(logger, tracerProvider, db, sessionManager, &background.CustomDomainRegistrationClient{TemporalEnv: temporalEnv}, authzEngine, auditLogger))
-			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, siteURL, posthogClient, openRouter, openRouterKeyRefresher, stripeClient, authzEngine, telemetryrepo.New(chDB), auditLogger, featureFlags, productFeatures, trialEmailNotifier))
+			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, siteURL, posthogClient, openRouter, stripeClient, authzEngine, telemetryrepo.New(chDB), auditLogger, featureFlags, productFeatures, trialEmailNotifier))
 			tm.Attach(mux, telemSvc)
 			functions.Attach(mux, functions.NewService(logger, tracerProvider, db, encryptionClient, tigrisStore))
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -712,6 +712,7 @@ func newStartCommand() *cli.Command {
 				return err
 			}
 
+			openRouterKeyRefresher := &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}
 			var openRouter interface {
 				openrouter.Provisioner
 				openrouter.SpendClient
@@ -726,7 +727,7 @@ func newStartCommand() *cli.Command {
 					db,
 					c.String("environment"),
 					c.String("openrouter-provisioning-key"),
-					&background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv},
+					openRouterKeyRefresher,
 					productFeatures,
 					billingTracker,
 					encryptionClient,
@@ -1450,7 +1451,7 @@ func newStartCommand() *cli.Command {
 			chat.Attach(mux, chatService)
 			variations.Attach(mux, variations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			customdomains.Attach(mux, customdomains.NewService(logger, tracerProvider, db, sessionManager, &background.CustomDomainRegistrationClient{TemporalEnv: temporalEnv}, authzEngine, auditLogger))
-			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, siteURL, posthogClient, openRouter, stripeClient, authzEngine, telemetryrepo.New(chDB), auditLogger, featureFlags, trialEmailNotifier))
+			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, siteURL, posthogClient, openRouter, openRouterKeyRefresher, stripeClient, authzEngine, telemetryrepo.New(chDB), auditLogger, featureFlags, productFeatures, trialEmailNotifier))
 			tm.Attach(mux, telemSvc)
 			functions.Attach(mux, functions.NewService(logger, tracerProvider, db, encryptionClient, tigrisStore))
 

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -33,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -59,6 +60,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/subscribers"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
+	"github.com/speakeasy-api/gram/server/internal/usage"
 	"github.com/speakeasy-api/gram/server/internal/webhooks/svixrelay"
 )
 
@@ -89,6 +91,34 @@ func newStreamsCommand() *cli.Command {
 			Usage:    "Database URL",
 			EnvVars:  []string{"GRAM_DATABASE_URL"},
 			Required: true,
+		},
+		&cli.StringFlag{
+			Name:    "temporal-address",
+			Usage:   "The address of the temporal server",
+			EnvVars: []string{"TEMPORAL_ADDRESS"},
+			Value:   "localhost:7233",
+		},
+		&cli.StringFlag{
+			Name:    "temporal-namespace",
+			Usage:   "The temporal namespace to use",
+			EnvVars: []string{"TEMPORAL_NAMESPACE"},
+			Value:   "default",
+		},
+		&cli.StringFlag{
+			Name:    "temporal-task-queue",
+			Usage:   "Task queue of the Temporal server",
+			EnvVars: []string{"TEMPORAL_TASK_QUEUE"},
+			Value:   "main",
+		},
+		&cli.StringFlag{
+			Name:    "temporal-client-cert",
+			Usage:   "Client cert of the Temporal server",
+			EnvVars: []string{"TEMPORAL_CLIENT_CERT"},
+		},
+		&cli.StringFlag{
+			Name:    "temporal-client-key",
+			Usage:   "Client key of the Temporal server",
+			EnvVars: []string{"TEMPORAL_CLIENT_KEY"},
 		},
 		&cli.StringFlag{
 			Name:     "encryption-key",
@@ -270,6 +300,22 @@ func newStreamsCommand() *cli.Command {
 				return fmt.Errorf("embedded descriptor set is empty: cannot generate pubsub topology")
 			}
 
+			temporalEnv, shutdown, err := newTemporalClient(logger, meterProvider, temporalClientOptions{
+				address:      c.String("temporal-address"),
+				namespace:    c.String("temporal-namespace"),
+				taskQueue:    c.String("temporal-task-queue"),
+				certPEMBlock: []byte(c.String("temporal-client-cert")),
+				keyPEMBlock:  []byte(c.String("temporal-client-key")),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create temporal client: %w", err)
+			}
+			if temporalEnv == nil {
+				return errors.New("insufficient options to create temporal client")
+			}
+			shutdownFuncs = append(shutdownFuncs, shutdown)
+			openRouterKeyRefresher := &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}
+
 			db, err := newDBClient(ctx, logger, meterProvider, c.String("database-url"), dbClientOptions{
 				enableUnsafeLogging: c.Bool("unsafe-db-log"),
 			})
@@ -399,7 +445,7 @@ func newStreamsCommand() *cli.Command {
 					[]*o11y.NamedResource[*o11y.HTTPEndpoint]{},
 					[]*o11y.NamedResource[*pgxpool.Pool]{{Name: "read-replica", Resource: replicaDB}},
 					[]*o11y.NamedResource[*redis.Client]{{Name: "default", Resource: redisClient}},
-					[]*o11y.NamedResource[client.Client]{},
+					[]*o11y.NamedResource[client.Client]{{Name: "default", Resource: temporalEnv.Client()}},
 				))
 				if err != nil {
 					return fmt.Errorf("failed to start control server: %w", err)
@@ -434,6 +480,13 @@ func newStreamsCommand() *cli.Command {
 			shutdownFuncs = append(shutdownFuncs, svixShutdown)
 
 			svixRelayHandler := svixrelay.NewHandler(logger, meterProvider, db, svixClient)
+			paygKeyRefreshHandler := usage.NewPaygKeyRefreshHandler(logger, openRouterKeyRefresher)
+			webhookEventHandler := streams.HandlerFunc[*webhooksv1.Event](func(ctx context.Context, event *webhooksv1.Event, metadata gcp.MessageMetadata) error {
+				if err := paygKeyRefreshHandler.Handle(ctx, event, metadata); err != nil {
+					return fmt.Errorf("schedule PAYG key refresh: %w", err)
+				}
+				return svixRelayHandler.Handle(ctx, event, metadata)
+			})
 
 			pingLogLevel := conv.Ternary(c.String("environment") == "local", slog.LevelInfo, slog.LevelDebug)
 
@@ -448,7 +501,7 @@ func newStreamsCommand() *cli.Command {
 
 				mustReceive(rg, &telemetryv1.LogRecord{}, &telemetryv1.Noop{}, new(subscribers.NoopHandler[*telemetryv1.LogRecord]))
 
-				mustReceive(rg, &webhooksv1.Event{}, &webhooksv1.SvixRelay{}, svixRelayHandler)
+				mustReceive(rg, &webhooksv1.Event{}, &webhooksv1.SvixRelay{}, webhookEventHandler)
 
 				mustReceive(
 					rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{},

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -27,11 +27,11 @@ const (
 
 	ActionOrganizationEnterpriseTrialArmed Action = "organization:enterprise_trial_armed"
 
-	ActionOrganizationEnterpriseTrialDemoted Action = "organization:enterprise_trial_demoted"
-
-	ActionOrganizationEnterpriseTrialRearmed Action = "organization:enterprise_trial_rearmed"
-
+	ActionOrganizationEnterpriseTrialDemoted  Action = "organization:enterprise_trial_demoted"
+	ActionOrganizationEnterpriseTrialRearmed  Action = "organization:enterprise_trial_rearmed"
 	ActionOrganizationEnterpriseTrialExtended Action = "organization:enterprise_trial_extended"
+
+	ActionOrganizationPaygActivated Action = "organization:payg_activated"
 )
 
 type LogOrganizationInviteCreateEvent struct {
@@ -532,4 +532,57 @@ func (l *Logger) LogOrganizationEnterpriseTrialDemoted(ctx context.Context, dbtx
 	}
 
 	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationEnterpriseTrialV1})
+}
+
+type OrganizationPaygActivationSnapshot struct {
+	AccountType string `json:"account_type"`
+	Whitelisted bool   `json:"whitelisted"`
+}
+
+type LogOrganizationPaygActivatedEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	OrganizationName string
+	OrganizationSlug string
+
+	OrganizationSnapshotBefore *OrganizationPaygActivationSnapshot
+	OrganizationSnapshotAfter  *OrganizationPaygActivationSnapshot
+}
+
+func (l *Logger) LogOrganizationPaygActivated(ctx context.Context, dbtx repo.DBTX, event LogOrganizationPaygActivatedEvent) error {
+	beforeSnapshot, err := marshalAuditPayload(event.OrganizationSnapshotBefore)
+	if err != nil {
+		return fmt.Errorf("marshal %s before snapshot: %w", ActionOrganizationPaygActivated, err)
+	}
+	afterSnapshot, err := marshalAuditPayload(event.OrganizationSnapshotAfter)
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", ActionOrganizationPaygActivated, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(ActionOrganizationPaygActivated),
+
+		SubjectID:          event.OrganizationID,
+		SubjectType:        "organization",
+		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.OrganizationSlug),
+
+		Metadata:       nil,
+		BeforeSnapshot: beforeSnapshot,
+		AfterSnapshot:  afterSnapshot,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationBillingV1})
 }

--- a/server/internal/background/openrouter_key_refresh.go
+++ b/server/internal/background/openrouter_key_refresh.go
@@ -2,6 +2,7 @@ package background
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -34,6 +36,34 @@ func (w *OpenRouterKeyRefresher) ScheduleOpenRouterKeyRefresh(ctx context.Contex
 		KeyType: string(keyType),
 	})
 	return err
+}
+
+// SchedulePaygOpenRouterKeyRefresh uses the durable outbox event ID as the
+// workflow identity, so Pub/Sub redelivery cannot start the same refresh twice.
+func (w *OpenRouterKeyRefresher) SchedulePaygOpenRouterKeyRefresh(ctx context.Context, eventID, orgID string, keyType openrouter.KeyType, limit *int) error {
+	if err := keyType.Validate(); err != nil {
+		return fmt.Errorf("refresh openrouter key workflow: %w", err)
+	}
+
+	_, err := w.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    fmt.Sprintf("v1:openrouter-key-refresh:payg-activation:%s", eventID),
+		TaskQueue:             string(w.TemporalEnv.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+		WorkflowRunTimeout:    3 * time.Minute,
+	}, OpenrouterKeyRefreshWorkflow, OpenRouterKeyRefreshParams{
+		OrgID:   orgID,
+		Limit:   limit,
+		KeyType: string(keyType),
+	})
+	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+	switch {
+	case errors.As(err, &alreadyStarted):
+		return nil
+	case err != nil:
+		return fmt.Errorf("start PAYG openrouter key refresh workflow: %w", err)
+	default:
+		return nil
+	}
 }
 
 // Called by your service to start (or restart) the workflow

--- a/server/internal/background/openrouter_key_refresh.go
+++ b/server/internal/background/openrouter_key_refresh.go
@@ -27,10 +27,10 @@ type OpenRouterKeyRefresher struct {
 	TemporalEnv *tenv.Environment
 }
 
-func (w *OpenRouterKeyRefresher) ScheduleOpenRouterKeyRefresh(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
+func (w *OpenRouterKeyRefresher) ScheduleOpenRouterKeyRefresh(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) error {
 	_, err := ExecuteOpenrouterKeyRefreshWorkflow(ctx, w.TemporalEnv, OpenRouterKeyRefreshParams{
 		OrgID:   orgID,
-		Limit:   nil,
+		Limit:   limit,
 		KeyType: string(keyType),
 	})
 	return err

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -44,6 +44,7 @@ var (
 	ModelProviderKeyV1                     = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.model_provider_key_event_v1", "Emitted when changes to customer model provider keys are made")
 	OpenRouterAPIKeyV1                     = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.openrouter_api_key_event_v1", "Emitted when changes to the organization's platform OpenRouter key are made")
 	OrganizationHooksFailOpenV1            = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_hooks_fail_open_event_v1", "Emitted when the organization's hooks fail-open setting is toggled")
+	OrganizationBillingV1                  = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_billing_event_v1", "Emitted when the organization's billing state changes")
 	OrganizationDeviceAgentConfigurationV1 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_device_agent_configuration_event_v1", "Emitted when the organization's device-agent configuration is changed")
 	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed")
 	OrganizationInviteV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_invite_event_v1", "Emitted when changes to organization invites are made")

--- a/server/internal/outbox/events/catalog_gen.go
+++ b/server/internal/outbox/events/catalog_gen.go
@@ -35,6 +35,7 @@ var All = []outbox.EventRegistration{
 	McpServerV1,
 	ModelProviderKeyV1,
 	OpenRouterAPIKeyV1,
+	OrganizationBillingV1,
 	OrganizationDeviceAgentConfigurationV1,
 	OrganizationEnterpriseTrialV1,
 	OrganizationHooksFailOpenV1,

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -1570,6 +1570,60 @@ webhooks:
                                 - subject_type
                             type: object
                 required: true
+    audit_log.organization_billing_event_v1:
+        post:
+            description: Emitted when the organization's billing state changes
+            operationId: audit_log.organization_billing_event_v1
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            additionalProperties: false
+                            properties:
+                                action:
+                                    type: string
+                                actor_display_name:
+                                    type: string
+                                actor_id:
+                                    type: string
+                                actor_slug:
+                                    type: string
+                                actor_type:
+                                    type: string
+                                after_snapshot:
+                                    additionalProperties: true
+                                before_snapshot:
+                                    additionalProperties: true
+                                id:
+                                    format: uuid
+                                    type: string
+                                metadata:
+                                    additionalProperties: true
+                                organization_id:
+                                    type: string
+                                project_id:
+                                    format: uuid
+                                    type:
+                                        - string
+                                        - "null"
+                                subject_display_name:
+                                    type: string
+                                subject_id:
+                                    type: string
+                                subject_slug:
+                                    type: string
+                                subject_type:
+                                    type: string
+                            required:
+                                - id
+                                - organization_id
+                                - actor_id
+                                - actor_type
+                                - action
+                                - subject_id
+                                - subject_type
+                            type: object
+                required: true
     audit_log.organization_device_agent_configuration_event_v1:
         post:
             description: Emitted when the organization's device-agent configuration is changed

--- a/server/internal/productfeatures/bundle_test.go
+++ b/server/internal/productfeatures/bundle_test.go
@@ -39,3 +39,52 @@ func TestSeedEnterpriseTrialBundleTx_Idempotent(t *testing.T) {
 		require.Truef(t, enabled, "feature %s should remain enabled after a replayed seed", feature)
 	}
 }
+
+func TestSeedPaygEntitlementsTxPreservesExplicitDisable(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestProductFeaturesService(t)
+	organizationID := activeOrganizationID(t, ctx)
+	seedOrganization(t, ctx, ti.conn, organizationID)
+
+	q := featurerepo.New(ti.conn)
+	_, err := q.EnableFeature(ctx, featurerepo.EnableFeatureParams{
+		OrganizationID: organizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+	_, err = q.DeleteFeature(ctx, featurerepo.DeleteFeatureParams{
+		OrganizationID: organizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+
+	tx := testenv.BeginTx(t, ctx, ti.conn)
+	enabled, err := productfeatures.SeedPaygEntitlementsTx(ctx, tx, organizationID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+	require.NotContains(t, enabled, productfeatures.FeatureSSO)
+
+	ssoEnabled, err := q.IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+		OrganizationID: organizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+	require.False(t, ssoEnabled)
+
+	for _, feature := range slices.Concat(
+		[]productfeatures.Feature{productfeatures.FeaturePlatformMCP},
+		productfeatures.EnterpriseTrialBundle,
+		[]productfeatures.Feature{productfeatures.FeatureSkills},
+	) {
+		if feature == productfeatures.FeatureSSO {
+			continue
+		}
+		featureEnabled, err := q.IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+		require.Truef(t, featureEnabled, "feature %s should be enabled", feature)
+	}
+}

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -205,6 +205,41 @@ func SeedEnterpriseTrialBundleTx(ctx context.Context, tx pgx.Tx, organizationID 
 	return nil
 }
 
+// SeedPaygEntitlementsTx grants PAYG capabilities only when an organization
+// has never configured them. A soft-deleted feature remains disabled. The
+// returned features are the rows this transaction inserted, so callers can
+// update caches after commit without exposing uncommitted state.
+func SeedPaygEntitlementsTx(ctx context.Context, tx pgx.Tx, organizationID string) ([]Feature, error) {
+	q := repo.New(tx)
+	features := make([]Feature, 0, len(EnterpriseTrialBundle)+2)
+	features = append(features, FeaturePlatformMCP)
+	features = append(features, EnterpriseTrialBundle...)
+	features = append(features, FeatureSkills)
+
+	enabled := make([]Feature, 0, len(features))
+	for _, feature := range features {
+		inserted, err := q.EnableFeatureIfNeverConfigured(ctx, repo.EnableFeatureIfNeverConfiguredParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("enable new PAYG entitlement %s: %w", feature, err)
+		}
+		if inserted == 0 {
+			continue
+		}
+
+		if feature == FeatureSkills {
+			if err := provisionSkillsSystemRoleGrantsTx(ctx, tx, organizationID); err != nil {
+				return nil, fmt.Errorf("provision PAYG Skills grants: %w", err)
+			}
+		}
+		enabled = append(enabled, feature)
+	}
+
+	return enabled, nil
+}
+
 // EnableSkillsTx provisions the built-in Skills grants and enables the
 // org-level Skills feature in the caller's transaction. Existing grants and
 // exclusions are preserved.

--- a/server/internal/productfeatures/queries.sql
+++ b/server/internal/productfeatures/queries.sql
@@ -34,6 +34,23 @@ INSERT INTO organization_features (
 ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE
 DO NOTHING;
 
+-- name: EnableFeatureIfNeverConfigured :execrows
+-- PAYG activation grants purchased capabilities to legacy organizations while
+-- preserving a soft-deleted row as an explicit administrator choice.
+INSERT INTO organization_features (
+    organization_id,
+    feature_name
+)
+SELECT @organization_id, @feature_name
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM organization_features
+    WHERE organization_id = @organization_id
+      AND feature_name = @feature_name
+)
+ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE
+DO NOTHING;
+
 -- name: DeleteFeature :one
 UPDATE organization_features
 SET deleted_at = clock_timestamp(),

--- a/server/internal/productfeatures/repo/queries.sql.go
+++ b/server/internal/productfeatures/repo/queries.sql.go
@@ -64,6 +64,37 @@ func (q *Queries) EnableFeature(ctx context.Context, arg EnableFeatureParams) (i
 	return result.RowsAffected(), nil
 }
 
+const enableFeatureIfNeverConfigured = `-- name: EnableFeatureIfNeverConfigured :execrows
+INSERT INTO organization_features (
+    organization_id,
+    feature_name
+)
+SELECT $1, $2
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM organization_features
+    WHERE organization_id = $1
+      AND feature_name = $2
+)
+ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE
+DO NOTHING
+`
+
+type EnableFeatureIfNeverConfiguredParams struct {
+	OrganizationID string
+	FeatureName    string
+}
+
+// PAYG activation grants purchased capabilities to legacy organizations while
+// preserving a soft-deleted row as an explicit administrator choice.
+func (q *Queries) EnableFeatureIfNeverConfigured(ctx context.Context, arg EnableFeatureIfNeverConfiguredParams) (int64, error) {
+	result, err := q.db.Exec(ctx, enableFeatureIfNeverConfigured, arg.OrganizationID, arg.FeatureName)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const hasDeviceAgentSync = `-- name: HasDeviceAgentSync :one
 SELECT EXISTS (
         SELECT 1

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -251,7 +251,7 @@ type Provisioner interface {
 }
 
 type KeyRefresher interface {
-	ScheduleOpenRouterKeyRefresh(ctx context.Context, orgID string, keyType KeyType) error
+	ScheduleOpenRouterKeyRefresh(ctx context.Context, orgID string, keyType KeyType, limit *int) error
 }
 
 type OpenRouter struct {
@@ -441,7 +441,7 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 	}
 
 	if o.refresher != nil {
-		if err := o.refresher.ScheduleOpenRouterKeyRefresh(ctx, orgID, keyType); err != nil {
+		if err := o.refresher.ScheduleOpenRouterKeyRefresh(ctx, orgID, keyType, nil); err != nil {
 			return "", oops.E(oops.CodeUnexpected, err, "error scheduling open router key refresh").LogError(ctx, o.logger)
 		}
 	}

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -56,6 +56,7 @@ func IsConfigured(value string) bool {
 type Client interface {
 	CreateCustomer(context.Context, CreateCustomerInput) (*Customer, error)
 	CreateCheckoutSession(context.Context, CreateCheckoutSessionInput) (*CheckoutSession, error)
+	GetCheckoutSession(context.Context, string) (*CheckoutSessionState, error)
 	CreateMeterEvent(context.Context, CreateMeterEventInput) error
 	VerifyWebhook(payload []byte, signature string) (*WebhookEvent, error)
 	Catalog() Catalog
@@ -103,6 +104,17 @@ type CheckoutSession struct {
 	URL string
 }
 
+// CheckoutSessionState is the current Stripe state used to activate PAYG.
+type CheckoutSessionState struct {
+	ID                     string
+	Status                 string
+	CustomerID             string
+	SubscriptionID         string
+	SubscriptionCustomerID string
+	SubscriptionStatus     string
+	BillingCycleAnchor     time.Time
+}
+
 // CreateMeterEventInput reports a TUM delta for one Stripe customer.
 type CreateMeterEventInput struct {
 	CustomerID     string
@@ -127,11 +139,15 @@ type WebhookEvent struct {
 
 	// CustomerID is the normalized customer identifier carried by the data object, when present.
 	CustomerID string
+
+	// SubscriptionID is the normalized subscription identifier carried by the data object, when present.
+	SubscriptionID string
 }
 
 type stripeAPI interface {
 	createCustomer(context.Context, *stripesdk.CustomerCreateParams) (*stripesdk.Customer, error)
 	createCheckoutSession(context.Context, *stripesdk.CheckoutSessionCreateParams) (*stripesdk.CheckoutSession, error)
+	retrieveCheckoutSession(context.Context, string, *stripesdk.CheckoutSessionRetrieveParams) (*stripesdk.CheckoutSession, error)
 	createMeterEvent(context.Context, *stripesdk.BillingMeterEventCreateParams) (*stripesdk.BillingMeterEvent, error)
 }
 
@@ -151,6 +167,14 @@ func (s *sdkAPI) createCheckoutSession(ctx context.Context, params *stripesdk.Ch
 	session, err := s.client.V1CheckoutSessions.Create(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("stripe SDK create Checkout session: %w", err)
+	}
+	return session, nil
+}
+
+func (s *sdkAPI) retrieveCheckoutSession(ctx context.Context, id string, params *stripesdk.CheckoutSessionRetrieveParams) (*stripesdk.CheckoutSession, error) {
+	session, err := s.client.V1CheckoutSessions.Retrieve(ctx, id, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe SDK retrieve Checkout session: %w", err)
 	}
 	return session, nil
 }
@@ -249,6 +273,44 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	return &CheckoutSession{URL: session.URL}, nil
 }
 
+func (c *client) GetCheckoutSession(ctx context.Context, id string) (*CheckoutSessionState, error) {
+	params := new(stripesdk.CheckoutSessionRetrieveParams)
+	params.AddExpand("subscription")
+
+	session, err := c.api.retrieveCheckoutSession(ctx, id, params)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve Stripe Checkout session: %w", err)
+	}
+	if session == nil {
+		return nil, errors.New("retrieve Stripe Checkout session: empty response")
+	}
+
+	state := &CheckoutSessionState{
+		ID:                     session.ID,
+		Status:                 string(session.Status),
+		CustomerID:             "",
+		SubscriptionID:         "",
+		SubscriptionCustomerID: "",
+		SubscriptionStatus:     "",
+		BillingCycleAnchor:     time.Time{},
+	}
+	if session.Customer != nil {
+		state.CustomerID = session.Customer.ID
+	}
+	if session.Subscription != nil {
+		state.SubscriptionID = session.Subscription.ID
+		state.SubscriptionStatus = string(session.Subscription.Status)
+		if session.Subscription.Customer != nil {
+			state.SubscriptionCustomerID = session.Subscription.Customer.ID
+		}
+		if session.Subscription.BillingCycleAnchor > 0 {
+			state.BillingCycleAnchor = time.Unix(session.Subscription.BillingCycleAnchor, 0).UTC()
+		}
+	}
+
+	return state, nil
+}
+
 func (c *client) CreateMeterEvent(ctx context.Context, input CreateMeterEventInput) error {
 	if input.IdempotencyKey == "" {
 		return errMissingIdempotencyKey
@@ -287,46 +349,53 @@ func (c *client) VerifyWebhook(payload []byte, signature string) (*WebhookEvent,
 
 	var objectID string
 	var customerID string
+	var subscriptionID string
 	if event.Data != nil {
-		objectID, customerID, err = webhookObjectIdentifiers(event.Data.Raw)
+		objectID, customerID, subscriptionID, err = webhookObjectIdentifiers(event.Data.Raw)
 		if err != nil {
 			return nil, fmt.Errorf("parse Stripe webhook data object: %w", err)
 		}
 	}
 	return &WebhookEvent{
-		ID:         event.ID,
-		Type:       string(event.Type),
-		Created:    time.Unix(event.Created, 0),
-		ObjectID:   objectID,
-		CustomerID: customerID,
+		ID:             event.ID,
+		Type:           string(event.Type),
+		Created:        time.Unix(event.Created, 0),
+		ObjectID:       objectID,
+		CustomerID:     customerID,
+		SubscriptionID: subscriptionID,
 	}, nil
 }
 
-func webhookObjectIdentifiers(raw json.RawMessage) (string, string, error) {
+func webhookObjectIdentifiers(raw json.RawMessage) (string, string, string, error) {
 	var object *struct {
-		ID       string          `json:"id"`
-		Customer json.RawMessage `json:"customer"`
+		ID           string          `json:"id"`
+		Customer     json.RawMessage `json:"customer"`
+		Subscription json.RawMessage `json:"subscription"`
 	}
 	if err := json.Unmarshal(raw, &object); err != nil {
-		return "", "", fmt.Errorf("decode data object: %w", err)
+		return "", "", "", fmt.Errorf("decode data object: %w", err)
 	}
 	if object == nil {
-		return "", "", errors.New("data object is null")
+		return "", "", "", errors.New("data object is null")
 	}
 
-	var customerID string
-	if err := json.Unmarshal(object.Customer, &customerID); err == nil {
-		return object.ID, customerID, nil
+	return object.ID, expandedObjectID(object.Customer), expandedObjectID(object.Subscription), nil
+}
+
+func expandedObjectID(raw json.RawMessage) string {
+	var id string
+	if err := json.Unmarshal(raw, &id); err == nil {
+		return id
 	}
 
-	var customer struct {
+	var object struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(object.Customer, &customer); err == nil {
-		return object.ID, customer.ID, nil
+	if err := json.Unmarshal(raw, &object); err == nil {
+		return object.ID
 	}
 
-	return object.ID, "", nil
+	return ""
 }
 
 func (c *client) Catalog() Catalog {
@@ -350,6 +419,10 @@ func (s *stubClient) CreateCustomer(ctx context.Context, _ CreateCustomerInput) 
 func (s *stubClient) CreateCheckoutSession(ctx context.Context, input CreateCheckoutSessionInput) (*CheckoutSession, error) {
 	s.logger.DebugContext(ctx, "stub Stripe Checkout session creation skipped")
 	return &CheckoutSession{URL: fmt.Sprintf("http://localhost:3000/%s/billing", url.PathEscape(input.OrganizationSlug))}, nil
+}
+
+func (s *stubClient) GetCheckoutSession(context.Context, string) (*CheckoutSessionState, error) {
+	return nil, errors.New("retrieve Stripe Checkout session is unavailable locally")
 }
 
 func (s *stubClient) CreateMeterEvent(ctx context.Context, _ CreateMeterEventInput) error {

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -80,11 +80,13 @@ func TestSDKPinsExpectedAPIVersion(t *testing.T) {
 }
 
 type fakeStripeAPI struct {
-	customerParams        *stripesdk.CustomerCreateParams
-	checkoutSessionParams *stripesdk.CheckoutSessionCreateParams
-	meterEventParams      *stripesdk.BillingMeterEventCreateParams
-	calls                 int
-	err                   error
+	customerParams         *stripesdk.CustomerCreateParams
+	checkoutSessionParams  *stripesdk.CheckoutSessionCreateParams
+	checkoutRetrieveParams *stripesdk.CheckoutSessionRetrieveParams
+	checkoutSession        *stripesdk.CheckoutSession
+	meterEventParams       *stripesdk.BillingMeterEventCreateParams
+	calls                  int
+	err                    error
 }
 
 func (f *fakeStripeAPI) createCustomer(_ context.Context, params *stripesdk.CustomerCreateParams) (*stripesdk.Customer, error) {
@@ -97,6 +99,12 @@ func (f *fakeStripeAPI) createCheckoutSession(_ context.Context, params *stripes
 	f.calls++
 	f.checkoutSessionParams = params
 	return &stripesdk.CheckoutSession{URL: "https://checkout.stripe.test/session"}, f.err
+}
+
+func (f *fakeStripeAPI) retrieveCheckoutSession(_ context.Context, _ string, params *stripesdk.CheckoutSessionRetrieveParams) (*stripesdk.CheckoutSession, error) {
+	f.calls++
+	f.checkoutRetrieveParams = params
+	return f.checkoutSession, f.err
 }
 
 func (f *fakeStripeAPI) createMeterEvent(_ context.Context, params *stripesdk.BillingMeterEventCreateParams) (*stripesdk.BillingMeterEvent, error) {
@@ -200,6 +208,35 @@ func TestCreateCheckoutSessionRejectsMissingIdempotencyKey(t *testing.T) {
 	require.Zero(t, api.calls)
 }
 
+func TestGetCheckoutSessionExpandsSubscription(t *testing.T) {
+	t.Parallel()
+
+	anchor := time.Date(2026, time.August, 21, 9, 30, 0, 0, time.UTC)
+	api := &fakeStripeAPI{checkoutSession: &stripesdk.CheckoutSession{
+		ID:       "cs_test",
+		Status:   stripesdk.CheckoutSessionStatusComplete,
+		Customer: &stripesdk.Customer{ID: "cus_test"},
+		Subscription: &stripesdk.Subscription{
+			ID:                 "sub_test",
+			Customer:           &stripesdk.Customer{ID: "cus_test"},
+			Status:             stripesdk.SubscriptionStatusTrialing,
+			BillingCycleAnchor: anchor.Unix(),
+		},
+	}}
+
+	state, err := (&client{api: api}).GetCheckoutSession(t.Context(), "cs_test")
+	require.NoError(t, err)
+	require.Equal(t, "cs_test", state.ID)
+	require.Equal(t, "complete", state.Status)
+	require.Equal(t, "cus_test", state.CustomerID)
+	require.Equal(t, "sub_test", state.SubscriptionID)
+	require.Equal(t, "cus_test", state.SubscriptionCustomerID)
+	require.Equal(t, "trialing", state.SubscriptionStatus)
+	require.Equal(t, anchor, state.BillingCycleAnchor)
+	require.Len(t, api.checkoutRetrieveParams.Expand, 1)
+	require.Equal(t, "subscription", stripesdk.StringValue(api.checkoutRetrieveParams.Expand[0]))
+}
+
 func TestCreateMeterEventPropagatesIdempotencyKey(t *testing.T) {
 	t.Parallel()
 
@@ -279,6 +316,7 @@ func TestVerifyWebhook(t *testing.T) {
 	require.Equal(t, created, event.Created)
 	require.Equal(t, "in_test", event.ObjectID)
 	require.Equal(t, "cus_test", event.CustomerID)
+	require.Empty(t, event.SubscriptionID)
 }
 
 func TestVerifyWebhookExtractsExpandedCustomer(t *testing.T) {
@@ -394,6 +432,24 @@ func TestVerifyWebhookExtractsCustomersForAcceptedEventTypes(t *testing.T) {
 		require.Equalf(t, "obj_test", event.ObjectID, "%s: object id", tt.name)
 		require.Equalf(t, tt.customerID, event.CustomerID, "%s: customer id", tt.name)
 	}
+}
+
+func TestVerifyWebhookExtractsCheckoutSubscription(t *testing.T) {
+	t.Parallel()
+
+	const secret = "whsec_test"
+	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
+		Payload: webhookPayloadForType(t, stripesdk.APIVersion, time.Now(), "checkout.session.completed", map[string]any{
+			"id":           "cs_test",
+			"customer":     "cus_test",
+			"subscription": "sub_test",
+		}),
+		Secret: secret,
+	})
+
+	event, err := (&client{webhookSecret: secret}).VerifyWebhook(signed.Payload, signed.Header)
+	require.NoError(t, err)
+	require.Equal(t, "sub_test", event.SubscriptionID)
 }
 
 func TestVerifyWebhookRejectsMalformedDataObject(t *testing.T) {

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -93,6 +93,10 @@ func (c *checkoutStripeClient) CreateCheckoutSession(_ context.Context, input st
 	return &stripeclient.CheckoutSession{URL: checkoutURL}, nil
 }
 
+func (c *checkoutStripeClient) GetCheckoutSession(context.Context, string) (*stripeclient.CheckoutSessionState, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (c *checkoutStripeClient) CreateMeterEvent(context.Context, stripeclient.CreateMeterEventInput) error {
 	return errors.New("not implemented")
 }

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -39,55 +40,65 @@ import (
 )
 
 type Service struct {
-	tracer        trace.Tracer
-	logger        *slog.Logger
-	auth          *auth.Auth
-	authz         *authz.Engine
-	serverURL     *url.URL
-	siteURL       *url.URL
-	db            *pgxpool.Pool
-	repo          *repo.Queries
-	billingRepo   billing.Repository
-	orgRepo       *orgRepo.Queries
-	telemetryRepo *telemetryrepo.Queries
-	auditLogger   *audit.Logger
-	posthogClient *posthog.Posthog
-	openRouter    openrouter.Provisioner
-	stripeClient  stripeclient.Client
-	stripeHandler stripeWebhookHandler
-	featureFlags  feature.Provider
-	trial         trialemails.Notifier
+	tracer          trace.Tracer
+	logger          *slog.Logger
+	auth            *auth.Auth
+	authz           *authz.Engine
+	serverURL       *url.URL
+	siteURL         *url.URL
+	db              *pgxpool.Pool
+	repo            *repo.Queries
+	billingRepo     billing.Repository
+	orgRepo         *orgRepo.Queries
+	telemetryRepo   *telemetryrepo.Queries
+	auditLogger     *audit.Logger
+	posthogClient   *posthog.Posthog
+	openRouter      openrouter.Provisioner
+	keyRefresher    openrouter.KeyRefresher
+	stripeClient    stripeclient.Client
+	stripeHandler   stripeWebhookHandler
+	featureFlags    feature.Provider
+	productFeatures productFeatureCacheUpdater
+	trial           trialemails.Notifier
+}
+
+type productFeatureCacheUpdater interface {
+	UpdateFeatureCache(context.Context, string, productfeatures.Feature, bool)
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, billingRepo billing.Repository, serverURL, siteURL *url.URL, posthogClient *posthog.Posthog, openRouter openrouter.Provisioner, stripeClient stripeclient.Client, authzEngine *authz.Engine, telemetryRepo *telemetryrepo.Queries, auditLogger *audit.Logger, featureFlags feature.Provider, trialNotifier trialemails.Notifier) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, billingRepo billing.Repository, serverURL, siteURL *url.URL, posthogClient *posthog.Posthog, openRouter openrouter.Provisioner, keyRefresher openrouter.KeyRefresher, stripeClient stripeclient.Client, authzEngine *authz.Engine, telemetryRepo *telemetryrepo.Queries, auditLogger *audit.Logger, featureFlags feature.Provider, productFeatures *productfeatures.Client, trialNotifier trialemails.Notifier) *Service {
 	logger = logger.With(attr.SlogComponent("usage"))
 
 	if trialNotifier == nil {
 		trialNotifier = trialemails.NoopNotifier{}
 	}
 
-	return &Service{
-		tracer:        tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/usage"),
-		logger:        logger,
-		auth:          auth.New(logger, db, sessions, authzEngine),
-		authz:         authzEngine,
-		serverURL:     serverURL,
-		siteURL:       siteURL,
-		db:            db,
-		repo:          repo.New(db),
-		billingRepo:   billingRepo,
-		orgRepo:       orgRepo.New(db),
-		telemetryRepo: telemetryRepo,
-		auditLogger:   auditLogger,
-		posthogClient: posthogClient,
-		openRouter:    openRouter,
-		stripeClient:  stripeClient,
-		stripeHandler: serviceStripeWebhookHandler,
-		featureFlags:  featureFlags,
-		trial:         trialNotifier,
+	service := &Service{
+		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/usage"),
+		logger:          logger,
+		auth:            auth.New(logger, db, sessions, authzEngine),
+		authz:           authzEngine,
+		serverURL:       serverURL,
+		siteURL:         siteURL,
+		db:              db,
+		repo:            repo.New(db),
+		billingRepo:     billingRepo,
+		orgRepo:         orgRepo.New(db),
+		telemetryRepo:   telemetryRepo,
+		auditLogger:     auditLogger,
+		posthogClient:   posthogClient,
+		openRouter:      openRouter,
+		keyRefresher:    keyRefresher,
+		stripeClient:    stripeClient,
+		stripeHandler:   nil,
+		featureFlags:    featureFlags,
+		productFeatures: productFeatures,
+		trial:           trialNotifier,
 	}
+	service.stripeHandler = service.serviceStripeWebhookHandler
+	return service
 }
 
 func Attach(mux goahttp.Muxer, service *Service) {

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -54,7 +54,6 @@ type Service struct {
 	auditLogger     *audit.Logger
 	posthogClient   *posthog.Posthog
 	openRouter      openrouter.Provisioner
-	keyRefresher    openrouter.KeyRefresher
 	stripeClient    stripeclient.Client
 	stripeHandler   stripeWebhookHandler
 	featureFlags    feature.Provider
@@ -68,7 +67,7 @@ type productFeatureCacheUpdater interface {
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, billingRepo billing.Repository, serverURL, siteURL *url.URL, posthogClient *posthog.Posthog, openRouter openrouter.Provisioner, keyRefresher openrouter.KeyRefresher, stripeClient stripeclient.Client, authzEngine *authz.Engine, telemetryRepo *telemetryrepo.Queries, auditLogger *audit.Logger, featureFlags feature.Provider, productFeatures *productfeatures.Client, trialNotifier trialemails.Notifier) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, billingRepo billing.Repository, serverURL, siteURL *url.URL, posthogClient *posthog.Posthog, openRouter openrouter.Provisioner, stripeClient stripeclient.Client, authzEngine *authz.Engine, telemetryRepo *telemetryrepo.Queries, auditLogger *audit.Logger, featureFlags feature.Provider, productFeatures *productfeatures.Client, trialNotifier trialemails.Notifier) *Service {
 	logger = logger.With(attr.SlogComponent("usage"))
 
 	if trialNotifier == nil {
@@ -90,7 +89,6 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		auditLogger:     auditLogger,
 		posthogClient:   posthogClient,
 		openRouter:      openRouter,
-		keyRefresher:    keyRefresher,
 		stripeClient:    stripeClient,
 		stripeHandler:   nil,
 		featureFlags:    featureFlags,

--- a/server/internal/usage/payg_key_refresh_handler.go
+++ b/server/internal/usage/payg_key_refresh_handler.go
@@ -1,0 +1,84 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+// PaygKeyRefreshHandler schedules the OpenRouter limit refresh represented by
+// a committed PAYG activation audit event.
+type PaygKeyRefreshHandler struct {
+	logger    *slog.Logger
+	refresher PaygKeyRefreshScheduler
+}
+
+// PaygKeyRefreshScheduler starts the idempotent refresh associated with one
+// committed outbox event.
+type PaygKeyRefreshScheduler interface {
+	SchedulePaygOpenRouterKeyRefresh(context.Context, string, string, openrouter.KeyType, *int) error
+}
+
+func NewPaygKeyRefreshHandler(logger *slog.Logger, refresher PaygKeyRefreshScheduler) *PaygKeyRefreshHandler {
+	return &PaygKeyRefreshHandler{
+		logger:    logger.With(attr.SlogComponent("payg-key-refresh")),
+		refresher: refresher,
+	}
+}
+
+func (h *PaygKeyRefreshHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gcp.MessageMetadata) error {
+	if event == nil {
+		h.logger.ErrorContext(ctx, "dropping nil PAYG key refresh event")
+		return nil
+	}
+
+	eventID := event.GetEventId()
+	organizationID := event.GetOrganizationId()
+	if eventID == "" || organizationID == "" || event.GetEventType() != string(events.OrganizationBillingV1.EventType()) {
+		h.logger.ErrorContext(ctx, "dropping invalid PAYG key refresh event",
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogOutboxPublicID(eventID),
+			attr.SlogEvent(event.GetEventType()),
+		)
+		return nil
+	}
+
+	var payload events.AuditLogCreatedPayloadV1
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		h.logger.ErrorContext(ctx, "dropping unreadable PAYG key refresh event",
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogOutboxPublicID(eventID),
+			attr.SlogError(err),
+		)
+		return nil
+	}
+	if payload.Action != string(audit.ActionOrganizationPaygActivated) {
+		return nil
+	}
+	if payload.OrganizationID != organizationID || payload.SubjectID != organizationID || payload.SubjectType != "organization" {
+		h.logger.ErrorContext(ctx, "dropping mismatched PAYG key refresh event",
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogOutboxPublicID(eventID),
+		)
+		return nil
+	}
+	if h.refresher == nil {
+		return errors.New("openrouter key refresh scheduler is unavailable")
+	}
+
+	limit := paygOpenRouterChatCreditLimit
+	if err := h.refresher.SchedulePaygOpenRouterKeyRefresh(ctx, eventID, organizationID, openrouter.KeyTypeChat, &limit); err != nil {
+		return fmt.Errorf("schedule PAYG OpenRouter chat key refresh: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/usage/payg_key_refresh_handler_test.go
+++ b/server/internal/usage/payg_key_refresh_handler_test.go
@@ -1,0 +1,101 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+type capturePaygKeyRefreshScheduler struct {
+	calls          atomic.Int32
+	eventID        string
+	organizationID string
+	limit          int
+	keyType        openrouter.KeyType
+	err            error
+}
+
+func (c *capturePaygKeyRefreshScheduler) SchedulePaygOpenRouterKeyRefresh(_ context.Context, eventID, organizationID string, keyType openrouter.KeyType, limit *int) error {
+	c.calls.Add(1)
+	c.eventID = eventID
+	c.organizationID = organizationID
+	c.keyType = keyType
+	if limit != nil {
+		c.limit = *limit
+	}
+	return c.err
+}
+
+func paygKeyRefreshEvent(t *testing.T) *webhooksv1.Event {
+	t.Helper()
+
+	payload, err := json.Marshal(map[string]any{
+		"organization_id": stripeWebhookOrganizationID,
+		"action":          string(audit.ActionOrganizationPaygActivated),
+		"subject_id":      stripeWebhookOrganizationID,
+		"subject_type":    "organization",
+	})
+	require.NoError(t, err)
+
+	eventID := "outbox_event_placeholder"
+	eventType := string(events.OrganizationBillingV1.EventType())
+	organizationID := stripeWebhookOrganizationID
+	createdAt := "2026-08-14T12:00:00Z"
+	return webhooksv1.Event_builder{
+		EventId:        &eventID,
+		OrganizationId: &organizationID,
+		EventType:      &eventType,
+		Payload:        payload,
+		CreatedAt:      &createdAt,
+	}.Build()
+}
+
+func TestPaygKeyRefreshHandlerRetriesSchedulingFailure(t *testing.T) {
+	t.Parallel()
+
+	refresher := &capturePaygKeyRefreshScheduler{err: errors.New("scheduler unavailable")}
+	handler := NewPaygKeyRefreshHandler(testenv.NewLogger(t), refresher)
+	metadata := gcp.MessageMetadata{ID: "message_placeholder", Attributes: nil, DeliveryAttempt: nil}
+	event := paygKeyRefreshEvent(t)
+
+	err := handler.Handle(t.Context(), event, metadata)
+	require.ErrorContains(t, err, "schedule PAYG OpenRouter chat key refresh")
+	refresher.err = nil
+	require.NoError(t, handler.Handle(t.Context(), event, metadata))
+
+	require.EqualValues(t, 2, refresher.calls.Load())
+	require.Equal(t, "outbox_event_placeholder", refresher.eventID)
+	require.Equal(t, stripeWebhookOrganizationID, refresher.organizationID)
+	require.Equal(t, openrouter.KeyTypeChat, refresher.keyType)
+	require.Equal(t, paygOpenRouterChatCreditLimit, refresher.limit)
+}
+
+func TestPaygKeyRefreshHandlerDropsUnrelatedBillingAction(t *testing.T) {
+	t.Parallel()
+
+	event := paygKeyRefreshEvent(t)
+	payload, err := json.Marshal(map[string]any{
+		"organization_id": stripeWebhookOrganizationID,
+		"action":          "organization:other_billing_change",
+		"subject_id":      stripeWebhookOrganizationID,
+		"subject_type":    "organization",
+	})
+	require.NoError(t, err)
+	event.SetPayload(payload)
+
+	refresher := &capturePaygKeyRefreshScheduler{}
+	handler := NewPaygKeyRefreshHandler(testenv.NewLogger(t), refresher)
+	require.NoError(t, handler.Handle(t.Context(), event, gcp.MessageMetadata{ID: "message_placeholder", Attributes: nil, DeliveryAttempt: nil}))
+	require.Zero(t, refresher.calls.Load())
+}

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -69,10 +69,11 @@ JOIN organization_metadata
 WHERE billing_metadata.organization_id = @organization_id
 FOR UPDATE OF billing_metadata, organization_metadata;
 
--- name: GetStripeSubscriptionOwner :one
+-- name: ListStripeSubscriptionOwners :many
 SELECT organization_id
 FROM billing_metadata
-WHERE stripe_subscription_id = @stripe_subscription_id;
+WHERE stripe_subscription_id = @stripe_subscription_id
+ORDER BY organization_id;
 
 -- name: ActivatePaygBillingMetadata :one
 UPDATE billing_metadata

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -42,6 +42,55 @@ WITH inserted AS (
 )
 SELECT EXISTS (SELECT 1 FROM inserted) AS inserted;
 
+-- name: StripeWebhookReceiptExists :one
+SELECT EXISTS (
+    SELECT 1
+    FROM stripe_webhook_receipts
+    WHERE stripe_event_id = @stripe_event_id
+) AS received;
+
+-- name: AcquireStripeSubscriptionActivationLock :exec
+-- Serializes distinct Stripe events that refer to the same subscription.
+SELECT pg_advisory_xact_lock(hashtextextended(@stripe_subscription_id, 0));
+
+-- name: GetPaygActivationState :one
+SELECT
+    billing_metadata.id AS billing_metadata_id
+  , billing_metadata.stripe_customer_id
+  , billing_metadata.stripe_subscription_id
+  , billing_metadata.billing_cycle_anchor_day
+  , organization_metadata.name AS organization_name
+  , organization_metadata.slug AS organization_slug
+  , organization_metadata.gram_account_type
+  , organization_metadata.whitelisted
+FROM billing_metadata
+JOIN organization_metadata
+  ON organization_metadata.id = billing_metadata.organization_id
+WHERE billing_metadata.organization_id = @organization_id
+FOR UPDATE OF billing_metadata, organization_metadata;
+
+-- name: GetStripeSubscriptionOwner :one
+SELECT organization_id
+FROM billing_metadata
+WHERE stripe_subscription_id = @stripe_subscription_id;
+
+-- name: ActivatePaygBillingMetadata :one
+UPDATE billing_metadata
+SET stripe_subscription_id = @stripe_subscription_id,
+    billing_cycle_anchor_day = @billing_cycle_anchor_day,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND stripe_customer_id = @stripe_customer_id
+  AND (stripe_subscription_id IS NULL OR stripe_subscription_id = @stripe_subscription_id)
+RETURNING *;
+
+-- name: ActivatePaygOrganization :exec
+UPDATE organization_metadata
+SET gram_account_type = 'payg',
+    whitelisted = TRUE,
+    updated_at = clock_timestamp()
+WHERE id = @organization_id;
+
 -- name: CreateStripeBillingMetadataFixture :exec
 -- Test-only fixture for webhook tests that need a Stripe customer association.
 INSERT INTO billing_metadata (organization_id, stripe_customer_id)
@@ -51,6 +100,12 @@ VALUES (@organization_id, @stripe_customer_id);
 -- Test-only fixture for checkout tests that need an existing Stripe subscription.
 INSERT INTO billing_metadata (organization_id, stripe_customer_id, stripe_subscription_id)
 VALUES (@organization_id, @stripe_customer_id, @stripe_subscription_id);
+
+-- name: SetStripeSubscriptionFixture :exec
+-- Test-only fixture for ownership-conflict webhook tests.
+UPDATE billing_metadata
+SET stripe_subscription_id = @stripe_subscription_id
+WHERE organization_id = @organization_id;
 
 -- name: CountStripeWebhookReceiptsFixture :one
 -- Test-only fixture assertion for durable webhook completion receipts.

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -232,19 +232,6 @@ func (q *Queries) GetPaygActivationState(ctx context.Context, organizationID str
 	return i, err
 }
 
-const getStripeSubscriptionOwner = `-- name: GetStripeSubscriptionOwner :one
-SELECT organization_id
-FROM billing_metadata
-WHERE stripe_subscription_id = $1
-`
-
-func (q *Queries) GetStripeSubscriptionOwner(ctx context.Context, stripeSubscriptionID pgtype.Text) (string, error) {
-	row := q.db.QueryRow(ctx, getStripeSubscriptionOwner, stripeSubscriptionID)
-	var organization_id string
-	err := row.Scan(&organization_id)
-	return organization_id, err
-}
-
 const listBillingCycleUsage = `-- name: ListBillingCycleUsage :many
 SELECT id, organization_id, cycle_start, cycle_end, tum_tokens, finalized_at, created_at, updated_at
 FROM billing_cycle_usage
@@ -330,6 +317,33 @@ func (q *Queries) ListFinalizedBillingCycleStarts(ctx context.Context, organizat
 			return nil, err
 		}
 		items = append(items, cycle_start)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listStripeSubscriptionOwners = `-- name: ListStripeSubscriptionOwners :many
+SELECT organization_id
+FROM billing_metadata
+WHERE stripe_subscription_id = $1
+ORDER BY organization_id
+`
+
+func (q *Queries) ListStripeSubscriptionOwners(ctx context.Context, stripeSubscriptionID pgtype.Text) ([]string, error) {
+	rows, err := q.db.Query(ctx, listStripeSubscriptionOwners, stripeSubscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var organization_id string
+		if err := rows.Scan(&organization_id); err != nil {
+			return nil, err
+		}
+		items = append(items, organization_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -12,6 +12,70 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const acquireStripeSubscriptionActivationLock = `-- name: AcquireStripeSubscriptionActivationLock :exec
+SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
+`
+
+// Serializes distinct Stripe events that refer to the same subscription.
+func (q *Queries) AcquireStripeSubscriptionActivationLock(ctx context.Context, stripeSubscriptionID string) error {
+	_, err := q.db.Exec(ctx, acquireStripeSubscriptionActivationLock, stripeSubscriptionID)
+	return err
+}
+
+const activatePaygBillingMetadata = `-- name: ActivatePaygBillingMetadata :one
+UPDATE billing_metadata
+SET stripe_subscription_id = $1,
+    billing_cycle_anchor_day = $2,
+    updated_at = clock_timestamp()
+WHERE organization_id = $3
+  AND stripe_customer_id = $4
+  AND (stripe_subscription_id IS NULL OR stripe_subscription_id = $1)
+RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
+`
+
+type ActivatePaygBillingMetadataParams struct {
+	StripeSubscriptionID  pgtype.Text
+	BillingCycleAnchorDay int32
+	OrganizationID        string
+	StripeCustomerID      pgtype.Text
+}
+
+func (q *Queries) ActivatePaygBillingMetadata(ctx context.Context, arg ActivatePaygBillingMetadataParams) (BillingMetadatum, error) {
+	row := q.db.QueryRow(ctx, activatePaygBillingMetadata,
+		arg.StripeSubscriptionID,
+		arg.BillingCycleAnchorDay,
+		arg.OrganizationID,
+		arg.StripeCustomerID,
+	)
+	var i BillingMetadatum
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
+		&i.TumMonthlyTokenLimit,
+		&i.AlertEmail,
+		&i.BillingCycleAnchorDay,
+		&i.TunneledMcpServerLimit,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const activatePaygOrganization = `-- name: ActivatePaygOrganization :exec
+UPDATE organization_metadata
+SET gram_account_type = 'payg',
+    whitelisted = TRUE,
+    updated_at = clock_timestamp()
+WHERE id = $1
+`
+
+func (q *Queries) ActivatePaygOrganization(ctx context.Context, organizationID string) error {
+	_, err := q.db.Exec(ctx, activatePaygOrganization, organizationID)
+	return err
+}
+
 const countStripeWebhookReceiptsFixture = `-- name: CountStripeWebhookReceiptsFixture :one
 SELECT count(*)
 FROM stripe_webhook_receipts
@@ -124,6 +188,63 @@ func (q *Queries) GetOrganizationName(ctx context.Context, organizationID string
 	return name, err
 }
 
+const getPaygActivationState = `-- name: GetPaygActivationState :one
+SELECT
+    billing_metadata.id AS billing_metadata_id
+  , billing_metadata.stripe_customer_id
+  , billing_metadata.stripe_subscription_id
+  , billing_metadata.billing_cycle_anchor_day
+  , organization_metadata.name AS organization_name
+  , organization_metadata.slug AS organization_slug
+  , organization_metadata.gram_account_type
+  , organization_metadata.whitelisted
+FROM billing_metadata
+JOIN organization_metadata
+  ON organization_metadata.id = billing_metadata.organization_id
+WHERE billing_metadata.organization_id = $1
+FOR UPDATE OF billing_metadata, organization_metadata
+`
+
+type GetPaygActivationStateRow struct {
+	BillingMetadataID     uuid.UUID
+	StripeCustomerID      pgtype.Text
+	StripeSubscriptionID  pgtype.Text
+	BillingCycleAnchorDay int32
+	OrganizationName      string
+	OrganizationSlug      string
+	GramAccountType       string
+	Whitelisted           bool
+}
+
+func (q *Queries) GetPaygActivationState(ctx context.Context, organizationID string) (GetPaygActivationStateRow, error) {
+	row := q.db.QueryRow(ctx, getPaygActivationState, organizationID)
+	var i GetPaygActivationStateRow
+	err := row.Scan(
+		&i.BillingMetadataID,
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
+		&i.BillingCycleAnchorDay,
+		&i.OrganizationName,
+		&i.OrganizationSlug,
+		&i.GramAccountType,
+		&i.Whitelisted,
+	)
+	return i, err
+}
+
+const getStripeSubscriptionOwner = `-- name: GetStripeSubscriptionOwner :one
+SELECT organization_id
+FROM billing_metadata
+WHERE stripe_subscription_id = $1
+`
+
+func (q *Queries) GetStripeSubscriptionOwner(ctx context.Context, stripeSubscriptionID pgtype.Text) (string, error) {
+	row := q.db.QueryRow(ctx, getStripeSubscriptionOwner, stripeSubscriptionID)
+	var organization_id string
+	err := row.Scan(&organization_id)
+	return organization_id, err
+}
+
 const listBillingCycleUsage = `-- name: ListBillingCycleUsage :many
 SELECT id, organization_id, cycle_start, cycle_end, tum_tokens, finalized_at, created_at, updated_at
 FROM billing_cycle_usage
@@ -216,6 +337,23 @@ func (q *Queries) ListFinalizedBillingCycleStarts(ctx context.Context, organizat
 	return items, nil
 }
 
+const setStripeSubscriptionFixture = `-- name: SetStripeSubscriptionFixture :exec
+UPDATE billing_metadata
+SET stripe_subscription_id = $1
+WHERE organization_id = $2
+`
+
+type SetStripeSubscriptionFixtureParams struct {
+	StripeSubscriptionID pgtype.Text
+	OrganizationID       string
+}
+
+// Test-only fixture for ownership-conflict webhook tests.
+func (q *Queries) SetStripeSubscriptionFixture(ctx context.Context, arg SetStripeSubscriptionFixtureParams) error {
+	_, err := q.db.Exec(ctx, setStripeSubscriptionFixture, arg.StripeSubscriptionID, arg.OrganizationID)
+	return err
+}
+
 const storeStripeCustomer = `-- name: StoreStripeCustomer :one
 INSERT INTO billing_metadata (organization_id, stripe_customer_id)
 VALUES ($1, $2)
@@ -249,6 +387,21 @@ func (q *Queries) StoreStripeCustomer(ctx context.Context, arg StoreStripeCustom
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const stripeWebhookReceiptExists = `-- name: StripeWebhookReceiptExists :one
+SELECT EXISTS (
+    SELECT 1
+    FROM stripe_webhook_receipts
+    WHERE stripe_event_id = $1
+) AS received
+`
+
+func (q *Queries) StripeWebhookReceiptExists(ctx context.Context, stripeEventID string) (bool, error) {
+	row := q.db.QueryRow(ctx, stripeWebhookReceiptExists, stripeEventID)
+	var received bool
+	err := row.Scan(&received)
+	return received, err
 }
 
 const tryInsertStripeWebhookReceipt = `-- name: TryInsertStripeWebhookReceipt :one

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -11,9 +12,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
@@ -26,7 +33,13 @@ var acceptedStripeWebhookEvents = map[string]struct{}{
 	"invoice.payment_failed":        {},
 }
 
-type stripeWebhookHandler func(context.Context, *slog.Logger, *repo.Queries, string, *stripeclient.WebhookEvent) error
+const paygOpenRouterChatCreditLimit = 100
+
+type stripeWebhookResult struct {
+	newlyEnabledFeatures []productfeatures.Feature
+}
+
+type stripeWebhookHandler func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error)
 
 func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
@@ -58,9 +71,32 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		logger.InfoContext(ctx, "skipping unsupported Stripe webhook event")
 		return nil
 	}
+	if event.Type == "checkout.session.completed" && (event.ObjectID == "" || event.CustomerID == "" || event.SubscriptionID == "") {
+		return oops.E(oops.CodeBadRequest, nil, "invalid Stripe Checkout completion identifiers").LogWarn(ctx, logger)
+	}
 	if event.CustomerID == "" {
+		if event.Type == "checkout.session.completed" {
+			return oops.E(oops.CodeBadRequest, nil, "invalid Stripe Checkout completion customer").LogWarn(ctx, logger)
+		}
 		logger.WarnContext(ctx, "skipping Stripe webhook event without a customer")
 		return nil
+	}
+	received, err := repo.New(s.db).StripeWebhookReceiptExists(ctx, event.ID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to check Stripe webhook receipt").LogError(ctx, logger)
+	}
+	if received {
+		logger.InfoContext(ctx, "skipping duplicate Stripe webhook event")
+		return nil
+	}
+
+	var checkoutState *stripeclient.CheckoutSessionState
+	checkoutEligible := true
+	if event.Type == "checkout.session.completed" {
+		checkoutState, checkoutEligible, err = s.currentCheckoutSession(ctx, event)
+		if err != nil {
+			return err
+		}
 	}
 
 	tx, err := s.db.Begin(ctx)
@@ -79,6 +115,15 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		return oops.E(oops.CodeUnexpected, err, "failed to resolve Stripe webhook customer").LogError(ctx, logger)
 	}
 
+	if event.Type == "checkout.session.completed" && checkoutEligible {
+		if _, err := trialsrepo.New(tx).MarkTrialConverted(ctx, organizationID); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to mark enterprise trial converted").LogError(ctx, logger)
+		}
+		if err := queries.AcquireStripeSubscriptionActivationLock(ctx, event.SubscriptionID); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to lock Stripe subscription activation").LogError(ctx, logger)
+		}
+	}
+
 	inserted, err := queries.TryInsertStripeWebhookReceipt(ctx, repo.TryInsertStripeWebhookReceiptParams{
 		StripeEventID:  event.ID,
 		OrganizationID: organizationID,
@@ -91,21 +136,64 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		logger.InfoContext(ctx, "skipping duplicate Stripe webhook event")
 		return nil
 	}
+	if !checkoutEligible {
+		if err := tx.Commit(ctx); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to commit Stripe webhook receipt").LogError(ctx, logger)
+		}
+		return nil
+	}
 
-	if err := s.stripeHandler(ctx, logger, queries, organizationID, event); err != nil {
+	result, err := s.stripeHandler(ctx, logger, tx, organizationID, event, checkoutState)
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to handle Stripe webhook event").LogError(ctx, logger)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to commit Stripe webhook transaction").LogError(ctx, logger)
 	}
+	if s.productFeatures != nil {
+		for _, enabledFeature := range result.newlyEnabledFeatures {
+			s.productFeatures.UpdateFeatureCache(ctx, organizationID, enabledFeature, true)
+		}
+	}
 
 	return nil
 }
 
-func serviceStripeWebhookHandler(ctx context.Context, logger *slog.Logger, _ *repo.Queries, _ string, event *stripeclient.WebhookEvent) error {
+func (s *Service) currentCheckoutSession(ctx context.Context, event *stripeclient.WebhookEvent) (*stripeclient.CheckoutSessionState, bool, error) {
+	if event.ObjectID == "" || event.SubscriptionID == "" {
+		return nil, false, oops.E(oops.CodeBadRequest, nil, "invalid Stripe Checkout completion identifiers").LogWarn(ctx, s.logger)
+	}
+
+	state, err := s.stripeClient.GetCheckoutSession(ctx, event.ObjectID)
+	if err != nil {
+		return nil, false, oops.E(oops.CodeUnavailable, err, "failed to retrieve current Stripe Checkout session").LogWarn(ctx, s.logger)
+	}
+	if state == nil || state.ID != event.ObjectID || state.CustomerID == "" || state.CustomerID != event.CustomerID || state.SubscriptionID == "" || state.SubscriptionID != event.SubscriptionID || state.SubscriptionCustomerID != event.CustomerID || state.BillingCycleAnchor.IsZero() {
+		return nil, false, oops.E(oops.CodeBadRequest, nil, "Stripe Checkout completion identifiers do not match current state").LogWarn(ctx, s.logger)
+	}
+
+	switch state.Status {
+	case "expired":
+		return state, false, nil
+	case "complete":
+	default:
+		return nil, false, oops.E(oops.CodeUnavailable, nil, "Stripe Checkout session is not complete").LogWarn(ctx, s.logger)
+	}
+
+	switch state.SubscriptionStatus {
+	case "active", "trialing", "past_due":
+		return state, true, nil
+	case "canceled", "incomplete_expired", "unpaid":
+		return state, false, nil
+	default:
+		return nil, false, oops.E(oops.CodeUnavailable, nil, "Stripe subscription is not ready for activation").LogWarn(ctx, s.logger)
+	}
+}
+
+func (s *Service) serviceStripeWebhookHandler(ctx context.Context, logger *slog.Logger, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
 	switch event.Type {
 	case "checkout.session.completed":
-		logger.InfoContext(ctx, "received Stripe checkout completion")
+		return s.activatePaygCheckout(ctx, tx, organizationID, event, checkout)
 	case "invoice.created":
 		logger.InfoContext(ctx, "received Stripe invoice creation")
 	case "invoice.payment_failed":
@@ -113,5 +201,94 @@ func serviceStripeWebhookHandler(ctx context.Context, logger *slog.Logger, _ *re
 	case "customer.subscription.deleted":
 		logger.InfoContext(ctx, "received Stripe subscription deletion")
 	}
-	return nil
+	return stripeWebhookResult{newlyEnabledFeatures: nil}, nil
+}
+
+func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+	if checkout == nil {
+		return stripeWebhookResult{}, errors.New("missing current Stripe Checkout state")
+	}
+
+	q := repo.New(tx)
+	state, err := q.GetPaygActivationState(ctx, organizationID)
+	if err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("lock PAYG activation state: %w", err)
+	}
+	if !state.StripeCustomerID.Valid || state.StripeCustomerID.String != event.CustomerID {
+		return stripeWebhookResult{}, errors.New("stripe customer does not own the organization's billing metadata")
+	}
+	if state.StripeSubscriptionID.Valid && state.StripeSubscriptionID.String != event.SubscriptionID {
+		return stripeWebhookResult{}, errors.New("organization already belongs to another Stripe subscription")
+	}
+
+	owner, err := q.GetStripeSubscriptionOwner(ctx, pgtype.Text{String: event.SubscriptionID, Valid: true})
+	switch {
+	case err == nil && owner != organizationID:
+		return stripeWebhookResult{}, errors.New("stripe subscription already belongs to another organization")
+	case err != nil && !errors.Is(err, pgx.ErrNoRows):
+		return stripeWebhookResult{}, fmt.Errorf("check Stripe subscription ownership: %w", err)
+	}
+
+	newlyEnabled := []productfeatures.Feature(nil)
+	if _, err := trialsrepo.New(tx).GetTrial(ctx, organizationID); errors.Is(err, pgx.ErrNoRows) {
+		newlyEnabled, err = productfeatures.SeedPaygEntitlementsTx(ctx, tx, organizationID)
+		if err != nil {
+			return stripeWebhookResult{}, fmt.Errorf("seed PAYG entitlements: %w", err)
+		}
+	} else if err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("read trial state for PAYG activation: %w", err)
+	}
+
+	anchorDay := conv.SafeInt32(checkout.BillingCycleAnchor.UTC().Day())
+	alreadyActivated := state.StripeSubscriptionID.Valid &&
+		state.StripeSubscriptionID.String == event.SubscriptionID &&
+		state.BillingCycleAnchorDay == anchorDay &&
+		state.GramAccountType == "payg" && state.Whitelisted
+	if alreadyActivated {
+		return stripeWebhookResult{newlyEnabledFeatures: newlyEnabled}, nil
+	}
+
+	if _, err := q.ActivatePaygBillingMetadata(ctx, repo.ActivatePaygBillingMetadataParams{
+		StripeSubscriptionID:  pgtype.Text{String: event.SubscriptionID, Valid: true},
+		BillingCycleAnchorDay: anchorDay,
+		OrganizationID:        organizationID,
+		StripeCustomerID:      pgtype.Text{String: event.CustomerID, Valid: true},
+	}); err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("store PAYG Stripe subscription: %w", err)
+	}
+	if err := q.ActivatePaygOrganization(ctx, organizationID); err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("activate PAYG organization: %w", err)
+	}
+
+	if s.keyRefresher == nil {
+		return stripeWebhookResult{}, errors.New("OpenRouter key refresh scheduler is unavailable")
+	}
+	limit := paygOpenRouterChatCreditLimit
+	if err := s.keyRefresher.ScheduleOpenRouterKeyRefresh(ctx, organizationID, openrouter.KeyTypeChat, &limit); err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("schedule PAYG OpenRouter chat key refresh: %w", err)
+	}
+
+	if s.auditLogger == nil {
+		return stripeWebhookResult{}, errors.New("audit logger is unavailable")
+	}
+	if err := s.auditLogger.LogOrganizationPaygActivated(ctx, tx, audit.LogOrganizationPaygActivatedEvent{
+		OrganizationID:   organizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, "system"),
+		ActorDisplayName: nil,
+		ActorSlug:        nil,
+		OrganizationName: state.OrganizationName,
+		OrganizationSlug: state.OrganizationSlug,
+		OrganizationSnapshotBefore: &audit.OrganizationPaygActivationSnapshot{
+			AccountType: state.GramAccountType,
+			Whitelisted: state.Whitelisted,
+		},
+		OrganizationSnapshotAfter: &audit.OrganizationPaygActivationSnapshot{
+			AccountType: "payg",
+			Whitelisted: true,
+		},
+	}); err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("log PAYG organization activation: %w", err)
+	}
+
+	return stripeWebhookResult{newlyEnabledFeatures: newlyEnabled}, nil
 }

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -17,7 +17,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
-	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -75,9 +74,6 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		return oops.E(oops.CodeBadRequest, nil, "invalid Stripe Checkout completion identifiers").LogWarn(ctx, logger)
 	}
 	if event.CustomerID == "" {
-		if event.Type == "checkout.session.completed" {
-			return oops.E(oops.CodeBadRequest, nil, "invalid Stripe Checkout completion customer").LogWarn(ctx, logger)
-		}
 		logger.WarnContext(ctx, "skipping Stripe webhook event without a customer")
 		return nil
 	}
@@ -221,12 +217,15 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 		return stripeWebhookResult{}, errors.New("organization already belongs to another Stripe subscription")
 	}
 
-	owner, err := q.GetStripeSubscriptionOwner(ctx, pgtype.Text{String: event.SubscriptionID, Valid: true})
-	switch {
-	case err == nil && owner != organizationID:
-		return stripeWebhookResult{}, errors.New("stripe subscription already belongs to another organization")
-	case err != nil && !errors.Is(err, pgx.ErrNoRows):
+	owners, err := q.ListStripeSubscriptionOwners(ctx, pgtype.Text{String: event.SubscriptionID, Valid: true})
+	if err != nil {
 		return stripeWebhookResult{}, fmt.Errorf("check Stripe subscription ownership: %w", err)
+	}
+	switch {
+	case len(owners) > 1:
+		return stripeWebhookResult{}, errors.New("stripe subscription belongs to multiple organizations")
+	case len(owners) == 1 && owners[0] != organizationID:
+		return stripeWebhookResult{}, errors.New("stripe subscription already belongs to another organization")
 	}
 
 	newlyEnabled := []productfeatures.Feature(nil)
@@ -258,14 +257,6 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 	}
 	if err := q.ActivatePaygOrganization(ctx, organizationID); err != nil {
 		return stripeWebhookResult{}, fmt.Errorf("activate PAYG organization: %w", err)
-	}
-
-	if s.keyRefresher == nil {
-		return stripeWebhookResult{}, errors.New("OpenRouter key refresh scheduler is unavailable")
-	}
-	limit := paygOpenRouterChatCreditLimit
-	if err := s.keyRefresher.ScheduleOpenRouterKeyRefresh(ctx, organizationID, openrouter.KeyTypeChat, &limit); err != nil {
-		return stripeWebhookResult{}, fmt.Errorf("schedule PAYG OpenRouter chat key refresh: %w", err)
 	}
 
 	if s.auditLogger == nil {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -17,16 +18,19 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	goahttp "goa.design/goa/v3/http"
+	"google.golang.org/protobuf/proto"
 
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
-	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
@@ -51,22 +55,6 @@ func (f *fakeStripeWebhookClient) CreateCheckoutSession(context.Context, stripec
 
 func (f *fakeStripeWebhookClient) GetCheckoutSession(context.Context, string) (*stripeclient.CheckoutSessionState, error) {
 	return f.checkout, f.checkoutError
-}
-
-type captureKeyRefresher struct {
-	calls   atomic.Int32
-	limit   int
-	keyType openrouter.KeyType
-	err     error
-}
-
-func (c *captureKeyRefresher) ScheduleOpenRouterKeyRefresh(_ context.Context, _ string, keyType openrouter.KeyType, limit *int) error {
-	c.calls.Add(1)
-	c.keyType = keyType
-	if limit != nil {
-		c.limit = *limit
-	}
-	return c.err
 }
 
 type captureFeatureCache struct {
@@ -161,6 +149,30 @@ func stripeWebhookReceiptCount(t *testing.T, db *pgxpool.Pool) int {
 	count, err := repo.New(db).CountStripeWebhookReceiptsFixture(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	return int(count)
+}
+
+func paygSchedulingIntentCount(t *testing.T, db *pgxpool.Pool) int {
+	t.Helper()
+
+	rows, err := testrepo.New(db).ListPublishOutboxRows(t.Context())
+	require.NoError(t, err)
+
+	count := 0
+	for _, row := range rows {
+		var event webhooksv1.Event
+		require.NoError(t, proto.Unmarshal(row.Message, &event))
+		if event.GetEventType() != string(events.OrganizationBillingV1.EventType()) {
+			continue
+		}
+
+		var payload events.AuditLogCreatedPayloadV1
+		require.NoError(t, json.Unmarshal(event.GetPayload(), &payload))
+		if payload.Action == string(audit.ActionOrganizationPaygActivated) {
+			count++
+		}
+	}
+
+	return count
 }
 
 func TestAttachStripeWebhookRoute(t *testing.T) {
@@ -436,7 +448,7 @@ func TestStripeWebhookHandlerFailureRollsBackForRetry(t *testing.T) {
 	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
 }
 
-func configurePaygCheckout(t *testing.T, service *Service, eventID, subscriptionID, subscriptionStatus string) (*captureKeyRefresher, *captureFeatureCache) {
+func configurePaygCheckout(t *testing.T, service *Service, eventID, subscriptionID, subscriptionStatus string) *captureFeatureCache {
 	t.Helper()
 
 	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
@@ -460,20 +472,18 @@ func configurePaygCheckout(t *testing.T, service *Service, eventID, subscription
 		SubscriptionStatus:     subscriptionStatus,
 		BillingCycleAnchor:     time.Date(2026, time.August, 23, 9, 0, 0, 0, time.UTC),
 	}
-	refresher := &captureKeyRefresher{}
 	featureCache := &captureFeatureCache{enabled: nil}
-	service.keyRefresher = refresher
 	service.productFeatures = featureCache
 	service.auditLogger = audit.NewLogger()
 	service.stripeHandler = service.serviceStripeWebhookHandler
-	return refresher, featureCache
+	return featureCache
 }
 
 func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	refresher, featureCache := configurePaygCheckout(t, service, "event_activation", "subscription_activation", "active")
+	featureCache := configurePaygCheckout(t, service, "event_activation", "subscription_activation", "active")
 	baseline, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
 	require.NoError(t, err)
 
@@ -488,9 +498,7 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "payg", organization.GramAccountType)
 	require.True(t, organization.Whitelisted)
-	require.EqualValues(t, 1, refresher.calls.Load())
-	require.Equal(t, openrouter.KeyTypeChat, refresher.keyType)
-	require.Equal(t, paygOpenRouterChatCreditLimit, refresher.limit)
+	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
 
 	expectedFeatures := append([]productfeatures.Feature{productfeatures.FeaturePlatformMCP}, productfeatures.EnterpriseTrialBundle...)
 	expectedFeatures = append(expectedFeatures, productfeatures.FeatureSkills)
@@ -520,7 +528,7 @@ func TestStripeCheckoutCompletionPreservesTrialFeatureChoices(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	_, featureCache := configurePaygCheckout(t, service, "event_trial", "subscription_trial", "trialing")
+	featureCache := configurePaygCheckout(t, service, "event_trial", "subscription_trial", "trialing")
 	ctx := t.Context()
 	tx := testenv.BeginTx(t, ctx, db)
 	require.NoError(t, productfeatures.SeedEnterpriseTrialBundleTx(ctx, tx, stripeWebhookOrganizationID))
@@ -558,7 +566,7 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	refresher, _ := configurePaygCheckout(t, service, "event_first", "subscription_replay", "past_due")
+	configurePaygCheckout(t, service, "event_first", "subscription_replay", "past_due")
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
 
 	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
@@ -575,7 +583,7 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 	}
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "second").Code)
 
-	require.EqualValues(t, 1, refresher.calls.Load())
+	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
 	require.Equal(t, 2, stripeWebhookReceiptCount(t, db))
 	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
 	require.NoError(t, err)
@@ -586,22 +594,22 @@ func TestStripeCheckoutExactReplaySkipsCurrentStateRetrieval(t *testing.T) {
 	t.Parallel()
 
 	service, _ := newStripeWebhookService(t, "customer_placeholder", nil)
-	refresher, _ := configurePaygCheckout(t, service, "event_exact_replay", "subscription_exact_replay", "active")
+	configurePaygCheckout(t, service, "event_exact_replay", "subscription_exact_replay", "active")
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
 
 	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
 	require.True(t, ok)
 	client.checkoutError = errors.New("Stripe retrieval unavailable")
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "replay").Code)
-	require.EqualValues(t, 1, refresher.calls.Load())
+	require.Equal(t, 1, paygSchedulingIntentCount(t, service.db))
 }
 
-func TestStripeCheckoutSchedulerFailureRollsBackActivation(t *testing.T) {
+func TestStripeCheckoutAuditFailureRollsBackActivationAndSchedulingIntent(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	refresher, featureCache := configurePaygCheckout(t, service, "event_scheduler_failure", "subscription_scheduler_failure", "active")
-	refresher.err = errors.New("scheduler unavailable")
+	featureCache := configurePaygCheckout(t, service, "event_audit_failure", "subscription_audit_failure", "active")
+	service.auditLogger = nil
 
 	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "failure").Code)
 
@@ -612,6 +620,7 @@ func TestStripeCheckoutSchedulerFailureRollsBackActivation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, "payg", organization.GramAccountType)
 	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Zero(t, paygSchedulingIntentCount(t, db))
 	require.Empty(t, featureCache.snapshot())
 	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
 	require.NoError(t, err)
@@ -622,7 +631,7 @@ func TestStripeCheckoutSubscriptionConflictRollsBackTrialConversion(t *testing.T
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	refresher, _ := configurePaygCheckout(t, service, "event_conflict", "subscription_new", "active")
+	configurePaygCheckout(t, service, "event_conflict", "subscription_new", "active")
 	ctx := t.Context()
 	require.NoError(t, repo.New(db).SetStripeSubscriptionFixture(ctx, repo.SetStripeSubscriptionFixtureParams{
 		StripeSubscriptionID: pgtype.Text{String: "subscription_existing", Valid: true},
@@ -643,18 +652,49 @@ func TestStripeCheckoutSubscriptionConflictRollsBackTrialConversion(t *testing.T
 	require.NoError(t, err)
 	require.Equal(t, "subscription_existing", metadata.StripeSubscriptionID.String)
 	require.Zero(t, stripeWebhookReceiptCount(t, db))
-	require.Zero(t, refresher.calls.Load())
+}
+
+func TestStripeCheckoutRejectsDuplicateSubscriptionOwners(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_duplicate_owners", "subscription_duplicate", "active")
+	ctx := t.Context()
+	require.NoError(t, repo.New(db).SetStripeSubscriptionFixture(ctx, repo.SetStripeSubscriptionFixtureParams{
+		StripeSubscriptionID: pgtype.Text{String: "subscription_duplicate", Valid: true},
+		OrganizationID:       stripeWebhookOrganizationID,
+	}))
+
+	const otherOrganizationID = "org_placeholder_other"
+	require.NoError(t, orgrepo.New(db).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   otherOrganizationID,
+		Name: "Other Placeholder Organization",
+		Slug: "other-placeholder-organization",
+	}))
+	require.NoError(t, repo.New(db).CreateStripeSubscriptionBillingMetadataFixture(ctx, repo.CreateStripeSubscriptionBillingMetadataFixtureParams{
+		OrganizationID:       otherOrganizationID,
+		StripeCustomerID:     pgtype.Text{String: "customer_placeholder_other", Valid: true},
+		StripeSubscriptionID: pgtype.Text{String: "subscription_duplicate", Valid: true},
+	}))
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "duplicate").Code)
+
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(ctx, stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.NotEqual(t, "payg", organization.GramAccountType)
+	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Zero(t, paygSchedulingIntentCount(t, db))
 }
 
 func TestStripeCheckoutTerminalStateIsDurableNoop(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	refresher, _ := configurePaygCheckout(t, service, "event_terminal", "subscription_terminal", "canceled")
+	configurePaygCheckout(t, service, "event_terminal", "subscription_terminal", "canceled")
 
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "terminal").Code)
 	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
-	require.Zero(t, refresher.calls.Load())
+	require.Zero(t, paygSchedulingIntentCount(t, db))
 	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	require.False(t, metadata.StripeSubscriptionID.Valid)

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -12,21 +12,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	goahttp "goa.design/goa/v3/http"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
 type fakeStripeWebhookClient struct {
-	verify      func([]byte, string) (*stripeclient.WebhookEvent, error)
-	verifyCalls atomic.Int32
+	verify        func([]byte, string) (*stripeclient.WebhookEvent, error)
+	checkout      *stripeclient.CheckoutSessionState
+	checkoutError error
+	verifyCalls   atomic.Int32
 }
 
 const stripeWebhookOrganizationID = "org_placeholder"
@@ -37,6 +47,46 @@ func (f *fakeStripeWebhookClient) CreateCustomer(context.Context, stripeclient.C
 
 func (f *fakeStripeWebhookClient) CreateCheckoutSession(context.Context, stripeclient.CreateCheckoutSessionInput) (*stripeclient.CheckoutSession, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (f *fakeStripeWebhookClient) GetCheckoutSession(context.Context, string) (*stripeclient.CheckoutSessionState, error) {
+	return f.checkout, f.checkoutError
+}
+
+type captureKeyRefresher struct {
+	calls   atomic.Int32
+	limit   int
+	keyType openrouter.KeyType
+	err     error
+}
+
+func (c *captureKeyRefresher) ScheduleOpenRouterKeyRefresh(_ context.Context, _ string, keyType openrouter.KeyType, limit *int) error {
+	c.calls.Add(1)
+	c.keyType = keyType
+	if limit != nil {
+		c.limit = *limit
+	}
+	return c.err
+}
+
+type captureFeatureCache struct {
+	mu      sync.Mutex
+	enabled []productfeatures.Feature
+}
+
+func (c *captureFeatureCache) UpdateFeatureCache(_ context.Context, _ string, feature productfeatures.Feature, enabled bool) {
+	if !enabled {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.enabled = append(c.enabled, feature)
+}
+
+func (c *captureFeatureCache) snapshot() []productfeatures.Feature {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]productfeatures.Feature(nil), c.enabled...)
 }
 
 func (f *fakeStripeWebhookClient) CreateMeterEvent(context.Context, stripeclient.CreateMeterEventInput) error {
@@ -52,6 +102,10 @@ func (f *fakeStripeWebhookClient) Catalog() stripeclient.Catalog {
 	return stripeclient.Catalog{PriceIDTUM: "", MeterEventName: ""}
 }
 
+func testStripeWebhookHandler(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+	return stripeWebhookResult{newlyEnabledFeatures: nil}, nil
+}
+
 func newStripeWebhookService(t *testing.T, customerID string, handler stripeWebhookHandler) (*Service, *pgxpool.Pool) {
 	t.Helper()
 
@@ -64,6 +118,7 @@ func newStripeWebhookService(t *testing.T, customerID string, handler stripeWebh
 		Slug: "placeholder-organization",
 	})
 	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(t.Context(), db, stripeWebhookOrganizationID))
 	err = repo.New(db).CreateStripeBillingMetadataFixture(t.Context(), repo.CreateStripeBillingMetadataFixtureParams{
 		OrganizationID:   stripeWebhookOrganizationID,
 		StripeCustomerID: pgtype.Text{String: customerID, Valid: true},
@@ -82,7 +137,7 @@ func newStripeWebhookService(t *testing.T, customerID string, handler stripeWebh
 		},
 	}
 	if handler == nil {
-		handler = serviceStripeWebhookHandler
+		handler = testStripeWebhookHandler
 	}
 
 	return &Service{
@@ -121,7 +176,7 @@ func TestAttachStripeWebhookRoute(t *testing.T) {
 			}, nil
 		},
 	}
-	service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: serviceStripeWebhookHandler}
+	service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: testStripeWebhookHandler}
 	mux := goahttp.NewMuxer()
 	Attach(mux, service)
 
@@ -136,7 +191,7 @@ func TestAttachStripeWebhookRoute(t *testing.T) {
 
 func TestAttachOmitsStripeWebhookRouteWithoutClient(t *testing.T) {
 	t.Parallel()
-	service := &Service{logger: testenv.NewLogger(t), stripeClient: nil, stripeHandler: serviceStripeWebhookHandler}
+	service := &Service{logger: testenv.NewLogger(t), stripeClient: nil, stripeHandler: testStripeWebhookHandler}
 	mux := goahttp.NewMuxer()
 	Attach(mux, service)
 
@@ -162,7 +217,7 @@ func TestStripeWebhookPreservesRawBody(t *testing.T) {
 			}, nil
 		},
 	}
-	service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: serviceStripeWebhookHandler}
+	service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: testStripeWebhookHandler}
 
 	recorder := serveStripeWebhook(service, expectedBody)
 
@@ -177,7 +232,7 @@ func TestStripeWebhookRejectsInvalidRequests(t *testing.T) {
 		service := &Service{
 			logger:        testenv.NewLogger(t),
 			stripeClient:  stripeclient.NewStubClient(testenv.NewLogger(t)),
-			stripeHandler: serviceStripeWebhookHandler,
+			stripeHandler: testStripeWebhookHandler,
 		}
 		require.Equal(t, http.StatusServiceUnavailable, serveStripeWebhook(service, "{}").Code)
 	})
@@ -187,7 +242,7 @@ func TestStripeWebhookRejectsInvalidRequests(t *testing.T) {
 		client := &fakeStripeWebhookClient{verify: func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
 			return nil, errors.New("signature mismatch")
 		}}
-		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: serviceStripeWebhookHandler}
+		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: testStripeWebhookHandler}
 		require.Equal(t, http.StatusBadRequest, serveStripeWebhook(service, "{}").Code)
 	})
 
@@ -197,7 +252,7 @@ func TestStripeWebhookRejectsInvalidRequests(t *testing.T) {
 			require.Empty(t, signature)
 			return nil, errors.New("missing signature")
 		}}
-		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: serviceStripeWebhookHandler}
+		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: testStripeWebhookHandler}
 		mux := goahttp.NewMuxer()
 		Attach(mux, service)
 		recorder := httptest.NewRecorder()
@@ -210,7 +265,7 @@ func TestStripeWebhookRejectsInvalidRequests(t *testing.T) {
 		client := &fakeStripeWebhookClient{verify: func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
 			return &stripeclient.WebhookEvent{ID: "", Type: "", Created: time.Time{}, ObjectID: "", CustomerID: ""}, nil
 		}}
-		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: serviceStripeWebhookHandler}
+		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: testStripeWebhookHandler}
 		require.Equal(t, http.StatusBadRequest, serveStripeWebhook(service, "{}").Code)
 	})
 
@@ -219,7 +274,7 @@ func TestStripeWebhookRejectsInvalidRequests(t *testing.T) {
 		client := &fakeStripeWebhookClient{verify: func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
 			return nil, errors.New("must not be called")
 		}}
-		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: serviceStripeWebhookHandler}
+		service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: testStripeWebhookHandler}
 		require.Equal(t, http.StatusRequestEntityTooLarge, serveStripeWebhook(service, strings.Repeat("x", maxStripeWebhookBodyBytes+1)).Code)
 		require.Zero(t, client.verifyCalls.Load())
 	})
@@ -228,10 +283,20 @@ func TestStripeWebhookRejectsInvalidRequests(t *testing.T) {
 func TestStripeWebhookDatabaseUnavailable(t *testing.T) {
 	t.Parallel()
 
-	service, db := newStripeWebhookService(t, "customer_placeholder", serviceStripeWebhookHandler)
+	service, db := newStripeWebhookService(t, "customer_placeholder", testStripeWebhookHandler)
 	db.Close()
 
 	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "{}").Code)
+
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	client.verify = func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+		return &stripeclient.WebhookEvent{
+			ID:   "event_missing_customer",
+			Type: "invoice.created",
+		}, nil
+	}
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "missing-customer").Code)
 }
 
 func TestStripeWebhookAcknowledgesEventsWithoutDispatch(t *testing.T) {
@@ -250,9 +315,9 @@ func TestStripeWebhookAcknowledgesEventsWithoutDispatch(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, *repo.Queries, string, *stripeclient.WebhookEvent) error {
+			service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
 				t.Fatal("handler must not run")
-				return nil
+				return stripeWebhookResult{}, nil
 			})
 			client, ok := service.stripeClient.(*fakeStripeWebhookClient)
 			require.True(t, ok)
@@ -275,9 +340,9 @@ func TestStripeWebhookSequentialDuplicateDispatchesOnce(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, *repo.Queries, string, *stripeclient.WebhookEvent) error {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
 		calls.Add(1)
-		return nil
+		return stripeWebhookResult{}, nil
 	})
 
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
@@ -293,11 +358,11 @@ func TestStripeWebhookConcurrentDuplicateDispatchesOnce(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	var enterOnce sync.Once
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, *repo.Queries, string, *stripeclient.WebhookEvent) error {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		enterOnce.Do(func() { close(entered) })
 		<-release
-		return nil
+		return stripeWebhookResult{}, nil
 	})
 
 	responses := make(chan int, 2)
@@ -323,10 +388,10 @@ func TestStripeWebhookConcurrentDistinctEventsForSameCustomerDoNotSerialize(t *t
 			close(release)
 		}
 	}()
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, *repo.Queries, string, *stripeclient.WebhookEvent) error {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		<-release
-		return nil
+		return stripeWebhookResult{}, nil
 	})
 	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
 	require.True(t, ok)
@@ -357,11 +422,11 @@ func TestStripeWebhookHandlerFailureRollsBackForRetry(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, *repo.Queries, string, *stripeclient.WebhookEvent) error {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
 		if calls.Add(1) == 1 {
-			return errors.New("transient handler failure")
+			return stripeWebhookResult{}, errors.New("transient handler failure")
 		}
-		return nil
+		return stripeWebhookResult{}, nil
 	})
 
 	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "first").Code)
@@ -369,4 +434,245 @@ func TestStripeWebhookHandlerFailureRollsBackForRetry(t *testing.T) {
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "retry").Code)
 	require.EqualValues(t, 2, calls.Load())
 	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+}
+
+func configurePaygCheckout(t *testing.T, service *Service, eventID, subscriptionID, subscriptionStatus string) (*captureKeyRefresher, *captureFeatureCache) {
+	t.Helper()
+
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	client.verify = func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+		return &stripeclient.WebhookEvent{
+			ID:             eventID,
+			Type:           "checkout.session.completed",
+			Created:        time.Now().UTC(),
+			ObjectID:       "checkout_placeholder",
+			CustomerID:     "customer_placeholder",
+			SubscriptionID: subscriptionID,
+		}, nil
+	}
+	client.checkout = &stripeclient.CheckoutSessionState{
+		ID:                     "checkout_placeholder",
+		Status:                 "complete",
+		CustomerID:             "customer_placeholder",
+		SubscriptionID:         subscriptionID,
+		SubscriptionCustomerID: "customer_placeholder",
+		SubscriptionStatus:     subscriptionStatus,
+		BillingCycleAnchor:     time.Date(2026, time.August, 23, 9, 0, 0, 0, time.UTC),
+	}
+	refresher := &captureKeyRefresher{}
+	featureCache := &captureFeatureCache{enabled: nil}
+	service.keyRefresher = refresher
+	service.productFeatures = featureCache
+	service.auditLogger = audit.NewLogger()
+	service.stripeHandler = service.serviceStripeWebhookHandler
+	return refresher, featureCache
+}
+
+func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	refresher, featureCache := configurePaygCheckout(t, service, "event_activation", "subscription_activation", "active")
+	baseline, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "activation").Code)
+
+	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "customer_placeholder", metadata.StripeCustomerID.String)
+	require.Equal(t, "subscription_activation", metadata.StripeSubscriptionID.String)
+	require.EqualValues(t, 23, metadata.BillingCycleAnchorDay)
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "payg", organization.GramAccountType)
+	require.True(t, organization.Whitelisted)
+	require.EqualValues(t, 1, refresher.calls.Load())
+	require.Equal(t, openrouter.KeyTypeChat, refresher.keyType)
+	require.Equal(t, paygOpenRouterChatCreditLimit, refresher.limit)
+
+	expectedFeatures := append([]productfeatures.Feature{productfeatures.FeaturePlatformMCP}, productfeatures.EnterpriseTrialBundle...)
+	expectedFeatures = append(expectedFeatures, productfeatures.FeatureSkills)
+	featureQueries := featurerepo.New(db)
+	for _, feature := range expectedFeatures {
+		enabled, err := featureQueries.IsFeatureEnabled(t.Context(), featurerepo.IsFeatureEnabledParams{
+			OrganizationID: stripeWebhookOrganizationID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+		require.Truef(t, enabled, "feature %s should be enabled", feature)
+	}
+	require.ElementsMatch(t, expectedFeatures, featureCache.snapshot())
+
+	after, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+	require.Equal(t, baseline+1, after)
+	record, err := audittest.LatestAuditLogByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+	require.Equal(t, "system", record.ActorID)
+	require.NotContains(t, string(record.Metadata), "customer_placeholder")
+	require.NotContains(t, string(record.BeforeSnapshot), "subscription_activation")
+	require.NotContains(t, string(record.AfterSnapshot), "subscription_activation")
+}
+
+func TestStripeCheckoutCompletionPreservesTrialFeatureChoices(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	_, featureCache := configurePaygCheckout(t, service, "event_trial", "subscription_trial", "trialing")
+	ctx := t.Context()
+	tx := testenv.BeginTx(t, ctx, db)
+	require.NoError(t, productfeatures.SeedEnterpriseTrialBundleTx(ctx, tx, stripeWebhookOrganizationID))
+	require.NoError(t, tx.Commit(ctx))
+	require.NoError(t, orgrepo.New(db).SetAccountType(ctx, orgrepo.SetAccountTypeParams{
+		ID:              stripeWebhookOrganizationID,
+		GramAccountType: "enterprise",
+	}))
+	require.NoError(t, trialsrepo.New(db).CreateTrial(ctx, trialsrepo.CreateTrialParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		Tier:           "enterprise",
+		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(7 * 24 * time.Hour), Valid: true},
+	}))
+	_, err := featurerepo.New(db).DeleteFeature(ctx, featurerepo.DeleteFeatureParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "trial").Code)
+
+	trial, err := trialsrepo.New(db).GetTrial(ctx, stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.True(t, trial.ConvertedAt.Valid)
+	ssoEnabled, err := featurerepo.New(db).IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+	require.False(t, ssoEnabled)
+	require.NotContains(t, featureCache.snapshot(), productfeatures.FeatureSSO)
+}
+
+func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	refresher, _ := configurePaygCheckout(t, service, "event_first", "subscription_replay", "past_due")
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
+
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	client.verify = func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+		return &stripeclient.WebhookEvent{
+			ID:             "event_second",
+			Type:           "checkout.session.completed",
+			Created:        time.Now().UTC(),
+			ObjectID:       "checkout_placeholder",
+			CustomerID:     "customer_placeholder",
+			SubscriptionID: "subscription_replay",
+		}, nil
+	}
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "second").Code)
+
+	require.EqualValues(t, 1, refresher.calls.Load())
+	require.Equal(t, 2, stripeWebhookReceiptCount(t, db))
+	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+}
+
+func TestStripeCheckoutExactReplaySkipsCurrentStateRetrieval(t *testing.T) {
+	t.Parallel()
+
+	service, _ := newStripeWebhookService(t, "customer_placeholder", nil)
+	refresher, _ := configurePaygCheckout(t, service, "event_exact_replay", "subscription_exact_replay", "active")
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
+
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	client.checkoutError = errors.New("Stripe retrieval unavailable")
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "replay").Code)
+	require.EqualValues(t, 1, refresher.calls.Load())
+}
+
+func TestStripeCheckoutSchedulerFailureRollsBackActivation(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	refresher, featureCache := configurePaygCheckout(t, service, "event_scheduler_failure", "subscription_scheduler_failure", "active")
+	refresher.err = errors.New("scheduler unavailable")
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "failure").Code)
+
+	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.False(t, metadata.StripeSubscriptionID.Valid)
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.NotEqual(t, "payg", organization.GramAccountType)
+	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Empty(t, featureCache.snapshot())
+	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+	require.Zero(t, count)
+}
+
+func TestStripeCheckoutSubscriptionConflictRollsBackTrialConversion(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	refresher, _ := configurePaygCheckout(t, service, "event_conflict", "subscription_new", "active")
+	ctx := t.Context()
+	require.NoError(t, repo.New(db).SetStripeSubscriptionFixture(ctx, repo.SetStripeSubscriptionFixtureParams{
+		StripeSubscriptionID: pgtype.Text{String: "subscription_existing", Valid: true},
+		OrganizationID:       stripeWebhookOrganizationID,
+	}))
+	require.NoError(t, trialsrepo.New(db).CreateTrial(ctx, trialsrepo.CreateTrialParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		Tier:           "enterprise",
+		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(7 * 24 * time.Hour), Valid: true},
+	}))
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "conflict").Code)
+
+	trial, err := trialsrepo.New(db).GetTrial(ctx, stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.False(t, trial.ConvertedAt.Valid)
+	metadata, err := repo.New(db).GetBillingMetadata(ctx, stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "subscription_existing", metadata.StripeSubscriptionID.String)
+	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Zero(t, refresher.calls.Load())
+}
+
+func TestStripeCheckoutTerminalStateIsDurableNoop(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	refresher, _ := configurePaygCheckout(t, service, "event_terminal", "subscription_terminal", "canceled")
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "terminal").Code)
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Zero(t, refresher.calls.Load())
+	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.False(t, metadata.StripeSubscriptionID.Valid)
+}
+
+func TestStripeCheckoutRejectsMalformedIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeStripeWebhookClient{verify: func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+		return &stripeclient.WebhookEvent{
+			ID:             "event_malformed",
+			Type:           "checkout.session.completed",
+			Created:        time.Now().UTC(),
+			ObjectID:       "checkout_placeholder",
+			CustomerID:     "customer_placeholder",
+			SubscriptionID: "",
+		}, nil
+	}}
+	service := &Service{logger: testenv.NewLogger(t), stripeClient: client, stripeHandler: testStripeWebhookHandler}
+	require.Equal(t, http.StatusBadRequest, serveStripeWebhook(service, "malformed").Code)
 }


### PR DESCRIPTION
## Summary

- reconcile completed Stripe Checkout events against current Checkout and subscription state before activating billing
- atomically persist the subscription and billing anchor, restore dashboard admission, convert any trial, and schedule the PAYG chat-key limit refresh
- preserve explicit feature disables while filling never-configured enterprise entitlements for cold organizations
- keep exact webhook replays, terminal subscription states, and conflicting subscriptions safe and idempotent

## Safety

- resolves organizations only through the stored Stripe customer mapping
- validates event, session, subscription, and customer identifiers without retaining raw Stripe payloads
- rolls back the webhook receipt and all local state when persistence, scheduling, or audit logging fails
- never gates webhook reconciliation on the rollout flag and never records Stripe identifiers in audit payloads

## Tests

- Stripe, usage, product-feature, background, and OpenRouter package tests
- dashboard audit-action and checkout component tests
- dashboard type-check
- server lint and readonly build
- SQLc and webhook-catalog regeneration checks

## Stack

- Base: #5321
- Blocks: DNO-840

Closes [DNO-841](https://linear.app/speakeasy/issue/DNO-841)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates PAYG when Stripe confirms a completed Checkout and schedules a 100‑credit OpenRouter chat key refresh via a durable outbox event. Previously `checkout.session.completed` was a no‑op; now we validate current Checkout/subscription state, atomically activate billing and the organization, convert any trial, seed PAYG entitlements, and trigger an idempotent refresh keyed by the outbox event.

- Stripe: adds `GetCheckoutSession` (expands `subscription`), exposes `SubscriptionID` in webhooks, validates session/subscription ownership and status, serializes by subscription (advisory lock), and no‑ops expired or terminal sessions. The local Stripe stub keeps `GetCheckoutSession` unavailable.
- Webhook flow: early durable receipt check and de‑dupe; subscription‑scoped lock; transactional trial conversion and activation (`ActivatePaygBillingMetadata`, `ActivatePaygOrganization`); audit under `organization:payg_activated` via `audit_log.organization_billing_event_v1` with before/after snapshots; post‑commit feature‑cache updates for any newly enabled entitlements. `SeedPaygEntitlementsTx` enables `FeaturePlatformMCP`, the `EnterpriseTrialBundle`, and `FeatureSkills` only when never configured and preserves explicit disables.
- Streams: `gram streams` initializes Temporal and uses `usage.PaygKeyRefreshHandler` to consume `audit_log.organization_billing_event_v1`, schedule the 100‑credit chat‑key refresh keyed by outbox event ID for Pub/Sub idempotency, then forward to the Svix relay.
- OpenRouter: `openrouter.KeyRefresher.ScheduleOpenRouterKeyRefresh(ctx, orgID, keyType, limit)` now accepts a credit limit; new `SchedulePaygOpenRouterKeyRefresh` uses the outbox event ID for workflow identity and handles already‑started gracefully.
- Dashboard: adds `organization:payg_activated` action and phrase.

- Update callers to the new `openrouter.KeyRefresher.ScheduleOpenRouterKeyRefresh(ctx, orgID, keyType, limit)` signature and pass `productfeatures.Client` to `usage.NewService(..., productFeatures)`.
- Configure Temporal for `gram streams` (`TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`, and related flags) or the process will fail to start.
- Regenerate SQLc and the outbox catalog if building outside CI.

Closes Linear DNO-841.

<sup>Written for commit 2102213653c4a051eee2b7408f6eb0678485b6ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

