### PR TITLE
fix: align PAYG Stripe cycles to UTC midnight

### DIFF
--- a/.changeset/align-payg-billing-cycles.md
+++ b/.changeset/align-payg-billing-cycles.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Align self-serve PAYG Stripe billing cycles to UTC midnight and persist the exact paid-period anchor.

--- a/.changeset/align-payg-billing-cycles.md
+++ b/.changeset/align-payg-billing-cycles.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Align self-serve PAYG Stripe billing cycles to UTC midnight and persist the exact paid-period anchor.
+Align self-serve PAYG Stripe billing cycles to UTC midnight. Checkout retries now reuse one durable session intent, active product trials retain their exact local end while Stripe supplies the free stub to midnight, and completed subscriptions persist the confirmed paid-period anchor.

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -30,6 +30,8 @@ var ErrWebhookNotConfigured = errors.New("stripe webhook is not configured")
 
 var errMissingIdempotencyKey = errors.New("idempotency key is required")
 
+var errMissingBillingCycleAnchor = errors.New("billing cycle anchor is required")
+
 // Catalog contains the Stripe object identifiers used by PAYG billing.
 type Catalog struct {
 	PriceIDTUM     string
@@ -93,6 +95,9 @@ type CreateCheckoutSessionInput struct {
 
 	// TrialEnd preserves an active in-product trial on the Stripe subscription.
 	TrialEnd *time.Time
+
+	// BillingCycleAnchor starts the first full paid period at an exact UTC boundary.
+	BillingCycleAnchor time.Time
 
 	// IdempotencyKey identifies one Checkout creation request.
 	IdempotencyKey string
@@ -238,6 +243,9 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	if input.IdempotencyKey == "" {
 		return nil, errMissingIdempotencyKey
 	}
+	if input.BillingCycleAnchor.IsZero() {
+		return nil, errMissingBillingCycleAnchor
+	}
 
 	params := new(stripesdk.CheckoutSessionCreateParams)
 	params.CancelURL = stripesdk.String(input.CancelURL)
@@ -256,10 +264,12 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	params.Mode = stripesdk.String(stripesdk.CheckoutSessionModeSubscription)
 	params.PaymentMethodCollection = stripesdk.String(stripesdk.CheckoutSessionPaymentMethodCollectionAlways)
 	params.SubscriptionData = new(stripesdk.CheckoutSessionCreateSubscriptionDataParams)
+	params.SubscriptionData.BillingCycleAnchor = new(input.BillingCycleAnchor.Unix())
 	params.SubscriptionData.Metadata = map[string]string{
 		organizationIDMetadataKey:   input.OrganizationID,
 		organizationSlugMetadataKey: input.OrganizationSlug,
 	}
+	params.SubscriptionData.ProrationBehavior = stripesdk.String("none")
 	params.SuccessURL = stripesdk.String(input.SuccessURL)
 	if input.TrialEnd != nil {
 		params.SubscriptionData.TrialEnd = new(input.TrialEnd.Unix())

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -32,6 +32,8 @@ var errMissingIdempotencyKey = errors.New("idempotency key is required")
 
 var errMissingBillingCycleAnchor = errors.New("billing cycle anchor is required")
 
+var errMissingCheckoutExpiration = errors.New("checkout expiration is required")
+
 // Catalog contains the Stripe object identifiers used by PAYG billing.
 type Catalog struct {
 	PriceIDTUM     string
@@ -93,11 +95,15 @@ type CreateCheckoutSessionInput struct {
 	// CancelURL is the browser destination when Checkout is canceled.
 	CancelURL string
 
-	// TrialEnd preserves an active in-product trial on the Stripe subscription.
+	// TrialEnd is the UTC-aligned financial trial end. Gram retains the exact
+	// product trial end separately and the interval between them is a free stub.
 	TrialEnd *time.Time
 
 	// BillingCycleAnchor starts the first full paid period at an exact UTC boundary.
 	BillingCycleAnchor time.Time
+
+	// ExpiresAt prevents the session from completing after its intended paid anchor.
+	ExpiresAt time.Time
 
 	// IdempotencyKey identifies one Checkout creation request.
 	IdempotencyKey string
@@ -105,6 +111,9 @@ type CreateCheckoutSessionInput struct {
 
 // CheckoutSession is the Stripe Checkout data needed by billing callers.
 type CheckoutSession struct {
+	// ID is Stripe's stable Checkout Session identifier.
+	ID string
+
 	// URL is Stripe's hosted Checkout page.
 	URL string
 }
@@ -246,11 +255,15 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	if input.BillingCycleAnchor.IsZero() {
 		return nil, errMissingBillingCycleAnchor
 	}
+	if input.ExpiresAt.IsZero() {
+		return nil, errMissingCheckoutExpiration
+	}
 
 	params := new(stripesdk.CheckoutSessionCreateParams)
 	params.CancelURL = stripesdk.String(input.CancelURL)
 	params.ClientReferenceID = stripesdk.String(input.OrganizationID)
 	params.Customer = stripesdk.String(input.CustomerID)
+	params.ExpiresAt = new(input.ExpiresAt.Unix())
 	params.LineItems = []*stripesdk.CheckoutSessionCreateLineItemParams{
 		{
 			Price:    stripesdk.String(c.catalog.PriceIDTUM),
@@ -264,15 +277,16 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	params.Mode = stripesdk.String(stripesdk.CheckoutSessionModeSubscription)
 	params.PaymentMethodCollection = stripesdk.String(stripesdk.CheckoutSessionPaymentMethodCollectionAlways)
 	params.SubscriptionData = new(stripesdk.CheckoutSessionCreateSubscriptionDataParams)
-	params.SubscriptionData.BillingCycleAnchor = new(input.BillingCycleAnchor.Unix())
 	params.SubscriptionData.Metadata = map[string]string{
 		organizationIDMetadataKey:   input.OrganizationID,
 		organizationSlugMetadataKey: input.OrganizationSlug,
 	}
-	params.SubscriptionData.ProrationBehavior = stripesdk.String("none")
 	params.SuccessURL = stripesdk.String(input.SuccessURL)
 	if input.TrialEnd != nil {
 		params.SubscriptionData.TrialEnd = new(input.TrialEnd.Unix())
+	} else {
+		params.SubscriptionData.BillingCycleAnchor = new(input.BillingCycleAnchor.Unix())
+		params.SubscriptionData.ProrationBehavior = stripesdk.String("none")
 	}
 	params.SetIdempotencyKey(input.IdempotencyKey)
 
@@ -280,7 +294,7 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	if err != nil {
 		return nil, fmt.Errorf("create Stripe Checkout session: %w", err)
 	}
-	return &CheckoutSession{URL: session.URL}, nil
+	return &CheckoutSession{ID: session.ID, URL: session.URL}, nil
 }
 
 func (c *client) GetCheckoutSession(ctx context.Context, id string) (*CheckoutSessionState, error) {
@@ -428,7 +442,7 @@ func (s *stubClient) CreateCustomer(ctx context.Context, _ CreateCustomerInput) 
 
 func (s *stubClient) CreateCheckoutSession(ctx context.Context, input CreateCheckoutSessionInput) (*CheckoutSession, error) {
 	s.logger.DebugContext(ctx, "stub Stripe Checkout session creation skipped")
-	return &CheckoutSession{URL: fmt.Sprintf("http://localhost:3000/%s/billing", url.PathEscape(input.OrganizationSlug))}, nil
+	return &CheckoutSession{ID: "cs_local_stub", URL: fmt.Sprintf("http://localhost:3000/%s/billing", url.PathEscape(input.OrganizationSlug))}, nil
 }
 
 func (s *stubClient) GetCheckoutSession(context.Context, string) (*CheckoutSessionState, error) {

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -98,7 +98,7 @@ func (f *fakeStripeAPI) createCustomer(_ context.Context, params *stripesdk.Cust
 func (f *fakeStripeAPI) createCheckoutSession(_ context.Context, params *stripesdk.CheckoutSessionCreateParams) (*stripesdk.CheckoutSession, error) {
 	f.calls++
 	f.checkoutSessionParams = params
-	return &stripesdk.CheckoutSession{URL: "https://checkout.stripe.test/session"}, f.err
+	return &stripesdk.CheckoutSession{ID: "cs_test", URL: "https://checkout.stripe.test/session"}, f.err
 }
 
 func (f *fakeStripeAPI) retrieveCheckoutSession(_ context.Context, _ string, params *stripesdk.CheckoutSessionRetrieveParams) (*stripesdk.CheckoutSession, error) {
@@ -153,8 +153,8 @@ func TestCreateCheckoutSessionBuildsMeteredSubscription(t *testing.T) {
 			MeterEventName: "tum",
 		},
 	}
-	trialEnd := time.Date(2026, time.August, 20, 10, 0, 0, 0, time.UTC)
 	billingCycleAnchor := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+	expiresAt := time.Date(2026, time.August, 15, 12, 0, 0, 0, time.UTC)
 
 	session, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
 		CustomerID:         "cus_test",
@@ -162,16 +162,19 @@ func TestCreateCheckoutSessionBuildsMeteredSubscription(t *testing.T) {
 		OrganizationSlug:   "the-customer",
 		SuccessURL:         "https://app.example.test/the-customer/billing",
 		CancelURL:          "https://app.example.test/the-customer/billing",
-		TrialEnd:           &trialEnd,
+		TrialEnd:           &billingCycleAnchor,
 		BillingCycleAnchor: billingCycleAnchor,
+		ExpiresAt:          expiresAt,
 		IdempotencyKey:     "checkout:<ORG_ID>:request",
 	})
 	require.NoError(t, err)
+	require.Equal(t, "cs_test", session.ID)
 	require.Equal(t, "https://checkout.stripe.test/session", session.URL)
 
 	params := api.checkoutSessionParams
 	require.Equal(t, "checkout:<ORG_ID>:request", stripesdk.StringValue(params.IdempotencyKey))
 	require.Equal(t, "cus_test", stripesdk.StringValue(params.Customer))
+	require.Equal(t, expiresAt.Unix(), stripesdk.Int64Value(params.ExpiresAt))
 	require.Equal(t, "<ORG_ID>", stripesdk.StringValue(params.ClientReferenceID))
 	require.Equal(t, "subscription", stripesdk.StringValue(params.Mode))
 	require.Equal(t, "always", stripesdk.StringValue(params.PaymentMethodCollection))
@@ -183,9 +186,9 @@ func TestCreateCheckoutSessionBuildsMeteredSubscription(t *testing.T) {
 	require.Equal(t, "<ORG_ID>", params.Metadata[organizationIDMetadataKey])
 	require.Equal(t, "the-customer", params.Metadata[organizationSlugMetadataKey])
 	require.NotNil(t, params.SubscriptionData)
-	require.Equal(t, trialEnd.Unix(), stripesdk.Int64Value(params.SubscriptionData.TrialEnd))
-	require.Equal(t, billingCycleAnchor.Unix(), stripesdk.Int64Value(params.SubscriptionData.BillingCycleAnchor))
-	require.Equal(t, "none", stripesdk.StringValue(params.SubscriptionData.ProrationBehavior))
+	require.Equal(t, billingCycleAnchor.Unix(), stripesdk.Int64Value(params.SubscriptionData.TrialEnd))
+	require.Nil(t, params.SubscriptionData.BillingCycleAnchor)
+	require.Nil(t, params.SubscriptionData.ProrationBehavior)
 	require.Equal(t, "<ORG_ID>", params.SubscriptionData.Metadata[organizationIDMetadataKey])
 	require.Equal(t, "the-customer", params.SubscriptionData.Metadata[organizationSlugMetadataKey])
 }
@@ -204,10 +207,13 @@ func TestCreateCheckoutSessionWithoutTrialStartsImmediately(t *testing.T) {
 		CancelURL:          "",
 		TrialEnd:           nil,
 		BillingCycleAnchor: time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC),
+		ExpiresAt:          time.Date(2026, time.August, 15, 12, 0, 0, 0, time.UTC),
 		IdempotencyKey:     "checkout",
 	})
 	require.NoError(t, err)
 	require.Nil(t, api.checkoutSessionParams.SubscriptionData.TrialEnd)
+	require.Equal(t, time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC).Unix(), stripesdk.Int64Value(api.checkoutSessionParams.SubscriptionData.BillingCycleAnchor))
+	require.Equal(t, "none", stripesdk.StringValue(api.checkoutSessionParams.SubscriptionData.ProrationBehavior))
 }
 
 func TestCreateCheckoutSessionRejectsMissingBillingCycleAnchor(t *testing.T) {
@@ -218,6 +224,20 @@ func TestCreateCheckoutSessionRejectsMissingBillingCycleAnchor(t *testing.T) {
 
 	_, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{IdempotencyKey: "checkout"})
 	require.ErrorIs(t, err, errMissingBillingCycleAnchor)
+	require.Zero(t, api.calls)
+}
+
+func TestCreateCheckoutSessionRejectsMissingExpiration(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	_, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
+		BillingCycleAnchor: time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC),
+		IdempotencyKey:     "checkout",
+	})
+	require.ErrorIs(t, err, errMissingCheckoutExpiration)
 	require.Zero(t, api.calls)
 }
 
@@ -314,6 +334,7 @@ func TestWritesWrapStripeErrors(t *testing.T) {
 
 	_, err = c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
 		BillingCycleAnchor: time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC),
+		ExpiresAt:          time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC),
 		IdempotencyKey:     "checkout",
 	})
 	require.ErrorIs(t, err, apiErr)
