### PR TITLE
fix: stop rotating hosted MCP refresh tokens

### DIFF
--- a/.changeset/mcp-refresh-token-reuse.md
+++ b/.changeset/mcp-refresh-token-reuse.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Stop hosted MCP OAuth from rotating refresh tokens on `/token`. MCP clients retry the refresh grant and share one credential store across processes; consuming the refresh token on first use was returning `invalid_grant` ("already used") and forcing a daily re-login. Access tokens still rotate, authorization lifetime is unchanged, and `/revoke` still invalidates the grant.

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -242,7 +242,7 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 		d := time.Duration(grant.DesiredSessionDurationHours) * time.Hour
 		desiredSessionDuration = &d
 	}
-	if err := s.mintSessionAndRespond(ctx, w, endpoint, clientRow, grant.Subject, desiredSessionDuration, nil, baseURL, logger); err != nil {
+	if err := s.mintSessionAndRespond(ctx, w, endpoint, clientRow, grant.Subject, desiredSessionDuration, nil, "", baseURL, logger); err != nil {
 		// Almost all errors here occur before the 200 is written — issuer
 		// lookup, session_duration validation, signing, or persisting the
 		// user_sessions row — so no token reached the client and failed is
@@ -261,16 +261,20 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	return nil
 }
 
-// handleTokenRefreshTokenGrant implements RFC 6749 §6 (and OAuth 2.1's
-// refresh-token rotation guidance). Hashes the supplied refresh token,
-// atomically soft-deletes the matching user_sessions row (single-use:
-// concurrent refreshes race for the slot), pushes the old access token's
-// JTI into the revocation cache, then mints a new session via
-// mintSessionAndRespond.
+// handleTokenRefreshTokenGrant implements RFC 6749 §6. Hashes the supplied
+// refresh token, loads the matching user_sessions row, pushes the old
+// access token's JTI into the revocation cache, then slides a new access
+// token onto the same row via mintSessionAndRespond.
 //
-// Client binding: the soft-deleted row's user_session_client_id MUST match
-// the authenticated client. This blocks Client B from refreshing tokens
-// issued to Client A even if B somehow obtains the opaque refresh token.
+// The refresh token is not rotated. MCP clients retry /token and share one
+// credential store across processes; consuming the refresh token on first
+// use is what surfaces as daily invalid_grant / "already used" failures
+// when the client presents the same token again. Authorization lifetime
+// still ends at refresh_expires_at, and /revoke still soft-deletes the row.
+//
+// Client binding: the row's user_session_client_id MUST match the
+// authenticated client. A mismatch soft-deletes the row so a leaking
+// client cannot keep probing another client's refresh token.
 func (s *Service) handleTokenRefreshTokenGrant(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -288,26 +292,27 @@ func (s *Service) handleTokenRefreshTokenGrant(
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
-	// Soft-delete by hash claims the single-use slot atomically. If the row
-	// is already gone (unknown / replayed / revoked), pgx.ErrNoRows surfaces
-	// here as invalid_grant.
-	oldSession, err := usersessions_repo.New(s.db).RevokeUserSessionByRefreshTokenHash(ctx, usersessions_repo.RevokeUserSessionByRefreshTokenHashParams{
+	queries := usersessions_repo.New(s.db)
+	refreshHash := sha256Hex(req.RefreshToken)
+	oldSession, err := queries.GetUserSessionByRefreshTokenHash(ctx, usersessions_repo.GetUserSessionByRefreshTokenHashParams{
 		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		RefreshTokenHash:    sha256Hex(req.RefreshToken),
+		RefreshTokenHash:    refreshHash,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_unknown_or_already_used")
-			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token is unknown or already used")
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_unknown_or_revoked")
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token is unknown or revoked")
 		}
-		return oops.E(oops.CodeUnexpected, err, "revoke old refresh token").LogError(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lookup refresh token").LogError(ctx, logger)
 	}
 
-	// Client binding: refuse if the original session was minted for a
-	// different client. We've already soft-deleted the row -- that's
-	// intentional, the alternative would let a leaking client poke at others'
-	// refresh tokens without invalidating them.
 	if !oldSession.UserSessionClientID.Valid || oldSession.UserSessionClientID.UUID != clientRow.ID {
+		if _, revokeErr := queries.RevokeUserSessionByRefreshTokenHash(ctx, usersessions_repo.RevokeUserSessionByRefreshTokenHashParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			RefreshTokenHash:    refreshHash,
+		}); revokeErr != nil && !errors.Is(revokeErr, pgx.ErrNoRows) {
+			logger.WarnContext(ctx, "failed to revoke refresh token after client mismatch", attr.SlogError(revokeErr))
+		}
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_client_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token was issued to a different client")
 	}
@@ -324,11 +329,11 @@ func (s *Service) handleTokenRefreshTokenGrant(
 		logger.WarnContext(ctx, "failed to revoke old access token jti on refresh", attr.SlogError(err))
 	}
 
-	// Session length is an absolute authorization lifetime. Rotation carries
+	// Session length is an absolute authorization lifetime. Refresh carries
 	// that deadline forward verbatim; it never opens a fresh authorization
 	// window merely because the client exchanged its refresh token.
 	authorizationExpiresAt := oldSession.RefreshExpiresAt.Time
-	return s.mintSessionAndRespond(ctx, w, endpoint, clientRow, oldSession.SubjectUrn, nil, &authorizationExpiresAt, baseURL, logger)
+	return s.mintSessionAndRespond(ctx, w, endpoint, clientRow, oldSession.SubjectUrn, nil, &authorizationExpiresAt, req.RefreshToken, baseURL, logger)
 }
 
 // accessTokenLifetime is the wall-clock validity of a minted access-token
@@ -337,16 +342,16 @@ func (s *Service) handleTokenRefreshTokenGrant(
 // authorization lifetime.
 const accessTokenLifetime = 1 * time.Hour
 
-// mintSessionAndRespond mints a new access-token JWT (HS256) and an opaque
-// refresh token, persists a fresh user_sessions row, and writes the RFC
-// 6749 §5.1 response. Shared by the authorization_code and refresh_token
-// grant handlers since both produce identical token responses.
+// mintSessionAndRespond mints a new access-token JWT (HS256) and writes
+// the RFC 6749 §5.1 response. Shared by the authorization_code and
+// refresh_token grant handlers.
 //
 // Lifetimes:
 //   - authorization: the subject's consent choice, capped by the issuer's
 //     session_duration, and fixed for the lifetime of the grant.
 //   - refresh token: the remaining authorization lifetime. Gram does not
-//     impose a separate refresh-token idle timeout.
+//     impose a separate refresh-token idle timeout, and does not rotate
+//     the refresh token on reuse.
 //   - access token: min(accessTokenLifetime, remaining authorization).
 //
 // `iss` / audience: the JWT issuer claim is built from baseURL (which the
@@ -356,8 +361,12 @@ const accessTokenLifetime = 1 * time.Hour
 // projects — prevents cross-project replay.
 // desiredSessionDuration is used only for an initial authorization: nil means
 // "no explicit choice", falling back to the issuer's session_duration.
-// authorizationExpiresAt is used only for rotation and is carried from the
+// authorizationExpiresAt is used only for refresh and is carried from the
 // prior row. Exactly one is normally non-nil.
+// reuseRefreshToken is the refresh token presented on a refresh_token
+// grant. Empty means mint a new refresh token and insert a session row
+// (authorization_code). Non-empty slides a new access token onto the
+// existing row and returns the same refresh token.
 func (s *Service) mintSessionAndRespond(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -366,6 +375,7 @@ func (s *Service) mintSessionAndRespond(
 	subject urn.SessionSubject,
 	desiredSessionDuration *time.Duration,
 	authorizationExpiresAt *time.Time,
+	reuseRefreshToken string,
 	baseURL string,
 	logger *slog.Logger,
 ) error {
@@ -430,21 +440,34 @@ func (s *Service) mintSessionAndRespond(
 		return oops.E(oops.CodeUnexpected, err, "mint session jwt").LogError(ctx, logger)
 	}
 
-	refreshTokenRaw, err := generateOpaqueToken()
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "generate refresh token").LogError(ctx, logger)
-	}
-
-	if _, err := usersessions_repo.New(s.db).CreateUserSession(ctx, usersessions_repo.CreateUserSessionParams{
-		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		UserSessionClientID: uuid.NullUUID{UUID: clientRow.ID, Valid: true},
-		SubjectUrn:          subject,
+	refreshTokenRaw := reuseRefreshToken
+	if refreshTokenRaw == "" {
+		generated, err := generateOpaqueToken()
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "generate refresh token").LogError(ctx, logger)
+		}
+		refreshTokenRaw = generated
+		if _, err := usersessions_repo.New(s.db).CreateUserSession(ctx, usersessions_repo.CreateUserSessionParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			UserSessionClientID: uuid.NullUUID{UUID: clientRow.ID, Valid: true},
+			SubjectUrn:          subject,
+			Jti:                 jti,
+			RefreshTokenHash:    sha256Hex(refreshTokenRaw),
+			ExpiresAt:           pgtype.Timestamptz{Time: accessExpiresAt, InfinityModifier: 0, Valid: true},
+			RefreshExpiresAt:    pgtype.Timestamptz{Time: *authorizationExpiresAt, InfinityModifier: 0, Valid: true},
+		}); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "persist user session").LogError(ctx, logger)
+		}
+	} else if _, err := usersessions_repo.New(s.db).RefreshUserSessionAccessToken(ctx, usersessions_repo.RefreshUserSessionAccessTokenParams{
 		Jti:                 jti,
-		RefreshTokenHash:    sha256Hex(refreshTokenRaw),
 		ExpiresAt:           pgtype.Timestamptz{Time: accessExpiresAt, InfinityModifier: 0, Valid: true},
-		RefreshExpiresAt:    pgtype.Timestamptz{Time: *authorizationExpiresAt, InfinityModifier: 0, Valid: true},
+		UserSessionIssuerID: endpoint.UserSessionIssuerID,
+		RefreshTokenHash:    sha256Hex(refreshTokenRaw),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "persist user session").LogError(ctx, logger)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token is unknown or revoked")
+		}
+		return oops.E(oops.CodeUnexpected, err, "slide user session access token").LogError(ctx, logger)
 	}
 
 	body, err := json.Marshal(tokenResponse{

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -1,0 +1,253 @@
+package mcp_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+type mintedTokens struct {
+	AccessToken            string `json:"access_token"`
+	RefreshToken           string `json:"refresh_token"`
+	TokenType              string `json:"token_type"`
+	ExpiresIn              int64  `json:"expires_in"`
+	AuthorizationExpiresIn int64  `json:"authorization_expires_in"`
+}
+
+func TestTokenRefresh_ReusesRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	first := mintIssuerTokens(t, ctx, ti, toolset.McpSlug.String, toolset.UserSessionIssuerID.UUID, client)
+
+	second := postRefreshToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, first.RefreshToken)
+	require.Equal(t, http.StatusOK, second.Code, "body=%s", second.Body.String())
+	replayed := decodeMintedTokens(t, second)
+	require.Equal(t, first.RefreshToken, replayed.RefreshToken, "refresh token must not rotate")
+	require.NotEqual(t, first.AccessToken, replayed.AccessToken)
+
+	third := postRefreshToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, first.RefreshToken)
+	require.Equal(t, http.StatusOK, third.Code, "body=%s", third.Body.String())
+	again := decodeMintedTokens(t, third)
+	require.Equal(t, first.RefreshToken, again.RefreshToken)
+	require.NotEqual(t, replayed.AccessToken, again.AccessToken)
+}
+
+func TestTokenRefresh_UnknownToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+
+	w := postRefreshToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, "not-a-real-refresh-token")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	requireTokenOAuthError(t, w, "invalid_grant")
+}
+
+func TestTokenRefresh_RevokedToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	tokens := mintIssuerTokens(t, ctx, ti, toolset.McpSlug.String, toolset.UserSessionIssuerID.UUID, client)
+
+	revoke := postRevokeToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, tokens.RefreshToken)
+	require.Equal(t, http.StatusOK, revoke.Code)
+
+	w := postRefreshToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, tokens.RefreshToken)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	requireTokenOAuthError(t, w, "invalid_grant")
+}
+
+func TestTokenRefresh_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	refresh := "expired-refresh-" + uuid.NewString()
+	_, err := usersessions_repo.New(ti.conn).CreateUserSession(ctx, usersessions_repo.CreateUserSessionParams{
+		UserSessionIssuerID: issuer.ID,
+		UserSessionClientID: uuid.NullUUID{UUID: client.ID, Valid: true},
+		SubjectUrn:          urn.NewAnonymousSubject(uuid.NewString()),
+		Jti:                 "jti-" + uuid.NewString(),
+		RefreshTokenHash:    opaqueRefreshHash(refresh),
+		RefreshExpiresAt:    pgtype.Timestamptz{Time: time.Now().Add(-time.Minute), InfinityModifier: 0, Valid: true},
+		ExpiresAt:           pgtype.Timestamptz{Time: time.Now().Add(-time.Minute), InfinityModifier: 0, Valid: true},
+	})
+	require.NoError(t, err)
+
+	w := postRefreshToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, refresh)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	requireTokenOAuthError(t, w, "invalid_grant")
+	require.Contains(t, w.Body.String(), "refresh_token has expired")
+}
+
+func TestTokenRefresh_ClientMismatchRevokesToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer, owner := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	other, err := usersessions_repo.New(ti.conn).CreateUserSessionClient(ctx, usersessions_repo.CreateUserSessionClientParams{
+		UserSessionIssuerID:   issuer.ID,
+		ClientID:              "other-client-" + uuid.NewString()[:8],
+		ClientSecretHash:      pgtype.Text{},
+		ClientName:            "other client",
+		RedirectUris:          []string{"http://localhost:3000/other"},
+		ClientSecretExpiresAt: pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+
+	tokens := mintIssuerTokens(t, ctx, ti, toolset.McpSlug.String, issuer.ID, owner)
+	mismatch := postRefreshToken(t, ctx, ti, toolset.McpSlug.String, other.ClientID, tokens.RefreshToken)
+	require.Equal(t, http.StatusBadRequest, mismatch.Code)
+	requireTokenOAuthError(t, mismatch, "invalid_grant")
+	require.Contains(t, mismatch.Body.String(), "issued to a different client")
+
+	ownerRetry := postRefreshToken(t, ctx, ti, toolset.McpSlug.String, owner.ClientID, tokens.RefreshToken)
+	require.Equal(t, http.StatusBadRequest, ownerRetry.Code)
+	requireTokenOAuthError(t, ownerRetry, "invalid_grant")
+}
+
+func TestTokenRefresh_ConcurrentReplaySucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	first := mintIssuerTokens(t, ctx, ti, toolset.McpSlug.String, toolset.UserSessionIssuerID.UUID, client)
+
+	const n = 8
+	results := make([]*httptest.ResponseRecorder, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			results[i] = postRefreshToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, first.RefreshToken)
+		}()
+	}
+	wg.Wait()
+
+	for i, w := range results {
+		require.Equal(t, http.StatusOK, w.Code, "request %d body=%s", i, w.Body.String())
+		got := decodeMintedTokens(t, w)
+		require.Equal(t, first.RefreshToken, got.RefreshToken)
+		require.NotEmpty(t, got.AccessToken)
+	}
+}
+
+func mintIssuerTokens(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	mcpSlug string,
+	issuerID uuid.UUID,
+	client usersessions_repo.UserSessionClient,
+) mintedTokens {
+	t.Helper()
+
+	redirectURI := client.RedirectUris[0]
+	verifier := "verifier-" + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	code := "auth-code-" + uuid.NewString()
+	grantCache := cache.NewTypedObjectCache[mcp.UserSessionGrant](ti.logger, ti.cacheAdapter, cache.SuffixNone)
+	require.NoError(t, grantCache.Store(ctx, mcp.UserSessionGrant{
+		Code:                        code,
+		FlowID:                      "",
+		UserSessionIssuerID:         issuerID,
+		UserSessionClientID:         client.ID,
+		ClientID:                    client.ClientID,
+		RedirectURI:                 redirectURI,
+		CodeChallenge:               base64.RawURLEncoding.EncodeToString(sum[:]),
+		CodeChallengeMethod:         "S256",
+		Subject:                     urn.NewAnonymousSubject(uuid.NewString()),
+		DesiredSessionDurationHours: 0,
+		CreatedAt:                   time.Now(),
+	}))
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", client.ClientID)
+	form.Set("code_verifier", verifier)
+	w := postTokenForm(t, ctx, ti, mcpSlug, form)
+	require.Equal(t, http.StatusOK, w.Code, "authorization_code grant: %s", w.Body.String())
+	tokens := decodeMintedTokens(t, w)
+	require.NotEmpty(t, tokens.AccessToken)
+	require.NotEmpty(t, tokens.RefreshToken)
+	return tokens
+}
+
+func postRefreshToken(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug, clientID, refreshToken string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", clientID)
+	return postTokenForm(t, ctx, ti, mcpSlug, form)
+}
+
+func postRevokeToken(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug, clientID, token string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	form := url.Values{}
+	form.Set("token", token)
+	form.Set("token_type_hint", "refresh_token")
+	form.Set("client_id", clientID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/mcp/"+mcpSlug+"/revoke", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleRevoke(w, req))
+	return w
+}
+
+func postTokenForm(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/mcp/"+mcpSlug+"/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleToken(w, req))
+	return w
+}
+
+func decodeMintedTokens(t *testing.T, w *httptest.ResponseRecorder) mintedTokens {
+	t.Helper()
+
+	var tokens mintedTokens
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &tokens))
+	return tokens
+}
+
+func opaqueRefreshHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -135,20 +136,26 @@ func TestTokenRefresh_ConcurrentReplaySucceeds(t *testing.T) {
 	first := mintIssuerTokens(t, ctx, ti, toolset.McpSlug.String, toolset.UserSessionIssuerID.UUID, client)
 
 	const n = 8
-	results := make([]*httptest.ResponseRecorder, n)
+	type refreshResult struct {
+		w   *httptest.ResponseRecorder
+		err error
+	}
+	results := make([]refreshResult, n)
 	var wg sync.WaitGroup
 	wg.Add(n)
 	for i := range n {
 		go func() {
 			defer wg.Done()
-			results[i] = postRefreshToken(t, ctx, ti, toolset.McpSlug.String, client.ClientID, first.RefreshToken)
+			w, err := doHostedTokenForm(ctx, ti, toolset.McpSlug.String, refreshTokenForm(client.ClientID, first.RefreshToken))
+			results[i] = refreshResult{w: w, err: err}
 		}()
 	}
 	wg.Wait()
 
-	for i, w := range results {
-		require.Equal(t, http.StatusOK, w.Code, "request %d body=%s", i, w.Body.String())
-		got := decodeMintedTokens(t, w)
+	for i, result := range results {
+		require.NoError(t, result.err, "request %d", i)
+		require.Equal(t, http.StatusOK, result.w.Code, "request %d body=%s", i, result.w.Body.String())
+		got := decodeMintedTokens(t, result.w)
 		require.Equal(t, first.RefreshToken, got.RefreshToken)
 		require.NotEmpty(t, got.AccessToken)
 	}
@@ -189,7 +196,7 @@ func mintIssuerTokens(
 	form.Set("redirect_uri", redirectURI)
 	form.Set("client_id", client.ClientID)
 	form.Set("code_verifier", verifier)
-	w := postTokenForm(t, ctx, ti, mcpSlug, form)
+	w := postHostedTokenForm(t, ctx, ti, mcpSlug, form)
 	require.Equal(t, http.StatusOK, w.Code, "authorization_code grant: %s", w.Body.String())
 	tokens := decodeMintedTokens(t, w)
 	require.NotEmpty(t, tokens.AccessToken)
@@ -197,14 +204,17 @@ func mintIssuerTokens(
 	return tokens
 }
 
-func postRefreshToken(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug, clientID, refreshToken string) *httptest.ResponseRecorder {
-	t.Helper()
-
+func refreshTokenForm(clientID, refreshToken string) url.Values {
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 	form.Set("client_id", clientID)
-	return postTokenForm(t, ctx, ti, mcpSlug, form)
+	return form
+}
+
+func postRefreshToken(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug, clientID, refreshToken string) *httptest.ResponseRecorder {
+	t.Helper()
+	return postHostedTokenForm(t, ctx, ti, mcpSlug, refreshTokenForm(clientID, refreshToken))
 }
 
 func postRevokeToken(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug, clientID, token string) *httptest.ResponseRecorder {
@@ -225,9 +235,15 @@ func postRevokeToken(t *testing.T, ctx context.Context, ti *testInstance, mcpSlu
 	return w
 }
 
-func postTokenForm(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug string, form url.Values) *httptest.ResponseRecorder {
+func postHostedTokenForm(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug string, form url.Values) *httptest.ResponseRecorder {
 	t.Helper()
 
+	w, err := doHostedTokenForm(ctx, ti, mcpSlug, form)
+	require.NoError(t, err)
+	return w
+}
+
+func doHostedTokenForm(ctx context.Context, ti *testInstance, mcpSlug string, form url.Values) (*httptest.ResponseRecorder, error) {
 	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/mcp/"+mcpSlug+"/token", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rctx := chi.NewRouteContext()
@@ -235,8 +251,10 @@ func postTokenForm(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug 
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	w := httptest.NewRecorder()
-	require.NoError(t, ti.service.HandleToken(w, req))
-	return w
+	if err := ti.service.HandleToken(w, req); err != nil {
+		return w, fmt.Errorf("handle token: %w", err)
+	}
+	return w, nil
 }
 
 func decodeMintedTokens(t *testing.T, w *httptest.ResponseRecorder) mintedTokens {

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -549,6 +549,25 @@ WHERE id = @id
   AND deleted IS FALSE
 RETURNING *;
 
+-- name: RefreshUserSessionAccessToken :one
+-- Slides the access-token half of a user session after a refresh_token
+-- grant. The refresh token itself is not rotated: MCP clients retry
+-- /token and share one credential store across processes, so consuming
+-- the refresh token on first use forces a re-login the next time the
+-- same token is presented. Authorization lifetime (refresh_expires_at)
+-- is unchanged. Scoped by issuer_id because the public MCP /token
+-- surface has no project in request context — same as
+-- GetUserSessionByRefreshTokenHash / RevokeUserSessionByRefreshTokenHash.
+UPDATE user_sessions
+SET
+    jti = @jti,
+    expires_at = @expires_at,
+    updated_at = clock_timestamp()
+WHERE user_session_issuer_id = @user_session_issuer_id
+  AND refresh_token_hash = @refresh_token_hash
+  AND deleted IS FALSE
+RETURNING *;
+
 -- name: CreateUserSession :one
 -- user_session_client_id binds the session to the DCR client that minted it.
 -- The /token refresh path requires the same client to refresh; see

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -1351,6 +1351,60 @@ func (q *Queries) PurgeUserSessionClientCIMDCache(ctx context.Context, id uuid.U
 	return i, err
 }
 
+const refreshUserSessionAccessToken = `-- name: RefreshUserSessionAccessToken :one
+UPDATE user_sessions
+SET
+    jti = $1,
+    expires_at = $2,
+    updated_at = clock_timestamp()
+WHERE user_session_issuer_id = $3
+  AND refresh_token_hash = $4
+  AND deleted IS FALSE
+RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
+`
+
+type RefreshUserSessionAccessTokenParams struct {
+	Jti                 string
+	ExpiresAt           pgtype.Timestamptz
+	UserSessionIssuerID uuid.UUID
+	RefreshTokenHash    string
+}
+
+// Slides the access-token half of a user session after a refresh_token
+// grant. The refresh token itself is not rotated: MCP clients retry
+// /token and share one credential store across processes, so consuming
+// the refresh token on first use forces a re-login the next time the
+// same token is presented. Authorization lifetime (refresh_expires_at)
+// is unchanged. Scoped by issuer_id because the public MCP /token
+// surface has no project in request context — same as
+// GetUserSessionByRefreshTokenHash / RevokeUserSessionByRefreshTokenHash.
+func (q *Queries) RefreshUserSessionAccessToken(ctx context.Context, arg RefreshUserSessionAccessTokenParams) (UserSession, error) {
+	row := q.db.QueryRow(ctx, refreshUserSessionAccessToken,
+		arg.Jti,
+		arg.ExpiresAt,
+		arg.UserSessionIssuerID,
+		arg.RefreshTokenHash,
+	)
+	var i UserSession
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.UserSessionIssuerID,
+		&i.UserSessionClientID,
+		&i.SubjectUrn,
+		&i.Jti,
+		&i.RefreshTokenHash,
+		&i.RefreshExpiresAt,
+		&i.ExpiresAt,
+		&i.ToolSelection,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const revokeUserSession = `-- name: RevokeUserSession :one
 UPDATE user_sessions AS s
 SET deleted_at = clock_timestamp()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hosted MCP OAuth (`POST /mcp/{slug}/token`, `grant_type=refresh_token`) consumed the refresh token on first use and minted a replacement. MCP clients retry that grant and share one credential store across processes, so the next presentation of the same token returned `invalid_grant` and forced a re-login.

The refresh token is now reused for the life of the authorization. A refresh still mints a new access token and slides it onto the existing `user_sessions` row. Authorization lifetime (`refresh_expires_at`) is unchanged. `/revoke` still soft-deletes the row. A client-id mismatch still revokes the grant so a leaking client cannot keep probing.

Fixes AIS-562.

## Test plan

- [x] `TestTokenRefresh_ReusesRefreshToken` — same refresh token works twice; access token rotates
- [x] `TestTokenRefresh_UnknownToken` / `_RevokedToken` / `_ExpiredToken`
- [x] `TestTokenRefresh_ClientMismatchRevokesToken` — mismatch invalidates the grant
- [x] `TestTokenRefresh_ConcurrentReplaySucceeds` — parallel refreshes all succeed with the same refresh token
- [x] `mise exec -- go test ./server/internal/mcp/ -run 'TestTokenRefresh_'`
- [x] golangci-lint on `internal/mcp` and `internal/usersessions`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-562](https://linear.app/speakeasy/issue/AIS-562/bug-codex-fails-to-refresh-mcp-authentication-reliably)

<div><a href="https://cursor.com/agents/bc-38767cdd-30a8-41b4-8224-8628a01c8389?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38767cdd-30a8-41b4-8224-8628a01c8389&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops rotating hosted MCP refresh tokens on refresh grants to prevent invalid_grant on client retries. Previously the refresh token was single-use; now it is reused for the authorization lifetime while access tokens still rotate.

- Applies to POST `/mcp/{slug}/token` with `grant_type=refresh_token`; authorization lifetime is unchanged and `/revoke` still invalidates the grant.
- On refresh, we look up the session by refresh-token hash, revoke the old access token JTI, and update the existing session row’s access token via a new `RefreshUserSessionAccessToken` query; we return the same refresh token.
- Enforces client binding: a client-id mismatch soft-deletes the grant and returns invalid_grant to prevent probing.
- Concurrent refreshes with the same refresh token now all succeed; error text uses “unknown or revoked” instead of “already used.”
- Adds tests for token reuse, unknown/revoked/expired tokens, client mismatch revocation, and concurrent refresh; moves assertions off goroutines and renames the hosted `/token` helper to avoid collisions. Addresses Linear AIS-562. No client changes required.

<sup>Written for commit b9279a24eb427ef0dbe21296e21bc9a83f2010f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

