### PR TITLE
fix(admin): stop the shell growing with the page

### DIFF
--- a/.changeset/admin-shell-stops-growing.md
+++ b/.changeset/admin-shell-stops-growing.md
@@ -1,0 +1,17 @@
+---
+"admin": patch
+---
+
+Scroll a long list in the admin app and the table moves, not the page. The
+search box, the filters and the pagination row hold their places while the rows
+travel under them, and the sidebar and the page header stay on screen
+throughout.
+
+Until now a list longer than the window grew the whole page instead. Reaching
+the fiftieth organization carried the search controls off the top of the screen
+and left the pagination row somewhere below the fold, so an operator who wanted
+the next page, or wanted to change a filter after reading the rows, had to
+scroll the document back up to find the controls again.
+
+Every page in the admin app gains the behaviour. Anything taller than the window
+now scrolls within the layout, and the shell around it stays put.

--- a/client/admin/src/layouts/AdminLayout.test.tsx
+++ b/client/admin/src/layouts/AdminLayout.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ?inline runs index.css through the Tailwind plugin and hands back the
+// generated stylesheet. Reading declarations out of it, keyed by the classes an
+// element actually carries, is what keeps this file off class strings: rename a
+// utility and the assertions still hold, drop one and they fail. happy-dom
+// cannot do this job with getComputedStyle, because it does not descend into
+// Tailwind's `@layer` blocks and does not resolve `svh`.
+import stylesheet from "@/index.css?inline";
+import type { AdminSessionInfo } from "@/lib/gramAdminApi";
+import { renderWithApp } from "@/test/harness";
+import { AdminLayout } from "./AdminLayout";
+
+// A ceiling that resolves to the viewport, however it is spelled. `min-h-svh`
+// is already on the wrapper, so a `max-height` clamp works as well as a
+// `height`, and the test should not reject either.
+const VIEWPORT_CEILING = /^(100svh|100dvh|100vh|100%)$/;
+const NO_MINIMUM = /^0(px)?$/;
+
+const SESSION: AdminSessionInfo = { email: "eng@example.test", name: "Eng" };
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+// NavUser reads the session on mount, and happy-dom resolves a relative URL
+// against localhost:3000, so without this the render leaves the process.
+function stubSession(): void {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json(SESSION)));
+}
+
+// Tailwind emits one flat rule per utility, so a body that admits no braces
+// matches innermost rules only and never an `@layer` or `@media` wrapper.
+const FLAT_RULE = /([^{}]+)\{([^{}]*)\}/g;
+
+// Every declaration the stylesheet applies to an element through its own
+// classes, in sheet order, so a later utility wins as it would in a browser.
+function declarationsFor(element: Element): Map<string, string> {
+  const classes = new Set(element.classList);
+  const declarations = new Map<string, string>();
+
+  for (const [, selector, body] of stylesheet.matchAll(FLAT_RULE)) {
+    const match = /^\.([^\s,>+~:[\]]+)$/.exec(selector!.trim());
+    // Tailwind escapes the characters a bare class cannot carry; undo that to
+    // compare against the class list.
+    if (!match || !classes.has(match[1]!.replaceAll("\\", ""))) continue;
+
+    for (const declaration of body!.split(";")) {
+      const colon = declaration.indexOf(":");
+      if (colon === -1) continue;
+      declarations.set(
+        declaration.slice(0, colon).trim(),
+        declaration.slice(colon + 1).trim(),
+      );
+    }
+  }
+
+  return declarations;
+}
+
+function scrollRegionWithin(root: Element): Element {
+  const regions = [...root.querySelectorAll("*")].filter(
+    (element) => declarationsFor(element).get("overflow") === "auto",
+  );
+  expect(regions).toHaveLength(1);
+  return regions[0]!;
+}
+
+describe("AdminLayout", () => {
+  it("caps the shell at the viewport", async () => {
+    stubSession();
+    await renderWithApp(<AdminLayout />);
+
+    const wrapper = document.querySelector('[data-slot="sidebar-wrapper"]');
+    expect(wrapper).not.toBeNull();
+    expect(screen.getByRole("main").parentElement).toBe(wrapper);
+
+    // Stock shadcn gives the wrapper `min-h-svh`, a floor with no ceiling, so a
+    // tall page grows the shell instead of scrolling inside it.
+    const declarations = declarationsFor(wrapper!);
+    const ceiling =
+      declarations.get("height") ?? declarations.get("max-height");
+    expect(ceiling).toMatch(VIEWPORT_CEILING);
+  });
+
+  it("keeps one scroll region and lets every element above it shrink", async () => {
+    stubSession();
+    await renderWithApp(<AdminLayout />);
+
+    const inset = screen.getByRole("main");
+    const scrollRegion = scrollRegionWithin(inset);
+
+    // Every link from the scroll region up to the inset has to give up its
+    // content-based minimum, because one that does not makes the whole chain
+    // below it content-sized and the ceiling above stops mattering.
+    for (
+      let element: Element | null = scrollRegion;
+      element && element !== inset;
+      element = element.parentElement
+    ) {
+      expect(declarationsFor(element).get("min-height")).toMatch(NO_MINIMUM);
+      expect(declarationsFor(element).get("flex")).toBe("1");
+    }
+  });
+});

