### PR TITLE
feat(admin): one Actions column, pinned to the right edge

### DIFF
--- a/.changeset/admin-organizations-actions-column.md
+++ b/.changeset/admin-organizations-actions-column.md
@@ -18,19 +18,28 @@ while the columns scroll underneath them.
 
 The pinned cell takes its colour from the row it belongs to rather than a flat
 one of its own, so it stays invisible as a cell: it matches the highlight on the
-row being peeked at, and it matches the hover. Hover and the open-menu highlight
-are now fully opaque, which they had to become. A translucent highlight was
-painted twice on the pinned cell, once by the row and once by the cell stacked
-above it, which made it visibly darker than the rest of its row and let the
-scrolled columns show through it.
+row being peeked at, and it matches the hover. To give it something opaque to
+inherit, rows in the organizations list now carry a background of their own, and
+their hover and open-menu highlights became fully opaque. A translucent
+highlight was painted twice on the pinned cell, once by the row and once by the
+cell stacked above it, which made it visibly darker than the rest of its row and
+let the scrolled columns show through it. Only this list changes; every other
+admin table keeps the highlights it had.
 
 Alt+click a row to peek at it, which the peek panel's first release had and then
 lost. Plain click still opens the organization, and the peek button in the
 Actions column still peeks, so the gesture is a shortcut rather than the only
 way in. It works on any part of the row including the organization's name, whose
 link would otherwise treat Alt+click as "save link as" and start a download;
-verified in Chromium that the download does not happen. Ctrl, Cmd and Shift are
-left alone, so opening a row in a new tab or window still belongs to the link.
+verified in Chromium that the download does not happen. Holding Alt together
+with Ctrl, Cmd or Shift does not peek, but it still cancels that download rather
+than leaving the operator with an HTML file they did not ask for.
+
+Ctrl, Cmd and Shift without Alt still belong to the link, so opening an
+organization in a new tab or window works as it did. Used anywhere else in the
+row they now do nothing. Until now they fell through and navigated the list away
+in the current tab, which took the list out from under the tab the operator was
+opening.
 
 The Actions column cannot be hidden from the Columns menu, which would otherwise
 put peek and every write out of reach of the whole list.

