### PR TITLE
feat(admin): set the account type on many organizations at once

### DIFF
--- a/.changeset/admin-bulk-account-type.md
+++ b/.changeset/admin-bulk-account-type.md
@@ -1,0 +1,22 @@
+---
+"server": patch
+---
+
+Platform admins can now set the account type on many organizations in one call.
+Until now the only way to move a batch was one request per organization, which
+left the operator half-applied if a request in the middle failed. The new admin
+endpoint takes a list of organization ids and one account type, writes them in a
+single statement, and reports back the ids it wrote and the ids from the request
+that matched no organization. A stale id in the paste therefore costs the
+operator that one row rather than the whole batch, and the response says which
+row it was instead of leaving them to compare lists by hand.
+
+Both write paths now accept only `free`, `pro` and `enterprise`, matched exactly.
+The single-organization update endpoint used to take any string at all, so a
+typo or a difference of capitalisation was written straight to the record and
+only showed up later as an organization on an account type nothing recognises.
+A value outside the list is now refused before anything is written, and the
+refusal names the value that was wrong. Existing records holding some other
+account type are left alone and keep working until somebody edits them.
+
+The admin dashboard's bulk selection and confirmation step follow.

--- a/.changeset/admin-bulk-account-type.md
+++ b/.changeset/admin-bulk-account-type.md
@@ -11,6 +11,10 @@ that matched no organization. A stale id in the paste therefore costs the
 operator that one row rather than the whole batch, and the response says which
 row it was instead of leaving them to compare lists by hand.
 
+One call carries at most 1000 organization ids. That is far above any selection
+an operator can realistically make in the dashboard, and it keeps a mistaken
+paste from producing a response that echoes the whole input back.
+
 Both write paths now accept only `free`, `pro` and `enterprise`, matched exactly.
 The single-organization update endpoint used to take any string at all, so a
 typo or a difference of capitalisation was written straight to the record and

--- a/.changeset/admin-bulk-account-type.md
+++ b/.changeset/admin-bulk-account-type.md
@@ -3,24 +3,15 @@
 ---
 
 Platform admins can now set the account type on many organizations in one call.
-Until now the only way to move a batch was one request per organization, which
-left the operator half-applied if a request in the middle failed. The new admin
-endpoint takes a list of organization ids and one account type, writes them in a
-single statement, and reports back the ids it wrote and the ids from the request
-that matched no organization. A stale id in the paste therefore costs the
-operator that one row rather than the whole batch, and the response says which
-row it was instead of leaving them to compare lists by hand.
+The new admin endpoint takes a list of organization ids and one account type,
+writes them in a single statement, and reports back the ids it wrote and the ids
+from the request that matched no organization. A stale id therefore costs that
+one row rather than the whole batch. One call carries at most 1000 ids.
 
-One call carries at most 1000 organization ids. That is far above any selection
-an operator can realistically make in the dashboard, and it keeps a mistaken
-paste from producing a response that echoes the whole input back.
-
-Both write paths now accept only `free`, `pro` and `enterprise`, matched exactly.
-The single-organization update endpoint used to take any string at all, so a
-typo or a difference of capitalisation was written straight to the record and
-only showed up later as an organization on an account type nothing recognises.
-A value outside the list is now refused before anything is written, and the
-refusal names the value that was wrong. Existing records holding some other
-account type are left alone and keep working until somebody edits them.
+Both admin write paths now accept only `free`, `pro` and `enterprise`, matched
+exactly. The single-organization update endpoint used to take any string, so a
+typo or a difference of capitalisation was written straight to the record. A
+value outside the list is now refused before anything is written, and the refusal
+names it. Existing records holding some other account type are left alone.
 
 The admin dashboard's bulk selection and confirmation step follow.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -55193,6 +55193,23 @@ components:
       description: Result of a strictly additive tool metadata batch insert.
       required:
         - tools
+    AdminBulkUpdateAccountTypeResult:
+      type: object
+      properties:
+        missing_ids:
+          type: array
+          items:
+            type: string
+          description: IDs from the request that matched no organization, deduplicated and in request order. Nothing was written for these.
+        updated_ids:
+          type: array
+          items:
+            type: string
+          description: 'IDs of the organizations whose account type was set. Order is unspecified: do not rely on it.'
+      description: Outcome of a bulk account type change.
+      required:
+        - updated_ids
+        - missing_ids
     AdminListOrganizationMembersResult:
       type: object
       properties:
@@ -56368,6 +56385,27 @@ components:
         - id
         - reason
         - description
+    BulkUpdateAccountTypeRequestBody:
+      type: object
+      properties:
+        account_type:
+          type: string
+          description: New gram_account_type for every listed organization.
+          enum:
+            - free
+            - pro
+            - enterprise
+        ids:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          description: Organization IDs to update.
+          minItems: 1
+          maxItems: 1000
+      required:
+        - ids
+        - account_type
     BusinessMemory:
       type: object
       properties:
@@ -75971,7 +76009,11 @@ components:
       properties:
         account_type:
           type: string
