### PR TITLE
feat(admin): show the platform counts above the organizations list

### DIFF
--- a/.changeset/admin-organizations-stat-strip.md
+++ b/.changeset/admin-organizations-stat-strip.md
@@ -10,23 +10,13 @@ created in the last seven days. Trials ending in 7 days counts the trials in the
 `ending_soon` state. Disabled counts the switched-off organizations and says how
 many were switched off in the last seven days.
 
-Each figure is a control. Pressing one filters the table to the rows behind it:
-Organizations opens the whole platform, Trials ending in 7 days applies
-`trial=ending_soon`, and Disabled applies `disabled=disabled`. A press replaces
-whatever was filtered rather than adding to it, so pressing Disabled while a
-trial filter is set leaves only the disabled filter, and the filter sheet
-follows. The search term is not one of the three filters and is left alone.
+Each figure is a control. Pressing one filters the table to the rows behind it,
+replacing whatever was filtered rather than adding to it, and clearing the
+search term the figure never counted.
 
-The first two cells set the status filter to both statuses rather than clearing
-it, because the table shows active organizations only when nothing is chosen.
-Without that, the figure and the list it opened would differ by exactly the
-number of disabled organizations.
+The figures describe the whole platform, so they do not change when you filter
+the table. Disabling an organization, re-enabling one or extending a trial moves
+a figure, so each of those refreshes the strip.
 
-The middle cell counts the same `ending_soon` state that the filter it applies
-sends, so the figure cannot disagree with the rows it navigates to.
-
-The figures describe the whole platform and do not change when you filter the
-table.
-
-Disabling an organization, re-enabling one or extending a trial moves a figure,
-so each of those refreshes the strip.
+Applying a filter set, from a figure or from the filter sheet, now returns to
+the first page even where the set applied is the one already on.

--- a/.changeset/admin-organizations-stat-strip.md
+++ b/.changeset/admin-organizations-stat-strip.md
@@ -20,3 +20,6 @@ a figure, so each of those refreshes the strip.
 
 Applying a filter set, from a figure or from the filter sheet, now returns to
 the first page even where the set applied is the one already on.
+
+The Status control now names the view it is showing, "Active and disabled",
+where it used to count it as "2 selected".

--- a/.changeset/admin-organizations-stat-strip.md
+++ b/.changeset/admin-organizations-stat-strip.md
@@ -11,18 +11,22 @@ created in the last seven days. Trials ending in 7 days counts the trials in the
 many were switched off in the last seven days.
 
 Each figure is a control. Pressing one filters the table to the rows behind it:
-Organizations clears every filter, Trials ending in 7 days applies
+Organizations opens the whole platform, Trials ending in 7 days applies
 `trial=ending_soon`, and Disabled applies `disabled=disabled`. A press replaces
 whatever was filtered rather than adding to it, so pressing Disabled while a
 trial filter is set leaves only the disabled filter, and the filter sheet
 follows. The search term is not one of the three filters and is left alone.
 
+The first two cells set the status filter to both statuses rather than clearing
+it, because the table shows active organizations only when nothing is chosen.
+Without that, the figure and the list it opened would differ by exactly the
+number of disabled organizations.
+
 The middle cell counts the same `ending_soon` state that the filter it applies
 sends, so the figure cannot disagree with the rows it navigates to.
 
-The figures describe the whole platform and deliberately ignore the table's own
-filters: they are fetched with no parameters, from a cache entry that has no
-key to move, so filtering the table cannot make the strip report the rows
-already on screen.
+The figures describe the whole platform and do not change when you filter the
+table.
 
-Fed by a new `GET /admin/organizations.stats` endpoint.
+Disabling an organization, re-enabling one or extending a trial moves a figure,
+so each of those refreshes the strip.