--- a/.changeset/admin-organizations-actions-column.md
+++ b/.changeset/admin-organizations-actions-column.md
@@ -1,0 +1,36 @@
+---
+"admin": patch
+---
+
+Gather the organizations list's two row controls into one Actions column, pinned
+to the right edge of the table. Peek and the row menu used to sit in two
+separate columns ahead of the name, which put two controls between the operator
+and the thing they came to read, and left the row's first column carrying
+nothing they could name. They are now one cell at the end of the row, peek
+first, sized to its contents so it does not read as an empty gutter.
+
+Pinned rather than merely last, because the list is wider than most windows. A
+trailing column that scrolled with the rest would start life off the right edge:
+in a 760 pixel wide window it sat 227 pixels past the edge of the viewport, so
+neither control could be seen or clicked until the operator scrolled the table
+sideways. Pinned, both are on screen from the start and hold their position
+while the columns scroll underneath them.
+
+The pinned cell takes its colour from the row it belongs to rather than a flat
+one of its own, so it stays invisible as a cell: it matches the highlight on the
+row being peeked at, and it matches the hover. Hover and the open-menu highlight
+are now fully opaque, which they had to become. A translucent highlight was
+painted twice on the pinned cell, once by the row and once by the cell stacked
+above it, which made it visibly darker than the rest of its row and let the
+scrolled columns show through it.
+
+Alt+click a row to peek at it, which the peek panel's first release had and then
+lost. Plain click still opens the organization, and the peek button in the
+Actions column still peeks, so the gesture is a shortcut rather than the only
+way in. It works on any part of the row including the organization's name, whose
+link would otherwise treat Alt+click as "save link as" and start a download;
+verified in Chromium that the download does not happen. Ctrl, Cmd and Shift are
+left alone, so opening a row in a new tab or window still belongs to the link.
+
+The Actions column cannot be hidden from the Columns menu, which would otherwise
+put peek and every write out of reach of the whole list.

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -32,13 +32,6 @@ import {
  */
 
 /**
- * The feature registry every admin table shares.
- *
- * Column visibility gates `row.getVisibleCells`, `column.getIsVisible` and
- * `column.getCanHide`, which this wrapper and its header both call. A table
- * with no Columns control still registers it for that reason.
- */
-/**
  * Per-column classes, carried on the column definition because the header and
  * the body cell are rendered here rather than by the page.
  */
@@ -47,6 +40,13 @@ export type DataTableColumnMeta = {
   cellClassName?: string;
 };
 
+/**
+ * The feature registry every admin table shares.
+ *
+ * Column visibility gates `row.getVisibleCells`, `column.getIsVisible` and
+ * `column.getCanHide`, which this wrapper and its header both call. A table
+ * with no Columns control still registers it for that reason.
+ */
 export const dataTableFeatures = tableFeatures({
   columnVisibilityFeature,
   columnMeta: metaHelper<DataTableColumnMeta>(),
@@ -147,22 +147,26 @@ function DataTableRow<T extends RowData>({
             "a,button,input,label",
           );
 
-          // Alt turns a link's default into "save link", never a navigation, so
-          // a row that wants the gesture may have it and cancels the download.
-          // The other three modifiers are the browser's open-in-tab and
-          // open-in-window, which stay the link's own.
-          if (
-            onAltClick &&
-            event.altKey &&
-            !event.ctrlKey &&
-            !event.metaKey &&
-            !event.shiftKey &&
-            (control === null || control.matches("a"))
-          ) {
-            event.preventDefault();
-            onAltClick(row.original, event);
+          const onRowOrLink = control === null || control.matches("a");
+
+          // Alt turns a link's default into "save link", never a navigation,
+          // so a row that claims the gesture cancels that download whatever
+          // else is held down. Peeking is the stricter case: Alt on its own,
+          // because Alt with a second modifier is a gesture nobody aimed here.
+          if (onAltClick && event.altKey) {
+            if (onRowOrLink) {
+              event.preventDefault();
+              if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
+                onAltClick(row.original, event);
+              }
+            }
             return;
           }
+
+          // Open-in-tab and open-in-window belong to the link in the name
+          // cell. Answering them anywhere else in the row would navigate this
+          // tab out from under the one the operator is opening.
+          if (event.ctrlKey || event.metaKey || event.shiftKey) return;
 
           if (!onClick || control) return;
           onClick(row.original, event);
@@ -172,15 +176,7 @@ function DataTableRow<T extends RowData>({
   return (
     <TableRow
       ref={ref}
-      // Every row state stays fully opaque, including the two the base row
-      // gives a half-alpha tint. A pinned cell inherits the colour and paints
-      // it a second time on its own layer, so a translucent one both doubles
-      // up and lets the scrolled row show through. A page's own colour wins.
-      className={cn(
-        "bg-background hover:bg-muted has-aria-expanded:bg-muted",
-        onClick && "cursor-pointer",
-        className,
-      )}
+      className={cn(onClick && "cursor-pointer", className)}
       onClick={handleClick}
     >
       {row.getVisibleCells().map((cell) => (

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -2,6 +2,7 @@
 import {
   columnVisibilityFeature,
   FlexRender,
+  metaHelper,
   tableFeatures,
   type ReactTable,
   type Row,
@@ -37,7 +38,19 @@ import {
  * `column.getCanHide`, which this wrapper and its header both call. A table
  * with no Columns control still registers it for that reason.
  */
-export const dataTableFeatures = tableFeatures({ columnVisibilityFeature });
+/**
+ * Per-column classes, carried on the column definition because the header and
+ * the body cell are rendered here rather than by the page.
+ */
+export type DataTableColumnMeta = {
+  headClassName?: string;
+  cellClassName?: string;
+};
+
+export const dataTableFeatures = tableFeatures({
+  columnVisibilityFeature,
+  columnMeta: metaHelper<DataTableColumnMeta>(),
+});
 
 export type DataTableFeatures = typeof dataTableFeatures;
 
@@ -93,7 +106,11 @@ function DataTableHeader<T extends RowData>({
             // A placeholder header and a colSpan above 1 both appear only when
             // columns are grouped. Handling one and not the other would leave a
             // group heading sitting over a single column.
-            <TableHead key={header.id} colSpan={header.colSpan}>
+            <TableHead
+              key={header.id}
+              colSpan={header.colSpan}
+              className={header.column.columnDef.meta?.headClassName}
+            >
               {header.isPlaceholder ? null : <FlexRender header={header} />}
             </TableHead>
           ))}
@@ -106,11 +123,13 @@ function DataTableHeader<T extends RowData>({
 function DataTableRow<T extends RowData>({
   row,
   onClick,
+  onAltClick,
   className,
   ref,
 }: {
   row: Row<DataTableFeatures, T>;
   onClick?: (row: T, event: React.MouseEvent<HTMLTableRowElement>) => void;
+  onAltClick?: (row: T, event: React.MouseEvent<HTMLTableRowElement>) => void;
   className?: string;
   ref?: React.Ref<HTMLTableRowElement>;
 }) {
@@ -119,25 +138,56 @@ function DataTableRow<T extends RowData>({
   // assistive technology walks. A clickable row instead carries a real link
   // in one of its cells, and that link owns the keyboard path and the
   // accessible name. This handler only widens the mouse target.
-  const handleClick = onClick
-    ? (event: React.MouseEvent<HTMLTableRowElement>) => {
-        // The link in the cell already navigates, and it also lets the
-        // operator open the record in a new tab.
-        if ((event.target as HTMLElement).closest("a,button,input,label")) {
-          return;
+  const handleClick =
+    onClick || onAltClick
+      ? (event: React.MouseEvent<HTMLTableRowElement>) => {
+          // The link in the cell already navigates, and it also lets the
+          // operator open the record in a new tab.
+          const control = (event.target as HTMLElement).closest(
+            "a,button,input,label",
+          );
+
+          // Alt turns a link's default into "save link", never a navigation, so
+          // a row that wants the gesture may have it and cancels the download.
+          // The other three modifiers are the browser's open-in-tab and
+          // open-in-window, which stay the link's own.
+          if (
+            onAltClick &&
+            event.altKey &&
+            !event.ctrlKey &&
+            !event.metaKey &&
+            !event.shiftKey &&
+            (control === null || control.matches("a"))
+          ) {
+            event.preventDefault();
+            onAltClick(row.original, event);
+            return;
+          }
+
+          if (!onClick || control) return;
+          onClick(row.original, event);
         }
-        onClick(row.original, event);
-      }
-    : undefined;
+      : undefined;
 
   return (
     <TableRow
       ref={ref}
-      className={cn(onClick && "cursor-pointer", className)}
+      // Every row state stays fully opaque, including the two the base row
+      // gives a half-alpha tint. A pinned cell inherits the colour and paints
+      // it a second time on its own layer, so a translucent one both doubles
+      // up and lets the scrolled row show through. A page's own colour wins.
+      className={cn(
+        "bg-background hover:bg-muted has-aria-expanded:bg-muted",
+        onClick && "cursor-pointer",
+        className,
+      )}
       onClick={handleClick}
     >
       {row.getVisibleCells().map((cell) => (
-        <TableCell key={cell.id}>
+        <TableCell
+          key={cell.id}
+          className={cell.column.columnDef.meta?.cellClassName}
+        >
           <FlexRender cell={cell} />
         </TableCell>
       ))}

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -13,36 +13,14 @@ import { PeekTrigger } from "./PeekTrigger";
 
 const column = createColumnHelper<DataTableFeatures, AdminOrganization>();
 
+// `w-px` shrinks the column to its content, so the pin does not read as a
+// gutter. The header row is already `z-10`, so this stays under it.
+const PINNED_RIGHT = "sticky right-0 z-1 w-px";
+
 // Module scope gives the array one identity for the life of the tab, so the
 // table does not rebuild its column model on every render. The header of each
 // column doubles as its label in the Columns control.
 export const ORG_COLUMNS = column.columns([
-  // First, not last: peek hides five columns while it is open, so a trailing
-  // control would slide sideways at the moment the operator is using it.
-  column.display({
-    id: "peek",
-    // A plain string, so the Columns control lists it as "Peek" rather than
-    // falling back to the column id.
-    header: "Peek",
-    // Hiding the control would put peek back out of reach of the keyboard.
-    enableHiding: false,
-    cell: ({ row }) => <PeekTrigger org={row.original} />,
-  }),
-  // Beside peek rather than trailing the row, for the reason above: the row
-  // menu is the control an operator reaches for while peek is open, and it is
-  // the five hidden columns' width away from where it was if it sits last.
-  //
-  // Deliberately in neither PEEK_HIDDEN_COLUMNS nor PEEK_COLUMN_OVERRIDES: an
-  // open peek is no reason to take the other rows' actions away, and hiding a
-  // control the Columns menu cannot bring back would strand it.
-  column.display({
-    id: "actions",
-    header: "Actions",
-    // Hiding the menu would put disable, re-enable and extend out of reach for
-    // the whole list, and the peek panel's copy of them covers one record.
-    enableHiding: false,
-    cell: ({ row }) => <OrganizationActions org={row.original} layout="menu" />,
-  }),
   column.accessor("name", {
     header: "Name",
     // The link, not the row, carries the keyboard path and the accessible
@@ -115,6 +93,27 @@ export const ORG_COLUMNS = column.columns([
     header: "Created",
     cell: ({ row }) => (
       <span className="text-sm">{fmtDateShort(row.original.created_at)}</span>
+    ),
+  }),
+  // Pinned, not merely last: the list is wider than most windows, so a column
+  // that scrolled would start life off the right edge, out of reach until the
+  // operator scrolled sideways to find it.
+  column.display({
+    id: "actions",
+    header: "Actions",
+    // Hiding it would put peek and every write out of reach of the whole list.
+    enableHiding: false,
+    meta: {
+      headClassName: cn(PINNED_RIGHT, "bg-muted"),
+      // Inherited, so the pinned cell repaints with the row rather than reading
+      // as a flat stripe over the peeked row's own colour.
+      cellClassName: cn(PINNED_RIGHT, "bg-inherit"),
+    },
+    cell: ({ row }) => (
+      <div className="flex items-center gap-1">
+        <PeekTrigger org={row.original} />
+        <OrganizationActions org={row.original} layout="menu" />
+      </div>
     ),
   }),
 ]);

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -207,6 +207,17 @@ async function withFakeTimers(
   }
 }
 
+// One turn of the macrotask queue, flushed through act. An assertion that
+// something did *not* navigate has to give the navigation a chance to happen
+// first, or it passes against a router that simply had not got there yet.
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+}
+
 // The router JSON-encodes and then percent-encodes an array, so decoding once
 // lets an assertion name the value the way the schema declares it.
 function currentSearch(router: AnyRouter): string {
@@ -307,8 +318,12 @@ function liveRegion(): HTMLElement {
 // sentence repeated word for word still changes the text node. Stripped here:
 // these assertions are about what is announced, not about the marker that
 // makes an unchanged sentence announceable.
+// The marker the region alternates. Written out rather than imported, so a
+// change to the page's own constant has to be made here as well.
+const ZERO_WIDTH_SPACE = "\u200b";
+
 function announcement(): string {
-  return (liveRegion().textContent ?? "").replaceAll("\u200b", "");
+  return (liveRegion().textContent ?? "").replaceAll(ZERO_WIDTH_SPACE, "");
 }
 
 function isPeeked(link: HTMLElement): boolean {
@@ -902,8 +917,6 @@ describe("organizations list", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
-      "Peek",
-      "Actions",
       "Name",
       "Slug",
       "Type",
@@ -912,16 +925,13 @@ describe("organizations list", () => {
       "Disabled",
       "Trial",
       "Created",
+      "Actions",
     ]);
     expect(
       within(rowFor(link))
         .getAllByRole("cell")
         .map((cell) => cell.textContent),
     ).toEqual([
-      // The peek control carries an icon and its name is on the button.
-      "",
-      // So does the row menu, for the same reason.
-      "",
       FIRST_ORG.name,
       FIRST_ORG.slug,
       FIRST_ORG.account_type,
@@ -936,6 +946,8 @@ describe("organizations list", () => {
       // here on the date alone.
       `Running ends ${shortDate(trialEndsAt)}`,
       shortDate(FIRST_ORG.created_at),
+      // Both controls carry an icon and their names are on the buttons.
+      "",
     ]);
   });
 
@@ -1011,11 +1023,7 @@ describe("organizations list", () => {
     // The browser opens the link in a background tab and the row handler has to
     // stay out of it. Without the guard the list the operator meant to keep
     // navigates away underneath the new tab.
-    await act(async () => {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      });
-    });
+    await settle();
     expect(router.state.location.pathname).toBe("/organizations");
   });
 
@@ -1064,7 +1072,7 @@ describe("organizations list peek", () => {
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Peek", "Actions", "Name", "Slug", "Type"]);
+    ).toEqual(["Name", "Slug", "Type", "Actions"]);
   });
 
   it("takes the trial column down with the rest while it is open", async () => {
@@ -1193,15 +1201,13 @@ describe("organizations list peek", () => {
     await peekOn(FIRST_ORG.name);
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Peek", "Actions", "Name", "Type"]);
+    ).toEqual(["Name", "Type", "Actions"]);
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
-      "Peek",
-      "Actions",
       "Name",
       "Type",
       "Members",
@@ -1209,6 +1215,7 @@ describe("organizations list peek", () => {
       "Disabled",
       "Trial",
       "Created",
+      "Actions",
     ]);
   });
 
@@ -1228,7 +1235,7 @@ describe("organizations list peek", () => {
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Peek", "Actions", "Name", "Slug", "Type"]);
+    ).toEqual(["Name", "Slug", "Type", "Actions"]);
     expect(screen.getByRole("link", { name: FIRST_ORG.name })).toBeTruthy();
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
@@ -1292,8 +1299,6 @@ describe("organizations list peek", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
-      "Peek",
-      "Actions",
       "Name",
       "Slug",
       "Type",
@@ -1302,6 +1307,7 @@ describe("organizations list peek", () => {
       "Disabled",
       "Trial",
       "Created",
+      "Actions",
     ]);
   });
 
@@ -1785,7 +1791,7 @@ describe("organizations list peek", () => {
     expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
   });
 
-  it("opens the organization on an alt-click rather than peeking at it", async () => {
+  it("peeks on an alt-click of the row rather than opening the organization", async () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",
     });
@@ -1793,9 +1799,54 @@ describe("organizations list peek", () => {
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
     const slugCell = cellUnder(rowFor(link), "Slug");
 
-    // The gesture is gone: browsers read Alt-click on an anchor as "save
-    // link", and the row's own handler carries no branch for it any more.
     fireEvent.click(slugCell, { altKey: true });
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    // The half that is not changing, and the half a careless fix breaks: the
+    // gesture peeks instead of navigating, not as well as navigating.
+    await settle();
+    expect(router.state.location.pathname).toBe("/organizations");
+  });
+
+  it("announces an alt-click peek the same way the control does", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const region = await screen.findByRole("status");
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    fireEvent.click(cellUnder(rowFor(link), "Slug"), { altKey: true });
+
+    // The same node and the same sentence. A second path into peek that
+    // announced differently, or into a region of its own, would reach a
+    // screen reader as a different feature.
+    expect(liveRegion()).toBe(region);
+    expect(announcement()).toBe(`Peeking at ${FIRST_ORG.name}.`);
+  });
+
+  it("closes the peek when the same row is alt-clicked again", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    const slugCell = cellUnder(rowFor(link), "Slug");
+
+    fireEvent.click(slugCell, { altKey: true });
+    expect(peekPanel()).toBeTruthy();
+
+    // The gesture toggles, the same way the control it stands in for does.
+    fireEvent.click(cellUnder(rowFor(link), "Slug"), { altKey: true });
+
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+  });
+
+  it("opens the organization on a plain click of the same cell", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    fireEvent.click(cellUnder(rowFor(link), "Slug"));
 
     await waitFor(() => {
       expect(router.state.location.pathname).toBe(
@@ -1807,12 +1858,49 @@ describe("organizations list peek", () => {
     ).toBeNull();
   });
 
+  // Ctrl, Meta and Shift are the browser's open-in-tab and open-in-window
+  // gestures on the link this row carries. A handler that peeked on any
+  // modifier rather than on Alt alone would eat all three.
+  for (const modifier of ["ctrlKey", "metaKey", "shiftKey"] as const) {
+    it(`leaves a ${modifier} click of the row to the browser`, async () => {
+      await renderRouteTree(routeTree, { initialPath: "/organizations" });
+      const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+      fireEvent.click(cellUnder(rowFor(link), "Slug"), { [modifier]: true });
+
+      expect(
+        screen.queryByRole("complementary", { name: "Organization peek" }),
+      ).toBeNull();
+    });
+  }
+
+  it("opens the peek once when the control itself is alt-clicked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const trigger = await peekTrigger(FIRST_ORG.name);
+
+    // The control sits in the row the gesture is also bound to, so the click
+    // reaches both. Only the control may answer it.
+    fireEvent.click(trigger, { altKey: true });
+
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    // Raw, marker included, because the count is the only trace a second
+    // answer leaves: both handlers read the same peeked id and both open the
+    // same record, so the panel looks right and the region has spoken twice.
+    // The zero-width space alternates to make a repeated sentence announceable
+    // at all, and a gesture answered twice quietly spends that guarantee.
+    expect(liveRegion().textContent).toBe(
+      `Peeking at ${FIRST_ORG.name}.` + ZERO_WIDTH_SPACE,
+    );
+  });
+
   it("will not let the Columns menu hide the control", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     await screen.findByRole("link", { name: FIRST_ORG.name });
 
     openOn(screen.getByRole("button", { name: "Columns" }));
-    const item = screen.getByRole("menuitemcheckbox", { name: "Peek" });
+    const item = screen.getByRole("menuitemcheckbox", { name: "Actions" });
     fireEvent.click(item);
 
     expect(item.getAttribute("aria-disabled")).toBe("true");
@@ -1823,7 +1911,9 @@ describe("organizations list peek", () => {
     fireEvent.keyDown(item, { key: "Escape" });
 
     await waitFor(() => {
-      expect(screen.getByRole("columnheader", { name: "Peek" })).toBeTruthy();
+      expect(
+        screen.getByRole("columnheader", { name: "Actions" }),
+      ).toBeTruthy();
     });
     expect(await peekTrigger(FIRST_ORG.name)).toBeTruthy();
   });
@@ -2502,24 +2592,165 @@ describe("organizations list write actions", () => {
   });
 });
 
+describe("organizations list actions column", () => {
+  function headers(): string[] {
+    return screen
+      .getAllByRole("columnheader")
+      .map((header) => header.textContent ?? "");
+  }
+
+  function actionsCell(name: string): HTMLElement {
+    return cellUnder(rowFor(screen.getByRole("link", { name })), "Actions");
+  }
+
+  function menuTrigger(name: string): HTMLElement {
+    return screen.getByRole("button", { name: `Actions for ${name}` });
+  }
+
+  it("puts the column last and leaves it there when peek opens", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    expect(headers().at(-1)).toBe("Actions");
+
+    await peekOn(FIRST_ORG.name);
+
+    // Peek takes five columns down. The controls are the ones the operator is
+    // reaching for at that moment, so they have to be where they were.
+    expect(headers().at(-1)).toBe("Actions");
+    expect(headers()).not.toContain("Created");
+  });
+
+  it("pins the column to the right edge rather than letting it scroll", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // Both halves of the column, because a pin on the header alone leaves the
+    // cells sliding under a header that stayed put. happy-dom lays nothing
+    // out, so these read the classes that carry the pin; the measurement that
+    // proves the column holds its x is in the browser.
+    for (const element of [
+      screen.getByRole("columnheader", { name: "Actions" }),
+      actionsCell(FIRST_ORG.name),
+    ]) {
+      expect(element.classList.contains("sticky")).toBe(true);
+      expect(element.classList.contains("right-0")).toBe(true);
+    }
+  });
+
+  it("gives the pinned cells a background the scrolled row cannot show through", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // The header's own colour, not the header row's: the pinned cell paints
+    // above its neighbours, so it needs one of its own to cover their text.
+    expect(
+      screen
+        .getByRole("columnheader", { name: "Actions" })
+        .classList.contains("bg-muted"),
+    ).toBe(true);
+
+    // The body cell takes the row's colour instead of a flat one, so it does
+    // not read as a stripe over the peeked row.
+    expect(actionsCell(FIRST_ORG.name).classList.contains("bg-inherit")).toBe(
+      true,
+    );
+    // Which is only opaque if the row it inherits from carries a colour.
+    expect(rowFor(link).classList.contains("bg-background")).toBe(true);
+  });
+
+  it("keeps the row's hover and expanded colours free of an alpha", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    const classes = [...rowFor(link).classList];
+
+    // The base row tints these two states at half alpha. Inherited, that alpha
+    // is painted twice and the scrolled row shows through the pinned cell, so
+    // each has to survive as its opaque form and neither may be left behind.
+    for (const state of ["hover", "has-aria-expanded"]) {
+      expect(classes).toContain(`${state}:bg-muted`);
+      expect(classes).not.toContain(`${state}:bg-muted/50`);
+    }
+  });
+
+  it("hands the peeked row's own colour to the cell pinned over it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+    await peekOn(FIRST_ORG.name);
+
+    // One colour on the row, not two. Both classes present would leave the
+    // stylesheet's order to decide which the pinned cell inherits.
+    expect(rowFor(link).classList.contains("bg-muted")).toBe(true);
+    expect(rowFor(link).classList.contains("bg-background")).toBe(false);
+  });
+
+  it("holds both controls in the one cell, the peek trigger first", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // Peek is the read action and the more frequent one; the menu holds the
+    // writes. Read by accessible name, which is what a screen reader
+    // announces and what an operator hears in this order.
+    expect(
+      within(actionsCell(FIRST_ORG.name))
+        .getAllByRole("button")
+        .map((control) => control.getAttribute("aria-label")),
+    ).toEqual([`Peek at ${FIRST_ORG.name}`, `Actions for ${FIRST_ORG.name}`]);
+  });
+
+  it("keeps both controls on the keyboard, peek before the menu", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // Adjacent stops in the sequential order Tab walks, which is also the
+    // assertion that neither one dropped out of it.
+    expect(tabStopBefore(menuTrigger(FIRST_ORG.name))).toBe(
+      await peekTrigger(FIRST_ORG.name),
+    );
+  });
+
+  it("keeps both controls reachable while the peek is open", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await peekOn(FIRST_ORG.name);
+
+    // The panel covers one record. The reason to reach another row's controls
+    // does not go away because it is open beside them.
+    expect(tabStopBefore(menuTrigger(SECOND_ORG.name))).toBe(
+      await peekTrigger(SECOND_ORG.name),
+    );
+    expect(
+      within(actionsCell(SECOND_ORG.name)).getAllByRole("button"),
+    ).toHaveLength(2);
+  });
+});
+
 // The bar takes a table, so the last-column case is reachable here by handing
 // it a two column table rather than by clicking seven items shut through a
 // menu that closes each time.
 describe("TableActionBar", () => {
   // Destructured off the tuple rather than off a slice, which widens each
   // element back to a bare column definition.
-  const [PEEK, ACTIONS, FIRST, SECOND, THIRD] = ORG_COLUMNS;
-  if (!PEEK || !ACTIONS || !FIRST || !SECOND || !THIRD) {
-    throw new Error("ORG_COLUMNS needs five columns");
+  const [FIRST, SECOND, THIRD] = ORG_COLUMNS;
+  // Found by id rather than by position, so a column added after it does not
+  // quietly become the one these cases are about.
+  const ACTIONS = ORG_COLUMNS.find((definition) => definition.id === "actions");
+  if (!FIRST || !SECOND || !THIRD || !ACTIONS) {
+    throw new Error("ORG_COLUMNS needs three data columns and an actions one");
   }
 
   // Sliced, so the array carries the element type useTable asks for. Two data
-  // columns for the cases about the bar's own two rules, and each control
+  // columns for the cases about the bar's own two rules, and the control
   // column beside one of them for the cases where a column that cannot be
   // hidden is in the count.
-  const MENU_COLUMNS = ORG_COLUMNS.slice(2, 4);
-  const WITH_PEEK_COLUMN: typeof MENU_COLUMNS = [PEEK, FIRST];
+  const MENU_COLUMNS = ORG_COLUMNS.slice(0, 2);
   const WITH_ACTIONS_COLUMN: typeof MENU_COLUMNS = [ACTIONS, FIRST];
+  // A second opt-out column, so the rule still has to count hideable columns
+  // rather than visible ones when more than one of them cannot be hidden.
+  const WITH_TWO_LOCKED_COLUMNS: typeof MENU_COLUMNS = [
+    ACTIONS,
+    { ...SECOND, enableHiding: false },
+    FIRST,
+  ];
 
   // An accessor column takes its id from its key unless it names one, and that
   // id is what the visibility state is keyed by.
@@ -2670,27 +2901,11 @@ describe("TableActionBar", () => {
   });
 
   it("stops the operator hiding the last column that carries data", () => {
-    // Peek and Name, both visible. Peek opts out of hiding, so it is on screen
-    // whatever the operator does and it is not the column that keeps the table
-    // readable. Counting it would leave Name free to go, and the table behind
-    // this menu would be a strip of controls above rows holding no record.
-    const { onVisibilityChange } = openColumnsMenu({}, WITH_PEEK_COLUMN);
-
-    const item = itemFor(FIRST.header);
-    fireEvent.click(item);
-
-    expect(onVisibilityChange).not.toHaveBeenCalled();
-    expect(item.getAttribute("aria-disabled")).toBe("true");
-    // The peek column is locked too, by its own opt-out rather than by this
-    // rule, so the operator cannot reach the same state from the other side.
-    expect(itemFor(PEEK.header).getAttribute("aria-disabled")).toBe("true");
-  });
-
-  it("stops the operator hiding the last data column beside the row menu", () => {
-    // The same case as above, from the column that arrived after the rule. A
-    // second column that opts out of hiding is a second way to make the count
-    // wrong, and a guard that counts every visible column instead of every
-    // hideable one now needs two data columns before it lets go of one.
+    // Actions and Name, both visible. Actions opts out of hiding, so it is on
+    // screen whatever the operator does and it is not the column that keeps
+    // the table readable. Counting it would leave Name free to go, and the
+    // table behind this menu would be a strip of controls above rows holding
+    // no record.
     const { onVisibilityChange } = openColumnsMenu({}, WITH_ACTIONS_COLUMN);
 
     const item = itemFor(FIRST.header);
@@ -2698,7 +2913,24 @@ describe("TableActionBar", () => {
 
     expect(onVisibilityChange).not.toHaveBeenCalled();
     expect(item.getAttribute("aria-disabled")).toBe("true");
+    // The actions column is locked too, by its own opt-out rather than by this
+    // rule, so the operator cannot reach the same state from the other side.
     expect(itemFor(ACTIONS.header).getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("stops the operator hiding the last data column beside two locked ones", () => {
+    // Every extra column that opts out of hiding is another way to make the
+    // count wrong: a guard counting every visible column instead of every
+    // hideable one now needs three columns on screen before it lets go of one.
+    const { onVisibilityChange } = openColumnsMenu({}, WITH_TWO_LOCKED_COLUMNS);
+
+    const item = itemFor(FIRST.header);
+    fireEvent.click(item);
+
+    expect(onVisibilityChange).not.toHaveBeenCalled();
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    expect(itemFor(ACTIONS.header).getAttribute("aria-disabled")).toBe("true");
+    expect(itemFor(SECOND.header).getAttribute("aria-disabled")).toBe("true");
   });
 
   it("locks a column that opts out of hiding", () => {

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -7,6 +7,7 @@ import {
 import {
   act,
   cleanup,
+  createEvent,
   fireEvent,
   render,
   screen,
@@ -1862,8 +1863,10 @@ describe("organizations list peek", () => {
   // gestures on the link this row carries. A handler that peeked on any
   // modifier rather than on Alt alone would eat all three.
   for (const modifier of ["ctrlKey", "metaKey", "shiftKey"] as const) {
-    it(`leaves a ${modifier} click of the row to the browser`, async () => {
-      await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    it(`neither peeks nor navigates on a ${modifier} click of the row`, async () => {
+      const { router } = await renderRouteTree(routeTree, {
+        initialPath: "/organizations",
+      });
       const link = await screen.findByRole("link", { name: FIRST_ORG.name });
 
       fireEvent.click(cellUnder(rowFor(link), "Slug"), { [modifier]: true });
@@ -1871,6 +1874,53 @@ describe("organizations list peek", () => {
       expect(
         screen.queryByRole("complementary", { name: "Organization peek" }),
       ).toBeNull();
+      // Staying put is the whole gesture. A modified click that navigated in
+      // this tab would take the list out from under the tab the operator
+      // meant to open, and the peek assertion above passes either way.
+      await settle();
+      expect(router.state.location.pathname).toBe("/organizations");
+    });
+  }
+
+  it("cancels the name link's download and peeks when it is alt-clicked", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // Dispatched by hand, because the assertion is on the event rather than on
+    // the DOM: a browser reads Alt on an anchor as "save link", so the row has
+    // to cancel the anchor's own default or the gesture downloads the page.
+    const event = createEvent.click(link, { altKey: true });
+    fireEvent(link, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(
+      within(peekPanel()).getByRole("heading", { name: FIRST_ORG.name }),
+    ).toBeTruthy();
+    await settle();
+    expect(router.state.location.pathname).toBe("/organizations");
+  });
+
+  // Alt plus a second modifier is a gesture nobody aimed at this row, but the
+  // anchor's default is still "save link". Cancelling has to survive the
+  // narrower peek test, or the operator downloads an HTML file.
+  for (const modifier of ["ctrlKey", "metaKey", "shiftKey"] as const) {
+    it(`cancels the download without peeking on an alt+${modifier} click of the name`, async () => {
+      const { router } = await renderRouteTree(routeTree, {
+        initialPath: "/organizations",
+      });
+      const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+      const event = createEvent.click(link, { altKey: true, [modifier]: true });
+      fireEvent(link, event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(
+        screen.queryByRole("complementary", { name: "Organization peek" }),
+      ).toBeNull();
+      await settle();
+      expect(router.state.location.pathname).toBe("/organizations");
     });
   }
 
@@ -2621,7 +2671,7 @@ describe("organizations list actions column", () => {
     expect(headers()).not.toContain("Created");
   });
 
-  it("pins the column to the right edge rather than letting it scroll", async () => {
+  it("marks the actions column sticky at the right edge, above its neighbours and no wider than its contents", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     await screen.findByRole("link", { name: FIRST_ORG.name });
 
@@ -2635,10 +2685,15 @@ describe("organizations list actions column", () => {
     ]) {
       expect(element.classList.contains("sticky")).toBe(true);
       expect(element.classList.contains("right-0")).toBe(true);
+      // Above the cells that scroll under it, below the sticky header row.
+      expect(element.classList.contains("z-1")).toBe(true);
+      // The table is `w-full`, so a column that did not shrink to its contents
+      // would take a share of the freed width and read as an empty gutter.
+      expect(element.classList.contains("w-px")).toBe(true);
     }
   });
 
-  it("gives the pinned cells a background the scrolled row cannot show through", async () => {
+  it("gives the pinned cells opaque colours rather than a transparent one", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
 
@@ -2673,7 +2728,7 @@ describe("organizations list actions column", () => {
     }
   });
 
-  it("hands the peeked row's own colour to the cell pinned over it", async () => {
+  it("leaves the peeked row one colour for the pinned cell to inherit", async () => {
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const link = await screen.findByRole("link", { name: FIRST_ORG.name });
     await peekOn(FIRST_ORG.name);

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -470,7 +470,17 @@ export function OrganizationsList(): JSX.Element {
                                 key={row.id}
                                 row={row}
                                 ref={isPeeked ? peekedRow : undefined}
-                                className={cn(isPeeked && "bg-muted")}
+                                // The pinned cell inherits the row's colour and
+                                // paints it again, so a translucent row doubles
+                                // up and shows the scrolled columns through the
+                                // pin. Overriding the two half-alpha states is
+                                // a twMerge collapse, not a cascade win: the
+                                // emitted CSS puts the `/50` rule last at equal
+                                // specificity, so it wins any tie.
+                                className={cn(
+                                  "bg-background hover:bg-muted has-aria-expanded:bg-muted",
+                                  isPeeked && "bg-muted",
+                                )}
                                 onClick={openOrganization}
                                 onAltClick={togglePeek}
                               />

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -472,6 +472,7 @@ export function OrganizationsList(): JSX.Element {
                                 ref={isPeeked ? peekedRow : undefined}
                                 className={cn(isPeeked && "bg-muted")}
                                 onClick={openOrganization}
+                                onAltClick={togglePeek}
                               />
                             );
                           })


### PR DESCRIPTION
The organizations list put its row controls on the left, ahead of the name, so an operator scanning the list read the controls before the thing they act on. This moves them into one Actions column pinned to the right edge. AGE-3234.

Peek and the actions menu now sit together in that column, peek first, in one flex cell. The column is last in DOM order and last visually, so tab order needs no correction. Alt+click on a row still peeks.

## Decisions worth a reviewer's attention

**Alt+click had to keep working on the Name link, and that is the whole risk of this change.** TanStack Router treats `altKey` as part of `isCtrlEvent`, so its `Link` declines an Alt-modified click and hands it to the row. Without a `preventDefault` the browser then runs its own default for an Alt-modified anchor click, which is "save link as": the operator gets an HTML download instead of a peek. The row cancels it.

Every other new-tab gesture is left to the browser. Middle-click and right-click fire `auxclick` and `contextmenu`, which React's `onClick` never sees. Cmd, Ctrl and Shift clicks reach the handler and return early without cancelling. The guard names all three negatives explicitly rather than the easy-to-invert `metaKey || ctrlKey`, so the macOS case is not the one that breaks.

**The Alt branch is gated on the page opting in.** A page that passes no `onAltClick` keeps "save link as" untouched. The cancellation is a property of pages that want the gesture, not of the shared table.

**Rows are opaque, and that lives on the page rather than in the shared table.** A pinned cell inherits its row colour and paints it again on its own layer, so a translucent row both doubles the tint and lets the scrolled columns show through the pin. The fix is an opaque base plus full-strength hover. It sits on this page because `DataTable` does no pinning of its own: pinning is opt-in per column. An earlier revision put it in the shared wrapper, where it silently doubled the hover tint on the organization detail page's two tables, including one whose rows are not clickable. The second commit moves it back.

Note that the override works because `cn` is `twMerge` and it collapses the half-alpha class out of the string. It is not a cascade win: the emitted CSS puts the half-alpha rule after the opaque one at equal specificity. Any future caller that assembles the row's classes outside `cn` silently gets the translucent form back.

## Behaviour change worth calling out

**A Cmd, Ctrl or Shift click on a row now does nothing, where it previously navigated in the current tab.** That old behaviour ignored the modifier and stole the tab, and three tests were named for leaving the gesture to the browser while asserting only that the peek panel stayed shut, so they passed because of the navigation rather than despite it. The row now returns early on those modifiers and the tests assert the location did not move. The Name column is an anchor and remains the route for a real new-tab gesture.

The trade is that an operator whose habit is "Cmd+click the row" now gets silence, and nothing signals that the name is the target. If that bites, the fix is to route the row's modified click into the same link rather than to drop it. That is a larger change than this one.

## Review round

A reviewer took the modifier handling apart against the actual TanStack Router and React DOM sources rather than against assumption, and confirmed all five new-tab and new-window gestures survive. It also confirmed that `has-aria-expanded:` compiles to `[aria-expanded="true"]` and not to attribute presence, which mattered: the peek trigger renders the attribute on every row, so a presence-matching variant would have tinted every row permanently. Accessible names identify the row on both controls, tab order follows visual order, and a second row's controls stay reachable while the peek panel is open.

Its findings were that the two lines making the guard correct had no unit coverage, that an Alt-modified click was still one extra modifier away from the download, and that the opaque-row change was in the wrong file. All three are fixed. Each fix was verified by applying the mutation it targets and watching the test fail, including a behaviour-preserving canary that survives, so the kills belong to the tests rather than to the harness.

## Known limits, stated rather than hidden

**The pinned column has no separator.** Scrolled content slides under a block of the same colour, and at hover both sides are the same colour, so there is no boundary at all. Text in the neighbouring cell clips mid-glyph at the pin's edge, which reads as truncated data rather than as an overlay. A border or a shadow would fix it. Which one is a visual design call.

**Focus can land under the pin.** A `Tab` to a control that the browser scrolls to the right edge can sit beneath the pinned column. Today the only focusable thing in the scrolling region is the Name link in the leftmost column, which is safe by position, so the practical risk is near zero.

**The pinning tests cannot measure pinning.** happy-dom performs no layout, so they assert the classes and say so in their names. The utilities were checked against a real production build's emitted CSS to prove they are not silently dropped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the organizations list’s two leading controls into one Actions column pinned to the right and restores Alt+click to peek. This improves scanability and keeps controls visible while scrolling; old behavior had separate Peek and Actions columns on the left and Alt+click navigated instead of peeking.

- Satisfies Linear AGE-3234: one Actions column on the far right; Alt+click peeks again.

**Key changes**
- Actions column: last, sticky at right, contains Peek first then the row menu; cannot be hidden; stays last when peek hides columns; inherits the row’s color to avoid a visible stripe.
- Row interaction: plain click still opens; Alt+click anywhere on the row (including the name link) toggles peek and cancels the link’s “save as” default; Cmd/Ctrl/Shift clicks on the row now do nothing (new-tabs still work via the Name link).
- DataTable infra: adds per-column meta for header/cell classNames and an optional onAltClick handler; Alt behavior is opt-in by page.
- Styling scope: opaque base/hover/expanded row colors applied only on the organizations list to keep the pinned cell visually consistent.
- Tests: cover Alt+click on links and cells, modifier click guards, sticky class presence, column order, and Columns menu rules (counts hideable columns; Actions remains locked).

<sup>Written for commit b374a9fb6e98d340b48e551399a647146c05fc40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