@@ -560,6 +581,7 @@ func TestStubClientIsSafeToCall(t *testing.T) {
 	require.Equal(t, "cus_local_stub", customer.ID)
 	checkout, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{OrganizationSlug: "test/org"})
 	require.NoError(t, err)
+	require.Equal(t, "cs_local_stub", checkout.ID)
 	require.Equal(t, "http://localhost:3000/test%2Forg/billing", checkout.URL)
 	require.NoError(t, c.CreateMeterEvent(t.Context(), CreateMeterEventInput{}))
 	require.Equal(t, Catalog{}, c.Catalog())

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -154,15 +154,17 @@ func TestCreateCheckoutSessionBuildsMeteredSubscription(t *testing.T) {
 		},
 	}
 	trialEnd := time.Date(2026, time.August, 20, 10, 0, 0, 0, time.UTC)
+	billingCycleAnchor := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
 
 	session, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
-		CustomerID:       "cus_test",
-		OrganizationID:   "<ORG_ID>",
-		OrganizationSlug: "the-customer",
-		SuccessURL:       "https://app.example.test/the-customer/billing",
-		CancelURL:        "https://app.example.test/the-customer/billing",
-		TrialEnd:         &trialEnd,
-		IdempotencyKey:   "checkout:<ORG_ID>:request",
+		CustomerID:         "cus_test",
+		OrganizationID:     "<ORG_ID>",
+		OrganizationSlug:   "the-customer",
+		SuccessURL:         "https://app.example.test/the-customer/billing",
+		CancelURL:          "https://app.example.test/the-customer/billing",
+		TrialEnd:           &trialEnd,
+		BillingCycleAnchor: billingCycleAnchor,
+		IdempotencyKey:     "checkout:<ORG_ID>:request",
 	})
 	require.NoError(t, err)
 	require.Equal(t, "https://checkout.stripe.test/session", session.URL)
@@ -182,6 +184,8 @@ func TestCreateCheckoutSessionBuildsMeteredSubscription(t *testing.T) {
 	require.Equal(t, "the-customer", params.Metadata[organizationSlugMetadataKey])
 	require.NotNil(t, params.SubscriptionData)
 	require.Equal(t, trialEnd.Unix(), stripesdk.Int64Value(params.SubscriptionData.TrialEnd))
+	require.Equal(t, billingCycleAnchor.Unix(), stripesdk.Int64Value(params.SubscriptionData.BillingCycleAnchor))
+	require.Equal(t, "none", stripesdk.StringValue(params.SubscriptionData.ProrationBehavior))
 	require.Equal(t, "<ORG_ID>", params.SubscriptionData.Metadata[organizationIDMetadataKey])
 	require.Equal(t, "the-customer", params.SubscriptionData.Metadata[organizationSlugMetadataKey])
 }
@@ -192,9 +196,29 @@ func TestCreateCheckoutSessionWithoutTrialStartsImmediately(t *testing.T) {
 	api := &fakeStripeAPI{}
 	c := &client{api: api, catalog: Catalog{PriceIDTUM: "price_tum", MeterEventName: "tum"}}
 
-	_, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{IdempotencyKey: "checkout"})
+	_, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
+		CustomerID:         "",
+		OrganizationID:     "",
+		OrganizationSlug:   "",
+		SuccessURL:         "",
+		CancelURL:          "",
+		TrialEnd:           nil,
+		BillingCycleAnchor: time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC),
+		IdempotencyKey:     "checkout",
+	})
 	require.NoError(t, err)
 	require.Nil(t, api.checkoutSessionParams.SubscriptionData.TrialEnd)
+}
+
+func TestCreateCheckoutSessionRejectsMissingBillingCycleAnchor(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	_, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{IdempotencyKey: "checkout"})
+	require.ErrorIs(t, err, errMissingBillingCycleAnchor)
+	require.Zero(t, api.calls)
 }
 
 func TestCreateCheckoutSessionRejectsMissingIdempotencyKey(t *testing.T) {
@@ -288,7 +312,10 @@ func TestWritesWrapStripeErrors(t *testing.T) {
 	require.ErrorIs(t, err, apiErr)
 	require.ErrorContains(t, err, "create Stripe meter event")
 
-	_, err = c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{IdempotencyKey: "checkout"})
+	_, err = c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
+		BillingCycleAnchor: time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC),
+		IdempotencyKey:     "checkout",
+	})
 	require.ErrorIs(t, err, apiErr)
 	require.ErrorContains(t, err, "create Stripe Checkout session")
 }

--- a/server/internal/usage/create_stripe_checkout.go
+++ b/server/internal/usage/create_stripe_checkout.go
@@ -90,14 +90,16 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 	}
 
 	billingURL := s.siteURL.JoinPath(authCtx.OrganizationSlug, "billing").String()
+	billingCycleAnchor := nextStripeBillingCycleAnchor(time.Now(), trialEnd)
 	checkout, err := s.stripeClient.CreateCheckoutSession(ctx, stripeclient.CreateCheckoutSessionInput{
-		CustomerID:       customerID,
-		OrganizationID:   authCtx.ActiveOrganizationID,
-		OrganizationSlug: authCtx.OrganizationSlug,
-		SuccessURL:       billingURL,
-		CancelURL:        billingURL,
-		TrialEnd:         trialEnd,
-		IdempotencyKey:   fmt.Sprintf("checkout-session:%s", authCtx.ActiveOrganizationID),
+		CustomerID:         customerID,
+		OrganizationID:     authCtx.ActiveOrganizationID,
+		OrganizationSlug:   authCtx.OrganizationSlug,
+		SuccessURL:         billingURL,
+		CancelURL:          billingURL,
+		TrialEnd:           trialEnd,
+		BillingCycleAnchor: billingCycleAnchor,
+		IdempotencyKey:     fmt.Sprintf("checkout-session:%s", authCtx.ActiveOrganizationID),
 	})
 	if err != nil {
 		return "", oops.E(oops.CodeUnexpected, err, "failed to create Stripe Checkout session").LogError(ctx, s.logger)
@@ -138,4 +140,17 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 	}
 
 	return checkout.URL, nil
