### PR TITLE
feat(admin): count the platform above the organizations list

### DIFF
--- a/.changeset/admin-organization-stats.md
+++ b/.changeset/admin-organization-stats.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The admin API can now report how big the platform is in one call. `GET /admin/organizations.stats` returns the number of organizations in total, the number created in the last 7 days, the number whose enterprise trial is ending soon, the number disabled, and the number disabled in the last 7 days. The total and both 7-day figures include disabled organizations, so the total reports the real platform size rather than the organizations list's default active-only view. None of the five figures narrows to the caller's list filters, so they stay put while an operator filters the list. The ending-soon figure is counted from the same trial state definition the organizations list filters on, so the figure agrees with the rows an operator lands on after clicking it.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -55381,6 +55381,36 @@ components:
         - display_name
         - created_at
         - updated_at
+    AdminOrganizationStats:
+      type: object
+      properties:
+        created_last_7_days:
+          type: integer
+          description: Organizations created in the last 7 days, whatever their current status.
+          format: int64
+        disabled:
+          type: integer
+          description: Organizations with disabled_at set.
+          format: int64
+        disabled_last_7_days:
+          type: integer
+          description: Organizations disabled in the last 7 days.
+          format: int64
+        total:
+          type: integer
+          description: Every organization on the platform, disabled ones included.
+          format: int64
+        trials_ending_soon:
+          type: integer
+          description: Organizations whose trial_state is ending_soon.
+          format: int64
+      description: Platform-wide organization counts surfaced above the admin organizations list.
+      required:
+        - total
+        - created_last_7_days
+        - trials_ending_soon
+        - disabled
+        - disabled_last_7_days
     AdminProject:
       type: object
       properties:

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -136,6 +136,17 @@ var AdminListOrganizationsResult = Type("AdminListOrganizationsResult", func() {
 	Attribute("total", Int64, "Number of organizations matching the filters, before paging.")
 })
 
+var AdminOrganizationStats = Type("AdminOrganizationStats", func() {
+	Description("Platform-wide organization counts surfaced above the admin organizations list.")
+	Required("total", "created_last_7_days", "trials_ending_soon", "disabled", "disabled_last_7_days")
+
+	Attribute("total", Int64, "Every organization on the platform, disabled ones included.")
+	Attribute("created_last_7_days", Int64, "Organizations created in the last 7 days, whatever their current status.")
+	Attribute("trials_ending_soon", Int64, "Organizations whose trial_state is ending_soon.")
+	Attribute("disabled", Int64, "Organizations with disabled_at set.")
+	Attribute("disabled_last_7_days", Int64, "Organizations disabled in the last 7 days.")
+})
+
 var _ = Service("admin", func() {
 	Description("Operations supporting admin tasks, protected by Google workspace auth.")
 	Security(security.AdminAuth)
@@ -529,5 +540,23 @@ var _ = Service("admin", func() {
 		})
 
 		Meta("openapi:operationId", "adminRearmTrial")
+	})
+
+	Method("getOrganizationStats", func() {
+		Description("Returns platform-wide organization counts for the strip above the organizations list. Every figure counts the whole platform: none of them narrows to the caller's list filters, so the strip does not move when an operator filters.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+		})
+
+		Result(AdminOrganizationStats)
+
+		HTTP(func() {
+			GET("/admin/organizations.stats")
+
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminGetOrganizationStats")
 	})
 })

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -29,10 +29,11 @@ type Client struct {
 	ExtendTrialEndpoint              goa.Endpoint
 	CreateOrganizationEndpoint       goa.Endpoint
 	RearmTrialEndpoint               goa.Endpoint
+	GetOrganizationStatsEndpoint     goa.Endpoint
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
@@ -48,6 +49,7 @@ func NewClient(login, callback, logout, getProject, updateOrganization, disableO
 		ExtendTrialEndpoint:              extendTrial,
 		CreateOrganizationEndpoint:       createOrganization,
 		RearmTrialEndpoint:               rearmTrial,
+		GetOrganizationStatsEndpoint:     getOrganizationStats,
 	}
 }
 
@@ -360,4 +362,27 @@ func (c *Client) RearmTrial(ctx context.Context, p *RearmTrialPayload) (res *Adm
 		return
 	}
 	return ires.(*AdminOrganization), nil
+}
+
+// GetOrganizationStats calls the "getOrganizationStats" endpoint of the
+// "admin" service.
+// GetOrganizationStats may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) GetOrganizationStats(ctx context.Context, p *GetOrganizationStatsPayload) (res *AdminOrganizationStats, err error) {
+	var ires any
+	ires, err = c.GetOrganizationStatsEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminOrganizationStats), nil
 }

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -30,6 +30,7 @@ type Endpoints struct {
 	ExtendTrial              goa.Endpoint
 	CreateOrganization       goa.Endpoint
 	RearmTrial               goa.Endpoint
+	GetOrganizationStats     goa.Endpoint
 }
 
 // NewEndpoints wraps the methods of the "admin" service with endpoints.
@@ -51,6 +52,7 @@ func NewEndpoints(s Service) *Endpoints {
 		ExtendTrial:              NewExtendTrialEndpoint(s, a.APIKeyAuth),
 		CreateOrganization:       NewCreateOrganizationEndpoint(s, a.APIKeyAuth),
 		RearmTrial:               NewRearmTrialEndpoint(s, a.APIKeyAuth),
+		GetOrganizationStats:     NewGetOrganizationStatsEndpoint(s, a.APIKeyAuth),
 	}
 }
 
@@ -70,6 +72,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.ExtendTrial = m(e.ExtendTrial)
 	e.CreateOrganization = m(e.CreateOrganization)
 	e.RearmTrial = m(e.RearmTrial)
+	e.GetOrganizationStats = m(e.GetOrganizationStats)
 }
 
 // NewLoginEndpoint returns an endpoint function that calls the method "login"
@@ -349,5 +352,28 @@ func NewRearmTrialEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.
 			return nil, err
 		}
 		return s.RearmTrial(ctx, p)
