### PR TITLE
feat: make the book-a-demo live demo CTA more prominent

### DIFF
--- a/client/dashboard/src/pages/demo/BookDemo.test.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/Auth", () => ({
+  useSessionData: () => ({
+    session: {
+      user: { email: "jane@acme.com" },
+      organization: { id: "org-1", name: "Acme", slug: "acme" },
+    },
+  }),
+}));
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: () => ({ auth: { logout: vi.fn() } }),
+}));
+
+vi.mock("@/contexts/Telemetry", () => ({
+  useCaptureEnterpriseGateViewed: vi.fn(),
+}));
+
+vi.mock("@/pages/demo/components/DemoBookingFlow", () => ({
+  DemoBookingFlow: () => <div data-testid="booking-flow" />,
+}));
+
+import BookDemo from "./BookDemo";
+
+afterEach(cleanup);
+
+describe("BookDemo", () => {
+  it("renders a secondary CTA into the live demo org", () => {
+    render(<BookDemo />);
+
+    const cta = screen.getByRole("link", { name: "Explore a Live Demo" });
+    expect(cta.getAttribute("href")).toBe("/explore-demo");
+    expect(screen.queryByText(/or explore a live demo org/i)).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -24,7 +24,7 @@ export default function BookDemo(): JSX.Element {
   return (
     <AuthShell
       page="Book a demo"
-      contentClassName="max-w-[800px] gap-3"
+      contentClassName="max-w-[50rem] gap-6"
       // The card carries its own prefill footnote instead ("2E Book a demo").
       showTerms={false}
       headerAction={
@@ -39,11 +39,11 @@ export default function BookDemo(): JSX.Element {
     >
       <DemoBookingFlow />
       <Button
-        variant="secondary"
+        variant="primary"
+        size="md"
         icon="arrow-right"
         iconAfter
         href="/explore-demo"
-        className="w-full"
       >
         Explore a Live Demo
       </Button>

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -24,7 +24,7 @@ export default function BookDemo(): JSX.Element {
   return (
     <AuthShell
       page="Book a demo"
-      contentClassName="max-w-[800px]"
+      contentClassName="max-w-[800px] gap-3"
       // The card carries its own prefill footnote instead ("2E Book a demo").
       showTerms={false}
       headerAction={
@@ -43,6 +43,7 @@ export default function BookDemo(): JSX.Element {
         icon="arrow-right"
         iconAfter
         href="/explore-demo"
+        className="w-full"
       >
         Explore a Live Demo
       </Button>

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -1,6 +1,6 @@
+import { Button } from "@/components/ui/Button";
 import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
-import { Link } from "react-router";
 import { useCaptureEnterpriseGateViewed } from "@/contexts/Telemetry";
 import { AuthShell } from "@/pages/login/components/auth-shell";
 import { DemoBookingFlow } from "@/pages/demo/components/DemoBookingFlow";
@@ -24,7 +24,7 @@ export default function BookDemo(): JSX.Element {
   return (
     <AuthShell
       page="Book a demo"
-      contentClassName="max-w-[560px]"
+      contentClassName="max-w-[800px]"
       // The card carries its own prefill footnote instead ("2E Book a demo").
       showTerms={false}
       headerAction={
@@ -38,14 +38,14 @@ export default function BookDemo(): JSX.Element {
       }
     >
       <DemoBookingFlow />
-      <div className="mt-6 text-center">
-        <Link
-          to="/explore-demo"
-          className="auth-mono text-xs text-(--muted) underline underline-offset-4 transition-colors hover:text-black"
-        >
-          Or explore a live demo org →
-        </Link>
-      </div>
+      <Button
+        variant="secondary"
+        icon="arrow-right"
+        iconAfter
+        href="/explore-demo"
+      >
+        Explore a Live Demo
+      </Button>
     </AuthShell>
   );
 }

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/trial-status";
 import { getGateCopy } from "@/pages/demo/upgrade-gate-copy";
 import { Link, Navigate } from "react-router";
+import { Button } from "@/components/ui/Button";
 
 const SALES_EMAIL = "sales@speakeasy.com";
 
@@ -111,20 +112,20 @@ function UpgradeGate({
           </div>
         }
       />
-      <div className="flex items-center justify-center gap-4">
-        <Link
-          to="/explore-demo"
-          className="auth-mono text-xs text-(--muted) underline underline-offset-4 transition-colors hover:text-black"
+      <div className="flex items-center justify-center gap-8">
+        <Button variant="secondary" size="md" href={`mailto:${SALES_EMAIL}`}>
+          Email {SALES_EMAIL}
+        </Button>
+
+        <Button
+          variant="primary"
+          size="md"
+          icon="arrow-right"
+          iconAfter
+          href="/explore-demo"
         >
-          Explore demo
-        </Link>
-        <span aria-hidden="true" className="h-3 w-px bg-(--edge)" />
-        <a
-          href={`mailto:${SALES_EMAIL}`}
-          className="auth-mono text-xs text-(--muted) underline underline-offset-4 transition-colors hover:text-black"
-        >
-          Email {SALES_EMAIL} →
-        </a>
+          Explore a Live Demo
+        </Button>
       </div>
     </AuthShell>
   );

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -130,7 +130,7 @@ export function DemoBookingFlow({
   const prefill = [email, companyName].filter(Boolean).join(" · ");
 
   return (
-    <div className="flex w-full flex-col items-center gap-6">
+    <div className="flex w-full flex-col items-center gap-4">
       {intro}
 
       <div className="w-full overflow-hidden border border-(--edge) bg-(--card)">

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -59,7 +59,7 @@ function useCalBranding() {
 // Sits above the card on the cold-signup gate. The expired-trial gate passes
 // its own header instead.
 const DEFAULT_INTRO = (
-  <div className="text-center">
+  <div className="text-center mb-4">
     <p className="text-[16px] tracking-[0.0025em]">
       Looks like your company is new to Speakeasy.
     </p>
@@ -130,7 +130,7 @@ export function DemoBookingFlow({
   const prefill = [email, companyName].filter(Boolean).join(" · ");
 
   return (
-    <div className="flex w-full flex-col items-center gap-4">
+    <div className="flex w-full flex-col items-center gap-2">
       {intro}
 
       <div className="w-full overflow-hidden border border-(--edge) bg-(--card)">
@@ -145,7 +145,7 @@ export function DemoBookingFlow({
 
         {/* Tall enough for a six-row month without clipping the last week,
             capped so the card still clears the fold on a laptop viewport. */}
-        <div className="h-[clamp(500px,58vh,600px)] w-full overflow-auto">
+        <div className="h-[clamp(500px,54vh,600px)] w-full overflow-auto">
           <Cal
             calLink={CAL_DEMO_LINK}
             config={{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the live-demo escape hatch easier to find on both demo gates (AGE-3237).

- Widen the booking column so the Cal.com month view can use more of the pane
- Promote **Explore a Live Demo** to a primary button (with a trailing arrow) on the book-a-demo gate and the trial-expired upgrade gate
- On the upgrade gate, pair it with a secondary **Email sales** button so the two actions read as a matched pair
- Tighten the booking card so the CTA row still clears the fold

### Book a demo (1800×1200)

![Book-a-demo gate at 1800 by 1200](https://cursor.com/artifacts/c/art-ea27a6ed-599f-4812-928a-01f40f5f8b8d)

### Talk to us (1800×1200)

![Trial-expired Talk to us gate at 1800 by 1200](https://cursor.com/artifacts/c/art-c6eb752e-c189-44f9-80fd-9a36ee6262bc)

## Test plan

- [x] `aube run -F dashboard test -- src/pages/demo` (26 tests)
- [x] Book-a-demo gate at 1800×1200: wider calendar plus primary **Explore a Live Demo** button
- [x] Trial-expired Talk to us gate at 1800×1200: secondary email button plus primary **Explore a Live Demo** button

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3237](https://linear.app/speakeasy/issue/AGE-3237/feat-on-the-book-a-demo-gate-make-demo-link-bigger)

<div><a href="https://cursor.com/agents/bc-3b5898c1-2c66-471e-b428-66e856d9c34f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b5898c1-2c66-471e-b428-66e856d9c34f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the “Explore a Live Demo” CTA so it’s easy to find on both the book‑a‑demo gate and the trial‑expired upgrade gate. Previously an underlined all‑caps text link; now a primary, full‑width button to `/explore-demo`, with layout tightened to keep it visible on laptop viewports.

- Book-a-demo page: widen content from 560px to 800px (`max-w-[50rem]`), add `gap-6`, and replace the link with a primary `Button` (`icon="arrow-right"`, `iconAfter`, `href="/explore-demo"`).
- Booking flow spacing: reduce gaps (`gap-6` → `gap-2`), add `mb-4` to the intro, and lower calendar height cap (`58vh` → `54vh`) so the CTA clears the fold.
- Trial-expired upgrade gate: replace text links with buttons — primary “Explore a Live Demo” (`/explore-demo`) and secondary “Email sales@speakeasy.com”.
- Tests: add `BookDemo.test.tsx` to assert the new CTA and removal of the old copy.
- No routing, auth, or analytics changes; Cal.com embed reflows. Fulfills AGE-3237.

<sup>Written for commit f78ef79d058150abc6b39df6f5d0026d139b74c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