+}
+
+func nextStripeBillingCycleAnchor(now time.Time, trialEnd *time.Time) time.Time {
+	start := now.UTC()
+	if trialEnd != nil {
+		start = trialEnd.UTC()
+	}
+
+	midnight := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+	if trialEnd != nil && start.Equal(midnight) {
+		return midnight
+	}
+	return midnight.AddDate(0, 0, 1)
 }

--- a/server/internal/usage/create_stripe_checkout.go
+++ b/server/internal/usage/create_stripe_checkout.go
@@ -22,7 +22,24 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
-const minimumStripeCheckoutTrialLead = 48 * time.Hour
+const (
+	minimumStripeCheckoutTrialLead       = 48 * time.Hour
+	minimumStripeCheckoutSessionLifetime = 30 * time.Minute
+	maximumStripeCheckoutSessionLifetime = 24 * time.Hour
+	stripeCheckoutExpirySafetyMargin     = time.Minute
+)
+
+type stripeCheckoutIntent struct {
+	idempotencyKey     string
+	billingCycleAnchor time.Time
+	trialEnd           *time.Time
+	expiresAt          time.Time
+}
+
+type preparedStripeCheckoutIntent struct {
+	stripeCheckoutIntent
+	customerID string
+}
 
 func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeCheckoutPayload) (string, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -52,18 +69,20 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 		return "", oops.E(oops.CodeUnavailable, nil, "self-serve billing is temporarily unavailable").LogWarn(ctx, s.logger)
 	}
 
-	var trialEnd *time.Time
+	now := time.Now().UTC().Truncate(time.Second)
+	var productTrialEnd *time.Time
 	trial, err := trialsrepo.New(s.db).GetActiveTrial(ctx, authCtx.ActiveOrganizationID)
 	switch {
 	case err == nil:
 		end := trial.EndsAt.Time.UTC()
-		if time.Until(end) < minimumStripeCheckoutTrialLead {
-			return "", oops.E(oops.CodeConflict, nil, "the active trial ends too soon to start self-serve billing").LogWarn(ctx, s.logger)
-		}
-		trialEnd = &end
+		productTrialEnd = &end
 	case errors.Is(err, pgx.ErrNoRows):
 	case err != nil:
 		return "", oops.E(oops.CodeUnexpected, err, "failed to check the active trial").LogError(ctx, s.logger)
+	}
+	proposedIntent := newStripeCheckoutIntent(authCtx.ActiveOrganizationID, now, productTrialEnd)
+	if proposedIntent.trialEnd != nil && proposedIntent.trialEnd.Sub(now) < minimumStripeCheckoutTrialLead {
+		return "", oops.E(oops.CodeConflict, nil, "the active trial ends too soon to start self-serve billing").LogWarn(ctx, s.logger)
 	}
 
 	billingMetadata, err := repo.New(s.db).GetBillingMetadata(ctx, authCtx.ActiveOrganizationID)
@@ -88,58 +107,217 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 		}
 		customerID = customer.ID
 	}
+	replaceExpiredSessionID, err := s.expiredCheckoutSessionForReplacement(ctx, billingMetadata, customerID, now)
+	if err != nil {
+		return "", err
+	}
+
+	preparedIntent, err := s.prepareStripeCheckoutIntent(ctx, authCtx.ActiveOrganizationID, customerID, now, proposedIntent, replaceExpiredSessionID)
+	if err != nil {
+		return "", err
+	}
 
 	billingURL := s.siteURL.JoinPath(authCtx.OrganizationSlug, "billing").String()
-	billingCycleAnchor := nextStripeBillingCycleAnchor(time.Now(), trialEnd)
 	checkout, err := s.stripeClient.CreateCheckoutSession(ctx, stripeclient.CreateCheckoutSessionInput{
-		CustomerID:         customerID,
+		CustomerID:         preparedIntent.customerID,
 		OrganizationID:     authCtx.ActiveOrganizationID,
 		OrganizationSlug:   authCtx.OrganizationSlug,
 		SuccessURL:         billingURL,
 		CancelURL:          billingURL,
-		TrialEnd:           trialEnd,
-		BillingCycleAnchor: billingCycleAnchor,
-		IdempotencyKey:     fmt.Sprintf("checkout-session:%s", authCtx.ActiveOrganizationID),
+		TrialEnd:           preparedIntent.trialEnd,
+		BillingCycleAnchor: preparedIntent.billingCycleAnchor,
+		ExpiresAt:          preparedIntent.expiresAt,
+		IdempotencyKey:     preparedIntent.idempotencyKey,
 	})
 	if err != nil {
 		return "", oops.E(oops.CodeUnexpected, err, "failed to create Stripe Checkout session").LogError(ctx, s.logger)
 	}
-	if checkout.URL == "" {
-		return "", oops.E(oops.CodeUnexpected, nil, "Stripe Checkout did not return a hosted URL").LogError(ctx, s.logger)
+	if checkout.ID == "" || checkout.URL == "" {
+		return "", oops.E(oops.CodeUnexpected, nil, "Stripe Checkout did not return a complete hosted session").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "failed to store Stripe customer").LogError(ctx, s.logger)
+		return "", oops.E(oops.CodeUnexpected, err, "failed to finalize Stripe Checkout").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
-	stored, err := repo.New(dbtx).StoreStripeCustomer(ctx, repo.StoreStripeCustomerParams{
-		OrganizationID:   authCtx.ActiveOrganizationID,
-		StripeCustomerID: pgtype.Text{String: customerID, Valid: true},
+	finalized, err := repo.New(dbtx).FinalizeStripeCheckoutIntent(ctx, repo.FinalizeStripeCheckoutIntentParams{
+		StripeCheckoutSessionID:          checkout.ID,
+		OrganizationID:                   authCtx.ActiveOrganizationID,
+		StripeCustomerID:                 preparedIntent.customerID,
+		StripeCheckoutIdempotencyKey:     preparedIntent.idempotencyKey,
+		StripeCheckoutBillingCycleAnchor: finiteTimestamptz(preparedIntent.billingCycleAnchor),
+		StripeCheckoutTrialEnd:           optionalTimestamptz(preparedIntent.trialEnd),
+		StripeCheckoutExpiresAt:          finiteTimestamptz(preparedIntent.expiresAt),
 	})
 	if err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "failed to store Stripe customer").LogError(ctx, s.logger)
-	}
-	if !stored.StripeCustomerID.Valid || stored.StripeCustomerID.String != customerID {
-		return "", oops.E(oops.CodeConflict, nil, "billing customer changed while Checkout was being created").LogWarn(ctx, s.logger)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", oops.E(oops.CodeConflict, nil, "billing state changed while Checkout was being created").LogWarn(ctx, s.logger)
+		}
+		return "", oops.E(oops.CodeUnexpected, err, "failed to finalize Stripe Checkout").LogError(ctx, s.logger)
 	}
 
-	if err := s.auditLogger.LogBillingMetadataCreateStripeCheckout(ctx, dbtx, audit.LogBillingMetadataCreateStripeCheckoutEvent{
-		OrganizationID:     authCtx.ActiveOrganizationID,
-		Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName:   authCtx.Email,
-		ActorSlug:          nil,
-		BillingMetadataURN: urn.NewBillingMetadata(stored.ID),
-	}); err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "failed to record Stripe Checkout audit event").LogError(ctx, s.logger)
+	if finalized.AttachedNewSession {
+		if err := s.auditLogger.LogBillingMetadataCreateStripeCheckout(ctx, dbtx, audit.LogBillingMetadataCreateStripeCheckoutEvent{
+			OrganizationID:     authCtx.ActiveOrganizationID,
+			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName:   authCtx.Email,
+			ActorSlug:          nil,
+			BillingMetadataURN: urn.NewBillingMetadata(finalized.BillingMetadataID),
+		}); err != nil {
+			return "", oops.E(oops.CodeUnexpected, err, "failed to record Stripe Checkout audit event").LogError(ctx, s.logger)
+		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "failed to store Stripe customer").LogError(ctx, s.logger)
+		return "", oops.E(oops.CodeUnexpected, err, "failed to finalize Stripe Checkout").LogError(ctx, s.logger)
 	}
 
 	return checkout.URL, nil
