### PR TITLE
chore: write pnpm-lock.yaml with pnpm, not aube

### DIFF
--- a/.agents/skills/admin-shadcn/SKILL.md
+++ b/.agents/skills/admin-shadcn/SKILL.md
@@ -31,6 +31,23 @@ Do not use `npx`, `npm`, `yarn`, or `pnpm dlx`. This repo uses `aube`.
 
 Read `docs <name>` before you decide that a variant or a sub-component is missing.
 
+### Components that need a new dependency
+
+`add <name>` cannot install one. It shells out to a bare `pnpm add`, and this
+tree's `node_modules` is aube-shaped, so it dies with
+`ERR_PNPM_HOIST_PATTERN_DIFF` before writing any file — including the component.
+It leaves `node_modules` intact.
+
+Install the dependency first, then re-run `add <name>`:
+
+```sh
+mise run install:lock -F admin react-day-picker
+aube dlx shadcn@latest add calendar
+```
+
+`add <name> --view` prints a component's source without installing anything, if
+you only need to read it.
+
 ## After you add a component
 
 Run these three commands, in this order:

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -69,6 +69,13 @@ jobs:
           fi
           echo "✅ No tracked files match .gitignore patterns."
 
+      # `aube install --frozen-lockfile` cannot catch an aube-written lockfile:
+      # it is self-consistent with every package.json even where aube has
+      # replaced a workspace link with a registry version.
+      - name: Check workspace links in the lockfile
+        shell: bash
+        run: bash .mise-tasks/check/lockfile.sh
+
       - name: Detect changed files
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter

--- a/.mise-tasks/check/lockfile.sh
+++ b/.mise-tasks/check/lockfile.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#MISE description="Check pnpm-lock.yaml still links every workspace dependency"
+
+set -euo pipefail
+
+lockfile="${MISE_CONFIG_ROOT:-.}/pnpm-lock.yaml"
+
+# aube (1.38.1 and 1.40.0) resolves `workspace:` specifiers to the registry
+# version instead of `link:` when it writes the lockfile, which swaps a local
+# package for a published one without failing any install. Catch that here:
+# `aube install --frozen-lockfile` cannot, because an aube-written lockfile is
+# self-consistent with every package.json.
+broken=$(
+  awk '
+    /^importers:/ { in_importers = 1; next }
+    /^[a-z]/ && !/^importers:/ { in_importers = 0 }
+    !in_importers { next }
+    /^  [^ ]/ { importer = $1; sub(/:$/, "", importer) }
+    /^      [^ ]+:$/ { dep = $1; sub(/:$/, "", dep) }
+    /^ +specifier: .?workspace:/ { pending = 1; next }
+    /^ +version: / {
+      if (pending && $2 !~ /^link:/) print "  - " importer " -> " dep " resolved to " $2
+      pending = 0
+    }
+  ' "$lockfile"
+)
+
+if [[ -n "$broken" ]]; then
+  echo "❌ Workspace dependencies resolved to registry versions in pnpm-lock.yaml:"
+  echo "$broken"
+  echo ""
+  echo "This lockfile was written by aube. Rewrite it with 'mise run install:lock'."
+  exit 1
+fi
+
+echo "✅ Every workspace: specifier in pnpm-lock.yaml resolves to a link."

--- a/.mise-tasks/install/lock.sh
+++ b/.mise-tasks/install/lock.sh
@@ -23,12 +23,21 @@ mirror="$(mktemp -d)"
 trap 'rm -rf "$mirror"' EXIT
 
 cd "$root"
+
+# --others so a workspace package whose package.json is not staged yet still
+# reaches the mirror; without it pnpm would resolve against a workspace missing
+# that importer and write an incomplete lockfile. --exclude-standard keeps
+# node_modules and other ignored trees out.
+manifests() {
+  git ls-files --cached --others --exclude-standard '*package.json' ':!:**/node_modules/**'
+}
+
 cp pnpm-lock.yaml pnpm-workspace.yaml "$mirror/"
 cp -R patches "$mirror/patches"
 while IFS= read -r manifest; do
   mkdir -p "$mirror/$(dirname "$manifest")"
   cp "$manifest" "$mirror/$manifest"
-done < <(git ls-files '*package.json' ':!:**/node_modules/**')
+done < <(manifests)
 
 cd "$mirror"
 if [[ -n "${usage_package:-}" ]]; then
@@ -46,9 +55,14 @@ cd "$root"
 cp "$mirror/pnpm-lock.yaml" pnpm-lock.yaml
 while IFS= read -r manifest; do
   cmp -s "$mirror/$manifest" "$manifest" || cp "$mirror/$manifest" "$manifest"
-done < <(git ls-files '*package.json' ':!:**/node_modules/**')
+done < <(manifests)
 
 # Called by path, not `mise run`: a mise task's PATH can resolve to a different
 # mise than the one running it.
 bash .mise-tasks/check/lockfile.sh
