### PR TITLE
feat: add SKILL.md template prefill in the create dialog

### DIFF
--- a/client/dashboard/src/pages/skills/SkillManifestDialog.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillManifestDialog.test.tsx
@@ -10,7 +10,10 @@ import {
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SkillManifestDialog } from "./SkillManifestDialog";
-import { MAX_SKILL_MANIFEST_BYTES } from "./skill-manifest";
+import {
+  MAX_SKILL_MANIFEST_BYTES,
+  SKILL_MANIFEST_TEMPLATE,
+} from "./skill-manifest";
 
 const testState = vi.hoisted(() => ({
   queryClient: { id: "query-client" },
@@ -427,6 +430,34 @@ describe("SkillManifestDialog", () => {
     expect(testState.create.mutateAsync).toHaveBeenCalledTimes(1);
   });
 
+  it("prefills the create dialog with a SKILL.md skeleton", () => {
+    render(<SkillManifestDialog mode="create" open onOpenChange={() => {}} />);
+
+    const textarea = screen.getByLabelText("SKILL.md content");
+    expect((textarea as HTMLTextAreaElement).value).toBe("");
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert template" }));
+
+    expect((textarea as HTMLTextAreaElement).value).toBe(SKILL_MANIFEST_TEMPLATE);
+  });
+
+  it("hides the template button outside create mode", () => {
+    render(
+      <SkillManifestDialog
+        mode="edit"
+        open
+        onOpenChange={() => {}}
+        skillId="skill_a"
+        derivedFromVersionId="version_source"
+        initialContent={UPDATED_MANIFEST}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Insert template" }),
+    ).toBeNull();
+  });
+
   it("rejects an oversized upload before reading it", async () => {
     const file = new File(
       [new Uint8Array(MAX_SKILL_MANIFEST_BYTES + 1)],
@@ -453,5 +484,10 @@ describe("SkillManifestDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen
+        .getByRole("button", { name: "Insert template" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
   });
 });

--- a/client/dashboard/src/pages/skills/SkillManifestDialog.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillManifestDialog.test.tsx
@@ -438,7 +438,9 @@ describe("SkillManifestDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Insert template" }));
 
-    expect((textarea as HTMLTextAreaElement).value).toBe(SKILL_MANIFEST_TEMPLATE);
+    expect((textarea as HTMLTextAreaElement).value).toBe(
+      SKILL_MANIFEST_TEMPLATE,
+    );
   });
 
   it("hides the template button outside create mode", () => {

--- a/client/dashboard/src/pages/skills/SkillManifestDialog.tsx
+++ b/client/dashboard/src/pages/skills/SkillManifestDialog.tsx
@@ -16,6 +16,7 @@ import {
   decodeManifestFile,
   manifestByteLength,
   MAX_SKILL_MANIFEST_BYTES,
+  SKILL_MANIFEST_TEMPLATE,
   validateManifestContent,
 } from "./skill-manifest";
 import { invalidateSkillQueries } from "./invalidate-skill-queries";
@@ -240,6 +241,13 @@ export function SkillManifestDialog({
     }
   };
 
+  const insertTemplate = (): void => {
+    setContent(SKILL_MANIFEST_TEMPLATE);
+    setFieldError(null);
+    if (!approvalUncertain) setMutationError(null);
+    setSavedResult(null);
+  };
+
   const continueEditing = (): void => {
     setSavedResult(null);
     setContinuing(true);
@@ -279,19 +287,33 @@ export function SkillManifestDialog({
               <label htmlFor={fieldId} className="text-sm font-medium">
                 SKILL.md content
               </label>
-              <label className="text-primary cursor-pointer text-sm font-medium hover:underline">
-                Upload .md file
-                <input
-                  type="file"
-                  accept=".md,text/markdown,text/plain"
-                  className="sr-only"
-                  disabled={isBusy || savedInvalid}
-                  onChange={(event) => {
-                    void handleFile(event.currentTarget.files?.[0]);
-                    event.currentTarget.value = "";
-                  }}
-                />
-              </label>
+              <div className="flex flex-wrap items-center gap-3">
+                {mode === "create" && (
+                  <Button
+                    type="button"
+                    variant="tertiary"
+                    size="xs"
+                    className="h-auto p-0"
+                    disabled={isBusy || savedInvalid}
+                    onClick={insertTemplate}
+                  >
+                    Insert template
+                  </Button>
+                )}
+                <label className="text-primary cursor-pointer text-sm font-medium hover:underline">
+                  Upload .md file
+                  <input
+                    type="file"
+                    accept=".md,text/markdown,text/plain"
+                    className="sr-only"
+                    disabled={isBusy || savedInvalid}
+                    onChange={(event) => {
+                      void handleFile(event.currentTarget.files?.[0]);
+                      event.currentTarget.value = "";
+                    }}
+                  />
+                </label>
+              </div>
             </div>
             <Textarea
               id={fieldId}

--- a/client/dashboard/src/pages/skills/skill-manifest.test.ts
+++ b/client/dashboard/src/pages/skills/skill-manifest.test.ts
@@ -3,6 +3,7 @@ import {
   decodeManifestFile,
   manifestByteLength,
   MAX_SKILL_MANIFEST_BYTES,
+  SKILL_MANIFEST_TEMPLATE,
   stripSkillFrontmatter,
   validateManifestContent,
 } from "./skill-manifest";
@@ -45,6 +46,14 @@ describe("skill manifest helpers", () => {
     const manifest =
       "--- \u2003\nname: example\ndescription: Example.\n---\t\n\n# Body  \ntext\u2003";
     expect(stripSkillFrontmatter(manifest)).toBe("# Body  \ntext\u2003");
+  });
+
+  it("exposes a create-dialog skeleton with required frontmatter and a body", () => {
+    expect(validateManifestContent(SKILL_MANIFEST_TEMPLATE)).toBeNull();
+    expect(SKILL_MANIFEST_TEMPLATE.startsWith("---\n")).toBe(true);
+    expect(SKILL_MANIFEST_TEMPLATE).toContain("name: my-skill");
+    expect(SKILL_MANIFEST_TEMPLATE).toContain("description:");
+    expect(stripSkillFrontmatter(SKILL_MANIFEST_TEMPLATE)).toMatch(/^# /);
   });
 
   it("safely returns malformed manifests unchanged", () => {

--- a/client/dashboard/src/pages/skills/skill-manifest.ts
+++ b/client/dashboard/src/pages/skills/skill-manifest.ts
@@ -1,5 +1,15 @@
 export const MAX_SKILL_MANIFEST_BYTES = 65_536;
 
+export const SKILL_MANIFEST_TEMPLATE = `---
+name: my-skill
+description: What this skill does and when to use it.
+---
+
+# My skill
+
+Describe the workflow, constraints, and expected output.
+`;
+
 const encoder = new TextEncoder();
 
 export function manifestByteLength(content: string): number {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When adding a skill by hand, the SKILL.md shape (YAML front matter plus a Markdown body) is easy to forget. The create dialog now has a subtle **Insert template** control above the textarea that prefills a valid skeleton.

## Changes

- Add `SKILL_MANIFEST_TEMPLATE` with required `name` / `description` front matter and a placeholder body
- Show **Insert template** only in create mode, styled as a tertiary text button next to **Upload .md file**
- Leave edit and suggestion-approval flows unchanged so existing content is not overwritten by accident

## Test plan

- [x] Unit tests for the template shape and create-dialog prefill (`aube run -F dashboard test -- src/pages/skills/skill-manifest.test.ts src/pages/skills/SkillManifestDialog.test.tsx` — 18 passed)
- [x] Open **Add Skill**, click **Insert template**, confirm the textarea fills with front matter plus body
- [x] Confirm the button is hidden when editing an existing skill
- [x] Confirm **Add skill** accepts the prefilled content and records a valid version

### Demo

![Empty Add skill dialog with Insert template](https://cursor.com/artifacts/c/art-6cf6a424-696e-4cfd-a6d6-63ad46ef6ac3)

![Add skill dialog after inserting the SKILL.md template](https://cursor.com/artifacts/c/art-11867301-5560-46f4-a188-9bd84aba0eee)

<a href="https://cursor.com/agents/bc-fb9761e0-fd74-4918-934e-91fc7e0b54d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finsert_skill_template.webm"><img src="https://cursor.com/artifacts/c/art-2aa447aa-fb17-457d-928f-fa2bca396f04" alt="insert_skill_template.webm" /></a>

What it shows:
1. Empty Add skill dialog with **Insert template** above the textarea
2. Click **Insert template**
3. Textarea fills with YAML front matter (`name`, `description`) plus a Markdown body

Fixes DNO-801

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-801](https://linear.app/speakeasy/issue/DNO-801/feat-add-manual-skill-template-prefill-button)

<div><a href="https://cursor.com/agents/bc-fb9761e0-fd74-4918-934e-91fc7e0b54d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb9761e0-fd74-4918-934e-91fc7e0b54d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Insert template control to the Add Skill dialog that prefills a valid SKILL.md skeleton, reducing manual formatting errors. Previously, users had to reconstruct the YAML front matter and body by hand.

- Adds `SKILL_MANIFEST_TEMPLATE` (required `name`/`description` front matter plus a Markdown body) and uses it to prefill the textarea on click.
- Shows Insert template only in create mode, next to Upload .md file; disables it while the dialog is busy.
- Leaves validation, upload behavior, and byte-limit checks unchanged; edit and suggestion-approval flows are unaffected.
- Tests cover template content, visibility, prefill, and disabled state. No API changes or migrations. Addresses Linear DNO-801.

<sup>Written for commit 6b698288cd10ff88e5f9cafb5fb262a3fa75bda6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