+}
+
+func (s *Service) prepareStripeCheckoutIntent(
+	ctx context.Context,
+	organizationID string,
+	customerID string,
+	preparedAt time.Time,
+	proposed stripeCheckoutIntent,
+	replaceExpiredSessionID pgtype.Text,
+) (preparedStripeCheckoutIntent, error) {
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return preparedStripeCheckoutIntent{}, oops.E(oops.CodeUnexpected, err, "failed to prepare Stripe Checkout").LogError(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	queries := repo.New(dbtx)
+	stored, err := queries.StoreStripeCustomer(ctx, repo.StoreStripeCustomerParams{
+		OrganizationID:   organizationID,
+		StripeCustomerID: pgtype.Text{String: customerID, Valid: true},
+	})
+	if err != nil {
+		return preparedStripeCheckoutIntent{}, oops.E(oops.CodeUnexpected, err, "failed to store Stripe customer").LogError(ctx, s.logger)
+	}
+	if !stored.StripeCustomerID.Valid || stored.StripeCustomerID.String != customerID {
+		return preparedStripeCheckoutIntent{}, oops.E(oops.CodeConflict, nil, "billing customer changed while Checkout was being prepared").LogWarn(ctx, s.logger)
+	}
+
+	prepared, err := queries.PrepareStripeCheckoutIntent(ctx, repo.PrepareStripeCheckoutIntentParams{
+		StripeCheckoutIdempotencyKey:     proposed.idempotencyKey,
+		StripeCheckoutBillingCycleAnchor: finiteTimestamptz(proposed.billingCycleAnchor),
+		StripeCheckoutTrialEnd:           optionalTimestamptz(proposed.trialEnd),
+		StripeCheckoutExpiresAt:          finiteTimestamptz(proposed.expiresAt),
+		PreparedAt:                       finiteTimestamptz(preparedAt),
+		OrganizationID:                   organizationID,
+		StripeCustomerID:                 customerID,
+		ReplaceExpiredSessionID:          replaceExpiredSessionID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return preparedStripeCheckoutIntent{}, oops.E(oops.CodeConflict, nil, "billing state changed while Checkout was being prepared").LogWarn(ctx, s.logger)
+		}
+		return preparedStripeCheckoutIntent{}, oops.E(oops.CodeUnexpected, err, "failed to prepare Stripe Checkout").LogError(ctx, s.logger)
+	}
+
+	intent, err := checkoutIntentFromRow(prepared)
+	if err != nil {
+		return preparedStripeCheckoutIntent{}, oops.E(oops.CodeUnexpected, err, "stored Stripe Checkout intent is incomplete").LogError(ctx, s.logger)
+	}
+	if err := dbtx.Commit(ctx); err != nil {
+		return preparedStripeCheckoutIntent{}, oops.E(oops.CodeUnexpected, err, "failed to prepare Stripe Checkout").LogError(ctx, s.logger)
+	}
+
+	return preparedStripeCheckoutIntent{
+		stripeCheckoutIntent: intent,
+		customerID:           customerID,
+	}, nil
+}
+
+func (s *Service) expiredCheckoutSessionForReplacement(
+	ctx context.Context,
+	metadata repo.BillingMetadatum,
+	customerID string,
+	now time.Time,
+) (pgtype.Text, error) {
+	if !metadata.StripeCheckoutSessionID.Valid ||
+		!metadata.StripeCheckoutExpiresAt.Valid ||
+		metadata.StripeCheckoutExpiresAt.Time.After(now) {
+		return pgtype.Text{String: "", Valid: false}, nil
+	}
+
+	sessionID := metadata.StripeCheckoutSessionID.String
+	state, err := s.stripeClient.GetCheckoutSession(ctx, sessionID)
+	if err != nil {
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeUnavailable, err, "failed to verify the previous Stripe Checkout session").LogWarn(ctx, s.logger)
+	}
+	if state == nil || state.ID != sessionID || state.CustomerID != customerID {
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeUnavailable, nil, "previous Stripe Checkout state does not match billing metadata").LogWarn(ctx, s.logger)
+	}
+	if state.Status != "expired" || state.SubscriptionID != "" {
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeConflict, nil, "the previous Stripe Checkout session is still being reconciled").LogWarn(ctx, s.logger)
+	}
+
+	return pgtype.Text{String: sessionID, Valid: true}, nil
+}
+
+func checkoutIntentFromRow(row repo.PrepareStripeCheckoutIntentRow) (stripeCheckoutIntent, error) {
+	if !row.StripeCheckoutIdempotencyKey.Valid ||
+		!row.StripeCheckoutBillingCycleAnchor.Valid ||
+		!row.StripeCheckoutExpiresAt.Valid {
+		return stripeCheckoutIntent{}, errors.New("required Checkout intent field is null")
+	}
+
+	var trialEnd *time.Time
+	if row.StripeCheckoutTrialEnd.Valid {
+		value := row.StripeCheckoutTrialEnd.Time.UTC()
+		trialEnd = &value
+	}
+
+	return stripeCheckoutIntent{
+		idempotencyKey:     row.StripeCheckoutIdempotencyKey.String,
+		billingCycleAnchor: row.StripeCheckoutBillingCycleAnchor.Time.UTC(),
+		trialEnd:           trialEnd,
+		expiresAt:          row.StripeCheckoutExpiresAt.Time.UTC(),
+	}, nil
+}
+
+func newStripeCheckoutIntent(organizationID string, now time.Time, productTrialEnd *time.Time) stripeCheckoutIntent {
+	now = now.UTC().Truncate(time.Second)
+	anchor := nextStripeBillingCycleAnchor(now, productTrialEnd)
+	if productTrialEnd == nil && anchor.Sub(now) < minimumStripeCheckoutSessionLifetime+stripeCheckoutExpirySafetyMargin {
+		anchor = anchor.AddDate(0, 0, 1)
+	}
+
+	expiresAt := anchor.Add(-stripeCheckoutExpirySafetyMargin)
+	latestExpiration := now.Add(maximumStripeCheckoutSessionLifetime - stripeCheckoutExpirySafetyMargin)
+	if latestExpiration.Before(expiresAt) {
+		expiresAt = latestExpiration
+	}
+
+	var stripeTrialEnd *time.Time
+	if productTrialEnd != nil {
+		alignedTrialEnd := anchor
+		stripeTrialEnd = &alignedTrialEnd
+	}
+
+	return stripeCheckoutIntent{
+		idempotencyKey:     fmt.Sprintf("checkout-session:%s:%d:%d", organizationID, anchor.Unix(), expiresAt.Unix()),
+		billingCycleAnchor: anchor,
+		trialEnd:           stripeTrialEnd,
+		expiresAt:          expiresAt,
+	}
+}
+
+func finiteTimestamptz(value time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: value.UTC(), InfinityModifier: pgtype.Finite, Valid: true}
+}
+
+func optionalTimestamptz(value *time.Time) pgtype.Timestamptz {
+	if value == nil {
+		return pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}
+	}
+	return finiteTimestamptz(*value)
 }
 
 func nextStripeBillingCycleAnchor(now time.Time, trialEnd *time.Time) time.Time {

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -125,13 +125,14 @@ func TestCheckoutStripeClientRejectsIdempotencyKeyReuseWithDifferentInput(t *tes
 
 	client := newCheckoutStripeClient()
 	input := stripeclient.CreateCheckoutSessionInput{
-		CustomerID:       "cus_first",
-		OrganizationID:   "<ORG_ID>",
-		OrganizationSlug: "billing-test",
-		SuccessURL:       "https://app.example.test/billing-test/billing",
-		CancelURL:        "https://app.example.test/billing-test/billing",
-		TrialEnd:         nil,
-		IdempotencyKey:   "checkout-session:<ORG_ID>",
+		CustomerID:         "cus_first",
+		OrganizationID:     "<ORG_ID>",
+		OrganizationSlug:   "billing-test",
+		SuccessURL:         "https://app.example.test/billing-test/billing",
+		CancelURL:          "https://app.example.test/billing-test/billing",
+		TrialEnd:           nil,
+		BillingCycleAnchor: time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC),
+		IdempotencyKey:     "checkout-session:<ORG_ID>",
 	}
 
 	_, err := client.CreateCheckoutSession(t.Context(), input)
@@ -139,6 +140,53 @@ func TestCheckoutStripeClientRejectsIdempotencyKeyReuseWithDifferentInput(t *tes
 	input.CustomerID = "cus_second"
 	_, err = client.CreateCheckoutSession(t.Context(), input)
 	require.ErrorContains(t, err, "reused with different checkout input")
+}
+
+func TestNextStripeBillingCycleAnchor(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 13, 45, 0, 0, time.FixedZone("test", 2*60*60))
+	trialAtMidnight := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+	trialDuringDay := time.Date(2026, time.August, 21, 9, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		now      time.Time
+		trialEnd *time.Time
+		want     time.Time
+	}{
+		{
+			name:     "immediate checkout uses next UTC midnight",
+			now:      now,
+			trialEnd: nil,
+			want:     time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "immediate checkout at midnight still gets a free day stub",
+			now:      time.Date(2026, time.August, 14, 0, 0, 0, 0, time.UTC),
+			trialEnd: nil,
+			want:     time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "midnight trial end is already aligned",
+			now:      now,
+			trialEnd: &trialAtMidnight,
+			want:     trialAtMidnight,
+		},
+		{
+			name:     "daytime trial end gets a free stub to midnight",
+			now:      now,
+			trialEnd: &trialDuringDay,
+			want:     time.Date(2026, time.August, 22, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, nextStripeBillingCycleAnchor(tt.now, tt.trialEnd))
+		})
+	}
 }
 
 type stripeCheckoutTestInstance struct {

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
@@ -42,10 +41,13 @@ type checkoutStripeClient struct {
 	checkoutInputs  []stripeclient.CreateCheckoutSessionInput
 	customerError   error
 	checkoutError   error
+	checkoutState   *stripeclient.CheckoutSessionState
+	checkoutGetErr  error
 }
 
 type checkoutStripeResult struct {
 	input stripeclient.CreateCheckoutSessionInput
+	id    string
 	url   string
 }
 
@@ -86,15 +88,26 @@ func (c *checkoutStripeClient) CreateCheckoutSession(_ context.Context, input st
 		if !reflect.DeepEqual(result.input, input) {
 			return nil, fmt.Errorf("idempotency key %q reused with different checkout input", input.IdempotencyKey)
 		}
-		return &stripeclient.CheckoutSession{URL: result.url}, nil
+		return &stripeclient.CheckoutSession{ID: result.id, URL: result.url}, nil
 	}
+	checkoutID := fmt.Sprintf("cs_%d", len(c.checkoutResults)+1)
 	checkoutURL := fmt.Sprintf("https://checkout.stripe.test/%d", len(c.checkoutResults)+1)
-	c.checkoutResults[input.IdempotencyKey] = checkoutStripeResult{input: input, url: checkoutURL}
-	return &stripeclient.CheckoutSession{URL: checkoutURL}, nil
+	c.checkoutResults[input.IdempotencyKey] = checkoutStripeResult{input: input, id: checkoutID, url: checkoutURL}
+	return &stripeclient.CheckoutSession{ID: checkoutID, URL: checkoutURL}, nil
 }
 
