### PR TITLE
feat(audit): record and render a restarted enterprise trial

### DIFF
--- a/.changeset/audit-trial-rearm-entry.md
+++ b/.changeset/audit-trial-rearm-entry.md
@@ -1,0 +1,22 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+The activity log can now record and render a restarted enterprise trial. The
+entry reads "restarted enterprise trial" and is credited to the Speakeasy team
+rather than to the individual operator, which is the label the log already gives
+a Speakeasy action taken inside a customer's organization.
+
+Nothing produces the entry yet. The admin action that restarts a trial follows
+separately, and this change is the log's half of it: the action name, the writer
+that records it, and the phrase the dashboard shows for it.
+
+The collective "Speakeasy Team" label now has one definition instead of two.
+The activity log applies it on read, by matching an actor against the members of
+the Speakeasy organization. A writer that already knows it is acting as staff
+has to apply the same label when it records the entry, because the read-time
+mask can only recognise an actor that has a Gram user id, and an operator
+authenticated through the admin app does not have one. Both paths now read the
+label from the same constant, so one action cannot appear under two different
+names depending on which path wrote it.

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -72,6 +72,7 @@ export const AUDIT_ACTIONS = [
   "organization:device_agent_configuration_updated",
   "organization:enterprise_trial_armed",
   "organization:enterprise_trial_demoted",
+  "organization:enterprise_trial_rearmed",
   "organization:hooks_fail_open_disabled",
   "organization:hooks_fail_open_enabled",
   "organization:webhooks_disabled",
@@ -356,6 +357,8 @@ export function staticActionPhrase(action: AuditAction): string {
       return "started enterprise trial";
     case "organization:enterprise_trial_demoted":
       return "ended enterprise trial";
+    case "organization:enterprise_trial_rearmed":
+      return "restarted enterprise trial";
 
     case "organization_invitation:create":
       return "invited";

--- a/server/internal/audit/actors.go
+++ b/server/internal/audit/actors.go
@@ -1,9 +1,5 @@
 package audit
 
-// SpeakeasyTeamActorLabel is the collective name a Speakeasy staff action
-// carries in a customer's audit feed, instead of the staff member's email.
-//
-// auditapi applies it on read, by actor id. A writer authenticated outside Gram
-// has no actor id to match, so it applies the label itself. One constant keeps
-// the two paths from drifting.
+// SpeakeasyTeamActorLabel is the collective name a Speakeasy staff action carries
+// in a customer's audit feed, instead of the staff member's own email.
 const SpeakeasyTeamActorLabel = "Speakeasy Team"

--- a/server/internal/audit/actors.go
+++ b/server/internal/audit/actors.go
@@ -1,15 +1,9 @@
 package audit
 
 // SpeakeasyTeamActorLabel is the collective name a Speakeasy staff action
-// carries in a customer's audit feed, instead of the staff member's own email.
+// carries in a customer's audit feed, instead of the staff member's email.
 //
-// It has two callers and they work in opposite directions. auditapi applies it
-// on read, masking an actor it recognises as a member of the Speakeasy
-// organization. A writer that already knows it is acting as staff inside a
-// customer's organization applies it at write time instead, because that mask
-// only fires for an actor id it can match against a Gram user, and a writer
-// authenticated somewhere other than Gram (the admin app's OIDC subject, for
-// one) has no such id. Both must produce the same string, or the same action
-// reads two different ways depending on which path recorded it, so there is one
-// definition here rather than a literal at each site.
+// auditapi applies it on read, by actor id. A writer authenticated outside Gram
+// has no actor id to match, so it applies the label itself. One constant keeps
+// the two paths from drifting.
 const SpeakeasyTeamActorLabel = "Speakeasy Team"

--- a/server/internal/audit/actors.go
+++ b/server/internal/audit/actors.go
@@ -1,0 +1,15 @@
+package audit
+
+// SpeakeasyTeamActorLabel is the collective name a Speakeasy staff action
+// carries in a customer's audit feed, instead of the staff member's own email.
+//
+// It has two callers and they work in opposite directions. auditapi applies it
+// on read, masking an actor it recognises as a member of the Speakeasy
+// organization. A writer that already knows it is acting as staff inside a
+// customer's organization applies it at write time instead, because that mask
+// only fires for an actor id it can match against a Gram user, and a writer
+// authenticated somewhere other than Gram (the admin app's OIDC subject, for
+// one) has no such id. Both must produce the same string, or the same action
+// reads two different ways depending on which path recorded it, so there is one
+// definition here rather than a literal at each site.
+const SpeakeasyTeamActorLabel = "Speakeasy Team"

--- a/server/internal/audit/audittest/helpers.go
+++ b/server/internal/audit/audittest/helpers.go
@@ -16,9 +16,7 @@ type LogRecord struct {
 	Action    string
 	ProjectID uuid.NullUUID
 
-	// ActorID and ActorType identify the actor. ActorDisplayName is for
-	// rendering and is masked for Speakeasy staff, so it cannot be asserted on
-	// alone.
+	// The display name is denormalized and masked for staff; assert on these instead.
 	ActorID          string
 	ActorType        string
 	ActorDisplayName *string

--- a/server/internal/audit/audittest/helpers.go
+++ b/server/internal/audit/audittest/helpers.go
@@ -13,8 +13,15 @@ import (
 )
 
 type LogRecord struct {
-	Action           string
-	ProjectID        uuid.NullUUID
+	Action    string
+	ProjectID uuid.NullUUID
+
+	// ActorID and ActorType are the authoritative record of who acted; the
+	// display name beside them is denormalized for rendering and is masked for
+	// Speakeasy staff. A test that asserts only the display name cannot tell an
+	// entry that identifies the actor from one that identifies nobody.
+	ActorID          string
+	ActorType        string
 	ActorDisplayName *string
 	SubjectType      string
 	SubjectDisplay   string
@@ -33,6 +40,8 @@ func LatestAuditLogByAction(ctx context.Context, dbtx repo.DBTX, action audit.Ac
 	return LogRecord{
 		Action:           row.Action,
 		ProjectID:        row.ProjectID,
+		ActorID:          row.ActorID,
+		ActorType:        row.ActorType,
 		ActorDisplayName: conv.FromPGText[string](row.ActorDisplayName),
 		SubjectType:      row.SubjectType,
 		SubjectDisplay:   conv.PtrValOr(conv.FromPGText[string](row.SubjectDisplayName), ""),

--- a/server/internal/audit/audittest/helpers.go
+++ b/server/internal/audit/audittest/helpers.go
@@ -16,10 +16,9 @@ type LogRecord struct {
 	Action    string
 	ProjectID uuid.NullUUID
 
-	// ActorID and ActorType are the authoritative record of who acted; the
-	// display name beside them is denormalized for rendering and is masked for
-	// Speakeasy staff. A test that asserts only the display name cannot tell an
-	// entry that identifies the actor from one that identifies nobody.
+	// ActorID and ActorType identify the actor. ActorDisplayName is for
+	// rendering and is masked for Speakeasy staff, so it cannot be asserted on
+	// alone.
 	ActorID          string
 	ActorType        string
 	ActorDisplayName *string

--- a/server/internal/audit/audittest/queries.sql
+++ b/server/internal/audit/audittest/queries.sql
@@ -2,6 +2,8 @@
 SELECT
   action,
   project_id,
+  actor_id,
+  actor_type,
   actor_display_name,
   subject_type,
   subject_display_name,

--- a/server/internal/audit/audittest/repo/queries.sql.go
+++ b/server/internal/audit/audittest/repo/queries.sql.go
@@ -41,6 +41,8 @@ const getLatestAuditLogByAction = `-- name: GetLatestAuditLogByAction :one
 SELECT
   action,
   project_id,
+  actor_id,
+  actor_type,
   actor_display_name,
   subject_type,
   subject_display_name,
@@ -57,6 +59,8 @@ LIMIT 1
 type GetLatestAuditLogByActionRow struct {
 	Action             string
 	ProjectID          uuid.NullUUID
+	ActorID            string
+	ActorType          string
 	ActorDisplayName   pgtype.Text
 	SubjectType        string
 	SubjectDisplayName pgtype.Text
@@ -72,6 +76,8 @@ func (q *Queries) GetLatestAuditLogByAction(ctx context.Context, action string) 
 	err := row.Scan(
 		&i.Action,
 		&i.ProjectID,
+		&i.ActorID,
+		&i.ActorType,
 		&i.ActorDisplayName,
 		&i.SubjectType,
 		&i.SubjectDisplayName,

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -28,6 +28,8 @@ const (
 	ActionOrganizationEnterpriseTrialArmed Action = "organization:enterprise_trial_armed"
 
 	ActionOrganizationEnterpriseTrialDemoted Action = "organization:enterprise_trial_demoted"
+
+	ActionOrganizationEnterpriseTrialRearmed Action = "organization:enterprise_trial_rearmed"
 )
 
 type LogOrganizationInviteCreateEvent struct {
@@ -344,6 +346,60 @@ func (l *Logger) LogOrganizationEnterpriseTrialArmed(ctx context.Context, dbtx r
 	action := ActionOrganizationEnterpriseTrialArmed
 
 	metadata, err := marshalAuditPayload(map[string]any{
+		"trial_ends_at": event.TrialEndsAt,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.OrganizationID,
+		SubjectType:        "organization",
+		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.OrganizationSlug),
+
+		Metadata:       metadata,
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationEnterpriseTrialV1})
+}
+
+// LogOrganizationEnterpriseTrialRearmedEvent records an operator putting a
+// demoted trial back on. AccountType is the tier the organization was restored
+// to, and it is on the entry because the demotion's own entry is the only place
+// the tier it overwrote survives: a reader comparing the two learns whether the
+// re-arm gave the organization back what it had.
+type LogOrganizationEnterpriseTrialRearmedEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	OrganizationName string
+	OrganizationSlug string
+
+	AccountType string
+	TrialEndsAt time.Time
+}
+
+func (l *Logger) LogOrganizationEnterpriseTrialRearmed(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialRearmedEvent) error {
+	action := ActionOrganizationEnterpriseTrialRearmed
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"account_type":  event.AccountType,
 		"trial_ends_at": event.TrialEndsAt,
 	})
 	if err != nil {

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -377,10 +377,8 @@ func (l *Logger) LogOrganizationEnterpriseTrialArmed(ctx context.Context, dbtx r
 }
 
 // LogOrganizationEnterpriseTrialRearmedEvent records an operator putting a
-// demoted trial back on. AccountType is the tier the organization was restored
-// to, and it is on the entry because the demotion's own entry is the only place
-// the tier it overwrote survives: a reader comparing the two learns whether the
-// re-arm gave the organization back what it had.
+// demoted trial back on. AccountType carries the restored tier so a reader can
+// compare it with the demotion entry, which is the only record of the old one.
 type LogOrganizationEnterpriseTrialRearmedEvent struct {
 	OrganizationID string
 

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -40,11 +40,6 @@ const listAuditLogsPageSize = 50
 // Speakeasy staff actions in customer orgs (e.g. via the dev-tools org
 // override) are shown under a collective label instead of the staff member's
 // email. Logs viewed within the Speakeasy org itself are not masked.
-//
-// The label itself lives in the audit package because writers that already know
-// they are staff apply it at write time, where this mask cannot reach them: it
-// matches an actor id against a Gram user, and an actor authenticated outside
-// Gram has no such id.
 const speakeasyTeamOrganizationID = "5a25158b-24dc-4d49-b03d-e85acfbea59c"
 
 type Service struct {

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -22,6 +22,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/auditlogs"
 	srv "github.com/speakeasy-api/gram/server/gen/http/auditlogs/server"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -39,10 +40,12 @@ const listAuditLogsPageSize = 50
 // Speakeasy staff actions in customer orgs (e.g. via the dev-tools org
 // override) are shown under a collective label instead of the staff member's
 // email. Logs viewed within the Speakeasy org itself are not masked.
-const (
-	speakeasyTeamOrganizationID = "5a25158b-24dc-4d49-b03d-e85acfbea59c"
-	speakeasyTeamActorLabel     = "Speakeasy Team"
-)
+//
+// The label itself lives in the audit package because writers that already know
+// they are staff apply it at write time, where this mask cannot reach them: it
+// matches an actor id against a Gram user, and an actor authenticated outside
+// Gram has no such id.
+const speakeasyTeamOrganizationID = "5a25158b-24dc-4d49-b03d-e85acfbea59c"
 
 type Service struct {
 	tracer trace.Tracer
@@ -149,7 +152,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 	}
 	for _, log := range logs {
 		if log.ActorType == "user" && speakeasyActors[log.ActorID] {
-			log.ActorDisplayName = conv.PtrEmpty(speakeasyTeamActorLabel)
+			log.ActorDisplayName = conv.PtrEmpty(audit.SpeakeasyTeamActorLabel)
 			log.ActorSlug = nil
 		}
 	}
@@ -232,7 +235,7 @@ func (s *Service) ListFacets(ctx context.Context, payload *gen.ListFacetsPayload
 	}
 	for _, actor := range actors {
 		if speakeasyActors[actor.Value] {
-			actor.DisplayName = speakeasyTeamActorLabel
+			actor.DisplayName = audit.SpeakeasyTeamActorLabel
 		}
 	}
 

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -44,7 +44,7 @@ var (
 	OpenRouterAPIKeyV1                     = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.openrouter_api_key_event_v1", "Emitted when changes to the organization's platform OpenRouter key are made")
 	OrganizationHooksFailOpenV1            = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_hooks_fail_open_event_v1", "Emitted when the organization's hooks fail-open setting is toggled")
 	OrganizationDeviceAgentConfigurationV1 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_device_agent_configuration_event_v1", "Emitted when the organization's device-agent configuration is changed")
-	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed or demoted")
+	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, demoted, or re-armed")
 	OrganizationInviteV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_invite_event_v1", "Emitted when changes to organization invites are made")
 	OrganizationWebhooksV1                 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_webhooks_event_v1", "Emitted when changes to organization webhooks are made")
 	OtelForwardingV1                       = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.otel_forwarding_event_v1", "Emitted when changes to OTEL forwarding configs are made")

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -1572,7 +1572,7 @@ webhooks:
                 required: true
     audit_log.organization_enterprise_trial_event_v1:
         post:
-            description: Emitted when the organization's enterprise trial is armed or demoted
+            description: Emitted when the organization's enterprise trial is armed, demoted, or re-armed
             operationId: audit_log.organization_enterprise_trial_event_v1
             requestBody:
                 content:


### PR DESCRIPTION
The activity log learns to record and render a restarted enterprise trial. Nothing produces the entry yet: this is the log's half of the re-arm feature, split out so it can be reviewed on its own.

This was the audit-log side of #5301. It is now the branch #5301 sits on, so the two can be reviewed separately.

## What is here

- `organization:enterprise_trial_rearmed`, and `LogOrganizationEnterpriseTrialRearmed`, the writer that records it.
- `"restarted enterprise trial"`, the phrase the dashboard renders for it.
- `audit.SpeakeasyTeamActorLabel`, lifted out of `auditapi`.
- `ActorID` and `ActorType` on the `audittest` `LogRecord`.

## Why the label moved

The activity log masks a Speakeasy staff action inside a customer's organization behind a collective label, applied on read by matching the actor against the members of the Speakeasy organization.

That match needs a Gram user id. An operator acting through the admin app authenticates against an OIDC subject and has no Gram user id, so the read-time mask cannot reach them and the writer has to apply the same label itself. Two sites now need the same string, and two literals that must agree is one edit away from an action that reads two different ways depending on which path recorded it. There is one constant instead.

## Why the test helper gained two fields

`audittest.LogRecord` carried only `ActorDisplayName`. A test asserting on the display name alone cannot tell an entry that identifies its actor from one that identifies nobody, which is exactly the distinction the label above turns on. `ActorID` and `ActorType` are the authoritative pair, so they are on the record.

## Verification

Run at `7b341c07f`, on this branch alone on top of `main`:

| gate | result |
| --- | --- |
| `mise lint:server` | exit 0 |
| `go test ./server/internal/admin/... ./server/internal/audit/... ./server/internal/auditapi/...` | exit 0, 3 packages ok |
| `aube run -F dashboard test src/lib/audit-actions.test.ts` | exit 0, 3 tests passed |

That last one is not incidental. `audit-actions.test.ts` parses every action constant out of `server/internal/audit/*.go` and asserts the TypeScript list matches, so the Go constant and the TypeScript line have to land together. They do, both here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records and renders a restarted enterprise trial to support re-arming demoted trials (AGE-3208). Previously there was no entry or dashboard phrase; now `organization:enterprise_trial_rearmed` is logged and displayed as "restarted enterprise trial."

- Adds the `organization:enterprise_trial_rearmed` action and `LogOrganizationEnterpriseTrialRearmed` in `server/internal/audit`; payload includes `account_type` and `trial_ends_at`. Nothing emits this event yet.
- Updates `client/dashboard/src/lib/audit-actions.ts` to include the action and phrase.
- Introduces `audit.SpeakeasyTeamActorLabel`; `server/internal/auditapi` now uses it so read-time masks and writers share the same staff label.
- Extends `audittest.LogRecord` with `ActorID` and `ActorType` for precise assertions.
- Updates outbox docs: `OrganizationEnterpriseTrialV1` now covers re-armed trials.

<sup>Written for commit 6f8d33e07e423a17942760d8d4fe4e3e32f965b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

