### PR TITLE
feat: report PAYG TUM usage to Stripe

### DIFF
--- a/.changeset/report-payg-tum-to-stripe.md
+++ b/.changeset/report-payg-tum-to-stripe.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Report PAYG tokens-under-management usage to Stripe from durable hourly snapshots. Signed meter intents retry safely, reconcile ambiguous delivery against Stripe summaries, freeze the billed baseline after 48 hours, and record one carry-forward correction after the 72-hour observation window.

--- a/.mise-tasks/stripe/setup.mts
+++ b/.mise-tasks/stripe/setup.mts
@@ -319,6 +319,7 @@ async function main() {
 
   const settings: Record<string, string> = {
     STRIPE_PRICE_ID_TUM: price.id,
+    STRIPE_METER_ID_TUM: meter.id,
     STRIPE_METER_EVENT_NAME: METER_EVENT_NAME,
   };
   if (prompted) {

--- a/mise.toml
+++ b/mise.toml
@@ -301,6 +301,7 @@ GRAM_RISK_FINGERPRINT_PEPPER_KEYRING = '{"current": "v1", "keys": {"v1": "bmvSy6
 STRIPE_API_KEY = { default = "unset" }
 STRIPE_WEBHOOK_SECRET = { default = "unset" }
 STRIPE_PRICE_ID_TUM = { default = "" }
+STRIPE_METER_ID_TUM = { default = "" }
 STRIPE_METER_EVENT_NAME = { default = "tum" }
 
 #########################

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -573,6 +573,7 @@ func newStripeClient(
 
 	catalog := stripeclient.Catalog{
 		PriceIDTUM:     c.String("stripe-price-id-tum"),
+		MeterIDTUM:     c.String("stripe-meter-id-tum"),
 		MeterEventName: c.String("stripe-meter-event-name"),
 	}
 	if err := catalog.Validate(); err != nil {

--- a/server/cmd/gram/deps_stripe_test.go
+++ b/server/cmd/gram/deps_stripe_test.go
@@ -19,6 +19,7 @@ func TestNewStripeClientLocalWithoutAPIKeyUsesStubBeforeCatalogValidation(t *tes
 		"environment":             "local",
 		"stripe-api-key":          "unset",
 		"stripe-price-id-tum":     "partial-price",
+		"stripe-meter-id-tum":     "",
 		"stripe-meter-event-name": "",
 	})
 
@@ -40,6 +41,7 @@ func TestNewStripeClientRealClientValidatesCatalog(t *testing.T) {
 		"environment":             "local",
 		"stripe-api-key":          "sk_test_placeholder",
 		"stripe-price-id-tum":     "partial-price",
+		"stripe-meter-id-tum":     "mtr_placeholder",
 		"stripe-meter-event-name": "",
 	})
 
@@ -79,6 +81,7 @@ func TestNewStripeClientRealClientUsesCatalog(t *testing.T) {
 		"stripe-api-key":          "sk_test_placeholder",
 		"stripe-webhook-secret":   "whsec_placeholder",
 		"stripe-price-id-tum":     "price_placeholder",
+		"stripe-meter-id-tum":     "mtr_placeholder",
 		"stripe-meter-event-name": "tum",
 	})
 
@@ -92,6 +95,7 @@ func TestNewStripeClientRealClientUsesCatalog(t *testing.T) {
 	require.NotNil(t, client)
 	require.Equal(t, stripeclient.Catalog{
 		PriceIDTUM:     "price_placeholder",
+		MeterIDTUM:     "mtr_placeholder",
 		MeterEventName: "tum",
 	}, client.Catalog())
 }
@@ -147,6 +151,7 @@ func newStripeCLIContext(t *testing.T, values map[string]string) *cli.Context {
 	set.String("stripe-api-key", "", "")
 	set.String("stripe-webhook-secret", "", "")
 	set.String("stripe-price-id-tum", "", "")
+	set.String("stripe-meter-id-tum", "", "")
 	set.String("stripe-meter-event-name", "", "")
 	set.String("polar-api-key", "", "")
 	for key, value := range values {

--- a/server/cmd/gram/flags_stripe_test.go
+++ b/server/cmd/gram/flags_stripe_test.go
@@ -35,6 +35,11 @@ func TestStripeFlagsAreAvailableInEveryServerProcess(t *testing.T) {
 			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")
 			require.Contains(t, priceID.Names(), "stripe.price_id_tum")
 
+			meterID := requireFlag(t, command.Flags, "stripe-meter-id-tum")
+			_, tomlSourceable = meterID.(altsrc.FlagInputSourceExtension)
+			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")
+			require.Contains(t, meterID.Names(), "stripe.meter_id_tum")
+
 			meterEventName := requireFlag(t, command.Flags, "stripe-meter-event-name")
 			_, tomlSourceable = meterEventName.(altsrc.FlagInputSourceExtension)
 			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -447,6 +447,12 @@ func newStartCommand() *cli.Command {
 			EnvVars: []string{"STRIPE_PRICE_ID_TUM"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-id-tum",
+			Aliases: []string{"stripe.meter_id_tum"},
+			Usage:   "The Stripe TUM billing meter ID",
+			EnvVars: []string{"STRIPE_METER_ID_TUM"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "stripe-meter-event-name",
 			Aliases: []string{"stripe.meter_event_name"},
 			Usage:   "The Stripe TUM meter event name",
@@ -1703,6 +1709,7 @@ func newStartCommand() *cli.Command {
 						SiteURL:                   siteURL,
 						BillingTracker:            billingTracker,
 						BillingRepository:         billingRepo,
+						StripeClient:              stripeClient,
 						RedisClient:               redisClient,
 						PosthogClient:             posthogClient,
 						FunctionsDeployer:         functionsOrchestrator,

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -153,6 +153,12 @@ func newStreamsCommand() *cli.Command {
 			EnvVars: []string{"STRIPE_PRICE_ID_TUM"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-id-tum",
+			Aliases: []string{"stripe.meter_id_tum"},
+			Usage:   "The Stripe TUM billing meter ID",
+			EnvVars: []string{"STRIPE_METER_ID_TUM"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "stripe-meter-event-name",
 			Aliases: []string{"stripe.meter_event_name"},
 			Usage:   "The Stripe TUM meter event name",

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -219,6 +219,12 @@ func newWorkerCommand() *cli.Command {
 			EnvVars: []string{"STRIPE_PRICE_ID_TUM"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-id-tum",
+			Aliases: []string{"stripe.meter_id_tum"},
+			Usage:   "The Stripe TUM billing meter ID",
+			EnvVars: []string{"STRIPE_METER_ID_TUM"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "stripe-meter-event-name",
 			Aliases: []string{"stripe.meter_event_name"},
 			Usage:   "The Stripe TUM meter event name",
@@ -903,6 +909,7 @@ func newWorkerCommand() *cli.Command {
 				SiteURL:                   siteURL,
 				BillingTracker:            billingTracker,
 				BillingRepository:         billingRepo,
+				StripeClient:              stripeClient,
 				RedisClient:               redisClient,
 				PosthogClient:             posthogClient,
 				EmailService:              emailService,

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -67,6 +67,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
 
@@ -114,6 +115,7 @@ type Activities struct {
 	reapFlyApps                     *activities.ReapFlyApps
 	refreshBillingUsage             *activities.RefreshBillingUsage
 	snapshotBillingCycleUsage       *activities.SnapshotBillingCycleUsage
+	reportTUMUsageToStripe          *activities.ReportTUMUsageToStripe
 	weeklyUsageSummary              *activities.WeeklyUsageSummary
 	forwardTokenUsageToPostHog      *activities.ForwardTokenUsageToPostHog
 	refreshOpenRouterKey            *activities.RefreshOpenRouterKey
@@ -180,6 +182,7 @@ func NewActivities(
 	siteURL *url.URL,
 	billingTracker billing.Tracker,
 	billingRepo billing.Repository,
+	stripeClient stripeclient.Client,
 	posthogClient *posthog.Posthog,
 	functionsDeployer functions.Deployer,
 	functionsVersion functions.RunnerVersion,
@@ -325,6 +328,7 @@ func NewActivities(
 		reapFlyApps:                     activities.NewReapFlyApps(logger, meterProvider, db, functionsDeployer, 1),
 		refreshBillingUsage:             activities.NewRefreshBillingUsage(logger, db, billingRepo),
 		snapshotBillingCycleUsage:       activities.NewSnapshotBillingCycleUsage(logger, db, chConn, cacheAdapter, emailService),
+		reportTUMUsageToStripe:          activities.NewReportTUMUsageToStripe(logger, db, stripeClient),
 		weeklyUsageSummary:              activities.NewWeeklyUsageSummary(logger, db, chConn, emailService, siteURL),
 		forwardTokenUsageToPostHog:      activities.NewForwardTokenUsageToPostHog(logger, db, posthogClient, cacheAdapter),
 		refreshOpenRouterKey:            activities.NewRefreshOpenRouterKey(logger, db, openrouterProvisioner),
@@ -542,6 +546,10 @@ func (a *Activities) RefreshBillingUsage(ctx context.Context, orgIDs []string) e
 
 func (a *Activities) SnapshotBillingCycleUsage(ctx context.Context, orgIDs []string) error {
 	return a.snapshotBillingCycleUsage.Do(ctx, orgIDs)
+}
+
+func (a *Activities) ReportTUMUsageToStripe(ctx context.Context, input activities.ReportTUMUsageToStripeInput) error {
+	return a.reportTUMUsageToStripe.Do(ctx, input)
 }
 
 func (a *Activities) ForwardTokenUsageToPostHog(ctx context.Context, orgIDs []string) error {

--- a/server/internal/background/activities/report_tum_usage_stripe.go
+++ b/server/internal/background/activities/report_tum_usage_stripe.go
@@ -285,7 +285,7 @@ func (r *ReportTUMUsageToStripe) reconcileExpiredAmbiguity(
 
 		totals, totalsErr := queries.GetTUMMeterReportTotals(ctx, usagerepo.GetTUMMeterReportTotalsParams{
 			OrganizationID:      organizationIDParam,
-			BillingCycleUsageID: cycle.BillingCycleUsageID,
+			BillingCycleUsageID: cycle.BillingCycleUsageID.UUID,
 		})
 		if totalsErr != nil {
 			errs = append(errs, fmt.Errorf("get report totals for cycle %s: %w", cycle.CycleStart.Time, totalsErr))

--- a/server/internal/background/activities/report_tum_usage_stripe.go
+++ b/server/internal/background/activities/report_tum_usage_stripe.go
@@ -1,0 +1,415 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+	"github.com/speakeasy-api/gram/server/internal/usage"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+const (
+	ErrTypeTUMStripeReporting = "tum_stripe_reporting_failed"
+
+	tumBillingFreezeDelay       = 48 * time.Hour
+	tumObservationDelay         = 72 * time.Hour
+	stripeIdentifierRetryWindow = 24 * time.Hour
+	// Stripe summaries are eventually consistent. Positive evidence can
+	// confirm delivery immediately, but absence must remain stable for 24
+	// hours after its first observation before a new identifier is emitted.
+	stripeMissingEvidenceWindow = 24 * time.Hour
+)
+
+// ReportTUMUsageToStripeFailureDetails survives Temporal error conversion so
+// the workflow can count the organizations that actually failed.
+type ReportTUMUsageToStripeFailureDetails struct {
+	FailedOrganizationCount int
+}
+
+// ReportTUMUsageToStripeInput carries one deterministic hourly reporting pass.
+type ReportTUMUsageToStripeInput struct {
+	OrganizationIDs []string
+	Now             time.Time
+}
+
+// ReportTUMUsageToStripe turns durable TUM snapshots into durable Stripe
+// delivery intents. It never recomputes usage from ClickHouse.
+type ReportTUMUsageToStripe struct {
+	logger       *slog.Logger
+	db           *pgxpool.Pool
+	stripeClient tumStripeClient
+}
+
+type tumStripeClient interface {
+	Catalog() stripeclient.Catalog
+	CreateMeterEvent(context.Context, stripeclient.CreateMeterEventInput) error
+	GetMeterEventSummary(context.Context, stripeclient.GetMeterEventSummaryInput) (float64, error)
+}
+
+func NewReportTUMUsageToStripe(logger *slog.Logger, db *pgxpool.Pool, stripeClient tumStripeClient) *ReportTUMUsageToStripe {
+	return &ReportTUMUsageToStripe{
+		logger:       logger,
+		db:           db,
+		stripeClient: stripeClient,
+	}
+}
+
+func (r *ReportTUMUsageToStripe) Do(ctx context.Context, input ReportTUMUsageToStripeInput) error {
+	if r.stripeClient == nil {
+		return nil
+	}
+
+	catalog := r.stripeClient.Catalog()
+	// Local and legacy-only deployments use the Stripe stub. They must keep
+	// the shared billing sweep healthy without manufacturing delivery intents.
+	if !stripeclient.IsConfigured(catalog.MeterIDTUM) || !stripeclient.IsConfigured(catalog.MeterEventName) {
+		return nil
+	}
+
+	now := input.Now.UTC()
+	if now.IsZero() {
+		return errors.New("report TUM usage to Stripe: current time is required")
+	}
+
+	queries := usagerepo.New(r.db)
+	var errs []error
+	for _, organizationID := range input.OrganizationIDs {
+		if err := r.reportOrganization(ctx, queries, catalog, organizationID, now); err != nil {
+			r.logger.ErrorContext(ctx, "failed to report TUM usage to Stripe",
+				attr.SlogOrganizationID(organizationID), attr.SlogError(err))
+			errs = append(errs, fmt.Errorf("report organization %s: %w", organizationID, err))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return temporal.NewApplicationErrorWithOptions(
+		"report TUM usage to Stripe",
+		ErrTypeTUMStripeReporting,
+		temporal.ApplicationErrorOptions{
+			Cause: errors.Join(errs...),
+			Details: []any{ReportTUMUsageToStripeFailureDetails{
+				FailedOrganizationCount: len(errs),
+			}},
+		},
+	)
+}
+
+func (r *ReportTUMUsageToStripe) reportOrganization(
+	ctx context.Context,
+	queries *usagerepo.Queries,
+	catalog stripeclient.Catalog,
+	organizationID string,
+	now time.Time,
+) error {
+	organization, err := queries.GetTUMMeteringOrganization(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get metering organization: %w", err)
+	}
+	if organization.GramAccountType != "payg" {
+		return nil
+	}
+	if !organization.StripeCustomerID.Valid || !organization.StripeSubscriptionID.Valid || !organization.StripeBillingCycleAnchor.Valid {
+		return errors.New("PAYG organization has incomplete Stripe billing identity")
+	}
+	organizationIDParam := pgtype.Text{String: organizationID, Valid: true}
+
+	var errs []error
+	didReconcile, reconcileErr := r.reconcileExpiredAmbiguity(ctx, queries, organizationID, now)
+	if reconcileErr != nil {
+		errs = append(errs, reconcileErr)
+	}
+
+	cycles, err := queries.ListTUMBillingCyclesForReporting(ctx, usagerepo.ListTUMBillingCyclesForReportingParams{
+		OrganizationID: organizationIDParam,
+		FirstPaidCycleStart: pgtype.Timestamptz{
+			Time:             organization.StripeBillingCycleAnchor.Time.UTC(),
+			Valid:            true,
+			InfinityModifier: pgtype.Finite,
+		},
+	})
+	if err != nil {
+		return errors.Join(append(errs, fmt.Errorf("list billing cycles: %w", err))...)
+	}
+
+	anchor := organization.StripeBillingCycleAnchor.Time.UTC()
+	for _, cycle := range cycles {
+		if !validPaidCycleBounds(cycle, anchor) {
+			continue
+		}
+
+		freezeAt := cycle.CycleEnd.Time.UTC().Add(tumBillingFreezeDelay)
+		observationEndsAt := cycle.CycleEnd.Time.UTC().Add(tumObservationDelay)
+		if !now.Before(freezeAt) && now.Before(observationEndsAt) && !cycle.BilledTumTokens.Valid {
+			frozen, freezeErr := queries.FreezeTUMBillingCycleBaseline(ctx, usagerepo.FreezeTUMBillingCycleBaselineParams{
+				FrozenAt:            pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+				OrganizationID:      organizationIDParam,
+				BillingCycleUsageID: cycle.ID,
+			})
+			if freezeErr != nil && !errors.Is(freezeErr, pgx.ErrNoRows) {
+				errs = append(errs, fmt.Errorf("freeze cycle %s: %w", cycle.CycleStart.Time, freezeErr))
+				continue
+			}
+			if freezeErr == nil {
+				cycle = frozen
+			}
+		}
+
+		if !now.Before(observationEndsAt) {
+			if !cycle.BilledTumTokens.Valid && cycle.FinalizedAt.Valid {
+				recovered, recoverErr := queries.FreezeMissedTUMBillingCycleBaseline(ctx, usagerepo.FreezeMissedTUMBillingCycleBaselineParams{
+					FrozenAt:            pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+					OrganizationID:      organizationIDParam,
+					BillingCycleUsageID: cycle.ID,
+				})
+				if recoverErr != nil && !errors.Is(recoverErr, pgx.ErrNoRows) {
+					errs = append(errs, fmt.Errorf("recover missed freeze for cycle %s: %w", cycle.CycleStart.Time, recoverErr))
+					continue
+				}
+				if recoverErr == nil {
+					cycle = recovered
+				}
+			}
+			if cycle.BilledTumTokens.Valid && cycle.FinalizedAt.Valid {
+				if _, allocationErr := queries.CreateTUMCarryAllocation(ctx, usagerepo.CreateTUMCarryAllocationParams{
+					OrganizationID:      organizationIDParam,
+					BillingCycleUsageID: cycle.ID,
+					TumUnitPriceUsd:     usage.TUMUnitPriceUSD,
+				}); allocationErr != nil {
+					errs = append(errs, fmt.Errorf("create carry allocation for cycle %s: %w", cycle.CycleStart.Time, allocationErr))
+				}
+			}
+			// Observation stops at +72h, but delivery of the immutable +48h
+			// baseline does not. A report found missing during reconciliation
+			// still needs a new identifier and correction after this cutoff.
+			if !cycle.BilledTumTokens.Valid {
+				continue
+			}
+		}
+
+		targetTokens := cycle.TumTokens
+		if cycle.BilledTumTokens.Valid {
+			targetTokens = cycle.BilledTumTokens.Int64
+		}
+		eventTimestamp := now.Truncate(time.Second)
+		if !now.Before(cycle.CycleEnd.Time) || cycle.BilledTumTokens.Valid {
+			eventTimestamp = cycle.CycleEnd.Time.UTC().Add(-time.Second)
+		}
+
+		_, intentErr := queries.CreateTUMMeterReportIntent(ctx, usagerepo.CreateTUMMeterReportIntentParams{
+			StripeCustomerID:     organization.StripeCustomerID,
+			StripeMeterEventName: pgtype.Text{String: catalog.MeterEventName, Valid: true},
+			EventTimestamp:       pgtype.Timestamptz{Time: eventTimestamp, Valid: true, InfinityModifier: pgtype.Finite},
+			OrganizationID:       organizationIDParam,
+			BillingCycleUsageID:  cycle.ID,
+			TargetTumTokens:      targetTokens,
+		})
+		if intentErr != nil && !errors.Is(intentErr, pgx.ErrNoRows) {
+			errs = append(errs, fmt.Errorf("create meter intent for cycle %s: %w", cycle.CycleStart.Time, intentErr))
+		}
+	}
+
+	// At most one Stripe operation is made per organization per activity run.
+	// With five organizations and a 30-second HTTP deadline, the activity's
+	// three-minute deadline remains a real upper bound even during backfills.
+	if !didReconcile {
+		if err := r.deliverPendingIntents(ctx, queries, organizationID, now); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validPaidCycleBounds(cycle usagerepo.BillingCycleUsage, anchor time.Time) bool {
+	start := cycle.CycleStart.Time.UTC()
+	end := cycle.CycleEnd.Time.UTC()
+	if !cycle.CycleStart.Valid || !cycle.CycleEnd.Valid || start.Before(anchor) {
+		return false
+	}
+
+	expectedStart, expectedEnd := usage.CurrentBillingCycle(start, anchor.Day())
+	return start.Equal(expectedStart) && end.Equal(expectedEnd)
+}
+
+func (r *ReportTUMUsageToStripe) reconcileExpiredAmbiguity(
+	ctx context.Context,
+	queries *usagerepo.Queries,
+	organizationID string,
+	now time.Time,
+) (bool, error) {
+	organizationIDParam := pgtype.Text{String: organizationID, Valid: true}
+	retryAfter := now.Add(-stripeIdentifierRetryWindow)
+	cycles, err := queries.ListStaleTUMMeterReportCycles(ctx, usagerepo.ListStaleTUMMeterReportCyclesParams{
+		OrganizationID: organizationIDParam,
+		RetryAfter:     pgtype.Timestamptz{Time: retryAfter, Valid: true, InfinityModifier: pgtype.Finite},
+	})
+	if err != nil {
+		return false, fmt.Errorf("list stale meter reports: %w", err)
+	}
+	if len(cycles) == 0 {
+		return false, nil
+	}
+
+	var errs []error
+	for _, cycle := range cycles {
+		observed, summaryErr := r.stripeClient.GetMeterEventSummary(ctx, stripeclient.GetMeterEventSummaryInput{
+			CustomerID: cycle.StripeCustomerID.String,
+			Start:      cycle.CycleStart.Time.UTC(),
+			End:        cycle.CycleEnd.Time.UTC(),
+		})
+		if summaryErr != nil {
+			errs = append(errs, fmt.Errorf("get Stripe summary for cycle %s: %w", cycle.CycleStart.Time, summaryErr))
+			continue
+		}
+		if math.IsNaN(observed) || math.IsInf(observed, 0) || math.Trunc(observed) != observed || observed > math.MaxInt64 || observed < math.MinInt64 {
+			errs = append(errs, fmt.Errorf("reconcile cycle %s: Stripe returned non-integral TUM total %v", cycle.CycleStart.Time, observed))
+			continue
+		}
+
+		totals, totalsErr := queries.GetTUMMeterReportTotals(ctx, usagerepo.GetTUMMeterReportTotalsParams{
+			OrganizationID:      organizationIDParam,
+			BillingCycleUsageID: cycle.BillingCycleUsageID,
+		})
+		if totalsErr != nil {
+			errs = append(errs, fmt.Errorf("get report totals for cycle %s: %w", cycle.CycleStart.Time, totalsErr))
+			continue
+		}
+
+		reconciledAt := pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite}
+		switch int64(observed) {
+		case totals.IntendedTokens:
+			_, err = queries.ConfirmReconciledTUMMeterReports(ctx, usagerepo.ConfirmReconciledTUMMeterReportsParams{
+				ReconciledAt:        reconciledAt,
+				OrganizationID:      organizationIDParam,
+				BillingCycleUsageID: cycle.BillingCycleUsageID,
+				RetryAfter:          pgtype.Timestamptz{Time: retryAfter, Valid: true, InfinityModifier: pgtype.Finite},
+			})
+		case totals.ConfirmedTokens:
+			if !cycle.AbsenceObservedAt.Valid {
+				_, err = queries.NoteTUMMeterReportReconciliation(ctx, usagerepo.NoteTUMMeterReportReconciliationParams{
+					ReconciledAt:        reconciledAt,
+					OrganizationID:      organizationIDParam,
+					BillingCycleUsageID: cycle.BillingCycleUsageID,
+					RetryAfter:          pgtype.Timestamptz{Time: retryAfter, Valid: true, InfinityModifier: pgtype.Finite},
+				})
+				if err == nil {
+					err = fmt.Errorf("stripe total %d first showed absence; awaiting confirmation window", int64(observed))
+				}
+			} else if cycle.AbsenceObservedAt.Time.After(now.Add(-stripeMissingEvidenceWindow)) {
+				err = fmt.Errorf("stripe total %d has not shown absence for the full reconciliation window", int64(observed))
+			} else {
+				_, err = queries.MarkReconciledTUMMeterReportsMissing(ctx, usagerepo.MarkReconciledTUMMeterReportsMissingParams{
+					ReconciledAt:        reconciledAt,
+					OrganizationID:      organizationIDParam,
+					BillingCycleUsageID: cycle.BillingCycleUsageID,
+					RetryAfter:          pgtype.Timestamptz{Time: retryAfter, Valid: true, InfinityModifier: pgtype.Finite},
+				})
+			}
+		default:
+			_, err = queries.NoteTUMMeterReportReconciliation(ctx, usagerepo.NoteTUMMeterReportReconciliationParams{
+				ReconciledAt: pgtype.Timestamptz{
+					Time:             time.Time{},
+					InfinityModifier: pgtype.Finite,
+					Valid:            false,
+				},
+				OrganizationID:      organizationIDParam,
+				BillingCycleUsageID: cycle.BillingCycleUsageID,
+				RetryAfter:          pgtype.Timestamptz{Time: retryAfter, Valid: true, InfinityModifier: pgtype.Finite},
+			})
+			if err == nil {
+				err = fmt.Errorf("stripe total %d matches neither confirmed %d nor intended %d", int64(observed), totals.ConfirmedTokens, totals.IntendedTokens)
+			}
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("reconcile cycle %s: %w", cycle.CycleStart.Time, err))
+		}
+	}
+
+	return true, errors.Join(errs...)
+}
+
+func (r *ReportTUMUsageToStripe) deliverPendingIntents(
+	ctx context.Context,
+	queries *usagerepo.Queries,
+	organizationID string,
+	now time.Time,
+) error {
+	organizationIDParam := pgtype.Text{String: organizationID, Valid: true}
+	reports, err := queries.ListTUMMeterReportsForDelivery(ctx, usagerepo.ListTUMMeterReportsForDeliveryParams{
+		OrganizationID: organizationIDParam,
+		RetryAfter:     pgtype.Timestamptz{Time: now.Add(-stripeIdentifierRetryWindow), Valid: true, InfinityModifier: pgtype.Finite},
+	})
+	if err != nil {
+		return fmt.Errorf("list meter reports for delivery: %w", err)
+	}
+
+	var errs []error
+	for _, report := range reports {
+		attempt, attemptErr := queries.BeginTUMMeterReportAttempt(ctx, usagerepo.BeginTUMMeterReportAttemptParams{
+			AttemptedAt:    pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+			OrganizationID: organizationIDParam,
+			ID:             report.ID,
+			RetryAfter:     pgtype.Timestamptz{Time: now.Add(-stripeIdentifierRetryWindow), Valid: true, InfinityModifier: pgtype.Finite},
+		})
+		if errors.Is(attemptErr, pgx.ErrNoRows) {
+			continue
+		}
+		if attemptErr != nil {
+			errs = append(errs, fmt.Errorf("begin meter report %s attempt: %w", report.ID, attemptErr))
+			continue
+		}
+		if !attempt.StripeCustomerID.Valid || !attempt.StripeMeterEventName.Valid || !attempt.StripeIdentifier.Valid || !attempt.EventTimestamp.Valid {
+			errs = append(errs, fmt.Errorf("meter report %s has incomplete durable payload", attempt.ID))
+			continue
+		}
+
+		createErr := r.stripeClient.CreateMeterEvent(ctx, stripeclient.CreateMeterEventInput{
+			CustomerID:     attempt.StripeCustomerID.String,
+			EventName:      attempt.StripeMeterEventName.String,
+			Value:          attempt.DeltaTokens,
+			Timestamp:      attempt.EventTimestamp.Time.UTC(),
+			IdempotencyKey: attempt.StripeIdentifier.String,
+		})
+		if createErr != nil {
+			if _, markErr := queries.MarkTUMMeterReportAmbiguous(ctx, usagerepo.MarkTUMMeterReportAmbiguousParams{
+				AmbiguousAt:    pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+				OrganizationID: organizationIDParam,
+				ID:             attempt.ID,
+			}); markErr != nil {
+				errs = append(errs, fmt.Errorf("mark meter report %s ambiguous: %w", attempt.ID, markErr))
+			}
+			errs = append(errs, fmt.Errorf("deliver meter report %s: %w", attempt.ID, createErr))
+			continue
+		}
+
+		rows, confirmErr := queries.ConfirmTUMMeterReport(ctx, usagerepo.ConfirmTUMMeterReportParams{
+			ConfirmedAt:    pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+			OrganizationID: organizationIDParam,
+			ID:             attempt.ID,
+		})
+		if confirmErr != nil {
+			errs = append(errs, fmt.Errorf("confirm meter report %s: %w", attempt.ID, confirmErr))
+		} else if rows != 1 {
+			errs = append(errs, fmt.Errorf("confirm meter report %s: updated %d rows", attempt.ID, rows))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/server/internal/background/activities/report_tum_usage_stripe_test.go
+++ b/server/internal/background/activities/report_tum_usage_stripe_test.go
@@ -1,0 +1,540 @@
+package activities_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+	"github.com/speakeasy-api/gram/server/internal/usage"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+type mockTUMStripeClient struct {
+	mock.Mock
+	catalog stripeclient.Catalog
+}
+
+func nullableOrganizationID(value string) pgtype.Text {
+	return pgtype.Text{String: value, Valid: true}
+}
+
+func (m *mockTUMStripeClient) Catalog() stripeclient.Catalog {
+	return m.catalog
+}
+
+func (m *mockTUMStripeClient) CreateMeterEvent(ctx context.Context, input stripeclient.CreateMeterEventInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
+func (m *mockTUMStripeClient) GetMeterEventSummary(ctx context.Context, input stripeclient.GetMeterEventSummaryInput) (float64, error) {
+	args := m.Called(ctx, input)
+	value, ok := args.Get(0).(float64)
+	if !ok {
+		panic("mock meter summary value is not a float64")
+	}
+
+	return value, args.Error(1)
+}
+
+func setupTUMStripeReporter(t *testing.T, name string, accountType string, anchor time.Time) (*activities.ReportTUMUsageToStripe, *mockTUMStripeClient, *pgxpool.Pool, string) {
+	t.Helper()
+	ctx := t.Context()
+
+	db, err := infra.CloneTestDatabase(t, name)
+	require.NoError(t, err)
+
+	organizationID := "org-" + uuid.NewString()[:8]
+	organizations := orgrepo.New(db)
+	_, err = organizations.UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Test Organization",
+		Slug:        organizationID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, organizations.SetAccountType(ctx, orgrepo.SetAccountTypeParams{
+		GramAccountType: accountType,
+		ID:              organizationID,
+	}))
+
+	usageQueries := usagerepo.New(db)
+	require.NoError(t, usageQueries.CreateStripeSubscriptionBillingMetadataFixture(ctx, usagerepo.CreateStripeSubscriptionBillingMetadataFixtureParams{
+		OrganizationID:       organizationID,
+		StripeCustomerID:     pgtype.Text{String: "cus_test", Valid: true},
+		StripeSubscriptionID: pgtype.Text{String: "sub_test", Valid: true},
+	}))
+	_, err = usageQueries.ActivatePaygBillingMetadata(ctx, usagerepo.ActivatePaygBillingMetadataParams{
+		StripeSubscriptionID:     pgtype.Text{String: "sub_test", Valid: true},
+		StripeBillingCycleAnchor: pgtype.Timestamptz{Time: anchor, Valid: true},
+		BillingCycleAnchorDay:    int32(anchor.Day()),
+		OrganizationID:           organizationID,
+		StripeCustomerID:         pgtype.Text{String: "cus_test", Valid: true},
+	})
+	require.NoError(t, err)
+
+	stripe := &mockTUMStripeClient{
+		Mock: mock.Mock{},
+		catalog: stripeclient.Catalog{
+			PriceIDTUM:     "price_tum",
+			MeterIDTUM:     "mtr_tum",
+			MeterEventName: "tum_tokens",
+		},
+	}
+	reporter := activities.NewReportTUMUsageToStripe(testenv.NewLogger(t), db, stripe)
+	return reporter, stripe, db, organizationID
+}
+
+func upsertTUMCycle(t *testing.T, db *pgxpool.Pool, organizationID string, start, end time.Time, tokens int64, finalizedAt *time.Time) {
+	t.Helper()
+	finalized := pgtype.Timestamptz{}
+	if finalizedAt != nil {
+		finalized = pgtype.Timestamptz{Time: finalizedAt.UTC(), Valid: true}
+	}
+	require.NoError(t, usagerepo.New(db).UpsertBillingCycleUsage(t.Context(), usagerepo.UpsertBillingCycleUsageParams{
+		OrganizationID: organizationID,
+		CycleStart:     pgtype.Timestamptz{Time: start.UTC(), Valid: true},
+		CycleEnd:       pgtype.Timestamptz{Time: end.UTC(), Valid: true},
+		TumTokens:      tokens,
+		FinalizedAt:    finalized,
+	}))
+}
+
+func TestReportTUMUsageToStripe_ReportsSignedDurableDeltas(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_deltas", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 100, nil)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		expectedIdentifier := "tum:" + organizationID + ":" + anchor.Format(time.RFC3339) + ":1"
+		return input.CustomerID == "cus_test" && input.EventName == "tum_tokens" && input.Value == 100 && input.IdempotencyKey == expectedIdentifier
+	})).Return(nil).Once()
+	now := anchor.Add(10 * 24 * time.Hour)
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{OrganizationIDs: []string{organizationID}, Now: now}))
+
+	// A missed hour heals from the new durable total, while the existing
+	// intended amount prevents replaying the first 100 tokens.
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 70, nil)
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == -30 && input.IdempotencyKey != ""
+	})).Return(nil).Once()
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{OrganizationIDs: []string{organizationID}, Now: now.Add(time.Hour)}))
+
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 2)
+	require.Equal(t, int64(100), reports[0].DeltaTokens)
+	require.Equal(t, int64(-30), reports[1].DeltaTokens)
+	require.Equal(t, "confirmed", reports[0].DeliveryState)
+	require.Equal(t, "confirmed", reports[1].DeliveryState)
+	require.NotEqual(t, reports[0].StripeIdentifier.String, reports[1].StripeIdentifier.String)
+	stripe.AssertExpectations(t)
+}
+
+func TestReportTUMUsageToStripe_BoundsRemoteDeliveryPerOrganization(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_bounded_delivery", "payg", anchor)
+	firstEnd := anchor.AddDate(0, 1, 0)
+	secondEnd := firstEnd.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, firstEnd, 100, nil)
+	upsertTUMCycle(t, db, organizationID, firstEnd, secondEnd, 200, nil)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 100
+	})).Return(nil).Once()
+	now := firstEnd.Add(24 * time.Hour)
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             now,
+	}))
+
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 2)
+	require.Equal(t, "confirmed", reports[0].DeliveryState)
+	require.Equal(t, "pending", reports[1].DeliveryState)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 200
+	})).Return(nil).Once()
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             now.Add(time.Minute),
+	}))
+	stripe.AssertExpectations(t)
+}
+
+func TestReportTUMUsageToStripe_ContinuesLegacyCycleSequence(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_legacy_sequence", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 100, nil)
+
+	queries := usagerepo.New(db)
+	_, err := queries.CreateLegacyTUMMeterReportFixture(t.Context(), usagerepo.CreateLegacyTUMMeterReportFixtureParams{
+		OrganizationID: nullableOrganizationID(organizationID),
+		CycleStart:     pgtype.Timestamptz{Time: anchor, Valid: true, InfinityModifier: pgtype.Finite},
+		Seq:            1,
+		DeltaTokens:    40,
+	})
+	require.NoError(t, err)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 60
+	})).Return(nil).Once()
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             anchor.Add(24 * time.Hour),
+	}))
+
+	reports, err := queries.ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 2)
+	require.EqualValues(t, 1, reports[0].Seq)
+	require.EqualValues(t, 2, reports[1].Seq)
+	require.Equal(t, int64(60), reports[1].DeltaTokens)
+	require.Equal(t, "confirmed", reports[1].DeliveryState)
+	stripe.AssertExpectations(t)
+}
+
+func TestReportTUMUsageToStripe_FreezesAt48HoursAndCarriesAt72Hours(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_freeze", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 100, nil)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 100 && input.Timestamp.Equal(cycleEnd.Add(-time.Second))
+	})).Return(nil).Once()
+	freezeTime := cycleEnd.Add(48 * time.Hour)
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{OrganizationIDs: []string{organizationID}, Now: freezeTime}))
+
+	// Late telemetry changes only the observed value after the freeze.
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 130, nil)
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{OrganizationIDs: []string{organizationID}, Now: cycleEnd.Add(60 * time.Hour)}))
+	finalizedAt := cycleEnd.Add(73 * time.Hour)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 130, &finalizedAt)
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{OrganizationIDs: []string{organizationID}, Now: finalizedAt}))
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{OrganizationIDs: []string{organizationID}, Now: finalizedAt.Add(time.Hour)}))
+
+	cycles, err := usagerepo.New(db).ListBillingCycleUsage(t.Context(), organizationID)
+	require.NoError(t, err)
+	require.Len(t, cycles, 1)
+	require.Equal(t, int64(100), cycles[0].BilledTumTokens.Int64)
+	require.Equal(t, int64(130), cycles[0].TumTokens)
+
+	allocations, err := usagerepo.New(db).ListTUMCarryAllocationsFixture(t.Context(), pgtype.Text{String: organizationID, Valid: true})
+	require.NoError(t, err)
+	require.Len(t, allocations, 1)
+	require.Equal(t, int64(30), allocations[0].DeltaTokens.Int64)
+	require.Equal(t, "pending", allocations[0].DeliveryState)
+	unitPrice, err := allocations[0].OriginalTumUnitPriceUsd.Float64Value()
+	require.NoError(t, err)
+	require.InDelta(t, 0.00000035, unitPrice.Float64, 0.000000000001)
+	stripe.AssertExpectations(t)
+}
+
+func TestCreateTUMCarryAllocationRoundsCumulativeChargesToCents(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	_, _, db, organizationID := setupTUMStripeReporter(t, "tum_carry_cent_boundary", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 14_285, nil)
+
+	queries := usagerepo.New(db)
+	cycles, err := queries.ListBillingCycleUsage(t.Context(), organizationID)
+	require.NoError(t, err)
+	require.Len(t, cycles, 1)
+	_, err = queries.FreezeTUMBillingCycleBaseline(t.Context(), usagerepo.FreezeTUMBillingCycleBaselineParams{
+		FrozenAt:            pgtype.Timestamptz{Time: cycleEnd.Add(48 * time.Hour), Valid: true, InfinityModifier: pgtype.Finite},
+		OrganizationID:      nullableOrganizationID(organizationID),
+		BillingCycleUsageID: cycles[0].ID,
+	})
+	require.NoError(t, err)
+
+	finalizedAt := cycleEnd.Add(73 * time.Hour)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 14_286, &finalizedAt)
+	_, err = queries.CreateTUMCarryAllocation(t.Context(), usagerepo.CreateTUMCarryAllocationParams{
+		TumUnitPriceUsd:     usage.TUMUnitPriceUSD,
+		OrganizationID:      nullableOrganizationID(organizationID),
+		BillingCycleUsageID: cycles[0].ID,
+	})
+	require.NoError(t, err)
+
+	allocations, err := queries.ListTUMCarryAllocationsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, allocations, 1)
+	require.Equal(t, int64(1), allocations[0].DeltaTokens.Int64)
+	amount, err := allocations[0].AmountUsd.Float64Value()
+	require.NoError(t, err)
+	require.InDelta(t, 0.01, amount.Float64, 0.0000001)
+}
+
+func TestReportTUMUsageToStripe_CarriesFullCycleAfterMissedFreezeWindow(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_missed_freeze", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	recoveredAt := cycleEnd.Add(73 * time.Hour)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 130, &recoveredAt)
+
+	reportInput := activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             recoveredAt,
+	}
+	require.NoError(t, reporter.Do(t.Context(), reportInput))
+	require.NoError(t, reporter.Do(t.Context(), reportInput))
+
+	cycles, err := usagerepo.New(db).ListBillingCycleUsage(t.Context(), organizationID)
+	require.NoError(t, err)
+	require.Len(t, cycles, 1)
+	require.Equal(t, int64(0), cycles[0].BilledTumTokens.Int64)
+	require.True(t, cycles[0].BilledFrozenAt.Valid)
+
+	allocations, err := usagerepo.New(db).ListTUMCarryAllocationsFixture(t.Context(), pgtype.Text{String: organizationID, Valid: true})
+	require.NoError(t, err)
+	require.Len(t, allocations, 1)
+	require.Equal(t, int64(130), allocations[0].DeltaTokens.Int64)
+	require.Equal(t, "pending", allocations[0].DeliveryState)
+
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Empty(t, reports)
+	stripe.AssertNotCalled(t, "CreateMeterEvent", mock.Anything, mock.Anything)
+}
+
+func TestReportTUMUsageToStripe_RepairsFrozenBaselineAfterObservationCutoff(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_post_cutoff_repair", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 100, nil)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 100 && input.Timestamp.Equal(cycleEnd.Add(-time.Second))
+	})).Return(errors.New("response lost")).Once()
+	freezeTime := cycleEnd.Add(48 * time.Hour)
+	require.Error(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             freezeTime,
+	}))
+
+	finalizedAt := cycleEnd.Add(73 * time.Hour)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 130, &finalizedAt)
+	stripe.On("GetMeterEventSummary", mock.Anything, stripeclient.GetMeterEventSummaryInput{
+		CustomerID: "cus_test",
+		Start:      anchor,
+		End:        cycleEnd,
+	}).Return(float64(0), nil).Once()
+	require.Error(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             freezeTime.Add(25 * time.Hour),
+	}))
+
+	stripe.On("GetMeterEventSummary", mock.Anything, stripeclient.GetMeterEventSummaryInput{
+		CustomerID: "cus_test",
+		Start:      anchor,
+		End:        cycleEnd,
+	}).Return(float64(0), nil).Once()
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 100 && input.Timestamp.Equal(cycleEnd.Add(-time.Second))
+	})).Return(nil).Once()
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             freezeTime.Add(49 * time.Hour),
+	}))
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             freezeTime.Add(49*time.Hour + time.Minute),
+	}))
+
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 2)
+	require.Equal(t, "reconciled_missing", reports[0].DeliveryState)
+	require.Equal(t, "confirmed", reports[1].DeliveryState)
+	require.NotEqual(t, reports[0].StripeIdentifier.String, reports[1].StripeIdentifier.String)
+
+	allocations, err := usagerepo.New(db).ListTUMCarryAllocationsFixture(t.Context(), pgtype.Text{String: organizationID, Valid: true})
+	require.NoError(t, err)
+	require.Len(t, allocations, 1)
+	require.Equal(t, int64(30), allocations[0].DeltaTokens.Int64)
+	stripe.AssertExpectations(t)
+}
+
+func TestReportTUMUsageToStripe_ReconcilesMissingAmbiguousDelivery(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_reconcile", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 100, nil)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.Anything).Return(errors.New("connection reset")).Once()
+	firstAttempt := anchor.Add(5 * 24 * time.Hour)
+	require.Error(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{OrganizationIDs: []string{organizationID}, Now: firstAttempt}))
+
+	stripe.On("GetMeterEventSummary", mock.Anything, stripeclient.GetMeterEventSummaryInput{
+		CustomerID: "cus_test",
+		Start:      anchor,
+		End:        cycleEnd,
+	}).Return(float64(0), nil).Once()
+	require.Error(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             firstAttempt.Add(25 * time.Hour),
+	}))
+
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	require.Equal(t, "ambiguous", reports[0].DeliveryState)
+	require.True(t, reports[0].ReconciledAt.Valid)
+
+	stripe.On("GetMeterEventSummary", mock.Anything, stripeclient.GetMeterEventSummaryInput{
+		CustomerID: "cus_test",
+		Start:      anchor,
+		End:        cycleEnd,
+	}).Return(float64(0), nil).Once()
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 100
+	})).Return(nil).Once()
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             firstAttempt.Add(49 * time.Hour),
+	}))
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             firstAttempt.Add(49*time.Hour + time.Minute),
+	}))
+
+	reports, err = usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 2)
+	require.Equal(t, "reconciled_missing", reports[0].DeliveryState)
+	require.True(t, reports[0].ReconciledAt.Valid)
+	require.Equal(t, "confirmed", reports[1].DeliveryState)
+	require.NotEqual(t, reports[0].StripeIdentifier.String, reports[1].StripeIdentifier.String)
+	stripe.AssertExpectations(t)
+}
+
+func TestReportTUMUsageToStripe_RetriesSameIdentifierWithin24Hours(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_retry", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 100, nil)
+
+	var identifier string
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		identifier = input.IdempotencyKey
+		return input.Value == 100 && identifier != ""
+	})).Return(errors.New("connection reset")).Once()
+	firstAttempt := anchor.Add(5 * 24 * time.Hour)
+	err := reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             firstAttempt,
+	})
+	require.Error(t, err)
+	var applicationErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &applicationErr)
+	var failureDetails activities.ReportTUMUsageToStripeFailureDetails
+	require.NoError(t, applicationErr.Details(&failureDetails))
+	require.Equal(t, 1, failureDetails.FailedOrganizationCount)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 100 && input.IdempotencyKey == identifier
+	})).Return(nil).Once()
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             firstAttempt.Add(time.Hour),
+	}))
+
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	require.Equal(t, "confirmed", reports[0].DeliveryState)
+	require.Equal(t, identifier, reports[0].StripeIdentifier.String)
+	stripe.AssertNotCalled(t, "GetMeterEventSummary", mock.Anything, mock.Anything)
+	stripe.AssertExpectations(t)
+}
+
+func TestReportTUMUsageToStripe_ReconcilesDeliveredAmbiguousIntent(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_reconcile_delivered", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 100, nil)
+
+	stripe.On("CreateMeterEvent", mock.Anything, mock.Anything).Return(errors.New("response lost after delivery")).Once()
+	firstAttempt := anchor.Add(5 * 24 * time.Hour)
+	require.Error(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             firstAttempt,
+	}))
+
+	stripe.On("GetMeterEventSummary", mock.Anything, stripeclient.GetMeterEventSummaryInput{
+		CustomerID: "cus_test",
+		Start:      anchor,
+		End:        cycleEnd,
+	}).Return(float64(100), nil).Once()
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             firstAttempt.Add(25 * time.Hour),
+	}))
+
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	require.Equal(t, "confirmed", reports[0].DeliveryState)
+	require.True(t, reports[0].ReconciledAt.Valid)
+	stripe.AssertExpectations(t)
+}
+
+func TestReportTUMUsageToStripe_SkipsNonPayg(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_skip_free", "free", anchor)
+	upsertTUMCycle(t, db, organizationID, anchor, anchor.AddDate(0, 1, 0), 100, nil)
+
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             anchor.Add(24 * time.Hour),
+	}))
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Empty(t, reports)
+	stripe.AssertNotCalled(t, "CreateMeterEvent", mock.Anything, mock.Anything)
+}
+
+func TestReportTUMUsageToStripe_SkipsPreAnchorCycles(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	reporter, stripe, db, organizationID := setupTUMStripeReporter(t, "tum_stripe_skip_pre_anchor", "payg", anchor)
+	upsertTUMCycle(t, db, organizationID, anchor.AddDate(0, -1, 0), anchor, 100, nil)
+
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             anchor.Add(24 * time.Hour),
+	}))
+	reports, err := usagerepo.New(db).ListTUMMeterReportsFixture(t.Context(), nullableOrganizationID(organizationID))
+	require.NoError(t, err)
+	require.Empty(t, reports)
+	stripe.AssertNotCalled(t, "CreateMeterEvent", mock.Anything, mock.Anything)
+}

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -2,9 +2,11 @@ package background
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
@@ -24,6 +26,10 @@ const (
 	// issues up to 12 cycles × 5 orgs of serial ClickHouse aggregate queries
 	// per attempt — far more work than the Polar refresh.
 	snapshotBillingCycleUsageStartToCloseTimeout = 5 * time.Minute
+	// One batch reports at most five organizations. Stripe permits only one
+	// concurrent meter write per customer and the client bounds each request
+	// at 30 seconds, so this leaves room for a fully serial degraded pass.
+	reportTUMUsageToStripeStartToCloseTimeout = 3 * time.Minute
 	// The PostHog forward only reads durable snapshots and posts events, so
 	// it keeps a short deadline of its own; letting it ride the wider Polar
 	// refresh deadline would inflate the batch worst-case window enough to
@@ -32,11 +38,11 @@ const (
 	forwardTokenUsageToPostHogStartToCloseTimeout = 60 * time.Second
 	refreshBillingUsageActivityMaximumAttempts    = 3
 	// Reserve more than the worst-case retry path for one batch: the Polar
-	// refresh (3 attempts × 2m), the cycle snapshot (3 attempts × 5m), and
-	// the PostHog usage forward (3 attempts × 60s), each with 10s/15s retry
-	// backoffs and Temporal jitter.
-	refreshBillingUsageBatchWorstCaseRetryWindow = 27 * time.Minute
-	refreshBillingUsageWorkflowRunTimeout        = 30 * time.Minute
+	// refresh (3 attempts × 2m), cycle snapshot (3 attempts × 5m), Stripe
+	// report (3 attempts × 3m), and PostHog forward (3 attempts × 60s), each
+	// with 10s/15s retry backoffs and Temporal jitter.
+	refreshBillingUsageBatchWorstCaseRetryWindow = 37 * time.Minute
+	refreshBillingUsageWorkflowRunTimeout        = 40 * time.Minute
 	refreshBillingUsagesWaitInterval             = 10 * time.Second
 )
 
@@ -161,6 +167,19 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 			failedOrgCount += len(batch)
 		}
 
