### PR TITLE
chore(otel): expose OTLP HTTP receiver and enable log pipeline

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -102,6 +102,7 @@ services:
       - ./local/otel-collector/config.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
       - "${OTLP_GRPC_PORT}:4317"
+      - "${OTLP_HTTP_PORT}:4318"
     depends_on:
       - lgtm
 

--- a/local/otel-collector/config.yaml
+++ b/local/otel-collector/config.yaml
@@ -3,6 +3,8 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   otlp/lgtm:
@@ -10,16 +12,14 @@ exporters:
     tls:
       insecure: true
 
-processors:
-  batch:
-
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
       exporters: [otlp/lgtm]
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      exporters: [otlp/lgtm]
+    logs:
+      receivers: [otlp]
       exporters: [otlp/lgtm]

--- a/mise.toml
+++ b/mise.toml
@@ -209,7 +209,9 @@ GRAM_PYSTREAMS_DETECT_BLOCKING = "1"
 ##########################
 OTLP_GRPC_HOST = "localhost"
 OTLP_GRPC_PORT = "4317"
+OTLP_HTTP_PORT = "4318"
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://{{env.OTLP_GRPC_HOST}}:{{env.OTLP_GRPC_PORT}}"
+OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
 ## Change these to 0 to disable OpenTelemetry traces and metrics to be emitted.
 GRAM_ENABLE_OTEL_TRACES = 1
 GRAM_ENABLE_OTEL_METRICS = 1


### PR DESCRIPTION
Local telemetry only supported gRPC; adding the HTTP endpoint (4318) and a logs pipeline lets components that emit via OTLP/HTTP (e.g. pystreams) send logs into the local LGTM stack alongside traces and metrics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the OTLP/HTTP receiver on 4318 and enables a logs pipeline in the local OpenTelemetry Collector so HTTP-emitting components (e.g., pystreams) can send logs to the local LGTM stack. Previously only gRPC was accepted and traces/metrics used a `batch` processor; now HTTP is accepted and traces, metrics, and logs are forwarded directly (no collector-side batching).

- Compose maps `${OTLP_HTTP_PORT}:4318`; `mise.toml` adds `OTLP_HTTP_PORT` and keeps `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` by default.
- Collector `otlp` receiver now listens on gRPC 4317 and HTTP 4318; adds a `logs` pipeline; exports to `lgtm:4317` (insecure).
- Traces/metrics no longer use the collector `batch` processor; expect more frequent, smaller exports.
- Migration: HTTP clients should set `OTEL_EXPORTER_OTLP_PROTOCOL=http` and send to `http://localhost:4318`; gRPC clients require no changes. If batching is required, enable it client-side or reintroduce the collector `batch` processor.

<sup>Written for commit 816eefbb5aea24f9f669f2d295f110780ca19b63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

