### PR TITLE
chore(ci): restore the aube cache before installing, not after

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -614,6 +614,20 @@ jobs:
       - name: Prepare GitHub Actions environment
         run: mise run github
 
+      - name: Cache aube store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ env.GH_CACHE_AUBE_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_AUBE_KEY }}
+            ${{ env.GH_CACHE_AUBE_KEY_PARTIAL }}
+          path: |
+            ${{ env.AUBE_STORE_PATH }}
+
+      # fly:init-runner is a .mts task that imports zx from the workspace.
+      - name: Install dependencies
+        run: aube install --frozen-lockfile
+
       - name: "[DEV] Create fly app"
         id: collectorFlyCreateDev
         shell: bash

--- a/.mise-tasks/github/_default
+++ b/.mise-tasks/github/_default
@@ -3,14 +3,10 @@
 
 set -e
 
+# Cache keys only. `aube install` deliberately does not run here: this task has
+# to emit AUBE_STORE_PATH before the job restores the aube store cache, so
+# installing here would always download the whole workspace from the registry.
+# Jobs run `aube install --frozen-lockfile` themselves after the cache step.
 echo Compute cache keys
 echo ==================
 mise run github:pre-cache
-echo
-echo Install scripting dependencies
-echo ==============================
-# pnpm could scope this to the workspace root (`--filter @gram/workspace`);
-# aube's filters only ever match workspace *members*, so there is no way to
-# ask for the root package alone. Install the workspace instead — the mise
-# .mts tasks that run before a job's own install step need these deps.
-aube install --frozen-lockfile


### PR DESCRIPTION
## The bug

`mise run github` did two things: compute cache keys, then run a full
`aube install --frozen-lockfile` over the workspace. Every job placed its
`Cache aube store` step _after_ that task:

```yaml
- name: Prepare GitHub Actions environment # computes keys, then installs 1270 pkgs
  run: mise run github
- name: Cache aube store # restores the store — too late
  uses: actions/cache@...
```

`actions/cache` restores at its step position, so that install always ran
against a cold store — roughly 1270 packages and ~16MB pulled live from the npm
registry, on every job of every run. The ordering could not simply be swapped:
the cache step needs `AUBE_STORE_PATH`, which the same task emits.

## Why it matters

This is the largest single source of merge queue ejections. Over the last ten
days it took out 17 merge queue runs. The failing package differs every time
(`@datadog/datadog-ci`, `@oxlint-tsgolint`, `posthog-js`, `lightningcss`,
`esbuild`, …) but the error never does:

```
× stream error for <pkg>: HTTP error: error decoding response body
```

That is registry flakiness under load, not a problem with any one dependency —
so the fix is to stop hitting the registry, not to pin or retry.

## The change

`.mise-tasks/github/_default` now only emits cache keys. Jobs run
`aube install --frozen-lockfile` themselves, after their cache restore. The
eight jobs that already had a `Cache aube store` + `Install dependencies` pair
were in the correct order and needed no edit — dropping the install from the
task is enough to fix them.

Of the ten jobs with no cache step, nine turn out never to touch
`node_modules`: every mise task they run (`build:server`, `test:server`,
`git:porcelain`, `go:tidy`, `install:uv`, `gen:infra`, …) is a shell or Go
task, and no step invokes `aube`, `npx` or `tsx` directly. They were paying for
a full workspace install they never used, and now skip it entirely.

Only `otel-collector` genuinely needs it — `fly:init-runner` is a `.mts` task
that imports `zx` from the workspace — so it gains the cache/install pair.

## Verification

Audited all four workflows that call `mise run github`. Every job that needs
`node_modules` has `Cache aube store` before `aube install`; the rest install
nothing:

| Workflow          | cache → install               | no aube needed |
| ----------------- | ----------------------------- | -------------- |
| `pr.yaml`         | 8 existing + `otel-collector` | 9 jobs         |
| `hygiene.yaml`    | `lint-pr`                     | —              |
| `release.yaml`    | `release`                     | —              |
| `litellm-e2e.yml` | —                             | `litellm-e2e`  |

Workflow YAML re-parsed after the edit; step order in `otel-collector` confirmed
as Prepare → Cache → Install → fly steps.

## Follow-ups (not in this PR)

The same "fetch a third-party artifact at CI time" pattern accounts for 23 more
ejections, from two other surfaces:

- `hk.pkl` amends `hk@1.38.0` straight from a GitHub release (12 ejections)
- `uv.lock` pins the spaCy `en_core_web_lg` wheel to a GitHub release URL (11)

Both fail as HTTP/2 `refused stream` / `request not processed by peer`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the `aube` store cache before installing and remove the implicit install from `mise run github` to eliminate cold-store installs that caused flaky CI. Old behavior: jobs ran `aube install` before cache restore; new behavior: jobs restore the cache first and install only when needed.

- .mise-tasks/github/_default: now only emits cache keys; it no longer runs `aube install`.
- pr.yaml: `otel-collector` adds `Cache aube store` then `aube install --frozen-lockfile`; other jobs keep correct order or skip install because they do not touch `node_modules`.
- Migration: for any new job that needs Node deps, add `Cache aube store` before `aube install --frozen-lockfile`.

<sup>Written for commit a7a8483ad2c02620eb4d9358669fe311bba4713d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

