### PR TITLE
chore(ci): stop fetching third-party artifacts on the merge queue critical path

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -318,10 +318,11 @@ jobs:
 
       # hk.pkl amends a pkl package hosted on github.com, so evaluating the
       # config is a network call on every run. Cache it against a blip there.
+      # Namespaced by runner provider, as the other cache families are.
       - name: Cache pkl packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: pkl-1-${{ runner.os }}-${{ hashFiles('hk.pkl') }}
+          key: pkl-blacksmith-v1-${{ runner.os }}-${{ hashFiles('hk.pkl') }}
           path: ~/.pkl/cache
 
       - name: Check formatting

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -316,9 +316,15 @@ jobs:
       - name: Install dependencies
         run: aube install --frozen-lockfile
 
+      # hk.pkl amends a pkl package hosted on github.com, so evaluating the
+      # config is a network call on every run. Cache it against a blip there.
+      - name: Cache pkl packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: pkl-1-${{ runner.os }}-${{ hashFiles('hk.pkl') }}
+          path: ~/.pkl/cache
+
       - name: Check formatting
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: hk check --all
 
       - name: Prune aube store
@@ -1120,6 +1126,8 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           install-mode: none
+          # Skips a JSONSchema fetch from golangci-lint.run on every run.
+          verify: false
           working-directory: server
 
       - name: Upload server build
@@ -1209,8 +1217,10 @@ jobs:
       - name: Lint proto files
         run: mise run lint:infra --against ".git#ref=origin/${{ github.base_ref || 'main' }}"
 
+      # gram-infra only. --all-packages would pull in pystreams, whose spaCy
+      # model is a 400MB wheel fetched from a github.com release on every run.
       - name: Install uv dependencies
-        run: mise run install:uv --all-packages --locked
+        run: mise run install:uv --package gram-infra --locked
 
       - name: Type-check and test the infra Python package
         run: mise run test:infra
@@ -1320,6 +1330,8 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           install-mode: none
+          # Skips a JSONSchema fetch from golangci-lint.run on every run.
+          verify: false
           working-directory: cli
 
       - name: Install Go tools
@@ -1423,6 +1435,8 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           install-mode: none
+          # Skips a JSONSchema fetch from golangci-lint.run on every run.
+          verify: false
           working-directory: plog
 
       - name: Test
@@ -1759,7 +1773,7 @@ jobs:
         working-directory: client/dashboard
 
       - name: Lint admin
-        run: pnpm lint
+        run: aube run lint
         working-directory: client/admin
 
       - name: Knip (dead code / unused deps)
@@ -1930,6 +1944,8 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           install-mode: none
+          # Skips a JSONSchema fetch from golangci-lint.run on every run.
+          verify: false
           working-directory: functions
 
       - name: Test Go server

--- a/client/admin/package.json
+++ b/client/admin/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "pnpm lint:format && pnpm lint:no-barrels && pnpm lint:oxlint && pnpm type-check",
+    "lint": "aube run lint:format && aube run lint:no-barrels && aube run lint:oxlint && aube run type-check",
     "lint:oxlint": "oxlint --type-aware",
     "lint:fix": "oxlint --type-aware --fix",
-    "lint:format": "oxfmt --check .",
+    "lint:format": "aube exec oxfmt -- --check .",
     "lint:no-barrels": "! grep -rEn '^export \\*' src --include='*.ts' --include='*.tsx' || (echo 'Barrel re-exports (export *) are not allowed. Re-export named symbols instead.' && exit 1)",
     "preview": "vite preview",
     "test": "vitest run",


### PR DESCRIPTION
Four CI steps fetch a third-party artifact on every run, uncached and unretried, so a blip on someone else's host ejects the PR from the merge queue.

Stacked on #5332, which fixes the largest instance of the same problem. This PR handles the rest.

## Context

The merge queue failed 88 of 296 runs over the last seven days, a 30% dequeue rate. Clustering those failures by job, and by how many distinct PRs each hit, the network-fetch class accounts for 26 of them, spread across unrelated PRs.

## The changes

**`golangci-lint-action` downloads a JSONSchema from `golangci-lint.run` to verify `.golangci.yaml`.** One merge-queue run already died on `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` fetching it. `verify: false` at all four call sites removes an unpinned third-party HTTP call from server, cli, plog and functions linting. The config is still linted; only the schema round trip goes away.