--- a/client/admin/src/layouts/AdminLayout.tsx
+++ b/client/admin/src/layouts/AdminLayout.tsx
@@ -17,7 +17,10 @@ export function AdminLayout(): JSX.Element {
   const [defaultOpen] = useState(sidebarOpen);
 
   return (
+    // The constraint belongs here rather than in sidebar.tsx: that file is
+    // vendored shadcn and stays pristine so the registry can be re-pulled.
     <SidebarProvider
+      className="h-svh"
       defaultOpen={defaultOpen}
       style={
         {

--- a/client/admin/vitest.config.ts
+++ b/client/admin/vitest.config.ts
@@ -1,3 +1,4 @@
+import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
@@ -7,13 +8,19 @@ export default defineConfig({
   define: {
     __GRAM_APP_URL__: JSON.stringify("https://app.gram.test"),
   },
-  plugins: [react()],
+  // Tailwind, so a test can import the generated stylesheet and assert on
+  // resolved declarations rather than on class strings.
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
   },
   test: {
+    // Off by default, and with it off an imported stylesheet resolves to an
+    // empty string instead of the generated CSS. Narrowed to the one sheet a
+    // test reads, so no other file changes behaviour.
+    css: { include: [/index\.css/] },
     environment: "happy-dom",
   },
 });


### PR DESCRIPTION
Scrolling the organizations list moved the whole page instead of the table, so the header, the search controls and the pagination row left the screen.

An operator could not reach the filters or the next page without scrolling back up. The shape below is what the page now holds at any viewport height.

    ---
    Header
    ---
    Table controls   (stable height)
    Table            (grows, scrolls its own rows)
    Pagination       (stable height)
    ---

## Before and after

At 1440x900, with 60 organizations. The pagination row is off-screen on the left and in place on the right.

| Before | After |
| --- | --- |
| <img width="480" src="https://gist.githubusercontent.com/walker-tx/471673888d8d41107b7437b601f4051c/raw/28d82fbe7a29e7034d18dd06097b9597ba0e522c/before-1440x900.png"> | <img width="480" src="https://gist.githubusercontent.com/walker-tx/471673888d8d41107b7437b601f4051c/raw/9fd43b1ce060780726dcd20ec8c6e9255d1b31c3/after-1440x900.png"> |

Scrolling the rows while the toolbar and the pagination row hold their positions:

![scrolling the table](https://gist.githubusercontent.com/walker-tx/471673888d8d41107b7437b601f4051c/raw/b3d02cdc6a2278116be502d4d3fb9498ebf41fca/scroll.gif)

## The change

One class. `SidebarProvider`'s wrapper carries `min-h-svh`, a floor with no ceiling, so it grew with its content and no descendant could scroll: the document was the scroller. `AdminLayout` now supplies the ceiling, so `components/ui/sidebar.tsx` stays pristine for a registry re-pull.

The layout's own chain of `min-h-0 flex-1` divs down to the `overflow-auto` region was already correct and is unchanged. So is the organizations page.

## Measured in the browser

Chromium, 60 rows, at two viewport heights.

| | 1440x900 | 1440x700 |
| --- | --- | --- |
| `document.body.scrollHeight` | 2225 to 900 | 700 |
| `<main data-slot="sidebar-inset">` height | 2209 to 884 | 684 |
| toolbar top, before and after a window scroll | 80 to 80 | 80 to 80 |
| rows region scrollable height | 1990 | yes |

## What the test does, and one thing it cannot do

`AdminLayout.test.tsx` reads the Tailwind-generated stylesheet and resolves the declarations for the classes each element actually carries, rather than asserting a class string is present somewhere in the tree. It fails when the ceiling is dropped or moved to another element, when any link in the shrink chain loses `min-h-0` or `flex-1`, and when the single scroll region is removed or duplicated. Renaming a utility does not break it.

**It cannot catch a layout regression directly.** happy-dom performs no layout, so this is a stylesheet-and-structure assertion. The browser numbers above are the real proof, and they are in the commit message so they survive.

Eight mutations are killed, including the two that reintroduce this exact bug: stripping `min-h-0` from the intermediate divs, and stripping `overflow-auto` from the scroll region. Three survive deliberately and act as canaries: `h-svh` to `h-dvh`, a cosmetic `gap` change, and `h-svh` to `max-h-svh`, which is a working alternative because stock already supplies `min-h-svh`. I re-ran the two kills and one canary independently.

`vitest.config.ts` gains the Tailwind plugin, which the stylesheet assertion needs, scoped with `css: { include: [/index\.css/] }` so CSS processing does not switch on for the other eight test files.

## Found while measuring, not fixed here

Printing the organizations list truncates 7 pages to 1. A viewport-height ceiling does that, and there is no `@media print` block anywhere in `client/admin`, so it is pre-existing in kind and outside this slice. Filing it separately.

## Checks

All four gates green, and the two static ones canaried to prove they were really running: `type-check`, `lint:oxlint`, `test` (9 files, 81 tests), `build`. I re-ran all four myself on the pushed head.

AGE-3182.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the admin shell from growing with page content so long lists scroll inside the table while the header, search, and pagination stay visible. Previously the whole document scrolled because the sidebar wrapper had a floor without a ceiling; `AdminLayout` now caps the shell at the viewport to keep the shell fixed.

**Review notes**
- Change: add `h-svh` to `SidebarProvider` in `AdminLayout`; leave `components/ui/sidebar.tsx` untouched.
- Scope: affects all admin pages using `AdminLayout`; no content or table logic changes.
- Tests: new `AdminLayout.test.tsx` reads Tailwind output to assert a single scroll region and the `min-h-0 flex-1` chain; `vitest` config adds `@tailwindcss/vite` with `css: { include: [/index\.css/] }`.
- Verify: at varied viewport heights, only the rows area scrolls; toolbar and pagination remain pinned; no double scrollbars.
- Addresses AGE-3182.

<sup>Written for commit 43d5c67128275f94d72b8624694c37f75ecbbf5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

