### PR TITLE
mig: add billing delivery and invoice allocation schema

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -120,6 +120,21 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
   -- Current Stripe subscription. NULL after cancellation and replaced when
   -- the organization subscribes again.
   stripe_subscription_id TEXT,
+  -- Exact UTC billing-cycle anchor for the current Stripe subscription. This
+  -- is the first paid-period boundary after any trial or free checkout stub.
+  -- NULL until Stripe confirms a subscription and cleared on subscription loss.
+  stripe_billing_cycle_anchor timestamptz,
+
+  -- Durable inputs for one pending Stripe Checkout intent. Retries reuse these
+  -- values until the session expires; a replacement intent clears or replaces
+  -- them together so sessions with different anchors cannot overlap.
+  stripe_checkout_idempotency_key TEXT,
+  stripe_checkout_billing_cycle_anchor timestamptz,
+  -- Stripe-side aligned trial end captured when Checkout starts during an
+  -- active product trial. NULL for immediate, non-prorated checkout.
+  stripe_checkout_trial_end timestamptz,
+  stripe_checkout_expires_at timestamptz,
+  stripe_checkout_session_id TEXT,
 
   -- Contracted monthly "tokens under management" allowance. NULL means no
   -- contracted limit has been configured.
@@ -149,6 +164,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_stripe_customer_id_key
 ON billing_metadata (stripe_customer_id)
 WHERE stripe_customer_id IS NOT NULL;
 
+CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_stripe_checkout_session_id_key
+ON billing_metadata (stripe_checkout_session_id)
+WHERE stripe_checkout_session_id IS NOT NULL;
+
 COMMENT ON COLUMN billing_metadata.tunneled_mcp_server_limit IS 'Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.';
 
 -- Durable completion receipts for accepted Stripe webhooks. A row commits