**`hk.pkl` line 1 amends a pkl package hosted on `github.com`.** Evaluating the config is a network call before any formatter runs. All 12 `Check formatting` failures died exactly there, with `request not processed by peer` (an HTTP/2 refused stream), having checked zero files. None of them were formatting problems. Caching `~/.pkl/cache` on a key derived from `hk.pkl` removes the fetch. The key is namespaced by runner provider, matching the convention #5306 introduced for the mise, Go, uv and aube cache families, so a GitHub-hosted job cannot populate a key a Blacksmith job then exact-hits.

**The infra job ran `install:uv --all-packages`.** That pulls in the `pystreams` workspace member and its `en_core_web_lg` spaCy model, a 400MB wheel fetched from a `github.com` release on every run. `infra/pyproject.toml` has no dependency on spaCy, so the job downloaded 400MB it never used, and 14 of the 27 `Install uv dependencies` failures were in that job. Scoping the sync to `gram-infra` removes the download.

Also drops the unused `BASE_SHA` env from the formatting step. That job runs `hk check --all` and never reads it.

## Also here

`client/admin` ran `pnpm lint` inside a workspace aube had installed. pnpm's dependency check then fired, printed `Recreating .../client/admin/node_modules`, and re-ran its own install mid-job. `client/dashboard` already routes the same chain through aube; admin now matches.

That change exposed a second bug worth calling out: `lint:format` invoked a bare `oxfmt`, but `oxfmt` is only a **root** devDependency. It resolved under pnpm and silently no-opped under aube. Switching it to `aube exec oxfmt` the way dashboard does means the check actually runs. It now reports 78 files and passes.

## Verification

- `aube run lint` in `client/admin` passes, and each of its four sub-checks was canaried with a deliberate violation (bad formatting, a `debugger` statement, an `export *`, and a type error). Each one fails the chain as it should, so the silence on a clean tree is real and not another false pass.
- `mise run install:uv --package gram-infra --locked` followed by `mise run test:infra` passes (82 python tests, 73 go tests), and `mise run gen:infra` leaves the tree clean. No spaCy in the resolved set.
- Confirmed `verify` is a real input on the pinned `golangci-lint-action` SHA, defaulting to `true`.
- Confirmed `~/.pkl/cache` is pkl's default cache directory and already holds `package-2/github.com/jdx/hk` locally.
- `pr.yaml` re-parses as YAML; `hk check --all` passes.
- Re-verified against `main` after #5306 landed: merges clean, and both sides survive intact (all four changes here, #5306's 22 `cache_key_prefix` additions, and its `lint:webhooks-server` jq fix). The branch was rebased onto post-#5306 `main`; the rebase preserved this work byte for byte, confirmed by identical patch-id.

## Not in this PR

The remaining flake clusters, for follow-ups: a UUIDv7 millisecond-resolution tiebreak in `server/internal/agent/queries.sql` that is a production ordering bug and not only a test flake, a ClickHouse async-insert flush used as a read barrier that is not one, and mirroring the spaCy wheel off the GitHub release CDN, which would also fix `docker-build-pystreams`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops uncached third‑party network fetches on the merge‑queue CI critical path to reduce flakes. Four steps previously fetched remote artifacts on every run; now we cache or avoid them without changing linting or tests.

- `golangci-lint-action`: set `verify: false` for `server`, `cli`, `plog`, and `functions` to skip the JSONSchema fetch; linting still runs.
- Cache `pkl` packages: add `actions/cache` for `~/.pkl/cache` keyed by `hk.pkl`, namespaced by runner provider to avoid cross‑runner collisions, so “Check formatting” no longer fetches the GitHub‑hosted package.
- Infra `uv` install: scope to `--package gram-infra --locked` to avoid pulling `pystreams` and the `en_core_web_lg` (400MB) model that infra does not use.
- `client/admin` lint: run `aube run lint` in CI to prevent `pnpm` from reinstalling mid‑job; update scripts to `aube run ...` and `aube exec oxfmt` so the root devDependency actually runs. Remove unused `BASE_SHA` from formatting.

<sup>Written for commit d7c0f8b7fdb871d70507a7a9e266681fdd050153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