+		// Metering consumes only the durable Postgres snapshot. A partial
+		// snapshot failure is safe: the next hourly pass derives the missing
+		// signed delta from the last committed total and prior intents.
+		reportCtx := workflow.WithStartToCloseTimeout(ctx, reportTUMUsageToStripeStartToCloseTimeout)
+		if err := workflow.ExecuteActivity(reportCtx, a.ReportTUMUsageToStripe, activities.ReportTUMUsageToStripeInput{
+			OrganizationIDs: batch,
+			Now:             workflow.Now(ctx).UTC(),
+		}).Get(ctx, nil); err != nil {
+			logger.Error("Failed to report TUM usage to Stripe", "error", err, "batch_start", i)
+			failedBatchCount++
+			failedOrgCount += failedTUMReportingOrganizationCount(err, len(batch))
+		}
+
 		// Forward the freshly snapshotted TUM usage to PostHog for GTM
 		// pricing analysis (AGE-2289). Reads only the durable snapshots, so
 		// it is cheap and safe even when the snapshot batch above partially
@@ -201,6 +220,20 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 
 	logger.Info("Billing usage refreshing completed successfully", "total_count", len(orgIDs))
 	return nil
+}
+
+func failedTUMReportingOrganizationCount(err error, fallback int) int {
+	var applicationErr *temporal.ApplicationError
+	if !errors.As(err, &applicationErr) || applicationErr.Type() != activities.ErrTypeTUMStripeReporting || !applicationErr.HasDetails() {
+		return fallback
+	}
+
+	var details activities.ReportTUMUsageToStripeFailureDetails
+	if detailErr := applicationErr.Details(&details); detailErr != nil || details.FailedOrganizationCount < 1 || details.FailedOrganizationCount > fallback {
+		return fallback
+	}
+
+	return details.FailedOrganizationCount
 }
 
 func shouldContinueRefreshBillingUsageAsNew(ctx workflow.Context) bool {

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -2,6 +2,7 @@ package background
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -12,6 +13,8 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
 )
 
 func TestRefreshBillingUsageWorkflow_ActivityStartToCloseTimeouts(t *testing.T) {
@@ -47,6 +50,17 @@ func TestRefreshBillingUsageWorkflow_ActivityStartToCloseTimeouts(t *testing.T) 
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
 	)
 
