### PR TITLE
fix: decode codex compliance identity groups as objects

### DIFF
--- a/server/internal/aiintegrations/codex_cost_import.go
+++ b/server/internal/aiintegrations/codex_cost_import.go
@@ -694,10 +694,18 @@ type codexCostPayload struct {
 }
 
 type codexCostIdentity struct {
-	UserID string   `json:"user_id"`
-	Email  string   `json:"email"`
-	Name   string   `json:"name"`
-	Groups []string `json:"groups"`
+	UserID string           `json:"user_id"`
+	Email  string           `json:"email"`
+	Name   string           `json:"name"`
+	Groups []codexCostGroup `json:"groups"`
+}
+
+// codexCostGroup is a workspace group attached to a compliance identity. The
+// feed sends objects, e.g. {"id":"<hex id>","name":"<group name>"}, so
+// decoding must not assume plain strings.
+type codexCostGroup struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type codexCostMeasures struct {

--- a/server/internal/aiintegrations/codex_cost_import_test.go
+++ b/server/internal/aiintegrations/codex_cost_import_test.go
@@ -331,6 +331,32 @@ func TestBuildCodexCostLogParamsDecodeErrorNamesLogAndCause(t *testing.T) {
 	require.Equal(t, body, contentErr.Payload)
 }
 
+// The compliance feed sends identity.groups as objects ({"id","name"}), not
+// strings. This mirrors the feed's COSTS record shape — including the
+// principal and actor envelope fields we ignore — to pin that such rows
+// decode.
+func TestBuildCodexCostLogParamsDecodesGroupObjects(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"event_id":"11111111-2222-4333-8444-555555555555","type":"COSTS","principal":{"id":"org-openai","type":"API_PLATFORM_ORG"},"actor":{"type":"SYSTEM","id":"costs_compliance"},"timestamp":"2026-07-15T14:59:59Z","payload":{"day":"2026-07-15","hour":14,"organization_id":"org-openai","identity":{"user_id":"user_1","email":"Dev@Example.com","name":"Dev User","groups":[{"id":"00000000000000000000000000000abc","name":"Example_Group"}]},"product":"ChatGPT","client":"web","surface":"chatgpt","model":"gpt-5-thinking","reasoning":"high","measures":{"billing":[{"sku":"gpt-5-thinking","quantity":{"value":2,"unit":"counts"},"cost":{"value":20,"unit":"CREDITS"}}]}}}` + "\n")
+
+	cfg := codexCostConfig()
+	file := codexapi.LogFile{
+		ID:         "eclf_groups",
+		EventType:  codexComplianceCostsEventType,
+		EndTime:    time.Date(2026, 7, 15, 15, 0, 0, 0, time.UTC),
+		FileName:   "COSTS_2026-07-15T15:00:00.000000+00:00.jsonl",
+		FileSize:   int64(len(body)),
+		FileSHA256: "",
+	}
+
+	logParams, err := buildCodexCostLogParams(cfg, file, body)
+	require.NoError(t, err)
+	require.Len(t, logParams, 1)
+	require.Equal(t, "dev@example.com", logParams[0].UserInfo.Email())
+	require.Equal(t, chatgptUsageMetricsURN, logParams[0].ToolInfo.URN)
+}
+
 // Pagination edge cases (empty windows, non-advancing last_end_time, window
 // truncation, foreign-type filtering) are covered for this source and the
 // ChatGPT conversation source together in logfile_source_pagination_test.go.


### PR DESCRIPTION
## Summary

The codex compliance COSTS feed sends `identity.groups` as objects (`{"id","name"}`), but `codexCostIdentity` typed the field as `[]string`. Any log containing a group failed to decode, aborting the whole page import and exhausting the poll's retry budget — the failure surfaced in production Temporal history after #5285 shipped the richer poll diagnostics.

- Type `groups` as `[]codexCostGroup` with `id`/`name` fields. Nothing reads the field yet, but the shape now matches the feed and the data is available when we want group breakdowns.
- Add a regression test decoding a COSTS record with the feed's full envelope (principal, actor, object-shaped groups) using synthetic identity values.

Recovery is automatic once deployed: the poll failure is retryable, so the schedule stays enqueued with backoff, and no partial rows were written for the failing windows.

## Test plan

- [x] `go test ./server/internal/aiintegrations/ -run TestBuildCodexCost` passes, including the new `TestBuildCodexCostLogParamsDecodesGroupObjects`
- [x] `mise lint:server` clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode Codex compliance COSTS identity groups as objects to match the feed and stop page import failures. Previously `groups` was `[]string` and any log with a group failed to decode; now it is `[]codexCostGroup{id,name}`, so pages import successfully. No consumer behavior changes yet.

- Change: Update `codexCostIdentity.Groups` to `[]codexCostGroup` and add a regression test that decodes a full COSTS envelope with object-shaped groups.
- Rollout: No migrations. Poll retries will reprocess affected windows automatically; no partial rows were written.

<sup>Written for commit c5ae964898641dce69bb30e7dfcaa22779de7b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