-          description: New gram_account_type (e.g. free, pro, enterprise).
+          description: New gram_account_type.
+          enum:
+            - free
+            - pro
+            - enterprise
         id:
           type: string
           description: Organization ID.

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -8,6 +8,7 @@ import (
 	"github.com/speakeasy-api/gram/server/design/security"
 	"github.com/speakeasy-api/gram/server/design/shared"
 	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 )
 
 var AdminOrganization = Type("AdminOrganization", func() {
@@ -151,13 +152,13 @@ var AdminBulkUpdateAccountTypeResult = Type("AdminBulkUpdateAccountTypeResult", 
 	Description("Outcome of a bulk account type change.")
 	Required("updated_ids", "missing_ids")
 
-	Attribute("updated_ids", ArrayOf(String), "IDs of the organizations whose account type was set.")
+	Attribute("updated_ids", ArrayOf(String), "IDs of the organizations whose account type was set. Order is unspecified: do not rely on it.")
 	Attribute("missing_ids", ArrayOf(String), "IDs from the request that matched no organization, deduplicated and in request order. Nothing was written for these.")
 })
 
-// Shared so the single and bulk write paths cannot drift apart into accepting
-// different sets.
-var accountTypes = []any{"free", "pro", "enterprise"}
+// Shared so the two write paths, and the service's own copy of the check,
+// cannot drift into accepting different sets.
+var accountTypes = conv.AnySlice(constants.AccountTypes)
 
 var _ = Service("admin", func() {
 	Description("Operations supporting admin tasks, protected by Google workspace auth.")
@@ -298,13 +299,11 @@ var _ = Service("admin", func() {
 			security.AdminAuthPayload()
 			Required("ids", "account_type")
 
-			// See disableOrganization for why this needs an explicit typename.
-			Meta("openapi:typename", "BulkUpdateAccountTypeRequestBody")
-
 			Attribute("ids", ArrayOf(String, func() {
 				MinLength(1)
 			}), "Organization IDs to update.", func() {
 				MinLength(1)
+				MaxLength(constants.MaxBulkAccountTypeIDs)
 			})
 			Attribute("account_type", String, "New gram_account_type for every listed organization.", func() {
 				Enum(accountTypes...)

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -147,6 +147,18 @@ var AdminOrganizationStats = Type("AdminOrganizationStats", func() {
 	Attribute("disabled_last_7_days", Int64, "Organizations disabled in the last 7 days.")
 })
 
+var AdminBulkUpdateAccountTypeResult = Type("AdminBulkUpdateAccountTypeResult", func() {
+	Description("Outcome of a bulk account type change.")
+	Required("updated_ids", "missing_ids")
+
+	Attribute("updated_ids", ArrayOf(String), "IDs of the organizations whose account type was set.")
+	Attribute("missing_ids", ArrayOf(String), "IDs from the request that matched no organization, deduplicated and in request order. Nothing was written for these.")
+})
+
+// Shared so the single and bulk write paths cannot drift apart into accepting
+// different sets.
+var accountTypes = []any{"free", "pro", "enterprise"}
+
 var _ = Service("admin", func() {
 	Description("Operations supporting admin tasks, protected by Google workspace auth.")
 	Security(security.AdminAuth)
@@ -263,7 +275,9 @@ var _ = Service("admin", func() {
 			Required("id")
 
 			Attribute("id", String, "Organization ID.")
-			Attribute("account_type", String, "New gram_account_type (e.g. free, pro, enterprise).")
+			Attribute("account_type", String, "New gram_account_type.", func() {
+				Enum(accountTypes...)
+			})
 			Attribute("whitelisted", Boolean, "New whitelisted flag.")
 		})
 
@@ -275,6 +289,36 @@ var _ = Service("admin", func() {
 		})
 
 		Meta("openapi:operationId", "adminUpdateOrganization")
+	})
+
+	Method("bulkUpdateAccountType", func() {
+		Description("Sets one account type on many organizations in a single statement. An ID that matches no organization is reported back rather than failing the batch, so a stale ID costs the operator that row and not the whole call.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("ids", "account_type")
+
+			// See disableOrganization for why this needs an explicit typename.
+			Meta("openapi:typename", "BulkUpdateAccountTypeRequestBody")
+
+			Attribute("ids", ArrayOf(String, func() {
+				MinLength(1)
+			}), "Organization IDs to update.", func() {
+				MinLength(1)
+			})
+			Attribute("account_type", String, "New gram_account_type for every listed organization.", func() {
+				Enum(accountTypes...)
+			})
+		})
+
+		Result(AdminBulkUpdateAccountTypeResult)
+
+		HTTP(func() {
+			POST("/admin/organizations.bulkUpdateAccountType")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminBulkUpdateAccountType")
 	})
 
 	Method("disableOrganization", func() {

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -20,6 +20,7 @@ type Client struct {
 	LogoutEndpoint                   goa.Endpoint
 	GetProjectEndpoint               goa.Endpoint
 	UpdateOrganizationEndpoint       goa.Endpoint
+	BulkUpdateAccountTypeEndpoint    goa.Endpoint
 	DisableOrganizationEndpoint      goa.Endpoint
 	EnableOrganizationEndpoint       goa.Endpoint
 	GetOrganizationEndpoint          goa.Endpoint
@@ -33,13 +34,14 @@ type Client struct {
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
 		LogoutEndpoint:                   logout,
 		GetProjectEndpoint:               getProject,
 		UpdateOrganizationEndpoint:       updateOrganization,
+		BulkUpdateAccountTypeEndpoint:    bulkUpdateAccountType,
 		DisableOrganizationEndpoint:      disableOrganization,
 		EnableOrganizationEndpoint:       enableOrganization,
 		GetOrganizationEndpoint:          getOrganization,
@@ -158,6 +160,29 @@ func (c *Client) UpdateOrganization(ctx context.Context, p *UpdateOrganizationPa
 		return
 	}
 	return ires.(*AdminOrganization), nil
+}
+
+// BulkUpdateAccountType calls the "bulkUpdateAccountType" endpoint of the
+// "admin" service.
+// BulkUpdateAccountType may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) BulkUpdateAccountType(ctx context.Context, p *BulkUpdateAccountTypePayload) (res *AdminBulkUpdateAccountTypeResult, err error) {
+	var ires any
+	ires, err = c.BulkUpdateAccountTypeEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminBulkUpdateAccountTypeResult), nil
 }
 
 // DisableOrganization calls the "disableOrganization" endpoint of the "admin"

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -21,6 +21,7 @@ type Endpoints struct {
 	Logout                   goa.Endpoint
 	GetProject               goa.Endpoint
 	UpdateOrganization       goa.Endpoint
+	BulkUpdateAccountType    goa.Endpoint
 	DisableOrganization      goa.Endpoint
 	EnableOrganization       goa.Endpoint
 	GetOrganization          goa.Endpoint
@@ -43,6 +44,7 @@ func NewEndpoints(s Service) *Endpoints {
 		Logout:                   NewLogoutEndpoint(s),
 		GetProject:               NewGetProjectEndpoint(s, a.APIKeyAuth),
 		UpdateOrganization:       NewUpdateOrganizationEndpoint(s, a.APIKeyAuth),
+		BulkUpdateAccountType:    NewBulkUpdateAccountTypeEndpoint(s, a.APIKeyAuth),
 		DisableOrganization:      NewDisableOrganizationEndpoint(s, a.APIKeyAuth),
 		EnableOrganization:       NewEnableOrganizationEndpoint(s, a.APIKeyAuth),
 		GetOrganization:          NewGetOrganizationEndpoint(s, a.APIKeyAuth),
@@ -63,6 +65,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.Logout = m(e.Logout)
 	e.GetProject = m(e.GetProject)
 	e.UpdateOrganization = m(e.UpdateOrganization)
+	e.BulkUpdateAccountType = m(e.BulkUpdateAccountType)
 	e.DisableOrganization = m(e.DisableOrganization)
 	e.EnableOrganization = m(e.EnableOrganization)
 	e.GetOrganization = m(e.GetOrganization)
@@ -145,6 +148,29 @@ func NewUpdateOrganizationEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFu
 			return nil, err
 		}
 		return s.UpdateOrganization(ctx, p)
+	}
+}
+
+// NewBulkUpdateAccountTypeEndpoint returns an endpoint function that calls the
+// method "bulkUpdateAccountType" of service "admin".
+func NewBulkUpdateAccountTypeEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*BulkUpdateAccountTypePayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.BulkUpdateAccountType(ctx, p)
 	}
 }
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -94,7 +94,8 @@ var MethodNames = [16]string{"login", "callback", "logout", "getProject", "updat
 // AdminBulkUpdateAccountTypeResult is the result type of the admin service
 // bulkUpdateAccountType method.
 type AdminBulkUpdateAccountTypeResult struct {
-	// IDs of the organizations whose account type was set.
+	// IDs of the organizations whose account type was set. Order is unspecified:
+	// do not rely on it.
 	UpdatedIds []string
 	// IDs from the request that matched no organization, deduplicated and in
 	// request order. Nothing was written for these.

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -28,6 +28,10 @@ type Service interface {
 	// Updates admin-managed fields on an organization. At least one of
 	// account_type or whitelisted must be supplied.
 	UpdateOrganization(context.Context, *UpdateOrganizationPayload) (res *AdminOrganization, err error)
+	// Sets one account type on many organizations in a single statement. An ID
+	// that matches no organization is reported back rather than failing the batch,
+	// so a stale ID costs the operator that row and not the whole call.
+	BulkUpdateAccountType(context.Context, *BulkUpdateAccountTypePayload) (res *AdminBulkUpdateAccountTypeResult, err error)
 	// Disables an organization, recording the moment of the action in disabled_at.
 	// Idempotent: disabling an already-disabled organization keeps the original
 	// timestamp.
@@ -85,7 +89,17 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [15]string{"login", "callback", "logout", "getProject", "updateOrganization", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats"}
+var MethodNames = [16]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats"}
+
+// AdminBulkUpdateAccountTypeResult is the result type of the admin service
+// bulkUpdateAccountType method.
+type AdminBulkUpdateAccountTypeResult struct {
+	// IDs of the organizations whose account type was set.
+	UpdatedIds []string
+	// IDs from the request that matched no organization, deduplicated and in
+	// request order. Nothing was written for these.
+	MissingIds []string
+}
 
 // AdminListOrganizationMembersResult is the result type of the admin service
 // listOrganizationMembers method.
@@ -217,6 +231,16 @@ type AdminProjectDetail struct {
 	AssistantCount int
 	CreatedAt      string
 	UpdatedAt      string
+}
+
+// BulkUpdateAccountTypePayload is the payload type of the admin service
+// bulkUpdateAccountType method.
+type BulkUpdateAccountTypePayload struct {
+	AdminSessionToken *string
+	// Organization IDs to update.
+	Ids []string
+	// New gram_account_type for every listed organization.
+	AccountType string
 }
 
 // CallbackPayload is the payload type of the admin service callback method.
@@ -401,7 +425,7 @@ type UpdateOrganizationPayload struct {
 	AdminSessionToken *string
 	// Organization ID.
 	ID string
-	// New gram_account_type (e.g. free, pro, enterprise).
+	// New gram_account_type.
 	AccountType *string
 	// New whitelisted flag.
 	Whitelisted *bool

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -166,6 +166,9 @@ func BuildBulkUpdateAccountTypePayload(adminBulkUpdateAccountTypeBody string, ad
 		if len(body.Ids) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids", body.Ids, len(body.Ids), 1, true))
 		}
+		if len(body.Ids) > 1000 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids", body.Ids, len(body.Ids), 1000, false))
+		}
 		for _, e := range body.Ids {
 			if utf8.RuneCountInString(e) < 1 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids[*]", e, utf8.RuneCountInString(e), 1, true))

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -123,7 +123,15 @@ func BuildUpdateOrganizationPayload(adminUpdateOrganizationBody string, adminUpd
 	{
 		err = json.Unmarshal([]byte(adminUpdateOrganizationBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"account_type\": \"abc123\",\n      \"id\": \"abc123\",\n      \"whitelisted\": false\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"account_type\": \"pro\",\n      \"id\": \"abc123\",\n      \"whitelisted\": false\n   }'")
+		}
+		if body.AccountType != nil {
+			if !(*body.AccountType == "free" || *body.AccountType == "pro" || *body.AccountType == "enterprise") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.account_type", *body.AccountType, []any{"free", "pro", "enterprise"}))
+			}
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 	var adminSessionToken *string
@@ -136,6 +144,56 @@ func BuildUpdateOrganizationPayload(adminUpdateOrganizationBody string, adminUpd
 		ID:          body.ID,
 		AccountType: body.AccountType,
 		Whitelisted: body.Whitelisted,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}
+
+// BuildBulkUpdateAccountTypePayload builds the payload for the admin
+// bulkUpdateAccountType endpoint from CLI flags.
+func BuildBulkUpdateAccountTypePayload(adminBulkUpdateAccountTypeBody string, adminBulkUpdateAccountTypeAdminSessionToken string) (*admin.BulkUpdateAccountTypePayload, error) {
+	var err error
+	var body BulkUpdateAccountTypeRequestBody
+	{
+		err = json.Unmarshal([]byte(adminBulkUpdateAccountTypeBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"account_type\": \"pro\",\n      \"ids\": [\n         \"aa\",\n         \"aa\"\n      ]\n   }'")
+		}
+		if body.Ids == nil {
+			err = goa.MergeErrors(err, goa.MissingFieldError("ids", "body"))
+		}
+		if len(body.Ids) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids", body.Ids, len(body.Ids), 1, true))
+		}
+		for _, e := range body.Ids {
+			if utf8.RuneCountInString(e) < 1 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids[*]", e, utf8.RuneCountInString(e), 1, true))
+			}
+		}
+		if !(body.AccountType == "free" || body.AccountType == "pro" || body.AccountType == "enterprise") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.account_type", body.AccountType, []any{"free", "pro", "enterprise"}))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminBulkUpdateAccountTypeAdminSessionToken != "" {
+			adminSessionToken = &adminBulkUpdateAccountTypeAdminSessionToken
+		}
+	}
+	v := &admin.BulkUpdateAccountTypePayload{
+		AccountType: body.AccountType,
+	}
+	if body.Ids != nil {
+		v.Ids = make([]string, len(body.Ids))
+		for i, val := range body.Ids {
+			v.Ids[i] = val
+		}
+	} else {
+		v.Ids = []string{}
 	}
 	v.AdminSessionToken = adminSessionToken
 

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -35,6 +35,10 @@ type Client struct {
 	// updateOrganization endpoint.
 	UpdateOrganizationDoer goahttp.Doer
 
+	// BulkUpdateAccountType Doer is the HTTP client used to make requests to the
+	// bulkUpdateAccountType endpoint.
+	BulkUpdateAccountTypeDoer goahttp.Doer
+
 	// DisableOrganization Doer is the HTTP client used to make requests to the
 	// disableOrganization endpoint.
 	DisableOrganizationDoer goahttp.Doer
@@ -100,6 +104,7 @@ func NewClient(
 		LogoutDoer:                   doer,
 		GetProjectDoer:               doer,
 		UpdateOrganizationDoer:       doer,
+		BulkUpdateAccountTypeDoer:    doer,
 		DisableOrganizationDoer:      doer,
 		EnableOrganizationDoer:       doer,
 		GetOrganizationDoer:          doer,
@@ -233,6 +238,30 @@ func (c *Client) UpdateOrganization() goa.Endpoint {
 		resp, err := c.UpdateOrganizationDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "updateOrganization", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// BulkUpdateAccountType returns an endpoint that makes HTTP requests to the
+// admin service bulkUpdateAccountType server.
+func (c *Client) BulkUpdateAccountType() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeBulkUpdateAccountTypeRequest(c.encoder)
+		decodeResponse = DecodeBulkUpdateAccountTypeResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildBulkUpdateAccountTypeRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.BulkUpdateAccountTypeDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "bulkUpdateAccountType", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -1218,6 +1218,241 @@ func DecodeUpdateOrganizationResponse(decoder func(*http.Response) goahttp.Decod
 	}
 }
 
+// BuildBulkUpdateAccountTypeRequest instantiates a HTTP request object with
+// method and path set to call the "admin" service "bulkUpdateAccountType"
+// endpoint
+func (c *Client) BuildBulkUpdateAccountTypeRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: BulkUpdateAccountTypeAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "bulkUpdateAccountType", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeBulkUpdateAccountTypeRequest returns an encoder for requests sent to
+// the admin bulkUpdateAccountType server.
+func EncodeBulkUpdateAccountTypeRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.BulkUpdateAccountTypePayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "bulkUpdateAccountType", "*admin.BulkUpdateAccountTypePayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewBulkUpdateAccountTypeRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "bulkUpdateAccountType", err)
+		}
+		return nil
+	}
+}
+
+// DecodeBulkUpdateAccountTypeResponse returns a decoder for responses returned
+// by the admin bulkUpdateAccountType endpoint. restoreBody controls whether
+// the response body should be restored after having been read.
+// DecodeBulkUpdateAccountTypeResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeBulkUpdateAccountTypeResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body BulkUpdateAccountTypeResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			res := NewBulkUpdateAccountTypeAdminBulkUpdateAccountTypeResultOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body BulkUpdateAccountTypeUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body BulkUpdateAccountTypeForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body BulkUpdateAccountTypeBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body BulkUpdateAccountTypeNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body BulkUpdateAccountTypeConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body BulkUpdateAccountTypeUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body BulkUpdateAccountTypeInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body BulkUpdateAccountTypeInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+				}
+				err = ValidateBulkUpdateAccountTypeInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+				}
+				return nil, NewBulkUpdateAccountTypeInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body BulkUpdateAccountTypeUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+				}
+				err = ValidateBulkUpdateAccountTypeUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+				}
+				return nil, NewBulkUpdateAccountTypeUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "bulkUpdateAccountType", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body BulkUpdateAccountTypeGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "bulkUpdateAccountType", err)
+			}
+			err = ValidateBulkUpdateAccountTypeGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "bulkUpdateAccountType", err)
+			}
+			return nil, NewBulkUpdateAccountTypeGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "bulkUpdateAccountType", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // BuildDisableOrganizationRequest instantiates a HTTP request object with
 // method and path set to call the "admin" service "disableOrganization"
 // endpoint

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -32,6 +32,11 @@ func UpdateOrganizationAdminPath() string {
 	return "/admin/organization.update"
 }
 
+// BulkUpdateAccountTypeAdminPath returns the URL path to the admin service bulkUpdateAccountType HTTP endpoint.
+func BulkUpdateAccountTypeAdminPath() string {
+	return "/admin/organizations.bulkUpdateAccountType"
+}
+
 // DisableOrganizationAdminPath returns the URL path to the admin service disableOrganization HTTP endpoint.
 func DisableOrganizationAdminPath() string {
 	return "/admin/organization.disable"

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -139,7 +139,8 @@ type UpdateOrganizationResponseBody struct {
 // BulkUpdateAccountTypeResponseBody is the type of the "admin" service
 // "bulkUpdateAccountType" endpoint HTTP response body.
 type BulkUpdateAccountTypeResponseBody struct {
-	// IDs of the organizations whose account type was set.
+	// IDs of the organizations whose account type was set. Order is unspecified:
+	// do not rely on it.
 	UpdatedIds []string `form:"updated_ids,omitempty" json:"updated_ids,omitempty" xml:"updated_ids,omitempty"`
 	// IDs from the request that matched no organization, deduplicated and in
 	// request order. Nothing was written for these.

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -17,10 +17,19 @@ import (
 type UpdateOrganizationRequestBody struct {
 	// Organization ID.
 	ID string `form:"id" json:"id" xml:"id"`
-	// New gram_account_type (e.g. free, pro, enterprise).
+	// New gram_account_type.
 	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
 	// New whitelisted flag.
 	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+}
+
+// BulkUpdateAccountTypeRequestBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP request body.
+type BulkUpdateAccountTypeRequestBody struct {
+	// Organization IDs to update.
+	Ids []string `form:"ids" json:"ids" xml:"ids"`
+	// New gram_account_type for every listed organization.
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
 }
 
 // DisableOrganizationRequestBody is the type of the "admin" service
@@ -125,6 +134,16 @@ type UpdateOrganizationResponseBody struct {
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// The last update date of the organization.
 	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
+}
+
+// BulkUpdateAccountTypeResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body.
+type BulkUpdateAccountTypeResponseBody struct {
+	// IDs of the organizations whose account type was set.
+	UpdatedIds []string `form:"updated_ids,omitempty" json:"updated_ids,omitempty" xml:"updated_ids,omitempty"`
+	// IDs from the request that matched no organization, deduplicated and in
+	// request order. Nothing was written for these.
+	MissingIds []string `form:"missing_ids,omitempty" json:"missing_ids,omitempty" xml:"missing_ids,omitempty"`
 }
 
 // DisableOrganizationResponseBody is the type of the "admin" service
@@ -1260,6 +1279,194 @@ type UpdateOrganizationUnexpectedResponseBody struct {
 // service "updateOrganization" endpoint HTTP response body for the
 // "gateway_error" error.
 type UpdateOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeUnauthorizedResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "unauthorized" error.
+type BulkUpdateAccountTypeUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeForbiddenResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "forbidden" error.
+type BulkUpdateAccountTypeForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeBadRequestResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "bad_request" error.
+type BulkUpdateAccountTypeBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeNotFoundResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body for the "not_found"
+// error.
+type BulkUpdateAccountTypeNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeConflictResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body for the "conflict" error.
+type BulkUpdateAccountTypeConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeUnsupportedMediaResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "unsupported_media" error.
+type BulkUpdateAccountTypeUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeInvalidResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body for the "invalid" error.
+type BulkUpdateAccountTypeInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeInvariantViolationResponseBody is the type of the
+// "admin" service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "invariant_violation" error.
+type BulkUpdateAccountTypeInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeUnexpectedResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "unexpected" error.
+type BulkUpdateAccountTypeUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// BulkUpdateAccountTypeGatewayErrorResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "gateway_error" error.
+type BulkUpdateAccountTypeGatewayErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -3194,6 +3401,23 @@ func NewUpdateOrganizationRequestBody(p *admin.UpdateOrganizationPayload) *Updat
 	return body
 }
 
+// NewBulkUpdateAccountTypeRequestBody builds the HTTP request body from the
+// payload of the "bulkUpdateAccountType" endpoint of the "admin" service.
+func NewBulkUpdateAccountTypeRequestBody(p *admin.BulkUpdateAccountTypePayload) *BulkUpdateAccountTypeRequestBody {
+	body := &BulkUpdateAccountTypeRequestBody{
+		AccountType: p.AccountType,
+	}
+	if p.Ids != nil {
+		body.Ids = make([]string, len(p.Ids))
+		for i, val := range p.Ids {
+			body.Ids[i] = val
+		}
+	} else {
+		body.Ids = []string{}
+	}
+	return body
+}
+
 // NewDisableOrganizationRequestBody builds the HTTP request body from the
 // payload of the "disableOrganization" endpoint of the "admin" service.
 func NewDisableOrganizationRequestBody(p *admin.DisableOrganizationPayload) *DisableOrganizationRequestBody {
@@ -4030,6 +4254,172 @@ func NewUpdateOrganizationUnexpected(body *UpdateOrganizationUnexpectedResponseB
 // NewUpdateOrganizationGatewayError builds a admin service updateOrganization
 // endpoint gateway_error error.
 func NewUpdateOrganizationGatewayError(body *UpdateOrganizationGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeAdminBulkUpdateAccountTypeResultOK builds a "admin"
+// service "bulkUpdateAccountType" endpoint result from a HTTP "OK" response.
+func NewBulkUpdateAccountTypeAdminBulkUpdateAccountTypeResultOK(body *BulkUpdateAccountTypeResponseBody) *admin.AdminBulkUpdateAccountTypeResult {
+	v := &admin.AdminBulkUpdateAccountTypeResult{}
+	v.UpdatedIds = make([]string, len(body.UpdatedIds))
+	for i, val := range body.UpdatedIds {
+		v.UpdatedIds[i] = val
+	}
+	v.MissingIds = make([]string, len(body.MissingIds))
+	for i, val := range body.MissingIds {
+		v.MissingIds[i] = val
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeUnauthorized builds a admin service
+// bulkUpdateAccountType endpoint unauthorized error.
+func NewBulkUpdateAccountTypeUnauthorized(body *BulkUpdateAccountTypeUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeForbidden builds a admin service
+// bulkUpdateAccountType endpoint forbidden error.
+func NewBulkUpdateAccountTypeForbidden(body *BulkUpdateAccountTypeForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeBadRequest builds a admin service
+// bulkUpdateAccountType endpoint bad_request error.
+func NewBulkUpdateAccountTypeBadRequest(body *BulkUpdateAccountTypeBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeNotFound builds a admin service
+// bulkUpdateAccountType endpoint not_found error.
+func NewBulkUpdateAccountTypeNotFound(body *BulkUpdateAccountTypeNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeConflict builds a admin service
+// bulkUpdateAccountType endpoint conflict error.
+func NewBulkUpdateAccountTypeConflict(body *BulkUpdateAccountTypeConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeUnsupportedMedia builds a admin service
+// bulkUpdateAccountType endpoint unsupported_media error.
+func NewBulkUpdateAccountTypeUnsupportedMedia(body *BulkUpdateAccountTypeUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeInvalid builds a admin service bulkUpdateAccountType
+// endpoint invalid error.
+func NewBulkUpdateAccountTypeInvalid(body *BulkUpdateAccountTypeInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeInvariantViolation builds a admin service
+// bulkUpdateAccountType endpoint invariant_violation error.
+func NewBulkUpdateAccountTypeInvariantViolation(body *BulkUpdateAccountTypeInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeUnexpected builds a admin service
+// bulkUpdateAccountType endpoint unexpected error.
+func NewBulkUpdateAccountTypeUnexpected(body *BulkUpdateAccountTypeUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewBulkUpdateAccountTypeGatewayError builds a admin service
+// bulkUpdateAccountType endpoint gateway_error error.
+func NewBulkUpdateAccountTypeGatewayError(body *BulkUpdateAccountTypeGatewayErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -5848,6 +6238,18 @@ func ValidateUpdateOrganizationResponseBody(body *UpdateOrganizationResponseBody
 	return
 }
 
+// ValidateBulkUpdateAccountTypeResponseBody runs the validations defined on
+// BulkUpdateAccountTypeResponseBody
+func ValidateBulkUpdateAccountTypeResponseBody(body *BulkUpdateAccountTypeResponseBody) (err error) {
+	if body.UpdatedIds == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("updated_ids", "body"))
+	}
+	if body.MissingIds == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("missing_ids", "body"))
+	}
+	return
+}
+
 // ValidateDisableOrganizationResponseBody runs the validations defined on
 // DisableOrganizationResponseBody
 func ValidateDisableOrganizationResponseBody(body *DisableOrganizationResponseBody) (err error) {
@@ -7417,6 +7819,247 @@ func ValidateUpdateOrganizationUnexpectedResponseBody(body *UpdateOrganizationUn
 // ValidateUpdateOrganizationGatewayErrorResponseBody runs the validations
 // defined on updateOrganization_gateway_error_response_body
 func ValidateUpdateOrganizationGatewayErrorResponseBody(body *UpdateOrganizationGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeUnauthorizedResponseBody runs the validations
+// defined on bulkUpdateAccountType_unauthorized_response_body
+func ValidateBulkUpdateAccountTypeUnauthorizedResponseBody(body *BulkUpdateAccountTypeUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeForbiddenResponseBody runs the validations
+// defined on bulkUpdateAccountType_forbidden_response_body
+func ValidateBulkUpdateAccountTypeForbiddenResponseBody(body *BulkUpdateAccountTypeForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeBadRequestResponseBody runs the validations
+// defined on bulkUpdateAccountType_bad_request_response_body
+func ValidateBulkUpdateAccountTypeBadRequestResponseBody(body *BulkUpdateAccountTypeBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeNotFoundResponseBody runs the validations
+// defined on bulkUpdateAccountType_not_found_response_body
+func ValidateBulkUpdateAccountTypeNotFoundResponseBody(body *BulkUpdateAccountTypeNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeConflictResponseBody runs the validations
+// defined on bulkUpdateAccountType_conflict_response_body
+func ValidateBulkUpdateAccountTypeConflictResponseBody(body *BulkUpdateAccountTypeConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeUnsupportedMediaResponseBody runs the
+// validations defined on bulkUpdateAccountType_unsupported_media_response_body
+func ValidateBulkUpdateAccountTypeUnsupportedMediaResponseBody(body *BulkUpdateAccountTypeUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeInvalidResponseBody runs the validations
+// defined on bulkUpdateAccountType_invalid_response_body
+func ValidateBulkUpdateAccountTypeInvalidResponseBody(body *BulkUpdateAccountTypeInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeInvariantViolationResponseBody runs the
+// validations defined on
+// bulkUpdateAccountType_invariant_violation_response_body
+func ValidateBulkUpdateAccountTypeInvariantViolationResponseBody(body *BulkUpdateAccountTypeInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeUnexpectedResponseBody runs the validations
+// defined on bulkUpdateAccountType_unexpected_response_body
+func ValidateBulkUpdateAccountTypeUnexpectedResponseBody(body *BulkUpdateAccountTypeUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeGatewayErrorResponseBody runs the validations
+// defined on bulkUpdateAccountType_gateway_error_response_body
+func ValidateBulkUpdateAccountTypeGatewayErrorResponseBody(body *BulkUpdateAccountTypeGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -1046,6 +1046,219 @@ func EncodeUpdateOrganizationError(encoder func(context.Context, http.ResponseWr
 	}
 }
 
+// EncodeBulkUpdateAccountTypeResponse returns an encoder for responses
+// returned by the admin bulkUpdateAccountType endpoint.
+func EncodeBulkUpdateAccountTypeResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminBulkUpdateAccountTypeResult)
+		enc := encoder(ctx, w)
+		body := NewBulkUpdateAccountTypeResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeBulkUpdateAccountTypeRequest returns a decoder for requests sent to
+// the admin bulkUpdateAccountType endpoint.
+func DecodeBulkUpdateAccountTypeRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.BulkUpdateAccountTypePayload, error) {
+	return func(r *http.Request) (*admin.BulkUpdateAccountTypePayload, error) {
+		var payload *admin.BulkUpdateAccountTypePayload
+		var (
+			body BulkUpdateAccountTypeRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateBulkUpdateAccountTypeRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewBulkUpdateAccountTypePayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeBulkUpdateAccountTypeError returns an encoder for errors returned by
+// the bulkUpdateAccountType admin endpoint.
+func EncodeBulkUpdateAccountTypeError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewBulkUpdateAccountTypeGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // EncodeDisableOrganizationResponse returns an encoder for responses returned
 // by the admin disableOrganization endpoint.
 func EncodeDisableOrganizationResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -32,6 +32,11 @@ func UpdateOrganizationAdminPath() string {
 	return "/admin/organization.update"
 }
 
+// BulkUpdateAccountTypeAdminPath returns the URL path to the admin service bulkUpdateAccountType HTTP endpoint.
+func BulkUpdateAccountTypeAdminPath() string {
+	return "/admin/organizations.bulkUpdateAccountType"
+}
+
 // DisableOrganizationAdminPath returns the URL path to the admin service disableOrganization HTTP endpoint.
 func DisableOrganizationAdminPath() string {
 	return "/admin/organization.disable"

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	Logout                   http.Handler
 	GetProject               http.Handler
 	UpdateOrganization       http.Handler
+	BulkUpdateAccountType    http.Handler
 	DisableOrganization      http.Handler
 	EnableOrganization       http.Handler
 	GetOrganization          http.Handler
@@ -68,6 +69,7 @@ func New(
 			{"Logout", "POST", "/admin/auth.logout"},
 			{"GetProject", "GET", "/admin/project.get"},
 			{"UpdateOrganization", "POST", "/admin/organization.update"},
+			{"BulkUpdateAccountType", "POST", "/admin/organizations.bulkUpdateAccountType"},
 			{"DisableOrganization", "POST", "/admin/organization.disable"},
 			{"EnableOrganization", "POST", "/admin/organization.enable"},
 			{"GetOrganization", "GET", "/admin/organization.get"},
@@ -84,6 +86,7 @@ func New(
 		Logout:                   NewLogoutHandler(e.Logout, mux, decoder, encoder, errhandler, formatter),
 		GetProject:               NewGetProjectHandler(e.GetProject, mux, decoder, encoder, errhandler, formatter),
 		UpdateOrganization:       NewUpdateOrganizationHandler(e.UpdateOrganization, mux, decoder, encoder, errhandler, formatter),
+		BulkUpdateAccountType:    NewBulkUpdateAccountTypeHandler(e.BulkUpdateAccountType, mux, decoder, encoder, errhandler, formatter),
 		DisableOrganization:      NewDisableOrganizationHandler(e.DisableOrganization, mux, decoder, encoder, errhandler, formatter),
 		EnableOrganization:       NewEnableOrganizationHandler(e.EnableOrganization, mux, decoder, encoder, errhandler, formatter),
 		GetOrganization:          NewGetOrganizationHandler(e.GetOrganization, mux, decoder, encoder, errhandler, formatter),
@@ -107,6 +110,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.Logout = m(s.Logout)
 	s.GetProject = m(s.GetProject)
 	s.UpdateOrganization = m(s.UpdateOrganization)
+	s.BulkUpdateAccountType = m(s.BulkUpdateAccountType)
 	s.DisableOrganization = m(s.DisableOrganization)
 	s.EnableOrganization = m(s.EnableOrganization)
 	s.GetOrganization = m(s.GetOrganization)
@@ -129,6 +133,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountLogoutHandler(mux, h.Logout)
 	MountGetProjectHandler(mux, h.GetProject)
 	MountUpdateOrganizationHandler(mux, h.UpdateOrganization)
+	MountBulkUpdateAccountTypeHandler(mux, h.BulkUpdateAccountType)
 	MountDisableOrganizationHandler(mux, h.DisableOrganization)
 	MountEnableOrganizationHandler(mux, h.EnableOrganization)
 	MountGetOrganizationHandler(mux, h.GetOrganization)
@@ -388,6 +393,59 @@ func NewUpdateOrganizationHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "updateOrganization")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountBulkUpdateAccountTypeHandler configures the mux to serve the "admin"
+// service "bulkUpdateAccountType" endpoint.
+func MountBulkUpdateAccountTypeHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/organizations.bulkUpdateAccountType", f)
+}
+
+// NewBulkUpdateAccountTypeHandler creates a HTTP handler which loads the HTTP
+// request and calls the "admin" service "bulkUpdateAccountType" endpoint.
+func NewBulkUpdateAccountTypeHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeBulkUpdateAccountTypeRequest(mux, decoder)
+		encodeResponse = EncodeBulkUpdateAccountTypeResponse(encoder)
+		encodeError    = EncodeBulkUpdateAccountTypeError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "bulkUpdateAccountType")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -141,7 +141,8 @@ type UpdateOrganizationResponseBody struct {
 // BulkUpdateAccountTypeResponseBody is the type of the "admin" service
 // "bulkUpdateAccountType" endpoint HTTP response body.
 type BulkUpdateAccountTypeResponseBody struct {
-	// IDs of the organizations whose account type was set.
+	// IDs of the organizations whose account type was set. Order is unspecified:
+	// do not rely on it.
 	UpdatedIds []string `form:"updated_ids" json:"updated_ids" xml:"updated_ids"`
 	// IDs from the request that matched no organization, deduplicated and in
 	// request order. Nothing was written for these.
@@ -6160,6 +6161,9 @@ func ValidateBulkUpdateAccountTypeRequestBody(body *BulkUpdateAccountTypeRequest
 	}
 	if len(body.Ids) < 1 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids", body.Ids, len(body.Ids), 1, true))
+	}
+	if len(body.Ids) > 1000 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids", body.Ids, len(body.Ids), 1000, false))
 	}
 	for _, e := range body.Ids {
 		if utf8.RuneCountInString(e) < 1 {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -19,10 +19,19 @@ import (
 type UpdateOrganizationRequestBody struct {
 	// Organization ID.
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
-	// New gram_account_type (e.g. free, pro, enterprise).
+	// New gram_account_type.
 	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
 	// New whitelisted flag.
 	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+}
+
+// BulkUpdateAccountTypeRequestBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP request body.
+type BulkUpdateAccountTypeRequestBody struct {
+	// Organization IDs to update.
+	Ids []string `form:"ids,omitempty" json:"ids,omitempty" xml:"ids,omitempty"`
+	// New gram_account_type for every listed organization.
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
 }
 
 // DisableOrganizationRequestBody is the type of the "admin" service
@@ -127,6 +136,16 @@ type UpdateOrganizationResponseBody struct {
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// The last update date of the organization.
 	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
+}
+
+// BulkUpdateAccountTypeResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body.
+type BulkUpdateAccountTypeResponseBody struct {
+	// IDs of the organizations whose account type was set.
+	UpdatedIds []string `form:"updated_ids" json:"updated_ids" xml:"updated_ids"`
+	// IDs from the request that matched no organization, deduplicated and in
+	// request order. Nothing was written for these.
+	MissingIds []string `form:"missing_ids" json:"missing_ids" xml:"missing_ids"`
 }
 
 // DisableOrganizationResponseBody is the type of the "admin" service
@@ -1262,6 +1281,194 @@ type UpdateOrganizationUnexpectedResponseBody struct {
 // service "updateOrganization" endpoint HTTP response body for the
 // "gateway_error" error.
 type UpdateOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeUnauthorizedResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "unauthorized" error.
+type BulkUpdateAccountTypeUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeForbiddenResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "forbidden" error.
+type BulkUpdateAccountTypeForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeBadRequestResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "bad_request" error.
+type BulkUpdateAccountTypeBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeNotFoundResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body for the "not_found"
+// error.
+type BulkUpdateAccountTypeNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeConflictResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body for the "conflict" error.
+type BulkUpdateAccountTypeConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeUnsupportedMediaResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "unsupported_media" error.
+type BulkUpdateAccountTypeUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeInvalidResponseBody is the type of the "admin" service
+// "bulkUpdateAccountType" endpoint HTTP response body for the "invalid" error.
+type BulkUpdateAccountTypeInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeInvariantViolationResponseBody is the type of the
+// "admin" service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "invariant_violation" error.
+type BulkUpdateAccountTypeInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeUnexpectedResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "unexpected" error.
+type BulkUpdateAccountTypeUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// BulkUpdateAccountTypeGatewayErrorResponseBody is the type of the "admin"
+// service "bulkUpdateAccountType" endpoint HTTP response body for the
+// "gateway_error" error.
+type BulkUpdateAccountTypeGatewayErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -3229,6 +3436,29 @@ func NewUpdateOrganizationResponseBody(res *admin.AdminOrganization) *UpdateOrga
 	return body
 }
 
+// NewBulkUpdateAccountTypeResponseBody builds the HTTP response body from the
+// result of the "bulkUpdateAccountType" endpoint of the "admin" service.
+func NewBulkUpdateAccountTypeResponseBody(res *admin.AdminBulkUpdateAccountTypeResult) *BulkUpdateAccountTypeResponseBody {
+	body := &BulkUpdateAccountTypeResponseBody{}
+	if res.UpdatedIds != nil {
+		body.UpdatedIds = make([]string, len(res.UpdatedIds))
+		for i, val := range res.UpdatedIds {
+			body.UpdatedIds[i] = val
+		}
+	} else {
+		body.UpdatedIds = []string{}
+	}
+	if res.MissingIds != nil {
+		body.MissingIds = make([]string, len(res.MissingIds))
+		for i, val := range res.MissingIds {
+			body.MissingIds[i] = val
+		}
+	} else {
+		body.MissingIds = []string{}
+	}
+	return body
+}
+
 // NewDisableOrganizationResponseBody builds the HTTP response body from the
 // result of the "disableOrganization" endpoint of the "admin" service.
 func NewDisableOrganizationResponseBody(res *admin.AdminOrganization) *DisableOrganizationResponseBody {
@@ -4126,6 +4356,156 @@ func NewUpdateOrganizationUnexpectedResponseBody(res *goa.ServiceError) *UpdateO
 // from the result of the "updateOrganization" endpoint of the "admin" service.
 func NewUpdateOrganizationGatewayErrorResponseBody(res *goa.ServiceError) *UpdateOrganizationGatewayErrorResponseBody {
 	body := &UpdateOrganizationGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeUnauthorizedResponseBody builds the HTTP response
+// body from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeUnauthorizedResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeUnauthorizedResponseBody {
+	body := &BulkUpdateAccountTypeUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeForbiddenResponseBody builds the HTTP response body
+// from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeForbiddenResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeForbiddenResponseBody {
+	body := &BulkUpdateAccountTypeForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeBadRequestResponseBody builds the HTTP response body
+// from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeBadRequestResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeBadRequestResponseBody {
+	body := &BulkUpdateAccountTypeBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeNotFoundResponseBody builds the HTTP response body
+// from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeNotFoundResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeNotFoundResponseBody {
+	body := &BulkUpdateAccountTypeNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeConflictResponseBody builds the HTTP response body
+// from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeConflictResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeConflictResponseBody {
+	body := &BulkUpdateAccountTypeConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeUnsupportedMediaResponseBody builds the HTTP
+// response body from the result of the "bulkUpdateAccountType" endpoint of the
+// "admin" service.
+func NewBulkUpdateAccountTypeUnsupportedMediaResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeUnsupportedMediaResponseBody {
+	body := &BulkUpdateAccountTypeUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeInvalidResponseBody builds the HTTP response body
+// from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeInvalidResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeInvalidResponseBody {
+	body := &BulkUpdateAccountTypeInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeInvariantViolationResponseBody builds the HTTP
+// response body from the result of the "bulkUpdateAccountType" endpoint of the
+// "admin" service.
+func NewBulkUpdateAccountTypeInvariantViolationResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeInvariantViolationResponseBody {
+	body := &BulkUpdateAccountTypeInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeUnexpectedResponseBody builds the HTTP response body
+// from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeUnexpectedResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeUnexpectedResponseBody {
+	body := &BulkUpdateAccountTypeUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewBulkUpdateAccountTypeGatewayErrorResponseBody builds the HTTP response
+// body from the result of the "bulkUpdateAccountType" endpoint of the "admin"
+// service.
+func NewBulkUpdateAccountTypeGatewayErrorResponseBody(res *goa.ServiceError) *BulkUpdateAccountTypeGatewayErrorResponseBody {
+	body := &BulkUpdateAccountTypeGatewayErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -5626,6 +6006,21 @@ func NewUpdateOrganizationPayload(body *UpdateOrganizationRequestBody, adminSess
 	return v
 }
 
+// NewBulkUpdateAccountTypePayload builds a admin service bulkUpdateAccountType
+// endpoint payload.
+func NewBulkUpdateAccountTypePayload(body *BulkUpdateAccountTypeRequestBody, adminSessionToken *string) *admin.BulkUpdateAccountTypePayload {
+	v := &admin.BulkUpdateAccountTypePayload{
+		AccountType: *body.AccountType,
+	}
+	v.Ids = make([]string, len(body.Ids))
+	for i, val := range body.Ids {
+		v.Ids[i] = val
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
 // NewDisableOrganizationPayload builds a admin service disableOrganization
 // endpoint payload.
 func NewDisableOrganizationPayload(body *DisableOrganizationRequestBody, adminSessionToken *string) *admin.DisableOrganizationPayload {
@@ -5745,6 +6140,36 @@ func NewGetOrganizationStatsPayload(adminSessionToken *string) *admin.GetOrganiz
 func ValidateUpdateOrganizationRequestBody(body *UpdateOrganizationRequestBody) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.AccountType != nil {
+		if !(*body.AccountType == "free" || *body.AccountType == "pro" || *body.AccountType == "enterprise") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.account_type", *body.AccountType, []any{"free", "pro", "enterprise"}))
+		}
+	}
+	return
+}
+
+// ValidateBulkUpdateAccountTypeRequestBody runs the validations defined on
+// BulkUpdateAccountTypeRequestBody
+func ValidateBulkUpdateAccountTypeRequestBody(body *BulkUpdateAccountTypeRequestBody) (err error) {
+	if body.Ids == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("ids", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if len(body.Ids) < 1 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids", body.Ids, len(body.Ids), 1, true))
+	}
+	for _, e := range body.Ids {
+		if utf8.RuneCountInString(e) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.ids[*]", e, utf8.RuneCountInString(e), 1, true))
+		}
+	}
+	if body.AccountType != nil {
+		if !(*body.AccountType == "free" || *body.AccountType == "pro" || *body.AccountType == "enterprise") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.account_type", *body.AccountType, []any{"free", "pro", "enterprise"}))
+		}
 	}
 	return
 }

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -97,7 +97,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|upsert-shadow-mcp-inventory-policy-bypass|delete-shadow-mcp-inventory-policy-bypass|block-shadow-mcp-inventory-server|unblock-shadow-mcp-inventory-server|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats)",
+		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -343,6 +343,10 @@ func ParseEndpoint(
 		adminUpdateOrganizationFlags                 = flag.NewFlagSet("update-organization", flag.ExitOnError)
 		adminUpdateOrganizationBodyFlag              = adminUpdateOrganizationFlags.String("body", "REQUIRED", "")
 		adminUpdateOrganizationAdminSessionTokenFlag = adminUpdateOrganizationFlags.String("admin-session-token", "", "")
+
+		adminBulkUpdateAccountTypeFlags                 = flag.NewFlagSet("bulk-update-account-type", flag.ExitOnError)
+		adminBulkUpdateAccountTypeBodyFlag              = adminBulkUpdateAccountTypeFlags.String("body", "REQUIRED", "")
+		adminBulkUpdateAccountTypeAdminSessionTokenFlag = adminBulkUpdateAccountTypeFlags.String("admin-session-token", "", "")
 
 		adminDisableOrganizationFlags                 = flag.NewFlagSet("disable-organization", flag.ExitOnError)
 		adminDisableOrganizationBodyFlag              = adminDisableOrganizationFlags.String("body", "REQUIRED", "")
@@ -3392,6 +3396,7 @@ func ParseEndpoint(
 	adminLogoutFlags.Usage = adminLogoutUsage
 	adminGetProjectFlags.Usage = adminGetProjectUsage
 	adminUpdateOrganizationFlags.Usage = adminUpdateOrganizationUsage
+	adminBulkUpdateAccountTypeFlags.Usage = adminBulkUpdateAccountTypeUsage
 	adminDisableOrganizationFlags.Usage = adminDisableOrganizationUsage
 	adminEnableOrganizationFlags.Usage = adminEnableOrganizationUsage
 	adminGetOrganizationFlags.Usage = adminGetOrganizationUsage
@@ -4332,6 +4337,9 @@ func ParseEndpoint(
 
 			case "update-organization":
 				epf = adminUpdateOrganizationFlags
+
+			case "bulk-update-account-type":
+				epf = adminBulkUpdateAccountTypeFlags
 
 			case "disable-organization":
 				epf = adminDisableOrganizationFlags
@@ -6318,6 +6326,9 @@ func ParseEndpoint(
 			case "update-organization":
 				endpoint = c.UpdateOrganization()
 				data, err = adminc.BuildUpdateOrganizationPayload(*adminUpdateOrganizationBodyFlag, *adminUpdateOrganizationAdminSessionTokenFlag)
+			case "bulk-update-account-type":
+				endpoint = c.BulkUpdateAccountType()
+				data, err = adminc.BuildBulkUpdateAccountTypePayload(*adminBulkUpdateAccountTypeBodyFlag, *adminBulkUpdateAccountTypeAdminSessionTokenFlag)
 			case "disable-organization":
 				endpoint = c.DisableOrganization()
 				data, err = adminc.BuildDisableOrganizationPayload(*adminDisableOrganizationBodyFlag, *adminDisableOrganizationAdminSessionTokenFlag)
@@ -8797,6 +8808,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    logout: Logout implements logout.`)
 	fmt.Fprintln(os.Stderr, `    get-project: Returns full admin details for a project by id or slug, including aggregated counts of child resources.`)
 	fmt.Fprintln(os.Stderr, `    update-organization: Updates admin-managed fields on an organization. At least one of account_type or whitelisted must be supplied.`)
+	fmt.Fprintln(os.Stderr, `    bulk-update-account-type: Sets one account type on many organizations in a single statement. An ID that matches no organization is reported back rather than failing the batch, so a stale ID costs the operator that row and not the whole call.`)
 	fmt.Fprintln(os.Stderr, `    disable-organization: Disables an organization, recording the moment of the action in disabled_at. Idempotent: disabling an already-disabled organization keeps the original timestamp.`)
 	fmt.Fprintln(os.Stderr, `    enable-organization: Re-enables a disabled organization by clearing disabled_at. Idempotent: an organization that is already active is unaffected.`)
 	fmt.Fprintln(os.Stderr, `    get-organization: Returns full admin details for a single organization by id or slug.`)
@@ -8912,7 +8924,27 @@ func adminUpdateOrganizationUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin update-organization --body '{\n      \"account_type\": \"abc123\",\n      \"id\": \"abc123\",\n      \"whitelisted\": false\n   }' --admin-session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin update-organization --body '{\n      \"account_type\": \"pro\",\n      \"id\": \"abc123\",\n      \"whitelisted\": false\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminBulkUpdateAccountTypeUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin bulk-update-account-type", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Sets one account type on many organizations in a single statement. An ID that matches no organization is reported back rather than failing the batch, so a stale ID costs the operator that row and not the whole call.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin bulk-update-account-type --body '{\n      \"account_type\": \"pro\",\n      \"ids\": [\n         \"aa\",\n         \"aa\"\n      ]\n   }' --admin-session-token \"abc123\"")
 }
 
 func adminDisableOrganizationUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -56007,7 +56007,7 @@ components:
                     type: array
                     items:
                         type: string
-                    description: IDs of the organizations whose account type was set.
+                    description: 'IDs of the organizations whose account type was set. Order is unspecified: do not rely on it.'
             description: Outcome of a bulk account type change.
             required:
                 - updated_ids
@@ -57204,6 +57204,7 @@ components:
                         minLength: 1
                     description: Organization IDs to update.
                     minItems: 1
+                    maxItems: 1000
             required:
                 - ids
                 - account_type

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -818,6 +818,82 @@ paths:
                                 $ref: '#/components/schemas/Error'
             security:
                 - admin_auth_header_Authorization: []
+    /admin/organizations.bulkUpdateAccountType:
+        post:
+            tags:
+                - admin
+            summary: bulkUpdateAccountType admin
+            description: Sets one account type on many organizations in a single statement. An ID that matches no organization is reported back rather than failing the batch, so a stale ID costs the operator that row and not the whole call.
+            operationId: adminBulkUpdateAccountType
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/BulkUpdateAccountTypeRequestBody'
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminBulkUpdateAccountTypeResult'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/organizations.list:
         get:
             description: Lists organizations for admin operations with optional search and filters.
@@ -55919,6 +55995,23 @@ components:
             description: Result of a strictly additive tool metadata batch insert.
             required:
                 - tools
+        AdminBulkUpdateAccountTypeResult:
+            type: object
+            properties:
+                missing_ids:
+                    type: array
+                    items:
+                        type: string
+                    description: IDs from the request that matched no organization, deduplicated and in request order. Nothing was written for these.
+                updated_ids:
+                    type: array
+                    items:
+                        type: string
+                    description: IDs of the organizations whose account type was set.
+            description: Outcome of a bulk account type change.
+            required:
+                - updated_ids
+                - missing_ids
         AdminListOrganizationMembersResult:
             type: object
             properties:
@@ -57094,6 +57187,26 @@ components:
                 - id
                 - reason
                 - description
+        BulkUpdateAccountTypeRequestBody:
+            type: object
+            properties:
+                account_type:
+                    type: string
+                    description: New gram_account_type for every listed organization.
+                    enum:
+                        - free
+                        - pro
+                        - enterprise
+                ids:
+                    type: array
+                    items:
+                        type: string
+                        minLength: 1
+                    description: Organization IDs to update.
+                    minItems: 1
+            required:
+                - ids
+                - account_type
         BusinessMemory:
             type: object
             properties:
@@ -76693,7 +76806,11 @@ components:
             properties:
                 account_type:
                     type: string
-                    description: New gram_account_type (e.g. free, pro, enterprise).
+                    description: New gram_account_type.
+                    enum:
+                        - free
+                        - pro
+                        - enterprise
                 id:
                     type: string
                     description: Organization ID.

--- a/server/internal/admin/bulkupdateaccounttype_test.go
+++ b/server/internal/admin/bulkupdateaccounttype_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,11 +14,11 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
 	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
-// postBulk drives a raw JSON body through the generated request decoder before
-// the handler, because the allow-list lives in the decoder and a test that calls
-// the handler directly never touches it.
+// Drives raw JSON through the generated decoder first, because the allow-list
+// lives there and a test that calls the handler directly never touches it.
 func postBulk(t *testing.T, ctx context.Context, svc *Service, body string) (*gen.AdminBulkUpdateAccountTypeResult, error) {
 	t.Helper()
 
@@ -32,21 +33,6 @@ func postBulk(t *testing.T, ctx context.Context, svc *Service, body string) (*ge
 	return svc.BulkUpdateAccountType(ctx, payload)
 }
 
-// postUpdateOrg is postBulk's twin for the single-organization write path.
-func postUpdateOrg(t *testing.T, ctx context.Context, svc *Service, body string) (*gen.AdminOrganization, error) {
-	t.Helper()
-
-	req := httptest.NewRequest(http.MethodPost, "/admin/organization.update", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-
-	payload, err := srv.DecodeUpdateOrganizationRequest(goahttp.NewMuxer(), goahttp.RequestDecoder)(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return svc.UpdateOrganization(ctx, payload)
-}
-
 func TestBulkUpdateAccountType_WritesOnlyTheListedIDs(t *testing.T) {
 	t.Parallel()
 
@@ -55,9 +41,8 @@ func TestBulkUpdateAccountType_WritesOnlyTheListedIDs(t *testing.T) {
 	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_a", name: "Bulk A", slug: "bulk-a", accountType: "free"})
 	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_b", name: "Bulk B", slug: "bulk-b", accountType: "pro"})
 
-	// The bystander is the whole point of this fixture: without a seeded
-	// organization outside ids, an UPDATE that dropped its WHERE clause and wrote
-	// the entire table would still look correct.
+	// Without an organization outside ids, an UPDATE that lost its WHERE clause
+	// and wrote the whole table would still look correct.
 	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_bystander", name: "Bystander", slug: "bystander", accountType: "free"})
 	bystanderBefore := readOrgState(t, ctx, conn, "org_bulk_bystander")
 
@@ -108,11 +93,11 @@ func TestBulkUpdateAccountType_ReportsMissingIDsAndWritesTheRest(t *testing.T) {
 	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_real", name: "Real Co", slug: "real-co", accountType: "free"})
 
 	res, err := postBulk(t, ctx, svc,
-		`{"ids":["org_bulk_ghost","org_bulk_real","org_bulk_ghost"],"account_type":"pro"}`)
+		`{"ids":["org_bulk_ghost","org_bulk_real","org_bulk_ghost","org_bulk_real"],"account_type":"pro"}`)
 	require.NoError(t, err, "a stale id must cost the operator that row, not the batch")
 
-	require.Equal(t, []string{"org_bulk_real"}, res.UpdatedIds)
-	require.Equal(t, []string{"org_bulk_ghost"}, res.MissingIds)
+	require.Equal(t, []string{"org_bulk_real"}, res.UpdatedIds, "a repeated id that was written must appear exactly once")
+	require.Equal(t, []string{"org_bulk_ghost"}, res.MissingIds, "a repeated id that was not written must appear exactly once")
 	require.Equal(t, "pro", readOrgState(t, ctx, conn, "org_bulk_real").GramAccountType)
 }
 
@@ -123,11 +108,13 @@ func TestBulkUpdateAccountType_AllIDsMissing(t *testing.T) {
 
 	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_only", name: "Only Co", slug: "only-co", accountType: "free"})
 
-	res, err := postBulk(t, ctx, svc, `{"ids":["ghost_one","ghost_two"],"account_type":"enterprise"}`)
+	// Unsorted on purpose, so a mutation that sorts is visible.
+	res, err := postBulk(t, ctx, svc, `{"ids":["ghost_zulu","ghost_alpha"],"account_type":"enterprise"}`)
 	require.NoError(t, err)
 	require.NotNil(t, res.UpdatedIds, "updated_ids is required, so it must serialise as [] rather than null")
+	require.NotNil(t, res.MissingIds, "missing_ids is required too, so it carries the same contract")
 	require.Empty(t, res.UpdatedIds)
-	require.Equal(t, []string{"ghost_one", "ghost_two"}, res.MissingIds)
+	require.Equal(t, []string{"ghost_zulu", "ghost_alpha"}, res.MissingIds)
 	require.Equal(t, "free", readOrgState(t, ctx, conn, "org_bulk_only").GramAccountType)
 }
 
@@ -135,9 +122,8 @@ func TestBulkUpdateAccountType_RejectedRequestsWriteNothing(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		body string
-		// names is the value the refusal must quote back to the operator.
+		name  string
+		body  string
 		names string
 	}{
 		{name: "unknown value", body: `{"ids":["org_bulk_bad"],"account_type":"gold"}`, names: "gold"},
@@ -176,73 +162,92 @@ func TestBulkUpdateAccountType_RejectedRequestsWriteNothing(t *testing.T) {
 func TestBulkUpdateAccountType_AcceptsEveryAllowedValue(t *testing.T) {
 	t.Parallel()
 
-	for _, accountType := range []string{"free", "pro", "enterprise"} {
-		t.Run(accountType, func(t *testing.T) {
+	cases := []struct{ seed, target string }{
+		{seed: "pro", target: "free"},
+		{seed: "free", target: "pro"},
+		{seed: "free", target: "enterprise"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.target, func(t *testing.T) {
 			t.Parallel()
 
 			ctx, svc, conn := newTestAdminService(t)
-			seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_ok", name: "Ok Co", slug: "ok-co", accountType: "free"})
+			seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_ok", name: "Ok Co", slug: "ok-co", accountType: tc.seed})
 
-			_, err := postBulk(t, ctx, svc, `{"ids":["org_bulk_ok"],"account_type":"`+accountType+`"}`)
+			res, err := postBulk(t, ctx, svc, `{"ids":["org_bulk_ok"],"account_type":"`+tc.target+`"}`)
 			require.NoError(t, err)
-			require.Equal(t, accountType, readOrgState(t, ctx, conn, "org_bulk_ok").GramAccountType)
+			require.Equal(t, []string{"org_bulk_ok"}, res.UpdatedIds, "an organization that was written must be reported as written")
+			require.Empty(t, res.MissingIds, "an organization that exists must never be reported missing")
+			require.Equal(t, tc.target, readOrgState(t, ctx, conn, "org_bulk_ok").GramAccountType)
 		})
 	}
 }
 
-// The two write paths accepting different sets of values is the defect this
-// endpoint exists to prevent, so dropping the allow-list from either one has to
-// turn a test red.
-func TestUpdateOrganization_AccountTypeAllowList(t *testing.T) {
+// Every other test here is a real transition, so this is the only one that sees
+// a "skip rows already correct" optimisation reporting a real organization missing.
+func TestBulkUpdateAccountType_AlreadyOnTargetIsNotMissing(t *testing.T) {
 	t.Parallel()
 
-	t.Run("refuses an out-of-list value and writes nothing", func(t *testing.T) {
-		t.Parallel()
+	ctx, svc, conn := newTestAdminService(t)
 
-		ctx, svc, conn := newTestAdminService(t)
-		seedOrg(t, ctx, conn, orgFixture{id: "org_single_bad", name: "Single Bad", slug: "single-bad", accountType: "free", whitelisted: true})
-		before := readOrgState(t, ctx, conn, "org_single_bad")
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_noop", name: "Noop Co", slug: "noop-co", accountType: "pro"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_move", name: "Move Co", slug: "move-co", accountType: "free"})
 
-		for _, bad := range []string{"gold", "Free", "FREE", ""} {
-			_, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_bad","account_type":"`+bad+`"}`)
-			require.Error(t, err, "the single path must refuse %q just as the bulk path does", bad)
-			if bad != "" {
-				require.ErrorContains(t, err, bad, "the refusal must name the offending value")
-			}
+	res, err := postBulk(t, ctx, svc, `{"ids":["org_bulk_noop","org_bulk_move"],"account_type":"pro"}`)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"org_bulk_noop", "org_bulk_move"}, res.UpdatedIds,
+		"an organization already on the target type exists, so it must be reported as written")
+	require.Empty(t, res.MissingIds, "an organization that exists must never be reported missing")
+
+	require.Equal(t, "pro", readOrgState(t, ctx, conn, "org_bulk_noop").GramAccountType)
+	require.Equal(t, "pro", readOrgState(t, ctx, conn, "org_bulk_move").GramAccountType)
+}
+
+func TestBulkUpdateAccountType_RejectsMoreIDsThanTheCap(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_cap", name: "Cap Co", slug: "cap-co", accountType: "free"})
+	before := readOrgState(t, ctx, conn, "org_bulk_cap")
+
+	atCap := make([]string, constants.MaxBulkAccountTypeIDs)
+	for i := range atCap {
+		atCap[i] = fmt.Sprintf(`"org_bulk_cap_%d"`, i)
+	}
+	overCap := append(append([]string{}, atCap...), `"org_bulk_cap"`)
+
+	_, err := postBulk(t, ctx, svc, `{"ids":[`+strings.Join(atCap, ",")+`],"account_type":"pro"}`)
+	require.NoError(t, err, "a request exactly at the cap must be accepted")
+
+	_, err = postBulk(t, ctx, svc, `{"ids":[`+strings.Join(overCap, ",")+`],"account_type":"pro"}`)
+	require.Error(t, err, "one id over the cap must be refused")
+
+	after := readOrgState(t, ctx, conn, "org_bulk_cap")
+	require.Equal(t, "free", after.GramAccountType, "the refused request must write nothing")
+	require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+}
+
+// Straight at the service on purpose: this is the check a future non-HTTP caller hits.
+func TestBulkUpdateAccountType_ServiceRefusesWhatTheDecoderWould(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_svc", name: "Svc Co", slug: "svc-co", accountType: "free"})
+	before := readOrgState(t, ctx, conn, "org_bulk_svc")
+
+	for _, bad := range []string{"gold", "Free", "FREE", ""} {
+		_, err := svc.BulkUpdateAccountType(ctx, &gen.BulkUpdateAccountTypePayload{
+			Ids:         []string{"org_bulk_svc"},
+			AccountType: bad,
+		})
+		require.Error(t, err, "the service must refuse %q even with no decoder in front of it", bad)
+		if bad != "" {
+			require.ErrorContains(t, err, bad, "the refusal must name the offending value")
 		}
+	}
 
-		after := readOrgState(t, ctx, conn, "org_single_bad")
-		require.Equal(t, "free", after.GramAccountType)
-		require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
-	})
-
-	t.Run("accepts every allowed value", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, svc, conn := newTestAdminService(t)
-		seedOrg(t, ctx, conn, orgFixture{id: "org_single_ok", name: "Single Ok", slug: "single-ok", accountType: "free"})
-
-		for _, good := range []string{"free", "pro", "enterprise"} {
-			res, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_ok","account_type":"`+good+`"}`)
-			require.NoError(t, err)
-			require.Equal(t, good, res.AccountType)
-		}
-	})
-
-	// The allow-list narrows account_type; it must not have made it required or
-	// disturbed the guard that rejects a body carrying neither field.
-	t.Run("whitelisted alone still works", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, svc, conn := newTestAdminService(t)
-		seedOrg(t, ctx, conn, orgFixture{id: "org_single_wl", name: "Single WL", slug: "single-wl", accountType: "pro", whitelisted: false})
-
-		res, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_wl","whitelisted":true}`)
-		require.NoError(t, err)
-		require.True(t, res.Whitelisted)
-		require.Equal(t, "pro", res.AccountType, "a whitelist-only write must leave the account type alone")
-
-		_, err = postUpdateOrg(t, ctx, svc, `{"id":"org_single_wl"}`)
-		require.Error(t, err, "a body with neither account_type nor whitelisted must still be rejected")
-	})
+	after := readOrgState(t, ctx, conn, "org_bulk_svc")
+	require.Equal(t, "free", after.GramAccountType)
+	require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
 }

--- a/server/internal/admin/bulkupdateaccounttype_test.go
+++ b/server/internal/admin/bulkupdateaccounttype_test.go
@@ -1,0 +1,248 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+)
+
+// postBulk drives a raw JSON body through the generated request decoder before
+// the handler, because the allow-list lives in the decoder and a test that calls
+// the handler directly never touches it.
+func postBulk(t *testing.T, ctx context.Context, svc *Service, body string) (*gen.AdminBulkUpdateAccountTypeResult, error) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/organizations.bulkUpdateAccountType", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	payload, err := srv.DecodeBulkUpdateAccountTypeRequest(goahttp.NewMuxer(), goahttp.RequestDecoder)(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc.BulkUpdateAccountType(ctx, payload)
+}
+
+// postUpdateOrg is postBulk's twin for the single-organization write path.
+func postUpdateOrg(t *testing.T, ctx context.Context, svc *Service, body string) (*gen.AdminOrganization, error) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/organization.update", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	payload, err := srv.DecodeUpdateOrganizationRequest(goahttp.NewMuxer(), goahttp.RequestDecoder)(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc.UpdateOrganization(ctx, payload)
+}
+
+func TestBulkUpdateAccountType_WritesOnlyTheListedIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_a", name: "Bulk A", slug: "bulk-a", accountType: "free"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_b", name: "Bulk B", slug: "bulk-b", accountType: "pro"})
+
+	// The bystander is the whole point of this fixture: without a seeded
+	// organization outside ids, an UPDATE that dropped its WHERE clause and wrote
+	// the entire table would still look correct.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_bystander", name: "Bystander", slug: "bystander", accountType: "free"})
+	bystanderBefore := readOrgState(t, ctx, conn, "org_bulk_bystander")
+
+	res, err := postBulk(t, ctx, svc, `{"ids":["org_bulk_a","org_bulk_b"],"account_type":"enterprise"}`)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"org_bulk_a", "org_bulk_b"}, res.UpdatedIds)
+	require.Empty(t, res.MissingIds)
+
+	require.Equal(t, "enterprise", readOrgState(t, ctx, conn, "org_bulk_a").GramAccountType)
+	require.Equal(t, "enterprise", readOrgState(t, ctx, conn, "org_bulk_b").GramAccountType)
+
+	bystanderAfter := readOrgState(t, ctx, conn, "org_bulk_bystander")
+	require.Equal(t, "free", bystanderAfter.GramAccountType, "an organization outside ids must not be written")
+	require.Equal(t, bystanderBefore.UpdatedAt.Time, bystanderAfter.UpdatedAt.Time, "an organization outside ids must not even be touched")
+}
+
+func TestBulkUpdateAccountType_LeavesOtherColumnsAlone(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	disabled := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{
+		id:          "org_bulk_cols",
+		name:        "Cols Co",
+		slug:        "cols-co",
+		accountType: "free",
+		whitelisted: true,
+		disabledAt:  &disabled,
+	})
+	before := readOrgState(t, ctx, conn, "org_bulk_cols")
+
+	_, err := postBulk(t, ctx, svc, `{"ids":["org_bulk_cols"],"account_type":"pro"}`)
+	require.NoError(t, err)
+
+	after := readOrgState(t, ctx, conn, "org_bulk_cols")
+	require.Equal(t, "pro", after.GramAccountType)
+	require.True(t, after.Whitelisted, "the bulk write must not reset whitelisted")
+	require.Equal(t, before.DisabledAt.Time, after.DisabledAt.Time, "a disabled organization must stay disabled")
+	require.True(t, after.UpdatedAt.Time.After(before.UpdatedAt.Time), "the write must move updated_at")
+}
+
+func TestBulkUpdateAccountType_ReportsMissingIDsAndWritesTheRest(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_real", name: "Real Co", slug: "real-co", accountType: "free"})
+
+	res, err := postBulk(t, ctx, svc,
+		`{"ids":["org_bulk_ghost","org_bulk_real","org_bulk_ghost"],"account_type":"pro"}`)
+	require.NoError(t, err, "a stale id must cost the operator that row, not the batch")
+
+	require.Equal(t, []string{"org_bulk_real"}, res.UpdatedIds)
+	require.Equal(t, []string{"org_bulk_ghost"}, res.MissingIds)
+	require.Equal(t, "pro", readOrgState(t, ctx, conn, "org_bulk_real").GramAccountType)
+}
+
+func TestBulkUpdateAccountType_AllIDsMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_only", name: "Only Co", slug: "only-co", accountType: "free"})
+
+	res, err := postBulk(t, ctx, svc, `{"ids":["ghost_one","ghost_two"],"account_type":"enterprise"}`)
+	require.NoError(t, err)
+	require.NotNil(t, res.UpdatedIds, "updated_ids is required, so it must serialise as [] rather than null")
+	require.Empty(t, res.UpdatedIds)
+	require.Equal(t, []string{"ghost_one", "ghost_two"}, res.MissingIds)
+	require.Equal(t, "free", readOrgState(t, ctx, conn, "org_bulk_only").GramAccountType)
+}
+
+func TestBulkUpdateAccountType_RejectedRequestsWriteNothing(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		// names is the value the refusal must quote back to the operator.
+		names string
+	}{
+		{name: "unknown value", body: `{"ids":["org_bulk_bad"],"account_type":"gold"}`, names: "gold"},
+		{name: "capitalised", body: `{"ids":["org_bulk_bad"],"account_type":"Free"}`, names: "Free"},
+		{name: "upper case", body: `{"ids":["org_bulk_bad"],"account_type":"FREE"}`, names: "FREE"},
+		{name: "padded", body: `{"ids":["org_bulk_bad"],"account_type":" free"}`, names: " free"},
+		{name: "empty value", body: `{"ids":["org_bulk_bad"],"account_type":""}`},
+		{name: "empty ids array", body: `{"ids":[],"account_type":"pro"}`},
+		{name: "empty id element", body: `{"ids":["org_bulk_bad",""],"account_type":"pro"}`},
+		{name: "missing ids", body: `{"account_type":"pro"}`},
+		{name: "missing account_type", body: `{"ids":["org_bulk_bad"]}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, svc, conn := newTestAdminService(t)
+			seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_bad", name: "Bad Co", slug: "bad-co", accountType: "free"})
+			before := readOrgState(t, ctx, conn, "org_bulk_bad")
+
+			_, err := postBulk(t, ctx, svc, tc.body)
+			require.Error(t, err, "the request decoder must refuse this before the handler runs")
+			if tc.names != "" {
+				require.ErrorContains(t, err, "account_type")
+				require.ErrorContains(t, err, tc.names, "the refusal must name the offending value")
+			}
+
+			after := readOrgState(t, ctx, conn, "org_bulk_bad")
+			require.Equal(t, "free", after.GramAccountType, "a refused request must write nothing at all")
+			require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+		})
+	}
+}
+
+func TestBulkUpdateAccountType_AcceptsEveryAllowedValue(t *testing.T) {
+	t.Parallel()
+
+	for _, accountType := range []string{"free", "pro", "enterprise"} {
+		t.Run(accountType, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, svc, conn := newTestAdminService(t)
+			seedOrg(t, ctx, conn, orgFixture{id: "org_bulk_ok", name: "Ok Co", slug: "ok-co", accountType: "free"})
+
+			_, err := postBulk(t, ctx, svc, `{"ids":["org_bulk_ok"],"account_type":"`+accountType+`"}`)
+			require.NoError(t, err)
+			require.Equal(t, accountType, readOrgState(t, ctx, conn, "org_bulk_ok").GramAccountType)
+		})
+	}
+}
+
+// The two write paths accepting different sets of values is the defect this
+// endpoint exists to prevent, so dropping the allow-list from either one has to
+// turn a test red.
+func TestUpdateOrganization_AccountTypeAllowList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("refuses an out-of-list value and writes nothing", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, svc, conn := newTestAdminService(t)
+		seedOrg(t, ctx, conn, orgFixture{id: "org_single_bad", name: "Single Bad", slug: "single-bad", accountType: "free", whitelisted: true})
+		before := readOrgState(t, ctx, conn, "org_single_bad")
+
+		for _, bad := range []string{"gold", "Free", "FREE", ""} {
+			_, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_bad","account_type":"`+bad+`"}`)
+			require.Error(t, err, "the single path must refuse %q just as the bulk path does", bad)
+			if bad != "" {
+				require.ErrorContains(t, err, bad, "the refusal must name the offending value")
+			}
+		}
+
+		after := readOrgState(t, ctx, conn, "org_single_bad")
+		require.Equal(t, "free", after.GramAccountType)
+		require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+	})
+
+	t.Run("accepts every allowed value", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, svc, conn := newTestAdminService(t)
+		seedOrg(t, ctx, conn, orgFixture{id: "org_single_ok", name: "Single Ok", slug: "single-ok", accountType: "free"})
+
+		for _, good := range []string{"free", "pro", "enterprise"} {
+			res, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_ok","account_type":"`+good+`"}`)
+			require.NoError(t, err)
+			require.Equal(t, good, res.AccountType)
+		}
+	})
+
+	// The allow-list narrows account_type; it must not have made it required or
+	// disturbed the guard that rejects a body carrying neither field.
+	t.Run("whitelisted alone still works", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, svc, conn := newTestAdminService(t)
+		seedOrg(t, ctx, conn, orgFixture{id: "org_single_wl", name: "Single WL", slug: "single-wl", accountType: "pro", whitelisted: false})
+
+		res, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_wl","whitelisted":true}`)
+		require.NoError(t, err)
+		require.True(t, res.Whitelisted)
+		require.Equal(t, "pro", res.AccountType, "a whitelist-only write must leave the account type alone")
+
+		_, err = postUpdateOrg(t, ctx, svc, `{"id":"org_single_wl"}`)
+		require.Error(t, err, "a body with neither account_type nor whitelisted must still be rejected")
+	})
+}

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -590,6 +590,11 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 	if payload.AccountType == nil && payload.Whitelisted == nil {
 		return nil, oops.E(oops.CodeBadRequest, nil, "at least one of account_type or whitelisted must be supplied")
 	}
+	// See ExtendTrial: the design bounds this too, but generated validation only
+	// runs at the HTTP boundary.
+	if payload.AccountType != nil && !constants.IsAccountType(*payload.AccountType) {
+		return nil, oops.E(oops.CodeInvalid, nil, "account_type must be one of %s, got %q", strings.Join(constants.AccountTypes, ", "), *payload.AccountType)
+	}
 
 	queries := repo.New(s.db)
 	if err := queries.AdminUpdateOrganization(ctx, repo.AdminUpdateOrganizationParams{
@@ -604,6 +609,10 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 }
 
 func (s *Service) BulkUpdateAccountType(ctx context.Context, payload *gen.BulkUpdateAccountTypePayload) (*gen.AdminBulkUpdateAccountTypeResult, error) {
+	if !constants.IsAccountType(payload.AccountType) {
+		return nil, oops.E(oops.CodeInvalid, nil, "account_type must be one of %s, got %q", strings.Join(constants.AccountTypes, ", "), payload.AccountType)
+	}
+
 	updated, err := repo.New(s.db).AdminBulkUpdateAccountType(ctx, repo.AdminBulkUpdateAccountTypeParams{
 		AccountType: payload.AccountType,
 		Ids:         payload.Ids,
@@ -617,8 +626,8 @@ func (s *Service) BulkUpdateAccountType(ctx context.Context, payload *gen.BulkUp
 		written[id] = struct{}{}
 	}
 
-	// An id that matched nothing is the operator's stale paste, and naming it is
-	// the only way they can tell the batch fell short of what they asked for.
+	// Naming the ids that matched nothing is the only way the operator can tell
+	// the batch fell short.
 	missing := make([]string, 0, len(payload.Ids))
 	seen := make(map[string]struct{}, len(payload.Ids))
 	for _, id := range payload.Ids {

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -603,6 +603,45 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after update")
 }
 
+func (s *Service) BulkUpdateAccountType(ctx context.Context, payload *gen.BulkUpdateAccountTypePayload) (*gen.AdminBulkUpdateAccountTypeResult, error) {
+	updated, err := repo.New(s.db).AdminBulkUpdateAccountType(ctx, repo.AdminBulkUpdateAccountTypeParams{
+		AccountType: payload.AccountType,
+		Ids:         payload.Ids,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "bulk update account type").LogError(ctx, s.logger)
+	}
+
+	written := make(map[string]struct{}, len(updated))
+	for _, id := range updated {
+		written[id] = struct{}{}
+	}
+
+	// An id that matched nothing is the operator's stale paste, and naming it is
+	// the only way they can tell the batch fell short of what they asked for.
+	missing := make([]string, 0, len(payload.Ids))
+	seen := make(map[string]struct{}, len(payload.Ids))
+	for _, id := range payload.Ids {
+		if _, ok := written[id]; ok {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		missing = append(missing, id)
+	}
+
+	if updated == nil {
+		updated = []string{}
+	}
+
+	return &gen.AdminBulkUpdateAccountTypeResult{
+		UpdatedIds: updated,
+		MissingIds: missing,
+	}, nil
+}
+
 func (s *Service) DisableOrganization(ctx context.Context, payload *gen.DisableOrganizationPayload) (*gen.AdminOrganization, error) {
 	rows, err := repo.New(s.db).AdminDisableOrganization(ctx, payload.ID)
 	if err != nil {

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"strings"
 	"testing"
@@ -12,8 +14,10 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
@@ -157,9 +161,104 @@ func TestUpdateOrganization_AccountTypeOnly(t *testing.T) {
 func TestUpdateOrganization_NoFieldsRejected(t *testing.T) {
 	t.Parallel()
 
-	ctx, svc, _ := newTestAdminService(t)
+	ctx, svc, conn := newTestAdminService(t)
+	// Must exist, or a missing guard is masked by the handler's not-found.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_x", name: "X Co", slug: "x-co", accountType: "free"})
+
 	_, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: "org_x"})
 	require.Error(t, err)
+	require.ErrorContains(t, err, "at least one of")
+}
+
+func postUpdateOrg(t *testing.T, ctx context.Context, svc *Service, body string) (*gen.AdminOrganization, error) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/organization.update", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	payload, err := srv.DecodeUpdateOrganizationRequest(goahttp.NewMuxer(), goahttp.RequestDecoder)(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc.UpdateOrganization(ctx, payload)
+}
+
+// The two paths accepting different sets is the defect this slice prevents, so
+// dropping the allow-list from either one has to turn a test red.
+func TestUpdateOrganization_AccountTypeAllowList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("refuses an out-of-list value and writes nothing", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, svc, conn := newTestAdminService(t)
+		seedOrg(t, ctx, conn, orgFixture{id: "org_single_bad", name: "Single Bad", slug: "single-bad", accountType: "free", whitelisted: true})
+		before := readOrgState(t, ctx, conn, "org_single_bad")
+
+		for _, bad := range []string{"gold", "Free", "FREE", ""} {
+			_, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_bad","account_type":"`+bad+`"}`)
+			require.Error(t, err, "the single path must refuse %q just as the bulk path does", bad)
+			if bad != "" {
+				require.ErrorContains(t, err, bad, "the refusal must name the offending value")
+			}
+		}
+
+		after := readOrgState(t, ctx, conn, "org_single_bad")
+		require.Equal(t, "free", after.GramAccountType)
+		require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+	})
+
+	t.Run("accepts every allowed value", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, svc, conn := newTestAdminService(t)
+		seedOrg(t, ctx, conn, orgFixture{id: "org_single_ok", name: "Single Ok", slug: "single-ok", accountType: "free"})
+
+		for _, good := range []string{"free", "pro", "enterprise"} {
+			res, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_ok","account_type":"`+good+`"}`)
+			require.NoError(t, err)
+			require.Equal(t, good, res.AccountType)
+		}
+	})
+
+	t.Run("whitelisted alone still works", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, svc, conn := newTestAdminService(t)
+		seedOrg(t, ctx, conn, orgFixture{id: "org_single_wl", name: "Single WL", slug: "single-wl", accountType: "pro", whitelisted: false})
+
+		res, err := postUpdateOrg(t, ctx, svc, `{"id":"org_single_wl","whitelisted":true}`)
+		require.NoError(t, err)
+		require.True(t, res.Whitelisted)
+		require.Equal(t, "pro", res.AccountType, "a whitelist-only write must leave the account type alone")
+
+		_, err = postUpdateOrg(t, ctx, svc, `{"id":"org_single_wl"}`)
+		require.Error(t, err, "a body with neither account_type nor whitelisted must still be rejected")
+	})
+
+	t.Run("the service refuses what the decoder would", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, svc, conn := newTestAdminService(t)
+		seedOrg(t, ctx, conn, orgFixture{id: "org_single_svc", name: "Single Svc", slug: "single-svc", accountType: "free"})
+		before := readOrgState(t, ctx, conn, "org_single_svc")
+
+		for _, bad := range []string{"gold", "Free", "FREE", ""} {
+			_, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{
+				ID:          "org_single_svc",
+				AccountType: &bad,
+			})
+			require.Error(t, err, "the service must refuse %q even with no decoder in front of it", bad)
+			if bad != "" {
+				require.ErrorContains(t, err, bad, "the refusal must name the offending value")
+			}
+		}
+
+		after := readOrgState(t, ctx, conn, "org_single_svc")
+		require.Equal(t, "free", after.GramAccountType)
+		require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+	})
 }
 
 func TestGetOrganization_NotFound(t *testing.T) {

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -244,6 +244,17 @@ SET
     updated_at = clock_timestamp()
 WHERE id = @id;
 
+-- name: AdminBulkUpdateAccountType :many
+-- Bulk sibling of AdminUpdateOrganization. One statement rather than a loop, so
+-- the whole batch lands or none of it does. Returns the ids it touched, which is
+-- how the caller learns which of its ids matched nothing.
+UPDATE organization_metadata
+SET
+    gram_account_type = @account_type::text,
+    updated_at = clock_timestamp()
+WHERE id = ANY(@ids::text[])
+RETURNING id;
+
 -- name: AdminDisableOrganization :execrows
 -- Operator-initiated disable. Keyed on the Gram organization id rather than
 -- workos_id so an organization that was never linked to WorkOS can still be

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -245,9 +245,8 @@ SET
 WHERE id = @id;
 
 -- name: AdminBulkUpdateAccountType :many
--- Bulk sibling of AdminUpdateOrganization. One statement rather than a loop, so
--- the whole batch lands or none of it does. Returns the ids it touched, which is
--- how the caller learns which of its ids matched nothing.
+-- One statement rather than a loop, so every id is matched against one snapshot.
+-- RETURNING is how the caller learns which of its ids matched nothing.
 UPDATE organization_metadata
 SET
     gram_account_type = @account_type::text,

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -12,6 +12,43 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const adminBulkUpdateAccountType = `-- name: AdminBulkUpdateAccountType :many
+UPDATE organization_metadata
+SET
+    gram_account_type = $1::text,
+    updated_at = clock_timestamp()
+WHERE id = ANY($2::text[])
+RETURNING id
+`
+
+type AdminBulkUpdateAccountTypeParams struct {
+	AccountType string
+	Ids         []string
+}
+
+// Bulk sibling of AdminUpdateOrganization. One statement rather than a loop, so
+// the whole batch lands or none of it does. Returns the ids it touched, which is
+// how the caller learns which of its ids matched nothing.
+func (q *Queries) AdminBulkUpdateAccountType(ctx context.Context, arg AdminBulkUpdateAccountTypeParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, adminBulkUpdateAccountType, arg.AccountType, arg.Ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const adminCountOrganizations = `-- name: AdminCountOrganizations :one
 WITH search AS (
     -- Identical to AdminListOrganizations, escaping included: a pasted id that

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -26,9 +26,8 @@ type AdminBulkUpdateAccountTypeParams struct {
 	Ids         []string
 }
 
-// Bulk sibling of AdminUpdateOrganization. One statement rather than a loop, so
-// the whole batch lands or none of it does. Returns the ids it touched, which is
-// how the caller learns which of its ids matched nothing.
+// One statement rather than a loop, so every id is matched against one snapshot.
+// RETURNING is how the caller learns which of its ids matched nothing.
 func (q *Queries) AdminBulkUpdateAccountType(ctx context.Context, arg AdminBulkUpdateAccountTypeParams) ([]string, error) {
 	rows, err := q.db.Query(ctx, adminBulkUpdateAccountType, arg.AccountType, arg.Ids)
 	if err != nil {

--- a/server/internal/constants/accounts.go
+++ b/server/internal/constants/accounts.go
@@ -1,0 +1,15 @@
+package constants
+
+import "slices"
+
+// AccountTypes is the closed set an operator may write. Shared by the Goa
+// design, which rejects anything else at the HTTP boundary, and by the admin
+// service, which repeats the check for a caller that arrives another way.
+var AccountTypes = []string{"free", "pro", "enterprise"}
+
+func IsAccountType(v string) bool {
+	return slices.Contains(AccountTypes, v)
+}
+
+// Far above any realistic selection, far below a list worth echoing back.
+const MaxBulkAccountTypeIDs = 1000


### PR DESCRIPTION
A platform admin correcting several organizations' account types has to open each one in turn, so this adds the endpoint that sets one account type on many organizations in a single statement. AGE-3193. Server half only: the list UI that calls it is a separate slice.

```
POST /admin/organizations.bulkUpdateAccountType

  ids           1 to 1000 organization ids
  account_type  free, pro or enterprise

  updated_ids   the ids that were written. Order unspecified
  missing_ids   ids that matched no organization, deduplicated, in request order
```

## Decisions worth a reviewer's attention

**A missing id is reported back rather than failing the batch.** An operator working from a list that has moved under them should lose the stale row, not the call. So the write is one `UPDATE ... WHERE id = ANY(...) RETURNING id`, and the ids that do not come back are the ids that matched nothing. One statement rather than a loop means every id is matched against one snapshot.

**The `UPDATE` deliberately does not skip rows already on the target type.** Adding `AND gram_account_type IS DISTINCT FROM @account_type` looks like a free optimisation and is not: `RETURNING` would then omit an organization that exists and is already correct, and the caller would report it to the operator as missing. `TestBulkUpdateAccountType_AlreadyOnTargetIsNotMissing` sends one organization already on `pro` alongside one moving to `pro` and pins that both come back written.

That test exists because the review round found the mutation surviving, and then found that the obvious fix hid it: making every subtest a real transition means the row's value always differs from the target, so `IS DISTINCT FROM` still matches and the mutation stays invisible. The case had to be built specifically.

**The allow-list is repeated in the service.** `constants.AccountTypes` is shared by the Goa design, which rejects anything else at the HTTP boundary, and by the service, which checks again for a caller arriving another way. This follows `ExtendTrial`, which already repeats its own bound. One list, two enforcement points, so they cannot drift into accepting different sets.

**The 1000 cap is a defensible default, not a derived number.** Far above any realistic selection and far below a request worth echoing back. **Reviewer input welcome on the number.** One asymmetry to know about: the cap is enforced only by the generated decoder's `maxItems`, so unlike the allow-list it has no service-side counterpart and a non-HTTP caller could pass more. That matches how `ExtendTrial` treats its own `Minimum` and `Maximum`, so this does not diverge from house practice, but the two bounds in this change are enforced in different numbers of places.

**`updated_ids` order is unspecified and the design says so.** `RETURNING` gives no ordering guarantee. The client half must treat it as a set.

**No audit entry, and the reason is specific.** This is an explicit non-goal of the epic. It is worth restating because the original justification is now obsolete: `admin.Service` does carry an audit logger, and `RearmTrial` writes an entry. The reason it still holds is in `adminActor`'s own doc comment: these entries surface in the customer's own feed, and auditapi's read-side mask cannot recognise an OIDC subject as staff. So auditing a platform-admin write would publish staff activity into customer-visible history under an unmasked actor. Recorded on AGE-3182 rather than filed as a ticket.

## Review round

Two reviewers ran 32 mutations between them. The bulk write, the allow-list, the auth, the generated output and the scope all came back clean. Nine findings were applied. The two that mattered were the one described above and a stale SDK spec.

Two of the reviewers' conclusions I want a reader to have:

- **`TestUpdateOrganization_NoFieldsRejected` was not exercising its guard.** It asserted a rejection that the handler would also have produced for an unseeded organization, so deleting the guard left it green. The organization is seeded now, and deleting the guard fails both that test and the allow-list one.
- **Dropping the `openapi:typename` Meta is a genuine no-op here.** Measured rather than assumed: removing it and regenerating into a clean tree left `git diff --stat -- server/gen` completely empty, because Goa infers the same name.

## The SDK spec commit

`.speakeasy/out.openapi.yaml` moves in this change, which looks unrelated to an admin-only endpoint and is not. `overlays/goa.yaml` strips the admin API from `$.paths` but never from `components.schemas`, so an admin request or response body orphans into the generated SDK source document. `.github/filters.yaml` puts `server/gen/http/openapi3.yaml` in the `sdk-gen` filter, so `sdk-gen-check` runs on this change and fails on a dirty tree. It did, and this fixes it.

43 lines added and 1 removed, in that file only. No generated SDK source moves. #5339 would make this class of commit unnecessary; it is parked, so for now every admin endpoint carries one.

## Notes

The route and the security scheme are correctly unexercised by the service tests, which reach the service directly. One consequence of repeating the allow-list: `TestBulkUpdateAccountType_RejectedRequestsWriteNothing` and `TestBulkUpdateAccountType_ServiceRefusesWhatTheDecoderWould` now both go red for a single cause, and neither failure distinguishes which layer broke.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bulk-set organization account types and align validation across admin writes.

- New: `POST /admin/organizations.bulkUpdateAccountType` updates up to 1000 orgs in one call. Old behavior required one request per org. The endpoint returns `updated_ids` (order unspecified) and `missing_ids` (deduplicated, in request order) instead of failing the whole batch on a stale ID. Rows already on the target type are included in `updated_ids`.
- Validation change: both admin write paths now accept only `free`, `pro`, or `enterprise`. Previously, `updateOrganization` accepted any string and wrote it. Now, out-of-list values are rejected before any write, and the error names the value. Reads are unchanged; no DB constraint is added.

**Review and migration notes**
- Endpoint contract: body `{ ids: string[1..1000], account_type: "free"|"pro"|"enterprise" }`; response `{ updated_ids: string[], missing_ids: string[] }`.
- One `UPDATE ... WHERE id = ANY(...) RETURNING id` powers the batch; `updated_ids` order is not guaranteed.
- Allow-list is defined once in `server/internal/constants` and enforced in both the Goa design and the service to protect non-HTTP callers.
- The 1000-id cap is enforced by the generated decoder; non-HTTP callers are not capped.
- No audit entry is written (per AGE-3182 rationale).
- OpenAPI spec (`.speakeasy/out.openapi.yaml`) updated so `sdk-gen-check` passes; no SDK source changed.
- Migration: any caller of `updateOrganization` must send only `free`, `pro`, or `enterprise`; other values will now be rejected. This implements the server half of AGE-3193.

<sup>Written for commit 09c6fd880f7f10862588de881642a80d35b128f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