--- a/.changeset/admin-organizations-stat-strip.md
+++ b/.changeset/admin-organizations-stat-strip.md
@@ -1,0 +1,28 @@
+---
+"admin": patch
+---
+
+Show a platform admin how much work the organizations list is holding, in a
+strip of three figures above the table.
+
+Organizations counts every organization on the platform and says how many were
+created in the last seven days. Trials ending in 7 days counts the trials in the
+`ending_soon` state. Disabled counts the switched-off organizations and says how
+many were switched off in the last seven days.
+
+Each figure is a control. Pressing one filters the table to the rows behind it:
+Organizations clears every filter, Trials ending in 7 days applies
+`trial=ending_soon`, and Disabled applies `disabled=disabled`. A press replaces
+whatever was filtered rather than adding to it, so pressing Disabled while a
+trial filter is set leaves only the disabled filter, and the filter sheet
+follows. The search term is not one of the three filters and is left alone.
+
+The middle cell counts the same `ending_soon` state that the filter it applies
+sends, so the figure cannot disagree with the rows it navigates to.
+
+The figures describe the whole platform and deliberately ignore the table's own
+filters: they are fetched with no parameters, from a cache entry that has no
+key to move, so filtering the table cannot make the strip report the rows
+already on screen.
+
+Fed by a new `GET /admin/organizations.stats` endpoint.

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -4,6 +4,7 @@ import {
   cancelOrganizationFetches,
   organizationQuery,
   organizationsListQuery,
+  organizationsStatsQuery,
   writeOrganizationToCache,
 } from "@/lib/adminQueries";
 import type {
@@ -134,6 +135,24 @@ describe("writeOrganizationToCache", () => {
 
     const after = qc.getQueryData<ListOrganizationsResult>(page.queryKey);
     expect(after?.organizations[0]).toEqual(DISABLED);
+  });
+
+  // Every write moves one of these, and a single record cannot move a count.
+  it("marks the platform totals for a refetch", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(organizationsStatsQuery.queryKey, {
+      total: 1,
+      created_last_7_days: 0,
+      trials_ending_soon: 0,
+      disabled: 0,
+      disabled_last_7_days: 0,
+    });
+
+    writeOrganizationToCache(qc, DISABLED);
+
+    expect(
+      qc.getQueryState(organizationsStatsQuery.queryKey)?.isInvalidated,
+    ).toBe(true);
   });
 
   it("leaves a page that never held the record exactly as it was", () => {

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -155,6 +155,30 @@ describe("writeOrganizationToCache", () => {
     ).toBe(true);
   });
 
+  // The cold-load window: the aggregate is still open, so it holds no data and
+  // the invalidation below has nothing to refire. Its pre-write answer would
+  // fill the cache and read as fresh.
+  it("survives a first stats read that was still open when it landed", async () => {
+    const qc = new QueryClient();
+
+    let land: (stats: unknown) => void = () => {};
+    const stale = new Promise((resolve) => {
+      land = resolve;
+    });
+    const inFlight = qc.prefetchQuery({
+      ...organizationsStatsQuery,
+      queryFn: () => stale as Promise<never>,
+    });
+
+    await cancelOrganizationFetches(qc);
+    writeOrganizationToCache(qc, DISABLED);
+
+    land({ total: 1, disabled: 0 });
+    await inFlight;
+
+    expect(qc.getQueryData(organizationsStatsQuery.queryKey)).toBeUndefined();
+  });
+
   it("leaves a page that never held the record exactly as it was", () => {
     const qc = new QueryClient();
     const page = organizationsListQuery({ q: "other" });

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -155,8 +155,8 @@ describe("writeOrganizationToCache", () => {
     ).toBe(true);
   });
 
-  // The cold-load window: the aggregate is still open, so it holds no data and
-  // the invalidation below has nothing to refire. Its pre-write answer would
+  // The cold-load window: the aggregate is still open, and an invalidation
+  // joins a running fetch rather than replacing it. Its pre-write answer would
   // fill the cache and read as fresh.
   it("survives a first stats read that was still open when it landed", async () => {
     const qc = new QueryClient();

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import {
   cancelOrganizationFetches,
+  invalidateOrganizationStats,
   organizationQuery,
   organizationsListQuery,
   organizationsStatsQuery,
@@ -81,6 +82,14 @@ describe("writeOrganizationToCache", () => {
   const DISABLED: AdminOrganization = {
     ...LIVE,
     disabled_at: "2026-08-01T00:00:00Z",
+  };
+  // Distinct from anything a cancelled read answers with below.
+  const FRESH = {
+    total: 2,
+    created_last_7_days: 1,
+    trials_ending_soon: 1,
+    disabled: 1,
+    disabled_last_7_days: 1,
   };
 
   it("answers the detail route by id and by slug", () => {
@@ -177,6 +186,48 @@ describe("writeOrganizationToCache", () => {
     await inFlight;
 
     expect(qc.getQueryData(organizationsStatsQuery.queryKey)).toBeUndefined();
+  });
+
+  // The same window, on the path where the write never lands. Nothing is put
+  // in the cache to replace what the cancel dropped, so the read that was
+  // cancelled has to be asked for again or the strip keeps its three dashes.
+  it("asks again for a stats read the cancel dropped when no write follows", async () => {
+    const qc = new QueryClient();
+
+    let land: (stats: unknown) => void = () => {};
+    const stale = new Promise((resolve) => {
+      land = resolve;
+    });
+    let calls = 0;
+    const queryFn = (): Promise<never> => {
+      calls += 1;
+      return (calls === 1 ? stale : Promise.resolve(FRESH)) as Promise<never>;
+    };
+    // Observed, because an invalidation refetches the queries something is
+    // watching. The strip is on screen for every write this covers.
+    const observer = new QueryObserver(qc, {
+      ...organizationsStatsQuery,
+      queryFn,
+    });
+    const unwatch = observer.subscribe(() => {});
+    await vi.waitFor(() => {
+      expect(calls).toBe(1);
+    });
+
+    await cancelOrganizationFetches(qc);
+    invalidateOrganizationStats(qc);
+
+    await vi.waitFor(() => {
+      expect(qc.getQueryData(organizationsStatsQuery.queryKey)).toEqual(FRESH);
+    });
+
+    // The cancelled read, answering late. It is dropped either way, and this
+    // pins that the second answer is not the one overwritten.
+    land({ total: 1, disabled: 0 });
+    await vi.waitFor(() => {
+      expect(qc.getQueryData(organizationsStatsQuery.queryKey)).toEqual(FRESH);
+    });
+    unwatch();
   });
 
   it("leaves a page that never held the record exactly as it was", () => {

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -185,7 +185,19 @@ export function writeOrganizationToCache(
   );
 
   // Refetched, not written: the response holds one record and these are counts
-  // over all of them. Not awaited, so the row repaints without waiting on it.
+  // over all of them.
+  invalidateOrganizationStats(qc);
+}
+
+/**
+ * The other half of the cancel above, for a write that never lands. The stats
+ * read it dropped has nothing to replace it, and a first read cancelled before
+ * its answer holds no figures to fall back on, so the strip keeps three dashes
+ * until a focus or a remount asks again.
+ *
+ * Not awaited anywhere: the counts are the last thing on the page to matter.
+ */
+export function invalidateOrganizationStats(qc: QueryClient): void {
   void qc.invalidateQueries({ queryKey: organizationsStatsQuery.queryKey });
 }
 

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -132,6 +132,9 @@ export function cancelOrganizationFetches(qc: QueryClient): Promise<void> {
     // Cancelling another organization's detail fetch costs that page a refetch
     // and nothing else, and only one detail query is ever in flight from here.
     qc.cancelQueries({ queryKey: [ORGANIZATION_KEY] }),
+    // A first fetch still open holds no data, so the invalidation below finds
+    // nothing to refire and the pre-write counts land as though they were new.
+    qc.cancelQueries({ queryKey: organizationsStatsQuery.queryKey }),
   ]).then(() => undefined);
 }
 

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -61,10 +61,8 @@ export function organizationsListQuery(
   });
 }
 
-// A constant rather than a function, and that is the whole design: the strip's
-// figures describe the platform, not the view. With no parameters there is no
-// key to move, so changing the table's filters cannot refetch these totals and
-// they cannot start tracking the filtered rows.
+// A constant, not a function: with no parameters there is no key to move, so
+// filtering the table cannot make these totals track the rows on screen.
 export const organizationsStatsQuery = queryOptions({
   queryKey: ["gram-admin-organization-stats"] as const,
   queryFn: getOrganizationStats,
@@ -181,6 +179,10 @@ export function writeOrganizationToCache(
       };
     },
   );
+
+  // Refetched, not written: the response holds one record and these are counts
+  // over all of them. Not awaited, so the row repaints without waiting on it.
+  void qc.invalidateQueries({ queryKey: organizationsStatsQuery.queryKey });
 }
 
 export function projectQuery(

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -132,8 +132,9 @@ export function cancelOrganizationFetches(qc: QueryClient): Promise<void> {
     // Cancelling another organization's detail fetch costs that page a refetch
     // and nothing else, and only one detail query is ever in flight from here.
     qc.cancelQueries({ queryKey: [ORGANIZATION_KEY] }),
-    // A first fetch still open holds no data, so the invalidation below finds
-    // nothing to refire and the pre-write counts land as though they were new.
+    // Measured: the invalidation below cannot refire a fetch that is already
+    // running. React Query joins the open request instead of starting a second
+    // one, and its pre-write answer clears the invalidated flag as it lands.
     qc.cancelQueries({ queryKey: organizationsStatsQuery.queryKey }),
   ]).then(() => undefined);
 }

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -11,6 +11,7 @@ import {
 } from "@tanstack/react-query";
 import {
   getOrganization,
+  getOrganizationStats,
   getProject,
   getSession,
   listOrganizationMembers,
@@ -59,6 +60,15 @@ export function organizationsListQuery(
     queryFn: () => listOrganizations(params),
   });
 }
+
+// A constant rather than a function, and that is the whole design: the strip's
+// figures describe the platform, not the view. With no parameters there is no
+// key to move, so changing the table's filters cannot refetch these totals and
+// they cannot start tracking the filtered rows.
+export const organizationsStatsQuery = queryOptions({
+  queryKey: ["gram-admin-organization-stats"] as const,
+  queryFn: getOrganizationStats,
+});
 
 // Named once, because the detail entry is reached two ways. The route takes an
 // id or a slug and each is its own entry, so this is the only thing the two

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -254,13 +254,6 @@ export function listOrganizations(
   );
 }
 
-// Platform-wide totals for the organizations list's strip. Every figure counts
-// every organization: the endpoint takes no parameters, so nothing an operator
-// filters the table by can narrow them.
-//
-// `trials_ending_soon` counts `trial_state = 'ending_soon'`, the same state the
-// Trial filter sends, so the figure cannot disagree with the rows it navigates
-// to.
 export type AdminOrganizationStats = {
   total: number;
   created_last_7_days: number;

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -254,6 +254,25 @@ export function listOrganizations(
   );
 }
 
+// Platform-wide totals for the organizations list's strip. Every figure counts
+// every organization: the endpoint takes no parameters, so nothing an operator
+// filters the table by can narrow them.
+//
+// `trials_ending_soon` counts `trial_state = 'ending_soon'`, the same state the
+// Trial filter sends, so the figure cannot disagree with the rows it navigates
+// to.
+export type AdminOrganizationStats = {
+  total: number;
+  created_last_7_days: number;
+  trials_ending_soon: number;
+  disabled: number;
+  disabled_last_7_days: number;
+};
+
+export function getOrganizationStats(): Promise<AdminOrganizationStats> {
+  return gramAdminFetch<AdminOrganizationStats>("/admin/organizations.stats");
+}
+
 export type AdminProjectDetail = {
   id: string;
   name: string;

--- a/client/admin/src/lib/organizationFilters.ts
+++ b/client/admin/src/lib/organizationFilters.ts
@@ -40,6 +40,10 @@ export type FilterGroup = {
   // "everything", and an operator cannot be expected to know which is which,
   // so each group says its own.
   emptyLabel: string;
+  // What every value at once amounts to, where that is worth naming. Absent on
+  // Type: an organization can carry a type the picker does not offer, so
+  // choosing all three still leaves rows out.
+  allLabel?: string;
   options: FilterOption[];
 };
 
@@ -63,6 +67,8 @@ export const FILTER_GROUPS: FilterGroup[] = [
     key: "trial",
     label: "Trial",
     emptyLabel: "All trial states",
+    // Every organization has exactly one of these, `none` included.
+    allLabel: "All trial states",
     // TRIAL_LABELS is the map the Trial cell renders its badge from, so the
     // filter and the rows it returns cannot say different words for one state.
     options: TRIAL_STATES.map((value) => ({
@@ -74,6 +80,8 @@ export const FILTER_GROUPS: FilterGroup[] = [
     key: "disabled",
     label: "Status",
     emptyLabel: "Active only",
+    // Not the empty label: this group's default is a filter, not everything.
+    allLabel: "Active and disabled",
     options: DISABLED_STATES.map((value) => ({
       value,
       label: DISABLED_LABELS[value],
@@ -95,6 +103,12 @@ export function filterSummary(
   const only = chosen[0];
   if (chosen.length === 1 && only !== undefined) {
     return options.find((option) => option.value === only)?.label ?? only;
+  }
+  if (
+    group.allLabel !== undefined &&
+    group.options.every((option) => chosen.includes(option.value))
+  ) {
+    return group.allLabel;
   }
   return `${chosen.length} selected`;
 }

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -70,6 +70,14 @@ const ORGS: AdminOrganization[] = [
   },
 ];
 
+// Spoken, never painted: each cell ends with a sentence naming what pressing
+// it does.
+const ACTION: Record<string, string> = {
+  Organizations: "Show every organization",
+  "Trials ending in 7 days": "Show the trials ending in 7 days",
+  Disabled: "Show the disabled organizations",
+};
+
 function figure(value: number): string {
   return value.toLocaleString();
 }
@@ -134,13 +142,13 @@ describe("organizations stat strip figures", () => {
     await renderList();
 
     expect(cell("Organizations").textContent).toBe(
-      `Organizations${figure(STATS.total)}${figure(STATS.created_last_7_days)} new this week`,
+      `Organizations${figure(STATS.total)}${figure(STATS.created_last_7_days)} new this week${ACTION["Organizations"]}`,
     );
     expect(cell("Trials ending in 7 days").textContent).toBe(
-      `Trials ending in 7 days${figure(STATS.trials_ending_soon)}`,
+      `Trials ending in 7 days${figure(STATS.trials_ending_soon)}${ACTION["Trials ending in 7 days"]}`,
     );
     expect(cell("Disabled").textContent).toBe(
-      `Disabled${figure(STATS.disabled)}${figure(STATS.disabled_last_7_days)} this week`,
+      `Disabled${figure(STATS.disabled)}${figure(STATS.disabled_last_7_days)} this week${ACTION["Disabled"]}`,
     );
   });
 
@@ -149,8 +157,8 @@ describe("organizations stat strip figures", () => {
 
     const trials = cell("Trials ending in 7 days");
     expect(within(trials).queryByText(/this week/)).toBeNull();
-    expect(trials.querySelectorAll("span").length).toBe(2);
-    expect(cell("Organizations").querySelectorAll("span").length).toBe(3);
+    expect(trials.querySelectorAll("span").length).toBe(3);
+    expect(cell("Organizations").querySelectorAll("span").length).toBe(4);
   });
 
   it("renders a figure of zero as a figure, not as a missing one", async () => {
@@ -159,7 +167,7 @@ describe("organizations stat strip figures", () => {
     await renderList();
 
     expect(cell("Disabled").textContent).toBe(
-      `Disabled0${figure(STATS.disabled_last_7_days)} this week`,
+      `Disabled0${figure(STATS.disabled_last_7_days)} this week${ACTION["Disabled"]}`,
     );
   });
 
@@ -172,7 +180,7 @@ describe("organizations stat strip figures", () => {
     await renderList();
 
     expect(cell("Disabled").textContent).toBe(
-      `Disabled${figure(STATS.disabled)}— this week`,
+      `Disabled${figure(STATS.disabled)}— this week${ACTION["Disabled"]}`,
     );
     expect(cell("Organizations").textContent).toContain(figure(STATS.total));
   });
@@ -187,8 +195,10 @@ describe("organizations stat strip figures", () => {
 
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    expect(cell("Organizations").textContent).toBe("Organizations—");
-    expect(cell("Disabled").textContent).toBe("Disabled—");
+    expect(cell("Organizations").textContent).toBe(
+      `Organizations—${ACTION["Organizations"]}`,
+    );
+    expect(cell("Disabled").textContent).toBe(`Disabled—${ACTION["Disabled"]}`);
 
     settle(STATS);
     await waitFor(() => {
@@ -201,14 +211,26 @@ describe("organizations stat strip figures", () => {
 
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    await screen.findByText(/Could not load the platform totals/);
+    // The reason as well as the headline: a banner that drops it tells the
+    // operator something failed and nothing about what.
+    await screen.findByText(
+      /Could not load the platform totals: stats are down/,
+    );
     // The cells too: a failure falling back to a figure would put three zeroes
     // above a table full of rows.
-    expect(cell("Organizations").textContent).toBe("Organizations—");
-    expect(cell("Trials ending in 7 days").textContent).toBe(
-      "Trials ending in 7 days—",
+    expect(cell("Organizations").textContent).toBe(
+      `Organizations—${ACTION["Organizations"]}`,
     );
-    expect(cell("Disabled").textContent).toBe("Disabled—");
+    expect(cell("Trials ending in 7 days").textContent).toBe(
+      `Trials ending in 7 days—${ACTION["Trials ending in 7 days"]}`,
+    );
+    expect(cell("Disabled").textContent).toBe(`Disabled—${ACTION["Disabled"]}`);
+  });
+
+  it("says nothing about a failure that did not happen", async () => {
+    await renderList();
+
+    expect(screen.queryByText(/Could not load the platform totals/)).toBeNull();
   });
 
   it("still filters from a cell whose figure never arrived", async () => {
@@ -245,9 +267,8 @@ describe("organizations stat strip navigation", () => {
 
     fireEvent.click(cell("Organizations"));
 
-    // Both statuses, spelled out. An absent status filter is not "no filter":
-    // the server reads it as active only, so the figure counts the disabled
-    // organizations and the list it opened would leave them out.
+    // Spelled out, because an absent status filter is not "no filter": the
+    // server reads it as active only.
     await waitFor(() => {
       expect(currentSearch(router)).toBe('?disabled=["active","disabled"]');
     });
@@ -306,7 +327,7 @@ describe("organizations stat strip navigation", () => {
     expect(lastListParams().trial_states).toBeUndefined();
   });
 
-  it("leaves the search term alone", async () => {
+  it("drops the search term the figure never counted", async () => {
     const router = await renderList(urlFor({ q: "acme", type: ["pro"] }));
 
     fireEvent.click(cell("Trials ending in 7 days"));
@@ -314,11 +335,55 @@ describe("organizations stat strip navigation", () => {
     await waitFor(() => {
       expect(lastListParams().trial_states).toEqual(["ending_soon"]);
     });
-    expect(lastListParams().q).toBe("acme");
-    expect(currentSearch(router)).toContain("q=acme");
-    expect(
-      (screen.getByLabelText("Search organizations") as HTMLInputElement).value,
-    ).toBe("acme");
+    expect(lastListParams().q).toBeUndefined();
+    expect(currentSearch(router)).not.toContain("q=");
+    // The box too, or the term is gone from the request and still on screen.
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Search organizations") as HTMLInputElement)
+          .value,
+      ).toBe("");
+    });
+  });
+
+  it("returns to the first page even where the filters do not change", async () => {
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: ORGS,
+      next_cursor: "cursor_page_two",
+    });
+    await renderList(urlFor({ disabled: ["disabled"] }));
+
+    const next = screen.getByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await waitFor(() => {
+      expect(lastListParams().cursor).toBe("cursor_page_two");
+    });
+
+    // The set this cell applies is the set already applied, so nothing in the
+    // URL moves and the pager has to be told rather than notice.
+    fireEvent.click(cell("Disabled"));
+
+    await waitFor(() => {
+      expect(lastListParams().cursor).toBeUndefined();
+    });
+  });
+
+  it("names the whole platform on the status control rather than counting it", async () => {
+    await renderList();
+
+    fireEvent.click(cell("Organizations"));
+
+    // "2 selected" reads as a narrowing, and "Active only" would be false.
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("button", { name: /^Status filter:/ })
+          .getAttribute("aria-label"),
+      ).toBe("Status filter: Active and disabled");
+    });
   });
 
   it("shows the applied filter on the control that opens the sheet", async () => {
@@ -464,12 +529,19 @@ describe("organizations stat strip accessible names", () => {
 
     // The computed name: an aria-label added later would drop the figure.
     for (const name of [
-      `Organizations ${figure(STATS.total)} ${figure(STATS.created_last_7_days)} new this week`,
-      `Trials ending in 7 days ${figure(STATS.trials_ending_soon)}`,
-      `Disabled ${figure(STATS.disabled)} ${figure(STATS.disabled_last_7_days)} this week`,
+      `Organizations ${figure(STATS.total)} ${figure(STATS.created_last_7_days)} new this week ${ACTION["Organizations"]}`,
+      `Trials ending in 7 days ${figure(STATS.trials_ending_soon)} ${ACTION["Trials ending in 7 days"]}`,
+      `Disabled ${figure(STATS.disabled)} ${figure(STATS.disabled_last_7_days)} this week ${ACTION["Disabled"]}`,
     ]) {
       expect(within(strip()).getByRole("button", { name })).toBeTruthy();
     }
+  });
+
+  it("says what pressing does without painting it", async () => {
+    await renderList();
+
+    const spoken = within(cell("Disabled")).getByText(ACTION["Disabled"] ?? "");
+    expect(spoken.className).toContain("sr-only");
   });
 
   it("leaves the name to come from the contents", async () => {

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -22,8 +22,7 @@ const mocks = vi.hoisted(() => ({
     vi.fn<
       (params?: ListOrganizationsParams) => Promise<ListOrganizationsResult>
     >(),
-  // Takes whatever it is handed: React Query calls a queryFn with its own
-  // context, and the key on that context is what the test below reads.
+  // Takes whatever it is handed: React Query passes a queryFn its own context.
   getOrganizationStats:
     vi.fn<(...args: unknown[]) => Promise<AdminOrganizationStats>>(),
   getSession: vi.fn(),
@@ -32,9 +31,7 @@ const mocks = vi.hoisted(() => ({
   listOrganizationMembers: vi.fn(),
 }));
 
-// Every endpoint the organizations route reaches, so nothing in this file
-// leaves a real request in flight. The rest of the module stays real: the query
-// layer's own key building is part of what is under test here.
+// Every endpoint the route reaches, so nothing here leaves a request in flight.
 vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
   return {
@@ -48,15 +45,14 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
   };
 });
 
-// Five distinct figures, none of them a multiple or a sum of another. A cell
-// that reads the wrong field then renders a number no assertion here accepts,
-// which is the whole reason not to reuse a value across two fields.
+// All distinct and all past a thousand: a misread field, or one rendered raw,
+// is then a number no assertion here accepts.
 const STATS: AdminOrganizationStats = {
-  total: 4821,
-  created_last_7_days: 137,
-  trials_ending_soon: 26,
-  disabled: 59,
-  disabled_last_7_days: 8,
+  total: 48213,
+  created_last_7_days: 1372,
+  trials_ending_soon: 926,
+  disabled: 5904,
+  disabled_last_7_days: 1064,
 };
 
 const ORGS: AdminOrganization[] = [
@@ -74,9 +70,6 @@ const ORGS: AdminOrganization[] = [
   },
 ];
 
-// The figures are rendered through toLocaleString, so the expected text comes
-// out of the same formatter. The thousands separator is not what is under test;
-// which field reached the cell is.
 function figure(value: number): string {
   return value.toLocaleString();
 }
@@ -85,9 +78,6 @@ function strip(): HTMLElement {
   return screen.getByRole("group", { name: "Platform totals" });
 }
 
-// By the accessible name, which the cell's own rendered text produces: there is
-// no aria-label standing in for it, so a cell that painted nothing cannot be
-// found here at all.
 function cell(label: string): HTMLElement {
   return within(strip()).getByRole("button", {
     name: new RegExp(`^${label}\\b`),
@@ -111,8 +101,6 @@ function lastListParams(): ListOrganizationsParams {
   return call?.[0] ?? {};
 }
 
-// The strip renders as soon as the query settles, and every assertion below is
-// about what it says once it has.
 async function renderList(initialPath = "/organizations"): Promise<AnyRouter> {
   const { router } = await renderRouteTree(routeTree, { initialPath });
   await waitFor(() => {
@@ -145,10 +133,6 @@ describe("organizations stat strip figures", () => {
   it("reads each cell out of the field the contract names for it", async () => {
     await renderList();
 
-    // Whole text, not a substring match: a cell that rendered its label and no
-    // number, or two numbers where the design has one, fails here. Every figure
-    // in STATS is distinct, so each of these is a statement about which field
-    // the cell read.
     expect(cell("Organizations").textContent).toBe(
       `Organizations${figure(STATS.total)}${figure(STATS.created_last_7_days)} new this week`,
     );
@@ -164,19 +148,36 @@ describe("organizations stat strip figures", () => {
     await renderList();
 
     const trials = cell("Trials ending in 7 days");
-    // The design's "N with no owner" is cut, and a placeholder for it is cut
-    // too. Two assertions, because the wording of a sub-line nobody has written
-    // yet is not knowable: one names the shape the other two cells use, and one
-    // counts the lines.
     expect(within(trials).queryByText(/this week/)).toBeNull();
     expect(trials.querySelectorAll("span").length).toBe(2);
     expect(cell("Organizations").querySelectorAll("span").length).toBe(3);
   });
 
+  it("renders a figure of zero as a figure, not as a missing one", async () => {
+    mocks.getOrganizationStats.mockResolvedValue({ ...STATS, disabled: 0 });
+
+    await renderList();
+
+    expect(cell("Disabled").textContent).toBe(
+      `Disabled0${figure(STATS.disabled_last_7_days)} this week`,
+    );
+  });
+
+  it("stands up to a payload that left a field out", async () => {
+    const { disabled_last_7_days: _dropped, ...partial } = STATS;
+    mocks.getOrganizationStats.mockResolvedValue(
+      partial as AdminOrganizationStats,
+    );
+
+    await renderList();
+
+    expect(cell("Disabled").textContent).toBe(
+      `Disabled${figure(STATS.disabled)}— this week`,
+    );
+    expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+  });
+
   it("says nothing where the figures have not arrived", async () => {
-    // A number that has not been fetched must not be shown as a number, and a
-    // cell must not be blank either: an operator reading a blank strip has no
-    // way to tell it from a platform with nothing on it.
     let settle: (stats: AdminOrganizationStats) => void = () => {};
     mocks.getOrganizationStats.mockReturnValue(
       new Promise((resolve) => {
@@ -193,6 +194,21 @@ describe("organizations stat strip figures", () => {
     await waitFor(() => {
       expect(cell("Organizations").textContent).toContain(figure(STATS.total));
     });
+  });
+
+  it("says the totals failed rather than showing a figure for them", async () => {
+    mocks.getOrganizationStats.mockRejectedValue(new Error("stats are down"));
+
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await screen.findByText(/Could not load the platform totals/);
+    // The cells too: a failure falling back to a figure would put three zeroes
+    // above a table full of rows.
+    expect(cell("Organizations").textContent).toBe("Organizations—");
+    expect(cell("Trials ending in 7 days").textContent).toBe(
+      "Trials ending in 7 days—",
+    );
+    expect(cell("Disabled").textContent).toBe("Disabled—");
   });
 
   it("still filters from a cell whose figure never arrived", async () => {
@@ -214,9 +230,6 @@ describe("organizations stat strip figures", () => {
 
     expect(mocks.getOrganizationStats).toHaveBeenCalled();
     for (const [context] of mocks.getOrganizationStats.mock.calls) {
-      // The cache key React Query fetched under. A key that carried the term or
-      // the filters is a separate entry per view, which is a strip that
-      // refetches with the table and reports the filtered rows.
       expect((context as { queryKey: unknown }).queryKey).toEqual([
         "gram-admin-organization-stats",
       ]);
@@ -225,36 +238,42 @@ describe("organizations stat strip figures", () => {
 });
 
 describe("organizations stat strip navigation", () => {
-  it("clears every filter from the first cell", async () => {
+  it("opens every organization from the first cell, disabled ones included", async () => {
     const router = await renderList(
       urlFor({ type: ["pro"], trial: ["running"], disabled: ["disabled"] }),
     );
 
     fireEvent.click(cell("Organizations"));
 
+    // Both statuses, spelled out. An absent status filter is not "no filter":
+    // the server reads it as active only, so the figure counts the disabled
+    // organizations and the list it opened would leave them out.
     await waitFor(() => {
-      expect(currentSearch(router)).toBe("");
+      expect(currentSearch(router)).toBe('?disabled=["active","disabled"]');
     });
     await waitFor(() => {
-      expect(lastListParams().account_types).toBeUndefined();
+      expect(lastListParams().disabled_states).toEqual(["active", "disabled"]);
     });
+    expect(lastListParams().account_types).toBeUndefined();
     expect(lastListParams().trial_states).toBeUndefined();
-    expect(lastListParams().disabled_states).toBeUndefined();
   });
 
-  it("filters to the trials the middle cell counted", async () => {
+  it("filters to the trials the middle cell counted, at either status", async () => {
     const router = await renderList();
 
     fireEvent.click(cell("Trials ending in 7 days"));
 
-    // `ending_soon`, which is the state the figure above it counts. Any other
-    // trial state would be a cell whose count and whose rows disagree.
+    // The figure counts `ending_soon` over every organization, so the list it
+    // opens has to ask for both statuses to reach the same rows.
     await waitFor(() => {
-      expect(currentSearch(router)).toBe('?trial=["ending_soon"]');
+      expect(currentSearch(router)).toBe(
+        '?trial=["ending_soon"]&disabled=["active","disabled"]',
+      );
     });
     await waitFor(() => {
       expect(lastListParams().trial_states).toEqual(["ending_soon"]);
     });
+    expect(lastListParams().disabled_states).toEqual(["active", "disabled"]);
   });
 
   it("filters to disabled organizations from the last cell", async () => {
@@ -277,9 +296,6 @@ describe("organizations stat strip navigation", () => {
 
     fireEvent.click(cell("Disabled"));
 
-    // Only the filter the cell names. A cell that merged would leave the type
-    // and the trial in place, and the rows would be the disabled pro
-    // organizations whose trial is running, which is not the figure clicked.
     await waitFor(() => {
       expect(currentSearch(router)).toBe('?disabled=["disabled"]');
     });
@@ -291,8 +307,6 @@ describe("organizations stat strip navigation", () => {
   });
 
   it("leaves the search term alone", async () => {
-    // The term is not one of the three filters, and an operator who clicked a
-    // figure has not asked to type it again.
     const router = await renderList(urlFor({ q: "acme", type: ["pro"] }));
 
     fireEvent.click(cell("Trials ending in 7 days"));
@@ -312,9 +326,6 @@ describe("organizations stat strip navigation", () => {
 
     fireEvent.click(cell("Disabled"));
 
-    // The URL is the state, so the sheet's own triggers have to follow a write
-    // the strip made. A strip that navigated some other way would leave these
-    // reading the filter the operator just replaced.
     await waitFor(() => {
       expect(
         screen
@@ -340,8 +351,6 @@ describe("organizations stat strip navigation", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Trial filter:/ }));
     const sheet = await screen.findByRole("dialog");
 
-    // The label the picker shows, not the value the URL carries: the two are
-    // different words, and the operator only ever reads the first.
     expect(
       within(sheet).getByRole("combobox", { name: /^Trial/ }).textContent,
     ).toContain("Ending soon");
@@ -362,16 +371,13 @@ describe("organizations stat strip and the table's filters", () => {
     await waitFor(() => {
       expect(lastListParams().trial_states).toEqual(["running"]);
     });
-    // The figures describe the platform. A strip keyed on the filters would
-    // refetch here and start reporting the rows already on screen.
     expect(mocks.getOrganizationStats.mock.calls.length).toBe(before);
   });
 
   it("holds its figures still while the table reloads under a filter", async () => {
     const router = await renderList();
 
-    // A second answer, so a strip that did refetch would visibly move rather
-    // than merely call the endpoint again.
+    // A second answer, so a strip that did refetch would visibly move.
     mocks.getOrganizationStats.mockResolvedValue({
       total: 1,
       created_last_7_days: 1,
@@ -409,14 +415,15 @@ describe("organizations stat strip and the table's filters", () => {
 });
 
 describe("organizations stat strip placement", () => {
-  it("paints above the table rather than inside the box that scrolls", async () => {
+  it("sits outside the table's scroll box, and before it in the document", async () => {
     await renderList();
 
     const scrollBox = screen.getByRole("region", {
       name: "Organizations table",
     });
-    // Outside the scroll box, and before it in the document. A strip inside it
-    // would scroll away with the rows it leads to.
+    // Tree facts only. happy-dom lays nothing out, so that the strip does not
+    // scroll away with the rows is checked by eye and stated in the pull
+    // request, not here.
     expect(scrollBox.contains(strip())).toBe(false);
     expect(
       strip().compareDocumentPosition(scrollBox) &
@@ -424,12 +431,10 @@ describe("organizations stat strip placement", () => {
     ).toBeTruthy();
   });
 
-  it("reads left to right in the order the design puts the figures", async () => {
+  it("deals the three figures out in the order the design names", async () => {
     await renderList();
 
-    // Every other assertion in this file finds a cell by its label, so the
-    // three could be dealt out in any order and nothing else here would notice.
-    // The first span of each is its label.
+    // Document order: every other assertion here finds a cell by its label.
     expect(
       within(strip())
         .getAllByRole("button")
@@ -446,25 +451,55 @@ describe("organizations stat strip placement", () => {
       "Disabled",
     ]) {
       const control = cell(label);
-      // A div with an onClick is not reachable by Tab and answers no key. The
-      // type matters too: a bare <button> inside a form submits it.
+      // A div with an onClick answers no key; a bare button in a form submits.
       expect(control.tagName).toBe("BUTTON");
       expect(control.getAttribute("type")).toBe("button");
     }
   });
+});
 
-  it("filters from the keyboard as well as the pointer", async () => {
-    const router = await renderList();
+describe("organizations stat strip accessible names", () => {
+  it("speaks the figure, not only what it counts", async () => {
+    await renderList();
 
-    const control = cell("Trials ending in 7 days");
-    control.focus();
-    expect(document.activeElement).toBe(control);
-    // A real button answers Enter and Space by firing a click, which is what
-    // happy-dom's click dispatch stands in for here.
-    fireEvent.click(control);
+    // The computed name: an aria-label added later would drop the figure.
+    for (const name of [
+      `Organizations ${figure(STATS.total)} ${figure(STATS.created_last_7_days)} new this week`,
+      `Trials ending in 7 days ${figure(STATS.trials_ending_soon)}`,
+      `Disabled ${figure(STATS.disabled)} ${figure(STATS.disabled_last_7_days)} this week`,
+    ]) {
+      expect(within(strip()).getByRole("button", { name })).toBeTruthy();
+    }
+  });
 
+  it("leaves the name to come from the contents", async () => {
+    await renderList();
+
+    for (const label of [
+      "Organizations",
+      "Trials ending in 7 days",
+      "Disabled",
+    ]) {
+      expect(cell(label).getAttribute("aria-label")).toBeNull();
+      expect(cell(label).getAttribute("aria-labelledby")).toBeNull();
+    }
+  });
+
+  it("says the figures are on their way while they are in flight", async () => {
+    let settle: (stats: AdminOrganizationStats) => void = () => {};
+    mocks.getOrganizationStats.mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    expect(cell("Organizations").getAttribute("aria-busy")).toBe("true");
+
+    settle(STATS);
     await waitFor(() => {
-      expect(currentSearch(router)).toBe('?trial=["ending_soon"]');
+      expect(cell("Organizations").getAttribute("aria-busy")).toBe("false");
     });
   });
 });

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -1,5 +1,6 @@
 import type { AnyRouter } from "@tanstack/react-router";
 import {
+  act,
   cleanup,
   fireEvent,
   screen,
@@ -77,6 +78,10 @@ const ACTION: Record<string, string> = {
   "Trials ending in 7 days": "Show the trials ending in 7 days",
   Disabled: "Show the disabled organizations",
 };
+
+// Written out rather than imported from the toolbar, so a shortened debounce
+// cannot move the assertions along with it.
+const DEBOUNCE_MS = 300;
 
 function figure(value: number): string {
   return value.toLocaleString();
@@ -344,6 +349,36 @@ describe("organizations stat strip navigation", () => {
           .value,
       ).toBe("");
     });
+  });
+
+  it("drops a term the operator typed and had not committed yet", async () => {
+    const router = await renderList();
+    const input = screen.getByLabelText("Search organizations");
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(input, { target: { value: "acme" } });
+      // Still inside the debounce, so the term is on screen and nowhere else.
+      // The URL never held it, so clearing `q` moves nothing the box watches.
+      await act(async () => {
+        vi.advanceTimersByTime(DEBOUNCE_MS - 1);
+      });
+
+      fireEvent.click(cell("Disabled"));
+
+      await act(async () => {
+        vi.advanceTimersByTime(DEBOUNCE_MS * 2);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(currentSearch(router)).not.toContain("q=");
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+    expect(lastListParams().q).toBeUndefined();
+    expect((input as HTMLInputElement).value).toBe("");
   });
 
   it("returns to the first page even where the filters do not change", async () => {

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -371,6 +371,38 @@ describe("organizations stat strip navigation", () => {
     });
   });
 
+  it("turns Previous off with the page it sends the operator back to", async () => {
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: ORGS,
+      next_cursor: "cursor_page_two",
+    });
+    await renderList(urlFor({ disabled: ["disabled"] }));
+
+    const next = screen.getByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await waitFor(() => {
+      expect(lastListParams().cursor).toBe("cursor_page_two");
+    });
+
+    fireEvent.click(cell("Disabled"));
+    await waitFor(() => {
+      expect(lastListParams().cursor).toBeUndefined();
+    });
+    // Enabled again, so the rows on screen are the first page rather than the
+    // one before it. Previous is disabled off the pages behind, not off this.
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+
+    // Page one has nothing behind it. Left on, Previous would go forwards.
+    expect(
+      screen.getByRole("button", { name: "Previous" }).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
   it("names the whole platform on the status control rather than counting it", async () => {
     await renderList();
 

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -1,0 +1,457 @@
+import type { AnyRouter } from "@tanstack/react-router";
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AdminOrganization,
+  AdminOrganizationStats,
+  ListOrganizationsParams,
+  ListOrganizationsResult,
+} from "@/lib/gramAdminApi";
+import { routeTree } from "@/routeTree.gen";
+import { renderRouteTree } from "@/test/harness";
+
+const mocks = vi.hoisted(() => ({
+  listOrganizations:
+    vi.fn<
+      (params?: ListOrganizationsParams) => Promise<ListOrganizationsResult>
+    >(),
+  // Takes whatever it is handed: React Query calls a queryFn with its own
+  // context, and the key on that context is what the test below reads.
+  getOrganizationStats:
+    vi.fn<(...args: unknown[]) => Promise<AdminOrganizationStats>>(),
+  getSession: vi.fn(),
+  getOrganization: vi.fn(),
+  listOrganizationProjects: vi.fn(),
+  listOrganizationMembers: vi.fn(),
+}));
+
+// Every endpoint the organizations route reaches, so nothing in this file
+// leaves a real request in flight. The rest of the module stays real: the query
+// layer's own key building is part of what is under test here.
+vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
+  return {
+    ...actual,
+    listOrganizations: mocks.listOrganizations,
+    getOrganizationStats: mocks.getOrganizationStats,
+    getSession: mocks.getSession,
+    getOrganization: mocks.getOrganization,
+    listOrganizationProjects: mocks.listOrganizationProjects,
+    listOrganizationMembers: mocks.listOrganizationMembers,
+  };
+});
+
+// Five distinct figures, none of them a multiple or a sum of another. A cell
+// that reads the wrong field then renders a number no assertion here accepts,
+// which is the whole reason not to reuse a value across two fields.
+const STATS: AdminOrganizationStats = {
+  total: 4821,
+  created_last_7_days: 137,
+  trials_ending_soon: 26,
+  disabled: 59,
+  disabled_last_7_days: 8,
+};
+
+const ORGS: AdminOrganization[] = [
+  {
+    id: "org_placeholder_one",
+    name: "Placeholder One",
+    slug: "placeholder-one",
+    account_type: "pro",
+    whitelisted: false,
+    trial_state: "ending_soon",
+    trial_ends_at: "2026-05-06T00:00:00Z",
+    member_count: 3,
+    created_at: "2026-01-02T00:00:00Z",
+    updated_at: "2026-01-07T00:00:00Z",
+  },
+];
+
+// The figures are rendered through toLocaleString, so the expected text comes
+// out of the same formatter. The thousands separator is not what is under test;
+// which field reached the cell is.
+function figure(value: number): string {
+  return value.toLocaleString();
+}
+
+function strip(): HTMLElement {
+  return screen.getByRole("group", { name: "Platform totals" });
+}
+
+// By the accessible name, which the cell's own rendered text produces: there is
+// no aria-label standing in for it, so a cell that painted nothing cannot be
+// found here at all.
+function cell(label: string): HTMLElement {
+  return within(strip()).getByRole("button", {
+    name: new RegExp(`^${label}\\b`),
+  });
+}
+
+function currentSearch(router: AnyRouter): string {
+  return decodeURIComponent(router.state.location.searchStr);
+}
+
+function urlFor(search: Record<string, unknown>): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(search)) {
+    qs.set(key, typeof value === "string" ? value : JSON.stringify(value));
+  }
+  return `/organizations?${qs.toString()}`;
+}
+
+function lastListParams(): ListOrganizationsParams {
+  const call = mocks.listOrganizations.mock.calls.at(-1);
+  return call?.[0] ?? {};
+}
+
+// The strip renders as soon as the query settles, and every assertion below is
+// about what it says once it has.
+async function renderList(initialPath = "/organizations"): Promise<AnyRouter> {
+  const { router } = await renderRouteTree(routeTree, { initialPath });
+  await waitFor(() => {
+    expect(within(strip()).getByText(figure(STATS.total))).toBeTruthy();
+  });
+  return router;
+}
+
+beforeEach(() => {
+  mocks.listOrganizations.mockReset();
+  mocks.listOrganizations.mockResolvedValue({ organizations: ORGS });
+  mocks.getOrganizationStats.mockReset();
+  mocks.getOrganizationStats.mockResolvedValue(STATS);
+  mocks.getSession.mockReset();
+  mocks.getSession.mockResolvedValue({
+    email: "ops@example.test",
+    name: "Ops",
+  });
+  mocks.getOrganization.mockReset();
+  mocks.getOrganization.mockResolvedValue(ORGS[0]);
+  mocks.listOrganizationProjects.mockReset();
+  mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
+  mocks.listOrganizationMembers.mockReset();
+  mocks.listOrganizationMembers.mockResolvedValue({ members: [] });
+});
+
+afterEach(cleanup);
+
+describe("organizations stat strip figures", () => {
+  it("reads each cell out of the field the contract names for it", async () => {
+    await renderList();
+
+    // Whole text, not a substring match: a cell that rendered its label and no
+    // number, or two numbers where the design has one, fails here. Every figure
+    // in STATS is distinct, so each of these is a statement about which field
+    // the cell read.
+    expect(cell("Organizations").textContent).toBe(
+      `Organizations${figure(STATS.total)}${figure(STATS.created_last_7_days)} new this week`,
+    );
+    expect(cell("Trials ending in 7 days").textContent).toBe(
+      `Trials ending in 7 days${figure(STATS.trials_ending_soon)}`,
+    );
+    expect(cell("Disabled").textContent).toBe(
+      `Disabled${figure(STATS.disabled)}${figure(STATS.disabled_last_7_days)} this week`,
+    );
+  });
+
+  it("leaves the middle cell without a second line", async () => {
+    await renderList();
+
+    const trials = cell("Trials ending in 7 days");
+    // The design's "N with no owner" is cut, and a placeholder for it is cut
+    // too. Two assertions, because the wording of a sub-line nobody has written
+    // yet is not knowable: one names the shape the other two cells use, and one
+    // counts the lines.
+    expect(within(trials).queryByText(/this week/)).toBeNull();
+    expect(trials.querySelectorAll("span").length).toBe(2);
+    expect(cell("Organizations").querySelectorAll("span").length).toBe(3);
+  });
+
+  it("says nothing where the figures have not arrived", async () => {
+    // A number that has not been fetched must not be shown as a number, and a
+    // cell must not be blank either: an operator reading a blank strip has no
+    // way to tell it from a platform with nothing on it.
+    let settle: (stats: AdminOrganizationStats) => void = () => {};
+    mocks.getOrganizationStats.mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    );
+
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    expect(cell("Organizations").textContent).toBe("Organizations—");
+    expect(cell("Disabled").textContent).toBe("Disabled—");
+
+    settle(STATS);
+    await waitFor(() => {
+      expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+    });
+  });
+
+  it("still filters from a cell whose figure never arrived", async () => {
+    mocks.getOrganizationStats.mockRejectedValue(new Error("stats are down"));
+
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    fireEvent.click(cell("Disabled"));
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toContain('disabled=["disabled"]');
+    });
+  });
+
+  it("asks for the totals under a key that holds none of the list's parameters", async () => {
+    await renderList(urlFor({ q: "acme", type: ["pro"], trial: ["running"] }));
+
+    expect(mocks.getOrganizationStats).toHaveBeenCalled();
+    for (const [context] of mocks.getOrganizationStats.mock.calls) {
+      // The cache key React Query fetched under. A key that carried the term or
+      // the filters is a separate entry per view, which is a strip that
+      // refetches with the table and reports the filtered rows.
+      expect((context as { queryKey: unknown }).queryKey).toEqual([
+        "gram-admin-organization-stats",
+      ]);
+    }
+  });
+});
+
+describe("organizations stat strip navigation", () => {
+  it("clears every filter from the first cell", async () => {
+    const router = await renderList(
+      urlFor({ type: ["pro"], trial: ["running"], disabled: ["disabled"] }),
+    );
+
+    fireEvent.click(cell("Organizations"));
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toBe("");
+    });
+    await waitFor(() => {
+      expect(lastListParams().account_types).toBeUndefined();
+    });
+    expect(lastListParams().trial_states).toBeUndefined();
+    expect(lastListParams().disabled_states).toBeUndefined();
+  });
+
+  it("filters to the trials the middle cell counted", async () => {
+    const router = await renderList();
+
+    fireEvent.click(cell("Trials ending in 7 days"));
+
+    // `ending_soon`, which is the state the figure above it counts. Any other
+    // trial state would be a cell whose count and whose rows disagree.
+    await waitFor(() => {
+      expect(currentSearch(router)).toBe('?trial=["ending_soon"]');
+    });
+    await waitFor(() => {
+      expect(lastListParams().trial_states).toEqual(["ending_soon"]);
+    });
+  });
+
+  it("filters to disabled organizations from the last cell", async () => {
+    const router = await renderList();
+
+    fireEvent.click(cell("Disabled"));
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toBe('?disabled=["disabled"]');
+    });
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+  });
+
+  it("replaces the filters that were set rather than adding to them", async () => {
+    const router = await renderList(
+      urlFor({ type: ["pro"], trial: ["running"] }),
+    );
+
+    fireEvent.click(cell("Disabled"));
+
+    // Only the filter the cell names. A cell that merged would leave the type
+    // and the trial in place, and the rows would be the disabled pro
+    // organizations whose trial is running, which is not the figure clicked.
+    await waitFor(() => {
+      expect(currentSearch(router)).toBe('?disabled=["disabled"]');
+    });
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+    expect(lastListParams().account_types).toBeUndefined();
+    expect(lastListParams().trial_states).toBeUndefined();
+  });
+
+  it("leaves the search term alone", async () => {
+    // The term is not one of the three filters, and an operator who clicked a
+    // figure has not asked to type it again.
+    const router = await renderList(urlFor({ q: "acme", type: ["pro"] }));
+
+    fireEvent.click(cell("Trials ending in 7 days"));
+
+    await waitFor(() => {
+      expect(lastListParams().trial_states).toEqual(["ending_soon"]);
+    });
+    expect(lastListParams().q).toBe("acme");
+    expect(currentSearch(router)).toContain("q=acme");
+    expect(
+      (screen.getByLabelText("Search organizations") as HTMLInputElement).value,
+    ).toBe("acme");
+  });
+
+  it("shows the applied filter on the control that opens the sheet", async () => {
+    await renderList(urlFor({ trial: ["running"] }));
+
+    fireEvent.click(cell("Disabled"));
+
+    // The URL is the state, so the sheet's own triggers have to follow a write
+    // the strip made. A strip that navigated some other way would leave these
+    // reading the filter the operator just replaced.
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("button", { name: /^Status filter:/ })
+          .getAttribute("aria-label"),
+      ).toContain("Disabled");
+    });
+    expect(
+      screen
+        .getByRole("button", { name: /^Trial filter:/ })
+        .getAttribute("aria-label"),
+    ).toContain("All trial states");
+  });
+
+  it("shows the strip's own filter inside the sheet it opens", async () => {
+    await renderList();
+
+    fireEvent.click(cell("Trials ending in 7 days"));
+    await waitFor(() => {
+      expect(lastListParams().trial_states).toEqual(["ending_soon"]);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^Trial filter:/ }));
+    const sheet = await screen.findByRole("dialog");
+
+    // The label the picker shows, not the value the URL carries: the two are
+    // different words, and the operator only ever reads the first.
+    expect(
+      within(sheet).getByRole("combobox", { name: /^Trial/ }).textContent,
+    ).toContain("Ending soon");
+  });
+});
+
+describe("organizations stat strip and the table's filters", () => {
+  it("does not fetch again when the operator filters the table", async () => {
+    const router = await renderList();
+    const before = mocks.getOrganizationStats.mock.calls.length;
+    expect(before).toBeGreaterThan(0);
+
+    await router.navigate({
+      to: "/organizations",
+      search: { trial: ["running"] },
+    });
+
+    await waitFor(() => {
+      expect(lastListParams().trial_states).toEqual(["running"]);
+    });
+    // The figures describe the platform. A strip keyed on the filters would
+    // refetch here and start reporting the rows already on screen.
+    expect(mocks.getOrganizationStats.mock.calls.length).toBe(before);
+  });
+
+  it("holds its figures still while the table reloads under a filter", async () => {
+    const router = await renderList();
+
+    // A second answer, so a strip that did refetch would visibly move rather
+    // than merely call the endpoint again.
+    mocks.getOrganizationStats.mockResolvedValue({
+      total: 1,
+      created_last_7_days: 1,
+      trials_ending_soon: 1,
+      disabled: 1,
+      disabled_last_7_days: 1,
+    });
+
+    await router.navigate({
+      to: "/organizations",
+      search: { disabled: ["disabled"] },
+    });
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+
+    expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+    expect(cell("Disabled").textContent).toContain(figure(STATS.disabled));
+  });
+
+  it("keeps the figures the same across a click of its own", async () => {
+    const router = await renderList();
+
+    fireEvent.click(cell("Disabled"));
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+
+    expect(currentSearch(router)).toBe('?disabled=["disabled"]');
+    expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+    expect(cell("Trials ending in 7 days").textContent).toContain(
+      figure(STATS.trials_ending_soon),
+    );
+  });
+});
+
+describe("organizations stat strip placement", () => {
+  it("paints above the table rather than inside the box that scrolls", async () => {
+    await renderList();
+
+    const scrollBox = screen.getByRole("region", {
+      name: "Organizations table",
+    });
+    // Outside the scroll box, and before it in the document. A strip inside it
+    // would scroll away with the rows it leads to.
+    expect(scrollBox.contains(strip())).toBe(false);
+    expect(
+      strip().compareDocumentPosition(scrollBox) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("offers each figure as a control the keyboard reaches", async () => {
+    await renderList();
+
+    for (const label of [
+      "Organizations",
+      "Trials ending in 7 days",
+      "Disabled",
+    ]) {
+      const control = cell(label);
+      // A div with an onClick is not reachable by Tab and answers no key. The
+      // type matters too: a bare <button> inside a form submits it.
+      expect(control.tagName).toBe("BUTTON");
+      expect(control.getAttribute("type")).toBe("button");
+    }
+  });
+
+  it("filters from the keyboard as well as the pointer", async () => {
+    const router = await renderList();
+
+    const control = cell("Trials ending in 7 days");
+    control.focus();
+    expect(document.activeElement).toBe(control);
+    // A real button answers Enter and Space by firing a click, which is what
+    // happy-dom's click dispatch stands in for here.
+    fireEvent.click(control);
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toBe('?trial=["ending_soon"]');
+    });
+  });
+});

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -424,6 +424,19 @@ describe("organizations stat strip placement", () => {
     ).toBeTruthy();
   });
 
+  it("reads left to right in the order the design puts the figures", async () => {
+    await renderList();
+
+    // Every other assertion in this file finds a cell by its label, so the
+    // three could be dealt out in any order and nothing else here would notice.
+    // The first span of each is its label.
+    expect(
+      within(strip())
+        .getAllByRole("button")
+        .map((control) => control.querySelector("span")?.textContent),
+    ).toEqual(["Organizations", "Trials ending in 7 days", "Disabled"]);
+  });
+
   it("offers each figure as a control the keyboard reaches", async () => {
     await renderList();
 

--- a/client/admin/src/pages/organizations/StatStrip.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.tsx
@@ -2,8 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 
 import { organizationsStatsQuery } from "@/lib/adminQueries";
-import type { AdminOrganizationStats, TrialState } from "@/lib/gramAdminApi";
 import {
+  errorMessage,
+  type AdminOrganizationStats,
+  type TrialState,
+} from "@/lib/gramAdminApi";
+import {
+  DISABLED_STATES,
   NO_FILTERS,
   type DisabledState,
   type FilterSelection,
@@ -11,16 +16,17 @@ import {
 
 import { useApplyFilters } from "./applyFilters";
 
-// Typed as the states themselves rather than left as bare strings. Both readers
-// drop a value they do not recognise, so a misspelling here would not filter on
-// the wrong thing, it would silently filter on nothing: the cell would clear
-// the filters and read as though it had worked.
+// Typed, not bare strings: both readers drop a value they do not recognise, so
+// a misspelling would filter on nothing rather than on the wrong thing.
 const ENDING_SOON: TrialState = "ending_soon";
 const DISABLED: DisabledState = "disabled";
 
-// What is shown where the figures have not arrived. A digit that turns out to
-// be wrong is worse than a dash, and the cells stay usable either way: which
-// filter a cell applies does not depend on the count it is showing.
+// The correction two of these cells carry: an absent status filter means active
+// only, and every figure here counts the disabled organizations too.
+const EVERY_STATUS: DisabledState[] = [...DISABLED_STATES];
+
+// A digit that turns out to be wrong is worse than a dash, and which filter a
+// cell applies does not depend on the count it shows.
 const NO_FIGURE = "—";
 
 type StatCell = {
@@ -28,7 +34,7 @@ type StatCell = {
   value: (stats: AdminOrganizationStats) => number;
   /** Absent where the cell has no second line. */
   subLine?: (stats: AdminOrganizationStats) => string;
-  /** Applied whole, so the two filters a cell does not name are cleared. */
+  /** Applied whole, so the filters a cell does not name are cleared. */
   filters: FilterSelection;
 };
 
@@ -37,14 +43,13 @@ const STAT_CELLS: StatCell[] = [
     label: "Organizations",
     value: (stats) => stats.total,
     subLine: (stats) => `${figure(stats.created_last_7_days)} new this week`,
-    filters: NO_FILTERS,
+    filters: { ...NO_FILTERS, disabled: EVERY_STATUS },
   },
   {
-    // No sub-line. The design's "N with no owner" is cut: Gram has no concept
-    // of an organization owner to count.
+    // No sub-line: the design's "N with no owner" is cut, Gram has no owners.
     label: "Trials ending in 7 days",
     value: (stats) => stats.trials_ending_soon,
-    filters: { ...NO_FILTERS, trial: [ENDING_SOON] },
+    filters: { ...NO_FILTERS, trial: [ENDING_SOON], disabled: EVERY_STATUS },
   },
   {
     label: "Disabled",
@@ -54,51 +59,58 @@ const STAT_CELLS: StatCell[] = [
   },
 ];
 
-function figure(value: number): string {
-  return value.toLocaleString();
+// All five fields are Required in the Goa design, so one cannot go missing.
+// Cheap insurance: nothing in this app catches a throw, so a page would go dark.
+function figure(value: number | undefined): string {
+  return typeof value === "number" ? value.toLocaleString() : NO_FIGURE;
 }
 
-/**
- * How much work is waiting, across the whole platform, with each figure a way
- * into the rows behind it.
- */
+/** How much work is waiting across the platform, each figure a way into it. */
 export function StatStrip(): JSX.Element {
   const applyFilters = useApplyFilters();
-
-  // Deliberately not given the list's filters, and the query takes none: these
-  // figures describe the platform rather than the current view. Passing the
-  // filters would make the strip refetch on every filter change and report the
-  // rows already on screen, which is a count the operator can read off the
-  // table.
-  const { data } = useQuery(organizationsStatsQuery);
+  const { data, isPending, isError, error } = useQuery(organizationsStatsQuery);
 
   return (
-    <div
-      // Named, because the three figures only mean something together and a
-      // screen reader arriving on one cell is otherwise told three numbers with
-      // no account of what they are counting.
-      role="group"
-      aria-label="Platform totals"
-      className="mb-2 grid grid-cols-3 divide-x rounded-lg border"
-    >
-      {STAT_CELLS.map((cell) => (
-        <button
-          key={cell.label}
-          type="button"
-          onClick={() => applyFilters(cell.filters)}
-          className="flex flex-col items-start gap-0.5 px-4 py-3 text-left transition-colors first:rounded-l-lg last:rounded-r-lg hover:bg-accent focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
-        >
-          <span className="text-muted-foreground text-xs">{cell.label}</span>
-          <span className="text-2xl font-semibold tabular-nums">
-            {data ? figure(cell.value(data)) : NO_FIGURE}
-          </span>
-          {cell.subLine && data ? (
-            <span className="text-muted-foreground text-xs">
-              {cell.subLine(data)}
+    <>
+      <div
+        // Named: the three figures only mean something together, and a reader
+        // arriving on one is otherwise told a number and not what it counts.
+        role="group"
+        aria-label="Platform totals"
+        className="mb-2 grid grid-cols-3 divide-x rounded-lg border"
+      >
+        {STAT_CELLS.map((cell) => (
+          <button
+            key={cell.label}
+            type="button"
+            // The dash is not spoken at default verbosity, so without this the
+            // cell is a label with no figure and no sign one is coming.
+            aria-busy={isPending}
+            onClick={() => applyFilters(cell.filters)}
+            className="flex flex-col items-start gap-0.5 px-4 py-3 text-left transition-colors first:rounded-l-lg last:rounded-r-lg hover:bg-accent focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+          >
+            <span className="text-muted-foreground text-xs">{cell.label}</span>
+            <span className="text-2xl font-semibold tabular-nums">
+              {data ? figure(cell.value(data)) : NO_FIGURE}
             </span>
-          ) : null}
-        </button>
-      ))}
-    </div>
+            {/* Empty, but holding its height: the toolbar and the table below
+                would otherwise drop a line when the figures land. */}
+            {cell.subLine ? (
+              <span className="text-muted-foreground min-h-4 text-xs">
+                {data ? cell.subLine(data) : null}
+              </span>
+            ) : null}
+          </button>
+        ))}
+      </div>
+
+      {/* Reported where the table reports its own failures. Without this a
+          strip of dashes reads the same as a platform with nothing on it. */}
+      {isError && (
+        <div className="text-muted-foreground mb-2 text-sm">
+          Could not load the platform totals: {errorMessage(error)}
+        </div>
+      )}
+    </>
   );
 }

--- a/client/admin/src/pages/organizations/StatStrip.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.tsx
@@ -1,0 +1,104 @@
+import { useQuery } from "@tanstack/react-query";
+import type { JSX } from "react";
+
+import { organizationsStatsQuery } from "@/lib/adminQueries";
+import type { AdminOrganizationStats, TrialState } from "@/lib/gramAdminApi";
+import {
+  NO_FILTERS,
+  type DisabledState,
+  type FilterSelection,
+} from "@/lib/organizationFilters";
+
+import { useApplyFilters } from "./applyFilters";
+
+// Typed as the states themselves rather than left as bare strings. Both readers
+// drop a value they do not recognise, so a misspelling here would not filter on
+// the wrong thing, it would silently filter on nothing: the cell would clear
+// the filters and read as though it had worked.
+const ENDING_SOON: TrialState = "ending_soon";
+const DISABLED: DisabledState = "disabled";
+
+// What is shown where the figures have not arrived. A digit that turns out to
+// be wrong is worse than a dash, and the cells stay usable either way: which
+// filter a cell applies does not depend on the count it is showing.
+const NO_FIGURE = "—";
+
+type StatCell = {
+  label: string;
+  value: (stats: AdminOrganizationStats) => number;
+  /** Absent where the cell has no second line. */
+  subLine?: (stats: AdminOrganizationStats) => string;
+  /** Applied whole, so the two filters a cell does not name are cleared. */
+  filters: FilterSelection;
+};
+
+const STAT_CELLS: StatCell[] = [
+  {
+    label: "Organizations",
+    value: (stats) => stats.total,
+    subLine: (stats) => `${figure(stats.created_last_7_days)} new this week`,
+    filters: NO_FILTERS,
+  },
+  {
+    // No sub-line. The design's "N with no owner" is cut: Gram has no concept
+    // of an organization owner to count.
+    label: "Trials ending in 7 days",
+    value: (stats) => stats.trials_ending_soon,
+    filters: { ...NO_FILTERS, trial: [ENDING_SOON] },
+  },
+  {
+    label: "Disabled",
+    value: (stats) => stats.disabled,
+    subLine: (stats) => `${figure(stats.disabled_last_7_days)} this week`,
+    filters: { ...NO_FILTERS, disabled: [DISABLED] },
+  },
+];
+
+function figure(value: number): string {
+  return value.toLocaleString();
+}
+
+/**
+ * How much work is waiting, across the whole platform, with each figure a way
+ * into the rows behind it.
+ */
+export function StatStrip(): JSX.Element {
+  const applyFilters = useApplyFilters();
+
+  // Deliberately not given the list's filters, and the query takes none: these
+  // figures describe the platform rather than the current view. Passing the
+  // filters would make the strip refetch on every filter change and report the
+  // rows already on screen, which is a count the operator can read off the
+  // table.
+  const { data } = useQuery(organizationsStatsQuery);
+
+  return (
+    <div
+      // Named, because the three figures only mean something together and a
+      // screen reader arriving on one cell is otherwise told three numbers with
+      // no account of what they are counting.
+      role="group"
+      aria-label="Platform totals"
+      className="mb-2 grid grid-cols-3 divide-x rounded-lg border"
+    >
+      {STAT_CELLS.map((cell) => (
+        <button
+          key={cell.label}
+          type="button"
+          onClick={() => applyFilters(cell.filters)}
+          className="flex flex-col items-start gap-0.5 px-4 py-3 text-left transition-colors first:rounded-l-lg last:rounded-r-lg hover:bg-accent focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+        >
+          <span className="text-muted-foreground text-xs">{cell.label}</span>
+          <span className="text-2xl font-semibold tabular-nums">
+            {data ? figure(cell.value(data)) : NO_FIGURE}
+          </span>
+          {cell.subLine && data ? (
+            <span className="text-muted-foreground text-xs">
+              {cell.subLine(data)}
+            </span>
+          ) : null}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/admin/src/pages/organizations/StatStrip.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.tsx
@@ -88,8 +88,8 @@ export function StatStrip(): JSX.Element {
           <button
             key={cell.label}
             type="button"
-            // Readable on demand rather than announced: the dash is not spoken
-            // at default verbosity, so the cell is a label with no figure.
+            // Without it the cell reads as a label with no figure: the dash
+            // standing in for one is not spoken at default verbosity.
             aria-busy={isPending}
             onClick={() => applyFilters(cell.filters, { clearSearch: true })}
             className="flex flex-col items-start gap-0.5 px-4 py-3 text-left transition-colors first:rounded-l-lg last:rounded-r-lg hover:bg-accent focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"

--- a/client/admin/src/pages/organizations/StatStrip.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.tsx
@@ -36,6 +36,8 @@ type StatCell = {
   subLine?: (stats: AdminOrganizationStats) => string;
   /** Applied whole, so the filters a cell does not name are cleared. */
   filters: FilterSelection;
+  /** What pressing does. The figure alone never says the cell is a control. */
+  action: string;
 };
 
 const STAT_CELLS: StatCell[] = [
@@ -44,18 +46,21 @@ const STAT_CELLS: StatCell[] = [
     value: (stats) => stats.total,
     subLine: (stats) => `${figure(stats.created_last_7_days)} new this week`,
     filters: { ...NO_FILTERS, disabled: EVERY_STATUS },
+    action: "Show every organization",
   },
   {
     // No sub-line: the design's "N with no owner" is cut, Gram has no owners.
     label: "Trials ending in 7 days",
     value: (stats) => stats.trials_ending_soon,
     filters: { ...NO_FILTERS, trial: [ENDING_SOON], disabled: EVERY_STATUS },
+    action: "Show the trials ending in 7 days",
   },
   {
     label: "Disabled",
     value: (stats) => stats.disabled,
     subLine: (stats) => `${figure(stats.disabled_last_7_days)} this week`,
     filters: { ...NO_FILTERS, disabled: [DISABLED] },
+    action: "Show the disabled organizations",
   },
 ];
 
@@ -83,10 +88,10 @@ export function StatStrip(): JSX.Element {
           <button
             key={cell.label}
             type="button"
-            // The dash is not spoken at default verbosity, so without this the
-            // cell is a label with no figure and no sign one is coming.
+            // Readable on demand rather than announced: the dash is not spoken
+            // at default verbosity, so the cell is a label with no figure.
             aria-busy={isPending}
-            onClick={() => applyFilters(cell.filters)}
+            onClick={() => applyFilters(cell.filters, { clearSearch: true })}
             className="flex flex-col items-start gap-0.5 px-4 py-3 text-left transition-colors first:rounded-l-lg last:rounded-r-lg hover:bg-accent focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
           >
             <span className="text-muted-foreground text-xs">{cell.label}</span>
@@ -100,6 +105,7 @@ export function StatStrip(): JSX.Element {
                 {data ? cell.subLine(data) : null}
               </span>
             ) : null}
+            <span className="sr-only">{cell.action}</span>
           </button>
         ))}
       </div>

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -66,7 +66,6 @@ export function Toolbar(): JSX.Element {
         search: (prev: OrganizationsSearch) => ({
           ...prev,
           q: next || undefined,
-          page: undefined,
         }),
         // Keystroke rate. One history entry per burst of typing, not one per
         // keystroke.

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -19,7 +19,6 @@ import { Input } from "@/components/ui/input";
 import {
   FILTER_GROUPS,
   filterSummary,
-  filtersToSearch,
   optionsFor,
   type FilterGroupKey,
   type FilterSelection,
@@ -27,6 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { OrganizationsSearch } from "@/routes/organizations.index";
 
+import { useApplyFilters } from "./applyFilters";
 import { FilterSheet } from "./FilterSheet";
 
 const ROUTE_ID = "/organizations/";
@@ -93,17 +93,7 @@ export function Toolbar(): JSX.Element {
     disabled: search.disabled ?? [],
   };
 
-  const applyFilters = (next: FilterSelection): void => {
-    void navigate({
-      search: (prev: OrganizationsSearch) => ({
-        ...prev,
-        ...filtersToSearch(next),
-        // Page 1. The rows a page-two cursor points at were counted under the
-        // filters that minted it.
-        page: undefined,
-      }),
-    });
-  };
+  const applyFilters = useApplyFilters();
 
   const openFilters = (group: FilterGroupKey): void => {
     openedFrom.current = group;

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -32,7 +32,15 @@ import { FilterSheet } from "./FilterSheet";
 const ROUTE_ID = "/organizations/";
 const SEARCH_DEBOUNCE_MS = 300;
 
-export function Toolbar(): JSX.Element {
+type ToolbarProps = {
+  /**
+   * Changes whenever a control cleared the search term. A draft still inside
+   * the debounce reached no URL, so the box has nothing else to notice by.
+   */
+  searchCleared: number;
+};
+
+export function Toolbar({ searchCleared }: ToolbarProps): JSX.Element {
   const search = useSearch({ from: ROUTE_ID });
   const navigate = useNavigate({ from: ROUTE_ID });
 
@@ -53,6 +61,14 @@ export function Toolbar(): JSX.Element {
     // operator just typed. `lastCommitted` still moves either way, or this
     // block runs on every render.
     if (draft.trim() !== committed) setDraft(committed);
+  }
+
+  const [lastCleared, setLastCleared] = useState(searchCleared);
+  if (searchCleared !== lastCleared) {
+    setLastCleared(searchCleared);
+    // Dropping the draft drops the commit it had pending with it: the effect
+    // below is keyed on the draft, so its cleanup clears the timer.
+    if (draft !== "") setDraft("");
   }
 
   useEffect(() => {

--- a/client/admin/src/pages/organizations/applyFilters.ts
+++ b/client/admin/src/pages/organizations/applyFilters.ts
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { createContext, useCallback, useContext } from "react";
 
 import {
   filtersToSearch,
@@ -9,25 +9,42 @@ import type { OrganizationsSearch } from "@/routes/organizations.index";
 
 const ROUTE_ID = "/organizations/";
 
+// The cursor is component state rather than a search param, so applying the
+// set that is already applied changes nothing the pager watches. It is told.
+export const FiltersApplied = createContext<() => void>(() => {});
+
+export type ApplyOptions = {
+  /**
+   * Drops the search term too. A stat figure counts rows no term narrowed, so
+   * the list it opens cannot keep one. The sheet's own controls do not.
+   */
+  clearSearch?: boolean;
+};
+
 /**
  * Writes a chosen set to the URL. All three params come from the set, so a
  * control that names one filter clears the two it does not.
  */
-export function useApplyFilters(): (next: FilterSelection) => void {
+export function useApplyFilters(): (
+  next: FilterSelection,
+  options?: ApplyOptions,
+) => void {
   const navigate = useNavigate({ from: ROUTE_ID });
+  const onApplied = useContext(FiltersApplied);
 
   return useCallback(
-    (next: FilterSelection): void => {
+    (next: FilterSelection, options: ApplyOptions = {}): void => {
+      // Page 1. The rows a page-two cursor points at were counted under the
+      // filters that minted it.
+      onApplied();
       void navigate({
         search: (prev: OrganizationsSearch) => ({
           ...prev,
           ...filtersToSearch(next),
-          // Page 1. The rows a page-two cursor points at were counted under the
-          // filters that minted it.
-          page: undefined,
+          ...(options.clearSearch ? { q: undefined } : {}),
         }),
       });
     },
-    [navigate],
+    [navigate, onApplied],
   );
 }

--- a/client/admin/src/pages/organizations/applyFilters.ts
+++ b/client/admin/src/pages/organizations/applyFilters.ts
@@ -1,0 +1,37 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+
+import {
+  filtersToSearch,
+  type FilterSelection,
+} from "@/lib/organizationFilters";
+import type { OrganizationsSearch } from "@/routes/organizations.index";
+
+const ROUTE_ID = "/organizations/";
+
+/**
+ * Writes a chosen set to the URL, which is where the list keeps its state.
+ *
+ * Every control that filters the list goes through this, so the filter sheet
+ * and the stat strip cannot disagree about what applying a set does: all three
+ * params are written from the set, so a control that names one filter clears
+ * the two it does not name rather than merging with whatever was there.
+ */
+export function useApplyFilters(): (next: FilterSelection) => void {
+  const navigate = useNavigate({ from: ROUTE_ID });
+
+  return useCallback(
+    (next: FilterSelection): void => {
+      void navigate({
+        search: (prev: OrganizationsSearch) => ({
+          ...prev,
+          ...filtersToSearch(next),
+          // Page 1. The rows a page-two cursor points at were counted under the
+          // filters that minted it.
+          page: undefined,
+        }),
+      });
+    },
+    [navigate],
+  );
+}

--- a/client/admin/src/pages/organizations/applyFilters.ts
+++ b/client/admin/src/pages/organizations/applyFilters.ts
@@ -10,12 +10,8 @@ import type { OrganizationsSearch } from "@/routes/organizations.index";
 const ROUTE_ID = "/organizations/";
 
 /**
- * Writes a chosen set to the URL, which is where the list keeps its state.
- *
- * Every control that filters the list goes through this, so the filter sheet
- * and the stat strip cannot disagree about what applying a set does: all three
- * params are written from the set, so a control that names one filter clears
- * the two it does not name rather than merging with whatever was there.
+ * Writes a chosen set to the URL. All three params come from the set, so a
+ * control that names one filter clears the two it does not.
  */
 export function useApplyFilters(): (next: FilterSelection) => void {
   const navigate = useNavigate({ from: ROUTE_ID });

--- a/client/admin/src/pages/organizations/applyFilters.ts
+++ b/client/admin/src/pages/organizations/applyFilters.ts
@@ -9,10 +9,6 @@ import type { OrganizationsSearch } from "@/routes/organizations.index";
 
 const ROUTE_ID = "/organizations/";
 
-// The cursor is component state rather than a search param, so applying the
-// set that is already applied changes nothing the pager watches. It is told.
-export const FiltersApplied = createContext<() => void>(() => {});
-
 export type ApplyOptions = {
   /**
    * Drops the search term too. A stat figure counts rows no term narrowed, so
@@ -20,6 +16,14 @@ export type ApplyOptions = {
    */
   clearSearch?: boolean;
 };
+
+// What applying leaves for the page to do itself. Two things it cannot read
+// off the URL: the cursor is component state, so applying the set already
+// applied moves nothing it watches, and a search term the box has not
+// committed yet is in no URL at all.
+export const FiltersApplied = createContext<(options: ApplyOptions) => void>(
+  () => {},
+);
 
 /**
  * Writes a chosen set to the URL. All three params come from the set, so a
@@ -36,7 +40,7 @@ export function useApplyFilters(): (
     (next: FilterSelection, options: ApplyOptions = {}): void => {
       // Page 1. The rows a page-two cursor points at were counted under the
       // filters that minted it.
-      onApplied();
+      onApplied(options);
       void navigate({
         search: (prev: OrganizationsSearch) => ({
           ...prev,

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -28,6 +28,7 @@ import {
   GramAdminError,
   TRIAL_STATES,
   type AdminOrganization,
+  type AdminOrganizationStats,
   type ListOrganizationsParams,
   type ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
@@ -51,6 +52,7 @@ const mocks = vi.hoisted(() => ({
       (params?: ListOrganizationsParams) => Promise<ListOrganizationsResult>
     >(),
   getSession: vi.fn(),
+  getOrganizationStats: vi.fn(),
   getOrganization: vi.fn(),
   listOrganizationProjects: vi.fn(),
   listOrganizationMembers: vi.fn(),
@@ -72,6 +74,7 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     ...actual,
     listOrganizations: mocks.listOrganizations,
     getSession: mocks.getSession,
+    getOrganizationStats: mocks.getOrganizationStats,
     getOrganization: mocks.getOrganization,
     listOrganizationProjects: mocks.listOrganizationProjects,
     listOrganizationMembers: mocks.listOrganizationMembers,
@@ -135,6 +138,16 @@ const ORGS: AdminOrganization[] = [
     updated_at: "2026-04-07T00:00:00Z",
   },
 ];
+
+// Only so the strip above the table has something to render. What it does with
+// these figures is pinned in StatStrip.test.tsx.
+const STATS: AdminOrganizationStats = {
+  total: 12,
+  created_last_7_days: 3,
+  trials_ending_soon: 2,
+  disabled: 1,
+  disabled_last_7_days: 1,
+};
 
 // A page the cursor leads to. Nothing it holds appears on the first page, so a
 // row that survives the page change is a reused node rather than a match.
@@ -362,6 +375,8 @@ beforeEach(() => {
     email: "ops@example.test",
     name: "Ops",
   });
+  mocks.getOrganizationStats.mockReset();
+  mocks.getOrganizationStats.mockResolvedValue(STATS);
   mocks.getOrganization.mockReset();
   mocks.getOrganization.mockResolvedValue(FIRST_ORG);
   mocks.listOrganizationProjects.mockReset();

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -828,21 +828,32 @@ describe("organizations list", () => {
     expect(url).toContain("dir=asc");
   });
 
-  it("returns to the first page when a filter is applied", async () => {
-    const { router } = await renderRouteTree(routeTree, {
-      initialPath: urlFor({ page: 3 }),
+  it("returns to the first page when the sheet applies the set already on", async () => {
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: ORGS,
+      next_cursor: "cursor_page_two",
+    });
+    await renderRouteTree(routeTree, {
+      initialPath: urlFor({ disabled: ["disabled"] }),
     });
 
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await waitFor(() => {
+      expect(lastListParams().cursor).toBe("cursor_page_two");
+    });
+
+    // Nothing in the URL moves, so the pager cannot notice on its own. Page
+    // three of a filter set is not the first page an operator asked for.
     await openFilters("Status");
-    await chooseFilter("Status", "Disabled");
     applyFilters();
 
     await waitFor(() => {
-      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+      expect(lastListParams().cursor).toBeUndefined();
     });
-    // Page three of the old filter set is not page three of the new one, and
-    // an operator who narrowed a list expects its first rows.
-    expect(currentSearch(router)).not.toContain("page");
   });
 
   it("keeps an unrecognised type on offer after the operator unchecks it", async () => {
@@ -3095,10 +3106,7 @@ describe("organizationsSearchSchema", () => {
     ["reads a direction in the union", { dir: "desc" }, { dir: "desc" }],
     ["drops a direction outside the union", { dir: "sideways" }, {}],
     ["drops the old disabled flag when it is off", { disabled: false }, {}],
-    ["drops page 1, which is the default", { page: 1 }, {}],
-    ["drops a page below 1", { page: 0 }, {}],
-    ["drops a page between two whole ones", { page: 2.5 }, {}],
-    ["keeps a page past the first", { page: 2 }, { page: 2 }],
+    ["drops a key the schema does not declare", { page: 2 }, {}],
   ];
 
   it.each(cases)("%s", (_name, search, expected) => {

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -2361,6 +2361,31 @@ describe("organizations list write actions", () => {
     });
   });
 
+  // The write drops the read in flight before it goes out. A write that then
+  // fails puts nothing in its place, and a first read holds no figures to fall
+  // back on, so the strip would keep the dashes it started with.
+  it("asks for the platform totals again when the write is refused", async () => {
+    mocks.disableOrganization.mockRejectedValue(
+      new GramAdminError(
+        409,
+        { name: "conflict", message: "organization is already disabled" },
+        "gram admin 409 Conflict",
+      ),
+    );
+    // Held open, so the cancel catches it before it has answered once.
+    mocks.getOrganizationStats.mockReturnValueOnce(new Promise(() => {}));
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: LIVE.name });
+    expect(mocks.getOrganizationStats.mock.calls.length).toBe(1);
+
+    await openRowMenu(LIVE.name);
+    await confirmDisable();
+
+    await waitFor(() => {
+      expect(mocks.getOrganizationStats.mock.calls.length).toBe(2);
+    });
+  });
+
   it("stays on the list while the operator works the menu it opened from a row", async () => {
     const { router } = await renderRouteTree(routeTree, {
       initialPath: "/organizations",

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -32,6 +32,7 @@ import {
   type ListOrganizationsParams,
   type ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
+import { ACCOUNT_TYPE_OPTIONS } from "@/lib/accountTypes";
 import { TRIAL_LABELS } from "@/lib/trialLabels";
 import { useState, type JSX } from "react";
 
@@ -720,6 +721,21 @@ describe("organizations list", () => {
     ).toBe("acme");
   });
 
+  it("counts a full set of types rather than calling it all of them", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: urlFor({ type: [...ACCOUNT_TYPE_OPTIONS] }),
+    });
+
+    await waitFor(() => {
+      expect(lastListParams().account_types).toEqual([...ACCOUNT_TYPE_OPTIONS]);
+    });
+    // An organization can carry a type the picker does not offer, so every
+    // option at once is still a narrowing and must not read as "All types".
+    expect(filterTrigger("Type").getAttribute("aria-label")).toBe(
+      `Type filter: ${ACCOUNT_TYPE_OPTIONS.length} selected`,
+    );
+  });
+
   it("keeps an account type the picker does not offer", async () => {
     // ACCOUNT_TYPE_OPTIONS is the list the picker offers, not the list the
     // column can hold. Dropping a value from outside it would widen the view a
@@ -808,6 +824,21 @@ describe("organizations list", () => {
     const options = await screen.findAllByRole("option");
     expect(options.map((option) => option.textContent)).toEqual(
       TRIAL_STATES.map((state) => TRIAL_LABELS[state]),
+    );
+  });
+
+  it("names every trial state at once rather than counting them", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: urlFor({ trial: [...TRIAL_STATES] }),
+    });
+
+    await waitFor(() => {
+      expect(lastListParams().trial_states).toEqual([...TRIAL_STATES]);
+    });
+    // Every organization holds exactly one of these, so all of them is the
+    // whole platform. "6 selected" reads as a narrowing that is not there.
+    expect(filterTrigger("Trial").getAttribute("aria-label")).toBe(
+      "Trial filter: All trial states",
     );
   });
 
@@ -919,6 +950,37 @@ describe("organizations list", () => {
     });
     // The cursor was minted by the previous filter set and points into a
     // different result set.
+    expect(lastListParams().cursor).toBeUndefined();
+  });
+
+  it("drops the cursor when the search box changes the term", async () => {
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: ORGS,
+      next_cursor: "cursor_page_two",
+    });
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await waitFor(() => {
+      expect(lastListParams().cursor).toBe("cursor_page_two");
+    });
+
+    // The box writes to the URL itself, so nothing tells the pager. Only the
+    // signature the render compares can catch this one.
+    fireEvent.change(screen.getByLabelText("Search organizations"), {
+      target: { value: "acme" },
+    });
+
+    await waitFor(
+      () => {
+        expect(lastListParams().q).toBe("acme");
+      },
+      { timeout: 2000 },
+    );
     expect(lastListParams().cursor).toBeUndefined();
   });
 

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -139,8 +139,6 @@ const ORGS: AdminOrganization[] = [
   },
 ];
 
-// Only so the strip above the table has something to render. What it does with
-// these figures is pinned in StatStrip.test.tsx.
 const STATS: AdminOrganizationStats = {
   total: 12,
   created_last_7_days: 3,
@@ -2271,6 +2269,23 @@ describe("organizations list write actions", () => {
     expect(cellUnder(rowFor(other), "Disabled").textContent).toBe(
       shortDate(FIRST_ORG.disabled_at ?? ""),
     );
+  });
+
+  // Unlike the row, which repaints from the answer the write already returned.
+  it("asks for the platform totals again after a write", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: LIVE.name });
+    const before = mocks.getOrganizationStats.mock.calls.length;
+    expect(before).toBeGreaterThan(0);
+
+    await openRowMenu(LIVE.name);
+    await confirmDisable();
+
+    await waitFor(() => {
+      expect(mocks.getOrganizationStats.mock.calls.length).toBeGreaterThan(
+        before,
+      );
+    });
   });
 
   it("stays on the list while the operator works the menu it opened from a row", async () => {

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -27,6 +27,7 @@ import { WriteReportProvider } from "./OrganizationActions";
 import { PeekPanel } from "./PeekPanel";
 import { PEEK_TRIGGER_SELECTOR, PeekProvider } from "./PeekTrigger";
 import { useOpenOrganization } from "./rowActions";
+import { StatStrip } from "./StatStrip";
 import { TableActionBar, Toolbar } from "./Toolbar";
 
 const ROUTE_ID = "/organizations/";
@@ -370,6 +371,10 @@ export function OrganizationsList(): JSX.Element {
   return (
     <div className="flex h-full flex-col">
       <section className="flex min-h-0 flex-1 flex-col">
+        {/* Outside the table's scroll box, so the figures stay on screen while
+            the operator scrolls the rows they lead to. */}
+        <StatStrip />
+
         <Toolbar />
 
         {/* A failed refetch keeps the previous rows, so the failure has to show

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -26,7 +26,7 @@ import { ORG_COLUMNS } from "./columns";
 import { WriteReportProvider } from "./OrganizationActions";
 import { PeekPanel } from "./PeekPanel";
 import { PEEK_TRIGGER_SELECTOR, PeekProvider } from "./PeekTrigger";
-import { FiltersApplied } from "./applyFilters";
+import { FiltersApplied, type ApplyOptions } from "./applyFilters";
 import { useOpenOrganization } from "./rowActions";
 import { StatStrip } from "./StatStrip";
 import { TableActionBar, Toolbar } from "./Toolbar";
@@ -161,10 +161,17 @@ export function OrganizationsList(): JSX.Element {
     placeholderData: keepPreviousData,
   });
 
+  // A token, read only when it changes: the search box drops the draft it is
+  // holding whenever a control clears the term.
+  const [searchCleared, setSearchCleared] = useState(0);
+
   // Applying a set the list already carries leaves the signature above
   // untouched, so the control that applies says so itself.
-  const resetPager = useCallback(() => {
+  const onFiltersApplied = useCallback((options: ApplyOptions) => {
     setPager((prev) => ({ ...prev, cursor: undefined, stack: [] }));
+    // A term still inside the debounce is in no URL, so clearing `q` is a
+    // no-op the box cannot see, and it would commit the term afterwards.
+    if (options.clearSearch) setSearchCleared((token) => token + 1);
   }, []);
 
   const goNext = () => {
@@ -378,12 +385,12 @@ export function OrganizationsList(): JSX.Element {
   return (
     <div className="flex h-full flex-col">
       <section className="flex min-h-0 flex-1 flex-col">
-        <FiltersApplied.Provider value={resetPager}>
+        <FiltersApplied.Provider value={onFiltersApplied}>
           {/* Outside the table's scroll box, so the figures stay on screen
               while the operator scrolls the rows they lead to. */}
           <StatStrip />
 
-          <Toolbar />
+          <Toolbar searchCleared={searchCleared} />
         </FiltersApplied.Provider>
 
         {/* A failed refetch keeps the previous rows, so the failure has to show

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -26,6 +26,7 @@ import { ORG_COLUMNS } from "./columns";
 import { WriteReportProvider } from "./OrganizationActions";
 import { PeekPanel } from "./PeekPanel";
 import { PEEK_TRIGGER_SELECTOR, PeekProvider } from "./PeekTrigger";
+import { FiltersApplied } from "./applyFilters";
 import { useOpenOrganization } from "./rowActions";
 import { StatStrip } from "./StatStrip";
 import { TableActionBar, Toolbar } from "./Toolbar";
@@ -159,6 +160,12 @@ export function OrganizationsList(): JSX.Element {
     // table empties on each change and the rows jump.
     placeholderData: keepPreviousData,
   });
+
+  // Applying a set the list already carries leaves the signature above
+  // untouched, so the control that applies says so itself.
+  const resetPager = useCallback(() => {
+    setPager((prev) => ({ ...prev, cursor: undefined, stack: [] }));
+  }, []);
 
   const goNext = () => {
     if (!data?.next_cursor) return;
@@ -371,11 +378,13 @@ export function OrganizationsList(): JSX.Element {
   return (
     <div className="flex h-full flex-col">
       <section className="flex min-h-0 flex-1 flex-col">
-        {/* Outside the table's scroll box, so the figures stay on screen while
-            the operator scrolls the rows they lead to. */}
-        <StatStrip />
+        <FiltersApplied.Provider value={resetPager}>
+          {/* Outside the table's scroll box, so the figures stay on screen
+              while the operator scrolls the rows they lead to. */}
+          <StatStrip />
 
-        <Toolbar />
+          <Toolbar />
+        </FiltersApplied.Provider>
 
         {/* A failed refetch keeps the previous rows, so the failure has to show
             outside the empty state or the operator reads stale data as fresh. */}

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -8,6 +8,7 @@ import { useCallback } from "react";
 
 import {
   cancelOrganizationFetches,
+  invalidateOrganizationStats,
   organizationQuery,
   writeOrganizationToCache,
 } from "@/lib/adminQueries";
@@ -81,12 +82,16 @@ type OrganizationWrite<TVariables> = UseMutationResult<
 // All three drop the reads already in flight first. React Query awaits
 // `onMutate` before it sends the request, so the stale fetch is cancelled
 // before the write leaves rather than racing it home.
+//
+// A write that fails replaces none of what it cancelled, so all three ask for
+// the totals again on that path. The row needs nothing: it was never repainted.
 export function useDisableOrganization(): OrganizationWrite<string> {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => disableOrganization({ id }),
     onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
+    onError: () => invalidateOrganizationStats(qc),
   });
 }
 
@@ -96,6 +101,7 @@ export function useEnableOrganization(): OrganizationWrite<string> {
     mutationFn: (id: string) => enableOrganization({ id }),
     onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
+    onError: () => invalidateOrganizationStats(qc),
   });
 }
 
@@ -107,5 +113,6 @@ export function useExtendTrial(): OrganizationWrite<ExtendTrialRequest> {
     mutationFn: (body: ExtendTrialRequest) => extendTrial(body),
     onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
+    onError: () => invalidateOrganizationStats(qc),
   });
 }

--- a/client/admin/src/routes/organizations.index.tsx
+++ b/client/admin/src/routes/organizations.index.tsx
@@ -31,8 +31,6 @@ export type OrganizationsSearch = {
   disabled?: DisabledState[];
   sort?: string;
   dir?: "asc" | "desc";
-  /** 1-based. Declared, not yet wired: the list API is still cursor-paged. */
-  page?: number;
 };
 
 // The router parses a param that reads as a JSON literal before this runs, so
@@ -78,12 +76,6 @@ function direction(value: unknown): "asc" | "desc" | undefined {
   return undefined;
 }
 
-// Page 1 is the default, so it never reaches the URL.
-function pageNumber(value: unknown): number | undefined {
-  const page = typeof value === "number" ? value : Number(value);
-  return Number.isInteger(page) && page > 1 ? page : undefined;
-}
-
 export function organizationsSearchSchema(
   search: Record<string, unknown>,
 ): OrganizationsSearch {
@@ -94,7 +86,6 @@ export function organizationsSearchSchema(
     disabled: statuses(search["disabled"]),
     sort: text(search["sort"]),
     dir: direction(search["dir"]),
-    page: pageNumber(search["page"]),
   };
 }
 


### PR DESCRIPTION
A platform admin opening the organizations list cannot tell how many organizations there are, so this puts three figures above it and makes each one a control that opens the rows it counted. AGE-3187, client half. The endpoint it reads landed in #5331.

Three cells: **Organizations** with the count of new ones this week, **Trials ending in 7 days**, and **Disabled**. Pressing one applies the filter set behind that figure, so the number and the rows below it agree.

## Decisions worth a reviewer's attention

**Pressing a cell clears the search term and returns to page one.** A cell means "show me the rows behind this number". A leftover search term contradicts the number, and a leftover page cursor makes the control look like it did nothing at all. Both were real: with `?q=acme` set the list request still carried `q`, and from page three of the disabled list the Disabled cell left the operator on page three.

The pager reset is the interesting half. Paging was not in the URL, so the list only reset when the JSON signature of its params changed, and a cell whose filters are already applied changes nothing. There was a `page` key in the route schema that was supposed to do this and was never wired to anything. It is deleted, and applying a filter set now resets the pager directly through a small context. A declared key that resets nothing is worse than no key.

**The Organizations cell sends every status explicitly, and this is not redundant.** An empty status filter means active only, so "show me the whole platform" has to spell out both values. That is why the resulting link carries `?disabled=["active","disabled"]`.

**A full selection is labelled, not treated as unfiltered.** Pressing Organizations used to make the Status trigger read "2 selected". The obvious fix, treating a full selection as no filter, is wrong here: Status's empty state resolves to `{"active"}` server side, so a full selection is genuinely broader than empty and the trigger would have read "Active only" while disabled rows sat on screen. Each group now carries an optional all-label instead. Status reads "Active and disabled", Trial reads "All trial states". **Type deliberately has none**, because an organization can carry an account type the picker does not offer, so choosing all three still leaves rows out. A test pins that absence.

**`created_last_7_days` and `disabled_last_7_days` are deliberately not clickable.** `listOrganizations` has no date filter, so there is no list for those two figures to open.

## Stated limits

**The visible toolbar still reads as filtered after pressing Organizations.** The all-label feeds the accessible name only. The badge and the button variant come from the raw selection count, so a screen-reader user now correctly hears "Active and disabled" while a sighted operator still sees a highlighted control with a `2` on it. The count is true, and the fix that would satisfy the sighted half is the same "full selection is unfiltered" rule that is false for Type. What "filtered" should mean visually belongs to whoever owns the toolbar, not to this slice.

**The strip refreshes while the row it counted stays in the list.** Disabling a row on the active-only list moves the Disabled figure immediately while the row itself remains. Before this change both were stale together. The row retention is deliberate and documented elsewhere, so this is a new visible inconsistency that is still the better of the two states.

**The error banner is not announced.** No `role="alert"`, no `aria-live`. It matches its immediate neighbour, the "Could not refresh organizations" banner, so fixing one without the other would be worse than leaving both. A follow-up covers both or neither.

**Three new tab stops now sit before the search box.** That is the cost of putting real buttons above the table, and it is not worth a roving tabindex here.

**No test in this change can prove layout.** happy-dom lays nothing out, so nothing here proves the strip stays on screen while the rows scroll, or that a figure is visible. The tests that assert a class say so in a comment. Structurally the strip is a sibling of the `overflow-auto` box inside a flex column, so the claim holds by construction rather than by test.

## Review

Three rounds, roughly 71 mutations, and each round found something the one before it missed.

Round two confirmed every cell's payload end to end, from the literal through the URL and the route schema into the SQL predicates, and found the two defects described above. Round three was scoped to the commit that fixed them, and found that **the fix had disarmed the guard on an unrelated pager reset**.

That last one is worth a reader's attention because nothing announced it. `index.tsx:150` is what returns the operator to page one when the filter signature changes outside the apply path, which is what the search box does: it navigates on its own and never touches the new context. Breaking that line left the whole suite green, because the new reset clears the cursor before the one test that guarded it could notice. From page two, typing a search term would have returned page two of the unsearched result set, which on a short list looks exactly like "the search found nothing". The line was always correct; only its test was lost, and the last commit restores it.

Three smaller assertions were missing for the same reason: the Type group's absent all-label was stated only in a comment, the Trial all-label was passing through its empty state because both strings are identical, and only half of the pager reset was defended, so a mutation that kept the page stack would have left **Previous** enabled on page one and pointing forwards.

**One comment claim was measured rather than argued.** The invalidation comment said a first fetch still open "holds no data, so the invalidation finds nothing to refire". That story is wrong, and so was the reviewer's replacement. A throwaway test with a call counter showed React Query joins the running request and its pre-write answer clears the invalidated flag as it lands, with and without a mounted observer, and a canary case that invalidates an idle query did fire a second fetch, so the counter was live. The comment now states the measured mechanism.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows platform totals above the admin organizations list and makes each figure a control that opens the rows it counted. Previously the page showed no totals and clicks could leave a search term or page cursor in place; now clicks replace filters, clear search (including any uncommitted draft), and return to page one.

- Adds a three-cell stat strip: Organizations (total + new this week), Trials ending in 7 days, and Disabled (total + disabled this week).
- Clicking a cell applies its filter set and replaces others:
  - Organizations sets `disabled=["active","disabled"]`.
  - Trials sets `trial=["ending_soon"]` and `disabled=["active","disabled"]`.
  - Disabled sets `disabled=["disabled"]`.
  - Clears the search term and any in-progress debounced draft, and resets pagination to the first page, even if the same filters were already applied.
- Fetches totals from a new admin endpoint via `organizationsStatsQuery` (fixed key) so the strip never follows table filters; shows a dash while loading, `aria-busy` on cells, and a banner on failure. Totals do not change when filters change.
- Cancels list and stats reads before writes to avoid joining in-flight requests (`@tanstack/react-query`); invalidates totals after successful writes, and refetches totals on write errors so a cancelled first fetch does not leave the strip as dashes.
- One apply path (`useApplyFilters`) drives both the sheet and the strip. Status now labels a full selection (“Active and disabled”), Trial labels a full selection (“All trial states”); Type deliberately has no “all” label.
- Removes the unused `page` search param; pager resets live in component state, and typing in the search box drops the cursor and stack.

Migration: If you link to this page with a `page` query param, remove it; it is ignored.

Linear AGE-3187: surfaces the “work queue” and lets admins jump directly to trials ending soon or disabled orgs without leaving the list.

<sup>Written for commit befaf93e898beef37fc4afc59fcbb8aef10b54bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