-func (c *checkoutStripeClient) GetCheckoutSession(context.Context, string) (*stripeclient.CheckoutSessionState, error) {
-	return nil, errors.New("not implemented")
+func (c *checkoutStripeClient) GetCheckoutSession(_ context.Context, id string) (*stripeclient.CheckoutSessionState, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.checkoutGetErr != nil {
+		return nil, c.checkoutGetErr
+	}
+	if c.checkoutState == nil || c.checkoutState.ID != id {
+		return nil, errors.New("checkout session not found")
+	}
+	state := *c.checkoutState
+	return &state, nil
 }
 
 func (c *checkoutStripeClient) CreateMeterEvent(context.Context, stripeclient.CreateMeterEventInput) error {
@@ -189,6 +202,42 @@ func TestNextStripeBillingCycleAnchor(t *testing.T) {
 	}
 }
 
+func TestNewStripeCheckoutIntent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 13, 45, 0, 0, time.UTC)
+	productTrialEnd := time.Date(2026, time.August, 21, 9, 30, 0, 0, time.UTC)
+
+	t.Run("active product trial uses aligned Stripe trial end", func(t *testing.T) {
+		t.Parallel()
+		intent := newStripeCheckoutIntent("<ORG_ID>", now, &productTrialEnd)
+		wantAnchor := time.Date(2026, time.August, 22, 0, 0, 0, 0, time.UTC)
+		require.Equal(t, wantAnchor, intent.billingCycleAnchor)
+		require.NotNil(t, intent.trialEnd)
+		require.Equal(t, wantAnchor, *intent.trialEnd)
+		require.Equal(t, now.Add(23*time.Hour+59*time.Minute), intent.expiresAt)
+	})
+
+	t.Run("immediate checkout expires at the next midnight anchor", func(t *testing.T) {
+		t.Parallel()
+		intent := newStripeCheckoutIntent("<ORG_ID>", now, nil)
+		wantAnchor := time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC)
+		require.Equal(t, wantAnchor, intent.billingCycleAnchor)
+		require.Nil(t, intent.trialEnd)
+		require.Equal(t, wantAnchor.Add(-stripeCheckoutExpirySafetyMargin), intent.expiresAt)
+	})
+
+	t.Run("checkout near midnight moves to the following anchor", func(t *testing.T) {
+		t.Parallel()
+		nearMidnight := time.Date(2026, time.August, 14, 23, 45, 0, 0, time.UTC)
+		intent := newStripeCheckoutIntent("<ORG_ID>", nearMidnight, nil)
+		require.Equal(t, time.Date(2026, time.August, 16, 0, 0, 0, 0, time.UTC), intent.billingCycleAnchor)
+		require.Equal(t, nearMidnight.Add(23*time.Hour+59*time.Minute), intent.expiresAt)
+		require.GreaterOrEqual(t, intent.expiresAt.Sub(nearMidnight), minimumStripeCheckoutSessionLifetime)
+		require.Less(t, intent.expiresAt, intent.billingCycleAnchor)
+	})
+}
+
 type stripeCheckoutTestInstance struct {
 	service *Service
 	db      repo.DBTX
@@ -279,6 +328,33 @@ func (ti *stripeCheckoutTestInstance) adminContext(t *testing.T) context.Context
 	return ti.context(t, authz.NewGrant(authz.ScopeOrgAdmin, ti.orgID))
 }
 