+	var reportTimeout time.Duration
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, input activities.ReportTUMUsageToStripeInput) error {
+			reportTimeout = startToClose(ctx)
+			require.Equal(t, orgIDs, input.OrganizationIDs)
+			require.False(t, input.Now.IsZero())
+			return nil
+		},
+		activity.RegisterOptions{Name: "ReportTUMUsageToStripe"},
+	)
+
 	var forwardTimeout time.Duration
 	env.RegisterActivityWithOptions(
 		func(ctx context.Context, _ []string) error {
@@ -69,6 +83,8 @@ func TestRefreshBillingUsageWorkflow_ActivityStartToCloseTimeouts(t *testing.T) 
 		"Polar refresh needs headroom for slow serialized /quantities meter queries")
 	require.Equal(t, 5*time.Minute, snapshotTimeout,
 		"snapshot keeps its wider first-run backfill deadline")
+	require.Equal(t, 3*time.Minute, reportTimeout,
+		"Stripe reporting covers a fully serial degraded batch")
 	require.Equal(t, time.Minute, forwardTimeout,
 		"posthog forward keeps a short deadline so the batch worst-case window stays inside the run timeout")
 }
@@ -115,6 +131,15 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) 
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
 	)
+	reportCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, input activities.ReportTUMUsageToStripeInput) error {
+			reportCallCount++
+			require.NotEmpty(t, input.OrganizationIDs)
+			return nil
+		},
+		activity.RegisterOptions{Name: "ReportTUMUsageToStripe"},
+	)
 
 	forwardCallCount := 0
 	env.RegisterActivityWithOptions(
@@ -141,6 +166,7 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) 
 	require.Equal(t, 1, getAllCallCount)
 	require.Equal(t, billingUsagePauseEveryBatches, refreshCallCount)
 	require.Equal(t, refreshCallCount, snapshotCallCount, "every batch gets a snapshot activity")
