### PR TITLE
fix: configure local assistant runtime during zero

### DIFF
--- a/.mise-tasks/zero/assistants.mts
+++ b/.mise-tasks/zero/assistants.mts
@@ -6,13 +6,34 @@
 //USAGE flag "--restart" default="false" help="Force local provider/image and rebuild the runtime image."
 //USAGE flag "--skip-image" default="false" help="Write env vars only; do not build the runtime image."
 
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { $ } from "zx";
 
 const LOCAL_PROVIDER = "local";
 const LOCAL_IMAGE = "gram-assistant-runtime";
+const PROVIDER_KEY = "GRAM_ASSISTANT_RUNTIME_PROVIDER";
+const IMAGE_KEY = "GRAM_ASSISTANT_RUNTIME_OCI_IMAGE";
 
 function isSet(value: string | undefined): boolean {
   return typeof value === "string" && value !== "" && value !== "unset";
+}
+
+function localConfigValue(key: string): string | undefined {
+  const configPath = join(process.cwd(), "mise.local.toml");
+  if (!existsSync(configPath)) {
+    return undefined;
+  }
+
+  const match = new RegExp(`^\\s*${key}\\s*=\\s*(.+?)\\s*$`, "m").exec(
+    readFileSync(configPath, "utf-8"),
+  );
+  if (!match) {
+    return undefined;
+  }
+
+  const value = match[1].trim().replace(/^["']|["']$/g, "");
+  return isSet(value) ? value : undefined;
 }
 
 async function saveConfig(key: string, value: string): Promise<void> {
@@ -31,32 +52,39 @@ async function imageExists(image: string): Promise<boolean> {
   return result.ok && result.stdout.trim() !== "";
 }
 
+async function ensureLocalConfig(
+  key: string,
+  fallback: string,
+  restart: boolean,
+): Promise<string> {
+  const existing = localConfigValue(key);
+  if (!restart && existing) {
+    console.log(`✅ ${key} is already set.`);
+    return existing;
+  }
+
+  // Persist a value already in the process environment (intentional override
+  // or a leftover from the old mise.toml defaults) so a later clean shell
+  // still has it. Fall back to the local default when nothing is set.
+  const value = restart
+    ? fallback
+    : isSet(process.env[key])
+      ? process.env[key]!
+      : fallback;
+  await saveConfig(key, value);
+  return value;
+}
+
 async function run() {
   const restart = process.env["usage_restart"] === "true";
   const skipImage = process.env["usage_skip_image"] === "true";
-  const providerSet = isSet(process.env["GRAM_ASSISTANT_RUNTIME_PROVIDER"]);
-  const imageSet = isSet(process.env["GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"]);
 
-  if (restart || !providerSet) {
-    await saveConfig("GRAM_ASSISTANT_RUNTIME_PROVIDER", LOCAL_PROVIDER);
-  } else {
-    console.log("✅ GRAM_ASSISTANT_RUNTIME_PROVIDER is already set.");
-  }
-
-  if (restart || !imageSet) {
-    await saveConfig("GRAM_ASSISTANT_RUNTIME_OCI_IMAGE", LOCAL_IMAGE);
-  } else {
-    console.log("✅ GRAM_ASSISTANT_RUNTIME_OCI_IMAGE is already set.");
-  }
-
-  const provider =
-    restart || !providerSet
-      ? LOCAL_PROVIDER
-      : process.env["GRAM_ASSISTANT_RUNTIME_PROVIDER"]!;
-  const imageName =
-    restart || !imageSet
-      ? LOCAL_IMAGE
-      : process.env["GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"]!;
+  const provider = await ensureLocalConfig(
+    PROVIDER_KEY,
+    LOCAL_PROVIDER,
+    restart,
+  );
+  const imageName = await ensureLocalConfig(IMAGE_KEY, LOCAL_IMAGE, restart);
   const imageRef = `${imageName}:dev`;
 
   if (skipImage) {

--- a/.mise-tasks/zero/assistants.mts
+++ b/.mise-tasks/zero/assistants.mts
@@ -1,0 +1,92 @@
+#!/usr/bin/env -S node
+
+//MISE description="Configure the local assistant runtime (provider, image, and initial build)"
+//MISE hide=true
+//MISE dir="{{ config_root }}"
+//USAGE flag "--restart" default="false" help="Force local provider/image and rebuild the runtime image."
+//USAGE flag "--skip-image" default="false" help="Write env vars only; do not build the runtime image."
+
+import { $ } from "zx";
+
+const LOCAL_PROVIDER = "local";
+const LOCAL_IMAGE = "gram-assistant-runtime";
+
+function isSet(value: string | undefined): boolean {
+  return typeof value === "string" && value !== "" && value !== "unset";
+}
+
+async function saveConfig(key: string, value: string): Promise<void> {
+  await $`touch mise.local.toml`;
+  await $`mise set --file mise.local.toml ${key}=${value}`;
+  console.log(`🔑 ${key} has been set in mise.local.toml`);
+}
+
+async function dockerAvailable(): Promise<boolean> {
+  const result = await $`docker info`.nothrow().quiet();
+  return result.ok;
+}
+
+async function imageExists(image: string): Promise<boolean> {
+  const result = await $`docker images -q ${image}`.nothrow().quiet();
+  return result.ok && result.stdout.trim() !== "";
+}
+
+async function run() {
+  const restart = process.env["usage_restart"] === "true";
+  const skipImage = process.env["usage_skip_image"] === "true";
+  const providerSet = isSet(process.env["GRAM_ASSISTANT_RUNTIME_PROVIDER"]);
+  const imageSet = isSet(process.env["GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"]);
+
+  if (restart || !providerSet) {
+    await saveConfig("GRAM_ASSISTANT_RUNTIME_PROVIDER", LOCAL_PROVIDER);
+  } else {
+    console.log("✅ GRAM_ASSISTANT_RUNTIME_PROVIDER is already set.");
+  }
+
+  if (restart || !imageSet) {
+    await saveConfig("GRAM_ASSISTANT_RUNTIME_OCI_IMAGE", LOCAL_IMAGE);
+  } else {
+    console.log("✅ GRAM_ASSISTANT_RUNTIME_OCI_IMAGE is already set.");
+  }
+
+  const provider =
+    restart || !providerSet
+      ? LOCAL_PROVIDER
+      : process.env["GRAM_ASSISTANT_RUNTIME_PROVIDER"]!;
+  const imageName =
+    restart || !imageSet
+      ? LOCAL_IMAGE
+      : process.env["GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"]!;
+  const imageRef = `${imageName}:dev`;
+
+  if (skipImage) {
+    return;
+  }
+
+  if (provider !== LOCAL_PROVIDER) {
+    console.log(
+      `✅ Assistant runtime provider is ${provider}; skipping local image build.`,
+    );
+    return;
+  }
+
+  if (!(await dockerAvailable())) {
+    console.log(
+      "⚠️ Docker is not available; skipping assistant runtime image build.",
+    );
+    console.log(
+      "⚠️ Run `mise run build:assistants-runtime-image` after Docker is up.",
+    );
+    return;
+  }
+
+  if (!restart && (await imageExists(imageRef))) {
+    console.log(`✅ Assistant runtime image ${imageRef} already exists.`);
+    return;
+  }
+
+  console.log(`💬 Building assistant runtime image ${imageRef}...`);
+  await $({ stdio: "inherit" })`mise run build:assistants-runtime-image`;
+}
+
+await run();

--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -57,9 +57,7 @@ if (assistantRuntimeProvider === "local") {
     ),
   );
 } else if (assistantRuntimeProvider) {
-  console.log(
-    `⚪︎ Assistant runtime provider: ${assistantRuntimeProvider}`,
-  );
+  console.log(`⚪︎ Assistant runtime provider: ${assistantRuntimeProvider}`);
 } else {
   console.log(
     "⚪︎ Assistant runtime provider is not configured (run `mise run zero:assistants`)",

--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -48,6 +48,24 @@ if (trueish.has(process.env["GRAM_ENABLE_OTEL_METRICS"] ?? "")) {
   );
 }
 
+const assistantRuntimeProvider =
+  process.env["GRAM_ASSISTANT_RUNTIME_PROVIDER"] ?? "";
+if (assistantRuntimeProvider === "local") {
+  console.log(
+    chalk.greenBright(
+      "⚫︎ Assistant runtimes run locally (GRAM_ASSISTANT_RUNTIME_PROVIDER)",
+    ),
+  );
+} else if (assistantRuntimeProvider) {
+  console.log(
+    `⚪︎ Assistant runtime provider: ${assistantRuntimeProvider}`,
+  );
+} else {
+  console.log(
+    "⚪︎ Assistant runtime provider is not configured (run `mise run zero:assistants`)",
+  );
+}
+
 const assistantRuntimeServerURL =
   process.env["GRAM_ASSISTANT_RUNTIME_SERVER_URL"] ?? "";
 if (assistantRuntimeServerURL) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,12 +92,9 @@ Use `pr-demo-gif` when a user-visible change needs a shareable PR screenshot, GI
 
 ### Testing assistants locally
 
-`./zero` (and `mise run zero:assistants`) writes local assistant runtime defaults into `mise.local.toml` when they are unset, and builds `gram-assistant-runtime:dev` if that image is missing:
+`./zero` (and `mise run zero:assistants`) writes `GRAM_ASSISTANT_RUNTIME_PROVIDER` and `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE` into `mise.local.toml` when those keys are missing there — persisting a value already in the environment, or `local` / `gram-assistant-runtime` if unset — and builds `gram-assistant-runtime:dev` if that image is missing.
 
-- `GRAM_ASSISTANT_RUNTIME_PROVIDER = "local"`
-- `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE = "gram-assistant-runtime"`
-
-`mise run zero:assistants --restart` rewrites those keys and rebuilds the image. Do not leave those keys in `mise.toml` — committed defaults make it impossible to tell an intentional override from a stale value. LLM chat still needs `OPENROUTER_DEV_KEY` in `mise.local.toml` (`mise run zero:openrouter`).
+`mise run zero:assistants --restart` rewrites those keys to the local defaults and rebuilds the image (use this when a stale `flyio` pin is in the way). Do not leave those keys in `mise.toml` — committed defaults make it impossible to tell an intentional override from a stale value. LLM chat still needs `OPENROUTER_DEV_KEY` in `mise.local.toml` (`mise run zero:openrouter`).
 
 `.mcp.json` registers the `assistants-dev` MCP server (`server/cmd/dev-mcp`), which drives the local management API without the dashboard UI. It logs into the local stack on its own (dev-idp auto-approves), so no setup is needed beyond a running dev stack. Use its tools — assistant CRUD, `run_turn` (send a message and wait for the assistant's reply), `load_chat`, and trigger CRUD — to exercise assistant runtime changes end to end. `whoami` lists the available project slugs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,13 @@ Use `pr-demo-gif` when a user-visible change needs a shareable PR screenshot, GI
 
 ### Testing assistants locally
 
+`./zero` (and `mise run zero:assistants`) writes local assistant runtime defaults into `mise.local.toml` when they are unset, and builds `gram-assistant-runtime:dev` if that image is missing:
+
+- `GRAM_ASSISTANT_RUNTIME_PROVIDER = "local"`
+- `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE = "gram-assistant-runtime"`
+
+`mise run zero:assistants --restart` rewrites those keys and rebuilds the image. Do not leave those keys in `mise.toml` — committed defaults make it impossible to tell an intentional override from a stale value. LLM chat still needs `OPENROUTER_DEV_KEY` in `mise.local.toml` (`mise run zero:openrouter`).
+
 `.mcp.json` registers the `assistants-dev` MCP server (`server/cmd/dev-mcp`), which drives the local management API without the dashboard UI. It logs into the local stack on its own (dev-idp auto-approves), so no setup is needed beyond a running dev stack. Use its tools — assistant CRUD, `run_turn` (send a message and wait for the assistant's reply), `load_chat`, and trigger CRUD — to exercise assistant runtime changes end to end. `whoami` lists the available project slugs.
 
 ### Database Migrations

--- a/agents/runtime-image/README.md
+++ b/agents/runtime-image/README.md
@@ -5,14 +5,21 @@ The container image assistant runtimes run in: the Rust runner
 
 ## Local development
 
-Local development uses the `local` assistant runtime provider (the default,
-`GRAM_ASSISTANT_RUNTIME_PROVIDER=local`): the Gram server starts one runtime
-container per assistant on your machine's Docker daemon, on demand. No Fly.io
-credentials, apps, or registry pushes are involved.
+Local development uses the `local` assistant runtime provider. `./zero`
+(including `./zero --agent`) runs `mise run zero:assistants`, which writes
+`GRAM_ASSISTANT_RUNTIME_PROVIDER=local` and
+`GRAM_ASSISTANT_RUNTIME_OCI_IMAGE=gram-assistant-runtime` into `mise.local.toml`
+when those vars are unset, and builds `gram-assistant-runtime:dev` if the image
+is missing. The Gram server then starts one runtime container per assistant on
+your machine's Docker daemon, on demand. No Fly.io credentials, apps, or
+registry pushes are involved.
+
+`mise run zero:assistants --restart` rewrites those keys and rebuilds the image.
 
 ### Workflow
 
-1. Build the image:
+1. First-time setup is `./zero` (or `mise run zero:assistants`). To rebuild
+   the image later:
 
    ```sh
    mise run build:assistants-runtime-image
@@ -57,7 +64,7 @@ mise run assistants:local-clean
 
 ### Smoke test
 
-1. `mise run build:assistants-runtime-image`
+1. `mise run zero:assistants` (or `mise run build:assistants-runtime-image`)
 2. Start the stack and send a turn to any assistant.
 3. `mise run assistants:local-status` — the assistant's container is `Up` with
    a `127.0.0.1:<port>->8081/tcp` publish, and the turn produces a reply.
@@ -68,5 +75,6 @@ mise run assistants:local-clean
 
 If your `mise.local.toml` still pins `GRAM_ASSISTANT_RUNTIME_PROVIDER=flyio`
 (or a `registry.fly.io/...` value for `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE`),
-remove those keys along with `GRAM_ASSISTANT_RUNTIME_FLYIO_*` to pick up the
-local defaults.
+`mise run zero:assistants --restart` overwrites those two keys with the local
+defaults and rebuilds the image. Remove any leftover `GRAM_ASSISTANT_RUNTIME_FLYIO_*`
+keys yourself.

--- a/mise.toml
+++ b/mise.toml
@@ -276,10 +276,17 @@ GRAM_FUNCTIONS_LOCAL_RUNNER_ROOT = "{{config_root}}/local/functions"
 ########################################
 ## Where assistant runtimes run.
 ## Allowed values: local, flyio, gke.
+## Left unset here so `./zero` / `mise run zero:assistants` can tell "not
+## configured" from an intentional override in mise.local.toml or the
+## environment. When unset, that task writes local defaults:
+##   GRAM_ASSISTANT_RUNTIME_PROVIDER = "local"
+##   GRAM_ASSISTANT_RUNTIME_OCI_IMAGE = "gram-assistant-runtime"
+## and builds `gram-assistant-runtime:dev` if the image is missing.
+## `mise run zero:assistants --restart` rewrites those keys and rebuilds.
 ## The local provider starts runtime containers on demand on this machine's
-## Docker daemon. Build the image with `mise run build:assistants-runtime-image`.
-GRAM_ASSISTANT_RUNTIME_PROVIDER = "local"
-GRAM_ASSISTANT_RUNTIME_OCI_IMAGE = "gram-assistant-runtime"
+## Docker daemon. Rebuild anytime with `mise run build:assistants-runtime-image`.
+# GRAM_ASSISTANT_RUNTIME_PROVIDER = "local"
+# GRAM_ASSISTANT_RUNTIME_OCI_IMAGE = "gram-assistant-runtime"
 
 ##################
 ## MCP Registry ##

--- a/zero
+++ b/zero
@@ -146,6 +146,8 @@ interactive_only mise run zero:melange
 interactive_only mise run zero:fly
 mise run zero:encryption
 mise run zero:tls
+# Env only here: the image build needs Docker, which infra:start confirms.
+mise run zero:assistants --skip-image
 
 echo -e "\n⏳ Updating VS Code and Cursor editor settings"
 mise run install:vscode
@@ -193,6 +195,9 @@ server_cache_pid=$!
 
 echo -e "\n⏳ Starting infra"
 mise infra:start
+
+echo -e "\n⏳ Configuring local assistant runtime"
+mise run zero:assistants
 
 echo -e "\n⏳ Running migrations"
 mise run zero:migrations


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`./zero --agent` did not set up the local assistant runtime on its own. `GRAM_ASSISTANT_RUNTIME_PROVIDER` and `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE` lived as committed defaults in `mise.toml`, so it was impossible to tell an intentional override from a stale value. First-time setup still required Slack-thread steps: build the image, then hand-edit `mise.local.toml`.

Fixes DNO-514.

## Change

- Comment those two keys out of `mise.toml` so "unset" is distinguishable from an override in `mise.local.toml` or the environment.
- Add `mise run zero:assistants`, which writes those keys into `mise.local.toml` when they are missing there (persisting a value already in the environment, or `local` / `gram-assistant-runtime` if unset) and builds `gram-assistant-runtime:dev` if the image is missing.
- `./zero` (including `--agent`) runs it twice: env-only before infra, then again after Docker is up so the image can be built.
- `--restart` force-rewrites the local keys and rebuilds, for stale Fly.io pins or a dirty local image.
- Document the flow in `CLAUDE.md` and `agents/runtime-image/README.md` so this is not Slack-only knowledge.

The task is idempotent and non-interactive. Existing `flyio` / `gke` pins in `mise.local.toml` are left alone unless `--restart` is passed. `OPENROUTER_DEV_KEY` is still configured separately via `mise run zero:openrouter`.

## Test

Ran `mise run zero:assistants` through the unset, persist, `--restart`, flyio-skip, image-exists, and missing-image paths. The missing-image path built `gram-assistant-runtime:dev` locally.

[zero:assistants test log](https://cursor.com/artifacts/c/art-b02ece4e-8e9b-47ed-ae1e-ed22db27f72a)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-514](https://linear.app/speakeasy/issue/DNO-514/bug-zero-does-not-configure-local-assistant-runtime-cleanly)

<div><a href="https://cursor.com/agents/bc-07a46aae-4e8a-4951-b972-97347812279c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07a46aae-4e8a-4951-b972-97347812279c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Zero now configures the local assistant runtime automatically. Previously `./zero --agent` relied on committed defaults and manual steps; now it writes local defaults to `mise.local.toml` when unset, persists any existing env values into that file, and builds `gram-assistant-runtime:dev` if missing. Addresses Linear DNO-514.

- Remove committed `GRAM_ASSISTANT_RUNTIME_PROVIDER` and `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE` defaults from `mise.toml` so unset is distinguishable from an override.
- Add `mise run zero:assistants` (idempotent, non-interactive): reads `mise.local.toml` as source of truth, writes missing keys (persisting any env value or defaulting to `local` / `gram-assistant-runtime`), and builds the image when needed.
- Update `./zero` to run that task twice: env-only before infra with `--skip-image`, then again after infra so Docker can build.
- Support `--restart` to force local provider/image and rebuild; otherwise existing `flyio`/`gke` overrides remain unchanged. `OPENROUTER_DEV_KEY` setup is unchanged (`mise run zero:openrouter`).
- Enhance `zero` summary to display the assistant runtime provider and hint to run `mise run zero:assistants` when unset.

**Migration**
- If your `mise.local.toml` pins a non-local runtime (e.g., `flyio`/`gke`), run: `mise run zero:assistants --restart`. Remove any `GRAM_ASSISTANT_RUNTIME_FLYIO_*` keys manually. No action needed for existing local setups.

<sup>Written for commit c5067bf9cf18e145ad4ec3d015904cf518852282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