+	}
+}
+
+// NewGetOrganizationStatsEndpoint returns an endpoint function that calls the
+// method "getOrganizationStats" of service "admin".
+func NewGetOrganizationStatsEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*GetOrganizationStatsPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.GetOrganizationStats(ctx, p)
 	}
 }

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -58,6 +58,11 @@ type Service interface {
 	// trial a fresh run of the given length counted from now. Only a demoted trial
 	// can be re-armed; one that has converted or is already running is rejected.
 	RearmTrial(context.Context, *RearmTrialPayload) (res *AdminOrganization, err error)
+	// Returns platform-wide organization counts for the strip above the
+	// organizations list. Every figure counts the whole platform: none of them
+	// narrows to the caller's list filters, so the strip does not move when an
+	// operator filters.
+	GetOrganizationStats(context.Context, *GetOrganizationStatsPayload) (res *AdminOrganizationStats, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.
@@ -80,7 +85,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [14]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial"}
+var MethodNames = [15]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats"}
 
 // AdminListOrganizationMembersResult is the result type of the admin service
 // listOrganizationMembers method.
@@ -153,6 +158,21 @@ type AdminOrganizationMember struct {
 	LastLogin *string
 	CreatedAt string
 	UpdatedAt string
+}
+
+// AdminOrganizationStats is the result type of the admin service
+// getOrganizationStats method.
+type AdminOrganizationStats struct {
+	// Every organization on the platform, disabled ones included.
+	Total int64
+	// Organizations created in the last 7 days, whatever their current status.
+	CreatedLast7Days int64
+	// Organizations whose trial_state is ending_soon.
+	TrialsEndingSoon int64
+	// Organizations with disabled_at set.
+	Disabled int64
+	// Organizations disabled in the last 7 days.
+	DisabledLast7Days int64
 }
 
 // Project summary surfaced to admin operators.
@@ -263,6 +283,12 @@ type GetOrganizationPayload struct {
 	AdminSessionToken *string
 	// Organization ID or slug.
 	IDOrSlug string
+}
+
+// GetOrganizationStatsPayload is the payload type of the admin service
+// getOrganizationStats method.
+type GetOrganizationStatsPayload struct {
+	AdminSessionToken *string
 }
 
 // GetProjectPayload is the payload type of the admin service getProject method.

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -489,3 +489,18 @@ func BuildRearmTrialPayload(adminRearmTrialBody string, adminRearmTrialAdminSess
 
 	return v, nil
 }
+
+// BuildGetOrganizationStatsPayload builds the payload for the admin
+// getOrganizationStats endpoint from CLI flags.
+func BuildGetOrganizationStatsPayload(adminGetOrganizationStatsAdminSessionToken string) (*admin.GetOrganizationStatsPayload, error) {
+	var adminSessionToken *string
+	{
+		if adminGetOrganizationStatsAdminSessionToken != "" {
+			adminSessionToken = &adminGetOrganizationStatsAdminSessionToken
+		}
+	}
+	v := &admin.GetOrganizationStatsPayload{}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -71,6 +71,10 @@ type Client struct {
 	// endpoint.
 	RearmTrialDoer goahttp.Doer
 
+	// GetOrganizationStats Doer is the HTTP client used to make requests to the
+	// getOrganizationStats endpoint.
+	GetOrganizationStatsDoer goahttp.Doer
+
 	// RestoreResponseBody controls whether the response bodies are reset after
 	// decoding so they can be read again.
 	RestoreResponseBody bool
@@ -105,6 +109,7 @@ func NewClient(
 		ExtendTrialDoer:              doer,
 		CreateOrganizationDoer:       doer,
 		RearmTrialDoer:               doer,
+		GetOrganizationStatsDoer:     doer,
 		RestoreResponseBody:          restoreBody,
 		scheme:                       scheme,
 		host:                         host,
@@ -444,6 +449,30 @@ func (c *Client) RearmTrial() goa.Endpoint {
 		resp, err := c.RearmTrialDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "rearmTrial", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// GetOrganizationStats returns an endpoint that makes HTTP requests to the
+// admin service getOrganizationStats server.
+func (c *Client) GetOrganizationStats() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeGetOrganizationStatsRequest(c.encoder)
+		decodeResponse = DecodeGetOrganizationStatsResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildGetOrganizationStatsRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.GetOrganizationStatsDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "getOrganizationStats", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -3355,6 +3355,237 @@ func DecodeRearmTrialResponse(decoder func(*http.Response) goahttp.Decoder, rest
 	}
 }
 
+// BuildGetOrganizationStatsRequest instantiates a HTTP request object with
+// method and path set to call the "admin" service "getOrganizationStats"
+// endpoint
+func (c *Client) BuildGetOrganizationStatsRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: GetOrganizationStatsAdminPath()}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "getOrganizationStats", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeGetOrganizationStatsRequest returns an encoder for requests sent to
+// the admin getOrganizationStats server.
+func EncodeGetOrganizationStatsRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.GetOrganizationStatsPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "getOrganizationStats", "*admin.GetOrganizationStatsPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		return nil
+	}
+}
+
+// DecodeGetOrganizationStatsResponse returns a decoder for responses returned
+// by the admin getOrganizationStats endpoint. restoreBody controls whether the
+// response body should be restored after having been read.
+// DecodeGetOrganizationStatsResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeGetOrganizationStatsResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body GetOrganizationStatsResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			res := NewGetOrganizationStatsAdminOrganizationStatsOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body GetOrganizationStatsUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body GetOrganizationStatsForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body GetOrganizationStatsBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body GetOrganizationStatsNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body GetOrganizationStatsConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body GetOrganizationStatsUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body GetOrganizationStatsInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body GetOrganizationStatsInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+				}
+				err = ValidateGetOrganizationStatsInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+				}
+				return nil, NewGetOrganizationStatsInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body GetOrganizationStatsUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+				}
+				err = ValidateGetOrganizationStatsUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+				}
+				return nil, NewGetOrganizationStatsUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "getOrganizationStats", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body GetOrganizationStatsGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getOrganizationStats", err)
+			}
+			err = ValidateGetOrganizationStatsGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getOrganizationStats", err)
+			}
+			return nil, NewGetOrganizationStatsGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "getOrganizationStats", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // unmarshalAdminOrganizationMemberResponseBodyToAdminAdminOrganizationMember
 // builds a value of type *admin.AdminOrganizationMember from a value of type
 // *AdminOrganizationMemberResponseBody.

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -76,3 +76,8 @@ func CreateOrganizationAdminPath() string {
 func RearmTrialAdminPath() string {
 	return "/admin/trial.rearm"
 }
+
+// GetOrganizationStatsAdminPath returns the URL path to the admin service getOrganizationStats HTTP endpoint.
+func GetOrganizationStatsAdminPath() string {
+	return "/admin/organizations.stats"
+}

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -356,6 +356,21 @@ type RearmTrialResponseBody struct {
 	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
 }
 
+// GetOrganizationStatsResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body.
+type GetOrganizationStatsResponseBody struct {
+	// Every organization on the platform, disabled ones included.
+	Total *int64 `form:"total,omitempty" json:"total,omitempty" xml:"total,omitempty"`
+	// Organizations created in the last 7 days, whatever their current status.
+	CreatedLast7Days *int64 `form:"created_last_7_days,omitempty" json:"created_last_7_days,omitempty" xml:"created_last_7_days,omitempty"`
+	// Organizations whose trial_state is ending_soon.
+	TrialsEndingSoon *int64 `form:"trials_ending_soon,omitempty" json:"trials_ending_soon,omitempty" xml:"trials_ending_soon,omitempty"`
+	// Organizations with disabled_at set.
+	Disabled *int64 `form:"disabled,omitempty" json:"disabled,omitempty" xml:"disabled,omitempty"`
+	// Organizations disabled in the last 7 days.
+	DisabledLast7Days *int64 `form:"disabled_last_7_days,omitempty" json:"disabled_last_7_days,omitempty" xml:"disabled_last_7_days,omitempty"`
+}
+
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
 // endpoint HTTP response body for the "unauthorized" error.
 type LoginUnauthorizedResponseBody struct {
@@ -2919,6 +2934,192 @@ type RearmTrialGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// GetOrganizationStatsUnauthorizedResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "unauthorized" error.
+type GetOrganizationStatsUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsForbiddenResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "forbidden" error.
+type GetOrganizationStatsForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsBadRequestResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "bad_request" error.
+type GetOrganizationStatsBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsNotFoundResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "not_found" error.
+type GetOrganizationStatsNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsConflictResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "conflict" error.
+type GetOrganizationStatsConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsUnsupportedMediaResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "unsupported_media" error.
+type GetOrganizationStatsUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsInvalidResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "invalid" error.
+type GetOrganizationStatsInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsInvariantViolationResponseBody is the type of the
+// "admin" service "getOrganizationStats" endpoint HTTP response body for the
+// "invariant_violation" error.
+type GetOrganizationStatsInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsUnexpectedResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "unexpected" error.
+type GetOrganizationStatsUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetOrganizationStatsGatewayErrorResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "gateway_error" error.
+type GetOrganizationStatsGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -5382,6 +5583,170 @@ func NewRearmTrialGatewayError(body *RearmTrialGatewayErrorResponseBody) *goa.Se
 	return v
 }
 
+// NewGetOrganizationStatsAdminOrganizationStatsOK builds a "admin" service
+// "getOrganizationStats" endpoint result from a HTTP "OK" response.
+func NewGetOrganizationStatsAdminOrganizationStatsOK(body *GetOrganizationStatsResponseBody) *admin.AdminOrganizationStats {
+	v := &admin.AdminOrganizationStats{
+		Total:             *body.Total,
+		CreatedLast7Days:  *body.CreatedLast7Days,
+		TrialsEndingSoon:  *body.TrialsEndingSoon,
+		Disabled:          *body.Disabled,
+		DisabledLast7Days: *body.DisabledLast7Days,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsUnauthorized builds a admin service
+// getOrganizationStats endpoint unauthorized error.
+func NewGetOrganizationStatsUnauthorized(body *GetOrganizationStatsUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsForbidden builds a admin service getOrganizationStats
+// endpoint forbidden error.
+func NewGetOrganizationStatsForbidden(body *GetOrganizationStatsForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsBadRequest builds a admin service
+// getOrganizationStats endpoint bad_request error.
+func NewGetOrganizationStatsBadRequest(body *GetOrganizationStatsBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsNotFound builds a admin service getOrganizationStats
+// endpoint not_found error.
+func NewGetOrganizationStatsNotFound(body *GetOrganizationStatsNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsConflict builds a admin service getOrganizationStats
+// endpoint conflict error.
+func NewGetOrganizationStatsConflict(body *GetOrganizationStatsConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsUnsupportedMedia builds a admin service
+// getOrganizationStats endpoint unsupported_media error.
+func NewGetOrganizationStatsUnsupportedMedia(body *GetOrganizationStatsUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsInvalid builds a admin service getOrganizationStats
+// endpoint invalid error.
+func NewGetOrganizationStatsInvalid(body *GetOrganizationStatsInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsInvariantViolation builds a admin service
+// getOrganizationStats endpoint invariant_violation error.
+func NewGetOrganizationStatsInvariantViolation(body *GetOrganizationStatsInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsUnexpected builds a admin service
+// getOrganizationStats endpoint unexpected error.
+func NewGetOrganizationStatsUnexpected(body *GetOrganizationStatsUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetOrganizationStatsGatewayError builds a admin service
+// getOrganizationStats endpoint gateway_error error.
+func NewGetOrganizationStatsGatewayError(body *GetOrganizationStatsGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // ValidateGetProjectResponseBody runs the validations defined on
 // GetProjectResponseBody
 func ValidateGetProjectResponseBody(body *GetProjectResponseBody) (err error) {
@@ -5848,6 +6213,27 @@ func ValidateRearmTrialResponseBody(body *RearmTrialResponseBody) (err error) {
 	}
 	if body.UpdatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsResponseBody runs the validations defined on
+// GetOrganizationStatsResponseBody
+func ValidateGetOrganizationStatsResponseBody(body *GetOrganizationStatsResponseBody) (err error) {
+	if body.Total == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("total", "body"))
+	}
+	if body.CreatedLast7Days == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("created_last_7_days", "body"))
+	}
+	if body.TrialsEndingSoon == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("trials_ending_soon", "body"))
+	}
+	if body.Disabled == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("disabled", "body"))
+	}
+	if body.DisabledLast7Days == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("disabled_last_7_days", "body"))
 	}
 	return
 }
@@ -9195,6 +9581,246 @@ func ValidateRearmTrialUnexpectedResponseBody(body *RearmTrialUnexpectedResponse
 // ValidateRearmTrialGatewayErrorResponseBody runs the validations defined on
 // rearmTrial_gateway_error_response_body
 func ValidateRearmTrialGatewayErrorResponseBody(body *RearmTrialGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsUnauthorizedResponseBody runs the validations
+// defined on getOrganizationStats_unauthorized_response_body
+func ValidateGetOrganizationStatsUnauthorizedResponseBody(body *GetOrganizationStatsUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsForbiddenResponseBody runs the validations
+// defined on getOrganizationStats_forbidden_response_body
+func ValidateGetOrganizationStatsForbiddenResponseBody(body *GetOrganizationStatsForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsBadRequestResponseBody runs the validations
+// defined on getOrganizationStats_bad_request_response_body
+func ValidateGetOrganizationStatsBadRequestResponseBody(body *GetOrganizationStatsBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsNotFoundResponseBody runs the validations
+// defined on getOrganizationStats_not_found_response_body
+func ValidateGetOrganizationStatsNotFoundResponseBody(body *GetOrganizationStatsNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsConflictResponseBody runs the validations
+// defined on getOrganizationStats_conflict_response_body
+func ValidateGetOrganizationStatsConflictResponseBody(body *GetOrganizationStatsConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsUnsupportedMediaResponseBody runs the
+// validations defined on getOrganizationStats_unsupported_media_response_body
+func ValidateGetOrganizationStatsUnsupportedMediaResponseBody(body *GetOrganizationStatsUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsInvalidResponseBody runs the validations defined
+// on getOrganizationStats_invalid_response_body
+func ValidateGetOrganizationStatsInvalidResponseBody(body *GetOrganizationStatsInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsInvariantViolationResponseBody runs the
+// validations defined on getOrganizationStats_invariant_violation_response_body
+func ValidateGetOrganizationStatsInvariantViolationResponseBody(body *GetOrganizationStatsInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsUnexpectedResponseBody runs the validations
+// defined on getOrganizationStats_unexpected_response_body
+func ValidateGetOrganizationStatsUnexpectedResponseBody(body *GetOrganizationStatsUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetOrganizationStatsGatewayErrorResponseBody runs the validations
+// defined on getOrganizationStats_gateway_error_response_body
+func ValidateGetOrganizationStatsGatewayErrorResponseBody(body *GetOrganizationStatsGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -2981,6 +2981,199 @@ func EncodeRearmTrialError(encoder func(context.Context, http.ResponseWriter) go
 	}
 }
 
+// EncodeGetOrganizationStatsResponse returns an encoder for responses returned
+// by the admin getOrganizationStats endpoint.
+func EncodeGetOrganizationStatsResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminOrganizationStats)
+		enc := encoder(ctx, w)
+		body := NewGetOrganizationStatsResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeGetOrganizationStatsRequest returns a decoder for requests sent to the
+// admin getOrganizationStats endpoint.
+func DecodeGetOrganizationStatsRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.GetOrganizationStatsPayload, error) {
+	return func(r *http.Request) (*admin.GetOrganizationStatsPayload, error) {
+		var payload *admin.GetOrganizationStatsPayload
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewGetOrganizationStatsPayload(adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeGetOrganizationStatsError returns an encoder for errors returned by
+// the getOrganizationStats admin endpoint.
+func EncodeGetOrganizationStatsError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetOrganizationStatsGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // marshalAdminAdminOrganizationMemberToAdminOrganizationMemberResponseBody
 // builds a value of type *AdminOrganizationMemberResponseBody from a value of
 // type *admin.AdminOrganizationMember.

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -76,3 +76,8 @@ func CreateOrganizationAdminPath() string {
 func RearmTrialAdminPath() string {
 	return "/admin/trial.rearm"
 }
+
+// GetOrganizationStatsAdminPath returns the URL path to the admin service getOrganizationStats HTTP endpoint.
+func GetOrganizationStatsAdminPath() string {
+	return "/admin/organizations.stats"
+}

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -33,6 +33,7 @@ type Server struct {
 	ExtendTrial              http.Handler
 	CreateOrganization       http.Handler
 	RearmTrial               http.Handler
+	GetOrganizationStats     http.Handler
 }
 
 // MountPoint holds information about the mounted endpoints.
@@ -76,6 +77,7 @@ func New(
 			{"ExtendTrial", "POST", "/admin/trial.extend"},
 			{"CreateOrganization", "POST", "/admin/organization.create"},
 			{"RearmTrial", "POST", "/admin/trial.rearm"},
+			{"GetOrganizationStats", "GET", "/admin/organizations.stats"},
 		},
 		Login:                    NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
 		Callback:                 NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
@@ -91,6 +93,7 @@ func New(
 		ExtendTrial:              NewExtendTrialHandler(e.ExtendTrial, mux, decoder, encoder, errhandler, formatter),
 		CreateOrganization:       NewCreateOrganizationHandler(e.CreateOrganization, mux, decoder, encoder, errhandler, formatter),
 		RearmTrial:               NewRearmTrialHandler(e.RearmTrial, mux, decoder, encoder, errhandler, formatter),
+		GetOrganizationStats:     NewGetOrganizationStatsHandler(e.GetOrganizationStats, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 
@@ -113,6 +116,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.ExtendTrial = m(s.ExtendTrial)
 	s.CreateOrganization = m(s.CreateOrganization)
 	s.RearmTrial = m(s.RearmTrial)
+	s.GetOrganizationStats = m(s.GetOrganizationStats)
 }
 
 // MethodNames returns the methods served.
@@ -134,6 +138,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountExtendTrialHandler(mux, h.ExtendTrial)
 	MountCreateOrganizationHandler(mux, h.CreateOrganization)
 	MountRearmTrialHandler(mux, h.RearmTrial)
+	MountGetOrganizationStatsHandler(mux, h.GetOrganizationStats)
 }
 
 // Mount configures the mux to serve the admin endpoints.
@@ -862,6 +867,59 @@ func NewRearmTrialHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "rearmTrial")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountGetOrganizationStatsHandler configures the mux to serve the "admin"
+// service "getOrganizationStats" endpoint.
+func MountGetOrganizationStatsHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("GET", "/admin/organizations.stats", f)
+}
+
+// NewGetOrganizationStatsHandler creates a HTTP handler which loads the HTTP
+// request and calls the "admin" service "getOrganizationStats" endpoint.
+func NewGetOrganizationStatsHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeGetOrganizationStatsRequest(mux, decoder)
+		encodeResponse = EncodeGetOrganizationStatsResponse(encoder)
+		encodeError    = EncodeGetOrganizationStatsError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "getOrganizationStats")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -358,6 +358,21 @@ type RearmTrialResponseBody struct {
 	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
 }
 
+// GetOrganizationStatsResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body.
+type GetOrganizationStatsResponseBody struct {
+	// Every organization on the platform, disabled ones included.
+	Total int64 `form:"total" json:"total" xml:"total"`
+	// Organizations created in the last 7 days, whatever their current status.
+	CreatedLast7Days int64 `form:"created_last_7_days" json:"created_last_7_days" xml:"created_last_7_days"`
+	// Organizations whose trial_state is ending_soon.
+	TrialsEndingSoon int64 `form:"trials_ending_soon" json:"trials_ending_soon" xml:"trials_ending_soon"`
+	// Organizations with disabled_at set.
+	Disabled int64 `form:"disabled" json:"disabled" xml:"disabled"`
+	// Organizations disabled in the last 7 days.
+	DisabledLast7Days int64 `form:"disabled_last_7_days" json:"disabled_last_7_days" xml:"disabled_last_7_days"`
+}
+
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
 // endpoint HTTP response body for the "unauthorized" error.
 type LoginUnauthorizedResponseBody struct {
@@ -2921,6 +2936,192 @@ type RearmTrialGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// GetOrganizationStatsUnauthorizedResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "unauthorized" error.
+type GetOrganizationStatsUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsForbiddenResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "forbidden" error.
+type GetOrganizationStatsForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsBadRequestResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "bad_request" error.
+type GetOrganizationStatsBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsNotFoundResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "not_found" error.
+type GetOrganizationStatsNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsConflictResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "conflict" error.
+type GetOrganizationStatsConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsUnsupportedMediaResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "unsupported_media" error.
+type GetOrganizationStatsUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsInvalidResponseBody is the type of the "admin" service
+// "getOrganizationStats" endpoint HTTP response body for the "invalid" error.
+type GetOrganizationStatsInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsInvariantViolationResponseBody is the type of the
+// "admin" service "getOrganizationStats" endpoint HTTP response body for the
+// "invariant_violation" error.
+type GetOrganizationStatsInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsUnexpectedResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "unexpected" error.
+type GetOrganizationStatsUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetOrganizationStatsGatewayErrorResponseBody is the type of the "admin"
+// service "getOrganizationStats" endpoint HTTP response body for the
+// "gateway_error" error.
+type GetOrganizationStatsGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -3216,6 +3417,19 @@ func NewRearmTrialResponseBody(res *admin.AdminOrganization) *RearmTrialResponse
 		MemberCount:        res.MemberCount,
 		CreatedAt:          res.CreatedAt,
 		UpdatedAt:          res.UpdatedAt,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsResponseBody builds the HTTP response body from the
+// result of the "getOrganizationStats" endpoint of the "admin" service.
+func NewGetOrganizationStatsResponseBody(res *admin.AdminOrganizationStats) *GetOrganizationStatsResponseBody {
+	body := &GetOrganizationStatsResponseBody{
+		Total:             res.Total,
+		CreatedLast7Days:  res.CreatedLast7Days,
+		TrialsEndingSoon:  res.TrialsEndingSoon,
+		Disabled:          res.Disabled,
+		DisabledLast7Days: res.DisabledLast7Days,
 	}
 	return body
 }
@@ -5211,6 +5425,156 @@ func NewRearmTrialGatewayErrorResponseBody(res *goa.ServiceError) *RearmTrialGat
 	return body
 }
 
+// NewGetOrganizationStatsUnauthorizedResponseBody builds the HTTP response
+// body from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsUnauthorizedResponseBody(res *goa.ServiceError) *GetOrganizationStatsUnauthorizedResponseBody {
+	body := &GetOrganizationStatsUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsForbiddenResponseBody builds the HTTP response body
+// from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsForbiddenResponseBody(res *goa.ServiceError) *GetOrganizationStatsForbiddenResponseBody {
+	body := &GetOrganizationStatsForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsBadRequestResponseBody builds the HTTP response body
+// from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsBadRequestResponseBody(res *goa.ServiceError) *GetOrganizationStatsBadRequestResponseBody {
+	body := &GetOrganizationStatsBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsNotFoundResponseBody builds the HTTP response body
+// from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsNotFoundResponseBody(res *goa.ServiceError) *GetOrganizationStatsNotFoundResponseBody {
+	body := &GetOrganizationStatsNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsConflictResponseBody builds the HTTP response body
+// from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsConflictResponseBody(res *goa.ServiceError) *GetOrganizationStatsConflictResponseBody {
+	body := &GetOrganizationStatsConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsUnsupportedMediaResponseBody builds the HTTP response
+// body from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsUnsupportedMediaResponseBody(res *goa.ServiceError) *GetOrganizationStatsUnsupportedMediaResponseBody {
+	body := &GetOrganizationStatsUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsInvalidResponseBody builds the HTTP response body
+// from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsInvalidResponseBody(res *goa.ServiceError) *GetOrganizationStatsInvalidResponseBody {
+	body := &GetOrganizationStatsInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsInvariantViolationResponseBody builds the HTTP
+// response body from the result of the "getOrganizationStats" endpoint of the
+// "admin" service.
+func NewGetOrganizationStatsInvariantViolationResponseBody(res *goa.ServiceError) *GetOrganizationStatsInvariantViolationResponseBody {
+	body := &GetOrganizationStatsInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsUnexpectedResponseBody builds the HTTP response body
+// from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsUnexpectedResponseBody(res *goa.ServiceError) *GetOrganizationStatsUnexpectedResponseBody {
+	body := &GetOrganizationStatsUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetOrganizationStatsGatewayErrorResponseBody builds the HTTP response
+// body from the result of the "getOrganizationStats" endpoint of the "admin"
+// service.
+func NewGetOrganizationStatsGatewayErrorResponseBody(res *goa.ServiceError) *GetOrganizationStatsGatewayErrorResponseBody {
+	body := &GetOrganizationStatsGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewLoginPayload builds a admin service login endpoint payload.
 func NewLoginPayload(returnTo *string, prompt *string) *admin.LoginPayload {
 	v := &admin.LoginPayload{}
@@ -5362,6 +5726,15 @@ func NewRearmTrialPayload(body *RearmTrialRequestBody, adminSessionToken *string
 		ID:   *body.ID,
 		Days: *body.Days,
 	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
+// NewGetOrganizationStatsPayload builds a admin service getOrganizationStats
+// endpoint payload.
+func NewGetOrganizationStatsPayload(adminSessionToken *string) *admin.GetOrganizationStatsPayload {
+	v := &admin.GetOrganizationStatsPayload{}
 	v.AdminSessionToken = adminSessionToken
 
 	return v

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -97,7 +97,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|upsert-shadow-mcp-inventory-policy-bypass|delete-shadow-mcp-inventory-policy-bypass|block-shadow-mcp-inventory-server|unblock-shadow-mcp-inventory-server|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial)",
+		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -389,6 +389,9 @@ func ParseEndpoint(
 		adminRearmTrialFlags                 = flag.NewFlagSet("rearm-trial", flag.ExitOnError)
 		adminRearmTrialBodyFlag              = adminRearmTrialFlags.String("body", "REQUIRED", "")
 		adminRearmTrialAdminSessionTokenFlag = adminRearmTrialFlags.String("admin-session-token", "", "")
+
+		adminGetOrganizationStatsFlags                 = flag.NewFlagSet("get-organization-stats", flag.ExitOnError)
+		adminGetOrganizationStatsAdminSessionTokenFlag = adminGetOrganizationStatsFlags.String("admin-session-token", "", "")
 
 		agentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
 
@@ -3398,6 +3401,7 @@ func ParseEndpoint(
 	adminExtendTrialFlags.Usage = adminExtendTrialUsage
 	adminCreateOrganizationFlags.Usage = adminCreateOrganizationUsage
 	adminRearmTrialFlags.Usage = adminRearmTrialUsage
+	adminGetOrganizationStatsFlags.Usage = adminGetOrganizationStatsUsage
 
 	agentFlags.Usage = agentUsage
 	agentGetPluginsFlags.Usage = agentGetPluginsUsage
@@ -4355,6 +4359,9 @@ func ParseEndpoint(
 
 			case "rearm-trial":
 				epf = adminRearmTrialFlags
+
+			case "get-organization-stats":
+				epf = adminGetOrganizationStatsFlags
 
 			}
 
@@ -6338,6 +6345,9 @@ func ParseEndpoint(
 			case "rearm-trial":
 				endpoint = c.RearmTrial()
 				data, err = adminc.BuildRearmTrialPayload(*adminRearmTrialBodyFlag, *adminRearmTrialAdminSessionTokenFlag)
+			case "get-organization-stats":
+				endpoint = c.GetOrganizationStats()
+				data, err = adminc.BuildGetOrganizationStatsPayload(*adminGetOrganizationStatsAdminSessionTokenFlag)
 			}
 		case "agent":
 			c := agentc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -8796,6 +8806,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    extend-trial: Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.`)
 	fmt.Fprintln(os.Stderr, `    create-organization: Creates an organization in WorkOS and in Gram, so an operator does not have to leave the admin app for the WorkOS dashboard. The organization starts with no members, is not whitelisted, and gets no trial. Idempotent against the WorkOS organization webhook: the Gram ID is derived from the WorkOS ID, so both writers converge on one row.`)
 	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
+	fmt.Fprintln(os.Stderr, `    get-organization-stats: Returns platform-wide organization counts for the strip above the organizations list. Every figure counts the whole platform: none of them narrows to the caller's list filters, so the strip does not move when an operator filters.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
 	fmt.Fprintf(os.Stderr, "    %s admin COMMAND --help\n", os.Args[0])
@@ -9102,6 +9113,24 @@ func adminRearmTrialUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin rearm-trial --body '{\n      \"days\": 2,\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminGetOrganizationStatsUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin get-organization-stats", os.Args[0])
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Returns platform-wide organization counts for the strip above the organizations list. Every figure counts the whole platform: none of them narrows to the caller's list filters, so the strip does not move when an operator filters.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin get-organization-stats --admin-session-token \"abc123\"")
 }
 
 // agentUsage displays the usage of the agent command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -982,6 +982,76 @@ paths:
                 outputs:
                     nextCursor: $.next_cursor
                 type: cursor
+    /admin/organizations.stats:
+        get:
+            tags:
+                - admin
+            summary: getOrganizationStats admin
+            description: 'Returns platform-wide organization counts for the strip above the organizations list. Every figure counts the whole platform: none of them narrows to the caller''s list filters, so the strip does not move when an operator filters.'
+            operationId: adminGetOrganizationStats
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminOrganizationStats'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/project.get:
         get:
             tags:
@@ -56037,6 +56107,36 @@ components:
                 - display_name
                 - created_at
                 - updated_at
+        AdminOrganizationStats:
+            type: object
+            properties:
+                created_last_7_days:
+                    type: integer
+                    description: Organizations created in the last 7 days, whatever their current status.
+                    format: int64
+                disabled:
+                    type: integer
+                    description: Organizations with disabled_at set.
+                    format: int64
+                disabled_last_7_days:
+                    type: integer
+                    description: Organizations disabled in the last 7 days.
+                    format: int64
+                total:
+                    type: integer
+                    description: Every organization on the platform, disabled ones included.
+                    format: int64
+                trials_ending_soon:
+                    type: integer
+                    description: Organizations whose trial_state is ending_soon.
+                    format: int64
+            description: Platform-wide organization counts surfaced above the admin organizations list.
+            required:
+                - total
+                - created_last_7_days
+                - trials_ending_soon
+                - disabled
+                - disabled_last_7_days
         AdminProject:
             type: object
             properties:

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -523,6 +523,23 @@ func listOrganizationsOffset(page *int, limit int32) int64 {
 	return (n - 1) * int64(limit)
 }
 
+// GetOrganizationStats counts the whole platform. It takes no filters, so the
+// figures stay put while an operator narrows the list below them.
+func (s *Service) GetOrganizationStats(ctx context.Context, payload *gen.GetOrganizationStatsPayload) (*gen.AdminOrganizationStats, error) {
+	row, err := repo.New(s.db).AdminGetOrganizationStats(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "organization stats").LogError(ctx, s.logger)
+	}
+
+	return &gen.AdminOrganizationStats{
+		Total:             row.Total,
+		CreatedLast7Days:  row.CreatedLast7Days,
+		TrialsEndingSoon:  row.TrialsEndingSoon,
+		Disabled:          row.Disabled,
+		DisabledLast7Days: row.DisabledLast7Days,
+	}, nil
+}
+
 func (s *Service) ListOrganizationMembers(ctx context.Context, payload *gen.ListOrganizationMembersPayload) (*gen.AdminListOrganizationMembersResult, error) {
 	rows, err := repo.New(s.db).AdminListOrganizationMembers(ctx, payload.OrganizationID)
 	if err != nil {

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -31,7 +31,10 @@ type orgFixture struct {
 	createdAt         *time.Time
 }
 
-func seedOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool, f orgFixture) {
+// The database handle is an interface rather than a pool so a seeder can share
+// one transaction with the query it is seeding for, which is what lets a
+// boundary fixture meet the same now() the predicate reads.
+func seedOrg(t *testing.T, ctx context.Context, conn testrepo.DBTX, f orgFixture) {
 	t.Helper()
 
 	if f.accountType == "" {
@@ -334,7 +337,7 @@ type trialFixture struct {
 	demotedAt   *time.Time
 }
 
-func seedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, f trialFixture) {
+func seedTrial(t *testing.T, ctx context.Context, conn trialsRepo.DBTX, f trialFixture) {
 	t.Helper()
 
 	if f.tier == "" {

--- a/server/internal/admin/organizationstats_test.go
+++ b/server/internal/admin/organizationstats_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/admin/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
 
 // statsFixture is one organization and, optionally, the trial hanging off it.
@@ -183,46 +186,81 @@ func TestGetOrganizationStats_IgnoresFilters(t *testing.T) {
 	}, after)
 }
 
-// TestGetOrganizationStats_Boundaries pins which side of each 7-day edge counts.
+// TestGetOrganizationStats_Boundaries pins which side of every edge in the query
+// counts, by seeding each fixture exactly on an edge.
 //
-// The two windows exclude their boundary: an organization created or disabled
-// exactly seven days ago is out. now() has already moved on by the time the
-// count runs, so a row seeded at exactly seven days is the only exact case a
-// test can state without racing the clock.
+// The whole test runs inside one transaction, and that is the mechanism rather
+// than tidiness. now() is the transaction timestamp, so a fixture offset from a
+// value read inside the transaction meets that same value again in the count.
+// Reading now() on a separate statement is not enough: the count then opens a
+// later transaction, its now() is strictly later, and every exact fixture drifts
+// off its edge before the comparison happens, leaving both sides of each
+// operator agreeing on the answer.
 //
-// The trial edge is inclusive, inherited from the ladder's `<=`: a trial ending
-// exactly seven days out is ending_soon.
+// The cost is that this addresses the repository rather than the handler, which
+// holds a pool and cannot be pointed at a transaction. Only the handler's field
+// mapping goes uncovered here, and the three tests above pin that.
 func TestGetOrganizationStats_Boundaries(t *testing.T) {
 	t.Parallel()
 
-	ctx, svc, conn := newTestAdminService(t)
+	ctx, _, conn := newTestAdminService(t)
 
-	now := time.Now().UTC()
-	const window = 7 * 24 * time.Hour
+	tx := testenv.BeginTx(t, ctx, conn)
 
-	seedStatsCorpus(t, ctx, conn, []statsFixture{
-		{id: "org_bound_created_inside", created: -(window - time.Hour)},
-		{id: "org_bound_created_exact", created: -window},
-		{id: "org_bound_created_outside", created: -(window + time.Hour)},
+	// Postgres computes the edges, so the fixtures cannot disagree with the
+	// predicates over what seven days of INTERVAL arithmetic comes to.
+	clock, err := testrepo.New(tx).GetTransactionClockFixture(ctx)
+	require.NoError(t, err)
+	txNow, windowEdge, trialEdge := clock.TransactionNow.Time, clock.SevenDaysAgo.Time, clock.InSevenDays.Time
 
-		{id: "org_bound_disabled_inside", created: -60 * 24 * time.Hour, disabled: -(window - time.Hour)},
-		{id: "org_bound_disabled_exact", created: -60 * 24 * time.Hour, disabled: -window},
-		{id: "org_bound_disabled_outside", created: -60 * 24 * time.Hour, disabled: -(window + time.Hour)},
+	// Old enough that no fixture lands in the created window by accident.
+	old := windowEdge.Add(-30 * 24 * time.Hour)
 
-		{id: "org_bound_trial_exact", created: -60 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(window)}},
-		{id: "org_bound_trial_outside", created: -60 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(window + time.Hour)}},
-	})
+	seedBoundaryOrg := func(id string, createdAt time.Time, disabledAt *time.Time) {
+		seedOrg(t, ctx, tx, orgFixture{
+			id:          id,
+			name:        "Org " + id,
+			slug:        id,
+			whitelisted: true,
+			disabledAt:  disabledAt,
+			createdAt:   &createdAt,
+		})
+	}
+	at := func(ts time.Time) *time.Time { return &ts }
 
-	res, err := svc.GetOrganizationStats(ctx, &gen.GetOrganizationStatsPayload{})
+	// created_at > now() - INTERVAL '7 days': exactly seven days old is out.
+	seedBoundaryOrg("org_bound_created_inside", windowEdge.Add(time.Hour), nil)
+	seedBoundaryOrg("org_bound_created_exact", windowEdge, nil)
+	seedBoundaryOrg("org_bound_created_outside", windowEdge.Add(-time.Hour), nil)
+
+	// disabled_at > now() - INTERVAL '7 days': the same edge, the other column.
+	seedBoundaryOrg("org_bound_disabled_inside", old, at(windowEdge.Add(time.Hour)))
+	seedBoundaryOrg("org_bound_disabled_exact", old, at(windowEdge))
+	seedBoundaryOrg("org_bound_disabled_outside", old, at(windowEdge.Add(-time.Hour)))
+
+	// The ladder's two date arms. ends_at <= now() + INTERVAL '7 days' takes the
+	// exact row, and ends_at <= now() claims a trial ending on the instant for
+	// expired before ending_soon can have it.
+	for _, trial := range []trialFixture{
+		{orgID: "org_bound_trial_exact", endsAt: trialEdge},
+		{orgID: "org_bound_trial_outside", endsAt: trialEdge.Add(time.Hour)},
+		{orgID: "org_bound_trial_expiry_exact", endsAt: txNow},
+		{orgID: "org_bound_trial_expiry_inside", endsAt: txNow.Add(time.Hour)},
+	} {
+		seedBoundaryOrg(trial.orgID, old, nil)
+		seedTrial(t, ctx, tx, trial)
+	}
+
+	row, err := repo.New(tx).AdminGetOrganizationStats(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, &gen.AdminOrganizationStats{
-		Total:             8,
+	require.Equal(t, repo.AdminGetOrganizationStatsRow{
+		Total:             10,
 		CreatedLast7Days:  1,
-		TrialsEndingSoon:  1,
+		TrialsEndingSoon:  2,
 		Disabled:          3,
 		DisabledLast7Days: 1,
-	}, res)
+	}, row)
 }
 
 // TestGetOrganizationStats_EmptyPlatform pins zeros rather than an error: the

--- a/server/internal/admin/organizationstats_test.go
+++ b/server/internal/admin/organizationstats_test.go
@@ -1,0 +1,239 @@
+package admin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+)
+
+// statsFixture is one organization and, optionally, the trial hanging off it.
+type statsFixture struct {
+	id      string
+	created time.Duration // age at seed time, always negative
+	// disabled is the age of disabled_at at seed time; zero leaves the
+	// organization active.
+	disabled time.Duration
+	trial    *trialFixture
+}
+
+func seedStatsCorpus(t *testing.T, ctx context.Context, conn *pgxpool.Pool, corpus []statsFixture) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	for _, f := range corpus {
+		createdAt := now.Add(f.created)
+
+		var disabledAt *time.Time
+		if f.disabled != 0 {
+			at := now.Add(f.disabled)
+			disabledAt = &at
+		}
+
+		seedOrg(t, ctx, conn, orgFixture{
+			id:          f.id,
+			name:        "Org " + f.id,
+			slug:        f.id,
+			whitelisted: true,
+			disabledAt:  disabledAt,
+			createdAt:   &createdAt,
+		})
+
+		if f.trial != nil {
+			trial := *f.trial
+			trial.orgID = f.id
+			seedTrial(t, ctx, conn, trial)
+		}
+	}
+}
+
+// TestGetOrganizationStats_Counts pins all five figures against one corpus in a
+// single assertion. No two of the five are equal, so a handler that deals two
+// fields out in the wrong order cannot pass by matching a neighbour's value.
+func TestGetOrganizationStats_Counts(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	now := time.Now().UTC()
+	convertedAt := now.Add(-10 * 24 * time.Hour)
+	demotedAt := now.Add(-10 * 24 * time.Hour)
+
+	corpus := []statsFixture{
+		// Active, never trialled. Two old, three inside the created window.
+		{id: "org_stats_old_a", created: -60 * 24 * time.Hour},
+		{id: "org_stats_old_b", created: -90 * 24 * time.Hour},
+		{id: "org_stats_new_a", created: -2 * 24 * time.Hour},
+		{id: "org_stats_new_b", created: -5 * 24 * time.Hour},
+		{id: "org_stats_new_c", created: -6 * 24 * time.Hour},
+
+		// Disabled. The second is also inside the created window, so a
+		// created count that excludes disabled organizations reads one short.
+		{id: "org_stats_disabled_recent_a", created: -60 * 24 * time.Hour, disabled: -24 * time.Hour},
+		{id: "org_stats_disabled_recent_b", created: -3 * 24 * time.Hour, disabled: -2 * 24 * time.Hour},
+		// Disabled long ago but created long ago too, so counting
+		// disabled_last_7_days off created_at cannot accidentally agree.
+		{id: "org_stats_disabled_old", created: -200 * 24 * time.Hour, disabled: -30 * 24 * time.Hour},
+
+		// Trials that are ending soon.
+		{id: "org_stats_trial_soon_a", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(2 * 24 * time.Hour)}},
+		{id: "org_stats_trial_soon_b", created: -4 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(6 * 24 * time.Hour)}},
+		{id: "org_stats_trial_soon_c", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(5 * 24 * time.Hour)}},
+		{id: "org_stats_trial_soon_d", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(24 * time.Hour)}},
+
+		// Trials that end inside the window but are not ending soon, because an
+		// earlier arm of the ladder claims them first.
+		{id: "org_stats_trial_converted", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(3 * 24 * time.Hour), convertedAt: &convertedAt}},
+		{id: "org_stats_trial_demoted", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(3 * 24 * time.Hour), demotedAt: &demotedAt}},
+		{id: "org_stats_trial_expired", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(-24 * time.Hour)}},
+		{id: "org_stats_trial_running", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(30 * 24 * time.Hour)}},
+	}
+
+	seedStatsCorpus(t, ctx, conn, corpus)
+
+	res, err := svc.GetOrganizationStats(ctx, &gen.GetOrganizationStatsPayload{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Equal(t, &gen.AdminOrganizationStats{
+		Total:             16,
+		CreatedLast7Days:  5,
+		TrialsEndingSoon:  4,
+		Disabled:          3,
+		DisabledLast7Days: 2,
+	}, res)
+}
+
+// TestGetOrganizationStats_AgreesWithTheListItNavigatesTo checks the middle cell
+// against the rows an operator lands on after clicking it. The figure and the
+// filtered list must come from one definition of ending_soon.
+func TestGetOrganizationStats_AgreesWithTheListItNavigatesTo(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	now := time.Now().UTC()
+	convertedAt := now.Add(-10 * 24 * time.Hour)
+	demotedAt := now.Add(-10 * 24 * time.Hour)
+
+	seedStatsCorpus(t, ctx, conn, []statsFixture{
+		{id: "org_agree_soon_a", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(2 * 24 * time.Hour)}},
+		{id: "org_agree_soon_b", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(6 * 24 * time.Hour)}},
+		{id: "org_agree_soon_disabled", created: -40 * 24 * time.Hour, disabled: -24 * time.Hour, trial: &trialFixture{endsAt: now.Add(4 * 24 * time.Hour)}},
+		{id: "org_agree_converted", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(3 * 24 * time.Hour), convertedAt: &convertedAt}},
+		{id: "org_agree_demoted", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(3 * 24 * time.Hour), demotedAt: &demotedAt}},
+		{id: "org_agree_expired", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(-24 * time.Hour)}},
+		{id: "org_agree_running", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(30 * 24 * time.Hour)}},
+	})
+
+	stats, err := svc.GetOrganizationStats(ctx, &gen.GetOrganizationStatsPayload{})
+	require.NoError(t, err)
+
+	// The strip counts the platform, so the list it navigates to has to ask for
+	// both statuses to see the same rows.
+	list, err := svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{
+		TrialStates:    []string{"ending_soon"},
+		DisabledStates: []string{"active", "disabled"},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, int64(3), stats.TrialsEndingSoon)
+	require.Equal(t, stats.TrialsEndingSoon, list.Total, "the strip and the list it navigates to disagree")
+	require.Len(t, list.Organizations, 3)
+}
+
+// TestGetOrganizationStats_IgnoresFilters pins the endpoint's one structural
+// promise: it takes no filters, so the figures are the same however the list
+// below them is narrowed.
+func TestGetOrganizationStats_IgnoresFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	now := time.Now().UTC()
+	seedStatsCorpus(t, ctx, conn, []statsFixture{
+		{id: "org_filterproof_active", created: -2 * 24 * time.Hour},
+		{id: "org_filterproof_disabled", created: -60 * 24 * time.Hour, disabled: -24 * time.Hour},
+		{id: "org_filterproof_soon", created: -60 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(2 * 24 * time.Hour)}},
+	})
+
+	before, err := svc.GetOrganizationStats(ctx, &gen.GetOrganizationStatsPayload{})
+	require.NoError(t, err)
+
+	_, err = svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{
+		TrialStates:    []string{"expired"},
+		DisabledStates: []string{"disabled"},
+	})
+	require.NoError(t, err)
+
+	after, err := svc.GetOrganizationStats(ctx, &gen.GetOrganizationStatsPayload{})
+	require.NoError(t, err)
+
+	require.Equal(t, before, after)
+	require.Equal(t, &gen.AdminOrganizationStats{
+		Total:             3,
+		CreatedLast7Days:  1,
+		TrialsEndingSoon:  1,
+		Disabled:          1,
+		DisabledLast7Days: 1,
+	}, after)
+}
+
+// TestGetOrganizationStats_Boundaries pins which side of each 7-day edge counts.
+//
+// The two windows exclude their boundary: an organization created or disabled
+// exactly seven days ago is out. now() has already moved on by the time the
+// count runs, so a row seeded at exactly seven days is the only exact case a
+// test can state without racing the clock.
+//
+// The trial edge is inclusive, inherited from the ladder's `<=`: a trial ending
+// exactly seven days out is ending_soon.
+func TestGetOrganizationStats_Boundaries(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	now := time.Now().UTC()
+	const window = 7 * 24 * time.Hour
+
+	seedStatsCorpus(t, ctx, conn, []statsFixture{
+		{id: "org_bound_created_inside", created: -(window - time.Hour)},
+		{id: "org_bound_created_exact", created: -window},
+		{id: "org_bound_created_outside", created: -(window + time.Hour)},
+
+		{id: "org_bound_disabled_inside", created: -60 * 24 * time.Hour, disabled: -(window - time.Hour)},
+		{id: "org_bound_disabled_exact", created: -60 * 24 * time.Hour, disabled: -window},
+		{id: "org_bound_disabled_outside", created: -60 * 24 * time.Hour, disabled: -(window + time.Hour)},
+
+		{id: "org_bound_trial_exact", created: -60 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(window)}},
+		{id: "org_bound_trial_outside", created: -60 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(window + time.Hour)}},
+	})
+
+	res, err := svc.GetOrganizationStats(ctx, &gen.GetOrganizationStatsPayload{})
+	require.NoError(t, err)
+
+	require.Equal(t, &gen.AdminOrganizationStats{
+		Total:             8,
+		CreatedLast7Days:  1,
+		TrialsEndingSoon:  1,
+		Disabled:          3,
+		DisabledLast7Days: 1,
+	}, res)
+}
+
+// TestGetOrganizationStats_EmptyPlatform pins zeros rather than an error: the
+// aggregate always produces a row, and the strip has to render on a fresh
+// platform.
+func TestGetOrganizationStats_EmptyPlatform(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, _ := newTestAdminService(t)
+
+	res, err := svc.GetOrganizationStats(ctx, &gen.GetOrganizationStatsPayload{})
+	require.NoError(t, err)
+	require.Equal(t, &gen.AdminOrganizationStats{}, res)
+}

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -201,6 +201,39 @@ filtered AS (
 SELECT count(*)::bigint FROM filtered
 WHERE coalesce(cardinality(sqlc.arg('trial_states')::text[]), 0) = 0 OR trial_state = ANY(sqlc.arg('trial_states')::text[]);
 
+-- name: AdminGetOrganizationStats :one
+-- Blind to the list's filters by design: these figures must not move when an
+-- operator filters. total and both 7-day windows count disabled organizations
+-- too, so the strip reports the real platform size rather than the list's
+-- default active-only view.
+--
+-- The join stays count-safe because organization_id is the trials primary key.
+-- Both 7-day windows exclude their boundary: exactly seven days old is outside.
+WITH orgs AS (
+    SELECT
+        om.created_at,
+        om.disabled_at,
+        -- Must stay identical to AdminListOrganizations: a figure counted from a
+        -- shortened predicate would disagree with the rows clicking it lands on.
+        CASE
+            WHEN t.organization_id IS NULL THEN 'none'
+            WHEN t.converted_at IS NOT NULL THEN 'converted'
+            WHEN t.demoted_at IS NOT NULL THEN 'demoted'
+            WHEN t.ends_at <= now() THEN 'expired'
+            WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
+            ELSE 'running'
+        END::text AS trial_state
+    FROM organization_metadata om
+    LEFT JOIN trials t ON t.organization_id = om.id
+)
+SELECT
+    count(*)::bigint AS total,
+    count(*) FILTER (WHERE created_at > now() - INTERVAL '7 days')::bigint AS created_last_7_days,
+    count(*) FILTER (WHERE trial_state = 'ending_soon')::bigint AS trials_ending_soon,
+    count(*) FILTER (WHERE disabled_at IS NOT NULL)::bigint AS disabled,
+    count(*) FILTER (WHERE disabled_at > now() - INTERVAL '7 days')::bigint AS disabled_last_7_days
+FROM orgs;
+
 -- name: AdminUpdateOrganization :exec
 -- Admin-only mutation. Both fields are optional — caller passes NULL to skip
 -- the field. NULL on both is a no-op (still touches updated_at).

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -212,6 +212,61 @@ func (q *Queries) AdminGetOrganization(ctx context.Context, arg AdminGetOrganiza
 	return i, err
 }
 
+const adminGetOrganizationStats = `-- name: AdminGetOrganizationStats :one
+WITH orgs AS (
+    SELECT
+        om.created_at,
+        om.disabled_at,
+        -- Must stay identical to AdminListOrganizations: a figure counted from a
+        -- shortened predicate would disagree with the rows clicking it lands on.
+        CASE
+            WHEN t.organization_id IS NULL THEN 'none'
+            WHEN t.converted_at IS NOT NULL THEN 'converted'
+            WHEN t.demoted_at IS NOT NULL THEN 'demoted'
+            WHEN t.ends_at <= now() THEN 'expired'
+            WHEN t.ends_at <= now() + INTERVAL '7 days' THEN 'ending_soon'
+            ELSE 'running'
+        END::text AS trial_state
+    FROM organization_metadata om
+    LEFT JOIN trials t ON t.organization_id = om.id
+)
+SELECT
+    count(*)::bigint AS total,
+    count(*) FILTER (WHERE created_at > now() - INTERVAL '7 days')::bigint AS created_last_7_days,
+    count(*) FILTER (WHERE trial_state = 'ending_soon')::bigint AS trials_ending_soon,
+    count(*) FILTER (WHERE disabled_at IS NOT NULL)::bigint AS disabled,
+    count(*) FILTER (WHERE disabled_at > now() - INTERVAL '7 days')::bigint AS disabled_last_7_days
+FROM orgs
+`
+
+type AdminGetOrganizationStatsRow struct {
+	Total             int64
+	CreatedLast7Days  int64
+	TrialsEndingSoon  int64
+	Disabled          int64
+	DisabledLast7Days int64
+}
+
+// Blind to the list's filters by design: these figures must not move when an
+// operator filters. total and both 7-day windows count disabled organizations
+// too, so the strip reports the real platform size rather than the list's
+// default active-only view.
+//
+// The join stays count-safe because organization_id is the trials primary key.
+// Both 7-day windows exclude their boundary: exactly seven days old is outside.
+func (q *Queries) AdminGetOrganizationStats(ctx context.Context) (AdminGetOrganizationStatsRow, error) {
+	row := q.db.QueryRow(ctx, adminGetOrganizationStats)
+	var i AdminGetOrganizationStatsRow
+	err := row.Scan(
+		&i.Total,
+		&i.CreatedLast7Days,
+		&i.TrialsEndingSoon,
+		&i.Disabled,
+		&i.DisabledLast7Days,
+	)
+	return i, err
+}
+
 const adminGetProjectDetailByID = `-- name: AdminGetProjectDetailByID :one
 SELECT
     p.id,

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -441,3 +441,18 @@ UPDATE user_accounts
 SET deleted_at = clock_timestamp()
 WHERE organization_id = @organization_id
   AND lower(email) = @email_lower::text;
+
+-- name: GetTransactionClockFixture :one
+-- Test-only. Returns the transaction timestamp and the two edges a 7-day
+-- INTERVAL predicate compares against, so a boundary fixture can be seeded
+-- exactly on an edge.
+--
+-- Postgres computes the offsets rather than the test, because INTERVAL day
+-- arithmetic on timestamptz runs in the session time zone and need not come to
+-- 168 hours. It must be read inside the transaction that also runs the query
+-- under test: now() is the transaction timestamp, so reading it on its own
+-- connection puts the fixture on an edge that has already moved.
+SELECT
+    now()::timestamptz AS transaction_now,
+    (now() - INTERVAL '7 days')::timestamptz AS seven_days_ago,
+    (now() + INTERVAL '7 days')::timestamptz AS in_seven_days;

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -707,6 +707,35 @@ func (q *Queries) GetToolCallBlockLinksFixture(ctx context.Context, id uuid.UUID
 	return i, err
 }
 
+const getTransactionClockFixture = `-- name: GetTransactionClockFixture :one
+SELECT
+    now()::timestamptz AS transaction_now,
+    (now() - INTERVAL '7 days')::timestamptz AS seven_days_ago,
+    (now() + INTERVAL '7 days')::timestamptz AS in_seven_days
+`
+
+type GetTransactionClockFixtureRow struct {
+	TransactionNow pgtype.Timestamptz
+	SevenDaysAgo   pgtype.Timestamptz
+	InSevenDays    pgtype.Timestamptz
+}
+
+// Test-only. Returns the transaction timestamp and the two edges a 7-day
+// INTERVAL predicate compares against, so a boundary fixture can be seeded
+// exactly on an edge.
+//
+// Postgres computes the offsets rather than the test, because INTERVAL day
+// arithmetic on timestamptz runs in the session time zone and need not come to
+// 168 hours. It must be read inside the transaction that also runs the query
+// under test: now() is the transaction timestamp, so reading it on its own
+// connection puts the fixture on an edge that has already moved.
+func (q *Queries) GetTransactionClockFixture(ctx context.Context) (GetTransactionClockFixtureRow, error) {
+	row := q.db.QueryRow(ctx, getTransactionClockFixture)
+	var i GetTransactionClockFixtureRow
+	err := row.Scan(&i.TransactionNow, &i.SevenDaysAgo, &i.InSevenDays)
+	return i, err
+}
+
 const insertChatContentPartFixture = `-- name: InsertChatContentPartFixture :one
 INSERT INTO chat_content_parts (chat_id, project_id, kind, content_asset_url)
 VALUES ($1, $2, $3, $4)


### PR DESCRIPTION
A platform admin opening the organizations list has nothing on the page that names the work needing action, so this adds the endpoint the stat strip reads.

`GET /admin/organizations.stats` returns five figures: the total number of organizations, how many were created in the last 7 days, how many have a trial ending soon, how many are disabled, and how many were disabled in the last 7 days. Repairs mark 1 of AGE-3182. The client half that renders them is a separate pull request stacked on this one.

## Decisions worth a reviewer's attention

**One statement, not five.** All five figures come from a single `count(*) FILTER` statement, so the strip costs one round trip. It also means they share one `now()` and one snapshot: Postgres `now()` is the transaction timestamp, so the five figures cannot disagree with each other.

**The totals count disabled organizations.** The list resolves an absent status filter to active only, so a total that excluded disabled rows would leave the real platform size nowhere on the page. This matters to the client half: a cell that displays a platform-wide figure has to navigate to a list that asks for both statuses, or the figure and the rows disagree. `TestGetOrganizationStats_AgreesWithTheListItNavigatesTo` pins exactly that.

**The ending-soon figure reuses the list's trial state ladder character for character**, converted and demoted arms included, so the figure agrees with the rows an operator lands on. That ladder now has four copies in `queries.sql`. Extracting it touches three queries this change has no business touching, so it is left for a follow-up.

**No figure reads the caller's filters.** The strip stays put while an operator narrows the list below it.

## Review round

A reviewer went at the SQL and the handler specifically and found no correctness defect. What it checked, so the same ground is not re-covered: all four ladder copies are character-identical including arm order, verified by a live canary showing that reordering the arms inflates the ending-soon figure by the converted-plus-demoted population; the join is a left join and the `trials_pkey` primary key prevents fan-out; every comparison is `timestamptz` on both sides; `count(*) FILTER` returns 0 rather than NULL against empty input; field order is correct through the SQL, the generated scan and the handler; and the security scheme is byte-identical to its siblings.

Its one finding was in a test, and the second commit fixes it. `TestGetOrganizationStats_Boundaries` claimed to pin which side of each 7-day edge counts and did not: its fixtures were seeded from Go's clock and compared against SQL `now()`, which is strictly later, so the drift pushed every "exact" fixture off its edge before the comparison. Three mutations survived it. Seeding and counting now share one transaction, so fixture and predicate read the same clock, and all four operator mutations fail the test. A behaviour-preserving canary survives, so the kills belong to the test rather than to the harness.

## Known gaps, stated rather than hidden

**Two of the five figures have no list filter to navigate to.** `created_last_7_days` and `disabled_last_7_days` count a date window, and `listOrganizations` offers no date filter. The client half must not make those two clickable.

**No audit entry is written.** This is the epic's explicit non-goal on audit events for platform-admin organization mutations, not an oversight. `server/internal/admin` never imports the audit package today.

## Stacking

Base is `main`, and this is the bottom of a three-branch stack. Both `walker/age-3193-bulk-account-type-server` and `walker/age-3187-stat-strip-client` sit on top of it and will retarget when this merges. Because the base is `main`, the hygiene checks (PR title lint, changeset lint, migration check) all run here, unlike on the two stacked above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /admin/organizations.stats` to return platform-wide organization counts for the admin stat strip. Previously the page showed no stats; now one call returns five figures that stay fixed while the list is filtered. Supports Linear AGE-3187.

- Figures: total, created_last_7_days, trials_ending_soon, disabled, disabled_last_7_days. Totals and both 7‑day windows include disabled orgs; 7‑day windows exclude their boundary.
- One SQL statement with count(*) FILTER and a single now() keeps numbers consistent; “ending soon” reuses the list’s trial-state ladder verbatim.
- Endpoint accepts no filters by design; numbers are platform-wide.
- Tests share the transaction clock to pin 7‑day and ends_at edges.
- No schema changes; auth matches existing admin endpoints; no audit events.
- Client: do not make created_last_7_days and disabled_last_7_days clickable until date filters exist.
- OpenAPI/SDK regenerated (`server/gen/http/openapi3.yaml`, `.speakeasy/out.openapi.yaml`); admin paths remain stripped by the overlay, but `AdminOrganizationStats` is present in `components`.

<sup>Written for commit 40135dbb4a152c0823cfc81ef1bfae7a64b98c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