+	require.Equal(t, refreshCallCount, reportCallCount, "every batch reports durable TUM usage")
 	require.Equal(t, refreshCallCount, forwardCallCount, "every batch forwards token usage to posthog")
 
 	var nextInput RefreshBillingUsageInput
@@ -189,6 +215,10 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewBeforeFirstBatchWhenBudgetExh
 			return nil
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ReportTUMUsageToStripeInput) error { return nil },
+		activity.RegisterOptions{Name: "ReportTUMUsageToStripe"},
 	)
 	env.RegisterActivityWithOptions(
 		func(_ context.Context, _ []string) error {
@@ -246,6 +276,10 @@ func TestRefreshBillingUsageWorkflow_ContinuedRunAlwaysMakesProgress(t *testing.
 			return nil
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ReportTUMUsageToStripeInput) error { return nil },
+		activity.RegisterOptions{Name: "ReportTUMUsageToStripe"},
 	)
 	env.RegisterActivityWithOptions(
 		func(_ context.Context, _ []string) error {
@@ -314,6 +348,15 @@ func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
 	)
+	reportCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, input activities.ReportTUMUsageToStripeInput) error {
+			reportCallCount++
+			require.NotEmpty(t, input.OrganizationIDs)
+			return nil
+		},
+		activity.RegisterOptions{Name: "ReportTUMUsageToStripe"},
+	)
 	forwardCallCount := 0
 	env.RegisterActivityWithOptions(
 		func(_ context.Context, batch []string) error {
@@ -335,7 +378,22 @@ func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
 	require.NoError(t, env.GetWorkflowError())
 	require.Equal(t, 2, refreshCallCount)
 	require.Equal(t, 2, snapshotCallCount, "snapshots still run when the Polar refresh batch fails")
+	require.Equal(t, 2, reportCallCount, "Stripe reporting still runs when the Polar refresh batch fails")
 	require.Equal(t, 2, forwardCallCount, "posthog forwarding still runs when the Polar refresh batch fails")
+}
+
+func TestFailedTUMReportingOrganizationCount(t *testing.T) {
+	t.Parallel()
+
+	err := temporal.NewApplicationErrorWithOptions(
+		"report failed",
+		activities.ErrTypeTUMStripeReporting,
+		temporal.ApplicationErrorOptions{Details: []any{activities.ReportTUMUsageToStripeFailureDetails{
+			FailedOrganizationCount: 1,
+		}}},
+	)
+	require.Equal(t, 1, failedTUMReportingOrganizationCount(err, refreshBillingUsageBatchSize))
+	require.Equal(t, refreshBillingUsageBatchSize, failedTUMReportingOrganizationCount(errors.New("unknown"), refreshBillingUsageBatchSize))
 }
 
 func TestRefreshBillingUsageWorkflow_SleepCancellationFailsRun(t *testing.T) {
@@ -372,6 +430,10 @@ func TestRefreshBillingUsageWorkflow_SleepCancellationFailsRun(t *testing.T) {
 			return nil
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ReportTUMUsageToStripeInput) error { return nil },
+		activity.RegisterOptions{Name: "ReportTUMUsageToStripe"},
 	)
 	forwardCallCount := 0
 	env.RegisterActivityWithOptions(

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -57,6 +57,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
@@ -77,6 +78,7 @@ type WorkerOptions struct {
 	SiteURL             *url.URL
 	BillingTracker      billing.Tracker
 	BillingRepository   billing.Repository
+	StripeClient        stripeclient.Client
 	RedisClient         *redis.Client
 	CacheAdapter        cache.Cache
 	EmailService        *email.Service
@@ -158,6 +160,7 @@ func ForDeploymentProcessing(
 		SiteURL:             nil,
 		BillingTracker:      nil,
 		BillingRepository:   nil,
+		StripeClient:        nil,
 		RagService:          nil,
 		RedisClient:         nil,
 		PosthogClient:       nil,
@@ -217,6 +220,7 @@ func NewTemporalWorker(
 		SiteURL:                   nil,
 		BillingTracker:            nil,
 		BillingRepository:         nil,
+		StripeClient:              nil,
 		RedisClient:               nil,
 		PosthogClient:             nil,
 		FunctionsDeployer:         nil,
@@ -264,6 +268,7 @@ func NewTemporalWorker(
 			SiteURL:                   conv.Default(o.SiteURL, opts.SiteURL),
 			BillingTracker:            conv.Default(o.BillingTracker, opts.BillingTracker),
 			BillingRepository:         conv.Default(o.BillingRepository, opts.BillingRepository),
+			StripeClient:              conv.Default(o.StripeClient, opts.StripeClient),
 			RedisClient:               conv.Default(o.RedisClient, opts.RedisClient),
 			PosthogClient:             conv.Default(o.PosthogClient, opts.PosthogClient),
 			FunctionsDeployer:         conv.Default(o.FunctionsDeployer, opts.FunctionsDeployer),
@@ -349,6 +354,7 @@ func NewTemporalWorker(
 		opts.SiteURL,
 		opts.BillingTracker,
 		opts.BillingRepository,
+		opts.StripeClient,
 		opts.PosthogClient,
 		opts.FunctionsDeployer,
 		opts.FunctionsVersion,
@@ -406,6 +412,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.RunDeviceIntegrationSync)
 	temporalWorker.RegisterActivity(activities.RefreshBillingUsage)
 	temporalWorker.RegisterActivity(activities.SnapshotBillingCycleUsage)
+	temporalWorker.RegisterActivity(activities.ReportTUMUsageToStripe)
 	temporalWorker.RegisterActivity(activities.ListWeeklyUsageSummaryTargets)
 	temporalWorker.RegisterActivity(activities.SendWeeklyUsageSummary)
 	temporalWorker.RegisterActivity(activities.ForwardTokenUsageToPostHog)

--- a/server/internal/billing/tier_limits.go
+++ b/server/internal/billing/tier_limits.go
@@ -2,8 +2,12 @@ package billing
 
 import gen "github.com/speakeasy-api/gram/server/gen/usage"
 
-// TUMPricePerMillionUSD is the exact PAYG list price rendered by clients.
-const TUMPricePerMillionUSD = "0.35"
+const (
+	// TUMUnitPriceUSD is the exact Stripe meter price for one managed token.
+	TUMUnitPriceUSD = "0.00000035"
+	// TUMPricePerMillionUSD is the same price in the customer-facing unit.
+	TUMPricePerMillionUSD = "0.35"
+)
 
 // NewPaygTierLimits returns the usage-tier contract shared by every billing
 // provider. Each call returns independently mutable slices.

--- a/server/internal/billing/usage_tiers_test.go
+++ b/server/internal/billing/usage_tiers_test.go
@@ -30,6 +30,7 @@ func TestNewPaygTierLimits(t *testing.T) {
 	require.Zero(t, want.PricePerAdditionalServer)
 	require.NotNil(t, want.TumPricePerMillionUsd)
 	require.Equal(t, billing.TUMPricePerMillionUSD, *want.TumPricePerMillionUsd)
+	require.Equal(t, "0.00000035", billing.TUMUnitPriceUSD)
 	require.Equal(t, []string{
 		"Other inference billed at provider cost",
 		"Security inference funded by Speakeasy",

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -30,13 +30,21 @@ var ErrWebhookNotConfigured = errors.New("stripe webhook is not configured")
 
 var errMissingIdempotencyKey = errors.New("idempotency key is required")
 
+var errMissingMeterEventName = errors.New("meter event name is required")
+
 var errMissingBillingCycleAnchor = errors.New("billing cycle anchor is required")
 
 var errMissingCheckoutExpiration = errors.New("checkout expiration is required")
 
 // Catalog contains the Stripe object identifiers used by PAYG billing.
 type Catalog struct {
-	PriceIDTUM     string
+	// PriceIDTUM identifies the Stripe price included in PAYG subscriptions.
+	PriceIDTUM string
+
+	// MeterIDTUM identifies the Stripe meter queried during reconciliation.
+	MeterIDTUM string
+
+	// MeterEventName identifies the event stream used when reporting TUM deltas.
 	MeterEventName string
 }
 
@@ -44,6 +52,9 @@ type Catalog struct {
 func (c Catalog) Validate() error {
 	if !IsConfigured(c.PriceIDTUM) {
 		return errors.New("missing TUM price id in catalog")
+	}
+	if !IsConfigured(c.MeterIDTUM) {
+		return errors.New("missing TUM meter id in catalog")
 	}
 	if !IsConfigured(c.MeterEventName) {
 		return errors.New("missing meter event name in catalog")
@@ -62,6 +73,7 @@ type Client interface {
 	CreateCheckoutSession(context.Context, CreateCheckoutSessionInput) (*CheckoutSession, error)
 	GetCheckoutSession(context.Context, string) (*CheckoutSessionState, error)
 	CreateMeterEvent(context.Context, CreateMeterEventInput) error
+	GetMeterEventSummary(context.Context, GetMeterEventSummaryInput) (float64, error)
 	VerifyWebhook(payload []byte, signature string) (*WebhookEvent, error)
 	Catalog() Catalog
 }
@@ -131,10 +143,32 @@ type CheckoutSessionState struct {
 
 // CreateMeterEventInput reports a TUM delta for one Stripe customer.
 type CreateMeterEventInput struct {
-	CustomerID     string
-	Value          int64
-	Timestamp      time.Time
+	// CustomerID identifies the Stripe customer receiving the usage.
+	CustomerID string
+
+	// EventName is the immutable event stream captured with the delivery intent.
+	EventName string
+
+	// Value is the signed TUM delta.
+	Value int64
+
+	// Timestamp places the event inside its billing cycle.
+	Timestamp time.Time
+
+	// IdempotencyKey is also used as Stripe's meter-event identifier.
 	IdempotencyKey string
+}
+
+// GetMeterEventSummaryInput identifies a customer's half-open metering interval.
+type GetMeterEventSummaryInput struct {
+	// CustomerID identifies the Stripe customer whose meter is queried.
+	CustomerID string
+
+	// Start is the inclusive, minute-aligned interval boundary.
+	Start time.Time
+
+	// End is the exclusive, minute-aligned interval boundary.
+	End time.Time
 }
 
 // WebhookEvent is the verified Stripe event envelope consumed by webhook handlers.
@@ -163,6 +197,7 @@ type stripeAPI interface {
 	createCheckoutSession(context.Context, *stripesdk.CheckoutSessionCreateParams) (*stripesdk.CheckoutSession, error)
 	retrieveCheckoutSession(context.Context, string, *stripesdk.CheckoutSessionRetrieveParams) (*stripesdk.CheckoutSession, error)
 	createMeterEvent(context.Context, *stripesdk.BillingMeterEventCreateParams) (*stripesdk.BillingMeterEvent, error)
+	listMeterEventSummaries(context.Context, *stripesdk.BillingMeterEventSummaryListParams) stripesdk.Seq2[*stripesdk.BillingMeterEventSummary, error]
 }
 
 type sdkAPI struct {
@@ -199,6 +234,10 @@ func (s *sdkAPI) createMeterEvent(ctx context.Context, params *stripesdk.Billing
 		return nil, fmt.Errorf("stripe SDK create meter event: %w", err)
 	}
 	return event, nil
+}
+
+func (s *sdkAPI) listMeterEventSummaries(ctx context.Context, params *stripesdk.BillingMeterEventSummaryListParams) stripesdk.Seq2[*stripesdk.BillingMeterEventSummary, error] {
+	return s.client.V1BillingMeterEventSummaries.List(ctx, params).All(ctx)
 }
 
 type client struct {
@@ -339,9 +378,12 @@ func (c *client) CreateMeterEvent(ctx context.Context, input CreateMeterEventInp
 	if input.IdempotencyKey == "" {
 		return errMissingIdempotencyKey
 	}
+	if !IsConfigured(input.EventName) {
+		return errMissingMeterEventName
+	}
 
 	params := new(stripesdk.BillingMeterEventCreateParams)
-	params.EventName = stripesdk.String(c.catalog.MeterEventName)
+	params.EventName = stripesdk.String(input.EventName)
 	params.Identifier = stripesdk.String(input.IdempotencyKey)
 	params.Payload = map[string]string{
 		meterCustomerPayloadKey: input.CustomerID,
@@ -356,6 +398,33 @@ func (c *client) CreateMeterEvent(ctx context.Context, input CreateMeterEventInp
 		return fmt.Errorf("create Stripe meter event: %w", err)
 	}
 	return nil
+}
+
+// GetMeterEventSummary returns Stripe's eventually consistent observed total.
+// Callers decide whether the value is sufficiently settled for reconciliation.
+func (c *client) GetMeterEventSummary(ctx context.Context, input GetMeterEventSummaryInput) (float64, error) {
+	if !input.Start.Equal(input.Start.Truncate(time.Minute)) || !input.End.Equal(input.End.Truncate(time.Minute)) {
+		return 0, errors.New("meter event summary bounds must be minute-aligned")
+	}
+	if !input.End.After(input.Start) {
+		return 0, errors.New("meter event summary end must be after start")
+	}
+
+	params := new(stripesdk.BillingMeterEventSummaryListParams)
+	params.ID = stripesdk.String(c.catalog.MeterIDTUM)
+	params.Customer = stripesdk.String(input.CustomerID)
+	params.StartTime = new(input.Start.Unix())
+	params.EndTime = new(input.End.Unix())
+	params.Limit = stripesdk.Int64(100)
+
+	var total float64
+	for summary, err := range c.api.listMeterEventSummaries(ctx, params) {
+		if err != nil {
+			return 0, fmt.Errorf("list Stripe meter event summaries: %w", err)
+		}
+		total += summary.AggregatedValue
+	}
+	return total, nil
 }
 
 func (c *client) VerifyWebhook(payload []byte, signature string) (*WebhookEvent, error) {
@@ -454,6 +523,11 @@ func (s *stubClient) CreateMeterEvent(ctx context.Context, _ CreateMeterEventInp
 	return nil
 }
 
+func (s *stubClient) GetMeterEventSummary(ctx context.Context, _ GetMeterEventSummaryInput) (float64, error) {
+	s.logger.DebugContext(ctx, "stub Stripe meter event summary skipped")
+	return 0, nil
+}
+
 func (s *stubClient) VerifyWebhook(_ []byte, _ string) (*WebhookEvent, error) {
 	return nil, fmt.Errorf("verify Stripe webhook: %w", ErrWebhookNotConfigured)
 }
@@ -461,6 +535,7 @@ func (s *stubClient) VerifyWebhook(_ []byte, _ string) (*WebhookEvent, error) {
 func (s *stubClient) Catalog() Catalog {
 	return Catalog{
 		PriceIDTUM:     "",
+		MeterIDTUM:     "",
 		MeterEventName: "",
 	}
 }

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -26,27 +26,38 @@ func TestCatalogValidate(t *testing.T) {
 			name: "valid",
 			catalog: Catalog{
 				PriceIDTUM:     "price_test",
+				MeterIDTUM:     "mtr_test",
 				MeterEventName: "tum",
 			},
 		},
 		{
 			name:    "missing price",
-			catalog: Catalog{MeterEventName: "tum"},
+			catalog: Catalog{MeterIDTUM: "mtr_test", MeterEventName: "tum"},
 			wantErr: "missing TUM price id",
 		},
 		{
+			name:    "missing meter",
+			catalog: Catalog{PriceIDTUM: "price_test", MeterEventName: "tum"},
+			wantErr: "missing TUM meter id",
+		},
+		{
 			name:    "missing meter event name",
-			catalog: Catalog{PriceIDTUM: "price_test"},
+			catalog: Catalog{PriceIDTUM: "price_test", MeterIDTUM: "mtr_test"},
 			wantErr: "missing meter event name",
 		},
 		{
 			name:    "unset price",
-			catalog: Catalog{PriceIDTUM: "unset", MeterEventName: "tum"},
+			catalog: Catalog{PriceIDTUM: "unset", MeterIDTUM: "mtr_test", MeterEventName: "tum"},
 			wantErr: "missing TUM price id",
 		},
 		{
+			name:    "unset meter",
+			catalog: Catalog{PriceIDTUM: "price_test", MeterIDTUM: "unset", MeterEventName: "tum"},
+			wantErr: "missing TUM meter id",
+		},
+		{
 			name:    "unset meter event name",
-			catalog: Catalog{PriceIDTUM: "price_test", MeterEventName: "unset"},
+			catalog: Catalog{PriceIDTUM: "price_test", MeterIDTUM: "mtr_test", MeterEventName: "unset"},
 			wantErr: "missing meter event name",
 		},
 	}
@@ -85,6 +96,8 @@ type fakeStripeAPI struct {
 	checkoutRetrieveParams *stripesdk.CheckoutSessionRetrieveParams
 	checkoutSession        *stripesdk.CheckoutSession
 	meterEventParams       *stripesdk.BillingMeterEventCreateParams
+	meterSummaryParams     *stripesdk.BillingMeterEventSummaryListParams
+	meterSummaries         []*stripesdk.BillingMeterEventSummary
 	calls                  int
 	err                    error
 }
@@ -111,6 +124,21 @@ func (f *fakeStripeAPI) createMeterEvent(_ context.Context, params *stripesdk.Bi
 	f.calls++
 	f.meterEventParams = params
 	return &stripesdk.BillingMeterEvent{}, f.err
+}
+
+func (f *fakeStripeAPI) listMeterEventSummaries(_ context.Context, params *stripesdk.BillingMeterEventSummaryListParams) stripesdk.Seq2[*stripesdk.BillingMeterEventSummary, error] {
+	f.calls++
+	f.meterSummaryParams = params
+	return func(yield func(*stripesdk.BillingMeterEventSummary, error) bool) {
+		for _, summary := range f.meterSummaries {
+			if !yield(summary, nil) {
+				return
+			}
+		}
+		if f.err != nil {
+			yield(nil, f.err)
+		}
+	}
 }
 
 func TestCreateCustomerPropagatesIdempotencyKey(t *testing.T) {
@@ -150,6 +178,7 @@ func TestCreateCheckoutSessionBuildsMeteredSubscription(t *testing.T) {
 		api: api,
 		catalog: Catalog{
 			PriceIDTUM:     "price_tum",
+			MeterIDTUM:     "mtr_tum",
 			MeterEventName: "tum",
 		},
 	}
@@ -197,7 +226,7 @@ func TestCreateCheckoutSessionWithoutTrialStartsImmediately(t *testing.T) {
 	t.Parallel()
 
 	api := &fakeStripeAPI{}
-	c := &client{api: api, catalog: Catalog{PriceIDTUM: "price_tum", MeterEventName: "tum"}}
+	c := &client{api: api, catalog: Catalog{PriceIDTUM: "price_tum", MeterIDTUM: "mtr_tum", MeterEventName: "tum"}}
 
 	_, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
 		CustomerID:         "",
@@ -287,12 +316,13 @@ func TestCreateMeterEventPropagatesIdempotencyKey(t *testing.T) {
 	api := &fakeStripeAPI{}
 	c := &client{
 		api:     api,
-		catalog: Catalog{MeterEventName: "tum"},
+		catalog: Catalog{PriceIDTUM: "", MeterIDTUM: "", MeterEventName: "tum"},
 	}
 	timestamp := time.Date(2026, time.August, 14, 10, 0, 0, 0, time.UTC)
 
 	err := c.CreateMeterEvent(t.Context(), CreateMeterEventInput{
 		CustomerID:     "cus_test",
+		EventName:      "tum_replay",
 		Value:          42,
 		Timestamp:      timestamp,
 		IdempotencyKey: "meter:<ORG_ID>:1",
@@ -300,7 +330,7 @@ func TestCreateMeterEventPropagatesIdempotencyKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "meter:<ORG_ID>:1", stripesdk.StringValue(api.meterEventParams.IdempotencyKey))
 	require.Equal(t, "meter:<ORG_ID>:1", stripesdk.StringValue(api.meterEventParams.Identifier))
-	require.Equal(t, "tum", stripesdk.StringValue(api.meterEventParams.EventName))
+	require.Equal(t, "tum_replay", stripesdk.StringValue(api.meterEventParams.EventName))
 	require.Equal(t, "cus_test", api.meterEventParams.Payload[meterCustomerPayloadKey])
 	require.Equal(t, "42", api.meterEventParams.Payload[meterValuePayloadKey])
 	require.Equal(t, timestamp.Unix(), stripesdk.Int64Value(api.meterEventParams.Timestamp))
@@ -317,18 +347,135 @@ func TestCreateMeterEventRejectsMissingIdempotencyKey(t *testing.T) {
 	require.Zero(t, api.calls)
 }
 
+func TestCreateMeterEventRejectsMissingEventName(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	err := c.CreateMeterEvent(t.Context(), CreateMeterEventInput{IdempotencyKey: "meter:<ORG_ID>:1"})
+	require.ErrorIs(t, err, errMissingMeterEventName)
+	require.Zero(t, api.calls)
+}
+
+func TestGetMeterEventSummaryAggregatesSDKSequence(t *testing.T) {
+	t.Parallel()
+	// stripe-go's All method owns HTTP pagination and exposes the resulting
+	// items as Seq2. This fake starts at that SDK boundary and verifies that
+	// the client aggregates every item in the sequence.
+
+	api := &fakeStripeAPI{meterSummaries: []*stripesdk.BillingMeterEventSummary{
+		{AggregatedValue: 10.5},
+		{AggregatedValue: -2},
+		{AggregatedValue: 4.25},
+	}}
+	c := &client{
+		api: api,
+		catalog: Catalog{
+			PriceIDTUM:     "",
+			MeterIDTUM:     "mtr_tum",
+			MeterEventName: "",
+		},
+	}
+	start := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+
+	total, err := c.GetMeterEventSummary(t.Context(), GetMeterEventSummaryInput{
+		CustomerID: "cus_test",
+		Start:      start,
+		End:        end,
+	})
+	require.NoError(t, err)
+	require.InDelta(t, 12.75, total, 0.000001)
+	require.Equal(t, "mtr_tum", stripesdk.StringValue(api.meterSummaryParams.ID))
+	require.Equal(t, "cus_test", stripesdk.StringValue(api.meterSummaryParams.Customer))
+	require.Equal(t, start.Unix(), stripesdk.Int64Value(api.meterSummaryParams.StartTime))
+	require.Equal(t, end.Unix(), stripesdk.Int64Value(api.meterSummaryParams.EndTime))
+	require.Equal(t, int64(100), stripesdk.Int64Value(api.meterSummaryParams.Limit))
+}
+
+func TestGetMeterEventSummaryValidatesBounds(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		start   time.Time
+		end     time.Time
+		wantErr string
+	}{
+		{
+			name:    "start not minute aligned",
+			start:   start.Add(time.Second),
+			end:     start.Add(time.Hour),
+			wantErr: "minute-aligned",
+		},
+		{
+			name:    "end not minute aligned",
+			start:   start,
+			end:     start.Add(time.Hour + time.Second),
+			wantErr: "minute-aligned",
+		},
+		{
+			name:    "empty interval",
+			start:   start,
+			end:     start,
+			wantErr: "end must be after start",
+		},
+		{
+			name:    "reversed interval",
+			start:   start,
+			end:     start.Add(-time.Minute),
+			wantErr: "end must be after start",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			api := &fakeStripeAPI{}
+			c := &client{api: api}
+			_, err := c.GetMeterEventSummary(t.Context(), GetMeterEventSummaryInput{
+				CustomerID: "cus_test",
+				Start:      tt.start,
+				End:        tt.end,
+			})
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Zero(t, api.calls)
+		})
+	}
+}
+
+func TestGetMeterEventSummaryWrapsListError(t *testing.T) {
+	t.Parallel()
+
+	apiErr := errors.New("request failed")
+	api := &fakeStripeAPI{err: apiErr}
+	c := &client{api: api}
+	start := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err := c.GetMeterEventSummary(t.Context(), GetMeterEventSummaryInput{
+		CustomerID: "cus_test",
+		Start:      start,
+		End:        start.Add(time.Hour),
+	})
+	require.ErrorIs(t, err, apiErr)
+	require.ErrorContains(t, err, "list Stripe meter event summaries")
+}
+
 func TestWritesWrapStripeErrors(t *testing.T) {
 	t.Parallel()
 
 	apiErr := errors.New("request failed")
 	api := &fakeStripeAPI{err: apiErr}
-	c := &client{api: api, catalog: Catalog{MeterEventName: "tum"}}
+	c := &client{api: api, catalog: Catalog{PriceIDTUM: "", MeterIDTUM: "", MeterEventName: "tum"}}
 
 	_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{IdempotencyKey: "customer"})
 	require.ErrorIs(t, err, apiErr)
 	require.ErrorContains(t, err, "create Stripe customer")
 
-	err = c.CreateMeterEvent(t.Context(), CreateMeterEventInput{IdempotencyKey: "meter"})
+	err = c.CreateMeterEvent(t.Context(), CreateMeterEventInput{EventName: "tum", IdempotencyKey: "meter"})
 	require.ErrorIs(t, err, apiErr)
 	require.ErrorContains(t, err, "create Stripe meter event")
 

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -114,12 +114,16 @@ func (c *checkoutStripeClient) CreateMeterEvent(context.Context, stripeclient.Cr
 	return errors.New("not implemented")
 }
 
+func (c *checkoutStripeClient) GetMeterEventSummary(context.Context, stripeclient.GetMeterEventSummaryInput) (float64, error) {
+	return 0, errors.New("not implemented")
+}
+
 func (c *checkoutStripeClient) VerifyWebhook([]byte, string) (*stripeclient.WebhookEvent, error) {
 	return nil, errors.New("not implemented")
 }
 
 func (c *checkoutStripeClient) Catalog() stripeclient.Catalog {
-	return stripeclient.Catalog{PriceIDTUM: "price_tum", MeterEventName: "tum"}
+	return stripeclient.Catalog{PriceIDTUM: "price_tum", MeterIDTUM: "mtr_tum", MeterEventName: "tum"}
 }
 
 func (c *checkoutStripeClient) snapshot() (int, []stripeclient.CreateCustomerInput, []stripeclient.CreateCheckoutSessionInput) {

--- a/server/internal/usage/pricing.go
+++ b/server/internal/usage/pricing.go
@@ -1,0 +1,6 @@
+package usage
+
+// TUMUnitPriceUSD is the immutable PAYG list price for a token under
+// management: $0.35 per million tokens. Carry-forward allocations persist
+// this value so their signed correction uses the original service contract.
+const TUMUnitPriceUSD = "0.00000035"

--- a/server/internal/usage/pricing.go
+++ b/server/internal/usage/pricing.go
@@ -1,6 +1,8 @@
 package usage
 
+import "github.com/speakeasy-api/gram/server/internal/billing"
+
 // TUMUnitPriceUSD is the immutable PAYG list price for a token under
 // management: $0.35 per million tokens. Carry-forward allocations persist
 // this value so their signed correction uses the original service contract.
-const TUMUnitPriceUSD = "0.00000035"
+const TUMUnitPriceUSD = billing.TUMUnitPriceUSD

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -485,8 +485,11 @@ SELECT
     COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state = 'confirmed'), 0)::bigint AS confirmed_tokens
   , COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state IN ('pending', 'ambiguous', 'confirmed')), 0)::bigint AS intended_tokens
 FROM stripe_meter_reports
-WHERE organization_id = @organization_id
-  AND billing_cycle_usage_id = @billing_cycle_usage_id;
+JOIN billing_cycle_usage
+  ON billing_cycle_usage.organization_id = stripe_meter_reports.organization_id
+ AND billing_cycle_usage.cycle_start = stripe_meter_reports.cycle_start
+WHERE billing_cycle_usage.organization_id = @organization_id
+  AND billing_cycle_usage.id = @billing_cycle_usage_id;
 
 -- name: ConfirmReconciledTUMMeterReports :execrows
 UPDATE stripe_meter_reports

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -311,3 +311,278 @@ SELECT *
 FROM billing_cycle_usage
 WHERE organization_id = @organization_id::text
 ORDER BY cycle_start;
+
+-- name: GetTUMMeteringOrganization :one
+SELECT
+    billing_metadata.organization_id
+  , billing_metadata.stripe_customer_id
+  , billing_metadata.stripe_subscription_id
+  , billing_metadata.stripe_billing_cycle_anchor
+  , organization_metadata.gram_account_type
+FROM billing_metadata
+JOIN organization_metadata
+  ON organization_metadata.id = billing_metadata.organization_id
+WHERE billing_metadata.organization_id = @organization_id;
+
+-- name: ListTUMBillingCyclesForReporting :many
+SELECT *
+FROM billing_cycle_usage
+WHERE organization_id = @organization_id
+  AND cycle_start >= @first_paid_cycle_start
+ORDER BY cycle_start;
+
+-- name: FreezeTUMBillingCycleBaseline :one
+UPDATE billing_cycle_usage
+SET billed_tum_tokens = tum_tokens,
+    billed_frozen_at = @frozen_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @billing_cycle_usage_id
+  AND billed_tum_tokens IS NULL
+  AND billed_frozen_at IS NULL
+RETURNING *;
+
+-- name: FreezeMissedTUMBillingCycleBaseline :one
+-- If reporting was unavailable for the entire +48h..+72h window, the closed
+-- invoice received no immutable baseline. Record zero as billed so the full
+-- finalized usage becomes one carry-forward allocation instead of disappearing.
+UPDATE billing_cycle_usage
+SET billed_tum_tokens = 0,
+    billed_frozen_at = @frozen_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @billing_cycle_usage_id
+  AND billed_tum_tokens IS NULL
+  AND billed_frozen_at IS NULL
+  AND finalized_at IS NOT NULL
+RETURNING *;
+
+-- name: CreateTUMMeterReportIntent :one
+WITH locked_cycle AS (
+  SELECT id, organization_id, cycle_start, cycle_end
+  FROM billing_cycle_usage
+  WHERE billing_cycle_usage.organization_id = @organization_id
+    AND billing_cycle_usage.id = @billing_cycle_usage_id
+  FOR UPDATE
+), report_totals AS (
+  SELECT
+      COALESCE(MAX(stripe_meter_reports.seq), 0)::int AS max_seq
+    , COALESCE(SUM(stripe_meter_reports.delta_tokens) FILTER (
+        WHERE stripe_meter_reports.delivery_state IN ('pending', 'ambiguous', 'confirmed')
+      ), 0)::bigint AS intended_tokens
+  FROM locked_cycle
+  LEFT JOIN stripe_meter_reports
+    ON stripe_meter_reports.organization_id = locked_cycle.organization_id
+   AND stripe_meter_reports.cycle_start = locked_cycle.cycle_start
+), intended AS (
+  SELECT
+      locked_cycle.*
+    , report_totals.max_seq + 1 AS next_seq
+    , sqlc.arg(target_tum_tokens)::bigint - report_totals.intended_tokens AS delta_tokens
+  FROM locked_cycle
+  CROSS JOIN report_totals
+)
+INSERT INTO stripe_meter_reports (
+    organization_id
+  , billing_cycle_usage_id
+  , cycle_start
+  , cycle_end
+  , seq
+  , stripe_customer_id
+  , stripe_meter_event_name
+  , stripe_identifier
+  , delta_tokens
+  , event_timestamp
+  , delivery_state
+)
+SELECT
+    intended.organization_id
+  , intended.id
+  , intended.cycle_start
+  , intended.cycle_end
+  , intended.next_seq
+  , @stripe_customer_id
+  , @stripe_meter_event_name
+  , 'tum:' || intended.organization_id || ':' || to_char(intended.cycle_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') || ':' || intended.next_seq::text
+  , intended.delta_tokens
+  , @event_timestamp
+  , 'pending'
+FROM intended
+WHERE intended.delta_tokens <> 0
+RETURNING *;
+
+-- name: ListTUMMeterReportsForDelivery :many
+SELECT *
+FROM stripe_meter_reports
+WHERE organization_id = @organization_id
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND billing_cycle_usage_id IS NOT NULL
+  AND cycle_end IS NOT NULL
+  AND stripe_customer_id IS NOT NULL
+  AND stripe_meter_event_name IS NOT NULL
+  AND stripe_identifier IS NOT NULL
+  AND event_timestamp IS NOT NULL
+  AND (first_attempted_at IS NULL OR first_attempted_at > @retry_after)
+ORDER BY cycle_start, seq
+LIMIT 1;
+
+-- name: BeginTUMMeterReportAttempt :one
+UPDATE stripe_meter_reports
+SET first_attempted_at = COALESCE(first_attempted_at, @attempted_at),
+    last_attempted_at = @attempted_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND (first_attempted_at IS NULL OR first_attempted_at > @retry_after)
+RETURNING *;
+
+-- name: ConfirmTUMMeterReport :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'confirmed',
+    confirmed_at = @confirmed_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND delivery_state IN ('pending', 'ambiguous');
+
+-- name: MarkTUMMeterReportAmbiguous :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'ambiguous',
+    ambiguous_at = COALESCE(ambiguous_at, @ambiguous_at),
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND delivery_state IN ('pending', 'ambiguous');
+
+-- name: ListStaleTUMMeterReportCycles :many
+SELECT
+    stripe_meter_reports.billing_cycle_usage_id
+  , stripe_meter_reports.cycle_start
+  , stripe_meter_reports.cycle_end
+  , stripe_meter_reports.stripe_customer_id
+  , MIN(stripe_meter_reports.reconciled_at)::timestamptz AS absence_observed_at
+FROM stripe_meter_reports
+WHERE organization_id = @organization_id
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND billing_cycle_usage_id IS NOT NULL
+  AND cycle_end IS NOT NULL
+  AND stripe_customer_id IS NOT NULL
+GROUP BY
+    stripe_meter_reports.billing_cycle_usage_id
+  , stripe_meter_reports.cycle_start
+  , stripe_meter_reports.cycle_end
+  , stripe_meter_reports.stripe_customer_id
+HAVING bool_and(
+  stripe_meter_reports.first_attempted_at IS NOT NULL
+  AND stripe_meter_reports.first_attempted_at <= @retry_after
+)
+ORDER BY cycle_start
+LIMIT 1;
+
+-- name: GetTUMMeterReportTotals :one
+SELECT
+    COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state = 'confirmed'), 0)::bigint AS confirmed_tokens
+  , COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state IN ('pending', 'ambiguous', 'confirmed')), 0)::bigint AS intended_tokens
+FROM stripe_meter_reports
+WHERE organization_id = @organization_id
+  AND billing_cycle_usage_id = @billing_cycle_usage_id;
+
+-- name: ConfirmReconciledTUMMeterReports :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'confirmed',
+    confirmed_at = COALESCE(confirmed_at, @reconciled_at),
+    reconciled_at = @reconciled_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND billing_cycle_usage_id = @billing_cycle_usage_id
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND first_attempted_at IS NOT NULL
+  AND first_attempted_at <= @retry_after;
+
+-- name: MarkReconciledTUMMeterReportsMissing :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'reconciled_missing',
+    reconciled_at = @reconciled_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND billing_cycle_usage_id = @billing_cycle_usage_id
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND first_attempted_at IS NOT NULL
+  AND first_attempted_at <= @retry_after;
+
+-- name: NoteTUMMeterReportReconciliation :execrows
+UPDATE stripe_meter_reports
+SET reconciled_at = @reconciled_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND billing_cycle_usage_id = @billing_cycle_usage_id
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND first_attempted_at IS NOT NULL
+  AND first_attempted_at <= @retry_after;
+
+-- name: CreateTUMCarryAllocation :execrows
+INSERT INTO stripe_invoice_allocations (
+    organization_id
+  , source_kind
+  , source_key
+  , seq
+  , source_period_start
+  , source_period_end
+  , source_snapshot_usd
+  , delta_tokens
+  , original_tum_unit_price_usd
+  , amount_usd
+  , idempotency_key
+  , delivery_state
+)
+SELECT
+    billing_cycle_usage.organization_id
+  , 'tum_cycle'
+  , extract(epoch FROM billing_cycle_usage.cycle_start)::bigint::text || ':' || extract(epoch FROM billing_cycle_usage.cycle_end)::bigint::text
+  , 1
+  , billing_cycle_usage.cycle_start
+  , billing_cycle_usage.cycle_end
+  , round(billing_cycle_usage.tum_tokens::numeric * sqlc.arg(tum_unit_price_usd)::text::numeric, 6)
+  , billing_cycle_usage.tum_tokens - billing_cycle_usage.billed_tum_tokens
+  , sqlc.arg(tum_unit_price_usd)::text::numeric
+  , round(billing_cycle_usage.tum_tokens::numeric * sqlc.arg(tum_unit_price_usd)::text::numeric, 2)
+    - round(billing_cycle_usage.billed_tum_tokens::numeric * sqlc.arg(tum_unit_price_usd)::text::numeric, 2)
+  , 'tum-carry:' || billing_cycle_usage.organization_id || ':' || extract(epoch FROM billing_cycle_usage.cycle_start)::bigint::text
+  , 'pending'
+FROM billing_cycle_usage
+WHERE billing_cycle_usage.organization_id = @organization_id
+  AND billing_cycle_usage.id = @billing_cycle_usage_id
+  AND billing_cycle_usage.billed_tum_tokens IS NOT NULL
+  AND billing_cycle_usage.finalized_at IS NOT NULL
+  AND billing_cycle_usage.tum_tokens <> billing_cycle_usage.billed_tum_tokens
+ON CONFLICT (organization_id, source_kind, source_key, seq) DO NOTHING;
+
+-- name: ListTUMMeterReportsFixture :many
+SELECT *
+FROM stripe_meter_reports
+WHERE organization_id = @organization_id
+ORDER BY cycle_start, seq;
+
+-- name: CreateLegacyTUMMeterReportFixture :one
+INSERT INTO stripe_meter_reports (
+    organization_id
+  , cycle_start
+  , seq
+  , delta_tokens
+  , delivery_state
+) VALUES (
+    @organization_id
+  , @cycle_start
+  , @seq
+  , @delta_tokens
+  , 'confirmed'
+)
+RETURNING *;
+
+-- name: ListTUMCarryAllocationsFixture :many
+SELECT *
+FROM stripe_invoice_allocations
+WHERE organization_id = @organization_id
+  AND source_kind = 'tum_cycle'
+ORDER BY source_period_start, seq;

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -41,3 +41,53 @@ type BillingMetadatum struct {
 	CreatedAt              pgtype.Timestamptz
 	UpdatedAt              pgtype.Timestamptz
 }
+
+type StripeInvoiceAllocation struct {
+	ID                      uuid.UUID
+	OrganizationID          pgtype.Text
+	SourceKind              string
+	SourceKey               string
+	Seq                     int32
+	SourceDay               pgtype.Date
+	SourcePeriodStart       pgtype.Timestamptz
+	SourcePeriodEnd         pgtype.Timestamptz
+	SourceSnapshotUsd       pgtype.Numeric
+	DeltaTokens             pgtype.Int8
+	OriginalTumUnitPriceUsd pgtype.Numeric
+	AmountUsd               pgtype.Numeric
+	OriginalInvoiceID       pgtype.Text
+	DestinationInvoiceID    pgtype.Text
+	StripeInvoiceItemID     pgtype.Text
+	StripeCreditNoteID      pgtype.Text
+	IdempotencyKey          string
+	DeliveryState           string
+	FirstAttemptedAt        pgtype.Timestamptz
+	LastAttemptedAt         pgtype.Timestamptz
+	ConfirmedAt             pgtype.Timestamptz
+	AmbiguousAt             pgtype.Timestamptz
+	ReconciledAt            pgtype.Timestamptz
+	CreatedAt               pgtype.Timestamptz
+	UpdatedAt               pgtype.Timestamptz
+}
+
+type StripeMeterReport struct {
+	ID                   uuid.UUID
+	OrganizationID       pgtype.Text
+	BillingCycleUsageID  uuid.NullUUID
+	CycleStart           pgtype.Timestamptz
+	CycleEnd             pgtype.Timestamptz
+	Seq                  int32
+	StripeCustomerID     pgtype.Text
+	StripeMeterEventName pgtype.Text
+	StripeIdentifier     pgtype.Text
+	DeltaTokens          int64
+	EventTimestamp       pgtype.Timestamptz
+	DeliveryState        string
+	FirstAttemptedAt     pgtype.Timestamptz
+	LastAttemptedAt      pgtype.Timestamptz
+	ConfirmedAt          pgtype.Timestamptz
+	AmbiguousAt          pgtype.Timestamptz
+	ReconciledAt         pgtype.Timestamptz
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -90,6 +90,114 @@ func (q *Queries) ActivatePaygOrganization(ctx context.Context, organizationID s
 	return err
 }
 
+const beginTUMMeterReportAttempt = `-- name: BeginTUMMeterReportAttempt :one
+UPDATE stripe_meter_reports
+SET first_attempted_at = COALESCE(first_attempted_at, $1),
+    last_attempted_at = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND id = $3
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND (first_attempted_at IS NULL OR first_attempted_at > $4)
+RETURNING id, organization_id, billing_cycle_usage_id, cycle_start, cycle_end, seq, stripe_customer_id, stripe_meter_event_name, stripe_identifier, delta_tokens, event_timestamp, delivery_state, first_attempted_at, last_attempted_at, confirmed_at, ambiguous_at, reconciled_at, created_at, updated_at
+`
+
+type BeginTUMMeterReportAttemptParams struct {
+	AttemptedAt    pgtype.Timestamptz
+	OrganizationID pgtype.Text
+	ID             uuid.UUID
+	RetryAfter     pgtype.Timestamptz
+}
+
+func (q *Queries) BeginTUMMeterReportAttempt(ctx context.Context, arg BeginTUMMeterReportAttemptParams) (StripeMeterReport, error) {
+	row := q.db.QueryRow(ctx, beginTUMMeterReportAttempt,
+		arg.AttemptedAt,
+		arg.OrganizationID,
+		arg.ID,
+		arg.RetryAfter,
+	)
+	var i StripeMeterReport
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.BillingCycleUsageID,
+		&i.CycleStart,
+		&i.CycleEnd,
+		&i.Seq,
+		&i.StripeCustomerID,
+		&i.StripeMeterEventName,
+		&i.StripeIdentifier,
+		&i.DeltaTokens,
+		&i.EventTimestamp,
+		&i.DeliveryState,
+		&i.FirstAttemptedAt,
+		&i.LastAttemptedAt,
+		&i.ConfirmedAt,
+		&i.AmbiguousAt,
+		&i.ReconciledAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const confirmReconciledTUMMeterReports = `-- name: ConfirmReconciledTUMMeterReports :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'confirmed',
+    confirmed_at = COALESCE(confirmed_at, $1),
+    reconciled_at = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND billing_cycle_usage_id = $3
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND first_attempted_at IS NOT NULL
+  AND first_attempted_at <= $4
+`
+
+type ConfirmReconciledTUMMeterReportsParams struct {
+	ReconciledAt        pgtype.Timestamptz
+	OrganizationID      pgtype.Text
+	BillingCycleUsageID uuid.NullUUID
+	RetryAfter          pgtype.Timestamptz
+}
+
+func (q *Queries) ConfirmReconciledTUMMeterReports(ctx context.Context, arg ConfirmReconciledTUMMeterReportsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, confirmReconciledTUMMeterReports,
+		arg.ReconciledAt,
+		arg.OrganizationID,
+		arg.BillingCycleUsageID,
+		arg.RetryAfter,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const confirmTUMMeterReport = `-- name: ConfirmTUMMeterReport :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'confirmed',
+    confirmed_at = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND id = $3
+  AND delivery_state IN ('pending', 'ambiguous')
+`
+
+type ConfirmTUMMeterReportParams struct {
+	ConfirmedAt    pgtype.Timestamptz
+	OrganizationID pgtype.Text
+	ID             uuid.UUID
+}
+
+func (q *Queries) ConfirmTUMMeterReport(ctx context.Context, arg ConfirmTUMMeterReportParams) (int64, error) {
+	result, err := q.db.Exec(ctx, confirmTUMMeterReport, arg.ConfirmedAt, arg.OrganizationID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countStripeWebhookReceiptsFixture = `-- name: CountStripeWebhookReceiptsFixture :one
 SELECT count(*)
 FROM stripe_webhook_receipts
@@ -102,6 +210,62 @@ func (q *Queries) CountStripeWebhookReceiptsFixture(ctx context.Context, organiz
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const createLegacyTUMMeterReportFixture = `-- name: CreateLegacyTUMMeterReportFixture :one
+INSERT INTO stripe_meter_reports (
+    organization_id
+  , cycle_start
+  , seq
+  , delta_tokens
+  , delivery_state
+) VALUES (
+    $1
+  , $2
+  , $3
+  , $4
+  , 'confirmed'
+)
+RETURNING id, organization_id, billing_cycle_usage_id, cycle_start, cycle_end, seq, stripe_customer_id, stripe_meter_event_name, stripe_identifier, delta_tokens, event_timestamp, delivery_state, first_attempted_at, last_attempted_at, confirmed_at, ambiguous_at, reconciled_at, created_at, updated_at
+`
+
+type CreateLegacyTUMMeterReportFixtureParams struct {
+	OrganizationID pgtype.Text
+	CycleStart     pgtype.Timestamptz
+	Seq            int32
+	DeltaTokens    int64
+}
+
+func (q *Queries) CreateLegacyTUMMeterReportFixture(ctx context.Context, arg CreateLegacyTUMMeterReportFixtureParams) (StripeMeterReport, error) {
+	row := q.db.QueryRow(ctx, createLegacyTUMMeterReportFixture,
+		arg.OrganizationID,
+		arg.CycleStart,
+		arg.Seq,
+		arg.DeltaTokens,
+	)
+	var i StripeMeterReport
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.BillingCycleUsageID,
+		&i.CycleStart,
+		&i.CycleEnd,
+		&i.Seq,
+		&i.StripeCustomerID,
+		&i.StripeMeterEventName,
+		&i.StripeIdentifier,
+		&i.DeltaTokens,
+		&i.EventTimestamp,
+		&i.DeliveryState,
+		&i.FirstAttemptedAt,
+		&i.LastAttemptedAt,
+		&i.ConfirmedAt,
+		&i.AmbiguousAt,
+		&i.ReconciledAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const createStripeBillingMetadataFixture = `-- name: CreateStripeBillingMetadataFixture :exec
@@ -135,6 +299,156 @@ type CreateStripeSubscriptionBillingMetadataFixtureParams struct {
 func (q *Queries) CreateStripeSubscriptionBillingMetadataFixture(ctx context.Context, arg CreateStripeSubscriptionBillingMetadataFixtureParams) error {
 	_, err := q.db.Exec(ctx, createStripeSubscriptionBillingMetadataFixture, arg.OrganizationID, arg.StripeCustomerID, arg.StripeSubscriptionID)
 	return err
+}
+
+const createTUMCarryAllocation = `-- name: CreateTUMCarryAllocation :execrows
+INSERT INTO stripe_invoice_allocations (
+    organization_id
+  , source_kind
+  , source_key
+  , seq
+  , source_period_start
+  , source_period_end
+  , source_snapshot_usd
+  , delta_tokens
+  , original_tum_unit_price_usd
+  , amount_usd
+  , idempotency_key
+  , delivery_state
+)
+SELECT
+    billing_cycle_usage.organization_id
+  , 'tum_cycle'
+  , extract(epoch FROM billing_cycle_usage.cycle_start)::bigint::text || ':' || extract(epoch FROM billing_cycle_usage.cycle_end)::bigint::text
+  , 1
+  , billing_cycle_usage.cycle_start
+  , billing_cycle_usage.cycle_end
+  , round(billing_cycle_usage.tum_tokens::numeric * $1::text::numeric, 6)
+  , billing_cycle_usage.tum_tokens - billing_cycle_usage.billed_tum_tokens
+  , $1::text::numeric
+  , round(billing_cycle_usage.tum_tokens::numeric * $1::text::numeric, 2)
+    - round(billing_cycle_usage.billed_tum_tokens::numeric * $1::text::numeric, 2)
+  , 'tum-carry:' || billing_cycle_usage.organization_id || ':' || extract(epoch FROM billing_cycle_usage.cycle_start)::bigint::text
+  , 'pending'
+FROM billing_cycle_usage
+WHERE billing_cycle_usage.organization_id = $2
+  AND billing_cycle_usage.id = $3
+  AND billing_cycle_usage.billed_tum_tokens IS NOT NULL
+  AND billing_cycle_usage.finalized_at IS NOT NULL
+  AND billing_cycle_usage.tum_tokens <> billing_cycle_usage.billed_tum_tokens
+ON CONFLICT (organization_id, source_kind, source_key, seq) DO NOTHING
+`
+
+type CreateTUMCarryAllocationParams struct {
+	TumUnitPriceUsd     string
+	OrganizationID      pgtype.Text
+	BillingCycleUsageID uuid.UUID
+}
+
+func (q *Queries) CreateTUMCarryAllocation(ctx context.Context, arg CreateTUMCarryAllocationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, createTUMCarryAllocation, arg.TumUnitPriceUsd, arg.OrganizationID, arg.BillingCycleUsageID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const createTUMMeterReportIntent = `-- name: CreateTUMMeterReportIntent :one
+WITH locked_cycle AS (
+  SELECT id, organization_id, cycle_start, cycle_end
+  FROM billing_cycle_usage
+  WHERE billing_cycle_usage.organization_id = $4
+    AND billing_cycle_usage.id = $5
+  FOR UPDATE
+), report_totals AS (
+  SELECT
+      COALESCE(MAX(stripe_meter_reports.seq), 0)::int AS max_seq
+    , COALESCE(SUM(stripe_meter_reports.delta_tokens) FILTER (
+        WHERE stripe_meter_reports.delivery_state IN ('pending', 'ambiguous', 'confirmed')
+      ), 0)::bigint AS intended_tokens
+  FROM locked_cycle
+  LEFT JOIN stripe_meter_reports
+    ON stripe_meter_reports.organization_id = locked_cycle.organization_id
+   AND stripe_meter_reports.cycle_start = locked_cycle.cycle_start
+), intended AS (
+  SELECT
+      locked_cycle.id, locked_cycle.organization_id, locked_cycle.cycle_start, locked_cycle.cycle_end
+    , report_totals.max_seq + 1 AS next_seq
+    , $6::bigint - report_totals.intended_tokens AS delta_tokens
+  FROM locked_cycle
+  CROSS JOIN report_totals
+)
+INSERT INTO stripe_meter_reports (
+    organization_id
+  , billing_cycle_usage_id
+  , cycle_start
+  , cycle_end
+  , seq
+  , stripe_customer_id
+  , stripe_meter_event_name
+  , stripe_identifier
+  , delta_tokens
+  , event_timestamp
+  , delivery_state
+)
+SELECT
+    intended.organization_id
+  , intended.id
+  , intended.cycle_start
+  , intended.cycle_end
+  , intended.next_seq
+  , $1
+  , $2
+  , 'tum:' || intended.organization_id || ':' || to_char(intended.cycle_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') || ':' || intended.next_seq::text
+  , intended.delta_tokens
+  , $3
+  , 'pending'
+FROM intended
+WHERE intended.delta_tokens <> 0
+RETURNING id, organization_id, billing_cycle_usage_id, cycle_start, cycle_end, seq, stripe_customer_id, stripe_meter_event_name, stripe_identifier, delta_tokens, event_timestamp, delivery_state, first_attempted_at, last_attempted_at, confirmed_at, ambiguous_at, reconciled_at, created_at, updated_at
+`
+
+type CreateTUMMeterReportIntentParams struct {
+	StripeCustomerID     pgtype.Text
+	StripeMeterEventName pgtype.Text
+	EventTimestamp       pgtype.Timestamptz
+	OrganizationID       pgtype.Text
+	BillingCycleUsageID  uuid.UUID
+	TargetTumTokens      int64
+}
+
+func (q *Queries) CreateTUMMeterReportIntent(ctx context.Context, arg CreateTUMMeterReportIntentParams) (StripeMeterReport, error) {
+	row := q.db.QueryRow(ctx, createTUMMeterReportIntent,
+		arg.StripeCustomerID,
+		arg.StripeMeterEventName,
+		arg.EventTimestamp,
+		arg.OrganizationID,
+		arg.BillingCycleUsageID,
+		arg.TargetTumTokens,
+	)
+	var i StripeMeterReport
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.BillingCycleUsageID,
+		&i.CycleStart,
+		&i.CycleEnd,
+		&i.Seq,
+		&i.StripeCustomerID,
+		&i.StripeMeterEventName,
+		&i.StripeIdentifier,
+		&i.DeltaTokens,
+		&i.EventTimestamp,
+		&i.DeliveryState,
+		&i.FirstAttemptedAt,
+		&i.LastAttemptedAt,
+		&i.ConfirmedAt,
+		&i.AmbiguousAt,
+		&i.ReconciledAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const finalizeStripeCheckoutIntent = `-- name: FinalizeStripeCheckoutIntent :one
@@ -204,6 +518,82 @@ func (q *Queries) FinalizeStripeCheckoutIntent(ctx context.Context, arg Finalize
 	)
 	var i FinalizeStripeCheckoutIntentRow
 	err := row.Scan(&i.BillingMetadataID, &i.AttachedNewSession)
+	return i, err
+}
+
+const freezeMissedTUMBillingCycleBaseline = `-- name: FreezeMissedTUMBillingCycleBaseline :one
+UPDATE billing_cycle_usage
+SET billed_tum_tokens = 0,
+    billed_frozen_at = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND id = $3
+  AND billed_tum_tokens IS NULL
+  AND billed_frozen_at IS NULL
+  AND finalized_at IS NOT NULL
+RETURNING id, organization_id, cycle_start, cycle_end, tum_tokens, billed_tum_tokens, billed_frozen_at, finalized_at, created_at, updated_at
+`
+
+type FreezeMissedTUMBillingCycleBaselineParams struct {
+	FrozenAt            pgtype.Timestamptz
+	OrganizationID      pgtype.Text
+	BillingCycleUsageID uuid.UUID
+}
+
+// If reporting was unavailable for the entire +48h..+72h window, the closed
+// invoice received no immutable baseline. Record zero as billed so the full
+// finalized usage becomes one carry-forward allocation instead of disappearing.
+func (q *Queries) FreezeMissedTUMBillingCycleBaseline(ctx context.Context, arg FreezeMissedTUMBillingCycleBaselineParams) (BillingCycleUsage, error) {
+	row := q.db.QueryRow(ctx, freezeMissedTUMBillingCycleBaseline, arg.FrozenAt, arg.OrganizationID, arg.BillingCycleUsageID)
+	var i BillingCycleUsage
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.CycleStart,
+		&i.CycleEnd,
+		&i.TumTokens,
+		&i.BilledTumTokens,
+		&i.BilledFrozenAt,
+		&i.FinalizedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const freezeTUMBillingCycleBaseline = `-- name: FreezeTUMBillingCycleBaseline :one
+UPDATE billing_cycle_usage
+SET billed_tum_tokens = tum_tokens,
+    billed_frozen_at = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND id = $3
+  AND billed_tum_tokens IS NULL
+  AND billed_frozen_at IS NULL
+RETURNING id, organization_id, cycle_start, cycle_end, tum_tokens, billed_tum_tokens, billed_frozen_at, finalized_at, created_at, updated_at
+`
+
+type FreezeTUMBillingCycleBaselineParams struct {
+	FrozenAt            pgtype.Timestamptz
+	OrganizationID      pgtype.Text
+	BillingCycleUsageID uuid.UUID
+}
+
+func (q *Queries) FreezeTUMBillingCycleBaseline(ctx context.Context, arg FreezeTUMBillingCycleBaselineParams) (BillingCycleUsage, error) {
+	row := q.db.QueryRow(ctx, freezeTUMBillingCycleBaseline, arg.FrozenAt, arg.OrganizationID, arg.BillingCycleUsageID)
+	var i BillingCycleUsage
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.CycleStart,
+		&i.CycleEnd,
+		&i.TumTokens,
+		&i.BilledTumTokens,
+		&i.BilledFrozenAt,
+		&i.FinalizedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
 	return i, err
 }
 
@@ -325,6 +715,66 @@ func (q *Queries) GetPaygActivationState(ctx context.Context, organizationID str
 	return i, err
 }
 
+const getTUMMeterReportTotals = `-- name: GetTUMMeterReportTotals :one
+SELECT
+    COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state = 'confirmed'), 0)::bigint AS confirmed_tokens
+  , COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state IN ('pending', 'ambiguous', 'confirmed')), 0)::bigint AS intended_tokens
+FROM stripe_meter_reports
+WHERE organization_id = $1
+  AND billing_cycle_usage_id = $2
+`
+
+type GetTUMMeterReportTotalsParams struct {
+	OrganizationID      pgtype.Text
+	BillingCycleUsageID uuid.NullUUID
+}
+
+type GetTUMMeterReportTotalsRow struct {
+	ConfirmedTokens int64
+	IntendedTokens  int64
+}
+
+func (q *Queries) GetTUMMeterReportTotals(ctx context.Context, arg GetTUMMeterReportTotalsParams) (GetTUMMeterReportTotalsRow, error) {
+	row := q.db.QueryRow(ctx, getTUMMeterReportTotals, arg.OrganizationID, arg.BillingCycleUsageID)
+	var i GetTUMMeterReportTotalsRow
+	err := row.Scan(&i.ConfirmedTokens, &i.IntendedTokens)
+	return i, err
+}
+
+const getTUMMeteringOrganization = `-- name: GetTUMMeteringOrganization :one
+SELECT
+    billing_metadata.organization_id
+  , billing_metadata.stripe_customer_id
+  , billing_metadata.stripe_subscription_id
+  , billing_metadata.stripe_billing_cycle_anchor
+  , organization_metadata.gram_account_type
+FROM billing_metadata
+JOIN organization_metadata
+  ON organization_metadata.id = billing_metadata.organization_id
+WHERE billing_metadata.organization_id = $1
+`
+
+type GetTUMMeteringOrganizationRow struct {
+	OrganizationID           string
+	StripeCustomerID         pgtype.Text
+	StripeSubscriptionID     pgtype.Text
+	StripeBillingCycleAnchor pgtype.Timestamptz
+	GramAccountType          string
+}
+
+func (q *Queries) GetTUMMeteringOrganization(ctx context.Context, organizationID string) (GetTUMMeteringOrganizationRow, error) {
+	row := q.db.QueryRow(ctx, getTUMMeteringOrganization, organizationID)
+	var i GetTUMMeteringOrganizationRow
+	err := row.Scan(
+		&i.OrganizationID,
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
+		&i.StripeBillingCycleAnchor,
+		&i.GramAccountType,
+	)
+	return i, err
+}
+
 const listBillingCycleUsage = `-- name: ListBillingCycleUsage :many
 SELECT id, organization_id, cycle_start, cycle_end, tum_tokens, billed_tum_tokens, billed_frozen_at, finalized_at, created_at, updated_at
 FROM billing_cycle_usage
@@ -419,6 +869,71 @@ func (q *Queries) ListFinalizedBillingCycleStarts(ctx context.Context, organizat
 	return items, nil
 }
 
+const listStaleTUMMeterReportCycles = `-- name: ListStaleTUMMeterReportCycles :many
+SELECT
+    stripe_meter_reports.billing_cycle_usage_id
+  , stripe_meter_reports.cycle_start
+  , stripe_meter_reports.cycle_end
+  , stripe_meter_reports.stripe_customer_id
+  , MIN(stripe_meter_reports.reconciled_at)::timestamptz AS absence_observed_at
+FROM stripe_meter_reports
+WHERE organization_id = $1
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND billing_cycle_usage_id IS NOT NULL
+  AND cycle_end IS NOT NULL
+  AND stripe_customer_id IS NOT NULL
+GROUP BY
+    stripe_meter_reports.billing_cycle_usage_id
+  , stripe_meter_reports.cycle_start
+  , stripe_meter_reports.cycle_end
+  , stripe_meter_reports.stripe_customer_id
+HAVING bool_and(
+  stripe_meter_reports.first_attempted_at IS NOT NULL
+  AND stripe_meter_reports.first_attempted_at <= $2
+)
+ORDER BY cycle_start
+LIMIT 1
+`
+
+type ListStaleTUMMeterReportCyclesParams struct {
+	OrganizationID pgtype.Text
+	RetryAfter     pgtype.Timestamptz
+}
+
+type ListStaleTUMMeterReportCyclesRow struct {
+	BillingCycleUsageID uuid.NullUUID
+	CycleStart          pgtype.Timestamptz
+	CycleEnd            pgtype.Timestamptz
+	StripeCustomerID    pgtype.Text
+	AbsenceObservedAt   pgtype.Timestamptz
+}
+
+func (q *Queries) ListStaleTUMMeterReportCycles(ctx context.Context, arg ListStaleTUMMeterReportCyclesParams) ([]ListStaleTUMMeterReportCyclesRow, error) {
+	rows, err := q.db.Query(ctx, listStaleTUMMeterReportCycles, arg.OrganizationID, arg.RetryAfter)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListStaleTUMMeterReportCyclesRow
+	for rows.Next() {
+		var i ListStaleTUMMeterReportCyclesRow
+		if err := rows.Scan(
+			&i.BillingCycleUsageID,
+			&i.CycleStart,
+			&i.CycleEnd,
+			&i.StripeCustomerID,
+			&i.AbsenceObservedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listStripeSubscriptionOwners = `-- name: ListStripeSubscriptionOwners :many
 SELECT organization_id
 FROM billing_metadata
@@ -444,6 +959,299 @@ func (q *Queries) ListStripeSubscriptionOwners(ctx context.Context, stripeSubscr
 		return nil, err
 	}
 	return items, nil
+}
+
+const listTUMBillingCyclesForReporting = `-- name: ListTUMBillingCyclesForReporting :many
+SELECT id, organization_id, cycle_start, cycle_end, tum_tokens, billed_tum_tokens, billed_frozen_at, finalized_at, created_at, updated_at
+FROM billing_cycle_usage
+WHERE organization_id = $1
+  AND cycle_start >= $2
+ORDER BY cycle_start
+`
+
+type ListTUMBillingCyclesForReportingParams struct {
+	OrganizationID      pgtype.Text
+	FirstPaidCycleStart pgtype.Timestamptz
+}
+
+func (q *Queries) ListTUMBillingCyclesForReporting(ctx context.Context, arg ListTUMBillingCyclesForReportingParams) ([]BillingCycleUsage, error) {
+	rows, err := q.db.Query(ctx, listTUMBillingCyclesForReporting, arg.OrganizationID, arg.FirstPaidCycleStart)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BillingCycleUsage
+	for rows.Next() {
+		var i BillingCycleUsage
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.CycleStart,
+			&i.CycleEnd,
+			&i.TumTokens,
+			&i.BilledTumTokens,
+			&i.BilledFrozenAt,
+			&i.FinalizedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTUMCarryAllocationsFixture = `-- name: ListTUMCarryAllocationsFixture :many
+SELECT id, organization_id, source_kind, source_key, seq, source_day, source_period_start, source_period_end, source_snapshot_usd, delta_tokens, original_tum_unit_price_usd, amount_usd, original_invoice_id, destination_invoice_id, stripe_invoice_item_id, stripe_credit_note_id, idempotency_key, delivery_state, first_attempted_at, last_attempted_at, confirmed_at, ambiguous_at, reconciled_at, created_at, updated_at
+FROM stripe_invoice_allocations
+WHERE organization_id = $1
+  AND source_kind = 'tum_cycle'
+ORDER BY source_period_start, seq
+`
+
+func (q *Queries) ListTUMCarryAllocationsFixture(ctx context.Context, organizationID pgtype.Text) ([]StripeInvoiceAllocation, error) {
+	rows, err := q.db.Query(ctx, listTUMCarryAllocationsFixture, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []StripeInvoiceAllocation
+	for rows.Next() {
+		var i StripeInvoiceAllocation
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.SourceKind,
+			&i.SourceKey,
+			&i.Seq,
+			&i.SourceDay,
+			&i.SourcePeriodStart,
+			&i.SourcePeriodEnd,
+			&i.SourceSnapshotUsd,
+			&i.DeltaTokens,
+			&i.OriginalTumUnitPriceUsd,
+			&i.AmountUsd,
+			&i.OriginalInvoiceID,
+			&i.DestinationInvoiceID,
+			&i.StripeInvoiceItemID,
+			&i.StripeCreditNoteID,
+			&i.IdempotencyKey,
+			&i.DeliveryState,
+			&i.FirstAttemptedAt,
+			&i.LastAttemptedAt,
+			&i.ConfirmedAt,
+			&i.AmbiguousAt,
+			&i.ReconciledAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTUMMeterReportsFixture = `-- name: ListTUMMeterReportsFixture :many
+SELECT id, organization_id, billing_cycle_usage_id, cycle_start, cycle_end, seq, stripe_customer_id, stripe_meter_event_name, stripe_identifier, delta_tokens, event_timestamp, delivery_state, first_attempted_at, last_attempted_at, confirmed_at, ambiguous_at, reconciled_at, created_at, updated_at
+FROM stripe_meter_reports
+WHERE organization_id = $1
+ORDER BY cycle_start, seq
+`
+
+func (q *Queries) ListTUMMeterReportsFixture(ctx context.Context, organizationID pgtype.Text) ([]StripeMeterReport, error) {
+	rows, err := q.db.Query(ctx, listTUMMeterReportsFixture, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []StripeMeterReport
+	for rows.Next() {
+		var i StripeMeterReport
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.BillingCycleUsageID,
+			&i.CycleStart,
+			&i.CycleEnd,
+			&i.Seq,
+			&i.StripeCustomerID,
+			&i.StripeMeterEventName,
+			&i.StripeIdentifier,
+			&i.DeltaTokens,
+			&i.EventTimestamp,
+			&i.DeliveryState,
+			&i.FirstAttemptedAt,
+			&i.LastAttemptedAt,
+			&i.ConfirmedAt,
+			&i.AmbiguousAt,
+			&i.ReconciledAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTUMMeterReportsForDelivery = `-- name: ListTUMMeterReportsForDelivery :many
+SELECT id, organization_id, billing_cycle_usage_id, cycle_start, cycle_end, seq, stripe_customer_id, stripe_meter_event_name, stripe_identifier, delta_tokens, event_timestamp, delivery_state, first_attempted_at, last_attempted_at, confirmed_at, ambiguous_at, reconciled_at, created_at, updated_at
+FROM stripe_meter_reports
+WHERE organization_id = $1
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND billing_cycle_usage_id IS NOT NULL
+  AND cycle_end IS NOT NULL
+  AND stripe_customer_id IS NOT NULL
+  AND stripe_meter_event_name IS NOT NULL
+  AND stripe_identifier IS NOT NULL
+  AND event_timestamp IS NOT NULL
+  AND (first_attempted_at IS NULL OR first_attempted_at > $2)
+ORDER BY cycle_start, seq
+LIMIT 1
+`
+
+type ListTUMMeterReportsForDeliveryParams struct {
+	OrganizationID pgtype.Text
+	RetryAfter     pgtype.Timestamptz
+}
+
+func (q *Queries) ListTUMMeterReportsForDelivery(ctx context.Context, arg ListTUMMeterReportsForDeliveryParams) ([]StripeMeterReport, error) {
+	rows, err := q.db.Query(ctx, listTUMMeterReportsForDelivery, arg.OrganizationID, arg.RetryAfter)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []StripeMeterReport
+	for rows.Next() {
+		var i StripeMeterReport
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.BillingCycleUsageID,
+			&i.CycleStart,
+			&i.CycleEnd,
+			&i.Seq,
+			&i.StripeCustomerID,
+			&i.StripeMeterEventName,
+			&i.StripeIdentifier,
+			&i.DeltaTokens,
+			&i.EventTimestamp,
+			&i.DeliveryState,
+			&i.FirstAttemptedAt,
+			&i.LastAttemptedAt,
+			&i.ConfirmedAt,
+			&i.AmbiguousAt,
+			&i.ReconciledAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const markReconciledTUMMeterReportsMissing = `-- name: MarkReconciledTUMMeterReportsMissing :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'reconciled_missing',
+    reconciled_at = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND billing_cycle_usage_id = $3
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND first_attempted_at IS NOT NULL
+  AND first_attempted_at <= $4
+`
+
+type MarkReconciledTUMMeterReportsMissingParams struct {
+	ReconciledAt        pgtype.Timestamptz
+	OrganizationID      pgtype.Text
+	BillingCycleUsageID uuid.NullUUID
+	RetryAfter          pgtype.Timestamptz
+}
+
+func (q *Queries) MarkReconciledTUMMeterReportsMissing(ctx context.Context, arg MarkReconciledTUMMeterReportsMissingParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markReconciledTUMMeterReportsMissing,
+		arg.ReconciledAt,
+		arg.OrganizationID,
+		arg.BillingCycleUsageID,
+		arg.RetryAfter,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const markTUMMeterReportAmbiguous = `-- name: MarkTUMMeterReportAmbiguous :execrows
+UPDATE stripe_meter_reports
+SET delivery_state = 'ambiguous',
+    ambiguous_at = COALESCE(ambiguous_at, $1),
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND id = $3
+  AND delivery_state IN ('pending', 'ambiguous')
+`
+
+type MarkTUMMeterReportAmbiguousParams struct {
+	AmbiguousAt    pgtype.Timestamptz
+	OrganizationID pgtype.Text
+	ID             uuid.UUID
+}
+
+func (q *Queries) MarkTUMMeterReportAmbiguous(ctx context.Context, arg MarkTUMMeterReportAmbiguousParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markTUMMeterReportAmbiguous, arg.AmbiguousAt, arg.OrganizationID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const noteTUMMeterReportReconciliation = `-- name: NoteTUMMeterReportReconciliation :execrows
+UPDATE stripe_meter_reports
+SET reconciled_at = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND billing_cycle_usage_id = $3
+  AND delivery_state IN ('pending', 'ambiguous')
+  AND first_attempted_at IS NOT NULL
+  AND first_attempted_at <= $4
+`
+
+type NoteTUMMeterReportReconciliationParams struct {
+	ReconciledAt        pgtype.Timestamptz
+	OrganizationID      pgtype.Text
+	BillingCycleUsageID uuid.NullUUID
+	RetryAfter          pgtype.Timestamptz
+}
+
+func (q *Queries) NoteTUMMeterReportReconciliation(ctx context.Context, arg NoteTUMMeterReportReconciliationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, noteTUMMeterReportReconciliation,
+		arg.ReconciledAt,
+		arg.OrganizationID,
+		arg.BillingCycleUsageID,
+		arg.RetryAfter,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const prepareStripeCheckoutIntent = `-- name: PrepareStripeCheckoutIntent :one

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -720,13 +720,16 @@ SELECT
     COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state = 'confirmed'), 0)::bigint AS confirmed_tokens
   , COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state IN ('pending', 'ambiguous', 'confirmed')), 0)::bigint AS intended_tokens
 FROM stripe_meter_reports
-WHERE organization_id = $1
-  AND billing_cycle_usage_id = $2
+JOIN billing_cycle_usage
+  ON billing_cycle_usage.organization_id = stripe_meter_reports.organization_id
+ AND billing_cycle_usage.cycle_start = stripe_meter_reports.cycle_start
+WHERE billing_cycle_usage.organization_id = $1
+  AND billing_cycle_usage.id = $2
 `
 
 type GetTUMMeterReportTotalsParams struct {
 	OrganizationID      pgtype.Text
-	BillingCycleUsageID uuid.NullUUID
+	BillingCycleUsageID uuid.UUID
 }
 
 type GetTUMMeterReportTotalsRow struct {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -81,13 +81,17 @@ func (f *fakeStripeWebhookClient) CreateMeterEvent(context.Context, stripeclient
 	return errors.New("not implemented")
 }
 
+func (f *fakeStripeWebhookClient) GetMeterEventSummary(context.Context, stripeclient.GetMeterEventSummaryInput) (float64, error) {
+	return 0, errors.New("not implemented")
+}
+
 func (f *fakeStripeWebhookClient) VerifyWebhook(payload []byte, signature string) (*stripeclient.WebhookEvent, error) {
 	f.verifyCalls.Add(1)
 	return f.verify(payload, signature)
 }
 
 func (f *fakeStripeWebhookClient) Catalog() stripeclient.Catalog {
-	return stripeclient.Catalog{PriceIDTUM: "", MeterEventName: ""}
+	return stripeclient.Catalog{PriceIDTUM: "", MeterIDTUM: "", MeterEventName: ""}
 }
 
 func testStripeWebhookHandler(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {


### PR DESCRIPTION
## Summary

- report signed hourly TUM deltas from durable Postgres snapshots after each billing refresh
- persist complete Stripe meter-event intents before delivery, retry the same identifier for less than 24 hours, and reconcile ambiguous outcomes against meter summaries before issuing a replacement
- freeze the immutable billed baseline 48 hours after cycle end and stop observation at 72 hours
- record one signed carry-forward allocation for late telemetry; if the entire freeze window was missed, carry the full finalized cycle instead of dropping it
- add and validate the Stripe TUM meter ID across setup, server, worker, and streams configuration

## Testing

- mise exec -- go test ./server/internal/background/... ./server/internal/usage/... ./server/internal/thirdparty/stripe/... ./server/cmd/gram/... -count=1
- mise run gen:sqlc-server
- mise run lint:server
- mise run build:server --readonly
- git diff --check

Stacked on #5340. Deployment must provide STRIPE_METER_ID_TUM alongside the existing Stripe price and event-name catalog values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports PAYG tokens-under-management usage to Stripe via hourly meter events with exactly-once delivery, reconciliation against complete-cycle totals, a 48h billing freeze, and a 72h carry-forward. Previously no TUM usage was sent; now we persist signed hourly deltas, reconcile ambiguous delivery, and price corrections at the original unit rate.

- Adds `ReportTUMUsageToStripe` to the hourly refresh: commits durable, signed intents before Stripe; uses identifier tum:{organization_id}:{cycle_start}:{seq}; retries within Stripe’s 24h dedupe window; reconciles ambiguous delivery against Stripe meter summaries for the full cycle; emits one durable correction if needed. Activity start-to-close is 3m; processes orgs independently; skips non-PAYG and misaligned cycles.
- Final true-up timestamps the last in-period delta at `cycle_end − 1s`; freezes the billed baseline at +48h; continues observation through +72h; carry-forward uses `usage.TUMUnitPriceUSD` ($0.00000035 per token).
- Extends the Stripe client/catalog: validates the TUM meter ID and event name; adds meter-summary reconciliation; injects `StripeClient` into `server` and `worker` flows; `mise` setup writes `STRIPE_METER_ID_TUM`; TOML/CLI flags and validation enforce it across `server`, `streams`, and `worker`.
- Implements Linear DNO-843.

**Rollout**
- Required: provision the Stripe TUM meter and set `STRIPE_METER_ID_TUM` in all environments.
- Required: deploy the schema from DNO-877 before this change.

<sup>Written for commit 71ac137ed581f8fe659ec700243d8aff0ed08176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