-exec aube install
+
+# --frozen-lockfile so aube can only read what pnpm just wrote. A plain install
+# re-resolves whenever node_modules/.aube-state is stale, which is exactly when
+# this task has just changed a manifest. Not `exec`: bash skips the EXIT trap on
+# a successful exec, which would leak the mirror.
+aube install --frozen-lockfile

--- a/.mise-tasks/install/lock.sh
+++ b/.mise-tasks/install/lock.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+#MISE description="Change NPM dependencies and rewrite pnpm-lock.yaml with pnpm"
+
+#USAGE flag "-F --filter <package>" help="Workspace package to add to, e.g. admin"
+#USAGE flag "-D --dev" help="Add to devDependencies"
+#USAGE arg "[package]..." var=#true help="Packages to add; omit to re-resolve the manifests as they stand"
+
+set -euo pipefail
+
+root="${MISE_CONFIG_ROOT:-$PWD}"
+
+# pnpm, not aube, writes this lockfile. aube 1.38.1 and 1.40.0 both rewrite it
+# wholesale on every write: they order peer suffixes differently (~1400 lines of
+# churn) and resolve `workspace:` specifiers to registry versions, silently
+# unlinking local packages. aube reads pnpm's output fine, which is all CI does.
+# See `mise run check:lockfile`.
+#
+# pnpm is run against a copy of the manifests because `pnpm add` links
+# node_modules even under --lockfile-only, and this tree's node_modules is
+# aube-shaped — pnpm would either clobber it or die on ERR_PNPM_HOIST_PATTERN_DIFF.
+mirror="$(mktemp -d)"
+trap 'rm -rf "$mirror"' EXIT
+
+cd "$root"
+cp pnpm-lock.yaml pnpm-workspace.yaml "$mirror/"
+cp -R patches "$mirror/patches"
+while IFS= read -r manifest; do
+  mkdir -p "$mirror/$(dirname "$manifest")"
+  cp "$manifest" "$mirror/$manifest"
+done < <(git ls-files '*package.json' ':!:**/node_modules/**')
+
+cd "$mirror"
+if [[ -n "${usage_package:-}" ]]; then
+  args=(add --lockfile-only)
+  [[ -n "${usage_filter:-}" ]] && args+=(--filter "$usage_filter")
+  [[ "${usage_dev:-}" == "true" ]] && args+=(--save-dev)
+  # usage passes variadic args as a shell-quoted string.
+  eval "set -- $usage_package"
+  pnpm "${args[@]}" "$@"
+else
+  pnpm install --lockfile-only --ignore-scripts
+fi
+
+cd "$root"
+cp "$mirror/pnpm-lock.yaml" pnpm-lock.yaml
+while IFS= read -r manifest; do
+  cmp -s "$mirror/$manifest" "$manifest" || cp "$mirror/$manifest" "$manifest"
+done < <(git ls-files '*package.json' ':!:**/node_modules/**')
+
+# Called by path, not `mise run`: a mise task's PATH can resolve to a different
+# mise than the one running it.
+bash .mise-tasks/check/lockfile.sh
+exec aube install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,14 @@ The main frontend application lives in `client/dashboard/` (not `client/` direct
 
 </commands>
 
+### Changing NPM dependencies
+
+Use `mise run install:lock` — `mise run install:lock -F admin react-day-picker`,
+or with no arguments after hand-editing a `package.json`. `aube` installs from
+`pnpm-lock.yaml` but must never write it; `aube add` and `aube install
+--fix-lockfile` rewrite ~1400 lines and unlink workspace packages. Never run
+bare `pnpm`: without a TTY it deletes `node_modules`.
+
 ### Dashboard browser automation
 
 Use the `gram-playwright-cli` skill and `mise run playwright` for routine dashboard inspection, page interaction, console or network debugging, and screenshots. The mise task uses the repository Playwright config, installs Chromium when missing, and writes ignored artifacts to `.playwright-cli/`.

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,13 @@ melange = "0.56.5"
 # mirror it falls through to whatever `node` is first on PATH.
 nodejs = "24.16.0"
 aube = "1.38.1"
-# Kept for `changeset publish` only, which shells out to a package manager by
+# Writes pnpm-lock.yaml, via `mise run install:lock`. aube installs from that
+# lockfile but must never write it: aube 1.38.1 and 1.40.0 both reorder every
+# peer suffix (~1400 lines of churn on any dependency change) and resolve
+# `workspace:` specifiers to registry versions, silently unlinking local
+# packages. `mise run check:lockfile` guards the second one.
+#
+# Also required by `changeset publish`, which shells out to a package manager by
 # name and has no aube branch — it picks between pnpm, yarn and npm. Both
 # versions resolve to pnpm here, off different inputs: 2.31.0 (what we pin)
 # asks package-manager-detector, which answers pnpm because pnpm-lock.yaml is

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,15 +161,15 @@ importers:
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1
-      react-grab:
-        specifier: ^0.1.48
-        version: 0.1.48(react@19.2.8)
       oxlint:
         specifier: ^1.71.0
         version: 1.77.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
         specifier: ^0.23.0
         version: 0.23.0
+      react-grab:
+        specifier: ^0.1.48
+        version: 0.1.48(react@19.2.8)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2


### PR DESCRIPTION
Adding one dependency to any package in this repo rewrote 1464 lines of `pnpm-lock.yaml` and silently unlinked a workspace package. This routes lockfile writes through pnpm, which does not.

## What was wrong

aube writes this lockfile differently from pnpm. Same edit (`react-day-picker` into `client/admin`), from a clean checkout of `main`:

| Writer | Lockfile diff |
| --- | --- |
| `pnpm install --lockfile-only` (11.19.0, already pinned in `mise.toml`) | **43 lines** |
| `aube install --lockfile-only` (1.38.1, and 1.40.0) | **1464 lines** |

Two defects are mixed into that churn:

1. **Peer suffixes come out in a different order.** aube writes `(@types/react)(@types/react-dom)(react)(react-dom)`; pnpm writes `(@types/react-dom)(@types/react)(react-dom)(react)`. Cosmetic, and ~1400 of the lines.
2. **Every `workspace:` specifier resolves to a registry version.** `ts-framework/create-function`'s `@gram-ai/functions` goes from `link:../functions` to `0.18.0`, so a published package replaces the local one. That package is not private — it ships.

Neither is caused by anything in this repo: `workspace:*` breaks the same way as `workspace:^`, and aube 1.40.0 reproduces both defects exactly, so upgrading is not the fix.

## What changed

CI only ever runs `aube install --frozen-lockfile`, and aube reads pnpm's output correctly, so aube never needs to write the lockfile.

- **`mise run install:lock`** resolves with pnpm, then relinks with aube. `mise run install:lock -F admin react-day-picker`, or no arguments after hand-editing a `package.json`. It runs pnpm against a *copy* of the manifests in a temp dir, because `pnpm add` links `node_modules` even under `--lockfile-only`, and this tree's `node_modules` is aube-shaped.
- **`mise run check:lockfile`**, run by hygiene. `--frozen-lockfile` cannot catch defect 2: an aube-written lockfile is self-consistent with every `package.json` even where the link is gone. This asserts every `workspace:` specifier still resolves to a `link:`.
- Notes in `CLAUDE.md`, `mise.toml` (its comment claimed pnpm was kept for `changeset publish` only) and the `admin-shadcn` skill, whose "Add a component" row cannot install a new dependency — `shadcn add` shells out to a bare `pnpm add` and dies on `ERR_PNPM_HOIST_PATTERN_DIFF` before writing the component.
- First commit normalizes three lines: `client/admin`'s `react-grab` entry has been out of alphabetical order since #5283. Nothing else moved, which confirms the committed lockfile was otherwise already pnpm-canonical.

## Verification

- `mise run install:lock -F admin react-day-picker` in a throwaway clone: **43-line lockfile diff**, only react-day-picker and its own transitive deps.
- `aube install --frozen-lockfile` accepts pnpm's output: exit 0, and `ts-framework/create-function/node_modules/@gram-ai/functions` is a real symlink to `../../../functions`.
- `check:lockfile` passes on this branch and fails on the aube-written lockfile, naming the exact importer.
- `aube run -F admin type-check` ✅ · `-F admin test` ✅ 292 passed · `-F dashboard type-check` ✅ · `-F dashboard build` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes `pnpm-lock.yaml` with `pnpm` instead of `aube` to eliminate 1400+ lines of churn and stop silent unlinking of `workspace:` packages. Before: `aube` reordered peer suffixes and resolved `workspace:` to registry versions. Now: `pnpm` writes the lockfile and `aube` only installs from it.

**Changes**
- Add `mise run install:lock` to resolve with `pnpm` against a manifest mirror, then `aube install --frozen-lockfile`. The task now cleans up the mirror, includes unstaged `package.json` files, and prevents re-resolution.
- Add `mise run check:lockfile`; hygiene runs it to ensure every `workspace:` specifier resolves to `link:`.
- Update docs (`CLAUDE.md`) and the `admin-shadcn` skill; alphabetize one `react-grab` entry in the lockfile.

**Developer actions**
- Use `mise run install:lock` for any dependency change or after editing a `package.json`. Do not use `aube add`, `aube install --fix-lockfile`, or bare `pnpm`.
- For `client/admin` shadcn components that need new deps: `mise run install:lock -F admin <package>` then `aube dlx shadcn@latest add <component>`.

<sup>Written for commit 03c65a006ed6a4bea3ec5c09d4b9a2f48f3a171b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