+func seedExpiredCheckoutSession(t *testing.T, ti *stripeCheckoutTestInstance, sessionID string) stripeCheckoutIntent {
+	t.Helper()
+	preparedAt := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Second)
+	proposal := newStripeCheckoutIntent(ti.orgID, preparedAt, nil)
+	prepared, err := ti.service.prepareStripeCheckoutIntent(
+		t.Context(),
+		ti.orgID,
+		"cus_test",
+		preparedAt,
+		proposal,
+		pgtype.Text{String: "", Valid: false},
+	)
+	require.NoError(t, err)
+	_, err = repo.New(ti.db).FinalizeStripeCheckoutIntent(t.Context(), repo.FinalizeStripeCheckoutIntentParams{
+		StripeCheckoutSessionID:          sessionID,
+		OrganizationID:                   ti.orgID,
+		StripeCustomerID:                 "cus_test",
+		StripeCheckoutIdempotencyKey:     prepared.idempotencyKey,
+		StripeCheckoutBillingCycleAnchor: finiteTimestamptz(prepared.billingCycleAnchor),
+		StripeCheckoutTrialEnd:           optionalTimestamptz(prepared.trialEnd),
+		StripeCheckoutExpiresAt:          finiteTimestamptz(prepared.expiresAt),
+	})
+	require.NoError(t, err)
+	require.LessOrEqual(t, prepared.expiresAt, time.Now().UTC())
+	return prepared.stripeCheckoutIntent
+}
+
 func requireOopsCode(t *testing.T, err error, code oops.Code) {
 	t.Helper()
 	var shareable *oops.ShareableError
@@ -344,7 +420,8 @@ func TestCreateStripeCheckoutAllowsGatedOrganizationAdmin(t *testing.T) {
 	require.Equal(t, "https://app.example.test/"+ti.orgSlug+"/billing", checkouts[0].SuccessURL)
 	require.Equal(t, checkouts[0].SuccessURL, checkouts[0].CancelURL)
 	require.Nil(t, checkouts[0].TrialEnd)
-	require.Equal(t, "checkout-session:"+ti.orgID, checkouts[0].IdempotencyKey)
+	require.Equal(t, stripeCheckoutExpirySafetyMargin, checkouts[0].BillingCycleAnchor.Sub(checkouts[0].ExpiresAt))
+	require.Contains(t, checkouts[0].IdempotencyKey, "checkout-session:"+ti.orgID+":")
 }
 
 func TestCreateStripeCheckoutFailsClosedWithoutRolloutProvider(t *testing.T) {
@@ -361,7 +438,7 @@ func TestCreateStripeCheckoutFailsClosedWithoutRolloutProvider(t *testing.T) {
 	require.Empty(t, checkouts)
 }
 
-func TestCreateStripeCheckoutPreservesActiveTrialEnd(t *testing.T) {
+func TestCreateStripeCheckoutAlignsStripeTrialEndWithoutChangingProductTrial(t *testing.T) {
 	t.Parallel()
 
 	ti := newStripeCheckoutTestInstance(t)
@@ -377,7 +454,14 @@ func TestCreateStripeCheckoutPreservesActiveTrialEnd(t *testing.T) {
 	_, _, checkouts := ti.stripe.snapshot()
 	require.Len(t, checkouts, 1)
 	require.NotNil(t, checkouts[0].TrialEnd)
-	require.Equal(t, trialEnd, *checkouts[0].TrialEnd)
+	wantAnchor := nextStripeBillingCycleAnchor(time.Now(), &trialEnd)
+	require.Equal(t, wantAnchor, *checkouts[0].TrialEnd)
+	require.Equal(t, wantAnchor, checkouts[0].BillingCycleAnchor)
+	require.Less(t, checkouts[0].ExpiresAt, wantAnchor)
+
+	storedTrial, err := trialsrepo.New(ti.db).GetActiveTrial(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.True(t, trialEnd.Equal(storedTrial.EndsAt.Time))
 }
 
 func TestCreateStripeCheckoutStartsImmediatelyWhenTrialExpired(t *testing.T) {
@@ -510,6 +594,82 @@ func TestCreateStripeCheckoutSequentialRequestsCreateCustomerOnce(t *testing.T) 
 	require.Len(t, checkouts, 2)
 	require.Equal(t, checkouts[0].CustomerID, checkouts[1].CustomerID)
 	require.Equal(t, checkouts[0].IdempotencyKey, checkouts[1].IdempotencyKey)
+	require.Equal(t, checkouts[0], checkouts[1])
+	auditCount, err := audittest.AuditLogCountByAction(t.Context(), ti.db, audit.ActionBillingMetadataCreateStripeCheckout)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, auditCount)
+}
+
+func TestPrepareStripeCheckoutIntentReusesAcrossMidnightAndRotatesAfterExpiry(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	beforeMidnight := time.Date(2026, time.August, 14, 23, 50, 0, 0, time.UTC)
+	firstProposal := newStripeCheckoutIntent(ti.orgID, beforeMidnight, nil)
+	first, err := ti.service.prepareStripeCheckoutIntent(t.Context(), ti.orgID, "cus_test", beforeMidnight, firstProposal, pgtype.Text{String: "", Valid: false})
+	require.NoError(t, err)
+
+	afterMidnight := time.Date(2026, time.August, 15, 0, 10, 0, 0, time.UTC)
+	secondProposal := newStripeCheckoutIntent(ti.orgID, afterMidnight, nil)
+	require.NotEqual(t, firstProposal.idempotencyKey, secondProposal.idempotencyKey)
+	second, err := ti.service.prepareStripeCheckoutIntent(t.Context(), ti.orgID, "cus_test", afterMidnight, secondProposal, pgtype.Text{String: "", Valid: false})
+	require.NoError(t, err)
+	require.Equal(t, first.stripeCheckoutIntent, second.stripeCheckoutIntent)
+
+	afterExpiry := first.expiresAt.Add(time.Second)
+	replacementProposal := newStripeCheckoutIntent(ti.orgID, afterExpiry, nil)
+	replacement, err := ti.service.prepareStripeCheckoutIntent(t.Context(), ti.orgID, "cus_test", afterExpiry, replacementProposal, pgtype.Text{String: "", Valid: false})
+	require.NoError(t, err)
+	require.Equal(t, replacementProposal, replacement.stripeCheckoutIntent)
+	require.NotEqual(t, first.idempotencyKey, replacement.idempotencyKey)
+}
+
+func TestCreateStripeCheckoutDoesNotRotateCompletedExpiredSession(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	oldIntent := seedExpiredCheckoutSession(t, ti, "cs_completed")
+	ti.stripe.checkoutState = &stripeclient.CheckoutSessionState{
+		ID:             "cs_completed",
+		Status:         "complete",
+		CustomerID:     "cus_test",
+		SubscriptionID: "sub_delayed_webhook",
+	}
+
+	_, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeConflict)
+	_, _, checkouts := ti.stripe.snapshot()
+	require.Empty(t, checkouts)
+
+	stored, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.Equal(t, oldIntent.idempotencyKey, stored.StripeCheckoutIdempotencyKey.String)
+	require.Equal(t, "cs_completed", stored.StripeCheckoutSessionID.String)
+}
+
+func TestCreateStripeCheckoutRotatesStripeConfirmedExpiredSession(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	oldIntent := seedExpiredCheckoutSession(t, ti, "cs_expired")
+	ti.stripe.checkoutState = &stripeclient.CheckoutSessionState{
+		ID:         "cs_expired",
+		Status:     "expired",
+		CustomerID: "cus_test",
+	}
+
+	checkoutURL, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+	require.Equal(t, "https://checkout.stripe.test/1", checkoutURL)
+	_, _, checkouts := ti.stripe.snapshot()
+	require.Len(t, checkouts, 1)
+	require.NotEqual(t, oldIntent.idempotencyKey, checkouts[0].IdempotencyKey)
+
+	stored, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.Equal(t, checkouts[0].IdempotencyKey, stored.StripeCheckoutIdempotencyKey.String)
+	require.Equal(t, "cs_1", stored.StripeCheckoutSessionID.String)
 }
 
 func TestCreateStripeCheckoutAuditsActingUserWithoutStripeMetadata(t *testing.T) {
@@ -569,8 +729,8 @@ func TestCreateStripeCheckoutConcurrentDoubleClickCreatesOneCustomer(t *testing.
 		require.Equal(t, "customer:"+ti.orgID, customer.IdempotencyKey)
 	}
 	require.Len(t, checkouts, 2)
-	require.Equal(t, "checkout-session:"+ti.orgID, checkouts[0].IdempotencyKey)
 	require.Equal(t, checkouts[0].IdempotencyKey, checkouts[1].IdempotencyKey)
+	require.Equal(t, checkouts[0], checkouts[1])
 
 	stored, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
 	require.NoError(t, err)
@@ -578,7 +738,7 @@ func TestCreateStripeCheckoutConcurrentDoubleClickCreatesOneCustomer(t *testing.
 	require.Equal(t, "cus_1", stored.StripeCustomerID.String)
 }
 
-func TestCreateStripeCheckoutDoesNotPersistCustomerWhenCheckoutFails(t *testing.T) {
+func TestCreateStripeCheckoutPersistsIntentWhenCheckoutFails(t *testing.T) {
 	t.Parallel()
 
 	ti := newStripeCheckoutTestInstance(t)
@@ -587,8 +747,13 @@ func TestCreateStripeCheckoutDoesNotPersistCustomerWhenCheckoutFails(t *testing.
 	_, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
 	require.Error(t, err)
 	requireOopsCode(t, err, oops.CodeUnexpected)
-	_, err = repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
-	require.ErrorIs(t, err, pgx.ErrNoRows)
+	stored, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.True(t, stored.StripeCustomerID.Valid)
+	require.True(t, stored.StripeCheckoutIdempotencyKey.Valid)
+	require.True(t, stored.StripeCheckoutBillingCycleAnchor.Valid)
+	require.True(t, stored.StripeCheckoutExpiresAt.Valid)
+	require.False(t, stored.StripeCheckoutSessionID.Valid)
 
 	count, err := audittest.AuditLogCountByAction(t.Context(), ti.db, audit.ActionBillingMetadataCreateStripeCheckout)
 	require.NoError(t, err)

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -58,6 +58,7 @@ SELECT
     billing_metadata.id AS billing_metadata_id
   , billing_metadata.stripe_customer_id
   , billing_metadata.stripe_subscription_id
+  , billing_metadata.stripe_billing_cycle_anchor
   , billing_metadata.billing_cycle_anchor_day
   , organization_metadata.name AS organization_name
   , organization_metadata.slug AS organization_slug
@@ -78,6 +79,7 @@ ORDER BY organization_id;
 -- name: ActivatePaygBillingMetadata :one
 UPDATE billing_metadata
 SET stripe_subscription_id = @stripe_subscription_id,
+    stripe_billing_cycle_anchor = @stripe_billing_cycle_anchor,
     billing_cycle_anchor_day = @billing_cycle_anchor_day,
     updated_at = clock_timestamp()
 WHERE organization_id = @organization_id

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -21,6 +21,125 @@ ON CONFLICT (organization_id) DO UPDATE SET
     END
 RETURNING *;
 
+-- name: PrepareStripeCheckoutIntent :one
+-- Call inside the Checkout transaction after the Stripe customer is stored.
+-- The row lock makes concurrent callers reuse one live intent. Once it expires,
+-- a caller may replace it only while no subscription has been activated.
+WITH locked AS (
+  SELECT
+      id
+    , stripe_checkout_idempotency_key
+    , stripe_checkout_billing_cycle_anchor
+    , stripe_checkout_trial_end
+    , stripe_checkout_expires_at
+    , stripe_checkout_session_id
+    , (
+        stripe_checkout_idempotency_key IS NOT NULL
+        AND stripe_checkout_billing_cycle_anchor IS NOT NULL
+        AND stripe_checkout_expires_at > sqlc.arg(prepared_at)::timestamptz
+      ) AS reuse_existing_intent
+  FROM billing_metadata
+  WHERE organization_id = sqlc.arg(organization_id)::text
+    AND stripe_customer_id = sqlc.arg(stripe_customer_id)::text
+  FOR UPDATE
+), prepared AS (
+  UPDATE billing_metadata AS metadata
+  SET
+      stripe_checkout_idempotency_key = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_idempotency_key
+        ELSE sqlc.arg(stripe_checkout_idempotency_key)::text
+      END
+    , stripe_checkout_billing_cycle_anchor = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_billing_cycle_anchor
+        ELSE sqlc.arg(stripe_checkout_billing_cycle_anchor)::timestamptz
+      END
+    , stripe_checkout_trial_end = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_trial_end
+        ELSE sqlc.narg(stripe_checkout_trial_end)::timestamptz
+      END
+    , stripe_checkout_expires_at = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_expires_at
+        ELSE sqlc.arg(stripe_checkout_expires_at)::timestamptz
+      END
+    , stripe_checkout_session_id = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_session_id
+        ELSE NULL
+      END
+    , updated_at = CASE
+        WHEN locked.reuse_existing_intent THEN metadata.updated_at
+        ELSE clock_timestamp()
+      END
+  FROM locked
+  WHERE metadata.id = locked.id
+    AND metadata.stripe_subscription_id IS NULL
+    -- An expired intent with a known remote session rotates only after the
+    -- caller has checked that exact session and explicitly authorizes replacing
+    -- it. A sessionless intent has no remote completion race to guard.
+    AND (
+      locked.reuse_existing_intent
+      OR locked.stripe_checkout_session_id IS NULL
+      OR locked.stripe_checkout_session_id = sqlc.narg(replace_expired_session_id)::text
+    )
+  RETURNING
+      metadata.id AS billing_metadata_id
+    , metadata.stripe_customer_id
+    , metadata.stripe_checkout_idempotency_key
+    , metadata.stripe_checkout_billing_cycle_anchor
+    , metadata.stripe_checkout_trial_end
+    , metadata.stripe_checkout_expires_at
+    , metadata.stripe_checkout_session_id
+    , locked.reuse_existing_intent
+)
+SELECT
+    billing_metadata_id
+  , stripe_customer_id
+  , stripe_checkout_idempotency_key
+  , stripe_checkout_billing_cycle_anchor
+  , stripe_checkout_trial_end
+  , stripe_checkout_expires_at
+  , stripe_checkout_session_id
+  , COALESCE(reuse_existing_intent, FALSE)::boolean AS reuse_existing_intent
+FROM prepared;
+
+-- name: FinalizeStripeCheckoutIntent :one
+-- Attach the remote session only to the exact intent used to create it. A retry
+-- may confirm the same session, but cannot replace it with another session ID.
+WITH locked AS (
+  SELECT
+      id
+    , stripe_checkout_session_id IS NULL AS attach_new_session
+  FROM billing_metadata
+  WHERE organization_id = sqlc.arg(organization_id)::text
+    AND stripe_customer_id = sqlc.arg(stripe_customer_id)::text
+  FOR UPDATE
+), finalized AS (
+  UPDATE billing_metadata AS metadata
+  SET
+      stripe_checkout_session_id = sqlc.arg(stripe_checkout_session_id)::text
+    , updated_at = CASE
+        WHEN locked.attach_new_session THEN clock_timestamp()
+        ELSE metadata.updated_at
+      END
+  FROM locked
+  WHERE metadata.id = locked.id
+    AND metadata.stripe_subscription_id IS NULL
+    AND metadata.stripe_checkout_idempotency_key = sqlc.arg(stripe_checkout_idempotency_key)::text
+    AND metadata.stripe_checkout_billing_cycle_anchor = sqlc.arg(stripe_checkout_billing_cycle_anchor)::timestamptz
+    AND metadata.stripe_checkout_trial_end IS NOT DISTINCT FROM sqlc.narg(stripe_checkout_trial_end)::timestamptz
+    AND metadata.stripe_checkout_expires_at = sqlc.arg(stripe_checkout_expires_at)::timestamptz
+    AND (
+      metadata.stripe_checkout_session_id IS NULL
+      OR metadata.stripe_checkout_session_id = sqlc.arg(stripe_checkout_session_id)::text
+    )
+  RETURNING
+      metadata.id AS billing_metadata_id
+    , locked.attach_new_session
+)
+SELECT
+    billing_metadata_id
+  , COALESCE(attach_new_session, FALSE)::boolean AS attached_new_session
+FROM finalized;
+
 -- name: GetBillingMetadataOrganizationByStripeCustomerID :one
 SELECT organization_id
 FROM billing_metadata
@@ -80,6 +199,11 @@ ORDER BY organization_id;
 UPDATE billing_metadata
 SET stripe_subscription_id = @stripe_subscription_id,
     stripe_billing_cycle_anchor = @stripe_billing_cycle_anchor,
+    stripe_checkout_idempotency_key = NULL,
+    stripe_checkout_billing_cycle_anchor = NULL,
+    stripe_checkout_trial_end = NULL,
+    stripe_checkout_expires_at = NULL,
+    stripe_checkout_session_id = NULL,
     billing_cycle_anchor_day = @billing_cycle_anchor_day,
     updated_at = clock_timestamp()
 WHERE organization_id = @organization_id

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -26,6 +26,11 @@ const activatePaygBillingMetadata = `-- name: ActivatePaygBillingMetadata :one
 UPDATE billing_metadata
 SET stripe_subscription_id = $1,
     stripe_billing_cycle_anchor = $2,
+    stripe_checkout_idempotency_key = NULL,
+    stripe_checkout_billing_cycle_anchor = NULL,
+    stripe_checkout_trial_end = NULL,
+    stripe_checkout_expires_at = NULL,
+    stripe_checkout_session_id = NULL,
     billing_cycle_anchor_day = $3,
     updated_at = clock_timestamp()
 WHERE organization_id = $4
@@ -130,6 +135,76 @@ type CreateStripeSubscriptionBillingMetadataFixtureParams struct {
 func (q *Queries) CreateStripeSubscriptionBillingMetadataFixture(ctx context.Context, arg CreateStripeSubscriptionBillingMetadataFixtureParams) error {
 	_, err := q.db.Exec(ctx, createStripeSubscriptionBillingMetadataFixture, arg.OrganizationID, arg.StripeCustomerID, arg.StripeSubscriptionID)
 	return err
+}
+
+const finalizeStripeCheckoutIntent = `-- name: FinalizeStripeCheckoutIntent :one
+WITH locked AS (
+  SELECT
+      id
+    , stripe_checkout_session_id IS NULL AS attach_new_session
+  FROM billing_metadata
+  WHERE organization_id = $1::text
+    AND stripe_customer_id = $2::text
+  FOR UPDATE
+), finalized AS (
+  UPDATE billing_metadata AS metadata
+  SET
+      stripe_checkout_session_id = $3::text
+    , updated_at = CASE
+        WHEN locked.attach_new_session THEN clock_timestamp()
+        ELSE metadata.updated_at
+      END
+  FROM locked
+  WHERE metadata.id = locked.id
+    AND metadata.stripe_subscription_id IS NULL
+    AND metadata.stripe_checkout_idempotency_key = $4::text
+    AND metadata.stripe_checkout_billing_cycle_anchor = $5::timestamptz
+    AND metadata.stripe_checkout_trial_end IS NOT DISTINCT FROM $6::timestamptz
+    AND metadata.stripe_checkout_expires_at = $7::timestamptz
+    AND (
+      metadata.stripe_checkout_session_id IS NULL
+      OR metadata.stripe_checkout_session_id = $3::text
+    )
+  RETURNING
+      metadata.id AS billing_metadata_id
+    , locked.attach_new_session
+)
+SELECT
+    billing_metadata_id
+  , COALESCE(attach_new_session, FALSE)::boolean AS attached_new_session
+FROM finalized
+`
+
+type FinalizeStripeCheckoutIntentParams struct {
+	OrganizationID                   string
+	StripeCustomerID                 string
+	StripeCheckoutSessionID          string
+	StripeCheckoutIdempotencyKey     string
+	StripeCheckoutBillingCycleAnchor pgtype.Timestamptz
+	StripeCheckoutTrialEnd           pgtype.Timestamptz
+	StripeCheckoutExpiresAt          pgtype.Timestamptz
+}
+
+type FinalizeStripeCheckoutIntentRow struct {
+	BillingMetadataID  uuid.UUID
+	AttachedNewSession bool
+}
+
+// Attach the remote session only to the exact intent used to create it. A retry
+// may confirm the same session, but cannot replace it with another session ID.
+func (q *Queries) FinalizeStripeCheckoutIntent(ctx context.Context, arg FinalizeStripeCheckoutIntentParams) (FinalizeStripeCheckoutIntentRow, error) {
+	row := q.db.QueryRow(ctx, finalizeStripeCheckoutIntent,
+		arg.OrganizationID,
+		arg.StripeCustomerID,
+		arg.StripeCheckoutSessionID,
+		arg.StripeCheckoutIdempotencyKey,
+		arg.StripeCheckoutBillingCycleAnchor,
+		arg.StripeCheckoutTrialEnd,
+		arg.StripeCheckoutExpiresAt,
+	)
+	var i FinalizeStripeCheckoutIntentRow
+	err := row.Scan(&i.BillingMetadataID, &i.AttachedNewSession)
+	return i, err
 }
 
 const getBillingMetadata = `-- name: GetBillingMetadata :one
@@ -369,6 +444,134 @@ func (q *Queries) ListStripeSubscriptionOwners(ctx context.Context, stripeSubscr
 		return nil, err
 	}
 	return items, nil
+}
+
+const prepareStripeCheckoutIntent = `-- name: PrepareStripeCheckoutIntent :one
+WITH locked AS (
+  SELECT
+      id
+    , stripe_checkout_idempotency_key
+    , stripe_checkout_billing_cycle_anchor
+    , stripe_checkout_trial_end
+    , stripe_checkout_expires_at
+    , stripe_checkout_session_id
+    , (
+        stripe_checkout_idempotency_key IS NOT NULL
+        AND stripe_checkout_billing_cycle_anchor IS NOT NULL
+        AND stripe_checkout_expires_at > $1::timestamptz
+      ) AS reuse_existing_intent
+  FROM billing_metadata
+  WHERE organization_id = $2::text
+    AND stripe_customer_id = $3::text
+  FOR UPDATE
+), prepared AS (
+  UPDATE billing_metadata AS metadata
+  SET
+      stripe_checkout_idempotency_key = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_idempotency_key
+        ELSE $4::text
+      END
+    , stripe_checkout_billing_cycle_anchor = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_billing_cycle_anchor
+        ELSE $5::timestamptz
+      END
+    , stripe_checkout_trial_end = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_trial_end
+        ELSE $6::timestamptz
+      END
+    , stripe_checkout_expires_at = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_expires_at
+        ELSE $7::timestamptz
+      END
+    , stripe_checkout_session_id = CASE
+        WHEN locked.reuse_existing_intent THEN locked.stripe_checkout_session_id
+        ELSE NULL
+      END
+    , updated_at = CASE
+        WHEN locked.reuse_existing_intent THEN metadata.updated_at
+        ELSE clock_timestamp()
+      END
+  FROM locked
+  WHERE metadata.id = locked.id
+    AND metadata.stripe_subscription_id IS NULL
+    -- An expired intent with a known remote session rotates only after the
+    -- caller has checked that exact session and explicitly authorizes replacing
+    -- it. A sessionless intent has no remote completion race to guard.
+    AND (
+      locked.reuse_existing_intent
+      OR locked.stripe_checkout_session_id IS NULL
+      OR locked.stripe_checkout_session_id = $8::text
+    )
+  RETURNING
+      metadata.id AS billing_metadata_id
+    , metadata.stripe_customer_id
+    , metadata.stripe_checkout_idempotency_key
+    , metadata.stripe_checkout_billing_cycle_anchor
+    , metadata.stripe_checkout_trial_end
+    , metadata.stripe_checkout_expires_at
+    , metadata.stripe_checkout_session_id
+    , locked.reuse_existing_intent
+)
+SELECT
+    billing_metadata_id
+  , stripe_customer_id
+  , stripe_checkout_idempotency_key
+  , stripe_checkout_billing_cycle_anchor
+  , stripe_checkout_trial_end
+  , stripe_checkout_expires_at
+  , stripe_checkout_session_id
+  , COALESCE(reuse_existing_intent, FALSE)::boolean AS reuse_existing_intent
+FROM prepared
+`
+
+type PrepareStripeCheckoutIntentParams struct {
+	PreparedAt                       pgtype.Timestamptz
+	OrganizationID                   string
+	StripeCustomerID                 string
+	StripeCheckoutIdempotencyKey     string
+	StripeCheckoutBillingCycleAnchor pgtype.Timestamptz
+	StripeCheckoutTrialEnd           pgtype.Timestamptz
+	StripeCheckoutExpiresAt          pgtype.Timestamptz
+	ReplaceExpiredSessionID          pgtype.Text
+}
+
+type PrepareStripeCheckoutIntentRow struct {
+	BillingMetadataID                uuid.UUID
+	StripeCustomerID                 pgtype.Text
+	StripeCheckoutIdempotencyKey     pgtype.Text
+	StripeCheckoutBillingCycleAnchor pgtype.Timestamptz
+	StripeCheckoutTrialEnd           pgtype.Timestamptz
+	StripeCheckoutExpiresAt          pgtype.Timestamptz
+	StripeCheckoutSessionID          pgtype.Text
+	ReuseExistingIntent              bool
+}
+
+// Call inside the Checkout transaction after the Stripe customer is stored.
+// The row lock makes concurrent callers reuse one live intent. Once it expires,
+// a caller may replace it only while no subscription has been activated.
+func (q *Queries) PrepareStripeCheckoutIntent(ctx context.Context, arg PrepareStripeCheckoutIntentParams) (PrepareStripeCheckoutIntentRow, error) {
+	row := q.db.QueryRow(ctx, prepareStripeCheckoutIntent,
+		arg.PreparedAt,
+		arg.OrganizationID,
+		arg.StripeCustomerID,
+		arg.StripeCheckoutIdempotencyKey,
+		arg.StripeCheckoutBillingCycleAnchor,
+		arg.StripeCheckoutTrialEnd,
+		arg.StripeCheckoutExpiresAt,
+		arg.ReplaceExpiredSessionID,
+	)
+	var i PrepareStripeCheckoutIntentRow
+	err := row.Scan(
+		&i.BillingMetadataID,
+		&i.StripeCustomerID,
+		&i.StripeCheckoutIdempotencyKey,
+		&i.StripeCheckoutBillingCycleAnchor,
+		&i.StripeCheckoutTrialEnd,
+		&i.StripeCheckoutExpiresAt,
+		&i.StripeCheckoutSessionID,
+		&i.ReuseExistingIntent,
+	)
+	return i, err
 }
 
 const setStripeSubscriptionFixture = `-- name: SetStripeSubscriptionFixture :exec

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -25,24 +25,27 @@ func (q *Queries) AcquireStripeSubscriptionActivationLock(ctx context.Context, s
 const activatePaygBillingMetadata = `-- name: ActivatePaygBillingMetadata :one
 UPDATE billing_metadata
 SET stripe_subscription_id = $1,
-    billing_cycle_anchor_day = $2,
+    stripe_billing_cycle_anchor = $2,
+    billing_cycle_anchor_day = $3,
     updated_at = clock_timestamp()
-WHERE organization_id = $3
-  AND stripe_customer_id = $4
+WHERE organization_id = $4
+  AND stripe_customer_id = $5
   AND (stripe_subscription_id IS NULL OR stripe_subscription_id = $1)
 RETURNING id, organization_id, stripe_customer_id, stripe_subscription_id, stripe_billing_cycle_anchor, stripe_checkout_idempotency_key, stripe_checkout_billing_cycle_anchor, stripe_checkout_trial_end, stripe_checkout_expires_at, stripe_checkout_session_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 `
 
 type ActivatePaygBillingMetadataParams struct {
-	StripeSubscriptionID  pgtype.Text
-	BillingCycleAnchorDay int32
-	OrganizationID        string
-	StripeCustomerID      pgtype.Text
+	StripeSubscriptionID     pgtype.Text
+	StripeBillingCycleAnchor pgtype.Timestamptz
+	BillingCycleAnchorDay    int32
+	OrganizationID           string
+	StripeCustomerID         pgtype.Text
 }
 
 func (q *Queries) ActivatePaygBillingMetadata(ctx context.Context, arg ActivatePaygBillingMetadataParams) (BillingMetadatum, error) {
 	row := q.db.QueryRow(ctx, activatePaygBillingMetadata,
 		arg.StripeSubscriptionID,
+		arg.StripeBillingCycleAnchor,
 		arg.BillingCycleAnchorDay,
 		arg.OrganizationID,
 		arg.StripeCustomerID,
@@ -205,6 +208,7 @@ SELECT
     billing_metadata.id AS billing_metadata_id
   , billing_metadata.stripe_customer_id
   , billing_metadata.stripe_subscription_id
+  , billing_metadata.stripe_billing_cycle_anchor
   , billing_metadata.billing_cycle_anchor_day
   , organization_metadata.name AS organization_name
   , organization_metadata.slug AS organization_slug
@@ -218,14 +222,15 @@ FOR UPDATE OF billing_metadata, organization_metadata
 `
 
 type GetPaygActivationStateRow struct {
-	BillingMetadataID     uuid.UUID
-	StripeCustomerID      pgtype.Text
-	StripeSubscriptionID  pgtype.Text
-	BillingCycleAnchorDay int32
-	OrganizationName      string
-	OrganizationSlug      string
-	GramAccountType       string
-	Whitelisted           bool
+	BillingMetadataID        uuid.UUID
+	StripeCustomerID         pgtype.Text
+	StripeSubscriptionID     pgtype.Text
+	StripeBillingCycleAnchor pgtype.Timestamptz
+	BillingCycleAnchorDay    int32
+	OrganizationName         string
+	OrganizationSlug         string
+	GramAccountType          string
+	Whitelisted              bool
 }
 
 func (q *Queries) GetPaygActivationState(ctx context.Context, organizationID string) (GetPaygActivationStateRow, error) {
@@ -235,6 +240,7 @@ func (q *Queries) GetPaygActivationState(ctx context.Context, organizationID str
 		&i.BillingMetadataID,
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
+		&i.StripeBillingCycleAnchor,
 		&i.BillingCycleAnchorDay,
 		&i.OrganizationName,
 		&i.OrganizationSlug,

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -241,6 +241,8 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 	anchorDay := conv.SafeInt32(checkout.BillingCycleAnchor.UTC().Day())
 	alreadyActivated := state.StripeSubscriptionID.Valid &&
 		state.StripeSubscriptionID.String == event.SubscriptionID &&
+		state.StripeBillingCycleAnchor.Valid &&
+		state.StripeBillingCycleAnchor.Time.Equal(checkout.BillingCycleAnchor) &&
 		state.BillingCycleAnchorDay == anchorDay &&
 		state.GramAccountType == "payg" && state.Whitelisted
 	if alreadyActivated {
@@ -248,10 +250,11 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 	}
 
 	if _, err := q.ActivatePaygBillingMetadata(ctx, repo.ActivatePaygBillingMetadataParams{
-		StripeSubscriptionID:  pgtype.Text{String: event.SubscriptionID, Valid: true},
-		BillingCycleAnchorDay: anchorDay,
-		OrganizationID:        organizationID,
-		StripeCustomerID:      pgtype.Text{String: event.CustomerID, Valid: true},
+		StripeSubscriptionID:     pgtype.Text{String: event.SubscriptionID, Valid: true},
+		StripeBillingCycleAnchor: pgtype.Timestamptz{Time: checkout.BillingCycleAnchor.UTC(), Valid: true},
+		BillingCycleAnchorDay:    anchorDay,
+		OrganizationID:           organizationID,
+		StripeCustomerID:         pgtype.Text{String: event.CustomerID, Valid: true},
 	}); err != nil {
 		return stripeWebhookResult{}, fmt.Errorf("store PAYG Stripe subscription: %w", err)
 	}

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -251,7 +251,7 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 
 	if _, err := q.ActivatePaygBillingMetadata(ctx, repo.ActivatePaygBillingMetadataParams{
 		StripeSubscriptionID:     pgtype.Text{String: event.SubscriptionID, Valid: true},
-		StripeBillingCycleAnchor: pgtype.Timestamptz{Time: checkout.BillingCycleAnchor.UTC(), Valid: true},
+		StripeBillingCycleAnchor: pgtype.Timestamptz{Time: checkout.BillingCycleAnchor.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
 		BillingCycleAnchorDay:    anchorDay,
 		OrganizationID:           organizationID,
 		StripeCustomerID:         pgtype.Text{String: event.CustomerID, Valid: true},

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -486,6 +486,16 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	featureCache := configurePaygCheckout(t, service, "event_activation", "subscription_activation", "active")
 	baseline, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
 	require.NoError(t, err)
+	preparedAt := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
+	_, err = service.prepareStripeCheckoutIntent(
+		t.Context(),
+		stripeWebhookOrganizationID,
+		"customer_placeholder",
+		preparedAt,
+		newStripeCheckoutIntent(stripeWebhookOrganizationID, preparedAt, nil),
+		pgtype.Text{String: "", Valid: false},
+	)
+	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "activation").Code)
 
@@ -494,8 +504,15 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.Equal(t, "customer_placeholder", metadata.StripeCustomerID.String)
 	require.Equal(t, "subscription_activation", metadata.StripeSubscriptionID.String)
 	require.True(t, metadata.StripeBillingCycleAnchor.Valid)
-	require.True(t, service.stripeClient.(*fakeStripeWebhookClient).checkout.BillingCycleAnchor.Equal(metadata.StripeBillingCycleAnchor.Time))
+	stripeClient, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	require.True(t, stripeClient.checkout.BillingCycleAnchor.Equal(metadata.StripeBillingCycleAnchor.Time))
 	require.EqualValues(t, 23, metadata.BillingCycleAnchorDay)
+	require.False(t, metadata.StripeCheckoutIdempotencyKey.Valid)
+	require.False(t, metadata.StripeCheckoutBillingCycleAnchor.Valid)
+	require.False(t, metadata.StripeCheckoutTrialEnd.Valid)
+	require.False(t, metadata.StripeCheckoutExpiresAt.Valid)
+	require.False(t, metadata.StripeCheckoutSessionID.Valid)
 	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	require.Equal(t, "payg", organization.GramAccountType)

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -493,6 +493,8 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "customer_placeholder", metadata.StripeCustomerID.String)
 	require.Equal(t, "subscription_activation", metadata.StripeSubscriptionID.String)
+	require.True(t, metadata.StripeBillingCycleAnchor.Valid)
+	require.True(t, service.stripeClient.(*fakeStripeWebhookClient).checkout.BillingCycleAnchor.Equal(metadata.StripeBillingCycleAnchor.Time))
 	require.EqualValues(t, 23, metadata.BillingCycleAnchorDay)
 	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- align every new PAYG paid period to UTC midnight without changing the exact local product-trial end
- use an aligned Stripe trial end for active trials; use a future billing anchor with no proration for immediate checkout
- persist one pending Checkout intent so retries reuse the same customer, idempotency key, anchor, trial mode, and expiry across processes and midnight
- rotate a stored expired session only after Stripe confirms that exact session expired, preventing delayed webhooks from opening duplicate subscriptions
- clear the pending intent and persist the subscription-confirmed paid-period anchor during activation

## Testing

- mise exec -- go test ./server/internal/thirdparty/stripe ./server/internal/usage -count=1
- mise run gen:sqlc-server
- mise run lint:server
- mise run build:server --readonly
- git diff --check

Stacked on #5337, which adds the nullable pending-intent fields and exact confirmed anchor.