@@ -173,59 +192,112 @@ ON stripe_webhook_receipts (organization_id);
 -- of each cycle's usage for billing, overage math, and admin reporting.
 CREATE TABLE IF NOT EXISTS billing_cycle_usage (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
-  organization_id TEXT NOT NULL,
+  -- Nullable so the permanent billing record survives organization deletion.
+  organization_id TEXT,
 
   -- [cycle_start, cycle_end) boundaries computed from
   -- billing_metadata.billing_cycle_anchor_day at snapshot time.
   cycle_start timestamptz NOT NULL,
   cycle_end timestamptz NOT NULL,
 
-  -- Total tokens under management observed for the cycle.
+  -- Latest tokens under management observed for the cycle. This may continue
+  -- changing during the late-arrival window after the billed baseline freezes.
   tum_tokens BIGINT NOT NULL DEFAULT 0,
 
-  -- Set once the cycle has closed plus an ingest grace period, after which the
-  -- row is treated as immutable. NULL while the cycle is still being refreshed.
+  -- Immutable billing baseline captured after the cycle's 48-hour ingest grace
+  -- period. NULL until the cycle is ready to bill.
+  billed_tum_tokens BIGINT,
+  billed_frozen_at timestamptz,
+
+  -- Set after the final 72-hour observation cutoff, after which tum_tokens is
+  -- no longer refreshed. NULL while late telemetry is still being observed.
   finalized_at timestamptz,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT billing_cycle_usage_pkey PRIMARY KEY (id),
-  CONSTRAINT billing_cycle_usage_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT billing_cycle_usage_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE SET NULL,
   CONSTRAINT billing_cycle_usage_cycle_bounds_check CHECK (cycle_end > cycle_start),
   -- Token counts originate from client-supplied OTEL attributes; a negative
   -- sum must never become part of the permanent billing record.
-  CONSTRAINT billing_cycle_usage_tum_tokens_check CHECK (tum_tokens >= 0)
+  CONSTRAINT billing_cycle_usage_tum_tokens_check CHECK (tum_tokens >= 0),
+  CONSTRAINT billing_cycle_usage_billed_tum_tokens_check CHECK (billed_tum_tokens IS NULL OR billed_tum_tokens >= 0),
+  CONSTRAINT billing_cycle_usage_billed_frozen_at_check CHECK (billed_frozen_at IS NULL OR billed_tum_tokens IS NOT NULL)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS billing_cycle_usage_organization_id_cycle_start_key
 ON billing_cycle_usage (organization_id, cycle_start);
 
--- Append-only mirror of TUM meter events reported to Stripe Billing. The
--- upstream event identifier derives from the organization, cycle start, and
--- sequence number, making sends idempotent and the ledger exactly replayable.
+CREATE UNIQUE INDEX IF NOT EXISTS billing_cycle_usage_organization_id_id_key
+ON billing_cycle_usage (organization_id, id);
+
+-- Durable TUM meter-event intents and their Stripe delivery state. Each row
+-- retains the complete intended event so pending and ambiguous deliveries can
+-- be reconciled without rebuilding payloads from mutable billing metadata.
 CREATE TABLE IF NOT EXISTS stripe_meter_reports (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
-  organization_id TEXT NOT NULL,
+  -- Nullable so intended-delivery history survives organization deletion.
+  organization_id TEXT,
 
-  -- Cycle boundary from billing_cycle_usage at report time.
+  -- Intended-event fields added during the migration-first rollout remain
+  -- nullable so existing reports migrate without DML. New reports bind directly
+  -- to the durable cycle row and persist every field required for replay.
+  billing_cycle_usage_id uuid,
   cycle_start timestamptz NOT NULL,
+  cycle_end timestamptz,
   -- Monotonic sequence within an organization's billing cycle.
   seq INT NOT NULL,
-  -- Tokens added by this report. The cycle's reported total is the sum of
-  -- these deltas.
+  -- Immutable Stripe routing data needed to replay the intended meter event
+  -- without reading mutable organization billing metadata.
+  stripe_customer_id TEXT,
+  stripe_meter_event_name TEXT,
+  -- Stable identifier supplied to Stripe for idempotent meter-event delivery.
+  stripe_identifier TEXT,
+  -- Signed correction to the cycle's previously reported total.
   delta_tokens BIGINT NOT NULL,
+  -- Timestamp assigned to the Stripe meter event. It remains inside the
+  -- service period even when delivery or reconciliation happens later.
+  event_timestamp timestamptz,
+
+  -- Allowed values (pending, confirmed, ambiguous) live in application code.
+  -- The confirmed default preserves the meaning of legacy sent-report rows;
+  -- new intended deliveries explicitly write pending.
+  delivery_state TEXT NOT NULL DEFAULT 'confirmed',
+  first_attempted_at timestamptz,
+  last_attempted_at timestamptz,
+  confirmed_at timestamptz,
+  ambiguous_at timestamptz,
+  reconciled_at timestamptz,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT stripe_meter_reports_pkey PRIMARY KEY (id),
-  CONSTRAINT stripe_meter_reports_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT stripe_meter_reports_delta_tokens_check CHECK (delta_tokens >= 0)
+  CONSTRAINT stripe_meter_reports_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE SET NULL,
+  CONSTRAINT stripe_meter_reports_org_billing_cycle_usage_fkey FOREIGN KEY (organization_id, billing_cycle_usage_id) REFERENCES billing_cycle_usage (organization_id, id) ON DELETE SET NULL,
+  CONSTRAINT stripe_meter_reports_cycle_bounds_check CHECK (cycle_end IS NULL OR cycle_end > cycle_start),
+  CONSTRAINT stripe_meter_reports_event_timestamp_check CHECK (
+    event_timestamp IS NULL
+    OR (cycle_end IS NOT NULL AND event_timestamp >= cycle_start AND event_timestamp < cycle_end)
+  )
 );
 
+-- Retained during the migration-first rollout so the deployed writer, which
+-- does not populate cycle_end yet, keeps its existing uniqueness guarantee.
 CREATE UNIQUE INDEX IF NOT EXISTS stripe_meter_reports_organization_id_cycle_start_seq_key
 ON stripe_meter_reports (organization_id, cycle_start, seq);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stripe_meter_reports_org_cycle_bounds_seq_key
+ON stripe_meter_reports (organization_id, cycle_start, cycle_end, seq);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stripe_meter_reports_stripe_identifier_key
+ON stripe_meter_reports (stripe_identifier)
+WHERE stripe_identifier IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS stripe_meter_reports_billing_cycle_usage_id_idx
+ON stripe_meter_reports (billing_cycle_usage_id)
+WHERE billing_cycle_usage_id IS NOT NULL;
 
 -- Durable per-day OpenRouter spend per platform-managed key. Upstream history
 -- expires, so these rows are the permanent billing-grade record. key_type
@@ -253,6 +325,104 @@ CREATE TABLE IF NOT EXISTS openrouter_spend_daily (
 
 CREATE UNIQUE INDEX IF NOT EXISTS openrouter_spend_daily_organization_id_key_type_day_key
 ON openrouter_spend_daily (organization_id, key_type, day);
+
+-- Stripe invoice identity and its UTC service period. Status values are
+-- validated by the application so Stripe can add states without a migration.
+-- Rows survive organization deletion because invoices remain an external
+-- financial record.
+CREATE TABLE IF NOT EXISTS stripe_invoices (
+  stripe_invoice_id TEXT NOT NULL,
+  organization_id TEXT,
+  stripe_customer_id TEXT NOT NULL,
+  stripe_subscription_id TEXT NOT NULL,
+  service_period_start timestamptz NOT NULL,
+  service_period_end timestamptz NOT NULL,
+  invoice_state TEXT NOT NULL,
+  finalized_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT stripe_invoices_pkey PRIMARY KEY (stripe_invoice_id),
+  CONSTRAINT stripe_invoices_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE SET NULL,
+  CONSTRAINT stripe_invoices_service_period_bounds_check CHECK (service_period_end > service_period_start)
+);
+
+CREATE INDEX IF NOT EXISTS stripe_invoices_organization_id_service_period_start_idx
+ON stripe_invoices (organization_id, service_period_start)
+WHERE organization_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS stripe_invoices_organization_id_stripe_invoice_id_key
+ON stripe_invoices (organization_id, stripe_invoice_id);
+
+-- Append-only settlements of cumulative source charges to Stripe invoices.
+-- source_kind and source_key form an application-defined logical identity so a
+-- missing OpenRouter day can be allocated before a source row exists. The source
+-- bounds and cumulative USD snapshot preserve the financial record independently
+-- of source-row lifecycle. The sum of confirmed signed amount_usd rows for a
+-- source is its billed baseline; a restatement or carry-forward uses the next seq.
+CREATE TABLE IF NOT EXISTS stripe_invoice_allocations (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT,
+  source_kind TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  seq INT NOT NULL,
+  source_day DATE,
+  source_period_start timestamptz,
+  source_period_end timestamptz,
+  source_snapshot_usd NUMERIC(14, 6),
+
+  -- TUM settlements retain their signed token delta and USD price per token for
+  -- invoice reconstruction. Both are NULL for non-TUM sources.
+  delta_tokens BIGINT,
+  original_tum_unit_price_usd NUMERIC(14, 12),
+  -- Positive values bill; negative values credit. Six decimal places retain
+  -- sub-cent amounts until a later allocation can be represented in Stripe.
+  -- NULL represents a planned missing-day settlement awaiting source data.
+  amount_usd NUMERIC(14, 6),
+
+  original_invoice_id TEXT,
+  destination_invoice_id TEXT,
+  stripe_invoice_item_id TEXT,
+  stripe_credit_note_id TEXT,
+  idempotency_key TEXT NOT NULL,
+
+  -- Allowed values (pending, confirmed, ambiguous) live in application code.
+  delivery_state TEXT NOT NULL DEFAULT 'pending',
+  first_attempted_at timestamptz,
+  last_attempted_at timestamptz,
+  confirmed_at timestamptz,
+  ambiguous_at timestamptz,
+  reconciled_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT stripe_invoice_allocations_pkey PRIMARY KEY (id),
+  CONSTRAINT stripe_invoice_allocations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE SET NULL,
+  CONSTRAINT stripe_invoice_allocations_org_original_invoice_fkey FOREIGN KEY (organization_id, original_invoice_id) REFERENCES stripe_invoices (organization_id, stripe_invoice_id) ON DELETE SET NULL,
+  CONSTRAINT stripe_invoice_allocations_org_destination_invoice_fkey FOREIGN KEY (organization_id, destination_invoice_id) REFERENCES stripe_invoices (organization_id, stripe_invoice_id) ON DELETE SET NULL,
+  CONSTRAINT stripe_invoice_allocations_source_period_bounds_check CHECK (
+    (source_day IS NOT NULL AND source_period_start IS NULL AND source_period_end IS NULL)
+    OR
+    (source_day IS NULL AND source_period_start IS NOT NULL AND source_period_end IS NOT NULL AND source_period_end > source_period_start)
+  ),
+  CONSTRAINT stripe_invoice_allocations_source_snapshot_usd_check CHECK (source_snapshot_usd IS NULL OR source_snapshot_usd >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stripe_invoice_allocations_idempotency_key_key
+ON stripe_invoice_allocations (idempotency_key);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stripe_invoice_allocations_org_source_seq_key
+ON stripe_invoice_allocations (organization_id, source_kind, source_key, seq);
+
+CREATE INDEX IF NOT EXISTS stripe_invoice_allocations_original_invoice_id_idx
+ON stripe_invoice_allocations (original_invoice_id)
+WHERE original_invoice_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS stripe_invoice_allocations_destination_invoice_id_idx
+ON stripe_invoice_allocations (destination_invoice_id)
+WHERE destination_invoice_id IS NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -302,24 +302,32 @@ type AwsKmsKey struct {
 }
 
 type BillingCycleUsage struct {
-	ID             uuid.UUID
-	OrganizationID string
-	CycleStart     pgtype.Timestamptz
-	CycleEnd       pgtype.Timestamptz
-	TumTokens      int64
-	FinalizedAt    pgtype.Timestamptz
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
+	ID              uuid.UUID
+	OrganizationID  pgtype.Text
+	CycleStart      pgtype.Timestamptz
+	CycleEnd        pgtype.Timestamptz
+	TumTokens       int64
+	BilledTumTokens pgtype.Int8
+	BilledFrozenAt  pgtype.Timestamptz
+	FinalizedAt     pgtype.Timestamptz
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
 }
 
 type BillingMetadatum struct {
-	ID                    uuid.UUID
-	OrganizationID        string
-	StripeCustomerID      pgtype.Text
-	StripeSubscriptionID  pgtype.Text
-	TumMonthlyTokenLimit  pgtype.Int8
-	AlertEmail            pgtype.Text
-	BillingCycleAnchorDay int32
+	ID                               uuid.UUID
+	OrganizationID                   string
+	StripeCustomerID                 pgtype.Text
+	StripeSubscriptionID             pgtype.Text
+	StripeBillingCycleAnchor         pgtype.Timestamptz
+	StripeCheckoutIdempotencyKey     pgtype.Text
+	StripeCheckoutBillingCycleAnchor pgtype.Timestamptz
+	StripeCheckoutTrialEnd           pgtype.Timestamptz
+	StripeCheckoutExpiresAt          pgtype.Timestamptz
+	StripeCheckoutSessionID          pgtype.Text
+	TumMonthlyTokenLimit             pgtype.Int8
+	AlertEmail                       pgtype.Text
+	BillingCycleAnchorDay            int32
 	// Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.
 	TunneledMcpServerLimit pgtype.Int4
 	CreatedAt              pgtype.Timestamptz
@@ -2496,14 +2504,67 @@ type SpendRuleEvent struct {
 	CreatedAt      pgtype.Timestamptz
 }
 
+type StripeInvoice struct {
+	StripeInvoiceID      string
+	OrganizationID       pgtype.Text
+	StripeCustomerID     string
+	StripeSubscriptionID string
+	ServicePeriodStart   pgtype.Timestamptz
+	ServicePeriodEnd     pgtype.Timestamptz
+	InvoiceState         string
+	FinalizedAt          pgtype.Timestamptz
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+type StripeInvoiceAllocation struct {
+	ID                      uuid.UUID
+	OrganizationID          pgtype.Text
+	SourceKind              string
+	SourceKey               string
+	Seq                     int32
+	SourceDay               pgtype.Date
+	SourcePeriodStart       pgtype.Timestamptz
+	SourcePeriodEnd         pgtype.Timestamptz
+	SourceSnapshotUsd       pgtype.Numeric
+	DeltaTokens             pgtype.Int8
+	OriginalTumUnitPriceUsd pgtype.Numeric
+	AmountUsd               pgtype.Numeric
+	OriginalInvoiceID       pgtype.Text
+	DestinationInvoiceID    pgtype.Text
+	StripeInvoiceItemID     pgtype.Text
+	StripeCreditNoteID      pgtype.Text
+	IdempotencyKey          string
+	DeliveryState           string
+	FirstAttemptedAt        pgtype.Timestamptz
+	LastAttemptedAt         pgtype.Timestamptz
+	ConfirmedAt             pgtype.Timestamptz
+	AmbiguousAt             pgtype.Timestamptz
+	ReconciledAt            pgtype.Timestamptz
+	CreatedAt               pgtype.Timestamptz
+	UpdatedAt               pgtype.Timestamptz
+}
+
 type StripeMeterReport struct {
-	ID             uuid.UUID
-	OrganizationID string
-	CycleStart     pgtype.Timestamptz
-	Seq            int32
-	DeltaTokens    int64
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
+	ID                   uuid.UUID
+	OrganizationID       pgtype.Text
+	BillingCycleUsageID  uuid.NullUUID
+	CycleStart           pgtype.Timestamptz
+	CycleEnd             pgtype.Timestamptz
+	Seq                  int32
+	StripeCustomerID     pgtype.Text
+	StripeMeterEventName pgtype.Text
+	StripeIdentifier     pgtype.Text
+	DeltaTokens          int64
+	EventTimestamp       pgtype.Timestamptz
+	DeliveryState        string
+	FirstAttemptedAt     pgtype.Timestamptz
+	LastAttemptedAt      pgtype.Timestamptz
+	ConfirmedAt          pgtype.Timestamptz
+	AmbiguousAt          pgtype.Timestamptz
+	ReconciledAt         pgtype.Timestamptz
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 type StripeWebhookReceipt struct {

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -159,7 +159,7 @@ INSERT INTO billing_cycle_usage (
   , tum_tokens
   , finalized_at
 ) VALUES (
-    @organization_id
+    @organization_id::text
   , @cycle_start
   , @cycle_end
   , @tum_tokens
@@ -177,11 +177,11 @@ WHERE billing_cycle_usage.finalized_at IS NULL;
 -- name: ListFinalizedBillingCycleStarts :many
 SELECT cycle_start
 FROM billing_cycle_usage
-WHERE organization_id = @organization_id
+WHERE organization_id = @organization_id::text
   AND finalized_at IS NOT NULL;
 
 -- name: ListBillingCycleUsage :many
 SELECT *
 FROM billing_cycle_usage
-WHERE organization_id = @organization_id
+WHERE organization_id = @organization_id::text
 ORDER BY cycle_start;

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -10,24 +10,32 @@ import (
 )
 
 type BillingCycleUsage struct {
-	ID             uuid.UUID
-	OrganizationID string
-	CycleStart     pgtype.Timestamptz
-	CycleEnd       pgtype.Timestamptz
-	TumTokens      int64
-	FinalizedAt    pgtype.Timestamptz
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
+	ID              uuid.UUID
+	OrganizationID  pgtype.Text
+	CycleStart      pgtype.Timestamptz
+	CycleEnd        pgtype.Timestamptz
+	TumTokens       int64
+	BilledTumTokens pgtype.Int8
+	BilledFrozenAt  pgtype.Timestamptz
+	FinalizedAt     pgtype.Timestamptz
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
 }
 
 type BillingMetadatum struct {
-	ID                    uuid.UUID
-	OrganizationID        string
-	StripeCustomerID      pgtype.Text
-	StripeSubscriptionID  pgtype.Text
-	TumMonthlyTokenLimit  pgtype.Int8
-	AlertEmail            pgtype.Text
-	BillingCycleAnchorDay int32
+	ID                               uuid.UUID
+	OrganizationID                   string
+	StripeCustomerID                 pgtype.Text
+	StripeSubscriptionID             pgtype.Text
+	StripeBillingCycleAnchor         pgtype.Timestamptz
+	StripeCheckoutIdempotencyKey     pgtype.Text
+	StripeCheckoutBillingCycleAnchor pgtype.Timestamptz
+	StripeCheckoutTrialEnd           pgtype.Timestamptz
+	StripeCheckoutExpiresAt          pgtype.Timestamptz
+	StripeCheckoutSessionID          pgtype.Text
+	TumMonthlyTokenLimit             pgtype.Int8
+	AlertEmail                       pgtype.Text
+	BillingCycleAnchorDay            int32
 	// Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.
 	TunneledMcpServerLimit pgtype.Int4
 	CreatedAt              pgtype.Timestamptz

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -30,7 +30,7 @@ SET stripe_subscription_id = $1,
 WHERE organization_id = $3
   AND stripe_customer_id = $4
   AND (stripe_subscription_id IS NULL OR stripe_subscription_id = $1)
-RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
+RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, stripe_billing_cycle_anchor, stripe_checkout_idempotency_key, stripe_checkout_billing_cycle_anchor, stripe_checkout_trial_end, stripe_checkout_expires_at, stripe_checkout_session_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 `
 
 type ActivatePaygBillingMetadataParams struct {
@@ -53,6 +53,12 @@ func (q *Queries) ActivatePaygBillingMetadata(ctx context.Context, arg ActivateP
 		&i.OrganizationID,
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
+		&i.StripeBillingCycleAnchor,
+		&i.StripeCheckoutIdempotencyKey,
+		&i.StripeCheckoutBillingCycleAnchor,
+		&i.StripeCheckoutTrialEnd,
+		&i.StripeCheckoutExpiresAt,
+		&i.StripeCheckoutSessionID,
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
@@ -124,7 +130,7 @@ func (q *Queries) CreateStripeSubscriptionBillingMetadataFixture(ctx context.Con
 }
 
 const getBillingMetadata = `-- name: GetBillingMetadata :one
-SELECT id, organization_id, stripe_customer_id, stripe_subscription_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
+SELECT id, organization_id, stripe_customer_id, stripe_subscription_id, stripe_billing_cycle_anchor, stripe_checkout_idempotency_key, stripe_checkout_billing_cycle_anchor, stripe_checkout_trial_end, stripe_checkout_expires_at, stripe_checkout_session_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 FROM billing_metadata
 WHERE organization_id = $1
 `
@@ -137,6 +143,12 @@ func (q *Queries) GetBillingMetadata(ctx context.Context, organizationID string)
 		&i.OrganizationID,
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
+		&i.StripeBillingCycleAnchor,
+		&i.StripeCheckoutIdempotencyKey,
+		&i.StripeCheckoutBillingCycleAnchor,
+		&i.StripeCheckoutTrialEnd,
+		&i.StripeCheckoutExpiresAt,
+		&i.StripeCheckoutSessionID,
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
@@ -233,9 +245,9 @@ func (q *Queries) GetPaygActivationState(ctx context.Context, organizationID str
 }
 
 const listBillingCycleUsage = `-- name: ListBillingCycleUsage :many
-SELECT id, organization_id, cycle_start, cycle_end, tum_tokens, finalized_at, created_at, updated_at
+SELECT id, organization_id, cycle_start, cycle_end, tum_tokens, billed_tum_tokens, billed_frozen_at, finalized_at, created_at, updated_at
 FROM billing_cycle_usage
-WHERE organization_id = $1
+WHERE organization_id = $1::text
 ORDER BY cycle_start
 `
 
@@ -254,6 +266,8 @@ func (q *Queries) ListBillingCycleUsage(ctx context.Context, organizationID stri
 			&i.CycleStart,
 			&i.CycleEnd,
 			&i.TumTokens,
+			&i.BilledTumTokens,
+			&i.BilledFrozenAt,
 			&i.FinalizedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -300,7 +314,7 @@ func (q *Queries) ListBillingProjectIDsByOrganization(ctx context.Context, organ
 const listFinalizedBillingCycleStarts = `-- name: ListFinalizedBillingCycleStarts :many
 SELECT cycle_start
 FROM billing_cycle_usage
-WHERE organization_id = $1
+WHERE organization_id = $1::text
   AND finalized_at IS NOT NULL
 `
 
@@ -377,7 +391,7 @@ ON CONFLICT (organization_id) DO UPDATE SET
       WHEN billing_metadata.stripe_customer_id IS NULL THEN clock_timestamp()
       ELSE billing_metadata.updated_at
     END
-RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
+RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, stripe_billing_cycle_anchor, stripe_checkout_idempotency_key, stripe_checkout_billing_cycle_anchor, stripe_checkout_trial_end, stripe_checkout_expires_at, stripe_checkout_session_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 `
 
 type StoreStripeCustomerParams struct {
@@ -393,6 +407,12 @@ func (q *Queries) StoreStripeCustomer(ctx context.Context, arg StoreStripeCustom
 		&i.OrganizationID,
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
+		&i.StripeBillingCycleAnchor,
+		&i.StripeCheckoutIdempotencyKey,
+		&i.StripeCheckoutBillingCycleAnchor,
+		&i.StripeCheckoutTrialEnd,
+		&i.StripeCheckoutExpiresAt,
+		&i.StripeCheckoutSessionID,
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
@@ -456,7 +476,7 @@ INSERT INTO billing_cycle_usage (
   , tum_tokens
   , finalized_at
 ) VALUES (
-    $1
+    $1::text
   , $2
   , $3
   , $4
@@ -513,7 +533,7 @@ ON CONFLICT (organization_id) DO UPDATE SET
   -- field (dashboard TUM form, older SDKs) must not silently clear it.
   , tunneled_mcp_server_limit = COALESCE(EXCLUDED.tunneled_mcp_server_limit, billing_metadata.tunneled_mcp_server_limit)
   , updated_at = clock_timestamp()
-RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
+RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, stripe_billing_cycle_anchor, stripe_checkout_idempotency_key, stripe_checkout_billing_cycle_anchor, stripe_checkout_trial_end, stripe_checkout_expires_at, stripe_checkout_session_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 `
 
 type UpsertBillingMetadataParams struct {
@@ -538,6 +558,12 @@ func (q *Queries) UpsertBillingMetadata(ctx context.Context, arg UpsertBillingMe
 		&i.OrganizationID,
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
+		&i.StripeBillingCycleAnchor,
+		&i.StripeCheckoutIdempotencyKey,
+		&i.StripeCheckoutBillingCycleAnchor,
+		&i.StripeCheckoutTrialEnd,
+		&i.StripeCheckoutExpiresAt,
+		&i.StripeCheckoutSessionID,
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,

--- a/server/migrations/20260817231000_dno-877-billing-delivery-and-invoice-allocation.sql
+++ b/server/migrations/20260817231000_dno-877-billing-delivery-and-invoice-allocation.sql
@@ -1,0 +1,80 @@
+-- atlas:txmode none
+
+-- Modify "billing_metadata" table
+ALTER TABLE "billing_metadata" ADD COLUMN "stripe_billing_cycle_anchor" timestamptz NULL, ADD COLUMN "stripe_checkout_idempotency_key" text NULL, ADD COLUMN "stripe_checkout_billing_cycle_anchor" timestamptz NULL, ADD COLUMN "stripe_checkout_trial_end" timestamptz NULL, ADD COLUMN "stripe_checkout_expires_at" timestamptz NULL, ADD COLUMN "stripe_checkout_session_id" text NULL;
+-- Create index "billing_metadata_stripe_checkout_session_id_key" to table: "billing_metadata"
+CREATE UNIQUE INDEX CONCURRENTLY "billing_metadata_stripe_checkout_session_id_key" ON "billing_metadata" ("stripe_checkout_session_id") WHERE (stripe_checkout_session_id IS NOT NULL);
+-- Modify "billing_cycle_usage" table
+ALTER TABLE "billing_cycle_usage" DROP CONSTRAINT "billing_cycle_usage_organization_id_fkey", ADD CONSTRAINT "billing_cycle_usage_billed_frozen_at_check" CHECK ((billed_frozen_at IS NULL) OR (billed_tum_tokens IS NOT NULL)), ADD CONSTRAINT "billing_cycle_usage_billed_tum_tokens_check" CHECK ((billed_tum_tokens IS NULL) OR (billed_tum_tokens >= 0)), ALTER COLUMN "organization_id" DROP NOT NULL, ADD COLUMN "billed_tum_tokens" bigint NULL, ADD COLUMN "billed_frozen_at" timestamptz NULL, ADD CONSTRAINT "billing_cycle_usage_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+-- Create index "billing_cycle_usage_organization_id_id_key" to table: "billing_cycle_usage"
+CREATE UNIQUE INDEX CONCURRENTLY "billing_cycle_usage_organization_id_id_key" ON "billing_cycle_usage" ("organization_id", "id");
+-- Create "stripe_invoices" table
+CREATE TABLE "stripe_invoices" (
+  "stripe_invoice_id" text NOT NULL,
+  "organization_id" text NULL,
+  "stripe_customer_id" text NOT NULL,
+  "stripe_subscription_id" text NOT NULL,
+  "service_period_start" timestamptz NOT NULL,
+  "service_period_end" timestamptz NOT NULL,
+  "invoice_state" text NOT NULL,
+  "finalized_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("stripe_invoice_id"),
+  CONSTRAINT "stripe_invoices_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "stripe_invoices_service_period_bounds_check" CHECK (service_period_end > service_period_start)
+);
+-- Create index "stripe_invoices_organization_id_service_period_start_idx" to table: "stripe_invoices"
+CREATE INDEX "stripe_invoices_organization_id_service_period_start_idx" ON "stripe_invoices" ("organization_id", "service_period_start") WHERE (organization_id IS NOT NULL);
+-- Create index "stripe_invoices_organization_id_stripe_invoice_id_key" to table: "stripe_invoices"
+CREATE UNIQUE INDEX "stripe_invoices_organization_id_stripe_invoice_id_key" ON "stripe_invoices" ("organization_id", "stripe_invoice_id");
+-- Create "stripe_invoice_allocations" table
+CREATE TABLE "stripe_invoice_allocations" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NULL,
+  "source_kind" text NOT NULL,
+  "source_key" text NOT NULL,
+  "seq" integer NOT NULL,
+  "source_day" date NULL,
+  "source_period_start" timestamptz NULL,
+  "source_period_end" timestamptz NULL,
+  "source_snapshot_usd" numeric(14,6) NULL,
+  "delta_tokens" bigint NULL,
+  "original_tum_unit_price_usd" numeric(14,12) NULL,
+  "amount_usd" numeric(14,6) NULL,
+  "original_invoice_id" text NULL,
+  "destination_invoice_id" text NULL,
+  "stripe_invoice_item_id" text NULL,
+  "stripe_credit_note_id" text NULL,
+  "idempotency_key" text NOT NULL,
+  "delivery_state" text NOT NULL DEFAULT 'pending',
+  "first_attempted_at" timestamptz NULL,
+  "last_attempted_at" timestamptz NULL,
+  "confirmed_at" timestamptz NULL,
+  "ambiguous_at" timestamptz NULL,
+  "reconciled_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "stripe_invoice_allocations_org_destination_invoice_fkey" FOREIGN KEY ("organization_id", "destination_invoice_id") REFERENCES "stripe_invoices" ("organization_id", "stripe_invoice_id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "stripe_invoice_allocations_org_original_invoice_fkey" FOREIGN KEY ("organization_id", "original_invoice_id") REFERENCES "stripe_invoices" ("organization_id", "stripe_invoice_id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "stripe_invoice_allocations_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "stripe_invoice_allocations_source_period_bounds_check" CHECK (((source_day IS NOT NULL) AND (source_period_start IS NULL) AND (source_period_end IS NULL)) OR ((source_day IS NULL) AND (source_period_start IS NOT NULL) AND (source_period_end IS NOT NULL) AND (source_period_end > source_period_start))),
+  CONSTRAINT "stripe_invoice_allocations_source_snapshot_usd_check" CHECK ((source_snapshot_usd IS NULL) OR (source_snapshot_usd >= (0)::numeric))
+);
+-- Create index "stripe_invoice_allocations_destination_invoice_id_idx" to table: "stripe_invoice_allocations"
+CREATE INDEX "stripe_invoice_allocations_destination_invoice_id_idx" ON "stripe_invoice_allocations" ("destination_invoice_id") WHERE (destination_invoice_id IS NOT NULL);
+-- Create index "stripe_invoice_allocations_idempotency_key_key" to table: "stripe_invoice_allocations"
+CREATE UNIQUE INDEX "stripe_invoice_allocations_idempotency_key_key" ON "stripe_invoice_allocations" ("idempotency_key");
+-- Create index "stripe_invoice_allocations_org_source_seq_key" to table: "stripe_invoice_allocations"
+CREATE UNIQUE INDEX "stripe_invoice_allocations_org_source_seq_key" ON "stripe_invoice_allocations" ("organization_id", "source_kind", "source_key", "seq");
+-- Create index "stripe_invoice_allocations_original_invoice_id_idx" to table: "stripe_invoice_allocations"
+CREATE INDEX "stripe_invoice_allocations_original_invoice_id_idx" ON "stripe_invoice_allocations" ("original_invoice_id") WHERE (original_invoice_id IS NOT NULL);
+-- Modify "stripe_meter_reports" table
+ALTER TABLE "stripe_meter_reports" DROP CONSTRAINT "stripe_meter_reports_delta_tokens_check", DROP CONSTRAINT "stripe_meter_reports_organization_id_fkey", ADD CONSTRAINT "stripe_meter_reports_cycle_bounds_check" CHECK ((cycle_end IS NULL) OR (cycle_end > cycle_start)), ADD CONSTRAINT "stripe_meter_reports_event_timestamp_check" CHECK ((event_timestamp IS NULL) OR ((cycle_end IS NOT NULL) AND (event_timestamp >= cycle_start) AND (event_timestamp < cycle_end))), ALTER COLUMN "organization_id" DROP NOT NULL, ADD COLUMN "billing_cycle_usage_id" uuid NULL, ADD COLUMN "cycle_end" timestamptz NULL, ADD COLUMN "stripe_customer_id" text NULL, ADD COLUMN "stripe_meter_event_name" text NULL, ADD COLUMN "stripe_identifier" text NULL, ADD COLUMN "event_timestamp" timestamptz NULL, ADD COLUMN "delivery_state" text NOT NULL DEFAULT 'confirmed', ADD COLUMN "first_attempted_at" timestamptz NULL, ADD COLUMN "last_attempted_at" timestamptz NULL, ADD COLUMN "confirmed_at" timestamptz NULL, ADD COLUMN "ambiguous_at" timestamptz NULL, ADD COLUMN "reconciled_at" timestamptz NULL, ADD CONSTRAINT "stripe_meter_reports_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE SET NULL, ADD CONSTRAINT "stripe_meter_reports_org_billing_cycle_usage_fkey" FOREIGN KEY ("organization_id", "billing_cycle_usage_id") REFERENCES "billing_cycle_usage" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE SET NULL;
+-- Create index "stripe_meter_reports_billing_cycle_usage_id_idx" to table: "stripe_meter_reports"
+CREATE INDEX CONCURRENTLY "stripe_meter_reports_billing_cycle_usage_id_idx" ON "stripe_meter_reports" ("billing_cycle_usage_id") WHERE (billing_cycle_usage_id IS NOT NULL);
+-- Create index "stripe_meter_reports_org_cycle_bounds_seq_key" to table: "stripe_meter_reports"
+CREATE UNIQUE INDEX CONCURRENTLY "stripe_meter_reports_org_cycle_bounds_seq_key" ON "stripe_meter_reports" ("organization_id", "cycle_start", "cycle_end", "seq");
+-- Create index "stripe_meter_reports_stripe_identifier_key" to table: "stripe_meter_reports"
+CREATE UNIQUE INDEX CONCURRENTLY "stripe_meter_reports_stripe_identifier_key" ON "stripe_meter_reports" ("stripe_identifier") WHERE (stripe_identifier IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:HS3qjvLGJvYfAa6lPunmwpkqpuM1304zoAbFj3tlZ2o=
+h1:jQIvB/oAwnu8DjPd935wlpjjNkpWbl40ZXJSRqV0ZeM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -347,3 +347,4 @@ h1:HS3qjvLGJvYfAa6lPunmwpkqpuM1304zoAbFj3tlZ2o=
 20260817183037_trials-sweep-index.sql h1:Vd4zXwW0xF48mg0dDPxAN9IzYgPMtUil9vcloAbuGjU=
 20260817190001_chats-add-cwd.sql h1:e+ExLDhu7He8Eh0nXIJzsndNFxbOgggnhArcBkrWF94=
 20260817191238_session-handoff-links.sql h1:siwUqZKazb04TWF+UgfRZA3W1VbNdxVfqjP8UdmXB1s=
+20260817231000_dno-877-billing-delivery-and-invoice-allocation.sql h1:MVlVK+soioM2/VTw+q92GSFsP+l+UJ5/BEr16LLGs8A=


### PR DESCRIPTION
## Summary

- separate the immutable billed TUM baseline from the later observed total
- persist complete Stripe meter-delivery intent and reconciliation state
- add durable Stripe invoice identity and a single signed settlement-allocation ledger

## Migration safety

- schema-only, with no application behavior or data backfill
- new columns on existing tables are nullable for expand-contract rollout
- retains the legacy meter-report uniqueness index until all writers populate cycle bounds
- financial evidence survives organization deletion through `ON DELETE SET NULL`

## Validation

- `atlas migrate validate`
- `atlas migrate lint --latest 1`
- clean scratch-database application of all migrations
- `mise run lint:migrations --no-atlas`
- `mise run gen:sqlc-server`
- `go test ./server/internal/usage/... ./server/internal/database`
- `mise run lint:server`
- `mise run build:server --readonly`

Linear: DNO-877

Depends on #5326.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable PAYG billing-delivery and invoice-allocation schema to enable M3 freeze-and-carry, reconciliation, and corrections without changing behavior. Previously, meter reports and invoices lacked durable delivery state and allocation history; now meter deliveries are replayable with signed deltas and invoices have stable identity with an allocation ledger.

- Schema
  - `billing_metadata`: add paid-period anchor and Checkout intent fields; unique on `stripe_checkout_session_id`.
  - `billing_cycle_usage`: make `organization_id` nullable with ON DELETE SET NULL; add `billed_tum_tokens` and `billed_frozen_at` with checks; unique on `(organization_id, id)`.
  - `stripe_meter_reports`: add `billing_cycle_usage_id`, `cycle_end`, Stripe routing, `stripe_identifier` (unique), in-period `event_timestamp`, delivery state and attempt/reconcile timestamps; allow signed `delta_tokens`; keep legacy `(org, cycle_start, seq)` uniqueness and add `(org, cycle_start, cycle_end, seq)`; index `billing_cycle_usage_id`; default delivery_state `confirmed` for legacy rows.
  - `stripe_invoices`: new durable invoice identity with service period, state, and `finalized_at`; ON DELETE SET NULL; index `(organization_id, service_period_start)` and unique `(organization_id, stripe_invoice_id)`.
  - `stripe_invoice_allocations`: append-only source-to-invoice ledger with signed `amount_usd`, optional TUM details, unique idempotency key, delivery-state timestamps; unique `(organization_id, source_kind, source_key, seq)`; FKs to invoices; day/period consistency checks.
  - Models/queries: add Go models for invoices and allocations; expose new Stripe anchor/Checkout and delivery fields; cast `organization_id` to text in usage queries.

- Rollout
  - Schema-only; no backfill or behavior change. New columns are nullable; indexes created concurrently where possible. Financial records survive org deletion via ON DELETE SET NULL; retains legacy meter-report uniqueness during rollout. Supports Linear DNO-877.

<sup>Written for commit bf42f2f3feca21bf36edd2169fcaa2361ab28c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Migration isolation

[skip migration check]

The only non-migration file is `server/internal/usage/queries.sql`, whose change is
limited to `::text` parameter casts that sqlc requires once the new columns land.
No business logic ships with the schema.
