### PR TITLE
fix(admin): a pasted id finds a disabled organization, at any casing

### DIFF
--- a/.changeset/admin-search-organization-ids-semantics.md
+++ b/.changeset/admin-search-organization-ids-semantics.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+A pasted organization id or WorkOS id in the admin organizations search now finds a disabled organization, because investigating a suspended organization is a leading reason to paste an id. Both id matches also ignore casing, so an id that arrived lowercased from a log pipeline still lands on the right organization. The search term is trimmed of surrounding whitespace, and % and _ inside it match literally instead of acting as wildcards. An id match still respects the account type, trial state and cursor filters.

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -390,7 +390,7 @@ var _ = Service("admin", func() {
 		Payload(func() {
 			security.AdminAuthPayload()
 
-			Attribute("q", String, "Search term applied to name and slug (case-insensitive substring).")
+			Attribute("q", String, "Search term, trimmed of surrounding whitespace. Matches name and slug as a case-insensitive substring, with % and _ taken literally, and matches organization id and WorkOS id exactly, ignoring case. An id match also returns an organization that disabled_states or include_disabled would otherwise hide; it still respects account_type, account_types, trial_states and cursor.")
 			Attribute("account_type", String, "Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.")
 			Attribute("account_types", ArrayOf(String), "Match any of these gram_account_type values. Empty matches every account type. A value no organization carries matches nothing rather than failing the request.")
 			Attribute("trial_states", ArrayOf(String), "Match any of running, ending_soon, expired, demoted, converted or none. Empty matches every trial state. An unrecognised value matches nothing rather than failing the request.")

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -273,7 +273,12 @@ type ListOrganizationProjectsPayload struct {
 // listOrganizations method.
 type ListOrganizationsPayload struct {
 	AdminSessionToken *string
-	// Search term applied to name and slug (case-insensitive substring).
+	// Search term, trimmed of surrounding whitespace. Matches name and slug as a
+	// case-insensitive substring, with % and _ taken literally, and matches
+	// organization id and WorkOS id exactly, ignoring case. An id match also
+	// returns an organization that disabled_states or include_disabled would
+	// otherwise hide; it still respects account_type, account_types, trial_states
+	// and cursor.
 	Q *string
 	// Filter by a single gram_account_type (e.g. free, pro, enterprise).
 	// Superseded by account_types, which it joins as one more member of the same

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -748,11 +748,11 @@ paths:
             operationId: adminListOrganizations
             parameters:
                 - allowEmptyValue: true
-                  description: Search term applied to name and slug (case-insensitive substring).
+                  description: Search term, trimmed of surrounding whitespace. Matches name and slug as a case-insensitive substring, with % and _ taken literally, and matches organization id and WorkOS id exactly, ignoring case. An id match also returns an organization that disabled_states or include_disabled would otherwise hide; it still respects account_type, account_types, trial_states and cursor.
                   in: query
                   name: q
                   schema:
-                    description: Search term applied to name and slug (case-insensitive substring).
+                    description: Search term, trimmed of surrounding whitespace. Matches name and slug as a case-insensitive substring, with % and _ taken literally, and matches organization id and WorkOS id exactly, ignoring case. An id match also returns an organization that disabled_states or include_disabled would otherwise hide; it still respects account_type, account_types, trial_states and cursor.
                     type: string
                 - allowEmptyValue: true
                   description: Filter by a single gram_account_type (e.g. free, pro, enterprise). Superseded by account_types, which it joins as one more member of the same set.

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -411,8 +411,14 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 
 	accountTypes, disabledStates := listOrganizationsFilters(payload)
 
+	// Trimmed once for both queries. A pasted id commonly arrives with the
+	// newline that ended the line it was copied from, and no arm matches through
+	// it; the id arms because they compare exactly, the name and slug arms
+	// because the whitespace lands inside the pattern.
+	searchTerm := conv.PtrToPGTextTrimmed(payload.Q)
+
 	rows, err := queries.AdminListOrganizations(ctx, repo.AdminListOrganizationsParams{
-		Q:              conv.PtrToPGText(payload.Q),
+		Q:              searchTerm,
 		AccountTypes:   accountTypes,
 		TrialStates:    payload.TrialStates,
 		DisabledStates: disabledStates,
@@ -430,7 +436,7 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 	// a count, and in cursor mode the page query has already discarded everything
 	// before the cursor.
 	total, err := queries.AdminCountOrganizations(ctx, repo.AdminCountOrganizationsParams{
-		Q:              conv.PtrToPGText(payload.Q),
+		Q:              searchTerm,
 		AccountTypes:   accountTypes,
 		TrialStates:    payload.TrialStates,
 		DisabledStates: disabledStates,

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -433,7 +433,7 @@ type searchByIDCase struct {
 }
 
 // requireSearchMatches asserts the exact set of organizations a payload returns, ignoring order.
-func requireSearchMatches(t *testing.T, ctx context.Context, svc *Service, payload *gen.ListOrganizationsPayload, wantIDs []string, label string) {
+func requireSearchMatches(t *testing.T, ctx context.Context, svc *Service, payload *gen.ListOrganizationsPayload, wantIDs []string, label string) *gen.AdminListOrganizationsResult {
 	t.Helper()
 
 	res, err := svc.ListOrganizations(ctx, payload)
@@ -444,6 +444,22 @@ func requireSearchMatches(t *testing.T, ctx context.Context, svc *Service, paylo
 		got[i] = o.ID
 	}
 	require.ElementsMatch(t, wantIDs, got, "organizations matched by %s", label)
+
+	return res
+}
+
+// requireSearchMatchesWithTotal adds the pager total to requireSearchMatches.
+// The count query carries its own copy of the filter arms, so a page that agrees
+// with the fixtures while the total disagrees is a real failure this catches and
+// the rows alone cannot. Only for payloads with no cursor: the count query has no
+// cursor predicate, so its total counts past one deliberately.
+func requireSearchMatchesWithTotal(t *testing.T, ctx context.Context, svc *Service, payload *gen.ListOrganizationsPayload, wantIDs []string, label string) {
+	t.Helper()
+
+	require.Nil(t, payload.Cursor, "total assertion is meaningless with a cursor, for %s", label)
+
+	res := requireSearchMatches(t, ctx, svc, payload, wantIDs, label)
+	require.Equal(t, int64(len(wantIDs)), res.Total, "total matched by %s", label)
 }
 
 func TestListOrganizations_SearchByID(t *testing.T) {
@@ -479,12 +495,12 @@ func TestListOrganizations_SearchByID(t *testing.T) {
 	}
 }
 
-func TestListOrganizations_SearchByIDIsCaseSensitive(t *testing.T) {
+func TestListOrganizations_SearchByIDIgnoresCase(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn := newTestAdminService(t)
 
-	// Both id spaces are opaque and case significant, and a real WorkOS id embeds an uppercase ULID.
+	// A real WorkOS id embeds an uppercase ULID, and a log pipeline hands the operator a lowercased copy of it.
 	const (
 		mixedID       = "org_search_id_MixedCase"
 		mixedWorkosID = "org_workos_placeholder_MixedCase"
@@ -493,59 +509,63 @@ func TestListOrganizations_SearchByIDIsCaseSensitive(t *testing.T) {
 	workosID := mixedWorkosID
 	seedOrg(t, ctx, conn, orgFixture{id: mixedID, name: "Mixed Case Holdings", slug: "mixed-case-holdings", workosID: &workosID, whitelisted: true})
 
+	// Each id runs at its own casing, folded down and folded up. Lowering only the column matches the folded form
+	// and misses the other two; lowering only the term matches nothing but the folded form either.
 	cases := []searchByIDCase{
 		{name: "organization id at its own casing", q: mixedID, wantIDs: []string{mixedID}},
-		{name: "organization id case folded", q: strings.ToLower(mixedID), wantIDs: nil},
+		{name: "organization id case folded", q: strings.ToLower(mixedID), wantIDs: []string{mixedID}},
+		{name: "organization id upper cased", q: strings.ToUpper(mixedID), wantIDs: []string{mixedID}},
 		{name: "workos id at its own casing", q: mixedWorkosID, wantIDs: []string{mixedID}},
-		{name: "workos id case folded", q: strings.ToLower(mixedWorkosID), wantIDs: nil},
+		{name: "workos id case folded", q: strings.ToLower(mixedWorkosID), wantIDs: []string{mixedID}},
+		{name: "workos id upper cased", q: strings.ToUpper(mixedWorkosID), wantIDs: []string{mixedID}},
 
-		// The contrast that makes the two case-folded rows above meaningful: name and slug still ignore casing.
+		// Case folding is all the id arms gained: they still compare whole and exactly.
+		{name: "an id differing by more than its casing", q: "org_search_id_MixedCases", wantIDs: nil},
+		{name: "fragment of an organization id, case folded", q: "search_id_mixedcase", wantIDs: nil},
+
 		{name: "name case folded", q: "mixed case holdings", wantIDs: []string{mixedID}},
 		{name: "slug upper cased", q: "MIXED-CASE-HOLDINGS", wantIDs: []string{mixedID}},
 	}
 
 	for _, c := range cases {
-		requireSearchMatches(t, ctx, svc, &gen.ListOrganizationsPayload{Q: conv.PtrEmpty(c.q)}, c.wantIDs, c.name)
+		requireSearchMatchesWithTotal(t, ctx, svc, &gen.ListOrganizationsPayload{Q: conv.PtrEmpty(c.q)}, c.wantIDs, c.name)
 	}
 }
 
 type searchFilterCase struct {
-	name            string
-	q               string
-	includeDisabled bool
-	accountType     string
-	cursor          string
-	wantIDs         []string
+	name        string
+	q           string
+	accountType string
+	trialStates []string
+	cursor      string
+	wantIDs     []string
 }
 
-// An id match is one arm of the q group, not an escape from the group: it still meets every other filter.
+// An id match escapes the disabled filter and no other: it is still one arm of
+// the q group as far as every remaining filter is concerned. TestListOrganizations_SearchByIDFindsADisabledOrganization
+// covers the one filter it does escape.
 func TestListOrganizations_SearchByIDRespectsFilters(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn := newTestAdminService(t)
 
 	const (
-		disabledID = "org_search_id_disabled"
-		proID      = "org_search_id_pro"
-		cursorID   = "org_search_id_cursor"
-
-		disabledWorkosID = "org_workos_placeholder_disabled"
+		proID    = "org_search_id_pro"
+		cursorID = "org_search_id_cursor"
+		trialID  = "org_search_id_trial"
 	)
 
-	disabledAt := time.Now().UTC().Add(-24 * time.Hour)
-	workosID := disabledWorkosID
-	seedOrg(t, ctx, conn, orgFixture{id: disabledID, name: "Disabled Holdings", slug: "disabled-holdings", workosID: &workosID, whitelisted: true, disabledAt: &disabledAt})
 	seedOrg(t, ctx, conn, orgFixture{id: proID, name: "Pro Holdings", slug: "pro-holdings", accountType: "pro", whitelisted: true})
 	seedOrg(t, ctx, conn, orgFixture{id: cursorID, name: "Cursor Holdings", slug: "cursor-holdings", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: trialID, name: "Trial Holdings", slug: "trial-holdings", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: trialID, endsAt: time.Now().UTC().Add(30 * 24 * time.Hour)})
 
 	cases := []searchFilterCase{
-		{name: "disabled organization by id, disabled excluded", q: disabledID, wantIDs: nil},
-		{name: "disabled organization by id, disabled included", q: disabledID, includeDisabled: true, wantIDs: []string{disabledID}},
-		{name: "disabled organization by workos id, disabled excluded", q: disabledWorkosID, wantIDs: nil},
-		{name: "disabled organization by workos id, disabled included", q: disabledWorkosID, includeDisabled: true, wantIDs: []string{disabledID}},
-
 		{name: "pro organization by id, filtered to free", q: proID, accountType: "free", wantIDs: nil},
 		{name: "pro organization by id, filtered to pro", q: proID, accountType: "pro", wantIDs: []string{proID}},
+
+		{name: "running trial by id, filtered to expired", q: trialID, trialStates: []string{"expired"}, wantIDs: nil},
+		{name: "running trial by id, filtered to running", q: trialID, trialStates: []string{"running"}, wantIDs: []string{trialID}},
 
 		{name: "organization by id, at or before the cursor", q: cursorID, cursor: cursorID, wantIDs: nil},
 		{name: "organization by id, after the cursor", q: cursorID, cursor: "org_search_id_a", wantIDs: []string{cursorID}},
@@ -553,12 +573,139 @@ func TestListOrganizations_SearchByIDRespectsFilters(t *testing.T) {
 
 	for _, c := range cases {
 		payload := &gen.ListOrganizationsPayload{
-			Q:               conv.PtrEmpty(c.q),
-			IncludeDisabled: conv.PtrEmpty(c.includeDisabled),
-			AccountType:     conv.PtrEmpty(c.accountType),
-			Cursor:          conv.PtrEmpty(c.cursor),
+			Q:           conv.PtrEmpty(c.q),
+			AccountType: conv.PtrEmpty(c.accountType),
+			TrialStates: c.trialStates,
+			Cursor:      conv.PtrEmpty(c.cursor),
 		}
 		requireSearchMatches(t, ctx, svc, payload, c.wantIDs, c.name)
+	}
+}
+
+type searchDisabledCase struct {
+	name            string
+	q               string
+	includeDisabled bool
+	disabledStates  []string
+	wantIDs         []string
+}
+
+// Pasting the id of a suspended organization is a leading reason to paste an id
+// at all, so an exact id match reaches one whatever the disabled filter says.
+// Only the id arms escape it; the name and slug arms do not.
+func TestListOrganizations_SearchByIDFindsADisabledOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	const (
+		disabledID = "org_search_id_disabled"
+		activeID   = "org_search_id_active"
+
+		disabledWorkosID = "org_workos_placeholder_Disabled"
+	)
+
+	disabledAt := time.Now().UTC().Add(-24 * time.Hour)
+	workosID := disabledWorkosID
+	seedOrg(t, ctx, conn, orgFixture{id: disabledID, name: "Disabled Holdings", slug: "disabled-holdings", workosID: &workosID, whitelisted: true, disabledAt: &disabledAt})
+	seedOrg(t, ctx, conn, orgFixture{id: activeID, name: "Active Holdings", slug: "active-holdings", whitelisted: true})
+
+	cases := []searchDisabledCase{
+		{name: "disabled organization by id, disabled excluded", q: disabledID, wantIDs: []string{disabledID}},
+		{name: "disabled organization by id, disabled included", q: disabledID, includeDisabled: true, wantIDs: []string{disabledID}},
+		{name: "disabled organization by id, disabled_states active", q: disabledID, disabledStates: []string{"active"}, wantIDs: []string{disabledID}},
+		{name: "disabled organization by workos id, disabled excluded", q: disabledWorkosID, wantIDs: []string{disabledID}},
+		{name: "disabled organization by lowercased workos id, disabled excluded", q: strings.ToLower(disabledWorkosID), wantIDs: []string{disabledID}},
+
+		// The bypass is the two id arms, not the whole q group.
+		{name: "disabled organization by name, disabled excluded", q: "Disabled Holdings", wantIDs: nil},
+		{name: "disabled organization by slug, disabled excluded", q: "disabled-holdings", wantIDs: nil},
+		{name: "disabled organization by name, disabled included", q: "Disabled Holdings", includeDisabled: true, wantIDs: []string{disabledID}},
+
+		// Symmetric: the id arms escape the filter rather than widening it to disabled rows.
+		{name: "active organization by id, disabled_states disabled", q: activeID, disabledStates: []string{"disabled"}, wantIDs: []string{activeID}},
+		{name: "active organization by name, disabled_states disabled", q: "Active Holdings", disabledStates: []string{"disabled"}, wantIDs: nil},
+	}
+
+	for _, c := range cases {
+		payload := &gen.ListOrganizationsPayload{
+			Q:               conv.PtrEmpty(c.q),
+			IncludeDisabled: conv.PtrEmpty(c.includeDisabled),
+			DisabledStates:  c.disabledStates,
+		}
+		requireSearchMatchesWithTotal(t, ctx, svc, payload, c.wantIDs, c.name)
+	}
+}
+
+// Every id in both id spaces contains underscores, and _ is a single-character
+// LIKE wildcard, so an unescaped pasted id draws incidental matches out of the
+// name and slug arms.
+func TestListOrganizations_SearchEscapesLikeMetacharacters(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	const (
+		pastedID     = "org_01_alpha"
+		incidentalID = "org_escape_incidental"
+		percentID    = "org_escape_percent"
+		nameDecoyID  = "org_escape_name_decoy"
+		slugDecoyID  = "org_escape_slug_decoy"
+		backslashID  = "org_escape_backslash"
+	)
+
+	seedOrg(t, ctx, conn, orgFixture{id: pastedID, name: "Alpha Systems", slug: "alpha-systems", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: incidentalID, name: "Acme org 01 alpha", slug: "acme-org-01-alpha", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: percentID, name: "Percent% Holdings", slug: "under_score-co", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: nameDecoyID, name: "PercentX Holdings", slug: "name-decoy-co", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: slugDecoyID, name: "Slug Decoy", slug: "underXscore-co", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: backslashID, name: `Back\slash_Co`, slug: "back-slash-co", whitelisted: true})
+
+	cases := []searchByIDCase{
+		// The motivating case: unescaped, this id also matches the other organization's name and slug.
+		{name: "a pasted id draws no incidental match", q: pastedID, wantIDs: []string{pastedID}},
+
+		// One decoy per arm, so escaping the name arm alone or the slug arm alone still fails.
+		{name: "percent in the name arm is literal", q: "Percent% Holdings", wantIDs: []string{percentID}},
+		{name: "underscore in the slug arm is literal", q: "under_score-co", wantIDs: []string{percentID}},
+
+		// Backslash is the escape character itself, so it has to be escaped before the two wildcards.
+		{name: "backslash in the term is literal", q: `Back\slash_Co`, wantIDs: []string{backslashID}},
+
+		// Escaping did not cost the arms their substring match.
+		{name: "a substring still matches", q: "Holdings", wantIDs: []string{percentID, nameDecoyID}},
+	}
+
+	for _, c := range cases {
+		requireSearchMatchesWithTotal(t, ctx, svc, &gen.ListOrganizationsPayload{Q: conv.PtrEmpty(c.q)}, c.wantIDs, c.name)
+	}
+}
+
+// A pasted id commonly arrives with the newline that ended the line it was
+// copied from. The dashboard trims before it asks, but a direct API caller does not.
+func TestListOrganizations_SearchTermIsTrimmed(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	const trimID = "org_search_trim_alpha"
+
+	workosID := "org_workos_placeholder_trim"
+	seedOrg(t, ctx, conn, orgFixture{id: trimID, name: "Trim Holdings", slug: "trim-holdings", workosID: &workosID, whitelisted: true})
+
+	cases := []searchByIDCase{
+		{name: "leading space", q: " " + trimID, wantIDs: []string{trimID}},
+		{name: "trailing newline", q: trimID + "\n", wantIDs: []string{trimID}},
+		{name: "trailing space", q: trimID + " ", wantIDs: []string{trimID}},
+		{name: "surrounded by mixed whitespace", q: "\t " + trimID + " \r\n", wantIDs: []string{trimID}},
+		{name: "workos id with a trailing newline", q: workosID + "\n", wantIDs: []string{trimID}},
+		{name: "name with a trailing newline", q: "Trim Holdings\n", wantIDs: []string{trimID}},
+		// Whitespace alone is no search term at all rather than a term nothing holds.
+		{name: "whitespace only", q: " \n\t ", wantIDs: []string{trimID}},
+	}
+
+	for _, c := range cases {
+		requireSearchMatchesWithTotal(t, ctx, svc, &gen.ListOrganizationsPayload{Q: conv.PtrEmpty(c.q)}, c.wantIDs, c.name)
 	}
 }
 

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -509,8 +509,8 @@ func TestListOrganizations_SearchByIDIgnoresCase(t *testing.T) {
 	workosID := mixedWorkosID
 	seedOrg(t, ctx, conn, orgFixture{id: mixedID, name: "Mixed Case Holdings", slug: "mixed-case-holdings", workosID: &workosID, whitelisted: true})
 
-	// Each id runs at its own casing, folded down and folded up. Lowering only the column matches the folded form
-	// and misses the other two; lowering only the term matches nothing but the folded form either.
+	// Lowering only the column matches the folded form and misses the other two;
+	// lowering only the term matches nothing but the folded form either.
 	cases := []searchByIDCase{
 		{name: "organization id at its own casing", q: mixedID, wantIDs: []string{mixedID}},
 		{name: "organization id case folded", q: strings.ToLower(mixedID), wantIDs: []string{mixedID}},
@@ -522,6 +522,7 @@ func TestListOrganizations_SearchByIDIgnoresCase(t *testing.T) {
 		// Case folding is all the id arms gained: they still compare whole and exactly.
 		{name: "an id differing by more than its casing", q: "org_search_id_MixedCases", wantIDs: nil},
 		{name: "fragment of an organization id, case folded", q: "search_id_mixedcase", wantIDs: nil},
+		{name: "fragment of a workos id, case folded", q: "placeholder_mixedcase", wantIDs: nil},
 
 		{name: "name case folded", q: "mixed case holdings", wantIDs: []string{mixedID}},
 		{name: "slug upper cased", q: "MIXED-CASE-HOLDINGS", wantIDs: []string{mixedID}},
@@ -578,7 +579,16 @@ func TestListOrganizations_SearchByIDRespectsFilters(t *testing.T) {
 			TrialStates: c.trialStates,
 			Cursor:      conv.PtrEmpty(c.cursor),
 		}
-		requireSearchMatches(t, ctx, svc, payload, c.wantIDs, c.name)
+
+		// The count query has no cursor predicate, so only the cursor-free cases
+		// can hold it to a total. The rest must, or the account type and trial
+		// state arms are checked in the page query alone.
+		if c.cursor != "" {
+			requireSearchMatches(t, ctx, svc, payload, c.wantIDs, c.name)
+			continue
+		}
+
+		requireSearchMatchesWithTotal(t, ctx, svc, payload, c.wantIDs, c.name)
 	}
 }
 
@@ -598,8 +608,11 @@ func TestListOrganizations_SearchByIDFindsADisabledOrganization(t *testing.T) {
 
 	ctx, svc, conn := newTestAdminService(t)
 
+	// Both ids are mixed case: the bypass carries its own copy of the id arms, so
+	// it needs its own proof that each folds case rather than borrowing the one
+	// TestListOrganizations_SearchByIDIgnoresCase gives an active organization.
 	const (
-		disabledID = "org_search_id_disabled"
+		disabledID = "org_search_id_Disabled"
 		activeID   = "org_search_id_active"
 
 		disabledWorkosID = "org_workos_placeholder_Disabled"
@@ -614,6 +627,7 @@ func TestListOrganizations_SearchByIDFindsADisabledOrganization(t *testing.T) {
 		{name: "disabled organization by id, disabled excluded", q: disabledID, wantIDs: []string{disabledID}},
 		{name: "disabled organization by id, disabled included", q: disabledID, includeDisabled: true, wantIDs: []string{disabledID}},
 		{name: "disabled organization by id, disabled_states active", q: disabledID, disabledStates: []string{"active"}, wantIDs: []string{disabledID}},
+		{name: "disabled organization by lowercased id, disabled excluded", q: strings.ToLower(disabledID), wantIDs: []string{disabledID}},
 		{name: "disabled organization by workos id, disabled excluded", q: disabledWorkosID, wantIDs: []string{disabledID}},
 		{name: "disabled organization by lowercased workos id, disabled excluded", q: strings.ToLower(disabledWorkosID), wantIDs: []string{disabledID}},
 
@@ -672,7 +686,6 @@ func TestListOrganizations_SearchEscapesLikeMetacharacters(t *testing.T) {
 		// Backslash is the escape character itself, so it has to be escaped before the two wildcards.
 		{name: "backslash in the term is literal", q: `Back\slash_Co`, wantIDs: []string{backslashID}},
 
-		// Escaping did not cost the arms their substring match.
 		{name: "a substring still matches", q: "Holdings", wantIDs: []string{percentID, nameDecoyID}},
 	}
 
@@ -688,10 +701,17 @@ func TestListOrganizations_SearchTermIsTrimmed(t *testing.T) {
 
 	ctx, svc, conn := newTestAdminService(t)
 
-	const trimID = "org_search_trim_alpha"
+	const (
+		trimID = "org_search_trim_alpha"
+		// Matches none of the terms below, so only a request carrying no term at
+		// all returns it alongside the first. Without it the whitespace-only case
+		// cannot tell a dropped term from a term that still happened to match.
+		bystanderID = "org_search_trim_bravo"
+	)
 
 	workosID := "org_workos_placeholder_trim"
 	seedOrg(t, ctx, conn, orgFixture{id: trimID, name: "Trim Holdings", slug: "trim-holdings", workosID: &workosID, whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: bystanderID, name: "Bystander Systems", slug: "bystander-systems", whitelisted: true})
 
 	cases := []searchByIDCase{
 		{name: "leading space", q: " " + trimID, wantIDs: []string{trimID}},
@@ -701,7 +721,7 @@ func TestListOrganizations_SearchTermIsTrimmed(t *testing.T) {
 		{name: "workos id with a trailing newline", q: workosID + "\n", wantIDs: []string{trimID}},
 		{name: "name with a trailing newline", q: "Trim Holdings\n", wantIDs: []string{trimID}},
 		// Whitespace alone is no search term at all rather than a term nothing holds.
-		{name: "whitespace only", q: " \n\t ", wantIDs: []string{trimID}},
+		{name: "whitespace only", q: " \n\t ", wantIDs: []string{trimID, bystanderID}},
 	}
 
 	for _, c := range cases {

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -54,7 +54,17 @@ WHERE p.slug = @slug
 -- Two paging modes share this query. A caller that supplies no sort key gets the
 -- cursor walk it always had: the sort ladder collapses to all-NULL and the
 -- tiebreaker alone orders the rows. A caller that supplies one gets offset paging.
-WITH filtered AS (
+WITH search AS (
+    -- Escaped once here rather than per arm so the name and the slug arm cannot
+    -- drift apart. Backslash goes first or it escapes the escapes that follow.
+    -- Every id in both id spaces contains underscores and _ is a
+    -- single-character wildcard, so an unescaped pasted id draws incidental
+    -- matches out of the name and slug arms.
+    SELECT
+        sqlc.narg('q')::text AS term,
+        '%' || replace(replace(replace(sqlc.narg('q')::text, '\', '\\'), '%', '\%'), '_', '\_') || '%' AS pattern
+),
+filtered AS (
     SELECT
         om.id,
         om.name,
@@ -85,22 +95,30 @@ WITH filtered AS (
         )::bigint AS member_count
     FROM organization_metadata om
     LEFT JOIN trials t ON t.organization_id = om.id
+    CROSS JOIN search
     WHERE
         -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
+        -- They compare case-insensitively because a real WorkOS id embeds an uppercase ULID and a log pipeline hands the operator a lowercased copy of it.
         -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
         (
-            sqlc.narg('q')::text IS NULL
-            OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
-            OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
-            OR om.id = sqlc.narg('q')::text
-            OR om.workos_id = sqlc.narg('q')::text
+            search.term IS NULL
+            OR om.name ILIKE search.pattern
+            OR om.slug ILIKE search.pattern
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
         )
         -- coalesce, not a bare cardinality: an absent filter reaches pgx as a nil
         -- slice and encodes to a NULL array, and cardinality(NULL) is NULL, which
         -- would drop every row instead of keeping every row.
         AND (coalesce(cardinality(sqlc.arg('account_types')::text[]), 0) = 0 OR om.gram_account_type = ANY(sqlc.arg('account_types')::text[]))
         -- No empty arm: the handler resolves an absent filter to {active}.
-        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY(sqlc.arg('disabled_states')::text[])
+        -- The id arms repeat here, and only here, so a pasted id reaches a disabled organization: investigating one is a leading reason to paste an id at all.
+        -- Deliberately not repeated on the account type arm or the cursor, which keep applying to an id match.
+        AND (
+            (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY(sqlc.arg('disabled_states')::text[])
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
+        )
         AND (sqlc.narg('after_id')::text IS NULL OR om.id > sqlc.narg('after_id')::text)
 )
 SELECT * FROM filtered
@@ -144,7 +162,15 @@ OFFSET sqlc.arg('page_offset')::bigint;
 -- query carries the join and the same CASE ladder. The join stays count-safe
 -- because organization_id is that table's primary key and cannot fan one
 -- organization out into several counted rows.
-WITH filtered AS (
+WITH search AS (
+    -- Identical to AdminListOrganizations, escaping included: a pasted id that
+    -- reaches the rows through an escaped pattern and the total through an
+    -- unescaped one gives the pager a count that disagrees with what it shows.
+    SELECT
+        sqlc.narg('q')::text AS term,
+        '%' || replace(replace(replace(sqlc.narg('q')::text, '\', '\\'), '%', '\%'), '_', '\_') || '%' AS pattern
+),
+filtered AS (
     SELECT
         CASE
             WHEN t.organization_id IS NULL THEN 'none'
@@ -156,16 +182,21 @@ WITH filtered AS (
         END::text AS trial_state
     FROM organization_metadata om
     LEFT JOIN trials t ON t.organization_id = om.id
+    CROSS JOIN search
     WHERE
         (
-            sqlc.narg('q')::text IS NULL
-            OR om.name ILIKE '%' || sqlc.narg('q')::text || '%'
-            OR om.slug ILIKE '%' || sqlc.narg('q')::text || '%'
-            OR om.id = sqlc.narg('q')::text
-            OR om.workos_id = sqlc.narg('q')::text
+            search.term IS NULL
+            OR om.name ILIKE search.pattern
+            OR om.slug ILIKE search.pattern
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
         )
         AND (coalesce(cardinality(sqlc.arg('account_types')::text[]), 0) = 0 OR om.gram_account_type = ANY(sqlc.arg('account_types')::text[]))
-        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY(sqlc.arg('disabled_states')::text[])
+        AND (
+            (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY(sqlc.arg('disabled_states')::text[])
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
+        )
 )
 SELECT count(*)::bigint FROM filtered
 WHERE coalesce(cardinality(sqlc.arg('trial_states')::text[]), 0) = 0 OR trial_state = ANY(sqlc.arg('trial_states')::text[]);

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -13,7 +13,15 @@ import (
 )
 
 const adminCountOrganizations = `-- name: AdminCountOrganizations :one
-WITH filtered AS (
+WITH search AS (
+    -- Identical to AdminListOrganizations, escaping included: a pasted id that
+    -- reaches the rows through an escaped pattern and the total through an
+    -- unescaped one gives the pager a count that disagrees with what it shows.
+    SELECT
+        $2::text AS term,
+        '%' || replace(replace(replace($2::text, '\', '\\'), '%', '\%'), '_', '\_') || '%' AS pattern
+),
+filtered AS (
     SELECT
         CASE
             WHEN t.organization_id IS NULL THEN 'none'
@@ -25,16 +33,21 @@ WITH filtered AS (
         END::text AS trial_state
     FROM organization_metadata om
     LEFT JOIN trials t ON t.organization_id = om.id
+    CROSS JOIN search
     WHERE
         (
-            $2::text IS NULL
-            OR om.name ILIKE '%' || $2::text || '%'
-            OR om.slug ILIKE '%' || $2::text || '%'
-            OR om.id = $2::text
-            OR om.workos_id = $2::text
+            search.term IS NULL
+            OR om.name ILIKE search.pattern
+            OR om.slug ILIKE search.pattern
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
         )
         AND (coalesce(cardinality($3::text[]), 0) = 0 OR om.gram_account_type = ANY($3::text[]))
-        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY($4::text[])
+        AND (
+            (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY($4::text[])
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
+        )
 )
 SELECT count(*)::bigint FROM filtered
 WHERE coalesce(cardinality($1::text[]), 0) = 0 OR trial_state = ANY($1::text[])
@@ -372,7 +385,17 @@ func (q *Queries) AdminListOrganizationMembers(ctx context.Context, organization
 }
 
 const adminListOrganizations = `-- name: AdminListOrganizations :many
-WITH filtered AS (
+WITH search AS (
+    -- Escaped once here rather than per arm so the name and the slug arm cannot
+    -- drift apart. Backslash goes first or it escapes the escapes that follow.
+    -- Every id in both id spaces contains underscores and _ is a
+    -- single-character wildcard, so an unescaped pasted id draws incidental
+    -- matches out of the name and slug arms.
+    SELECT
+        $6::text AS term,
+        '%' || replace(replace(replace($6::text, '\', '\\'), '%', '\%'), '_', '\_') || '%' AS pattern
+),
+filtered AS (
     SELECT
         om.id,
         om.name,
@@ -403,22 +426,30 @@ WITH filtered AS (
         )::bigint AS member_count
     FROM organization_metadata om
     LEFT JOIN trials t ON t.organization_id = om.id
+    CROSS JOIN search
     WHERE
         -- The id arms compare exactly because a substring match on an opaque high-cardinality id produces incidental hits an operator cannot explain.
+        -- They compare case-insensitively because a real WorkOS id embeds an uppercase ULID and a log pipeline hands the operator a lowercased copy of it.
         -- Exactness buys no index here, so do not "restore" one: the ILIKE arms share this OR group and no trigram index exists, so Postgres cannot build a BitmapOr and any non-null q scans the table whatever the id arms do.
         (
-            $6::text IS NULL
-            OR om.name ILIKE '%' || $6::text || '%'
-            OR om.slug ILIKE '%' || $6::text || '%'
-            OR om.id = $6::text
-            OR om.workos_id = $6::text
+            search.term IS NULL
+            OR om.name ILIKE search.pattern
+            OR om.slug ILIKE search.pattern
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
         )
         -- coalesce, not a bare cardinality: an absent filter reaches pgx as a nil
         -- slice and encodes to a NULL array, and cardinality(NULL) is NULL, which
         -- would drop every row instead of keeping every row.
         AND (coalesce(cardinality($7::text[]), 0) = 0 OR om.gram_account_type = ANY($7::text[]))
         -- No empty arm: the handler resolves an absent filter to {active}.
-        AND (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY($8::text[])
+        -- The id arms repeat here, and only here, so a pasted id reaches a disabled organization: investigating one is a leading reason to paste an id at all.
+        -- Deliberately not repeated on the account type arm or the cursor, which keep applying to an id match.
+        AND (
+            (CASE WHEN om.disabled_at IS NULL THEN 'active' ELSE 'disabled' END) = ANY($8::text[])
+            OR lower(om.id) = lower(search.term)
+            OR lower(om.workos_id) = lower(search.term)
+        )
         AND ($9::text IS NULL OR om.id > $9::text)
 )
 SELECT id, name, slug, account_type, workos_id, whitelisted, disabled_at, free_trial_started_at, free_trial_ends_at, trial_state, trial_ends_at, created_at, updated_at, member_count FROM filtered


### PR DESCRIPTION
Pasting an organization id into the admin organizations search returned nothing when the organization was disabled, which is the case an operator pastes an id for most often.

AGE-3205, and AGE-3204 folded in because both change the same two predicates.

## What changes

- **An exact id match escapes the disabled filter, and only that filter.** The account type, trial state and cursor filters keep applying. Widening the bypass to every filter is a one-line change if that turns out to be wanted; the narrow version is deliberate.
- **Both id arms compare case insensitively.** They compared case sensitively while the name and slug arms did not, so an id that arrived lowercased from a log pipeline missed.
- **The search term is trimmed in the handler**, so one normalisation point serves every arm.
- **`%` and `_` in the term match literally.** Every id in both id spaces contains underscores, so an unescaped one drew incidental matches through the name and slug arms.

The page query and the count query carry every one of these changes. Either one left behind gives the pager a total that disagrees with the rows on screen.

## Verification

A three-lens review round ran before this PR: SQL and handler correctness, tests and mutation coverage, scope and hygiene. It found no production defect and two confirmed test gaps, one of which two reviewers found independently. The second commit closes those and three smaller ones.

Mutation evidence, each read back in the same shell as the test run:

| mutation | outcome |
| --- | --- |
| drop `lower()` from both sides of the `om.id` arm inside the bypass conjunct, in both statements | killed |
| add the id bypass to the count statement's account-type arm | killed, and only the total moved |
| turn the count statement's workos arm into an `ILIKE` on the pattern | killed |

The first round's 24-mutation sweep was re-run as a regression check: all 24 still killed, and the deliberately behaviour-preserving canary still survives.

`mise lint:server`, `go test ./server/internal/admin/...` and the dashboard `audit-actions` guard all pass. I ran the admin suite again myself on the final tip.

## Notes for the reviewer

- The two cursor cases in `TestListOrganizations_SearchByIDRespectsFilters` stay on the row-only helper on purpose. The count query carries no cursor predicate, so its total counts past the cursor deliberately, and the helper's `require.Nil(t, payload.Cursor)` guard exists to stop the total being asserted where that would be wrong.
- One removed test case, "disabled organization by workos id, disabled included", is genuinely redundant rather than lost coverage: `include_disabled: true` resolves to both states, so the CASE arm is unconditionally true and the workos bypass is unreachable. No mutation kills it alone.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pasted organization IDs in the admin search now match disabled organizations and ignore casing. Previously, exact ID matches respected the disabled filter and were case-sensitive, causing empty results for disabled orgs and lowercased IDs.

- Exact ID or WorkOS ID match bypasses only the disabled filter; `account_type`, `trial_states`, and `cursor` still apply. Applied to both the page and count queries to keep totals aligned.
- ID comparisons are exact and case-insensitive; name and slug remain case-insensitive substrings.
- The search term is trimmed once in the handler and reused for both queries.
- `%` and `_` in the term match literally (escaped once via a shared `search` CTE); backslash is escaped first.
- Updated API docs in `server/design/admin/design.go` and regenerated `service.go`/OpenAPI to reflect the semantics.
- Tests cover disabled bypass, case-insensitive IDs, metacharacter escaping, trimming, and total alignment (cursor-free).

Linked Linear: AGE-3205 (implements: bypass disabled on exact ID; ignore case). Includes mechanical follow-ups from AGE-3204 (escape LIKE metacharacters, doc corrections).

<sup>Written for commit 8e68936cd434bfcecc0f1417e8a7795259646b09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

