### PR TITLE
feat: make the description optional when creating a role

### DIFF
--- a/.changeset/easy-hotels-speak.md
+++ b/.changeset/easy-hotels-speak.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+access.createRole no longer requires a description. The Create Role dialog accepts an empty description field and omits it from the request, so roles can be created without one.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -61888,7 +61888,7 @@ components:
       properties:
         description:
           type: string
-          description: Description of what this role can do.
+          description: Optional description of what this role can do.
         grants:
           type: array
           items:
@@ -61904,7 +61904,6 @@ components:
           description: Display name for the role.
       required:
         - name
-        - description
         - grants
     CreateServerForm:
       type: object

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -510,7 +510,7 @@ export function CreateRoleDialog({
         request: {
           createRoleForm: {
             name,
-            description,
+            description: description.trim() || undefined,
             grants: sdkGrants,
             memberIds:
               selectedMembers.size > 0
@@ -644,7 +644,6 @@ export function CreateRoleDialog({
                   <textarea
                     {...props}
                     rows={2}
-                    required
                     disabled={editingRole?.isSystem}
                     placeholder="Describe what this role can do..."
                     value={description}

--- a/client/dashboard/src/pages/access/roleDialogState.test.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.test.ts
@@ -218,10 +218,10 @@ describe("isSaveDisabled", () => {
       );
     });
 
-    it("empty description → disabled", () => {
+    it("empty description → enabled (description is optional)", () => {
       expect(
         isSaveDisabled(makeInput({ isEditing: false, description: "" })),
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it("no grants → disabled", () => {

--- a/client/dashboard/src/pages/access/roleDialogState.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.ts
@@ -89,13 +89,10 @@ export function hasFormChanges(input: SaveButtonInput): boolean {
   );
 }
 
-/** Whether the form fields are valid enough to submit */
+/** Whether the form fields are valid enough to submit.
+ *  Description is optional. */
 function isFormValid(input: SaveButtonInput): boolean {
-  return (
-    input.name.trim().length > 0 &&
-    input.description.trim().length > 0 &&
-    effectiveGrantCount(input.grants) > 0
-  );
+  return input.name.trim().length > 0 && effectiveGrantCount(input.grants) > 0;
 }
 
 /** Returns true when the Save/Create button should be disabled */

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -3705,7 +3705,7 @@ examples:
   createRole:
     speakeasy-default-create-role:
       requestBody:
-        application/json: {"description": "swerve hm receptor how", "grants": [{"scope": "environment:write"}], "name": "<value>"}
+        application/json: {"grants": [{"scope": "environment:write"}], "name": "<value>"}
       responses:
         "201":
           application/json: {"created_at": "2024-08-15T08:14:35.208Z", "description": "mmm co-producer instead achieve through decision carefully ah", "grants": [], "id": "<id>", "is_system": false, "member_count": 747343, "name": "<value>", "principal_urn": "<value>", "slug": "<value>", "updated_at": "2024-02-02T13:39:51.749Z"}

--- a/client/dashboard/src/sdk/src/models/components/createroleform.ts
+++ b/client/dashboard/src/sdk/src/models/components/createroleform.ts
@@ -12,9 +12,9 @@ import {
 
 export type CreateRoleForm = {
   /**
-   * Description of what this role can do.
+   * Optional description of what this role can do.
    */
-  description: string;
+  description?: string | undefined;
   /**
    * Scope grants to assign.
    */
@@ -31,7 +31,7 @@ export type CreateRoleForm = {
 
 /** @internal */
 export type CreateRoleForm$Outbound = {
-  description: string;
+  description?: string | undefined;
   grants: Array<RoleGrant$Outbound>;
   member_ids?: Array<string> | undefined;
   name: string;
@@ -43,7 +43,7 @@ export const CreateRoleForm$outboundSchema: z.ZodMiniType<
   CreateRoleForm
 > = z.pipe(
   z.object({
-    description: z.string(),
+    description: z.optional(z.string()),
     grants: z.array(RoleGrant$outboundSchema),
     memberIds: z.optional(z.array(z.string())),
     name: z.string(),

--- a/server/design/access/design.go
+++ b/server/design/access/design.go
@@ -707,10 +707,10 @@ var ListScopesResult = Type("ListScopesResult", func() {
 })
 
 var CreateRoleForm = Type("CreateRoleForm", func() {
-	Required("name", "description", "grants")
+	Required("name", "grants")
 
 	Attribute("name", String, "Display name for the role.")
-	Attribute("description", String, "Description of what this role can do.")
+	Attribute("description", String, "Optional description of what this role can do.")
 	Attribute("grants", ArrayOf(RoleGrantModel), "Scope grants to assign.")
 	Attribute("member_ids", ArrayOf(String), "Optional member IDs to additionally assign to this role on creation.")
 })

--- a/server/gen/access/service.go
+++ b/server/gen/access/service.go
@@ -231,8 +231,8 @@ type CreateRolePayload struct {
 	SessionToken *string
 	// Display name for the role.
 	Name string
-	// Description of what this role can do.
-	Description string
+	// Optional description of what this role can do.
+	Description *string
 	// Scope grants to assign.
 	Grants []*RoleGrant
 	// Optional member IDs to additionally assign to this role on creation.

--- a/server/gen/http/access/client/types.go
+++ b/server/gen/http/access/client/types.go
@@ -17,8 +17,8 @@ import (
 type CreateRoleRequestBody struct {
 	// Display name for the role.
 	Name string `form:"name" json:"name" xml:"name"`
-	// Description of what this role can do.
-	Description string `form:"description" json:"description" xml:"description"`
+	// Optional description of what this role can do.
+	Description *string `form:"description,omitempty" json:"description,omitempty" xml:"description,omitempty"`
 	// Scope grants to assign.
 	Grants []*RoleGrantRequestBody `form:"grants" json:"grants" xml:"grants"`
 	// Optional member IDs to additionally assign to this role on creation.

--- a/server/gen/http/access/server/types.go
+++ b/server/gen/http/access/server/types.go
@@ -19,7 +19,7 @@ import (
 type CreateRoleRequestBody struct {
 	// Display name for the role.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// Description of what this role can do.
+	// Optional description of what this role can do.
 	Description *string `form:"description,omitempty" json:"description,omitempty" xml:"description,omitempty"`
 	// Scope grants to assign.
 	Grants []*RoleGrantRequestBody `form:"grants,omitempty" json:"grants,omitempty" xml:"grants,omitempty"`
@@ -7276,7 +7276,7 @@ func NewGetRolePayload(id string, apikeyToken *string, sessionToken *string) *ac
 func NewCreateRolePayload(body *CreateRoleRequestBody, apikeyToken *string, sessionToken *string) *access.CreateRolePayload {
 	v := &access.CreateRolePayload{
 		Name:        *body.Name,
-		Description: *body.Description,
+		Description: body.Description,
 	}
 	v.Grants = make([]*access.RoleGrant, len(body.Grants))
 	for i, val := range body.Grants {
@@ -7546,9 +7546,6 @@ func NewResolveChallengePayload(body *ResolveChallengeRequestBody, apikeyToken *
 func ValidateCreateRoleRequestBody(body *CreateRoleRequestBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
-	}
-	if body.Description == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("description", "body"))
 	}
 	if body.Grants == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("grants", "body"))

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -63052,7 +63052,7 @@ components:
             properties:
                 description:
                     type: string
-                    description: Description of what this role can do.
+                    description: Optional description of what this role can do.
                 grants:
                     type: array
                     items:
@@ -63068,7 +63068,6 @@ components:
                     description: Display name for the role.
             required:
                 - name
-                - description
                 - grants
         CreateServerForm:
             type: object

--- a/server/internal/access/createrole_test.go
+++ b/server/internal/access/createrole_test.go
@@ -66,7 +66,7 @@ func TestService_CreateRole(t *testing.T) {
 
 	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Custom Builder",
-		Description: "Can build selected resources",
+		Description: conv.PtrEmpty("Can build selected resources"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}, {ResourceKind: "project", ResourceID: "project-2"}}},
 			{Scope: string(authz.ScopeMCPConnect), Selectors: nil},
@@ -98,7 +98,7 @@ func TestService_CreateRole_RejectsRiskPolicyGrant(t *testing.T) {
 
 	_, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Risk Policy Writer",
-		Description: "Should not be allowed through access roles",
+		Description: conv.PtrEmpty("Should not be allowed through access roles"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeRiskPolicyEvaluate), Selectors: nil},
 		},
@@ -108,6 +108,39 @@ func TestService_CreateRole_RejectsRiskPolicyGrant(t *testing.T) {
 	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
 	require.ErrorContains(t, err, `managed by "risk_policy" grants`)
 	ti.roles.AssertNotCalled(t, "CreateRole", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestService_CreateRole_WithoutDescription(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	ti.roles.On("CreateRole", mock.Anything, mockidp.MockOrgID, thirdpartyworkos.CreateRoleOpts{
+		Name:        "Custom Builder",
+		Slug:        "org-custom-builder",
+		Description: "",
+	}).Return(&thirdpartyworkos.Role{
+		ID:          "role_1",
+		Name:        "Custom Builder",
+		Slug:        "org-custom-builder",
+		Description: "",
+		CreatedAt:   mockRoleTimestamp,
+		UpdatedAt:   mockRoleTimestamp,
+	}, nil).Once()
+
+	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
+		Name:        "Custom Builder",
+		Description: nil,
+		Grants: []*gen.RoleGrant{
+			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Custom Builder", role.Name)
+	require.Empty(t, role.Description)
+
+	roundtrip, err := ti.service.GetRole(ctx, &gen.GetRolePayload{ID: role.ID})
+	require.NoError(t, err)
+	require.Empty(t, roundtrip.Description)
 }
 
 func TestService_CreateRole_WorkOSCreateFailure(t *testing.T) {
@@ -122,7 +155,7 @@ func TestService_CreateRole_WorkOSCreateFailure(t *testing.T) {
 
 	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Custom Builder",
-		Description: "Can build selected resources",
+		Description: conv.PtrEmpty("Can build selected resources"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}}},
 		},
@@ -143,7 +176,7 @@ func TestService_CreateRole_WorkOSConflictFailure(t *testing.T) {
 
 	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Custom Builder",
-		Description: "Can build selected resources",
+		Description: conv.PtrEmpty("Can build selected resources"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}}},
 		},
@@ -164,7 +197,7 @@ func TestService_CreateRole_RejectsActiveLocalSlugCollision(t *testing.T) {
 
 	_, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Custom Builder",
-		Description: "Can build selected resources",
+		Description: conv.PtrEmpty("Can build selected resources"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}}},
 		},
@@ -221,7 +254,7 @@ func TestService_CreateRole_ReactivatesDeletedSlug(t *testing.T) {
 
 	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Custom Builder",
-		Description: "New description",
+		Description: conv.PtrEmpty("New description"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}}},
 		},
@@ -250,7 +283,7 @@ func TestService_CreateRole_RejectsEmptySlug(t *testing.T) {
 
 	_, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "!!!",
-		Description: "Can build selected resources",
+		Description: conv.PtrEmpty("Can build selected resources"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}}},
 		},
@@ -281,7 +314,7 @@ func TestService_CreateRole_AuditLog(t *testing.T) {
 
 	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Audit Builder",
-		Description: "Tracks audit writes",
+		Description: conv.PtrEmpty("Tracks audit writes"),
 		Grants: []*gen.RoleGrant{{
 			Scope:     string(authz.ScopeProjectRead),
 			Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}},
@@ -322,7 +355,7 @@ func TestService_CreateRole_LocalRoleWriteFailureDoesNotAssignMembers(t *testing
 		DisplayName: authCtx.Email,
 	}, &gen.CreateRolePayload{
 		Name:        "Broken Builder",
-		Description: "Will fail local write",
+		Description: conv.PtrEmpty("Will fail local write"),
 		Grants: []*gen.RoleGrant{
 			{Scope: string(authz.ScopeProjectRead), Selectors: []*gen.Selector{{ResourceKind: "project", ResourceID: "project-1"}}},
 		},

--- a/server/internal/access/rbac_test.go
+++ b/server/internal/access/rbac_test.go
@@ -12,6 +12,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/access"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
@@ -125,7 +126,7 @@ func TestService_CreateRole_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	ctx, ti := newTestAccessService(t)
 	ctx = withRBACGrants(t, ctx)
 
-	_, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{Name: "Denied", Description: "Denied"})
+	_, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{Name: "Denied", Description: conv.PtrEmpty("Denied")})
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
@@ -150,7 +151,7 @@ func TestService_CreateRole_AllowsOrgAdminGrant(t *testing.T) {
 		UpdatedAt:   mockRoleTimestamp,
 	}, nil).Once()
 
-	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{Name: "Allowed", Description: "Allowed"})
+	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{Name: "Allowed", Description: conv.PtrEmpty("Allowed")})
 	require.NoError(t, err)
 	require.NotEmpty(t, role.ID)
 	require.NotEqual(t, "role_allowed", role.ID)

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -155,6 +155,7 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 	if err != nil {
 		return roleCreateResult{}, err
 	}
+	description := conv.PtrValOr(payload.Description, "")
 	grants := roleGrantPayloads(payload.Grants)
 	if err := authz.ValidateGrantSurface(authz.GrantSurfaceAccess, grants); err != nil {
 		return roleCreateResult{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
@@ -171,7 +172,7 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 		OrganizationID:    gramOrgID,
 		WorkosSlug:        roleSlug,
 		WorkosName:        payload.Name,
-		WorkosDescription: conv.ToPGTextEmpty(payload.Description),
+		WorkosDescription: conv.ToPGTextEmpty(description),
 		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
 		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
 		WorkosLastEventID: conv.ToPGTextEmpty(""),
@@ -208,7 +209,7 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 			_, err := r.roles.CreateRole(ctx, workosOrgID, workos.CreateRoleOpts{
 				Name:        payload.Name,
 				Slug:        roleSlug,
-				Description: payload.Description,
+				Description: description,
 			})
 			var apiErr *workos.APIError
 			if errors.As(err, &apiErr) && apiErr.StatusCode == 409 {


### PR DESCRIPTION
Creating a role required a description: the Create Role dialog kept "Create Role" disabled until the field was filled in, and `access.createRole` rejected a payload without it. Neither the data model nor anything downstream needs one — the column is nullable and the roles list renders an empty cell fine — so this makes it optional.

## Changes

- **Design** — `description` drops out of `CreateRoleForm`'s `Required(...)`, so the payload field is now `*string`. Regenerated Goa, OpenAPI, and the TypeScript SDK.
- **Handler** — `RoleManager.CreateRole` resolves the pointer once and feeds it to both the local row write (stored as NULL when empty) and the WorkOS sync.
- **Dialog** — save gating no longer requires a description, the textarea drops `required` (so the label picks up the automatic "optional" suffix), and a blank description is omitted from the request rather than sent as `""`. Name and at least one permission are still required.

`updateRole` is untouched — description was already optional there.

## Testing

- New `TestService_CreateRole_WithoutDescription` covers create-with-nil-description end to end, including the `getRole` round-trip.
- Existing frontend unit test flipped: empty description now leaves the save button enabled.
- `mise run test:server ./internal/access/...`, `mise run lint:server`, `pnpm -F dashboard type-check`, and the `roleDialogState` vitest suite all pass.
- Exercised in the local dashboard: created a role with the description left empty (`POST /rpc/access.createRole` → 201), confirmed it renders in Roles & Permissions with a blank description cell, then deleted it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make role descriptions optional on creation to match the nullable column and existing list rendering. Previously, `Create Role` required a non-empty description and `access.createRole` rejected requests without it; now the dialog allows an empty description and the API accepts omitted/empty values.

- API: `CreateRoleForm.description` is optional in Goa/OpenAPI and the dashboard SDK; server `CreateRolePayload.Description` is now `*string`. No migration required; existing clients that send a description still work.
- UI: The Create Role dialog no longer gates save on description. It trims and omits an empty description from the `access.createRole` request. Name and at least one grant remain required.
- Server: Resolves a nil description to an empty string for WorkOS and stores NULL locally. `updateRole` is unchanged.
- Tests: Added create-without-description test and updated UI save-state test.

<sup>Written for commit a5eb627b7d4fb11aa2782f8e9c4c3b2cad974fb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

