### PR TITLE
feat: forbid raw user_email filtering in ClickHouse queries via glint

### DIFF
--- a/.changeset/no-raw-user-email-glint-rule.md
+++ b/.changeset/no-raw-user-email-glint-rule.md
@@ -1,0 +1,9 @@
+---
+"server": patch
+---
+
+Add a glint rule (no-raw-user-email-filter) forbidding raw user_email
+matching or bucketing in squirrel-built ClickHouse queries: the email
+dimension must go through the canonical identity fold so one employee's
+linked emails read as one identity. Known legacy sites carry explicit
+nolint annotations that double as the GA cleanup checklist.

--- a/glint/no_raw_user_email_filter.go
+++ b/glint/no_raw_user_email_filter.go
@@ -137,7 +137,25 @@ func reportRawUserEmailLiterals(pass *analysis.Pass, expr ast.Expr, reported map
 	ast.Inspect(expr, func(n ast.Node) bool {
 		switch e := n.(type) {
 		case *ast.CallExpr:
+			// Matching the funnel by name prefix is deliberate: the remaining
+			// canonical-fold flips keep adding canonical* helpers, and a
+			// type-pinned function list would need updating for each one. The
+			// trade-off is that any function named canonical* is trusted to
+			// fold — do not name a helper canonical* unless it routes through
+			// the identity_map.
 			if calleeName(e) != "" && strings.HasPrefix(strings.ToLower(calleeName(e)), "canonical") {
+				return false
+			}
+		case *ast.CompositeLit:
+			// squirrel map values are filter DATA, not column expressions: a
+			// value that happens to equal "user_email" (e.g. querying for a
+			// dimension by that name) is not a violation. Scan keys only.
+			if isSquirrelMapType(pass.TypesInfo.TypeOf(e)) {
+				for _, elt := range e.Elts {
+					if kv, ok := elt.(*ast.KeyValueExpr); ok {
+						reportRawUserEmailLiterals(pass, kv.Key, reported)
+					}
+				}
 				return false
 			}
 		case *ast.BasicLit:

--- a/glint/no_raw_user_email_filter.go
+++ b/glint/no_raw_user_email_filter.go
@@ -1,0 +1,172 @@
+package glint
+
+// no-raw-user-email-filter forbids matching or bucketing the email dimension
+// on raw user_email in squirrel-built ClickHouse queries. Employee identity is
+// folded through the identity_map at read time (joinGet — see
+// server/internal/telemetry/repo/canonical_identity.go); a raw comparison or
+// GROUP BY splits one employee across their work, personal, and case-variant
+// emails, which is the regression class behind DNO-827/DNO-425 and the reason
+// the canonical fold exists. Squirrel is only permitted for ClickHouse in this
+// repository (Postgres must use sqlc), so squirrel usage is the precise scope
+// of the rule; SELECT projections are deliberately out of scope — reading the
+// email for display is fine, matching on it is not.
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const (
+	noRawUserEmailFilterAnalyzer       = "norawuseremailfilter"
+	noRawUserEmailFilterDefaultMessage = "route email matching through the canonical identity fold (canonicalEmailExpr / joinGet over identity_map) instead of raw user_email — raw matching splits one employee across their linked emails"
+)
+
+const squirrelPkgPath = "github.com/Masterminds/squirrel"
+
+// squirrelFilterMethods are the SelectBuilder methods that express matching or
+// bucketing. Select/Column projections are intentionally absent.
+var squirrelFilterMethods = map[string]bool{
+	"Where":      true,
+	"Having":     true,
+	"GroupBy":    true,
+	"JoinClause": true,
+}
+
+type noRawUserEmailFilterSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newNoRawUserEmailFilterAnalyzer(_ noRawUserEmailFilterSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:     noRawUserEmailFilterAnalyzer,
+		Doc:      noRawUserEmailFilterDefaultMessage,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run:      runNoRawUserEmailFilter,
+	}
+}
+
+func runNoRawUserEmailFilter(pass *analysis.Pass) (any, error) {
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	reported := make(map[token.Pos]bool)
+
+	ins.Preorder([]ast.Node{(*ast.CallExpr)(nil), (*ast.CompositeLit)(nil)}, func(node ast.Node) {
+		switch n := node.(type) {
+		case *ast.CallExpr:
+			if isSquirrelFilterCall(pass, n) || isSquirrelExprCall(pass, n) {
+				for _, arg := range n.Args {
+					reportRawUserEmailLiterals(pass, arg, reported)
+				}
+			}
+		case *ast.CompositeLit:
+			// squirrel.Eq / squirrel.NotEq map keys are column expressions
+			// wherever the literal appears, including inside helpers that
+			// return predicates for a later Where.
+			if isSquirrelMapType(pass.TypesInfo.TypeOf(n)) {
+				for _, elt := range n.Elts {
+					if kv, ok := elt.(*ast.KeyValueExpr); ok {
+						reportRawUserEmailLiterals(pass, kv.Key, reported)
+					}
+				}
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+// isSquirrelFilterCall reports whether call is a matching/bucketing method on
+// a squirrel builder.
+func isSquirrelFilterCall(pass *analysis.Pass, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !squirrelFilterMethods[sel.Sel.Name] {
+		return false
+	}
+	return isSquirrelType(pass.TypesInfo.TypeOf(sel.X))
+}
+
+// isSquirrelExprCall reports whether call is squirrel.Expr(...), the escape
+// hatch every hand-written predicate goes through.
+func isSquirrelExprCall(pass *analysis.Pass, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Expr" {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	pkgName, ok := pass.TypesInfo.Uses[ident].(*types.PkgName)
+	return ok && pkgName.Imported().Path() == squirrelPkgPath
+}
+
+func isSquirrelType(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok || named.Obj().Pkg() == nil {
+		return false
+	}
+	return named.Obj().Pkg().Path() == squirrelPkgPath
+}
+
+func isSquirrelMapType(t types.Type) bool {
+	if !isSquirrelType(t) {
+		return false
+	}
+	named := t.(*types.Named)
+	name := named.Obj().Name()
+	return name == "Eq" || name == "NotEq"
+}
+
+// reportRawUserEmailLiterals walks an expression and reports every string
+// literal that names user_email. Descent stops at calls to the canonical fold
+// helpers (canonical*): a literal handed to them is the sanctioned path, and
+// the emitted SQL folds it through joinGet.
+func reportRawUserEmailLiterals(pass *analysis.Pass, expr ast.Expr, reported map[token.Pos]bool) {
+	ast.Inspect(expr, func(n ast.Node) bool {
+		switch e := n.(type) {
+		case *ast.CallExpr:
+			if calleeName(e) != "" && strings.HasPrefix(strings.ToLower(calleeName(e)), "canonical") {
+				return false
+			}
+		case *ast.BasicLit:
+			if e.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(e.Value)
+			if err != nil {
+				return true
+			}
+			if !strings.Contains(value, "user_email") || strings.Contains(value, "joinGet('identity_map'") {
+				return true
+			}
+			if reported[e.Pos()] {
+				return true
+			}
+			reported[e.Pos()] = true
+			pass.ReportRangef(e, "%s", noRawUserEmailFilterDefaultMessage)
+		}
+		return true
+	})
+}
+
+func calleeName(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		return fun.Sel.Name
+	}
+	return ""
+}

--- a/glint/no_raw_user_email_filter.go
+++ b/glint/no_raw_user_email_filter.go
@@ -60,7 +60,15 @@ func runNoRawUserEmailFilter(pass *analysis.Pass) (any, error) {
 		switch n := node.(type) {
 		case *ast.CallExpr:
 			if isSquirrelFilterCall(pass, n) || isSquirrelExprCall(pass, n) {
-				for _, arg := range n.Args {
+				// Only the predicate/SQL arguments carry column expressions.
+				// For Where/Having/JoinClause/Expr that is the first argument;
+				// the rest are bound values — data that may legitimately
+				// contain "user_email". GroupBy is variadic SQL throughout.
+				args := n.Args
+				if !isGroupByCall(n) && len(args) > 1 {
+					args = args[:1]
+				}
+				for _, arg := range args {
 					reportRawUserEmailLiterals(pass, arg, reported)
 				}
 			}
@@ -79,6 +87,11 @@ func runNoRawUserEmailFilter(pass *analysis.Pass) (any, error) {
 	})
 
 	return nil, nil
+}
+
+func isGroupByCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "GroupBy"
 }
 
 // isSquirrelFilterCall reports whether call is a matching/bucketing method on

--- a/glint/no_raw_user_email_filter_test.go
+++ b/glint/no_raw_user_email_filter_test.go
@@ -1,0 +1,27 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestNoRawUserEmailFilter(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newNoRawUserEmailFilterAnalyzer(noRawUserEmailFilterSettings{}), "norawuseremailfilter")
+}
+
+func TestBuildAnalyzersSkipsDisabledNoRawUserEmailFilter(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+	p.settings.Rules.NoRawUserEmailFilter.Disabled = false
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, noRawUserEmailFilterAnalyzer, analyzers[0].Name)
+}

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -36,6 +36,7 @@ type ruleSettings struct {
 	NoClientErrorLogError      noClientErrorLogErrorSettings      `json:"no-client-error-log-error"`
 	NoBareSqlstate             noBareSqlstateSettings             `json:"no-bare-sqlstate"`
 	RpcEndpointFormat          rpcEndpointFormatSettings          `json:"rpc-endpoint-format"`
+	NoRawUserEmailFilter       noRawUserEmailFilterSettings       `json:"no-raw-user-email-filter"`
 }
 
 type plugin struct {
@@ -100,6 +101,9 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	}
 	if !p.settings.Rules.RpcEndpointFormat.Disabled {
 		analyzers = append(analyzers, newRpcEndpointFormatAnalyzer(p.settings.Rules.RpcEndpointFormat))
+	}
+	if !p.settings.Rules.NoRawUserEmailFilter.Disabled {
+		analyzers = append(analyzers, newNoRawUserEmailFilterAnalyzer(p.settings.Rules.NoRawUserEmailFilter))
 	}
 
 	return analyzers, nil

--- a/glint/plugin_test.go
+++ b/glint/plugin_test.go
@@ -28,6 +28,7 @@ func disabledAllRulesPlugin() *plugin {
 				NoClientErrorLogError:      noClientErrorLogErrorSettings{Disabled: true},
 				NoBareSqlstate:             noBareSqlstateSettings{Disabled: true},
 				RpcEndpointFormat:          rpcEndpointFormatSettings{Disabled: true},
+				NoRawUserEmailFilter:       noRawUserEmailFilterSettings{Disabled: true},
 			},
 		},
 	}
@@ -48,5 +49,5 @@ func TestBuildAnalyzersAllEnabled(t *testing.T) {
 	p := &plugin{}
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
-	require.Len(t, analyzers, 16)
+	require.Len(t, analyzers, 17)
 }

--- a/glint/testdata/src/github.com/Masterminds/squirrel/squirrel.go
+++ b/glint/testdata/src/github.com/Masterminds/squirrel/squirrel.go
@@ -1,0 +1,28 @@
+package squirrel
+
+type Sqlizer interface {
+	ToSql() (string, []interface{}, error)
+}
+
+type SelectBuilder struct{}
+
+func Select(columns ...string) SelectBuilder                                           { return SelectBuilder{} }
+func (b SelectBuilder) Where(pred interface{}, args ...interface{}) SelectBuilder      { return b }
+func (b SelectBuilder) Having(pred interface{}, args ...interface{}) SelectBuilder     { return b }
+func (b SelectBuilder) GroupBy(groupBys ...string) SelectBuilder                       { return b }
+func (b SelectBuilder) JoinClause(pred interface{}, args ...interface{}) SelectBuilder { return b }
+func (b SelectBuilder) Column(column interface{}, args ...interface{}) SelectBuilder   { return b }
+
+type Eq map[string]interface{}
+
+func (e Eq) ToSql() (string, []interface{}, error) { return "", nil, nil }
+
+type NotEq map[string]interface{}
+
+func (e NotEq) ToSql() (string, []interface{}, error) { return "", nil, nil }
+
+type expr struct{}
+
+func (expr) ToSql() (string, []interface{}, error) { return "", nil, nil }
+
+func Expr(sql string, args ...interface{}) Sqlizer { return expr{} }

--- a/glint/testdata/src/norawuseremailfilter/example.go
+++ b/glint/testdata/src/norawuseremailfilter/example.go
@@ -29,6 +29,10 @@ func allowed() {
 	sb = sb.Where(squirrel.Eq{"user_id": "u"})
 	// Map VALUES are filter data, not column expressions.
 	sb = sb.Where(squirrel.Eq{"dimension": "user_email"})
+	// Bound values after the predicate argument are data too.
+	sb = sb.Where("dimension = ?", "user_email")
+	sb = sb.Having("countIf(dim = ?) > 0", "user_email")
+	_ = squirrel.Expr("dimension = ?", "user_email")
 	sb = sb.GroupBy("hook_hostname")
 	_ = squirrel.Expr("joinGet('identity_map', 'canonical_user_id', 'org', lower(user_email))")
 	_ = sb

--- a/glint/testdata/src/norawuseremailfilter/example.go
+++ b/glint/testdata/src/norawuseremailfilter/example.go
@@ -1,0 +1,33 @@
+package norawuseremailfilter
+
+import "github.com/Masterminds/squirrel"
+
+func canonicalEmailExpr(orgLit, expr string) string {
+	return "joinGet('identity_map', 'canonical_email', " + orgLit + ", lower(" + expr + "))"
+}
+
+func filters() {
+	sb := squirrel.Select("user_email AS user_id")                                // projections are allowed
+	sb = sb.Where("lower(user_email) = ?", "x")                                   // want "route email matching through the canonical identity fold"
+	sb = sb.GroupBy("user_email")                                                 // want "route email matching through the canonical identity fold"
+	sb = sb.Having("countIf(user_email != '') = 0")                               // want "route email matching through the canonical identity fold"
+	sb = sb.Where(squirrel.Eq{"lower(telemetry_logs.user_email)": []string{"x"}}) // want "route email matching through the canonical identity fold"
+	_ = sb
+}
+
+func predicateHelpers() {
+	// Eq keys are column expressions wherever the literal lives.
+	pred := squirrel.Eq{"user_email": ""} // want "route email matching through the canonical identity fold"
+	_ = pred
+	_ = squirrel.Expr("session_user_email IN (?)", "x") // want "route email matching through the canonical identity fold"
+}
+
+func allowed() {
+	// The fold itself and literals routed through the canonical helpers.
+	sb := squirrel.Select("x")
+	sb = sb.Where("(user_id = '' AND " + canonicalEmailExpr("'org'", "telemetry_logs.user_email") + " = ?)")
+	sb = sb.Where(squirrel.Eq{"user_id": "u"})
+	sb = sb.GroupBy("hook_hostname")
+	_ = squirrel.Expr("joinGet('identity_map', 'canonical_user_id', 'org', lower(user_email))")
+	_ = sb
+}

--- a/glint/testdata/src/norawuseremailfilter/example.go
+++ b/glint/testdata/src/norawuseremailfilter/example.go
@@ -27,6 +27,8 @@ func allowed() {
 	sb := squirrel.Select("x")
 	sb = sb.Where("(user_id = '' AND " + canonicalEmailExpr("'org'", "telemetry_logs.user_email") + " = ?)")
 	sb = sb.Where(squirrel.Eq{"user_id": "u"})
+	// Map VALUES are filter data, not column expressions.
+	sb = sb.Where(squirrel.Eq{"dimension": "user_email"})
 	sb = sb.GroupBy("hook_hostname")
 	_ = squirrel.Expr("joinGet('identity_map', 'canonical_user_id', 'org', lower(user_email))")
 	_ = sb

--- a/server/internal/spendrules/chrepo/queries.go
+++ b/server/internal/spendrules/chrepo/queries.go
@@ -106,8 +106,8 @@ func (q *Queries) ListActorSpendForRules(ctx context.Context, projectIDs []strin
 		Where(squirrel.Eq{"gram_project_id": projectIDs}).
 		Where("time_bucket >= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeStart).
 		Where("time_bucket <= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeEnd).
-		Where("user_email != ''").
-		GroupBy("user_email")
+		Where("user_email != ''"). //nolint:glint // fold-neutral emptiness check; spend enforcement identity semantics pending a product decision (DNO-857 tail)
+		GroupBy("user_email")      //nolint:glint // actor rows keyed by literal email; casing collapsed in Go after read - enforcement fold pending decision (DNO-857 tail)
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -136,8 +136,8 @@ func (q *Queries) ListActorWindowSpendForRules(
 		Where(squirrel.Eq{"gram_project_id": projectIDs}).
 		Where("time_bucket >= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeStart).
 		Where("time_bucket <= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeEnd).
-		Where("user_email != ''").
-		GroupBy("user_email")
+		Where("user_email != ''"). //nolint:glint // fold-neutral emptiness check; spend enforcement identity semantics pending a product decision (DNO-857 tail)
+		GroupBy("user_email")      //nolint:glint // actor rows keyed by literal email; casing collapsed in Go after read - enforcement fold pending decision (DNO-857 tail)
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -185,8 +185,8 @@ func (q *Queries) ListActorWindowSpendForRulesByEmail(
 		Where(squirrel.Eq{"gram_project_id": projectIDs}).
 		Where("time_bucket >= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeStart).
 		Where("time_bucket <= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeEnd).
-		Where("lowerUTF8(user_email) = ?", email).
-		GroupBy("user_email")
+		Where("lowerUTF8(user_email) = ?", email). //nolint:glint // spend ENFORCEMENT matches the literal actor email deliberately - folding changes blocking semantics and needs its own decision (DNO-857 tail)
+		GroupBy("user_email")                      //nolint:glint // actor rows keyed by literal email; casing collapsed in Go after read - enforcement fold pending decision (DNO-857 tail)
 
 	query, args, err := sb.ToSql()
 	if err != nil {

--- a/server/internal/telemetry/repo/employee_agent_usage.go
+++ b/server/internal/telemetry/repo/employee_agent_usage.go
@@ -74,7 +74,7 @@ func (q *Queries) SearchEmployeeAgentUsage(ctx context.Context, arg SearchEmploy
 		Where("time_bucket <= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeEnd).
 		// Email-keyed rows only; the empty-email bucket is handled by
 		// ListEmaillessIdentities so it isn't shown as one synthetic user.
-		Where("user_email != ''").
+		Where("user_email != ''"). //nolint:glint // fold-neutral emptiness check - the fold never maps empty to non-empty or back
 		GroupBy(emailKey).
 		// Order by the group expression, not the alias: the user_email alias
 		// shadows the base column and ClickHouse resolves ORDER BY identifiers
@@ -147,7 +147,7 @@ func (q *Queries) ListEmaillessIdentities(ctx context.Context, arg ListEmailless
 		GroupBy("user_id").
 		// Keep only user_ids that never co-occur with an email in the window;
 		// those that do are folded into an email key by SearchEmployeeAgentUsage.
-		Having("max(user_email != '') = 0").
+		Having("max(user_email != '') = 0"). //nolint:glint // fold-neutral emptiness check partitioning email-less identities
 		OrderBy("last_seen_unix_nano DESC", "user_id DESC").
 		Limit(uint64(arg.Limit)) //nolint:gosec // Limit is always positive
 

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -5680,7 +5680,7 @@ func (q *Queries) GetHooksUserSummary(ctx context.Context, arg GetHooksUserSumma
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, arg.TypesToInclude)
 
 	sb = sb.GroupBy("user_email"). //nolint:glint // hooks user summary, not yet folded (DNO-857 tail)
-		OrderBy("event_count DESC")
+					OrderBy("event_count DESC")
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -5804,7 +5804,7 @@ func (q *Queries) GetSkillBreakdown(ctx context.Context, arg GetSkillBreakdownPa
 	// Apply attribute filters (user, server) but not type filters — skill type is hardcoded above.
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, nil)
 	sb = sb.GroupBy("skill_name", "user_email").OrderBy("skill_name", "use_count DESC"). //nolint:glint // skill breakdown, not yet folded (DNO-857 tail)
-		Limit(10000) // Defensive cap
+												Limit(10000) // Defensive cap
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -5872,8 +5872,8 @@ func (q *Queries) GetHooksBreakdown(ctx context.Context, arg GetHooksBreakdownPa
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, arg.TypesToInclude)
 
 	sb = sb.GroupBy("user_email", "server_name", "hook_source", "tool_name"). //nolint:glint // hooks breakdown, not yet folded (DNO-857 tail)
-		OrderBy("event_count DESC").
-		Limit(1000) // Defensive cap: top 1000 combinations ordered by volume
+											OrderBy("event_count DESC").
+											Limit(1000) // Defensive cap: top 1000 combinations ordered by volume
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -5942,8 +5942,8 @@ func (q *Queries) GetHooksTimeSeries(ctx context.Context, arg GetHooksTimeSeries
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, arg.TypesToInclude)
 
 	sb = sb.GroupBy("bucket_start", "server_name", "user_email"). //nolint:glint // unproxied MCP usage, not yet folded (DNO-857 tail)
-		OrderBy("bucket_start ASC").
-		Limit(10000) // Defensive cap: 288 buckets/day * ~34 server/user combos at 5min resolution
+									OrderBy("bucket_start ASC").
+									Limit(10000) // Defensive cap: 288 buckets/day * ~34 server/user combos at 5min resolution
 
 	query, args, err := sb.ToSql()
 	if err != nil {

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -99,7 +99,7 @@ func withUserIdentityFilter(sb squirrel.SelectBuilder, identity UserIdentity, ca
 	if len(identity.Emails) > 0 {
 		match = append(match, squirrel.And{
 			squirrel.Eq{"telemetry_logs.user_id": ""},
-			squirrel.Eq{"lower(telemetry_logs.user_email)": identity.Emails},
+			squirrel.Eq{"lower(telemetry_logs.user_email)": identity.Emails}, //nolint:glint // legacy flag-off identity path; deleted at GA with the canonical fold rollout
 		})
 	}
 
@@ -1582,7 +1582,7 @@ func (q *Queries) GetUnproxiedMcpServerUserUsage(ctx context.Context, arg GetUnp
 		FromSelect(innerSb, "per_trace").
 		Where("server_url != ''").
 		Where(unproxiedMcpServerUsageURLMatch(arg.CanonicalURL)).
-		GroupBy("user_email").
+		GroupBy("user_email"). //nolint:glint // searchUsers raw-logs path, not yet folded; needs its own shadow comparison (DNO-857 tail)
 		OrderBy("call_count DESC", "user_email ASC").
 		Limit(uint64(limit + 1)). //nolint:gosec // limit is clamped to 1..500 by clampUnproxiedMcpServerUsageLimit.
 		Offset(uint64(offset))    //nolint:gosec // offset comes from a decoded, non-negative cursor.
@@ -5679,7 +5679,7 @@ func (q *Queries) GetHooksUserSummary(ctx context.Context, arg GetHooksUserSumma
 
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, arg.TypesToInclude)
 
-	sb = sb.GroupBy("user_email").
+	sb = sb.GroupBy("user_email"). //nolint:glint // hooks user summary, not yet folded (DNO-857 tail)
 		OrderBy("event_count DESC")
 
 	query, args, err := sb.ToSql()
@@ -5803,7 +5803,7 @@ func (q *Queries) GetSkillBreakdown(ctx context.Context, arg GetSkillBreakdownPa
 
 	// Apply attribute filters (user, server) but not type filters — skill type is hardcoded above.
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, nil)
-	sb = sb.GroupBy("skill_name", "user_email").OrderBy("skill_name", "use_count DESC").
+	sb = sb.GroupBy("skill_name", "user_email").OrderBy("skill_name", "use_count DESC"). //nolint:glint // skill breakdown, not yet folded (DNO-857 tail)
 		Limit(10000) // Defensive cap
 
 	query, args, err := sb.ToSql()
@@ -5871,7 +5871,7 @@ func (q *Queries) GetHooksBreakdown(ctx context.Context, arg GetHooksBreakdownPa
 
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, arg.TypesToInclude)
 
-	sb = sb.GroupBy("user_email", "server_name", "hook_source", "tool_name").
+	sb = sb.GroupBy("user_email", "server_name", "hook_source", "tool_name"). //nolint:glint // hooks breakdown, not yet folded (DNO-857 tail)
 		OrderBy("event_count DESC").
 		Limit(1000) // Defensive cap: top 1000 combinations ordered by volume
 
@@ -5941,7 +5941,7 @@ func (q *Queries) GetHooksTimeSeries(ctx context.Context, arg GetHooksTimeSeries
 
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, arg.TypesToInclude)
 
-	sb = sb.GroupBy("bucket_start", "server_name", "user_email").
+	sb = sb.GroupBy("bucket_start", "server_name", "user_email"). //nolint:glint // unproxied MCP usage, not yet folded (DNO-857 tail)
 		OrderBy("bucket_start ASC").
 		Limit(10000) // Defensive cap: 288 buckets/day * ~34 server/user combos at 5min resolution
 
@@ -6146,7 +6146,7 @@ func (q *Queries) ListHooksTraces(ctx context.Context, arg ListHooksTracesParams
 		}
 	}
 
-	sb = sb.GroupBy("trace_id", "tool_name", "tool_source", "event_source", "user_email", "hook_source", "skill_name")
+	sb = sb.GroupBy("trace_id", "tool_name", "tool_source", "event_source", "user_email", "hook_source", "skill_name") //nolint:glint // hooks timeseries, not yet folded (DNO-857 tail)
 
 	// Pagination based on trace_id cursor
 	if arg.Cursor != "" {


### PR DESCRIPTION
Fixes DNO-858 (Canonical Identity Map for Cost Analytics). Standalone off `main` — the fold this rule protects merged with stack #5253.

## What

A new glint analyzer, `no-raw-user-email-filter`, forbidding raw `user_email` matching or bucketing in squirrel-built ClickHouse queries. The email dimension must go through the canonical identity fold (`canonicalEmailExpr` / `joinGet` over `identity_map`); a raw comparison or GROUP BY splits one employee across their work, personal, and case-variant emails — the silent regression class behind DNO-827/DNO-425, which recurred four separate times because nothing structural prevented it. Same playbook as the sqlclint tenant-scoping gate: conventions enforced by CI, not review memory.

## Detection

Type-based where it matters, per glint conventions:

- string literals naming `user_email` in args to `Where`/`Having`/`GroupBy`/`JoinClause` on squirrel builders (receiver type resolved via `TypesInfo` to the squirrel package),
- keys of `squirrel.Eq`/`NotEq` composite literals wherever they appear (helpers building predicates for a later `Where` included),
- args to `squirrel.Expr` (the escape hatch every hand-written predicate uses).

Exemptions built into the walk: descent stops at calls to the `canonical*` fold helpers (the sanctioned funnel), and literals containing the `identity_map` joinGet are the fold itself. `Select` projections are deliberately out of scope — reading the email for display is fine; matching on it is not. Squirrel is ClickHouse-only in this repo (Postgres must use sqlc), so squirrel usage is precisely the rule's scope with no package allowlist.

Known limitation, documented: columns carried through variables (e.g. a registry-supplied expression) evade literal detection. Every historical incident was introduced via a direct literal, which this catches.

## The allowlist is the GA checklist

The 15 existing sites carry `//nolint:glint` annotations naming _why_ each is allowed:

- fold-neutral emptiness checks (`user_email != ''` — the fold never maps empty↔non-empty),
- the flag-off legacy identity path (deleted at GA),
- the not-yet-folded DNO-857-tail surfaces (searchUsers raw path, hooks/skill/MCP breakdowns),
- spend **enforcement** matching (folding changes blocking semantics; pending its own decision).

GA cleanup is done when these annotations are gone; the rule then enforces zero suppressions forever.

## Verification

- `analysistest` fixture covering direct filters, Eq keys in helpers, `squirrel.Expr`, and the allowed shapes (projections, canonical-helper routing, the joinGet expression, non-email columns); plugin registration tests updated (17 analyzers).
- `mise lint:server` green with the rule active across the server tree (initial run surfaced exactly the 15 known sites and nothing else — no false positives).
- `go test ./glint`, full server build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forbids raw `user_email` filters and group-bys in ClickHouse `squirrel` queries via a new `glint` analyzer, enforcing the canonical identity fold. Previously, raw comparisons and bucketing were allowed and split one employee across linked emails; now CI flags these and requires the canonical expression.

- Flags string literals naming `user_email` in `Where`/`Having`/`JoinClause` (scans only the predicate SQL arg, ignores bound values), `GroupBy` (all args), `squirrel.Expr` predicates, and keys of `squirrel.Eq`/`NotEq` (map keys only; values are treated as data).
- Exempts literals routed through canonical* helpers and those containing `joinGet('identity_map', ...)`; `SELECT` projections remain allowed. Scope is ClickHouse-only (`squirrel`).
- Known limitation: column expressions passed via variables evade literal detection.
- Registers the rule in `glint`, adds tests/testdata, and updates plugin registration (17 analyzers).
- Connects to Linear DNO-858. Adds explicit `//nolint:glint` to 15 legacy sites (fold-neutral emptiness checks, flag-off legacy identity path, not-yet-folded DNO-857 surfaces, spend enforcement semantics) — this allowlist doubles as the GA cleanup checklist.
- Required migration: route all email matching/bucketing through the canonical fold (e.g., `canonicalEmailExpr` / `joinGet` over `identity_map`); do not compare or group by raw `user_email`. Spend enforcement and the legacy flag-off path remain temporarily allowed until their separate decisions land.

<sup>Written for commit bfcf4cb1968c78c4edac5642964dae1af6105be3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

