### PR TITLE
feat: bill Other inference spend through Stripe invoices

### DIFF
--- a/.changeset/bill-openrouter-usage-on-stripe-invoices.md
+++ b/.changeset/bill-openrouter-usage-on-stripe-invoices.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Bill PAYG OpenRouter chat spend through durable Stripe invoice allocations. Daily charges freeze after 48 hours, signed corrections carry forward after the 72-hour observation window, and ambiguous invoice items or credit notes reconcile before retrying.

--- a/.changeset/bill-openrouter-usage-on-stripe-invoices.md
+++ b/.changeset/bill-openrouter-usage-on-stripe-invoices.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Bill PAYG OpenRouter chat spend through durable Stripe invoice allocations. Daily charges freeze after 48 hours, signed corrections carry forward after the 72-hour observation window, and ambiguous invoice items or credit notes reconcile before retrying.
+Bill PAYG Other inference spend through durable Stripe invoice allocations. Daily charges freeze after 48 hours, signed corrections carry forward after the 72-hour observation window, and ambiguous invoice items or credit notes reconcile before retrying.

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -93,6 +93,7 @@ type Activities struct {
 	temporalEnv                     *tenv.Environment
 	collectOpenRouterCreditsMetrics *activities.CollectOpenRouterCreditsMetrics
 	collectOpenRouterDailySpend     *activities.CollectOpenRouterDailySpend
+	settleStripeInvoiceAllocations  *activities.SettleStripeInvoiceAllocations
 	collectPlatformUsageMetrics     *activities.CollectPlatformUsageMetrics
 	getAIIntegrationsCandidates     *activities.GetAIIntegrationsCandidates
 	pollAIData                      *activities.PollAIData
@@ -306,6 +307,7 @@ func NewActivities(
 		temporalEnv:                     temporalEnv,
 		collectOpenRouterCreditsMetrics: activities.NewCollectOpenRouterCreditsMetrics(logger, db, openrouterProvisioner, encryption),
 		collectOpenRouterDailySpend:     activities.NewCollectOpenRouterDailySpend(logger, db, openrouterSpendClient),
+		settleStripeInvoiceAllocations:  activities.NewSettleStripeInvoiceAllocations(logger, db, stripeClient),
 		collectPlatformUsageMetrics:     activities.NewCollectPlatformUsageMetrics(logger, db),
 		getAIIntegrationsCandidates:     activities.NewGetAIIntegrationsCandidates(logger, db, encryption),
 		pollAIData:                      activities.NewPollAIData(logger, db, encryption, telemetryLogger, guardianPolicy, chatWriter),
@@ -504,8 +506,16 @@ func (a *Activities) CollectOpenRouterCreditsMetrics(ctx context.Context, args a
 	return a.collectOpenRouterCreditsMetrics.Do(ctx, args)
 }
 
-func (a *Activities) CollectOpenRouterDailySpend(ctx context.Context, args activities.CollectOpenRouterDailySpendArgs) error {
-	return a.collectOpenRouterDailySpend.Do(ctx, args)
+func (a *Activities) CollectOpenRouterDailySpend(ctx context.Context, args activities.CollectOpenRouterDailySpendArgs) (activities.CollectOpenRouterDailySpendResult, error) {
+	result, err := a.collectOpenRouterDailySpend.DoWithResult(ctx, args)
+	if err != nil {
+		return activities.CollectOpenRouterDailySpendResult{}, fmt.Errorf("collect OpenRouter daily spend: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) SettleStripeInvoiceAllocations(ctx context.Context, args activities.SettleStripeInvoiceAllocationsArgs) error {
+	return a.settleStripeInvoiceAllocations.Do(ctx, args)
 }
 
 func (a *Activities) FireOpenRouterCreditsMetrics(ctx context.Context, metrics []activities.OpenRouterCreditsMetric) error {

--- a/server/internal/background/activities/openrouter_daily_spend.go
+++ b/server/internal/background/activities/openrouter_daily_spend.go
@@ -30,6 +30,12 @@ type CollectOpenRouterDailySpendArgs struct {
 	EndDay time.Time
 }
 
+// CollectOpenRouterDailySpendResult identifies organizations whose chat spend
+// is fresh and gap-free for every known invoice source day.
+type CollectOpenRouterDailySpendResult struct {
+	ReadyOrganizationIDs []string
+}
+
 // CollectOpenRouterDailySpend stores billing-grade daily spend for every live
 // platform-managed OpenRouter key.
 type CollectOpenRouterDailySpend struct {
@@ -51,27 +57,34 @@ func NewCollectOpenRouterDailySpend(
 }
 
 func (c *CollectOpenRouterDailySpend) Do(ctx context.Context, args CollectOpenRouterDailySpendArgs) error {
+	_, err := c.DoWithResult(ctx, args)
+	return err
+}
+
+func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args CollectOpenRouterDailySpendArgs) (CollectOpenRouterDailySpendResult, error) {
 	startDay, err := exactUTCDay(args.StartDay)
 	if err != nil {
-		return fmt.Errorf("validate openrouter spend start day: %w", err)
+		return CollectOpenRouterDailySpendResult{}, fmt.Errorf("validate openrouter spend start day: %w", err)
 	}
 	endDay, err := exactUTCDay(args.EndDay)
 	if err != nil {
-		return fmt.Errorf("validate openrouter spend end day: %w", err)
+		return CollectOpenRouterDailySpendResult{}, fmt.Errorf("validate openrouter spend end day: %w", err)
 	}
 	if !startDay.Before(endDay) {
-		return errors.New("validate openrouter spend range: start day must precede end day")
+		return CollectOpenRouterDailySpendResult{}, errors.New("validate openrouter spend range: start day must precede end day")
 	}
 
 	queries := repo.New(c.db)
 	targets, err := queries.ListOpenRouterDailySpendTargets(ctx)
 	if err != nil {
-		return fmt.Errorf("list openrouter daily spend targets: %w", err)
+		return CollectOpenRouterDailySpendResult{}, fmt.Errorf("list openrouter daily spend targets: %w", err)
 	}
 
 	var failures []error
+	readyOrganizations := make(map[string]struct{})
 	for i, target := range targets {
 		keyType := openrouter.KeyType(target.KeyType)
+		isChat := keyType == openrouter.KeyTypeChat
 		if err := keyType.Validate(); err != nil {
 			failures = append(failures, fmt.Errorf("collect spend for organization %s: %w", target.OrganizationID, err))
 			c.recordHeartbeat(ctx, i+1, len(targets))
@@ -83,7 +96,25 @@ func (c *CollectOpenRouterDailySpend) Do(ctx context.Context, args CollectOpenRo
 		if createdDay.After(targetStart) {
 			targetStart = createdDay
 		}
+		if isChat {
+			recoveryStart, err := queries.GetOpenRouterDailySpendRecoveryStartDay(ctx, repo.GetOpenRouterDailySpendRecoveryStartDayParams{
+				TargetOrganizationID: pgtype.Text{String: target.OrganizationID, Valid: true},
+				TargetEarliestDay:    pgtype.Date{Time: createdDay, InfinityModifier: pgtype.Finite, Valid: true},
+				TargetEndDay:         pgtype.Date{Time: endDay, InfinityModifier: pgtype.Finite, Valid: true},
+			})
+			if err != nil {
+				failures = append(failures, fmt.Errorf("find spend recovery start for organization %s: %w", target.OrganizationID, err))
+				c.recordHeartbeat(ctx, i+1, len(targets))
+				continue
+			}
+			if recoveryStart.Valid && recoveryStart.Time.Before(targetStart) {
+				targetStart = startOfUTCDay(recoveryStart.Time)
+			}
+		}
 		if !targetStart.Before(endDay) {
+			if isChat {
+				readyOrganizations[target.OrganizationID] = struct{}{}
+			}
 			c.recordHeartbeat(ctx, i+1, len(targets))
 			continue
 		}
@@ -117,29 +148,42 @@ func (c *CollectOpenRouterDailySpend) Do(ctx context.Context, args CollectOpenRo
 				attr.SlogOpenRouterKeyType(target.KeyType),
 				attr.SlogError(err),
 			)
+			c.recordHeartbeat(ctx, i+1, len(targets))
+			continue
+		}
+		if isChat {
+			missing, err := queries.CountOpenRouterInvoiceSpendGaps(ctx, repo.CountOpenRouterInvoiceSpendGapsParams{
+				TargetKeyType:        target.KeyType,
+				TargetOrganizationID: pgtype.Text{String: target.OrganizationID, Valid: true},
+				TargetEarliestDay:    pgtype.Date{Time: createdDay, InfinityModifier: pgtype.Finite, Valid: true},
+				TargetEndDay:         pgtype.Date{Time: endDay, InfinityModifier: pgtype.Finite, Valid: true},
+			})
+			if err != nil {
+				failures = append(failures, fmt.Errorf("check invoice spend gaps for organization %s: %w", target.OrganizationID, err))
+			} else if missing > 0 {
+				failures = append(failures, fmt.Errorf("organization %s has %d unresolved invoice spend gaps", target.OrganizationID, missing))
+			} else {
+				readyOrganizations[target.OrganizationID] = struct{}{}
+			}
 		}
 		c.recordHeartbeat(ctx, i+1, len(targets))
 	}
 
-	// A gap before StartDay is outside the overlapping recovery window. Start
-	// from the first stored row so rollout and newly created keys do not alert
-	// for history the collector never had an opportunity to fetch.
+	result := CollectOpenRouterDailySpendResult{
+		ReadyOrganizationIDs: make([]string, 0, len(readyOrganizations)),
+	}
 	for _, target := range targets {
-		missing, err := queries.CountOpenRouterDailySpendGaps(ctx, repo.CountOpenRouterDailySpendGapsParams{
-			TargetOrganizationID: target.OrganizationID,
-			TargetKeyType:        target.KeyType,
-			TargetCutoffDay:      pgtype.Date{Time: startDay, InfinityModifier: pgtype.Finite, Valid: true},
-		})
-		if err != nil {
-			failures = append(failures, fmt.Errorf("check spend gaps for organization %s key type %s: %w", target.OrganizationID, target.KeyType, err))
-			continue
-		}
-		if missing > 0 {
-			failures = append(failures, fmt.Errorf("organization %s key type %s has %d daily spend gaps before recovery window", target.OrganizationID, target.KeyType, missing))
+		if _, ready := readyOrganizations[target.OrganizationID]; ready {
+			result.ReadyOrganizationIDs = append(result.ReadyOrganizationIDs, target.OrganizationID)
+			delete(readyOrganizations, target.OrganizationID)
 		}
 	}
 
-	return errors.Join(failures...)
+	if len(failures) > 0 {
+		c.logger.WarnContext(ctx, "some OpenRouter daily spend targets were not ready",
+			attr.SlogError(errors.Join(failures...)))
+	}
+	return result, nil
 }
 
 func (c *CollectOpenRouterDailySpend) storeTargetDays(

--- a/server/internal/background/activities/openrouter_daily_spend_test.go
+++ b/server/internal/background/activities/openrouter_daily_spend_test.go
@@ -173,8 +173,9 @@ func TestCollectOpenRouterDailySpend_ContinuesAfterUpstreamFailure(t *testing.T)
 		}, nil).Once()
 
 	act := activities.NewCollectOpenRouterDailySpend(testenv.NewLogger(t), conn, client)
-	err := act.Do(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: startDay, EndDay: endDay})
-	require.ErrorContains(t, err, "management API unavailable")
+	result, err := act.DoWithResult(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: startDay, EndDay: endDay})
+	require.NoError(t, err)
+	require.Empty(t, result.ReadyOrganizationIDs)
 
 	queries := backgroundrepo.New(conn)
 	chatRows, err := queries.ListOpenRouterDailySpend(ctx, backgroundrepo.ListOpenRouterDailySpendParams{
@@ -229,8 +230,9 @@ func TestCollectOpenRouterDailySpend_RejectsUnrepresentableSpend(t *testing.T) {
 				}, nil).Once()
 
 			act := activities.NewCollectOpenRouterDailySpend(testenv.NewLogger(t), conn, client)
-			err := act.Do(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: startDay, EndDay: endDay})
-			require.ErrorContains(t, err, test.errText)
+			result, err := act.DoWithResult(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: startDay, EndDay: endDay})
+			require.NoError(t, err)
+			require.Empty(t, result.ReadyOrganizationIDs, test.errText)
 
 			rows, queryErr := backgroundrepo.New(conn).ListOpenRouterDailySpend(ctx, backgroundrepo.ListOpenRouterDailySpendParams{
 				OrganizationID: orgID,
@@ -268,30 +270,80 @@ func TestCollectOpenRouterDailySpend_ClampsToKeyCreationDay(t *testing.T) {
 	client.AssertExpectations(t)
 }
 
-func TestCollectOpenRouterDailySpend_ReportsGapOlderThanRecoveryWindow(t *testing.T) {
+func TestCollectOpenRouterDailySpend_RecoversStaleInvoiceDayBeyond96Hours(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	conn, orgID := setupOpenRouterDailySpendTest(t, "openrouter_daily_spend_gap")
-	createOpenRouterSpendTarget(t, conn, orgID, openrouter.KeyTypeChat, '1')
+	conn, orgID := setupOpenRouterDailySpendTest(t, "openrouter_daily_spend_stale_recovery")
+	keyHash := createOpenRouterSpendTarget(t, conn, orgID, openrouter.KeyTypeChat, '1')
 	queries := backgroundrepo.New(conn)
 
-	firstDay := utcDay(-6)
-	for _, day := range []time.Time{firstDay, firstDay.AddDate(0, 0, 2)} {
-		var spend pgtype.Numeric
-		require.NoError(t, spend.Scan("1"))
-		require.NoError(t, queries.UpsertOpenRouterDailySpend(ctx, backgroundrepo.UpsertOpenRouterDailySpendParams{
-			TargetOrganizationID: orgID,
-			TargetKeyType:        string(openrouter.KeyTypeChat),
-			TargetDay:            pgtype.Date{Time: day, Valid: true},
-			TargetSpendUsd:       spend,
-		}))
-	}
+	invoiceDay := utcDay(-7)
+	require.NoError(t, queries.SetOpenRouterAPIKeyCreatedAtFixture(ctx, backgroundrepo.SetOpenRouterAPIKeyCreatedAtFixtureParams{
+		CreatedAt:      pgtype.Timestamptz{Time: invoiceDay, InfinityModifier: pgtype.Finite, Valid: true},
+		OrganizationID: orgID,
+		KeyType:        "chat",
+	}))
+	require.NoError(t, queries.CreateStripeInvoiceFixture(ctx, backgroundrepo.CreateStripeInvoiceFixtureParams{
+		StripeInvoiceID:      "in_stale",
+		OrganizationID:       pgtype.Text{String: orgID, Valid: true},
+		StripeCustomerID:     "cus_stale",
+		StripeSubscriptionID: "sub_stale",
+		ServicePeriodStart:   pgtype.Timestamptz{Time: invoiceDay, InfinityModifier: pgtype.Finite, Valid: true},
+		ServicePeriodEnd:     pgtype.Timestamptz{Time: invoiceDay.AddDate(0, 0, 1), InfinityModifier: pgtype.Finite, Valid: true},
+		InvoiceState:         "open",
+		FinalizedAt:          pgtype.Timestamptz{Time: invoiceDay.AddDate(0, 0, 1), InfinityModifier: pgtype.Finite, Valid: true},
+	}))
+	var stale pgtype.Numeric
+	require.NoError(t, stale.Scan("1"))
+	require.NoError(t, queries.UpsertOpenRouterDailySpend(ctx, backgroundrepo.UpsertOpenRouterDailySpendParams{
+		TargetOrganizationID: orgID,
+		TargetKeyType:        string(openrouter.KeyTypeChat),
+		TargetDay:            pgtype.Date{Time: invoiceDay, Valid: true},
+		TargetSpendUsd:       stale,
+	}))
 
 	client := &mockOpenRouterSpendClient{}
+	client.On("GetDailySpend", mock.Anything, keyHash, invoiceDay, utcDay(0)).
+		Return(openrouter.DailySpendResult{
+			Days:   []openrouter.DailySpendDay{{Day: invoiceDay, SpendUSD: "2.5"}},
+			Source: openrouter.DailySpendSourceAnalytics,
+		}, nil).Once()
 	act := activities.NewCollectOpenRouterDailySpend(testenv.NewLogger(t), conn, client)
-	err := act.Do(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: utcDay(-3), EndDay: utcDay(0)})
-	require.ErrorContains(t, err, "has 1 daily spend gaps before recovery window")
-	client.AssertNotCalled(t, "GetDailySpend", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	result, err := act.DoWithResult(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: utcDay(-4), EndDay: utcDay(0)})
+	require.NoError(t, err)
+	require.Equal(t, []string{orgID}, result.ReadyOrganizationIDs)
+	rows, err := queries.ListOpenRouterDailySpend(ctx, backgroundrepo.ListOpenRouterDailySpendParams{
+		OrganizationID: orgID,
+		KeyType:        string(openrouter.KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "2.500000", numericString(t, rows[0].SpendUsd))
+	client.AssertExpectations(t)
+}
+
+func TestCollectOpenRouterDailySpend_ReturnsHealthyOrganizationWhenPeerFails(t *testing.T) {
+	t.Parallel()
+	conn, failedOrgID := setupOpenRouterDailySpendTest(t, "openrouter_daily_spend_org_isolation")
+	failedHash := createOpenRouterSpendTarget(t, conn, failedOrgID, openrouter.KeyTypeChat, '3')
+	healthyOrgID := "org-" + uuid.NewString()[:8]
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID: healthyOrgID, Name: "Healthy", Slug: healthyOrgID, WorkosID: pgtype.Text{}, Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	healthyHash := createOpenRouterSpendTarget(t, conn, healthyOrgID, openrouter.KeyTypeChat, '4')
+	startDay := utcDay(0)
+	endDay := utcDay(1)
+	client := &mockOpenRouterSpendClient{}
+	client.On("GetDailySpend", mock.Anything, failedHash, startDay, endDay).
+		Return(openrouter.DailySpendResult{}, errors.New("one org unavailable")).Once()
+	client.On("GetDailySpend", mock.Anything, healthyHash, startDay, endDay).
+		Return(openrouter.DailySpendResult{Source: openrouter.DailySpendSourceAnalytics}, nil).Once()
+
+	result, err := activities.NewCollectOpenRouterDailySpend(testenv.NewLogger(t), conn, client).
+		DoWithResult(t.Context(), activities.CollectOpenRouterDailySpendArgs{StartDay: startDay, EndDay: endDay})
+	require.NoError(t, err)
+	require.Equal(t, []string{healthyOrgID}, result.ReadyOrganizationIDs)
+	client.AssertExpectations(t)
 }
 
 func TestCollectOpenRouterDailySpend_NewKeyHasNoHistoricalGap(t *testing.T) {

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -369,13 +369,13 @@ SELECT
     allocation.source_key
   , allocation.source_day
   , allocation.source_snapshot_usd
-  , COALESCE(spend.spend_usd, 0::numeric) AS final_spend_usd
+  , spend.spend_usd AS final_spend_usd
   , allocation.original_invoice_id
 FROM stripe_invoice_allocations allocation
 JOIN stripe_invoices invoice
   ON invoice.organization_id = allocation.organization_id
  AND invoice.stripe_invoice_id = allocation.original_invoice_id
-LEFT JOIN openrouter_spend_daily spend
+JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = allocation.source_day

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -214,14 +214,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '48 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 1
         )
     )
@@ -231,14 +231,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '72 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 2
         )
     )
@@ -281,14 +281,14 @@ WHERE invoice.organization_id = @organization_id
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '48 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 1
         )
     )
@@ -298,14 +298,14 @@ WHERE invoice.organization_id = @organization_id
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '72 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 2
         )
     )

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -373,6 +373,9 @@ SELECT
       WHEN chat_key.created_at IS NULL
         OR allocation.source_day < (chat_key.created_at AT TIME ZONE 'UTC')::date
         THEN 0::numeric
+	  WHEN chat_key.deleted_at IS NOT NULL
+	    AND allocation.source_day >= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
+	    THEN COALESCE(spend.spend_usd, 0::numeric)
       ELSE spend.spend_usd
     END)::numeric(14, 6) AS final_spend_usd
   , carry.amount_usd AS existing_carry_amount_usd
@@ -388,6 +391,10 @@ LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = allocation.source_day
+ AND (
+   chat_key.deleted_at IS NULL
+   OR spend.day <= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
+ )
 LEFT JOIN stripe_invoice_allocations carry
   ON carry.organization_id = allocation.organization_id
  AND carry.source_kind = allocation.source_kind
@@ -599,6 +606,12 @@ WHERE organization_id = @organization_id
 -- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
 UPDATE openrouter_api_keys
 SET created_at = @created_at
+WHERE organization_id = @organization_id
+  AND key_type = @key_type;
+
+-- name: SetOpenRouterAPIKeyDeletedAtFixture :exec
+UPDATE openrouter_api_keys
+SET deleted_at = @deleted_at
 WHERE organization_id = @organization_id
   AND key_type = @key_type;
 

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -369,16 +369,30 @@ SELECT
     allocation.source_key
   , allocation.source_day
   , allocation.source_snapshot_usd
-  , spend.spend_usd AS final_spend_usd
+  , (CASE
+      WHEN chat_key.created_at IS NULL
+        OR allocation.source_day < (chat_key.created_at AT TIME ZONE 'UTC')::date
+        THEN 0::numeric
+      ELSE spend.spend_usd
+    END)::numeric(14, 6) AS final_spend_usd
+  , carry.amount_usd AS existing_carry_amount_usd
   , allocation.original_invoice_id
 FROM stripe_invoice_allocations allocation
 JOIN stripe_invoices invoice
   ON invoice.organization_id = allocation.organization_id
  AND invoice.stripe_invoice_id = allocation.original_invoice_id
-JOIN openrouter_spend_daily spend
+LEFT JOIN openrouter_api_keys chat_key
+  ON chat_key.organization_id = allocation.organization_id
+ AND chat_key.key_type = 'chat'
+LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = allocation.source_day
+LEFT JOIN stripe_invoice_allocations carry
+  ON carry.organization_id = allocation.organization_id
+ AND carry.source_kind = allocation.source_kind
+ AND carry.source_key = allocation.source_key
+ AND carry.seq = 2
 WHERE allocation.organization_id = @organization_id
   AND invoice.stripe_invoice_id = @stripe_invoice_id
   AND invoice.service_period_end + interval '72 hours' <= @now

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -108,34 +108,84 @@ SET
     updated_at = clock_timestamp()
 WHERE openrouter_spend_daily.spend_usd IS DISTINCT FROM @target_spend_usd;
 
--- name: CountOpenRouterDailySpendGaps :one
--- Search only after the first successfully stored day. This avoids reporting
--- pre-rollout history or a newly created key as missing. The caller supplies
--- the start of its recovery window as cutoff_day, so every returned gap is too
--- old for the overlapping daily pull to repair automatically.
-WITH RECURSIVE calendar(day) AS (
-  SELECT MIN(openrouter_spend_daily.day)
-  FROM openrouter_spend_daily
-  WHERE openrouter_spend_daily.organization_id = @target_organization_id
-    AND openrouter_spend_daily.key_type = @target_key_type
-  UNION ALL
-  SELECT calendar.day + 1
-  FROM calendar
-  WHERE calendar.day + 1 < @target_cutoff_day::date
-), missing AS (
-  SELECT calendar.day
-  FROM calendar
-  LEFT JOIN openrouter_spend_daily spend
-    ON spend.organization_id = @target_organization_id
-   AND spend.key_type = @target_key_type
-   AND spend.day = calendar.day
-  WHERE calendar.day IS NOT NULL
-    AND spend.id IS NULL
-  ORDER BY calendar.day
-)
-SELECT
-  COUNT(*)::bigint AS missing_count
-FROM missing;
+-- name: GetOpenRouterDailySpendRecoveryStartDay :one
+-- Expand collection to the oldest unresolved invoice day. This heals outages
+-- beyond the normal overlap instead of permanently detecting the same gap.
+SELECT MIN(generated.source_timestamp)::date AS recovery_start_day
+FROM stripe_invoices invoice
+CROSS JOIN LATERAL generate_series(
+  invoice.service_period_start,
+  invoice.service_period_end - interval '1 day',
+  interval '1 day'
+) AS generated(source_timestamp)
+WHERE invoice.organization_id = @target_organization_id
+  AND generated.source_timestamp::date >= @target_earliest_day::date
+  AND generated.source_timestamp::date < @target_end_day::date
+  AND (
+    (
+      invoice.service_period_end + interval '48 hours' <= @target_end_day::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 1
+      )
+    )
+    OR (
+      invoice.service_period_end + interval '72 hours' <= @target_end_day::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 2
+      )
+    )
+  );
+
+-- name: CountOpenRouterInvoiceSpendGaps :one
+SELECT COUNT(*)::bigint AS missing_count
+FROM stripe_invoices invoice
+CROSS JOIN LATERAL generate_series(
+  invoice.service_period_start,
+  invoice.service_period_end - interval '1 day',
+  interval '1 day'
+) AS generated(source_timestamp)
+LEFT JOIN openrouter_spend_daily spend
+  ON spend.organization_id = invoice.organization_id
+ AND spend.key_type = @target_key_type
+ AND spend.day = generated.source_timestamp::date
+WHERE invoice.organization_id = @target_organization_id
+  AND generated.source_timestamp::date >= @target_earliest_day::date
+  AND generated.source_timestamp::date < @target_end_day::date
+  AND spend.id IS NULL
+  AND (
+    (
+      invoice.service_period_end + interval '48 hours' <= @target_end_day::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 1
+      )
+    )
+    OR (
+      invoice.service_period_end + interval '72 hours' <= @target_end_day::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 2
+      )
+    )
+  );
 
 -- name: ListOpenRouterDailySpend :many
 SELECT
@@ -149,6 +199,464 @@ FROM openrouter_spend_daily
 WHERE organization_id = @organization_id
   AND key_type = @key_type
 ORDER BY day;
+
+-- name: ListStripeInvoiceBillingOrganizations :many
+-- Organizations remain candidates for as long as a required immutable
+-- snapshot, a delivery, or a destination assignment is missing. There is no
+-- age cutoff: an outage must delay billing rather than erase it.
+SELECT DISTINCT invoice.organization_id::text AS organization_id
+FROM stripe_invoices invoice
+WHERE invoice.organization_id IS NOT NULL
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '48 hours' <= @now
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 1
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '72 hours' <= @now
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 2
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM stripe_invoice_allocations allocation
+      WHERE allocation.organization_id = invoice.organization_id
+        AND (
+          allocation.delivery_state IN ('pending', 'ambiguous')
+          OR (
+            allocation.amount_usd > 0
+            AND allocation.destination_invoice_id IS NULL
+            AND allocation.original_invoice_id IS NOT NULL
+          )
+          OR (
+            allocation.source_kind = 'tum_cycle'
+            AND allocation.original_invoice_id IS NULL
+          )
+        )
+    )
+  )
+ORDER BY organization_id;
+
+-- name: ListStripeInvoicesForOpenRouterBilling :many
+SELECT
+    stripe_invoice_id
+  , organization_id::text AS organization_id
+  , stripe_customer_id
+  , stripe_subscription_id
+  , service_period_start
+  , service_period_end
+  , invoice_state
+  , finalized_at
+FROM stripe_invoices invoice
+WHERE invoice.organization_id = @organization_id
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '48 hours' <= @now
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 1
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '72 hours' <= @now
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 2
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM stripe_invoice_allocations allocation
+      WHERE allocation.organization_id = invoice.organization_id
+        AND (
+          allocation.original_invoice_id = invoice.stripe_invoice_id
+          OR allocation.destination_invoice_id = invoice.stripe_invoice_id
+          OR (
+            invoice.invoice_state = 'draft'
+            AND allocation.amount_usd > 0
+            AND allocation.destination_invoice_id IS NULL
+            AND allocation.original_invoice_id IS NOT NULL
+          )
+          OR (
+            allocation.source_kind = 'tum_cycle'
+            AND allocation.original_invoice_id IS NULL
+            AND allocation.source_period_start = invoice.service_period_start
+            AND allocation.source_period_end = invoice.service_period_end
+          )
+        )
+    )
+  )
+ORDER BY service_period_start;
+
+-- name: UpdateStripeInvoiceState :execrows
+UPDATE stripe_invoices
+SET invoice_state = @invoice_state,
+    finalized_at = @finalized_at,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND stripe_invoice_id = @stripe_invoice_id
+  AND stripe_customer_id = @stripe_customer_id
+  AND stripe_subscription_id = @stripe_subscription_id
+  AND service_period_start = @service_period_start
+  AND service_period_end = @service_period_end;
+
+-- name: ListOpenRouterInvoiceSourceDays :many
+SELECT
+    generated.source_timestamp::date AS source_day
+  , COALESCE(spend.spend_usd, 0::numeric) AS spend_usd
+FROM stripe_invoices invoice
+CROSS JOIN LATERAL generate_series(
+  invoice.service_period_start,
+  invoice.service_period_end - interval '1 day',
+  interval '1 day'
+) AS generated(source_timestamp)
+LEFT JOIN openrouter_spend_daily spend
+  ON spend.organization_id = invoice.organization_id
+ AND spend.key_type = 'chat'
+ AND spend.day = generated.source_timestamp::date
+WHERE invoice.organization_id = @organization_id
+  AND invoice.stripe_invoice_id = @stripe_invoice_id
+  AND invoice.service_period_end + interval '48 hours' <= @now
+ORDER BY source_day;
+
+-- name: ListOpenRouterInvoiceBaselines :many
+SELECT
+    allocation.source_key
+  , allocation.source_day
+  , allocation.source_snapshot_usd
+  , COALESCE(spend.spend_usd, 0::numeric) AS final_spend_usd
+  , allocation.original_invoice_id
+FROM stripe_invoice_allocations allocation
+JOIN stripe_invoices invoice
+  ON invoice.organization_id = allocation.organization_id
+ AND invoice.stripe_invoice_id = allocation.original_invoice_id
+LEFT JOIN openrouter_spend_daily spend
+  ON spend.organization_id = allocation.organization_id
+ AND spend.key_type = 'chat'
+ AND spend.day = allocation.source_day
+WHERE allocation.organization_id = @organization_id
+  AND invoice.stripe_invoice_id = @stripe_invoice_id
+  AND invoice.service_period_end + interval '72 hours' <= @now
+  AND allocation.source_kind = 'openrouter_daily_spend'
+  AND allocation.seq = 1
+ORDER BY allocation.source_day;
+
+-- name: CreateOpenRouterInvoiceAllocation :execrows
+INSERT INTO stripe_invoice_allocations (
+    organization_id
+  , source_kind
+  , source_key
+  , seq
+  , source_day
+  , source_snapshot_usd
+  , amount_usd
+  , original_invoice_id
+  , destination_invoice_id
+  , idempotency_key
+  , delivery_state
+  , confirmed_at
+) VALUES (
+    @organization_id
+  , 'openrouter_daily_spend'
+  , @source_key
+  , @seq
+  , @source_day
+  , @source_snapshot_usd
+  , @amount_usd
+  , @original_invoice_id
+  , @destination_invoice_id
+  , @idempotency_key
+  , @delivery_state
+  , @confirmed_at
+)
+ON CONFLICT (organization_id, source_kind, source_key, seq) DO NOTHING;
+
+-- name: AttachTUMCarryToOriginalInvoice :execrows
+UPDATE stripe_invoice_allocations allocation
+SET original_invoice_id = invoice.stripe_invoice_id,
+    destination_invoice_id = CASE WHEN allocation.amount_usd < 0 THEN invoice.stripe_invoice_id END,
+    updated_at = clock_timestamp()
+FROM stripe_invoices invoice
+WHERE allocation.organization_id = @organization_id
+  AND allocation.source_kind = 'tum_cycle'
+  AND allocation.original_invoice_id IS NULL
+  AND invoice.organization_id = allocation.organization_id
+  AND invoice.service_period_start = allocation.source_period_start
+  AND invoice.service_period_end = allocation.source_period_end;
+
+-- name: AssignPositiveCarryToStripeInvoice :execrows
+-- Assign every positive carry to the earliest eligible draft. The NULL guard
+-- is the compare-and-swap fence for concurrent settlement runs.
+WITH assignments AS (
+  SELECT
+      allocation.id
+    , (
+        SELECT candidate.stripe_invoice_id
+        FROM stripe_invoices original
+        JOIN stripe_invoices candidate
+          ON candidate.organization_id = original.organization_id
+         AND candidate.invoice_state = 'draft'
+         AND original.service_period_end <= candidate.service_period_start
+        WHERE original.organization_id = allocation.organization_id
+          AND original.stripe_invoice_id = allocation.original_invoice_id
+        ORDER BY candidate.service_period_start, candidate.stripe_invoice_id
+        LIMIT 1
+      ) AS destination_invoice_id
+  FROM stripe_invoice_allocations allocation
+  WHERE allocation.organization_id = @organization_id
+    AND allocation.amount_usd > 0
+    AND allocation.destination_invoice_id IS NULL
+    AND allocation.original_invoice_id IS NOT NULL
+)
+UPDATE stripe_invoice_allocations allocation
+SET destination_invoice_id = assignments.destination_invoice_id,
+    updated_at = clock_timestamp()
+FROM assignments
+WHERE allocation.organization_id = @organization_id
+  AND allocation.id = assignments.id
+  AND assignments.destination_invoice_id IS NOT NULL
+  AND allocation.amount_usd > 0
+  AND allocation.destination_invoice_id IS NULL
+  AND allocation.original_invoice_id IS NOT NULL;
+
+-- name: ClaimNextStripeInvoiceAllocation :one
+WITH candidate AS (
+  SELECT
+      allocation.id
+    , allocation.first_attempted_at AS previous_first_attempted_at
+    , allocation.delivery_state AS previous_delivery_state
+  FROM stripe_invoice_allocations allocation
+  JOIN stripe_invoices destination
+    ON destination.stripe_invoice_id = allocation.destination_invoice_id
+   AND destination.organization_id = allocation.organization_id
+  WHERE allocation.organization_id = @organization_id
+    AND allocation.delivery_state IN ('pending', 'ambiguous')
+    AND allocation.amount_usd <> 0
+    AND (
+      allocation.last_attempted_at IS NULL
+      OR allocation.last_attempted_at <= @lease_before
+    )
+  ORDER BY allocation.created_at, allocation.source_kind, allocation.source_key, allocation.seq
+  LIMIT 1
+  FOR UPDATE OF allocation SKIP LOCKED
+), claimed AS (
+  UPDATE stripe_invoice_allocations allocation
+  SET first_attempted_at = COALESCE(allocation.first_attempted_at, @attempted_at),
+      last_attempted_at = @attempted_at,
+      delivery_state = 'pending',
+      updated_at = clock_timestamp()
+  FROM candidate
+  WHERE allocation.organization_id = @organization_id
+    AND allocation.id = candidate.id
+  RETURNING
+    allocation.id
+  , allocation.organization_id::text AS organization_id
+  , allocation.source_kind
+  , allocation.source_key
+  , allocation.seq
+  , allocation.source_day
+  , allocation.source_period_start
+  , allocation.source_period_end
+  , allocation.amount_usd
+  , allocation.original_invoice_id
+  , allocation.destination_invoice_id
+  , allocation.idempotency_key
+  , allocation.delivery_state
+  , candidate.previous_first_attempted_at
+  , candidate.previous_delivery_state
+)
+SELECT
+    claimed.*
+  , destination.stripe_customer_id
+  , destination.stripe_subscription_id
+  , destination.service_period_start AS destination_period_start
+  , destination.service_period_end AS destination_period_end
+  , destination.invoice_state AS destination_invoice_state
+FROM claimed
+JOIN stripe_invoices destination
+  ON destination.stripe_invoice_id = claimed.destination_invoice_id
+ AND destination.organization_id = claimed.organization_id;
+
+-- name: MarkStripeInvoiceAllocationAmbiguous :execrows
+UPDATE stripe_invoice_allocations
+SET first_attempted_at = COALESCE(first_attempted_at, @attempted_at),
+    last_attempted_at = @attempted_at,
+    ambiguous_at = COALESCE(ambiguous_at, @attempted_at),
+    delivery_state = 'ambiguous',
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND delivery_state = 'pending'
+  AND last_attempted_at = @attempted_at;
+
+-- name: ReconcileAndRotateStripeInvoiceAllocation :one
+UPDATE stripe_invoice_allocations
+SET reconciled_at = @reconciled_at,
+    idempotency_key = regexp_replace(idempotency_key, ':retry:[0-9]+$', '')
+      || ':retry:' || extract(epoch FROM @reconciled_at::timestamptz)::bigint::text,
+    first_attempted_at = @reconciled_at,
+    ambiguous_at = NULL,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND delivery_state = 'pending'
+  AND last_attempted_at = @attempted_at
+RETURNING idempotency_key;
+
+-- name: UnassignPositiveStripeInvoiceAllocation :execrows
+UPDATE stripe_invoice_allocations
+SET destination_invoice_id = NULL,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND amount_usd > 0
+  AND delivery_state = 'pending'
+  AND last_attempted_at = @attempted_at;
+
+-- name: ConfirmStripeInvoiceItemAllocation :execrows
+UPDATE stripe_invoice_allocations
+SET stripe_invoice_item_id = @stripe_invoice_item_id,
+    delivery_state = 'confirmed',
+    confirmed_at = COALESCE(confirmed_at, @confirmed_at),
+    reconciled_at = CASE WHEN @reconciled::boolean THEN @confirmed_at ELSE reconciled_at END,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND delivery_state = 'pending'
+  AND last_attempted_at = @attempted_at;
+
+-- name: ConfirmStripeCreditNoteAllocation :execrows
+UPDATE stripe_invoice_allocations
+SET stripe_credit_note_id = @stripe_credit_note_id,
+    delivery_state = 'confirmed',
+    confirmed_at = COALESCE(confirmed_at, @confirmed_at),
+    reconciled_at = CASE WHEN @reconciled::boolean THEN @confirmed_at ELSE reconciled_at END,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND id = @id
+  AND delivery_state = 'pending'
+  AND last_attempted_at = @attempted_at;
+
+-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
+UPDATE openrouter_api_keys
+SET created_at = @created_at
+WHERE organization_id = @organization_id
+  AND key_type = @key_type;
+
+-- name: CreateStripeInvoiceFixture :exec
+INSERT INTO stripe_invoices (
+    stripe_invoice_id
+  , organization_id
+  , stripe_customer_id
+  , stripe_subscription_id
+  , service_period_start
+  , service_period_end
+  , invoice_state
+  , finalized_at
+) VALUES (
+    @stripe_invoice_id
+  , @organization_id
+  , @stripe_customer_id
+  , @stripe_subscription_id
+  , @service_period_start
+  , @service_period_end
+  , @invoice_state
+  , @finalized_at
+);
+
+-- name: CreateTUMInvoiceAllocationFixture :exec
+INSERT INTO stripe_invoice_allocations (
+    organization_id
+  , source_kind
+  , source_key
+  , seq
+  , source_period_start
+  , source_period_end
+  , source_snapshot_usd
+  , delta_tokens
+  , original_tum_unit_price_usd
+  , amount_usd
+  , idempotency_key
+  , delivery_state
+) VALUES (
+    @organization_id
+  , 'tum_cycle'
+  , @source_key
+  , 1
+  , @source_period_start
+  , @source_period_end
+  , @source_snapshot_usd
+  , 1
+  , 0.000000350000
+  , @amount_usd
+  , @idempotency_key
+  , 'pending'
+);
+
+-- name: ListStripeInvoiceAllocationsFixture :many
+SELECT
+    seq
+  , source_kind
+  , source_key
+  , source_snapshot_usd
+  , amount_usd
+  , original_invoice_id
+  , destination_invoice_id
+  , idempotency_key
+  , delivery_state
+  , stripe_invoice_item_id
+  , stripe_credit_note_id
+  , first_attempted_at
+  , last_attempted_at
+  , reconciled_at
+FROM stripe_invoice_allocations
+WHERE organization_id = @organization_id
+ORDER BY source_key, seq;
 
 -- name: GetOpenRouterCreditsAlertRecipients :many
 -- Resolve the billing alert recipient for each supplied organization that

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -12,6 +12,72 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const assignPositiveCarryToStripeInvoice = `-- name: AssignPositiveCarryToStripeInvoice :execrows
+WITH assignments AS (
+  SELECT
+      allocation.id
+    , (
+        SELECT candidate.stripe_invoice_id
+        FROM stripe_invoices original
+        JOIN stripe_invoices candidate
+          ON candidate.organization_id = original.organization_id
+         AND candidate.invoice_state = 'draft'
+         AND original.service_period_end <= candidate.service_period_start
+        WHERE original.organization_id = allocation.organization_id
+          AND original.stripe_invoice_id = allocation.original_invoice_id
+        ORDER BY candidate.service_period_start, candidate.stripe_invoice_id
+        LIMIT 1
+      ) AS destination_invoice_id
+  FROM stripe_invoice_allocations allocation
+  WHERE allocation.organization_id = $1
+    AND allocation.amount_usd > 0
+    AND allocation.destination_invoice_id IS NULL
+    AND allocation.original_invoice_id IS NOT NULL
+)
+UPDATE stripe_invoice_allocations allocation
+SET destination_invoice_id = assignments.destination_invoice_id,
+    updated_at = clock_timestamp()
+FROM assignments
+WHERE allocation.organization_id = $1
+  AND allocation.id = assignments.id
+  AND assignments.destination_invoice_id IS NOT NULL
+  AND allocation.amount_usd > 0
+  AND allocation.destination_invoice_id IS NULL
+  AND allocation.original_invoice_id IS NOT NULL
+`
+
+// Assign every positive carry to the earliest eligible draft. The NULL guard
+// is the compare-and-swap fence for concurrent settlement runs.
+func (q *Queries) AssignPositiveCarryToStripeInvoice(ctx context.Context, organizationID pgtype.Text) (int64, error) {
+	result, err := q.db.Exec(ctx, assignPositiveCarryToStripeInvoice, organizationID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const attachTUMCarryToOriginalInvoice = `-- name: AttachTUMCarryToOriginalInvoice :execrows
+UPDATE stripe_invoice_allocations allocation
+SET original_invoice_id = invoice.stripe_invoice_id,
+    destination_invoice_id = CASE WHEN allocation.amount_usd < 0 THEN invoice.stripe_invoice_id END,
+    updated_at = clock_timestamp()
+FROM stripe_invoices invoice
+WHERE allocation.organization_id = $1
+  AND allocation.source_kind = 'tum_cycle'
+  AND allocation.original_invoice_id IS NULL
+  AND invoice.organization_id = allocation.organization_id
+  AND invoice.service_period_start = allocation.source_period_start
+  AND invoice.service_period_end = allocation.source_period_end
+`
+
+func (q *Queries) AttachTUMCarryToOriginalInvoice(ctx context.Context, organizationID pgtype.Text) (int64, error) {
+	result, err := q.db.Exec(ctx, attachTUMCarryToOriginalInvoice, organizationID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const backfillClaudeUserMessagePromptID = `-- name: BackfillClaudeUserMessagePromptID :exec
 UPDATE chat_messages
 SET message_id = $1
@@ -37,6 +103,122 @@ func (q *Queries) BackfillClaudeUserMessagePromptID(ctx context.Context, arg Bac
 		arg.ProjectID,
 	)
 	return err
+}
+
+const claimNextStripeInvoiceAllocation = `-- name: ClaimNextStripeInvoiceAllocation :one
+WITH candidate AS (
+  SELECT
+      allocation.id
+    , allocation.first_attempted_at AS previous_first_attempted_at
+    , allocation.delivery_state AS previous_delivery_state
+  FROM stripe_invoice_allocations allocation
+  JOIN stripe_invoices destination
+    ON destination.stripe_invoice_id = allocation.destination_invoice_id
+   AND destination.organization_id = allocation.organization_id
+  WHERE allocation.organization_id = $1
+    AND allocation.delivery_state IN ('pending', 'ambiguous')
+    AND allocation.amount_usd <> 0
+    AND (
+      allocation.last_attempted_at IS NULL
+      OR allocation.last_attempted_at <= $2
+    )
+  ORDER BY allocation.created_at, allocation.source_kind, allocation.source_key, allocation.seq
+  LIMIT 1
+  FOR UPDATE OF allocation SKIP LOCKED
+), claimed AS (
+  UPDATE stripe_invoice_allocations allocation
+  SET first_attempted_at = COALESCE(allocation.first_attempted_at, $3),
+      last_attempted_at = $3,
+      delivery_state = 'pending',
+      updated_at = clock_timestamp()
+  FROM candidate
+  WHERE allocation.organization_id = $1
+    AND allocation.id = candidate.id
+  RETURNING
+    allocation.id
+  , allocation.organization_id::text AS organization_id
+  , allocation.source_kind
+  , allocation.source_key
+  , allocation.seq
+  , allocation.source_day
+  , allocation.source_period_start
+  , allocation.source_period_end
+  , allocation.amount_usd
+  , allocation.original_invoice_id
+  , allocation.destination_invoice_id
+  , allocation.idempotency_key
+  , allocation.delivery_state
+  , candidate.previous_first_attempted_at
+  , candidate.previous_delivery_state
+)
+SELECT
+    claimed.id, claimed.organization_id, claimed.source_kind, claimed.source_key, claimed.seq, claimed.source_day, claimed.source_period_start, claimed.source_period_end, claimed.amount_usd, claimed.original_invoice_id, claimed.destination_invoice_id, claimed.idempotency_key, claimed.delivery_state, claimed.previous_first_attempted_at, claimed.previous_delivery_state
+  , destination.stripe_customer_id
+  , destination.stripe_subscription_id
+  , destination.service_period_start AS destination_period_start
+  , destination.service_period_end AS destination_period_end
+  , destination.invoice_state AS destination_invoice_state
+FROM claimed
+JOIN stripe_invoices destination
+  ON destination.stripe_invoice_id = claimed.destination_invoice_id
+ AND destination.organization_id = claimed.organization_id
+`
+
+type ClaimNextStripeInvoiceAllocationParams struct {
+	OrganizationID pgtype.Text
+	LeaseBefore    pgtype.Timestamptz
+	AttemptedAt    pgtype.Timestamptz
+}
+
+type ClaimNextStripeInvoiceAllocationRow struct {
+	ID                       uuid.UUID
+	OrganizationID           string
+	SourceKind               string
+	SourceKey                string
+	Seq                      int32
+	SourceDay                pgtype.Date
+	SourcePeriodStart        pgtype.Timestamptz
+	SourcePeriodEnd          pgtype.Timestamptz
+	AmountUsd                pgtype.Numeric
+	OriginalInvoiceID        pgtype.Text
+	DestinationInvoiceID     pgtype.Text
+	IdempotencyKey           string
+	DeliveryState            string
+	PreviousFirstAttemptedAt pgtype.Timestamptz
+	PreviousDeliveryState    string
+	StripeCustomerID         string
+	StripeSubscriptionID     string
+	DestinationPeriodStart   pgtype.Timestamptz
+	DestinationPeriodEnd     pgtype.Timestamptz
+	DestinationInvoiceState  string
+}
+
+func (q *Queries) ClaimNextStripeInvoiceAllocation(ctx context.Context, arg ClaimNextStripeInvoiceAllocationParams) (ClaimNextStripeInvoiceAllocationRow, error) {
+	row := q.db.QueryRow(ctx, claimNextStripeInvoiceAllocation, arg.OrganizationID, arg.LeaseBefore, arg.AttemptedAt)
+	var i ClaimNextStripeInvoiceAllocationRow
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.SourceKind,
+		&i.SourceKey,
+		&i.Seq,
+		&i.SourceDay,
+		&i.SourcePeriodStart,
+		&i.SourcePeriodEnd,
+		&i.AmountUsd,
+		&i.OriginalInvoiceID,
+		&i.DestinationInvoiceID,
+		&i.IdempotencyKey,
+		&i.DeliveryState,
+		&i.PreviousFirstAttemptedAt,
+		&i.PreviousDeliveryState,
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
+		&i.DestinationPeriodStart,
+		&i.DestinationPeriodEnd,
+		&i.DestinationInvoiceState,
+	)
+	return i, err
 }
 
 const claimPublishOutboxBatch = `-- name: ClaimPublishOutboxBatch :many
@@ -122,44 +304,136 @@ func (q *Queries) ClaimPublishOutboxBatch(ctx context.Context, arg ClaimPublishO
 	return items, nil
 }
 
-const countOpenRouterDailySpendGaps = `-- name: CountOpenRouterDailySpendGaps :one
-WITH RECURSIVE calendar(day) AS (
-  SELECT MIN(openrouter_spend_daily.day)
-  FROM openrouter_spend_daily
-  WHERE openrouter_spend_daily.organization_id = $1
-    AND openrouter_spend_daily.key_type = $2
-  UNION ALL
-  SELECT calendar.day + 1
-  FROM calendar
-  WHERE calendar.day + 1 < $3::date
-), missing AS (
-  SELECT calendar.day
-  FROM calendar
-  LEFT JOIN openrouter_spend_daily spend
-    ON spend.organization_id = $1
-   AND spend.key_type = $2
-   AND spend.day = calendar.day
-  WHERE calendar.day IS NOT NULL
-    AND spend.id IS NULL
-  ORDER BY calendar.day
-)
-SELECT
-  COUNT(*)::bigint AS missing_count
-FROM missing
+const confirmStripeCreditNoteAllocation = `-- name: ConfirmStripeCreditNoteAllocation :execrows
+UPDATE stripe_invoice_allocations
+SET stripe_credit_note_id = $1,
+    delivery_state = 'confirmed',
+    confirmed_at = COALESCE(confirmed_at, $2),
+    reconciled_at = CASE WHEN $3::boolean THEN $2 ELSE reconciled_at END,
+    updated_at = clock_timestamp()
+WHERE organization_id = $4
+  AND id = $5
+  AND delivery_state = 'pending'
+  AND last_attempted_at = $6
 `
 
-type CountOpenRouterDailySpendGapsParams struct {
-	TargetOrganizationID string
-	TargetKeyType        string
-	TargetCutoffDay      pgtype.Date
+type ConfirmStripeCreditNoteAllocationParams struct {
+	StripeCreditNoteID pgtype.Text
+	ConfirmedAt        pgtype.Timestamptz
+	Reconciled         bool
+	OrganizationID     pgtype.Text
+	ID                 uuid.UUID
+	AttemptedAt        pgtype.Timestamptz
 }
 
-// Search only after the first successfully stored day. This avoids reporting
-// pre-rollout history or a newly created key as missing. The caller supplies
-// the start of its recovery window as cutoff_day, so every returned gap is too
-// old for the overlapping daily pull to repair automatically.
-func (q *Queries) CountOpenRouterDailySpendGaps(ctx context.Context, arg CountOpenRouterDailySpendGapsParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countOpenRouterDailySpendGaps, arg.TargetOrganizationID, arg.TargetKeyType, arg.TargetCutoffDay)
+func (q *Queries) ConfirmStripeCreditNoteAllocation(ctx context.Context, arg ConfirmStripeCreditNoteAllocationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, confirmStripeCreditNoteAllocation,
+		arg.StripeCreditNoteID,
+		arg.ConfirmedAt,
+		arg.Reconciled,
+		arg.OrganizationID,
+		arg.ID,
+		arg.AttemptedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const confirmStripeInvoiceItemAllocation = `-- name: ConfirmStripeInvoiceItemAllocation :execrows
+UPDATE stripe_invoice_allocations
+SET stripe_invoice_item_id = $1,
+    delivery_state = 'confirmed',
+    confirmed_at = COALESCE(confirmed_at, $2),
+    reconciled_at = CASE WHEN $3::boolean THEN $2 ELSE reconciled_at END,
+    updated_at = clock_timestamp()
+WHERE organization_id = $4
+  AND id = $5
+  AND delivery_state = 'pending'
+  AND last_attempted_at = $6
+`
+
+type ConfirmStripeInvoiceItemAllocationParams struct {
+	StripeInvoiceItemID pgtype.Text
+	ConfirmedAt         pgtype.Timestamptz
+	Reconciled          bool
+	OrganizationID      pgtype.Text
+	ID                  uuid.UUID
+	AttemptedAt         pgtype.Timestamptz
+}
+
+func (q *Queries) ConfirmStripeInvoiceItemAllocation(ctx context.Context, arg ConfirmStripeInvoiceItemAllocationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, confirmStripeInvoiceItemAllocation,
+		arg.StripeInvoiceItemID,
+		arg.ConfirmedAt,
+		arg.Reconciled,
+		arg.OrganizationID,
+		arg.ID,
+		arg.AttemptedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const countOpenRouterInvoiceSpendGaps = `-- name: CountOpenRouterInvoiceSpendGaps :one
+SELECT COUNT(*)::bigint AS missing_count
+FROM stripe_invoices invoice
+CROSS JOIN LATERAL generate_series(
+  invoice.service_period_start,
+  invoice.service_period_end - interval '1 day',
+  interval '1 day'
+) AS generated(source_timestamp)
+LEFT JOIN openrouter_spend_daily spend
+  ON spend.organization_id = invoice.organization_id
+ AND spend.key_type = $1
+ AND spend.day = generated.source_timestamp::date
+WHERE invoice.organization_id = $2
+  AND generated.source_timestamp::date >= $3::date
+  AND generated.source_timestamp::date < $4::date
+  AND spend.id IS NULL
+  AND (
+    (
+      invoice.service_period_end + interval '48 hours' <= $4::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 1
+      )
+    )
+    OR (
+      invoice.service_period_end + interval '72 hours' <= $4::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 2
+      )
+    )
+  )
+`
+
+type CountOpenRouterInvoiceSpendGapsParams struct {
+	TargetKeyType        string
+	TargetOrganizationID pgtype.Text
+	TargetEarliestDay    pgtype.Date
+	TargetEndDay         pgtype.Date
+}
+
+func (q *Queries) CountOpenRouterInvoiceSpendGaps(ctx context.Context, arg CountOpenRouterInvoiceSpendGapsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countOpenRouterInvoiceSpendGaps,
+		arg.TargetKeyType,
+		arg.TargetOrganizationID,
+		arg.TargetEarliestDay,
+		arg.TargetEndDay,
+	)
 	var missing_count int64
 	err := row.Scan(&missing_count)
 	return missing_count, err
@@ -176,6 +450,171 @@ func (q *Queries) CountPendingPublishOutboxRows(ctx context.Context) (int64, err
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const createOpenRouterInvoiceAllocation = `-- name: CreateOpenRouterInvoiceAllocation :execrows
+INSERT INTO stripe_invoice_allocations (
+    organization_id
+  , source_kind
+  , source_key
+  , seq
+  , source_day
+  , source_snapshot_usd
+  , amount_usd
+  , original_invoice_id
+  , destination_invoice_id
+  , idempotency_key
+  , delivery_state
+  , confirmed_at
+) VALUES (
+    $1
+  , 'openrouter_daily_spend'
+  , $2
+  , $3
+  , $4
+  , $5
+  , $6
+  , $7
+  , $8
+  , $9
+  , $10
+  , $11
+)
+ON CONFLICT (organization_id, source_kind, source_key, seq) DO NOTHING
+`
+
+type CreateOpenRouterInvoiceAllocationParams struct {
+	OrganizationID       pgtype.Text
+	SourceKey            string
+	Seq                  int32
+	SourceDay            pgtype.Date
+	SourceSnapshotUsd    pgtype.Numeric
+	AmountUsd            pgtype.Numeric
+	OriginalInvoiceID    pgtype.Text
+	DestinationInvoiceID pgtype.Text
+	IdempotencyKey       string
+	DeliveryState        string
+	ConfirmedAt          pgtype.Timestamptz
+}
+
+func (q *Queries) CreateOpenRouterInvoiceAllocation(ctx context.Context, arg CreateOpenRouterInvoiceAllocationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, createOpenRouterInvoiceAllocation,
+		arg.OrganizationID,
+		arg.SourceKey,
+		arg.Seq,
+		arg.SourceDay,
+		arg.SourceSnapshotUsd,
+		arg.AmountUsd,
+		arg.OriginalInvoiceID,
+		arg.DestinationInvoiceID,
+		arg.IdempotencyKey,
+		arg.DeliveryState,
+		arg.ConfirmedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const createStripeInvoiceFixture = `-- name: CreateStripeInvoiceFixture :exec
+INSERT INTO stripe_invoices (
+    stripe_invoice_id
+  , organization_id
+  , stripe_customer_id
+  , stripe_subscription_id
+  , service_period_start
+  , service_period_end
+  , invoice_state
+  , finalized_at
+) VALUES (
+    $1
+  , $2
+  , $3
+  , $4
+  , $5
+  , $6
+  , $7
+  , $8
+)
+`
+
+type CreateStripeInvoiceFixtureParams struct {
+	StripeInvoiceID      string
+	OrganizationID       pgtype.Text
+	StripeCustomerID     string
+	StripeSubscriptionID string
+	ServicePeriodStart   pgtype.Timestamptz
+	ServicePeriodEnd     pgtype.Timestamptz
+	InvoiceState         string
+	FinalizedAt          pgtype.Timestamptz
+}
+
+func (q *Queries) CreateStripeInvoiceFixture(ctx context.Context, arg CreateStripeInvoiceFixtureParams) error {
+	_, err := q.db.Exec(ctx, createStripeInvoiceFixture,
+		arg.StripeInvoiceID,
+		arg.OrganizationID,
+		arg.StripeCustomerID,
+		arg.StripeSubscriptionID,
+		arg.ServicePeriodStart,
+		arg.ServicePeriodEnd,
+		arg.InvoiceState,
+		arg.FinalizedAt,
+	)
+	return err
+}
+
+const createTUMInvoiceAllocationFixture = `-- name: CreateTUMInvoiceAllocationFixture :exec
+INSERT INTO stripe_invoice_allocations (
+    organization_id
+  , source_kind
+  , source_key
+  , seq
+  , source_period_start
+  , source_period_end
+  , source_snapshot_usd
+  , delta_tokens
+  , original_tum_unit_price_usd
+  , amount_usd
+  , idempotency_key
+  , delivery_state
+) VALUES (
+    $1
+  , 'tum_cycle'
+  , $2
+  , 1
+  , $3
+  , $4
+  , $5
+  , 1
+  , 0.000000350000
+  , $6
+  , $7
+  , 'pending'
+)
+`
+
+type CreateTUMInvoiceAllocationFixtureParams struct {
+	OrganizationID    pgtype.Text
+	SourceKey         string
+	SourcePeriodStart pgtype.Timestamptz
+	SourcePeriodEnd   pgtype.Timestamptz
+	SourceSnapshotUsd pgtype.Numeric
+	AmountUsd         pgtype.Numeric
+	IdempotencyKey    string
+}
+
+func (q *Queries) CreateTUMInvoiceAllocationFixture(ctx context.Context, arg CreateTUMInvoiceAllocationFixtureParams) error {
+	_, err := q.db.Exec(ctx, createTUMInvoiceAllocationFixture,
+		arg.OrganizationID,
+		arg.SourceKey,
+		arg.SourcePeriodStart,
+		arg.SourcePeriodEnd,
+		arg.SourceSnapshotUsd,
+		arg.AmountUsd,
+		arg.IdempotencyKey,
+	)
+	return err
 }
 
 const deadLetterPublishOutboxRows = `-- name: DeadLetterPublishOutboxRows :execrows
@@ -574,6 +1013,58 @@ func (q *Queries) GetOpenRouterCreditsMonitoringTargets(ctx context.Context, acc
 	return items, nil
 }
 
+const getOpenRouterDailySpendRecoveryStartDay = `-- name: GetOpenRouterDailySpendRecoveryStartDay :one
+SELECT MIN(generated.source_timestamp)::date AS recovery_start_day
+FROM stripe_invoices invoice
+CROSS JOIN LATERAL generate_series(
+  invoice.service_period_start,
+  invoice.service_period_end - interval '1 day',
+  interval '1 day'
+) AS generated(source_timestamp)
+WHERE invoice.organization_id = $1
+  AND generated.source_timestamp::date >= $2::date
+  AND generated.source_timestamp::date < $3::date
+  AND (
+    (
+      invoice.service_period_end + interval '48 hours' <= $3::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 1
+      )
+    )
+    OR (
+      invoice.service_period_end + interval '72 hours' <= $3::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM stripe_invoice_allocations allocation
+        WHERE allocation.organization_id = invoice.organization_id
+          AND allocation.source_kind = 'openrouter_daily_spend'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.seq = 2
+      )
+    )
+  )
+`
+
+type GetOpenRouterDailySpendRecoveryStartDayParams struct {
+	TargetOrganizationID pgtype.Text
+	TargetEarliestDay    pgtype.Date
+	TargetEndDay         pgtype.Date
+}
+
+// Expand collection to the oldest unresolved invoice day. This heals outages
+// beyond the normal overlap instead of permanently detecting the same gap.
+func (q *Queries) GetOpenRouterDailySpendRecoveryStartDay(ctx context.Context, arg GetOpenRouterDailySpendRecoveryStartDayParams) (pgtype.Date, error) {
+	row := q.db.QueryRow(ctx, getOpenRouterDailySpendRecoveryStartDay, arg.TargetOrganizationID, arg.TargetEarliestDay, arg.TargetEndDay)
+	var recovery_start_day pgtype.Date
+	err := row.Scan(&recovery_start_day)
+	return recovery_start_day, err
+}
+
 const getPlatformUsageMetrics = `-- name: GetPlatformUsageMetrics :many
 WITH latest_deployments AS (
   SELECT DISTINCT ON (project_id) project_id, d.id as deployment_id
@@ -897,6 +1388,393 @@ func (q *Queries) ListOpenRouterDailySpendTargets(ctx context.Context) ([]ListOp
 	return items, nil
 }
 
+const listOpenRouterInvoiceBaselines = `-- name: ListOpenRouterInvoiceBaselines :many
+SELECT
+    allocation.source_key
+  , allocation.source_day
+  , allocation.source_snapshot_usd
+  , COALESCE(spend.spend_usd, 0::numeric) AS final_spend_usd
+  , allocation.original_invoice_id
+FROM stripe_invoice_allocations allocation
+JOIN stripe_invoices invoice
+  ON invoice.organization_id = allocation.organization_id
+ AND invoice.stripe_invoice_id = allocation.original_invoice_id
+LEFT JOIN openrouter_spend_daily spend
+  ON spend.organization_id = allocation.organization_id
+ AND spend.key_type = 'chat'
+ AND spend.day = allocation.source_day
+WHERE allocation.organization_id = $1
+  AND invoice.stripe_invoice_id = $2
+  AND invoice.service_period_end + interval '72 hours' <= $3
+  AND allocation.source_kind = 'openrouter_daily_spend'
+  AND allocation.seq = 1
+ORDER BY allocation.source_day
+`
+
+type ListOpenRouterInvoiceBaselinesParams struct {
+	OrganizationID  pgtype.Text
+	StripeInvoiceID string
+	Now             pgtype.Timestamptz
+}
+
+type ListOpenRouterInvoiceBaselinesRow struct {
+	SourceKey         string
+	SourceDay         pgtype.Date
+	SourceSnapshotUsd pgtype.Numeric
+	FinalSpendUsd     pgtype.Numeric
+	OriginalInvoiceID pgtype.Text
+}
+
+func (q *Queries) ListOpenRouterInvoiceBaselines(ctx context.Context, arg ListOpenRouterInvoiceBaselinesParams) ([]ListOpenRouterInvoiceBaselinesRow, error) {
+	rows, err := q.db.Query(ctx, listOpenRouterInvoiceBaselines, arg.OrganizationID, arg.StripeInvoiceID, arg.Now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOpenRouterInvoiceBaselinesRow
+	for rows.Next() {
+		var i ListOpenRouterInvoiceBaselinesRow
+		if err := rows.Scan(
+			&i.SourceKey,
+			&i.SourceDay,
+			&i.SourceSnapshotUsd,
+			&i.FinalSpendUsd,
+			&i.OriginalInvoiceID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOpenRouterInvoiceSourceDays = `-- name: ListOpenRouterInvoiceSourceDays :many
+SELECT
+    generated.source_timestamp::date AS source_day
+  , COALESCE(spend.spend_usd, 0::numeric) AS spend_usd
+FROM stripe_invoices invoice
+CROSS JOIN LATERAL generate_series(
+  invoice.service_period_start,
+  invoice.service_period_end - interval '1 day',
+  interval '1 day'
+) AS generated(source_timestamp)
+LEFT JOIN openrouter_spend_daily spend
+  ON spend.organization_id = invoice.organization_id
+ AND spend.key_type = 'chat'
+ AND spend.day = generated.source_timestamp::date
+WHERE invoice.organization_id = $1
+  AND invoice.stripe_invoice_id = $2
+  AND invoice.service_period_end + interval '48 hours' <= $3
+ORDER BY source_day
+`
+
+type ListOpenRouterInvoiceSourceDaysParams struct {
+	OrganizationID  pgtype.Text
+	StripeInvoiceID string
+	Now             pgtype.Timestamptz
+}
+
+type ListOpenRouterInvoiceSourceDaysRow struct {
+	SourceDay pgtype.Date
+	SpendUsd  pgtype.Numeric
+}
+
+func (q *Queries) ListOpenRouterInvoiceSourceDays(ctx context.Context, arg ListOpenRouterInvoiceSourceDaysParams) ([]ListOpenRouterInvoiceSourceDaysRow, error) {
+	rows, err := q.db.Query(ctx, listOpenRouterInvoiceSourceDays, arg.OrganizationID, arg.StripeInvoiceID, arg.Now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOpenRouterInvoiceSourceDaysRow
+	for rows.Next() {
+		var i ListOpenRouterInvoiceSourceDaysRow
+		if err := rows.Scan(&i.SourceDay, &i.SpendUsd); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listStripeInvoiceAllocationsFixture = `-- name: ListStripeInvoiceAllocationsFixture :many
+SELECT
+    seq
+  , source_kind
+  , source_key
+  , source_snapshot_usd
+  , amount_usd
+  , original_invoice_id
+  , destination_invoice_id
+  , idempotency_key
+  , delivery_state
+  , stripe_invoice_item_id
+  , stripe_credit_note_id
+  , first_attempted_at
+  , last_attempted_at
+  , reconciled_at
+FROM stripe_invoice_allocations
+WHERE organization_id = $1
+ORDER BY source_key, seq
+`
+
+type ListStripeInvoiceAllocationsFixtureRow struct {
+	Seq                  int32
+	SourceKind           string
+	SourceKey            string
+	SourceSnapshotUsd    pgtype.Numeric
+	AmountUsd            pgtype.Numeric
+	OriginalInvoiceID    pgtype.Text
+	DestinationInvoiceID pgtype.Text
+	IdempotencyKey       string
+	DeliveryState        string
+	StripeInvoiceItemID  pgtype.Text
+	StripeCreditNoteID   pgtype.Text
+	FirstAttemptedAt     pgtype.Timestamptz
+	LastAttemptedAt      pgtype.Timestamptz
+	ReconciledAt         pgtype.Timestamptz
+}
+
+func (q *Queries) ListStripeInvoiceAllocationsFixture(ctx context.Context, organizationID pgtype.Text) ([]ListStripeInvoiceAllocationsFixtureRow, error) {
+	rows, err := q.db.Query(ctx, listStripeInvoiceAllocationsFixture, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListStripeInvoiceAllocationsFixtureRow
+	for rows.Next() {
+		var i ListStripeInvoiceAllocationsFixtureRow
+		if err := rows.Scan(
+			&i.Seq,
+			&i.SourceKind,
+			&i.SourceKey,
+			&i.SourceSnapshotUsd,
+			&i.AmountUsd,
+			&i.OriginalInvoiceID,
+			&i.DestinationInvoiceID,
+			&i.IdempotencyKey,
+			&i.DeliveryState,
+			&i.StripeInvoiceItemID,
+			&i.StripeCreditNoteID,
+			&i.FirstAttemptedAt,
+			&i.LastAttemptedAt,
+			&i.ReconciledAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listStripeInvoiceBillingOrganizations = `-- name: ListStripeInvoiceBillingOrganizations :many
+SELECT DISTINCT invoice.organization_id::text AS organization_id
+FROM stripe_invoices invoice
+WHERE invoice.organization_id IS NOT NULL
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '48 hours' <= $1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 1
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '72 hours' <= $1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 2
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM stripe_invoice_allocations allocation
+      WHERE allocation.organization_id = invoice.organization_id
+        AND (
+          allocation.delivery_state IN ('pending', 'ambiguous')
+          OR (
+            allocation.amount_usd > 0
+            AND allocation.destination_invoice_id IS NULL
+            AND allocation.original_invoice_id IS NOT NULL
+          )
+          OR (
+            allocation.source_kind = 'tum_cycle'
+            AND allocation.original_invoice_id IS NULL
+          )
+        )
+    )
+  )
+ORDER BY organization_id
+`
+
+// Organizations remain candidates for as long as a required immutable
+// snapshot, a delivery, or a destination assignment is missing. There is no
+// age cutoff: an outage must delay billing rather than erase it.
+func (q *Queries) ListStripeInvoiceBillingOrganizations(ctx context.Context, now pgtype.Timestamptz) ([]string, error) {
+	rows, err := q.db.Query(ctx, listStripeInvoiceBillingOrganizations, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var organization_id string
+		if err := rows.Scan(&organization_id); err != nil {
+			return nil, err
+		}
+		items = append(items, organization_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listStripeInvoicesForOpenRouterBilling = `-- name: ListStripeInvoicesForOpenRouterBilling :many
+SELECT
+    stripe_invoice_id
+  , organization_id::text AS organization_id
+  , stripe_customer_id
+  , stripe_subscription_id
+  , service_period_start
+  , service_period_end
+  , invoice_state
+  , finalized_at
+FROM stripe_invoices invoice
+WHERE invoice.organization_id = $1
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '48 hours' <= $2
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 1
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM generate_series(
+        invoice.service_period_start,
+        invoice.service_period_end - interval '1 day',
+        interval '1 day'
+      ) AS source_day
+      WHERE invoice.service_period_end + interval '72 hours' <= $2
+        AND NOT EXISTS (
+          SELECT 1
+          FROM stripe_invoice_allocations allocation
+          WHERE allocation.organization_id = invoice.organization_id
+            AND allocation.source_kind = 'openrouter_daily_spend'
+            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.seq = 2
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM stripe_invoice_allocations allocation
+      WHERE allocation.organization_id = invoice.organization_id
+        AND (
+          allocation.original_invoice_id = invoice.stripe_invoice_id
+          OR allocation.destination_invoice_id = invoice.stripe_invoice_id
+          OR (
+            invoice.invoice_state = 'draft'
+            AND allocation.amount_usd > 0
+            AND allocation.destination_invoice_id IS NULL
+            AND allocation.original_invoice_id IS NOT NULL
+          )
+          OR (
+            allocation.source_kind = 'tum_cycle'
+            AND allocation.original_invoice_id IS NULL
+            AND allocation.source_period_start = invoice.service_period_start
+            AND allocation.source_period_end = invoice.service_period_end
+          )
+        )
+    )
+  )
+ORDER BY service_period_start
+`
+
+type ListStripeInvoicesForOpenRouterBillingParams struct {
+	OrganizationID pgtype.Text
+	Now            pgtype.Timestamptz
+}
+
+type ListStripeInvoicesForOpenRouterBillingRow struct {
+	StripeInvoiceID      string
+	OrganizationID       string
+	StripeCustomerID     string
+	StripeSubscriptionID string
+	ServicePeriodStart   pgtype.Timestamptz
+	ServicePeriodEnd     pgtype.Timestamptz
+	InvoiceState         string
+	FinalizedAt          pgtype.Timestamptz
+}
+
+func (q *Queries) ListStripeInvoicesForOpenRouterBilling(ctx context.Context, arg ListStripeInvoicesForOpenRouterBillingParams) ([]ListStripeInvoicesForOpenRouterBillingRow, error) {
+	rows, err := q.db.Query(ctx, listStripeInvoicesForOpenRouterBilling, arg.OrganizationID, arg.Now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListStripeInvoicesForOpenRouterBillingRow
+	for rows.Next() {
+		var i ListStripeInvoicesForOpenRouterBillingRow
+		if err := rows.Scan(
+			&i.StripeInvoiceID,
+			&i.OrganizationID,
+			&i.StripeCustomerID,
+			&i.StripeSubscriptionID,
+			&i.ServicePeriodStart,
+			&i.ServicePeriodEnd,
+			&i.InvoiceState,
+			&i.FinalizedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUnlinkedClaudeUserMessagesForCorrelation = `-- name: ListUnlinkedClaudeUserMessagesForCorrelation :many
 SELECT id, seq, content, created_at
 FROM chat_messages
@@ -1119,6 +1997,67 @@ func (q *Queries) MarkPublishOutboxFailed(ctx context.Context, arg MarkPublishOu
 	return err
 }
 
+const markStripeInvoiceAllocationAmbiguous = `-- name: MarkStripeInvoiceAllocationAmbiguous :execrows
+UPDATE stripe_invoice_allocations
+SET first_attempted_at = COALESCE(first_attempted_at, $1),
+    last_attempted_at = $1,
+    ambiguous_at = COALESCE(ambiguous_at, $1),
+    delivery_state = 'ambiguous',
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND id = $3
+  AND delivery_state = 'pending'
+  AND last_attempted_at = $1
+`
+
+type MarkStripeInvoiceAllocationAmbiguousParams struct {
+	AttemptedAt    pgtype.Timestamptz
+	OrganizationID pgtype.Text
+	ID             uuid.UUID
+}
+
+func (q *Queries) MarkStripeInvoiceAllocationAmbiguous(ctx context.Context, arg MarkStripeInvoiceAllocationAmbiguousParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markStripeInvoiceAllocationAmbiguous, arg.AttemptedAt, arg.OrganizationID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const reconcileAndRotateStripeInvoiceAllocation = `-- name: ReconcileAndRotateStripeInvoiceAllocation :one
+UPDATE stripe_invoice_allocations
+SET reconciled_at = $1,
+    idempotency_key = regexp_replace(idempotency_key, ':retry:[0-9]+$', '')
+      || ':retry:' || extract(epoch FROM $1::timestamptz)::bigint::text,
+    first_attempted_at = $1,
+    ambiguous_at = NULL,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND id = $3
+  AND delivery_state = 'pending'
+  AND last_attempted_at = $4
+RETURNING idempotency_key
+`
+
+type ReconcileAndRotateStripeInvoiceAllocationParams struct {
+	ReconciledAt   pgtype.Timestamptz
+	OrganizationID pgtype.Text
+	ID             uuid.UUID
+	AttemptedAt    pgtype.Timestamptz
+}
+
+func (q *Queries) ReconcileAndRotateStripeInvoiceAllocation(ctx context.Context, arg ReconcileAndRotateStripeInvoiceAllocationParams) (string, error) {
+	row := q.db.QueryRow(ctx, reconcileAndRotateStripeInvoiceAllocation,
+		arg.ReconciledAt,
+		arg.OrganizationID,
+		arg.ID,
+		arg.AttemptedAt,
+	)
+	var idempotency_key string
+	err := row.Scan(&idempotency_key)
+	return idempotency_key, err
+}
+
 const releasePublishOutboxRows = `-- name: ReleasePublishOutboxRows :exec
 UPDATE publish_outbox SET
     locked_until = NULL,
@@ -1140,6 +2079,90 @@ type ReleasePublishOutboxRowsParams struct {
 func (q *Queries) ReleasePublishOutboxRows(ctx context.Context, arg ReleasePublishOutboxRowsParams) error {
 	_, err := q.db.Exec(ctx, releasePublishOutboxRows, arg.Ids, arg.LeaseToken)
 	return err
+}
+
+const setOpenRouterAPIKeyCreatedAtFixture = `-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
+UPDATE openrouter_api_keys
+SET created_at = $1
+WHERE organization_id = $2
+  AND key_type = $3
+`
+
+type SetOpenRouterAPIKeyCreatedAtFixtureParams struct {
+	CreatedAt      pgtype.Timestamptz
+	OrganizationID string
+	KeyType        string
+}
+
+func (q *Queries) SetOpenRouterAPIKeyCreatedAtFixture(ctx context.Context, arg SetOpenRouterAPIKeyCreatedAtFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyCreatedAtFixture, arg.CreatedAt, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
+const unassignPositiveStripeInvoiceAllocation = `-- name: UnassignPositiveStripeInvoiceAllocation :execrows
+UPDATE stripe_invoice_allocations
+SET destination_invoice_id = NULL,
+    updated_at = clock_timestamp()
+WHERE organization_id = $1
+  AND id = $2
+  AND amount_usd > 0
+  AND delivery_state = 'pending'
+  AND last_attempted_at = $3
+`
+
+type UnassignPositiveStripeInvoiceAllocationParams struct {
+	OrganizationID pgtype.Text
+	ID             uuid.UUID
+	AttemptedAt    pgtype.Timestamptz
+}
+
+func (q *Queries) UnassignPositiveStripeInvoiceAllocation(ctx context.Context, arg UnassignPositiveStripeInvoiceAllocationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, unassignPositiveStripeInvoiceAllocation, arg.OrganizationID, arg.ID, arg.AttemptedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateStripeInvoiceState = `-- name: UpdateStripeInvoiceState :execrows
+UPDATE stripe_invoices
+SET invoice_state = $1,
+    finalized_at = $2,
+    updated_at = clock_timestamp()
+WHERE organization_id = $3
+  AND stripe_invoice_id = $4
+  AND stripe_customer_id = $5
+  AND stripe_subscription_id = $6
+  AND service_period_start = $7
+  AND service_period_end = $8
+`
+
+type UpdateStripeInvoiceStateParams struct {
+	InvoiceState         string
+	FinalizedAt          pgtype.Timestamptz
+	OrganizationID       pgtype.Text
+	StripeInvoiceID      string
+	StripeCustomerID     string
+	StripeSubscriptionID string
+	ServicePeriodStart   pgtype.Timestamptz
+	ServicePeriodEnd     pgtype.Timestamptz
+}
+
+func (q *Queries) UpdateStripeInvoiceState(ctx context.Context, arg UpdateStripeInvoiceStateParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateStripeInvoiceState,
+		arg.InvoiceState,
+		arg.FinalizedAt,
+		arg.OrganizationID,
+		arg.StripeInvoiceID,
+		arg.StripeCustomerID,
+		arg.StripeSubscriptionID,
+		arg.ServicePeriodStart,
+		arg.ServicePeriodEnd,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const upsertOpenRouterDailySpend = `-- name: UpsertOpenRouterDailySpend :exec

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -1397,6 +1397,9 @@ SELECT
       WHEN chat_key.created_at IS NULL
         OR allocation.source_day < (chat_key.created_at AT TIME ZONE 'UTC')::date
         THEN 0::numeric
+	  WHEN chat_key.deleted_at IS NOT NULL
+	    AND allocation.source_day >= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
+	    THEN COALESCE(spend.spend_usd, 0::numeric)
       ELSE spend.spend_usd
     END)::numeric(14, 6) AS final_spend_usd
   , carry.amount_usd AS existing_carry_amount_usd
@@ -1412,6 +1415,10 @@ LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = allocation.source_day
+ AND (
+   chat_key.deleted_at IS NULL
+   OR spend.day <= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
+ )
 LEFT JOIN stripe_invoice_allocations carry
   ON carry.organization_id = allocation.organization_id
  AND carry.source_kind = allocation.source_kind
@@ -2112,6 +2119,24 @@ type SetOpenRouterAPIKeyCreatedAtFixtureParams struct {
 
 func (q *Queries) SetOpenRouterAPIKeyCreatedAtFixture(ctx context.Context, arg SetOpenRouterAPIKeyCreatedAtFixtureParams) error {
 	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyCreatedAtFixture, arg.CreatedAt, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
+const setOpenRouterAPIKeyDeletedAtFixture = `-- name: SetOpenRouterAPIKeyDeletedAtFixture :exec
+UPDATE openrouter_api_keys
+SET deleted_at = $1
+WHERE organization_id = $2
+  AND key_type = $3
+`
+
+type SetOpenRouterAPIKeyDeletedAtFixtureParams struct {
+	DeletedAt      pgtype.Timestamptz
+	OrganizationID string
+	KeyType        string
+}
+
+func (q *Queries) SetOpenRouterAPIKeyDeletedAtFixture(ctx context.Context, arg SetOpenRouterAPIKeyDeletedAtFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyDeletedAtFixture, arg.DeletedAt, arg.OrganizationID, arg.KeyType)
 	return err
 }
 

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -1393,13 +1393,13 @@ SELECT
     allocation.source_key
   , allocation.source_day
   , allocation.source_snapshot_usd
-  , COALESCE(spend.spend_usd, 0::numeric) AS final_spend_usd
+  , spend.spend_usd AS final_spend_usd
   , allocation.original_invoice_id
 FROM stripe_invoice_allocations allocation
 JOIN stripe_invoices invoice
   ON invoice.organization_id = allocation.organization_id
  AND invoice.stripe_invoice_id = allocation.original_invoice_id
-LEFT JOIN openrouter_spend_daily spend
+JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = allocation.source_day

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -1602,14 +1602,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '48 hours' <= $1
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 1
         )
     )
@@ -1619,14 +1619,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '72 hours' <= $1
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 2
         )
     )
@@ -1693,14 +1693,14 @@ WHERE invoice.organization_id = $1
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '48 hours' <= $2
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 1
         )
     )
@@ -1710,14 +1710,14 @@ WHERE invoice.organization_id = $1
         invoice.service_period_start,
         invoice.service_period_end - interval '1 day',
         interval '1 day'
-      ) AS source_day
+      ) AS generated(source_timestamp)
       WHERE invoice.service_period_end + interval '72 hours' <= $2
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = source_day::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
             AND allocation.seq = 2
         )
     )

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -1393,16 +1393,30 @@ SELECT
     allocation.source_key
   , allocation.source_day
   , allocation.source_snapshot_usd
-  , spend.spend_usd AS final_spend_usd
+  , (CASE
+      WHEN chat_key.created_at IS NULL
+        OR allocation.source_day < (chat_key.created_at AT TIME ZONE 'UTC')::date
+        THEN 0::numeric
+      ELSE spend.spend_usd
+    END)::numeric(14, 6) AS final_spend_usd
+  , carry.amount_usd AS existing_carry_amount_usd
   , allocation.original_invoice_id
 FROM stripe_invoice_allocations allocation
 JOIN stripe_invoices invoice
   ON invoice.organization_id = allocation.organization_id
  AND invoice.stripe_invoice_id = allocation.original_invoice_id
-JOIN openrouter_spend_daily spend
+LEFT JOIN openrouter_api_keys chat_key
+  ON chat_key.organization_id = allocation.organization_id
+ AND chat_key.key_type = 'chat'
+LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = allocation.source_day
+LEFT JOIN stripe_invoice_allocations carry
+  ON carry.organization_id = allocation.organization_id
+ AND carry.source_kind = allocation.source_kind
+ AND carry.source_key = allocation.source_key
+ AND carry.seq = 2
 WHERE allocation.organization_id = $1
   AND invoice.stripe_invoice_id = $2
   AND invoice.service_period_end + interval '72 hours' <= $3
@@ -1418,11 +1432,12 @@ type ListOpenRouterInvoiceBaselinesParams struct {
 }
 
 type ListOpenRouterInvoiceBaselinesRow struct {
-	SourceKey         string
-	SourceDay         pgtype.Date
-	SourceSnapshotUsd pgtype.Numeric
-	FinalSpendUsd     pgtype.Numeric
-	OriginalInvoiceID pgtype.Text
+	SourceKey              string
+	SourceDay              pgtype.Date
+	SourceSnapshotUsd      pgtype.Numeric
+	FinalSpendUsd          pgtype.Numeric
+	ExistingCarryAmountUsd pgtype.Numeric
+	OriginalInvoiceID      pgtype.Text
 }
 
 func (q *Queries) ListOpenRouterInvoiceBaselines(ctx context.Context, arg ListOpenRouterInvoiceBaselinesParams) ([]ListOpenRouterInvoiceBaselinesRow, error) {
@@ -1439,6 +1454,7 @@ func (q *Queries) ListOpenRouterInvoiceBaselines(ctx context.Context, arg ListOp
 			&i.SourceDay,
 			&i.SourceSnapshotUsd,
 			&i.FinalSpendUsd,
+			&i.ExistingCarryAmountUsd,
 			&i.OriginalInvoiceID,
 		); err != nil {
 			return nil, err

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -216,10 +216,25 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 	if err != nil {
 		return fmt.Errorf("list final source snapshots for invoice %s: %w", invoice.StripeInvoiceID, err)
 	}
+	// A final row is either durable spend or an authoritative pre-key zero. Do
+	// not allocate past the first unresolved day: later cents depend on every
+	// earlier exact snapshot.
+	readyCount := 0
+	for _, baseline := range baselines {
+		if !baseline.FinalSpendUsd.Valid {
+			break
+		}
+		readyCount++
+	}
+	baselines = baselines[:readyCount]
+
 	frozenSnapshots := make([]pgtype.Numeric, 0, len(baselines))
 	finalSnapshots := make([]pgtype.Numeric, 0, len(baselines))
 	previousCumulativeDeltaCents := int64(0)
-	for _, baseline := range baselines {
+	idealCarryCents := make([]int64, len(baselines))
+	existingCarryCents := int64(0)
+	missingCarryCount := 0
+	for i, baseline := range baselines {
 		frozenSnapshots = append(frozenSnapshots, baseline.SourceSnapshotUsd)
 		finalSnapshots = append(finalSnapshots, baseline.FinalSpendUsd)
 		frozenCents, err := roundNumericsToCents(frozenSnapshots)
@@ -231,8 +246,33 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 			return fmt.Errorf("round final snapshot for %s: %w", baseline.SourceKey, err)
 		}
 		cumulativeDeltaCents := finalCents - frozenCents
-		deltaCents := cumulativeDeltaCents - previousCumulativeDeltaCents
+		idealCarryCents[i] = cumulativeDeltaCents - previousCumulativeDeltaCents
 		previousCumulativeDeltaCents = cumulativeDeltaCents
+		if baseline.ExistingCarryAmountUsd.Valid {
+			cents, err := roundNumericToCents(baseline.ExistingCarryAmountUsd)
+			if err != nil {
+				return fmt.Errorf("read existing carry for %s: %w", baseline.SourceKey, err)
+			}
+			existingCarryCents += cents
+		} else {
+			missingCarryCount++
+		}
+	}
+
+	// Existing carries are immutable. If an older run stored a later sibling
+	// before a missing middle day arrived, put the aggregate reconciliation on
+	// the last missing row so all seq=2 rows still sum to the rounded cycle delta.
+	remainingCarryCents := previousCumulativeDeltaCents - existingCarryCents
+	for i, baseline := range baselines {
+		if baseline.ExistingCarryAmountUsd.Valid {
+			continue
+		}
+		deltaCents := idealCarryCents[i]
+		missingCarryCount--
+		if missingCarryCount == 0 {
+			deltaCents = remainingCarryCents
+		}
+		remainingCarryCents -= deltaCents
 		destination := pgtype.Text{String: "", Valid: false}
 		if deltaCents < 0 {
 			destination = pgtype.Text{String: invoice.StripeInvoiceID, Valid: true}

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -22,6 +22,7 @@ const (
 	openRouterInvoiceObservationDelay = 72 * time.Hour
 	stripeAllocationRetryWindow       = 24 * time.Hour
 	stripeAllocationClaimLease        = 5 * time.Minute
+	stripeAllocationMaxBatchSize      = 64
 
 	stripeAllocationSourceOpenRouter = "openrouter_daily_spend"
 	stripeAllocationSourceTUM        = "tum_cycle"
@@ -38,7 +39,7 @@ type SettleStripeInvoiceAllocationsArgs struct {
 }
 
 // SettleStripeInvoiceAllocations freezes OpenRouter charges, attaches TUM
-// carries, and delivers at most one claimed allocation per organization.
+// carries, and drains a bounded allocation batch for each organization.
 type SettleStripeInvoiceAllocations struct {
 	logger       *slog.Logger
 	db           *pgxpool.Pool
@@ -128,19 +129,26 @@ func (s *SettleStripeInvoiceAllocations) settleOrganization(
 		return fmt.Errorf("assign positive carry to draft invoice: %w", err)
 	}
 
-	claimed, err := queries.ClaimNextStripeInvoiceAllocation(ctx, repo.ClaimNextStripeInvoiceAllocationParams{
-		OrganizationID: organizationIDParam,
-		LeaseBefore:    timestamptz(now.Add(-stripeAllocationClaimLease)),
-		AttemptedAt:    timestamptz(now),
-	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("claim invoice allocation: %w", err)
+	var failures []error
+	for range stripeAllocationMaxBatchSize {
+		claimed, err := queries.ClaimNextStripeInvoiceAllocation(ctx, repo.ClaimNextStripeInvoiceAllocationParams{
+			OrganizationID: organizationIDParam,
+			LeaseBefore:    timestamptz(now.Add(-stripeAllocationClaimLease)),
+			AttemptedAt:    timestamptz(now),
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			break
+		}
+		if err != nil {
+			failures = append(failures, fmt.Errorf("claim invoice allocation: %w", err))
+			break
+		}
+		if err := s.deliverClaim(ctx, queries, claimed, now); err != nil {
+			failures = append(failures, fmt.Errorf("deliver allocation %s: %w", claimed.ID, err))
+		}
 	}
 
-	return s.deliverClaim(ctx, queries, claimed, now)
+	return errors.Join(failures...)
 }
 
 func (s *SettleStripeInvoiceAllocations) freezeInvoice(
@@ -162,15 +170,20 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 		}
 
 		missedFreeze := !now.Before(cycleEnd.Add(openRouterInvoiceObservationDelay))
+		frozenSnapshots := make([]pgtype.Numeric, 0, len(days))
+		previousCumulativeCents := int64(0)
 		for _, day := range days {
 			snapshot := day.SpendUsd
 			if missedFreeze {
 				snapshot = numericFromCents(0)
 			}
-			cents, err := roundNumericToCents(snapshot)
+			frozenSnapshots = append(frozenSnapshots, snapshot)
+			cumulativeCents, err := roundNumericsToCents(frozenSnapshots)
 			if err != nil {
 				return fmt.Errorf("round baseline for %s: %w", day.SourceDay.Time.Format(time.DateOnly), err)
 			}
+			cents := cumulativeCents - previousCumulativeCents
+			previousCumulativeCents = cumulativeCents
 
 			destination := pgtype.Text{String: "", Valid: false}
 			if cents != 0 && invoice.InvoiceState == "draft" {
@@ -203,16 +216,23 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 	if err != nil {
 		return fmt.Errorf("list final source snapshots for invoice %s: %w", invoice.StripeInvoiceID, err)
 	}
+	frozenSnapshots := make([]pgtype.Numeric, 0, len(baselines))
+	finalSnapshots := make([]pgtype.Numeric, 0, len(baselines))
+	previousCumulativeDeltaCents := int64(0)
 	for _, baseline := range baselines {
-		frozenCents, err := roundNumericToCents(baseline.SourceSnapshotUsd)
+		frozenSnapshots = append(frozenSnapshots, baseline.SourceSnapshotUsd)
+		finalSnapshots = append(finalSnapshots, baseline.FinalSpendUsd)
+		frozenCents, err := roundNumericsToCents(frozenSnapshots)
 		if err != nil {
 			return fmt.Errorf("round frozen snapshot for %s: %w", baseline.SourceKey, err)
 		}
-		finalCents, err := roundNumericToCents(baseline.FinalSpendUsd)
+		finalCents, err := roundNumericsToCents(finalSnapshots)
 		if err != nil {
 			return fmt.Errorf("round final snapshot for %s: %w", baseline.SourceKey, err)
 		}
-		deltaCents := finalCents - frozenCents
+		cumulativeDeltaCents := finalCents - frozenCents
+		deltaCents := cumulativeDeltaCents - previousCumulativeDeltaCents
+		previousCumulativeDeltaCents = cumulativeDeltaCents
 		destination := pgtype.Text{String: "", Valid: false}
 		if deltaCents < 0 {
 			destination = pgtype.Text{String: invoice.StripeInvoiceID, Valid: true}
@@ -588,29 +608,40 @@ func allocationDescription(claim repo.ClaimNextStripeInvoiceAllocationRow) strin
 }
 
 func roundNumericToCents(value pgtype.Numeric) (int64, error) {
-	if !value.Valid || value.NaN || value.InfinityModifier != pgtype.Finite || value.Int == nil {
-		return 0, errors.New("amount is not a finite numeric")
+	return roundNumericsToCents([]pgtype.Numeric{value})
+}
+
+func roundNumericsToCents(values []pgtype.Numeric) (int64, error) {
+	total := new(big.Rat)
+	for _, value := range values {
+		if !value.Valid || value.NaN || value.InfinityModifier != pgtype.Finite || value.Int == nil {
+			return 0, errors.New("amount is not a finite numeric")
+		}
+
+		term := new(big.Rat).SetInt(value.Int)
+		if value.Exp >= 0 {
+			factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(value.Exp)), nil)
+			term.Mul(term, new(big.Rat).SetInt(factor))
+		} else {
+			divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(-int64(value.Exp)), nil)
+			term.Quo(term, new(big.Rat).SetInt(divisor))
+		}
+		total.Add(total, term)
 	}
 
-	abs := new(big.Int).Abs(new(big.Int).Set(value.Int))
-	exponent := int64(value.Exp) + 2
-	if exponent >= 0 {
-		abs.Mul(abs, new(big.Int).Exp(big.NewInt(10), big.NewInt(exponent), nil))
-	} else {
-		divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(-exponent), nil)
-		quotient, remainder := new(big.Int).QuoRem(abs, divisor, new(big.Int))
-		if new(big.Int).Lsh(remainder, 1).Cmp(divisor) >= 0 {
-			quotient.Add(quotient, big.NewInt(1))
-		}
-		abs = quotient
+	scaled := new(big.Rat).Mul(total, big.NewRat(100, 1))
+	absNumerator := new(big.Int).Abs(new(big.Int).Set(scaled.Num()))
+	quotient, remainder := new(big.Int).QuoRem(absNumerator, scaled.Denom(), new(big.Int))
+	if new(big.Int).Lsh(remainder, 1).Cmp(scaled.Denom()) >= 0 {
+		quotient.Add(quotient, big.NewInt(1))
 	}
-	if value.Int.Sign() < 0 {
-		abs.Neg(abs)
+	if scaled.Sign() < 0 {
+		quotient.Neg(quotient)
 	}
-	if !abs.IsInt64() {
+	if !quotient.IsInt64() {
 		return 0, errors.New("amount exceeds Stripe minor-unit range")
 	}
-	return abs.Int64(), nil
+	return quotient.Int64(), nil
 }
 
 func numericFromCents(cents int64) pgtype.Numeric {

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -1,0 +1,632 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+)
+
+const (
+	openRouterInvoiceFreezeDelay      = 48 * time.Hour
+	openRouterInvoiceObservationDelay = 72 * time.Hour
+	stripeAllocationRetryWindow       = 24 * time.Hour
+	stripeAllocationClaimLease        = 5 * time.Minute
+
+	stripeAllocationSourceOpenRouter = "openrouter_daily_spend"
+	stripeAllocationSourceTUM        = "tum_cycle"
+)
+
+// SettleStripeInvoiceAllocationsArgs fixes the observation time for one daily
+// settlement pass.
+type SettleStripeInvoiceAllocationsArgs struct {
+	Now time.Time
+	// RestrictOpenRouterToReadyOrganizations is explicit so an empty list from
+	// Temporal means "freeze no chat spend", never "freeze every org".
+	RestrictOpenRouterToReadyOrganizations bool
+	OpenRouterReadyOrganizationIDs         []string
+}
+
+// SettleStripeInvoiceAllocations freezes OpenRouter charges, attaches TUM
+// carries, and delivers at most one claimed allocation per organization.
+type SettleStripeInvoiceAllocations struct {
+	logger       *slog.Logger
+	db           *pgxpool.Pool
+	stripeClient stripeInvoiceAllocationClient
+}
+
+type stripeInvoiceAllocationClient interface {
+	GetInvoice(context.Context, string) (*stripeclient.InvoiceState, error)
+	CreateInvoiceItem(context.Context, stripeclient.CreateInvoiceItemInput) (*stripeclient.InvoiceItem, error)
+	CreateCreditNote(context.Context, stripeclient.CreateCreditNoteInput) (*stripeclient.CreditNote, error)
+	FindInvoiceItem(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.InvoiceItem, error)
+	FindCreditNote(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.CreditNote, error)
+}
+
+func NewSettleStripeInvoiceAllocations(
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+	stripeClient stripeInvoiceAllocationClient,
+) *SettleStripeInvoiceAllocations {
+	return &SettleStripeInvoiceAllocations{
+		logger:       logger.With(attr.SlogComponent("settle_stripe_invoice_allocations")),
+		db:           db,
+		stripeClient: stripeClient,
+	}
+}
+
+func (s *SettleStripeInvoiceAllocations) Do(ctx context.Context, args SettleStripeInvoiceAllocationsArgs) error {
+	now := args.Now.UTC()
+	if now.IsZero() {
+		return errors.New("settle Stripe invoice allocations: current time is required")
+	}
+
+	queries := repo.New(s.db)
+	organizations, err := queries.ListStripeInvoiceBillingOrganizations(ctx, timestamptz(now))
+	if err != nil {
+		return fmt.Errorf("list Stripe invoice billing organizations: %w", err)
+	}
+	ready := make(map[string]struct{}, len(args.OpenRouterReadyOrganizationIDs))
+	for _, organizationID := range args.OpenRouterReadyOrganizationIDs {
+		ready[organizationID] = struct{}{}
+	}
+
+	var failures []error
+	for _, organizationID := range organizations {
+		_, openRouterReady := ready[organizationID]
+		if err := s.settleOrganization(ctx, queries, organizationID, now,
+			!args.RestrictOpenRouterToReadyOrganizations || openRouterReady); err != nil {
+			s.logger.ErrorContext(ctx, "settle Stripe invoice allocations",
+				attr.SlogOrganizationID(organizationID),
+				attr.SlogError(err),
+			)
+			failures = append(failures, fmt.Errorf("settle organization %s: %w", organizationID, err))
+		}
+	}
+
+	return errors.Join(failures...)
+}
+
+func (s *SettleStripeInvoiceAllocations) settleOrganization(
+	ctx context.Context,
+	queries *repo.Queries,
+	organizationID string,
+	now time.Time,
+	freezeOpenRouter bool,
+) error {
+	organizationIDParam := pgtype.Text{String: organizationID, Valid: true}
+	invoices, err := queries.ListStripeInvoicesForOpenRouterBilling(ctx, repo.ListStripeInvoicesForOpenRouterBillingParams{
+		OrganizationID: organizationIDParam,
+		Now:            timestamptz(now),
+	})
+	if err != nil {
+		return fmt.Errorf("list invoices: %w", err)
+	}
+
+	if freezeOpenRouter {
+		for _, invoice := range invoices {
+			if err := s.freezeInvoice(ctx, queries, organizationIDParam, invoice, now); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := queries.AttachTUMCarryToOriginalInvoice(ctx, organizationIDParam); err != nil {
+		return fmt.Errorf("attach TUM carry to original invoice: %w", err)
+	}
+	if _, err := queries.AssignPositiveCarryToStripeInvoice(ctx, organizationIDParam); err != nil {
+		return fmt.Errorf("assign positive carry to draft invoice: %w", err)
+	}
+
+	claimed, err := queries.ClaimNextStripeInvoiceAllocation(ctx, repo.ClaimNextStripeInvoiceAllocationParams{
+		OrganizationID: organizationIDParam,
+		LeaseBefore:    timestamptz(now.Add(-stripeAllocationClaimLease)),
+		AttemptedAt:    timestamptz(now),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("claim invoice allocation: %w", err)
+	}
+
+	return s.deliverClaim(ctx, queries, claimed, now)
+}
+
+func (s *SettleStripeInvoiceAllocations) freezeInvoice(
+	ctx context.Context,
+	queries *repo.Queries,
+	organizationID pgtype.Text,
+	invoice repo.ListStripeInvoicesForOpenRouterBillingRow,
+	now time.Time,
+) error {
+	cycleEnd := invoice.ServicePeriodEnd.Time.UTC()
+	if invoice.ServicePeriodEnd.Valid && !now.Before(cycleEnd.Add(openRouterInvoiceFreezeDelay)) {
+		days, err := queries.ListOpenRouterInvoiceSourceDays(ctx, repo.ListOpenRouterInvoiceSourceDaysParams{
+			OrganizationID:  organizationID,
+			StripeInvoiceID: invoice.StripeInvoiceID,
+			Now:             timestamptz(now),
+		})
+		if err != nil {
+			return fmt.Errorf("list source days for invoice %s: %w", invoice.StripeInvoiceID, err)
+		}
+
+		missedFreeze := !now.Before(cycleEnd.Add(openRouterInvoiceObservationDelay))
+		for _, day := range days {
+			snapshot := day.SpendUsd
+			if missedFreeze {
+				snapshot = numericFromCents(0)
+			}
+			cents, err := roundNumericToCents(snapshot)
+			if err != nil {
+				return fmt.Errorf("round baseline for %s: %w", day.SourceDay.Time.Format(time.DateOnly), err)
+			}
+
+			destination := pgtype.Text{String: "", Valid: false}
+			if cents != 0 && invoice.InvoiceState == "draft" {
+				destination = pgtype.Text{String: invoice.StripeInvoiceID, Valid: true}
+			}
+			if _, err := queries.CreateOpenRouterInvoiceAllocation(ctx, openRouterAllocationParams(
+				organizationID,
+				day.SourceDay,
+				1,
+				snapshot,
+				cents,
+				invoice.StripeInvoiceID,
+				destination,
+				now,
+			)); err != nil {
+				return fmt.Errorf("freeze baseline for %s: %w", day.SourceDay.Time.Format(time.DateOnly), err)
+			}
+		}
+	}
+
+	if !invoice.ServicePeriodEnd.Valid || now.Before(cycleEnd.Add(openRouterInvoiceObservationDelay)) {
+		return nil
+	}
+
+	baselines, err := queries.ListOpenRouterInvoiceBaselines(ctx, repo.ListOpenRouterInvoiceBaselinesParams{
+		OrganizationID:  organizationID,
+		StripeInvoiceID: invoice.StripeInvoiceID,
+		Now:             timestamptz(now),
+	})
+	if err != nil {
+		return fmt.Errorf("list final source snapshots for invoice %s: %w", invoice.StripeInvoiceID, err)
+	}
+	for _, baseline := range baselines {
+		frozenCents, err := roundNumericToCents(baseline.SourceSnapshotUsd)
+		if err != nil {
+			return fmt.Errorf("round frozen snapshot for %s: %w", baseline.SourceKey, err)
+		}
+		finalCents, err := roundNumericToCents(baseline.FinalSpendUsd)
+		if err != nil {
+			return fmt.Errorf("round final snapshot for %s: %w", baseline.SourceKey, err)
+		}
+		deltaCents := finalCents - frozenCents
+		destination := pgtype.Text{String: "", Valid: false}
+		if deltaCents < 0 {
+			destination = pgtype.Text{String: invoice.StripeInvoiceID, Valid: true}
+		}
+		if _, err := queries.CreateOpenRouterInvoiceAllocation(ctx, openRouterAllocationParams(
+			organizationID,
+			baseline.SourceDay,
+			2,
+			baseline.FinalSpendUsd,
+			deltaCents,
+			invoice.StripeInvoiceID,
+			destination,
+			now,
+		)); err != nil {
+			return fmt.Errorf("freeze carry for %s: %w", baseline.SourceKey, err)
+		}
+	}
+
+	return nil
+}
+
+func openRouterAllocationParams(
+	organizationID pgtype.Text,
+	day pgtype.Date,
+	seq int32,
+	snapshot pgtype.Numeric,
+	cents int64,
+	originalInvoiceID string,
+	destinationInvoiceID pgtype.Text,
+	now time.Time,
+) repo.CreateOpenRouterInvoiceAllocationParams {
+	deliveryState := "pending"
+	confirmedAt := pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}
+	if cents == 0 {
+		deliveryState = "confirmed"
+		confirmedAt = timestamptz(now)
+	}
+	dayText := day.Time.UTC().Format(time.DateOnly)
+	return repo.CreateOpenRouterInvoiceAllocationParams{
+		OrganizationID:       organizationID,
+		SourceKey:            dayText + ":chat",
+		Seq:                  seq,
+		SourceDay:            day,
+		SourceSnapshotUsd:    snapshot,
+		AmountUsd:            numericFromCents(cents),
+		OriginalInvoiceID:    pgtype.Text{String: originalInvoiceID, Valid: true},
+		DestinationInvoiceID: destinationInvoiceID,
+		IdempotencyKey:       fmt.Sprintf("openrouter:%s:%s:%d", organizationID.String, dayText, seq),
+		DeliveryState:        deliveryState,
+		ConfirmedAt:          confirmedAt,
+	}
+}
+
+func (s *SettleStripeInvoiceAllocations) deliverClaim(
+	ctx context.Context,
+	queries *repo.Queries,
+	claim repo.ClaimNextStripeInvoiceAllocationRow,
+	now time.Time,
+) error {
+	cents, err := roundNumericToCents(claim.AmountUsd)
+	if err != nil {
+		return fmt.Errorf("read claimed allocation amount: %w", err)
+	}
+	if cents == 0 {
+		return errors.New("claimed zero-dollar allocation")
+	}
+
+	reconcile := claim.PreviousFirstAttemptedAt.Valid &&
+		!now.Before(claim.PreviousFirstAttemptedAt.Time.UTC().Add(stripeAllocationRetryWindow))
+	reconciledAbsent := false
+	if reconcile {
+		found, err := s.findAllocation(ctx, claim, cents)
+		if err != nil {
+			s.markAmbiguous(ctx, queries, claim, now)
+			return err
+		}
+		if found != "" {
+			return s.confirmAllocation(ctx, queries, claim, found, cents < 0, true, now)
+		}
+		rotatedKey, err := reconcileAndRotateAllocation(ctx, queries, claim, now)
+		if err != nil {
+			return err
+		}
+		claim.IdempotencyKey = rotatedKey
+		reconciledAbsent = true
+	}
+
+	// A credit-note retry cannot recompute credit_amount inside Stripe's
+	// idempotency window: invoice payment may have changed since the first
+	// request. Wait for metadata reconciliation, then create from current state
+	// after the key's retention window.
+	if cents < 0 && claim.PreviousFirstAttemptedAt.Valid && !reconcile {
+		return nil
+	}
+
+	invoice, err := s.stripeClient.GetInvoice(ctx, claim.DestinationInvoiceID.String)
+	if err != nil {
+		s.markAmbiguous(ctx, queries, claim, now)
+		return fmt.Errorf("retrieve destination invoice: %w", err)
+	}
+	if err := validateClaimInvoice(claim, invoice); err != nil {
+		s.markAmbiguous(ctx, queries, claim, now)
+		return err
+	}
+	if err := updateClaimInvoiceState(ctx, queries, claim, invoice); err != nil {
+		return err
+	}
+
+	if cents > 0 {
+		if invoice.Status != "draft" {
+			// A destination that closes after an ambiguous write cannot be
+			// rebound on one eventually-consistent list response. Hold it until
+			// the attempt's 24-hour reconciliation boundary.
+			if claim.PreviousFirstAttemptedAt.Valid && !reconciledAbsent {
+				return nil
+			}
+			updated, err := queries.UnassignPositiveStripeInvoiceAllocation(ctx, repo.UnassignPositiveStripeInvoiceAllocationParams{
+				OrganizationID: pgtype.Text{String: claim.OrganizationID, Valid: true},
+				ID:             claim.ID,
+				AttemptedAt:    timestamptz(now),
+			})
+			if err != nil {
+				return fmt.Errorf("unassign closed destination invoice: %w", err)
+			}
+			if updated != 1 {
+				return errors.New("unassign closed destination invoice: claim lost")
+			}
+			return nil
+		}
+
+		periodStart, periodEnd, description, err := allocationPeriodAndDescription(claim)
+		if err != nil {
+			return err
+		}
+		item, err := s.stripeClient.CreateInvoiceItem(ctx, stripeclient.CreateInvoiceItemInput{
+			CustomerID:     claim.StripeCustomerID,
+			SubscriptionID: claim.StripeSubscriptionID,
+			InvoiceID:      claim.DestinationInvoiceID.String,
+			Description:    description,
+			AmountCents:    cents,
+			PeriodStart:    periodStart,
+			PeriodEnd:      periodEnd,
+			AllocationKey:  claim.IdempotencyKey,
+			IdempotencyKey: claim.IdempotencyKey,
+		})
+		if err != nil {
+			s.markAmbiguous(ctx, queries, claim, now)
+			return fmt.Errorf("create Stripe invoice item: %w", err)
+		}
+		return s.confirmAllocation(ctx, queries, claim, item.ID, false, false, now)
+	}
+
+	if invoice.Status != "open" && invoice.Status != "paid" {
+		return fmt.Errorf("destination invoice status %q does not support credit notes", invoice.Status)
+	}
+	if invoice.FinalizedAt.IsZero() {
+		return errors.New("destination invoice is not finalized")
+	}
+	return s.createCreditNote(ctx, queries, claim, invoice, -cents, now)
+}
+
+func (s *SettleStripeInvoiceAllocations) findAllocation(
+	ctx context.Context,
+	claim repo.ClaimNextStripeInvoiceAllocationRow,
+	cents int64,
+) (string, error) {
+	input := stripeclient.FindInvoiceAllocationInput{
+		InvoiceID:     claim.DestinationInvoiceID.String,
+		AllocationKey: claim.IdempotencyKey,
+		AmountCents:   max(cents, -cents),
+	}
+	if cents > 0 {
+		item, err := s.stripeClient.FindInvoiceItem(ctx, input)
+		if err != nil {
+			return "", fmt.Errorf("reconcile Stripe invoice item: %w", err)
+		}
+		if item == nil {
+			return "", nil
+		}
+		if item.ID == "" || item.InvoiceID != input.InvoiceID || item.Currency != "usd" || item.AmountCents != input.AmountCents {
+			return "", errors.New("reconcile Stripe invoice item: metadata match had different invoice, currency, or amount")
+		}
+		return item.ID, nil
+	}
+
+	note, err := s.stripeClient.FindCreditNote(ctx, input)
+	if err != nil {
+		return "", fmt.Errorf("reconcile Stripe credit note: %w", err)
+	}
+	if note == nil {
+		return "", nil
+	}
+	if note.ID == "" || note.InvoiceID != input.InvoiceID || note.Currency != "usd" || note.AmountCents != input.AmountCents {
+		return "", errors.New("reconcile Stripe credit note: metadata match had different invoice, currency, or amount")
+	}
+	return note.ID, nil
+}
+
+func (s *SettleStripeInvoiceAllocations) createCreditNote(
+	ctx context.Context,
+	queries *repo.Queries,
+	claim repo.ClaimNextStripeInvoiceAllocationRow,
+	invoice *stripeclient.InvoiceState,
+	amountCents int64,
+	now time.Time,
+) error {
+	remaining := max(invoice.AmountRemaining, 0)
+	note, err := s.stripeClient.CreateCreditNote(ctx, stripeclient.CreateCreditNoteInput{
+		InvoiceID:         claim.DestinationInvoiceID.String,
+		Description:       allocationDescription(claim),
+		AmountCents:       amountCents,
+		CreditAmountCents: max(amountCents-remaining, 0),
+		AllocationKey:     claim.IdempotencyKey,
+		IdempotencyKey:    claim.IdempotencyKey,
+	})
+	if err != nil {
+		s.markAmbiguous(ctx, queries, claim, now)
+		return fmt.Errorf("create Stripe credit note: %w", err)
+	}
+	return s.confirmAllocation(ctx, queries, claim, note.ID, true, false, now)
+}
+
+func reconcileAndRotateAllocation(
+	ctx context.Context,
+	queries *repo.Queries,
+	claim repo.ClaimNextStripeInvoiceAllocationRow,
+	now time.Time,
+) (string, error) {
+	key, err := queries.ReconcileAndRotateStripeInvoiceAllocation(ctx, repo.ReconcileAndRotateStripeInvoiceAllocationParams{
+		ReconciledAt:   timestamptz(now),
+		OrganizationID: pgtype.Text{String: claim.OrganizationID, Valid: true},
+		ID:             claim.ID,
+		AttemptedAt:    timestamptz(now),
+	})
+	if err != nil {
+		return "", fmt.Errorf("record Stripe allocation reconciliation: %w", err)
+	}
+	if key == "" {
+		return "", errors.New("record Stripe allocation reconciliation: empty rotated key")
+	}
+	return key, nil
+}
+
+func validateClaimInvoice(claim repo.ClaimNextStripeInvoiceAllocationRow, invoice *stripeclient.InvoiceState) error {
+	if invoice == nil {
+		return errors.New("retrieve destination invoice: empty response")
+	}
+	if invoice.ID != claim.DestinationInvoiceID.String ||
+		invoice.CustomerID != claim.StripeCustomerID ||
+		invoice.SubscriptionID != claim.StripeSubscriptionID ||
+		!invoice.ServicePeriodStart.Equal(claim.DestinationPeriodStart.Time.UTC()) ||
+		!invoice.ServicePeriodEnd.Equal(claim.DestinationPeriodEnd.Time.UTC()) {
+		return errors.New("destination invoice identity or service period changed")
+	}
+	if invoice.Currency != "usd" {
+		return fmt.Errorf("destination invoice currency is %q, want usd", invoice.Currency)
+	}
+	return nil
+}
+
+func updateClaimInvoiceState(
+	ctx context.Context,
+	queries *repo.Queries,
+	claim repo.ClaimNextStripeInvoiceAllocationRow,
+	invoice *stripeclient.InvoiceState,
+) error {
+	finalizedAt := pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}
+	if !invoice.FinalizedAt.IsZero() {
+		finalizedAt = timestamptz(invoice.FinalizedAt)
+	}
+	updated, err := queries.UpdateStripeInvoiceState(ctx, repo.UpdateStripeInvoiceStateParams{
+		InvoiceState:         invoice.Status,
+		FinalizedAt:          finalizedAt,
+		OrganizationID:       pgtype.Text{String: claim.OrganizationID, Valid: true},
+		StripeInvoiceID:      invoice.ID,
+		StripeCustomerID:     invoice.CustomerID,
+		StripeSubscriptionID: invoice.SubscriptionID,
+		ServicePeriodStart:   timestamptz(invoice.ServicePeriodStart),
+		ServicePeriodEnd:     timestamptz(invoice.ServicePeriodEnd),
+	})
+	if err != nil {
+		return fmt.Errorf("update destination invoice state: %w", err)
+	}
+	if updated != 1 {
+		return errors.New("update destination invoice state: identity mismatch")
+	}
+	return nil
+}
+
+func (s *SettleStripeInvoiceAllocations) markAmbiguous(
+	ctx context.Context,
+	queries *repo.Queries,
+	claim repo.ClaimNextStripeInvoiceAllocationRow,
+	now time.Time,
+) {
+	if _, err := queries.MarkStripeInvoiceAllocationAmbiguous(ctx, repo.MarkStripeInvoiceAllocationAmbiguousParams{
+		AttemptedAt:    timestamptz(now),
+		OrganizationID: pgtype.Text{String: claim.OrganizationID, Valid: true},
+		ID:             claim.ID,
+	}); err != nil {
+		s.logger.ErrorContext(ctx, "mark Stripe invoice allocation ambiguous", attr.SlogError(err))
+	}
+}
+
+func (s *SettleStripeInvoiceAllocations) confirmAllocation(
+	ctx context.Context,
+	queries *repo.Queries,
+	claim repo.ClaimNextStripeInvoiceAllocationRow,
+	stripeID string,
+	creditNote bool,
+	reconciled bool,
+	now time.Time,
+) error {
+	if stripeID == "" {
+		return errors.New("confirm Stripe allocation: empty Stripe object id")
+	}
+	organizationID := pgtype.Text{String: claim.OrganizationID, Valid: true}
+	var updated int64
+	var err error
+	if creditNote {
+		updated, err = queries.ConfirmStripeCreditNoteAllocation(ctx, repo.ConfirmStripeCreditNoteAllocationParams{
+			StripeCreditNoteID: pgtype.Text{String: stripeID, Valid: true},
+			ConfirmedAt:        timestamptz(now),
+			Reconciled:         reconciled,
+			OrganizationID:     organizationID,
+			ID:                 claim.ID,
+			AttemptedAt:        timestamptz(now),
+		})
+	} else {
+		updated, err = queries.ConfirmStripeInvoiceItemAllocation(ctx, repo.ConfirmStripeInvoiceItemAllocationParams{
+			StripeInvoiceItemID: pgtype.Text{String: stripeID, Valid: true},
+			ConfirmedAt:         timestamptz(now),
+			Reconciled:          reconciled,
+			OrganizationID:      organizationID,
+			ID:                  claim.ID,
+			AttemptedAt:         timestamptz(now),
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("confirm Stripe allocation: %w", err)
+	}
+	if updated != 1 {
+		return errors.New("confirm Stripe allocation: claim lost")
+	}
+	return nil
+}
+
+func allocationPeriodAndDescription(claim repo.ClaimNextStripeInvoiceAllocationRow) (time.Time, time.Time, string, error) {
+	if claim.SourceKind == stripeAllocationSourceOpenRouter && claim.SourceDay.Valid {
+		start := time.Date(claim.SourceDay.Time.Year(), claim.SourceDay.Time.Month(), claim.SourceDay.Time.Day(), 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(0, 0, 1), allocationDescription(claim), nil
+	}
+	if claim.SourceKind == stripeAllocationSourceTUM && claim.SourcePeriodStart.Valid && claim.SourcePeriodEnd.Valid {
+		start := claim.SourcePeriodStart.Time.UTC()
+		end := claim.SourcePeriodEnd.Time.UTC()
+		if end.After(start) {
+			return start, end, allocationDescription(claim), nil
+		}
+	}
+	return time.Time{}, time.Time{}, "", fmt.Errorf("allocation %s has invalid source bounds", claim.ID)
+}
+
+func allocationDescription(claim repo.ClaimNextStripeInvoiceAllocationRow) string {
+	if claim.SourceKind == stripeAllocationSourceOpenRouter && claim.SourceDay.Valid {
+		return "OpenRouter chat usage for " + claim.SourceDay.Time.UTC().Format(time.DateOnly)
+	}
+	if claim.SourceKind == stripeAllocationSourceTUM && claim.SourcePeriodStart.Valid && claim.SourcePeriodEnd.Valid {
+		return fmt.Sprintf("TUM usage adjustment for %s to %s",
+			claim.SourcePeriodStart.Time.UTC().Format(time.DateOnly),
+			claim.SourcePeriodEnd.Time.UTC().Format(time.DateOnly))
+	}
+	return "Usage adjustment"
+}
+
+func roundNumericToCents(value pgtype.Numeric) (int64, error) {
+	if !value.Valid || value.NaN || value.InfinityModifier != pgtype.Finite || value.Int == nil {
+		return 0, errors.New("amount is not a finite numeric")
+	}
+
+	abs := new(big.Int).Abs(new(big.Int).Set(value.Int))
+	exponent := int64(value.Exp) + 2
+	if exponent >= 0 {
+		abs.Mul(abs, new(big.Int).Exp(big.NewInt(10), big.NewInt(exponent), nil))
+	} else {
+		divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(-exponent), nil)
+		quotient, remainder := new(big.Int).QuoRem(abs, divisor, new(big.Int))
+		if new(big.Int).Lsh(remainder, 1).Cmp(divisor) >= 0 {
+			quotient.Add(quotient, big.NewInt(1))
+		}
+		abs = quotient
+	}
+	if value.Int.Sign() < 0 {
+		abs.Neg(abs)
+	}
+	if !abs.IsInt64() {
+		return 0, errors.New("amount exceeds Stripe minor-unit range")
+	}
+	return abs.Int64(), nil
+}
+
+func numericFromCents(cents int64) pgtype.Numeric {
+	negative := cents < 0
+	abs := new(big.Int).SetInt64(cents)
+	if negative {
+		abs.Abs(abs)
+	}
+	text := fmt.Sprintf("%s%s.%02d", map[bool]string{true: "-", false: ""}[negative], new(big.Int).Quo(abs, big.NewInt(100)).String(), new(big.Int).Mod(abs, big.NewInt(100)).Int64())
+	var result pgtype.Numeric
+	if err := result.Scan(text); err != nil {
+		panic(fmt.Sprintf("represent cents as numeric: %v", err))
+	}
+	return result
+}
+
+func timestamptz(value time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: value.UTC(), InfinityModifier: pgtype.Finite, Valid: true}
+}

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -531,6 +531,7 @@ func TestSettleStripeInvoiceAllocations_PreKeyDaysFinalizeAsDurableZero(t *testi
 	keyDay := start.AddDate(0, 0, 2)
 	end := start.AddDate(0, 0, 3)
 	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
 	setChatKeyCreatedAt(t, db, organizationID, keyDay.Add(12*time.Hour))
 	putDailySpend(t, db, organizationID, keyDay, "0.015000")
 	now := end.Add(76 * time.Hour)

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -429,6 +429,65 @@ func TestSettleStripeInvoiceAllocations_MissingBaselineBecomesPositiveCarry(t *t
 	require.NotEqual(t, "awaiting_source", rows[0].DeliveryState)
 }
 
+func TestSettleStripeInvoiceAllocations_MissingFinalSourceRemainsRecoverable(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_missing_final")
+	start := time.Date(2026, time.August, 5, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "open", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(76 * time.Hour)}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 1, "missing durable spend must not be finalized as a zero carry")
+	require.Equal(t, int32(1), rows[0].Seq)
+	require.Equal(t, "0", numericString(t, rows[0].SourceSnapshotUsd))
+
+	putDailySpend(t, db, organizationID, start, "0.015000")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(77 * time.Hour)}))
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, int32(2), rows[1].Seq)
+	require.Equal(t, "0.020000", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, "confirmed", rows[1].DeliveryState)
+	require.Len(t, stripe.itemInputs, 1)
+}
+
+func TestSettleStripeInvoiceAllocations_RoundsCumulativeCycleTotalsAndDrainsBatch(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_cumulative_rounding")
+	start := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
+	secondDay := start.AddDate(0, 0, 1)
+	end := start.AddDate(0, 0, 2)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+	putDailySpend(t, db, organizationID, start, "0.004000")
+	putDailySpend(t, db, organizationID, secondDay, "0.004000")
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(48 * time.Hour)}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, "0", numericString(t, rows[0].AmountUsd))
+	require.Equal(t, "0.010000", numericString(t, rows[1].AmountUsd))
+	require.Len(t, stripe.itemInputs, 1, "fractional daily rows must round once at the cumulative cycle boundary")
+	require.Equal(t, int64(1), stripe.itemInputs[0].AmountCents)
+
+	putDailySpend(t, db, organizationID, start, "0.006000")
+	putDailySpend(t, db, organizationID, secondDay, "0.006000")
+	state := stripe.invoices["in_original"]
+	state.Status = "open"
+	state.FinalizedAt = end.Add(time.Hour)
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(72 * time.Hour)}))
+
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 4)
+	require.Equal(t, "0.010000", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, "0.010000", numericString(t, rows[2].AmountUsd))
+	require.Equal(t, "-0.010000", numericString(t, rows[3].AmountUsd))
+	require.Len(t, stripe.itemInputs, 2, "the bounded batch must drain both pending carry allocations")
+	require.Len(t, stripe.creditInputs, 1)
+}
+
 func TestSettleStripeInvoiceAllocations_TUMPositiveCarryIgnoresChatReadinessAndBindsExactBounds(t *testing.T) {
 	t.Parallel()
 	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_tum_positive")

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -1,0 +1,558 @@
+package activities_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	backgroundrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+)
+
+type allocationStripeMock struct {
+	mu sync.Mutex
+
+	invoices map[string]*stripeclient.InvoiceState
+	getState func(string, int) *stripeclient.InvoiceState
+	getCalls int
+
+	itemInputs   []stripeclient.CreateInvoiceItemInput
+	creditInputs []stripeclient.CreateCreditNoteInput
+	itemErrors   []error
+	creditErrors []error
+
+	foundItem *stripeclient.InvoiceItem
+	foundNote *stripeclient.CreditNote
+	findItems int
+	findNotes int
+}
+
+func (m *allocationStripeMock) GetInvoice(_ context.Context, id string) (*stripeclient.InvoiceState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls++
+	var state *stripeclient.InvoiceState
+	if m.getState != nil {
+		state = m.getState(id, m.getCalls)
+	} else {
+		state = m.invoices[id]
+	}
+	if state == nil {
+		return nil, fmt.Errorf("invoice %s not found", id)
+	}
+	invoiceCopy := *state
+	return &invoiceCopy, nil
+}
+
+func (m *allocationStripeMock) CreateInvoiceItem(_ context.Context, input stripeclient.CreateInvoiceItemInput) (*stripeclient.InvoiceItem, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.itemInputs = append(m.itemInputs, input)
+	if len(m.itemErrors) > 0 {
+		err := m.itemErrors[0]
+		m.itemErrors = m.itemErrors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &stripeclient.InvoiceItem{
+		ID:          fmt.Sprintf("ii_%d", len(m.itemInputs)),
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}, nil
+}
+
+func (m *allocationStripeMock) CreateCreditNote(_ context.Context, input stripeclient.CreateCreditNoteInput) (*stripeclient.CreditNote, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.creditInputs = append(m.creditInputs, input)
+	if len(m.creditErrors) > 0 {
+		err := m.creditErrors[0]
+		m.creditErrors = m.creditErrors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &stripeclient.CreditNote{
+		ID:          fmt.Sprintf("cn_%d", len(m.creditInputs)),
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}, nil
+}
+
+func (m *allocationStripeMock) FindInvoiceItem(_ context.Context, _ stripeclient.FindInvoiceAllocationInput) (*stripeclient.InvoiceItem, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.findItems++
+	return m.foundItem, nil
+}
+
+func (m *allocationStripeMock) FindCreditNote(_ context.Context, _ stripeclient.FindInvoiceAllocationInput) (*stripeclient.CreditNote, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.findNotes++
+	return m.foundNote, nil
+}
+
+func setupAllocationTest(t *testing.T, name string) (*pgxpool.Pool, string, *allocationStripeMock, *activities.SettleStripeInvoiceAllocations) {
+	t.Helper()
+	db, err := infra.CloneTestDatabase(t, name)
+	require.NoError(t, err)
+	organizationID := "org-" + uuid.NewString()[:8]
+	_, err = orgrepo.New(db).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Allocation Test Organization",
+		Slug:        organizationID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	stripe := &allocationStripeMock{invoices: make(map[string]*stripeclient.InvoiceState)}
+	activity := activities.NewSettleStripeInvoiceAllocations(testenv.NewLogger(t), db, stripe)
+	return db, organizationID, stripe, activity
+}
+
+func addStripeInvoice(t *testing.T, db *pgxpool.Pool, stripe *allocationStripeMock, organizationID, invoiceID string, start, end time.Time, state string, remaining int64) {
+	t.Helper()
+	remoteFinalizedAt := time.Time{}
+	finalized := pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}
+	if state != "draft" {
+		remoteFinalizedAt = end.Add(time.Hour)
+		finalized = pgtype.Timestamptz{Time: remoteFinalizedAt.UTC(), InfinityModifier: pgtype.Finite, Valid: true}
+	}
+	err := backgroundrepo.New(db).CreateStripeInvoiceFixture(t.Context(), backgroundrepo.CreateStripeInvoiceFixtureParams{
+		StripeInvoiceID:      invoiceID,
+		OrganizationID:       pgtype.Text{String: organizationID, Valid: true},
+		StripeCustomerID:     "cus_" + organizationID,
+		StripeSubscriptionID: "sub_" + organizationID,
+		ServicePeriodStart:   pgtype.Timestamptz{Time: start.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+		ServicePeriodEnd:     pgtype.Timestamptz{Time: end.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+		InvoiceState:         state,
+		FinalizedAt:          finalized,
+	})
+	require.NoError(t, err)
+	stripe.invoices[invoiceID] = &stripeclient.InvoiceState{
+		ID:                 invoiceID,
+		CustomerID:         "cus_" + organizationID,
+		SubscriptionID:     "sub_" + organizationID,
+		Currency:           "usd",
+		BillingReason:      "subscription_cycle",
+		Status:             state,
+		ServicePeriodStart: start.UTC(),
+		ServicePeriodEnd:   end.UTC(),
+		FinalizedAt:        remoteFinalizedAt,
+		AmountRemaining:    remaining,
+	}
+}
+
+func putDailySpend(t *testing.T, db *pgxpool.Pool, organizationID string, day time.Time, amount string) {
+	t.Helper()
+	var spend pgtype.Numeric
+	require.NoError(t, spend.Scan(amount))
+	require.NoError(t, backgroundrepo.New(db).UpsertOpenRouterDailySpend(t.Context(), backgroundrepo.UpsertOpenRouterDailySpendParams{
+		TargetOrganizationID: organizationID,
+		TargetKeyType:        "chat",
+		TargetDay:            pgtype.Date{Time: day.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+		TargetSpendUsd:       spend,
+	}))
+}
+
+func listAllocationFixtures(t *testing.T, db *pgxpool.Pool, organizationID string) []backgroundrepo.ListStripeInvoiceAllocationsFixtureRow {
+	t.Helper()
+	rows, err := backgroundrepo.New(db).ListStripeInvoiceAllocationsFixture(
+		t.Context(), pgtype.Text{String: organizationID, Valid: true})
+	require.NoError(t, err)
+	return rows
+}
+
+func addTUMCarry(t *testing.T, db *pgxpool.Pool, organizationID string, start, end time.Time, cents int64, key string) {
+	t.Helper()
+	snapshot := pgtype.Numeric{}
+	amount := pgtype.Numeric{}
+	require.NoError(t, snapshot.Scan(fmt.Sprintf("%d.%02d", max(cents, -cents)/100, max(cents, -cents)%100)))
+	sign := ""
+	if cents < 0 {
+		sign = "-"
+	}
+	absCents := max(cents, -cents)
+	require.NoError(t, amount.Scan(fmt.Sprintf("%s%d.%02d", sign, absCents/100, absCents%100)))
+	require.NoError(t, backgroundrepo.New(db).CreateTUMInvoiceAllocationFixture(t.Context(), backgroundrepo.CreateTUMInvoiceAllocationFixtureParams{
+		OrganizationID:    pgtype.Text{String: organizationID, Valid: true},
+		SourceKey:         key,
+		SourcePeriodStart: pgtype.Timestamptz{Time: start.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+		SourcePeriodEnd:   pgtype.Timestamptz{Time: end.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+		SourceSnapshotUsd: snapshot,
+		AmountUsd:         amount,
+		IdempotencyKey:    "tum-carry:" + organizationID + ":" + key,
+	}))
+}
+
+func TestSettleStripeInvoiceAllocations_BoundariesAndHalfAwayFromZero(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_boundaries")
+	start := time.Date(2026, time.January, 31, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "1.005000")
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
+		Now: end.Add(48*time.Hour - time.Nanosecond),
+	}))
+	require.Empty(t, listAllocationFixtures(t, db, organizationID))
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
+		Now: end.Add(48 * time.Hour),
+	}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 1)
+	require.Equal(t, "1.005000", numericString(t, rows[0].SourceSnapshotUsd))
+	require.Equal(t, "1.010000", numericString(t, rows[0].AmountUsd))
+	require.Equal(t, "confirmed", rows[0].DeliveryState)
+	require.Len(t, stripe.itemInputs, 1)
+	require.Equal(t, int64(101), stripe.itemInputs[0].AmountCents)
+	require.Equal(t, start, stripe.itemInputs[0].PeriodStart)
+	require.Equal(t, end, stripe.itemInputs[0].PeriodEnd)
+
+	putDailySpend(t, db, organizationID, start, "1.014999")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
+		Now: end.Add(72 * time.Hour),
+	}))
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, int32(2), rows[1].Seq)
+	require.Equal(t, "1.014999", numericString(t, rows[1].SourceSnapshotUsd))
+	require.Equal(t, "0", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, "confirmed", rows[1].DeliveryState)
+}
+
+func TestSettleStripeInvoiceAllocations_MissedWindowRecoversAfter96Hours(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_missed_window")
+	start := time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "open", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 4), end.AddDate(0, 0, 5), "draft", 0)
+	putDailySpend(t, db, organizationID, start, "2.345678")
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
+		Now: end.Add(120 * time.Hour),
+	}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, int32(1), rows[0].Seq)
+	require.Equal(t, "0", numericString(t, rows[0].SourceSnapshotUsd))
+	require.Equal(t, "0", numericString(t, rows[0].AmountUsd))
+	require.Equal(t, int32(2), rows[1].Seq)
+	require.Equal(t, "2.345678", numericString(t, rows[1].SourceSnapshotUsd))
+	require.Equal(t, "2.350000", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, "in_future", rows[1].DestinationInvoiceID.String)
+	require.Len(t, stripe.itemInputs, 1)
+	require.Equal(t, int64(235), stripe.itemInputs[0].AmountCents)
+}
+
+func TestSettleStripeInvoiceAllocations_AssignsEarliestDraftWithinTenant(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_earliest_draft")
+	start := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "open", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_later", end.AddDate(0, 0, 3), end.AddDate(0, 0, 4), "draft", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_earlier", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+	putDailySpend(t, db, organizationID, start, "0.015000")
+
+	otherID := "org-" + uuid.NewString()[:8]
+	_, err := orgrepo.New(db).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID: otherID, Name: "Other", Slug: otherID, WorkosID: pgtype.Text{}, Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	addStripeInvoice(t, db, stripe, otherID, "in_cross_tenant", end.AddDate(0, 0, 1), end.AddDate(0, 0, 2), "draft", 0)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
+		Now: end.Add(52 * time.Hour),
+	}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 1)
+	require.Equal(t, "0.020000", numericString(t, rows[0].AmountUsd))
+	require.Equal(t, "in_earlier", rows[0].DestinationInvoiceID.String)
+	require.Len(t, stripe.itemInputs, 1)
+	require.Equal(t, "in_earlier", stripe.itemInputs[0].InvoiceID)
+}
+
+func TestSettleStripeInvoiceAllocations_NegativeCarryCreditsPaidPortion(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_negative_credit")
+	start := time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "2.005000")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(52 * time.Hour)}))
+
+	putDailySpend(t, db, organizationID, start, "1.000000")
+	state := stripe.invoices["in_original"]
+	state.Status = "open"
+	state.FinalizedAt = end.Add(time.Hour)
+	state.AmountRemaining = 40
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(76 * time.Hour)}))
+
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, "-1.010000", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, "in_original", rows[1].DestinationInvoiceID.String)
+	require.Equal(t, "confirmed", rows[1].DeliveryState)
+	require.Len(t, stripe.creditInputs, 1)
+	require.Equal(t, int64(101), stripe.creditInputs[0].AmountCents)
+	require.Equal(t, int64(61), stripe.creditInputs[0].CreditAmountCents)
+}
+
+func TestSettleStripeInvoiceAllocations_PaymentRaceRefetchesAndRetries(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_payment_race")
+	start := time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "2.005000")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(52 * time.Hour)}))
+
+	putDailySpend(t, db, organizationID, start, "1.000000")
+	base := *stripe.invoices["in_original"]
+	base.Status = "open"
+	base.FinalizedAt = end.Add(time.Hour)
+	stripe.getState = func(_ string, call int) *stripeclient.InvoiceState {
+		state := base
+		if call >= 3 {
+			state.AmountRemaining = 0
+		} else {
+			state.AmountRemaining = 101
+		}
+		return &state
+	}
+	stripe.creditErrors = []error{errors.New("invoice payment changed"), nil}
+	firstAttempt := end.Add(76 * time.Hour)
+	require.Error(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt}))
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(time.Hour)}))
+	require.Len(t, stripe.creditInputs, 1, "ambiguous credit must not drift within the idempotency window")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25 * time.Hour)}))
+	require.Len(t, stripe.creditInputs, 2)
+	require.Equal(t, int64(0), stripe.creditInputs[0].CreditAmountCents)
+	require.Equal(t, int64(101), stripe.creditInputs[1].CreditAmountCents)
+	require.NotEqual(t, stripe.creditInputs[0].IdempotencyKey, stripe.creditInputs[1].IdempotencyKey)
+	require.LessOrEqual(t, len(stripe.creditInputs[1].IdempotencyKey), 255)
+}
+
+func TestSettleStripeInvoiceAllocations_ReconcilesAfter24Hours(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_reconcile")
+	start := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "1.250000")
+	stripe.itemErrors = []error{errors.New("response lost")}
+	firstAttempt := end.Add(48 * time.Hour)
+	require.Error(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt}))
+
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 1)
+	stripe.foundItem = &stripeclient.InvoiceItem{
+		ID:          "ii_reconciled",
+		InvoiceID:   "in_original",
+		Currency:    "usd",
+		AmountCents: 125,
+	}
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25 * time.Hour)}))
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Equal(t, "confirmed", rows[0].DeliveryState)
+	require.Equal(t, "ii_reconciled", rows[0].StripeInvoiceItemID.String)
+	require.True(t, rows[0].ReconciledAt.Valid)
+	require.Equal(t, 1, stripe.findItems)
+	require.Len(t, stripe.itemInputs, 1, "reconciled delivery must not be created twice")
+}
+
+func TestSettleStripeInvoiceAllocations_ConcurrentClaimsWriteOnce(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_concurrent")
+	start := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "0.010000")
+	now := end.Add(48 * time.Hour)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for range 2 {
+		wg.Go(func() {
+			errs <- activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now})
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Len(t, stripe.itemInputs, 1)
+}
+
+func TestSettleStripeInvoiceAllocations_MissingBaselineBecomesPositiveCarry(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_missing_then_carry")
+	start := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "open", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(52 * time.Hour)}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 1)
+	require.Equal(t, "0", numericString(t, rows[0].SourceSnapshotUsd))
+	require.Equal(t, "0", numericString(t, rows[0].AmountUsd))
+	require.Equal(t, "confirmed", rows[0].DeliveryState)
+
+	putDailySpend(t, db, organizationID, start, "0.015000")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(76 * time.Hour)}))
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, "0.020000", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, "in_future", rows[1].DestinationInvoiceID.String)
+	require.NotEqual(t, "awaiting_source", rows[0].DeliveryState)
+}
+
+func TestSettleStripeInvoiceAllocations_TUMPositiveCarryIgnoresChatReadinessAndBindsExactBounds(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_tum_positive")
+	start := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "open", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end, end.AddDate(0, 1, 0), "draft", 0)
+	addTUMCarry(t, db, organizationID, start, end, 35, "positive")
+
+	otherID := "org-" + uuid.NewString()[:8]
+	_, err := orgrepo.New(db).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID: otherID, Name: "Other", Slug: otherID, WorkosID: pgtype.Text{}, Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	addStripeInvoice(t, db, stripe, otherID, "in_cross_tenant_exact", start, end, "open", 0)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
+		Now:                                    end.Add(24 * time.Hour),
+		RestrictOpenRouterToReadyOrganizations: true,
+		OpenRouterReadyOrganizationIDs:         []string{},
+	}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 1)
+	require.Equal(t, "in_original", rows[0].OriginalInvoiceID.String)
+	require.Equal(t, "in_future", rows[0].DestinationInvoiceID.String)
+	require.Equal(t, "confirmed", rows[0].DeliveryState)
+	require.Len(t, stripe.itemInputs, 1)
+	require.Equal(t, int64(35), stripe.itemInputs[0].AmountCents)
+	require.Equal(t, start, stripe.itemInputs[0].PeriodStart)
+	require.Equal(t, end, stripe.itemInputs[0].PeriodEnd)
+}
+
+func TestSettleStripeInvoiceAllocations_TUMNegativeCarryCreditsOriginal(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_tum_negative")
+	start := time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "paid", 0)
+	addTUMCarry(t, db, organizationID, start, end, -35, "negative")
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(24 * time.Hour)}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 1)
+	require.Equal(t, "in_original", rows[0].DestinationInvoiceID.String)
+	require.Equal(t, "confirmed", rows[0].DeliveryState)
+	require.Len(t, stripe.creditInputs, 1)
+	require.Equal(t, int64(35), stripe.creditInputs[0].AmountCents)
+	require.Equal(t, int64(35), stripe.creditInputs[0].CreditAmountCents)
+}
+
+func TestSettleStripeInvoiceAllocations_AmbiguousItemWaitsForVisibilityBeforeClosedRebind(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_closed_reconcile")
+	start := time.Date(2026, time.November, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+	putDailySpend(t, db, organizationID, start, "1.000000")
+	stripe.itemErrors = []error{errors.New("response lost")}
+	firstAttempt := end.Add(52 * time.Hour)
+	require.Error(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt}))
+	oldKey := stripe.itemInputs[0].IdempotencyKey
+
+	state := stripe.invoices["in_original"]
+	state.Status = "open"
+	state.FinalizedAt = end.Add(time.Hour)
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(time.Hour)}))
+	require.Zero(t, stripe.findItems, "eventual visibility cannot be decided inside 24 hours")
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Equal(t, "in_original", rows[0].DestinationInvoiceID.String)
+
+	stripe.foundItem = &stripeclient.InvoiceItem{ID: "ii_visible_later", InvoiceID: "in_original", Currency: "usd", AmountCents: 100}
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25 * time.Hour)}))
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Equal(t, "confirmed", rows[0].DeliveryState)
+	require.Equal(t, "in_original", rows[0].DestinationInvoiceID.String)
+	require.Equal(t, "ii_visible_later", rows[0].StripeInvoiceItemID.String)
+	require.Equal(t, oldKey, stripe.itemInputs[0].IdempotencyKey)
+	require.Len(t, stripe.itemInputs, 1, "visible old write must not be rebound or recreated")
+}
+
+func TestSettleStripeInvoiceAllocations_ProvenAbsentClosedItemRebindsWithRotatedKey(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_closed_rebind")
+	start := time.Date(2026, time.November, 5, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+	putDailySpend(t, db, organizationID, start, "1.000000")
+	stripe.itemErrors = []error{errors.New("response lost"), errors.New("second response lost")}
+	firstAttempt := end.Add(52 * time.Hour)
+	require.Error(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt}))
+	oldKey := stripe.itemInputs[0].IdempotencyKey
+
+	state := stripe.invoices["in_original"]
+	state.Status = "open"
+	state.FinalizedAt = end.Add(time.Hour)
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25 * time.Hour)}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.False(t, rows[0].DestinationInvoiceID.Valid, "proven-absent closed destination is released")
+	require.True(t, rows[0].ReconciledAt.Valid)
+	require.LessOrEqual(t, len(rows[0].IdempotencyKey), 255)
+
+	require.Error(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25*time.Hour + 6*time.Minute)}))
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(51 * time.Hour)}))
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Equal(t, "in_future", rows[0].DestinationInvoiceID.String)
+	require.Equal(t, "confirmed", rows[0].DeliveryState)
+	require.Len(t, stripe.itemInputs, 3)
+	require.NotEqual(t, oldKey, stripe.itemInputs[1].IdempotencyKey)
+	require.NotEqual(t, stripe.itemInputs[1].IdempotencyKey, stripe.itemInputs[2].IdempotencyKey)
+	require.LessOrEqual(t, len(stripe.itemInputs[2].IdempotencyKey), 255)
+	require.Equal(t, 1, strings.Count(stripe.itemInputs[2].IdempotencyKey, ":retry:"))
+}
+
+func TestSettleStripeInvoiceAllocations_RefusesVoidCreditDestination(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_void_credit")
+	start := time.Date(2026, time.December, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "void", 0)
+	addTUMCarry(t, db, organizationID, start, end, -10, "void")
+
+	err := activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(24 * time.Hour)})
+	require.ErrorContains(t, err, `status "void" does not support credit notes`)
+	require.Empty(t, stripe.creditInputs)
+}

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -209,6 +209,17 @@ func setChatKeyCreatedAt(t *testing.T, db *pgxpool.Pool, organizationID string, 
 	))
 }
 
+func setChatKeyDeletedAt(t *testing.T, db *pgxpool.Pool, organizationID string, deletedAt time.Time) {
+	t.Helper()
+	require.NoError(t, backgroundrepo.New(db).SetOpenRouterAPIKeyDeletedAtFixture(
+		t.Context(), backgroundrepo.SetOpenRouterAPIKeyDeletedAtFixtureParams{
+			DeletedAt:      pgtype.Timestamptz{Time: deletedAt.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+			OrganizationID: organizationID,
+			KeyType:        "chat",
+		},
+	))
+}
+
 func addOpenRouterCarryFixture(
 	t *testing.T,
 	db *pgxpool.Pool,
@@ -581,6 +592,34 @@ func TestSettleStripeInvoiceAllocations_NoKeyDaysFinalizeAsDurableZero(t *testin
 		t.Context(), pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true})
 	require.NoError(t, err)
 	require.Empty(t, candidates, "an organization without a chat key cannot have chat spend")
+}
+
+func TestSettleStripeInvoiceAllocations_PostDeletionDaysFinalizeAsDurableZero(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_deleted_key_zero")
+	start := time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+	deletionDay := start.AddDate(0, 0, 1)
+	end := start.AddDate(0, 0, 3)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "open", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+	setChatKeyCreatedAt(t, db, organizationID, start.Add(-time.Hour))
+	setChatKeyDeletedAt(t, db, organizationID, deletionDay.Add(12*time.Hour))
+	putDailySpend(t, db, organizationID, start, "0.010000")
+	putDailySpend(t, db, organizationID, deletionDay, "0.020000")
+	now := end.Add(76 * time.Hour)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 6)
+	require.Equal(t, "0.010000", numericString(t, rows[1].SourceSnapshotUsd))
+	require.Equal(t, "0.020000", numericString(t, rows[3].SourceSnapshotUsd), "deletion-day spend remains billable")
+	require.Equal(t, "0", numericString(t, rows[5].SourceSnapshotUsd), "post-deletion day is an authoritative zero")
+	require.Equal(t, int32(2), rows[5].Seq)
+
+	candidates, err := backgroundrepo.New(db).ListStripeInvoiceBillingOrganizations(
+		t.Context(), pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true})
+	require.NoError(t, err)
+	require.Empty(t, candidates, "post-deletion zeroes must finish the invoice candidate")
 }
 
 func TestSettleStripeInvoiceAllocations_LateMiddleDayReconcilesExistingLaterCarry(t *testing.T) {

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -189,7 +189,6 @@ func createChatKeyAt(t *testing.T, db *pgxpool.Pool, organizationID string, crea
 	_, err := openrouterrepo.New(db).CreateOpenRouterAPIKey(t.Context(), openrouterrepo.CreateOpenRouterAPIKeyParams{
 		OrganizationID: organizationID,
 		KeyType:        "chat",
-		Key:            pgtype.Text{},
 		KeyEncrypted:   pgtype.Text{},
 		KeyHash:        strings.Repeat("a", 64),
 		MonthlyCredits: 0,

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -18,6 +18,7 @@ import (
 	backgroundrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 )
 
@@ -110,6 +111,15 @@ func (m *allocationStripeMock) FindCreditNote(_ context.Context, _ stripeclient.
 
 func setupAllocationTest(t *testing.T, name string) (*pgxpool.Pool, string, *allocationStripeMock, *activities.SettleStripeInvoiceAllocations) {
 	t.Helper()
+	return setupAllocationTestWithChatKey(t, name, true)
+}
+
+func setupAllocationTestWithChatKey(
+	t *testing.T,
+	name string,
+	withChatKey bool,
+) (*pgxpool.Pool, string, *allocationStripeMock, *activities.SettleStripeInvoiceAllocations) {
+	t.Helper()
 	db, err := infra.CloneTestDatabase(t, name)
 	require.NoError(t, err)
 	organizationID := "org-" + uuid.NewString()[:8]
@@ -121,6 +131,9 @@ func setupAllocationTest(t *testing.T, name string) (*pgxpool.Pool, string, *all
 		Whitelisted: pgtype.Bool{},
 	})
 	require.NoError(t, err)
+	if withChatKey {
+		createChatKeyAt(t, db, organizationID, time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC))
+	}
 	stripe := &allocationStripeMock{invoices: make(map[string]*stripeclient.InvoiceState)}
 	activity := activities.NewSettleStripeInvoiceAllocations(testenv.NewLogger(t), db, stripe)
 	return db, organizationID, stripe, activity
@@ -169,6 +182,64 @@ func putDailySpend(t *testing.T, db *pgxpool.Pool, organizationID string, day ti
 		TargetDay:            pgtype.Date{Time: day.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
 		TargetSpendUsd:       spend,
 	}))
+}
+
+func createChatKeyAt(t *testing.T, db *pgxpool.Pool, organizationID string, createdAt time.Time) {
+	t.Helper()
+	_, err := openrouterrepo.New(db).CreateOpenRouterAPIKey(t.Context(), openrouterrepo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: organizationID,
+		KeyType:        "chat",
+		Key:            pgtype.Text{},
+		KeyEncrypted:   pgtype.Text{},
+		KeyHash:        strings.Repeat("a", 64),
+		MonthlyCredits: 0,
+	})
+	require.NoError(t, err)
+	setChatKeyCreatedAt(t, db, organizationID, createdAt)
+}
+
+func setChatKeyCreatedAt(t *testing.T, db *pgxpool.Pool, organizationID string, createdAt time.Time) {
+	t.Helper()
+	require.NoError(t, backgroundrepo.New(db).SetOpenRouterAPIKeyCreatedAtFixture(
+		t.Context(), backgroundrepo.SetOpenRouterAPIKeyCreatedAtFixtureParams{
+			CreatedAt:      pgtype.Timestamptz{Time: createdAt.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+			OrganizationID: organizationID,
+			KeyType:        "chat",
+		},
+	))
+}
+
+func addOpenRouterCarryFixture(
+	t *testing.T,
+	db *pgxpool.Pool,
+	organizationID string,
+	day time.Time,
+	snapshot string,
+	amount string,
+	invoiceID string,
+) {
+	t.Helper()
+	var snapshotNumeric pgtype.Numeric
+	require.NoError(t, snapshotNumeric.Scan(snapshot))
+	var amountNumeric pgtype.Numeric
+	require.NoError(t, amountNumeric.Scan(amount))
+	now := time.Now().UTC()
+	_, err := backgroundrepo.New(db).CreateOpenRouterInvoiceAllocation(
+		t.Context(), backgroundrepo.CreateOpenRouterInvoiceAllocationParams{
+			OrganizationID:       pgtype.Text{String: organizationID, Valid: true},
+			SourceKey:            day.UTC().Format(time.DateOnly) + ":chat",
+			Seq:                  2,
+			SourceDay:            pgtype.Date{Time: day.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+			SourceSnapshotUsd:    snapshotNumeric,
+			AmountUsd:            amountNumeric,
+			OriginalInvoiceID:    pgtype.Text{String: invoiceID, Valid: true},
+			DestinationInvoiceID: pgtype.Text{String: invoiceID, Valid: true},
+			IdempotencyKey:       "openrouter:" + organizationID + ":" + day.UTC().Format(time.DateOnly) + ":2",
+			DeliveryState:        "confirmed",
+			ConfirmedAt:          pgtype.Timestamptz{Time: now, InfinityModifier: pgtype.Finite, Valid: true},
+		},
+	)
+	require.NoError(t, err)
 }
 
 func listAllocationFixtures(t *testing.T, db *pgxpool.Pool, organizationID string) []backgroundrepo.ListStripeInvoiceAllocationsFixtureRow {
@@ -451,6 +522,104 @@ func TestSettleStripeInvoiceAllocations_MissingFinalSourceRemainsRecoverable(t *
 	require.Equal(t, "0.020000", numericString(t, rows[1].AmountUsd))
 	require.Equal(t, "confirmed", rows[1].DeliveryState)
 	require.Len(t, stripe.itemInputs, 1)
+}
+
+func TestSettleStripeInvoiceAllocations_PreKeyDaysFinalizeAsDurableZero(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_pre_key_zero")
+	start := time.Date(2026, time.August, 7, 0, 0, 0, 0, time.UTC)
+	keyDay := start.AddDate(0, 0, 2)
+	end := start.AddDate(0, 0, 3)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	setChatKeyCreatedAt(t, db, organizationID, keyDay.Add(12*time.Hour))
+	putDailySpend(t, db, organizationID, keyDay, "0.015000")
+	now := end.Add(76 * time.Hour)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 6)
+	require.Equal(t, int32(2), rows[1].Seq)
+	require.Equal(t, "0", numericString(t, rows[1].SourceSnapshotUsd))
+	require.Equal(t, "0", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, int32(2), rows[3].Seq)
+	require.Equal(t, "0", numericString(t, rows[3].SourceSnapshotUsd))
+	require.Equal(t, "0", numericString(t, rows[3].AmountUsd))
+	require.Equal(t, int32(2), rows[5].Seq)
+	require.Equal(t, "0.015000", numericString(t, rows[5].SourceSnapshotUsd))
+	require.Equal(t, "0.020000", numericString(t, rows[5].AmountUsd))
+	require.Len(t, stripe.itemInputs, 1)
+
+	candidates, err := backgroundrepo.New(db).ListStripeInvoiceBillingOrganizations(
+		t.Context(), pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true})
+	require.NoError(t, err)
+	require.Empty(t, candidates, "authoritative pre-key zeroes must finish the invoice candidate")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(time.Hour)}))
+	require.Len(t, listAllocationFixtures(t, db, organizationID), 6)
+	require.Len(t, stripe.itemInputs, 1)
+}
+
+func TestSettleStripeInvoiceAllocations_NoKeyDaysFinalizeAsDurableZero(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTestWithChatKey(t, "stripe_alloc_no_key_zero", false)
+	start := time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 2)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	now := end.Add(76 * time.Hour)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 4)
+	for _, row := range rows {
+		require.Equal(t, "0", numericString(t, row.SourceSnapshotUsd))
+		require.Equal(t, "0", numericString(t, row.AmountUsd))
+		require.Equal(t, "confirmed", row.DeliveryState)
+	}
+	require.Empty(t, stripe.itemInputs)
+
+	candidates, err := backgroundrepo.New(db).ListStripeInvoiceBillingOrganizations(
+		t.Context(), pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true})
+	require.NoError(t, err)
+	require.Empty(t, candidates, "an organization without a chat key cannot have chat spend")
+}
+
+func TestSettleStripeInvoiceAllocations_LateMiddleDayReconcilesExistingLaterCarry(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_late_middle_day")
+	start := time.Date(2026, time.August, 14, 0, 0, 0, 0, time.UTC)
+	middleDay := start.AddDate(0, 0, 1)
+	lastDay := start.AddDate(0, 0, 2)
+	end := start.AddDate(0, 0, 3)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "0.004000")
+	putDailySpend(t, db, organizationID, lastDay, "0.004000")
+	now := end.Add(76 * time.Hour)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 4)
+	require.Equal(t, start.Format(time.DateOnly)+":chat", rows[1].SourceKey)
+	require.Equal(t, int32(2), rows[1].Seq)
+	require.Equal(t, "0", numericString(t, rows[1].AmountUsd))
+	addOpenRouterCarryFixture(t, db, organizationID, lastDay, "0.004000", "0.010000", "in_original")
+
+	putDailySpend(t, db, organizationID, middleDay, "0.004000")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(time.Hour)}))
+	rows = listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 6)
+	require.Equal(t, middleDay.Format(time.DateOnly)+":chat", rows[3].SourceKey)
+	require.Equal(t, int32(2), rows[3].Seq)
+	require.Equal(t, "0.004000", numericString(t, rows[3].SourceSnapshotUsd))
+	require.Equal(t, "0", numericString(t, rows[3].AmountUsd))
+	require.Equal(t, lastDay.Format(time.DateOnly)+":chat", rows[5].SourceKey)
+	require.Equal(t, "0.010000", numericString(t, rows[5].AmountUsd), "the existing later carry stays immutable")
+
+	require.Equal(t, "0", numericString(t, rows[1].AmountUsd))
+	require.Equal(t, "0", numericString(t, rows[3].AmountUsd))
+	require.Equal(t, "0.010000", numericString(t, rows[5].AmountUsd), "three 0.004 USD days round once to one cycle cent")
+	require.Empty(t, stripe.itemInputs)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(2 * time.Hour)}))
+	require.Len(t, listAllocationFixtures(t, db, organizationID), 6)
 }
 
 func TestSettleStripeInvoiceAllocations_RoundsCumulativeCycleTotalsAndDrainsBatch(t *testing.T) {

--- a/server/internal/background/openrouter_daily_spend.go
+++ b/server/internal/background/openrouter_daily_spend.go
@@ -25,9 +25,10 @@ const (
 	openRouterDailySpendActivityMaxAttempts = 3
 	openRouterDailySpendActivityTimeout     = 2 * time.Hour
 	// Schedule-to-close covers all three two-hour attempts, retry backoff, and
-	// queueing delay. The workflow gets a further hour to record the result.
+	// queueing delay. Collection and settlement run serially, and the workflow
+	// gets a further hour to record their results.
 	openRouterDailySpendActivityScheduleToCloseTimeout = 7 * time.Hour
-	openRouterDailySpendWorkflowRunTimeout             = openRouterDailySpendActivityScheduleToCloseTimeout + time.Hour
+	openRouterDailySpendWorkflowRunTimeout             = 2*openRouterDailySpendActivityScheduleToCloseTimeout + time.Hour
 )
 
 func CollectOpenRouterDailySpendWorkflow(ctx workflow.Context) error {
@@ -48,25 +49,27 @@ func CollectOpenRouterDailySpendWorkflow(ctx workflow.Context) error {
 
 	var a *Activities
 	var collected activities.CollectOpenRouterDailySpendResult
-	if err := workflow.ExecuteActivity(ctx, a.CollectOpenRouterDailySpend, activities.CollectOpenRouterDailySpendArgs{
+	collectionErr := workflow.ExecuteActivity(ctx, a.CollectOpenRouterDailySpend, activities.CollectOpenRouterDailySpendArgs{
 		StartDay: startDay,
 		EndDay:   endDay,
-	}).Get(ctx, &collected); err != nil {
-		return fmt.Errorf("collect openrouter daily spend: %w", err)
+	}).Get(ctx, &collected)
+	if collectionErr != nil {
+		collectionErr = fmt.Errorf("collect openrouter daily spend: %w", collectionErr)
+		collected.ReadyOrganizationIDs = nil
 	}
 
-	// Settlement consumes only the durable rows written by the successful
-	// collection above. A failed or exhausted collection never bills a stale
-	// snapshot.
-	if err := workflow.ExecuteActivity(ctx, a.SettleStripeInvoiceAllocations, activities.SettleStripeInvoiceAllocationsArgs{
+	// A failed collection leaves the ready set empty, so settlement still routes
+	// independent TUM carries without freezing stale OpenRouter spend.
+	settlementErr := workflow.ExecuteActivity(ctx, a.SettleStripeInvoiceAllocations, activities.SettleStripeInvoiceAllocationsArgs{
 		Now:                                    workflow.Now(ctx).UTC(),
 		RestrictOpenRouterToReadyOrganizations: true,
 		OpenRouterReadyOrganizationIDs:         collected.ReadyOrganizationIDs,
-	}).Get(ctx, nil); err != nil {
-		return fmt.Errorf("settle Stripe invoice allocations: %w", err)
+	}).Get(ctx, nil)
+	if settlementErr != nil {
+		settlementErr = fmt.Errorf("settle Stripe invoice allocations: %w", settlementErr)
 	}
 
-	return nil
+	return errors.Join(collectionErr, settlementErr)
 }
 
 func openRouterDailySpendScheduleOptions(taskQueue string) client.ScheduleOptions {

--- a/server/internal/background/openrouter_daily_spend.go
+++ b/server/internal/background/openrouter_daily_spend.go
@@ -19,7 +19,9 @@ const (
 	openRouterDailySpendScheduleID          = "v1:collect-openrouter-daily-spend-schedule"
 	openRouterDailySpendScheduledWorkflowID = "v1:collect-openrouter-daily-spend/scheduled"
 
-	openRouterDailySpendLookbackDays        = 3
+	// Four completed days keeps the last invoice day in the +76h final
+	// observation collected immediately before settlement.
+	openRouterDailySpendLookbackDays        = 4
 	openRouterDailySpendActivityMaxAttempts = 3
 	openRouterDailySpendActivityTimeout     = 2 * time.Hour
 	// Schedule-to-close covers all three two-hour attempts, retry backoff, and
@@ -45,11 +47,23 @@ func CollectOpenRouterDailySpendWorkflow(ctx workflow.Context) error {
 	})
 
 	var a *Activities
+	var collected activities.CollectOpenRouterDailySpendResult
 	if err := workflow.ExecuteActivity(ctx, a.CollectOpenRouterDailySpend, activities.CollectOpenRouterDailySpendArgs{
 		StartDay: startDay,
 		EndDay:   endDay,
-	}).Get(ctx, nil); err != nil {
+	}).Get(ctx, &collected); err != nil {
 		return fmt.Errorf("collect openrouter daily spend: %w", err)
+	}
+
+	// Settlement consumes only the durable rows written by the successful
+	// collection above. A failed or exhausted collection never bills a stale
+	// snapshot.
+	if err := workflow.ExecuteActivity(ctx, a.SettleStripeInvoiceAllocations, activities.SettleStripeInvoiceAllocationsArgs{
+		Now:                                    workflow.Now(ctx).UTC(),
+		RestrictOpenRouterToReadyOrganizations: true,
+		OpenRouterReadyOrganizationIDs:         collected.ReadyOrganizationIDs,
+	}).Get(ctx, nil); err != nil {
+		return fmt.Errorf("settle Stripe invoice allocations: %w", err)
 	}
 
 	return nil

--- a/server/internal/background/openrouter_daily_spend_test.go
+++ b/server/internal/background/openrouter_daily_spend_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 )
 
-func TestCollectOpenRouterDailySpendWorkflowCollectsLastThreeCompletedUTCDays(t *testing.T) {
+func TestCollectOpenRouterDailySpendWorkflowCollectsLastFourCompletedUTCDays(t *testing.T) {
 	t.Parallel()
 
 	var suite testsuite.WorkflowTestSuite
@@ -58,6 +58,7 @@ func TestCollectOpenRouterDailySpendWorkflowPropagatesFailureAfterRetries(t *tes
 	env := suite.NewTestWorkflowEnvironment()
 	var attempts atomic.Int32
 	var settlementAttempts atomic.Int32
+	var settled activities.SettleStripeInvoiceAllocationsArgs
 	env.RegisterActivityWithOptions(
 		func(context.Context, activities.CollectOpenRouterDailySpendArgs) (activities.CollectOpenRouterDailySpendResult, error) {
 			attempts.Add(1)
@@ -66,8 +67,9 @@ func TestCollectOpenRouterDailySpendWorkflowPropagatesFailureAfterRetries(t *tes
 		activity.RegisterOptions{Name: "CollectOpenRouterDailySpend"},
 	)
 	env.RegisterActivityWithOptions(
-		func(context.Context, activities.SettleStripeInvoiceAllocationsArgs) error {
+		func(_ context.Context, args activities.SettleStripeInvoiceAllocationsArgs) error {
 			settlementAttempts.Add(1)
+			settled = args
 			return nil
 		},
 		activity.RegisterOptions{Name: "SettleStripeInvoiceAllocations"},
@@ -78,7 +80,9 @@ func TestCollectOpenRouterDailySpendWorkflowPropagatesFailureAfterRetries(t *tes
 	require.True(t, env.IsWorkflowCompleted())
 	require.ErrorContains(t, env.GetWorkflowError(), "collect openrouter daily spend")
 	require.EqualValues(t, openRouterDailySpendActivityMaxAttempts, attempts.Load())
-	require.Zero(t, settlementAttempts.Load(), "failed collection must not settle stale spend")
+	require.EqualValues(t, 1, settlementAttempts.Load(), "failed collection must still route independent TUM carries")
+	require.True(t, settled.RestrictOpenRouterToReadyOrganizations)
+	require.Empty(t, settled.OpenRouterReadyOrganizationIDs)
 }
 
 func TestOpenRouterDailySpendScheduleOptions(t *testing.T) {
@@ -96,5 +100,5 @@ func TestOpenRouterDailySpendScheduleOptions(t *testing.T) {
 	require.Equal(t, openRouterDailySpendScheduledWorkflowID, action.ID)
 	require.Equal(t, "test-task-queue", action.TaskQueue)
 	require.Equal(t, openRouterDailySpendWorkflowRunTimeout, action.WorkflowRunTimeout)
-	require.Greater(t, openRouterDailySpendWorkflowRunTimeout, openRouterDailySpendActivityScheduleToCloseTimeout)
+	require.Greater(t, openRouterDailySpendWorkflowRunTimeout, 2*openRouterDailySpendActivityScheduleToCloseTimeout)
 }

--- a/server/internal/background/openrouter_daily_spend_test.go
+++ b/server/internal/background/openrouter_daily_spend_test.go
@@ -24,20 +24,31 @@ func TestCollectOpenRouterDailySpendWorkflowCollectsLastThreeCompletedUTCDays(t 
 	env.SetStartTime(time.Date(2026, time.August, 14, 23, 30, 0, 0, time.FixedZone("UTC-7", -7*60*60)))
 
 	var received activities.CollectOpenRouterDailySpendArgs
+	var settled activities.SettleStripeInvoiceAllocationsArgs
 	env.RegisterActivityWithOptions(
-		func(_ context.Context, args activities.CollectOpenRouterDailySpendArgs) error {
+		func(_ context.Context, args activities.CollectOpenRouterDailySpendArgs) (activities.CollectOpenRouterDailySpendResult, error) {
 			received = args
-			return nil
+			return activities.CollectOpenRouterDailySpendResult{ReadyOrganizationIDs: []string{"org-ready"}}, nil
 		},
 		activity.RegisterOptions{Name: "CollectOpenRouterDailySpend"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, args activities.SettleStripeInvoiceAllocationsArgs) error {
+			settled = args
+			return nil
+		},
+		activity.RegisterOptions{Name: "SettleStripeInvoiceAllocations"},
 	)
 
 	env.ExecuteWorkflow(CollectOpenRouterDailySpendWorkflow)
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
-	require.Equal(t, time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC), received.StartDay)
+	require.Equal(t, time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC), received.StartDay)
 	require.Equal(t, time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC), received.EndDay)
+	require.Equal(t, time.Date(2026, time.August, 15, 6, 30, 0, 0, time.UTC), settled.Now)
+	require.True(t, settled.RestrictOpenRouterToReadyOrganizations)
+	require.Equal(t, []string{"org-ready"}, settled.OpenRouterReadyOrganizationIDs)
 }
 
 func TestCollectOpenRouterDailySpendWorkflowPropagatesFailureAfterRetries(t *testing.T) {
@@ -46,12 +57,20 @@ func TestCollectOpenRouterDailySpendWorkflowPropagatesFailureAfterRetries(t *tes
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	var attempts atomic.Int32
+	var settlementAttempts atomic.Int32
 	env.RegisterActivityWithOptions(
-		func(context.Context, activities.CollectOpenRouterDailySpendArgs) error {
+		func(context.Context, activities.CollectOpenRouterDailySpendArgs) (activities.CollectOpenRouterDailySpendResult, error) {
 			attempts.Add(1)
-			return errors.New("OpenRouter unavailable")
+			return activities.CollectOpenRouterDailySpendResult{}, errors.New("OpenRouter unavailable")
 		},
 		activity.RegisterOptions{Name: "CollectOpenRouterDailySpend"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, activities.SettleStripeInvoiceAllocationsArgs) error {
+			settlementAttempts.Add(1)
+			return nil
+		},
+		activity.RegisterOptions{Name: "SettleStripeInvoiceAllocations"},
 	)
 
 	env.ExecuteWorkflow(CollectOpenRouterDailySpendWorkflow)
@@ -59,6 +78,7 @@ func TestCollectOpenRouterDailySpendWorkflowPropagatesFailureAfterRetries(t *tes
 	require.True(t, env.IsWorkflowCompleted())
 	require.ErrorContains(t, env.GetWorkflowError(), "collect openrouter daily spend")
 	require.EqualValues(t, openRouterDailySpendActivityMaxAttempts, attempts.Load())
+	require.Zero(t, settlementAttempts.Load(), "failed collection must not settle stale spend")
 }
 
 func TestOpenRouterDailySpendScheduleOptions(t *testing.T) {

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -403,6 +403,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.FindOrphanCustomDomainResources)
 	temporalWorker.RegisterActivity(activities.CollectOpenRouterCreditsMetrics)
 	temporalWorker.RegisterActivity(activities.CollectOpenRouterDailySpend)
+	temporalWorker.RegisterActivity(activities.SettleStripeInvoiceAllocations)
 	temporalWorker.RegisterActivity(activities.FireOpenRouterCreditsMetrics)
 	temporalWorker.RegisterActivity(activities.MaybeSendOpenRouterCreditsAlerts)
 	temporalWorker.RegisterActivity(activities.CollectPlatformUsageMetrics)

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -279,3 +279,34 @@ func TestRefreshAPIKeyLimit_KeepsLockdownThatLandsMidRefresh(t *testing.T) {
 	require.True(t, row.Disabled, "a refresh must not clear a lockdown it never saw")
 	require.Equal(t, int64(42), row.MonthlyCredits)
 }
+
+func TestRefreshAPIKeyLimit_RejectsChangedUpstreamIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	_, err = queries.UpdateOpenRouterKey(ctx, repo.UpdateOpenRouterKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		MonthlyCredits: 100,
+		KeyHash:        "hash-stored",
+		Reinstate:      false,
+	})
+	require.NoError(t, err)
+
+	limit := 42
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeChat, &limit)
+	require.ErrorContains(t, err, "upstream key identity changed")
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hash-stored", row.KeyHash)
+	require.Equal(t, int64(100), row.MonthlyCredits)
+}

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -489,6 +489,9 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	if err != nil {
 		return 0, err
 	}
+	if keyResponse.Data.Hash != key.KeyHash {
+		return 0, errors.New("refresh openrouter key limit: upstream key identity changed")
+	}
 
 	_, err = o.repo.UpdateOpenRouterKey(ctx, repo.UpdateOpenRouterKeyParams{
 		OrganizationID: orgID,

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -22,6 +22,7 @@ const (
 	organizationSlugMetadataKey = "organization_slug"
 	meterCustomerPayloadKey     = "stripe_customer_id"
 	meterValuePayloadKey        = "value"
+	allocationMetadataKey       = "gram_billing_allocation"
 )
 
 // ErrWebhookNotConfigured indicates that webhook verification cannot run because
@@ -74,6 +75,11 @@ type Client interface {
 	GetCheckoutSession(context.Context, string) (*CheckoutSessionState, error)
 	CreateMeterEvent(context.Context, CreateMeterEventInput) error
 	GetMeterEventSummary(context.Context, GetMeterEventSummaryInput) (float64, error)
+	GetInvoice(context.Context, string) (*InvoiceState, error)
+	CreateInvoiceItem(context.Context, CreateInvoiceItemInput) (*InvoiceItem, error)
+	CreateCreditNote(context.Context, CreateCreditNoteInput) (*CreditNote, error)
+	FindInvoiceItem(context.Context, FindInvoiceAllocationInput) (*InvoiceItem, error)
+	FindCreditNote(context.Context, FindInvoiceAllocationInput) (*CreditNote, error)
 	VerifyWebhook(payload []byte, signature string) (*WebhookEvent, error)
 	Catalog() Catalog
 }
@@ -171,6 +177,68 @@ type GetMeterEventSummaryInput struct {
 	End time.Time
 }
 
+// InvoiceState is the current Stripe invoice state required by pass-through
+// billing. Amounts are Stripe minor units.
+type InvoiceState struct {
+	ID                 string
+	CustomerID         string
+	SubscriptionID     string
+	Currency           string
+	BillingReason      string
+	Status             string
+	ServicePeriodStart time.Time
+	ServicePeriodEnd   time.Time
+	FinalizedAt        time.Time
+	AmountRemaining    int64
+}
+
+// CreateInvoiceItemInput adds one allocation to a draft Stripe invoice.
+type CreateInvoiceItemInput struct {
+	CustomerID     string
+	SubscriptionID string
+	InvoiceID      string
+	Description    string
+	AmountCents    int64
+	PeriodStart    time.Time
+	PeriodEnd      time.Time
+	AllocationKey  string
+	IdempotencyKey string
+}
+
+// InvoiceItem identifies a confirmed Stripe invoice item.
+type InvoiceItem struct {
+	ID          string
+	InvoiceID   string
+	Currency    string
+	AmountCents int64
+}
+
+// CreateCreditNoteInput credits one allocation against a finalized invoice.
+type CreateCreditNoteInput struct {
+	InvoiceID         string
+	Description       string
+	AmountCents       int64
+	CreditAmountCents int64
+	AllocationKey     string
+	IdempotencyKey    string
+}
+
+// CreditNote identifies a confirmed Stripe credit note.
+type CreditNote struct {
+	ID          string
+	InvoiceID   string
+	Currency    string
+	AmountCents int64
+}
+
+// FindInvoiceAllocationInput finds a prior Stripe write by durable allocation
+// metadata after its idempotency window has elapsed.
+type FindInvoiceAllocationInput struct {
+	InvoiceID     string
+	AllocationKey string
+	AmountCents   int64
+}
+
 // WebhookEvent is the verified Stripe event envelope consumed by webhook handlers.
 type WebhookEvent struct {
 	// ID is Stripe's globally unique event identifier.
@@ -198,6 +266,11 @@ type stripeAPI interface {
 	retrieveCheckoutSession(context.Context, string, *stripesdk.CheckoutSessionRetrieveParams) (*stripesdk.CheckoutSession, error)
 	createMeterEvent(context.Context, *stripesdk.BillingMeterEventCreateParams) (*stripesdk.BillingMeterEvent, error)
 	listMeterEventSummaries(context.Context, *stripesdk.BillingMeterEventSummaryListParams) stripesdk.Seq2[*stripesdk.BillingMeterEventSummary, error]
+	retrieveInvoice(context.Context, string, *stripesdk.InvoiceRetrieveParams) (*stripesdk.Invoice, error)
+	createInvoiceItem(context.Context, *stripesdk.InvoiceItemCreateParams) (*stripesdk.InvoiceItem, error)
+	listInvoiceItems(context.Context, *stripesdk.InvoiceItemListParams) stripesdk.Seq2[*stripesdk.InvoiceItem, error]
+	createCreditNote(context.Context, *stripesdk.CreditNoteCreateParams) (*stripesdk.CreditNote, error)
+	listCreditNotes(context.Context, *stripesdk.CreditNoteListParams) stripesdk.Seq2[*stripesdk.CreditNote, error]
 }
 
 type sdkAPI struct {
@@ -238,6 +311,38 @@ func (s *sdkAPI) createMeterEvent(ctx context.Context, params *stripesdk.Billing
 
 func (s *sdkAPI) listMeterEventSummaries(ctx context.Context, params *stripesdk.BillingMeterEventSummaryListParams) stripesdk.Seq2[*stripesdk.BillingMeterEventSummary, error] {
 	return s.client.V1BillingMeterEventSummaries.List(ctx, params).All(ctx)
+}
+
+func (s *sdkAPI) retrieveInvoice(ctx context.Context, id string, params *stripesdk.InvoiceRetrieveParams) (*stripesdk.Invoice, error) {
+	invoice, err := s.client.V1Invoices.Retrieve(ctx, id, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe SDK retrieve invoice: %w", err)
+	}
+	return invoice, nil
+}
+
+func (s *sdkAPI) createInvoiceItem(ctx context.Context, params *stripesdk.InvoiceItemCreateParams) (*stripesdk.InvoiceItem, error) {
+	item, err := s.client.V1InvoiceItems.Create(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe SDK create invoice item: %w", err)
+	}
+	return item, nil
+}
+
+func (s *sdkAPI) listInvoiceItems(ctx context.Context, params *stripesdk.InvoiceItemListParams) stripesdk.Seq2[*stripesdk.InvoiceItem, error] {
+	return s.client.V1InvoiceItems.List(ctx, params).All(ctx)
+}
+
+func (s *sdkAPI) createCreditNote(ctx context.Context, params *stripesdk.CreditNoteCreateParams) (*stripesdk.CreditNote, error) {
+	note, err := s.client.V1CreditNotes.Create(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe SDK create credit note: %w", err)
+	}
+	return note, nil
+}
+
+func (s *sdkAPI) listCreditNotes(ctx context.Context, params *stripesdk.CreditNoteListParams) stripesdk.Seq2[*stripesdk.CreditNote, error] {
+	return s.client.V1CreditNotes.List(ctx, params).All(ctx)
 }
 
 type client struct {
@@ -427,6 +532,179 @@ func (c *client) GetMeterEventSummary(ctx context.Context, input GetMeterEventSu
 	return total, nil
 }
 
+func (c *client) GetInvoice(ctx context.Context, id string) (*InvoiceState, error) {
+	if id == "" {
+		return nil, errors.New("invoice id is required")
+	}
+
+	params := new(stripesdk.InvoiceRetrieveParams)
+	params.AddExpand("parent.subscription_details.subscription")
+	invoice, err := c.api.retrieveInvoice(ctx, id, params)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve Stripe invoice: %w", err)
+	}
+	if invoice == nil {
+		return nil, errors.New("retrieve Stripe invoice: empty response")
+	}
+
+	state := &InvoiceState{
+		ID:                 invoice.ID,
+		CustomerID:         "",
+		SubscriptionID:     "",
+		Currency:           string(invoice.Currency),
+		BillingReason:      string(invoice.BillingReason),
+		Status:             string(invoice.Status),
+		ServicePeriodStart: time.Unix(invoice.PeriodStart, 0).UTC(),
+		ServicePeriodEnd:   time.Unix(invoice.PeriodEnd, 0).UTC(),
+		FinalizedAt:        time.Time{},
+		AmountRemaining:    invoice.AmountRemaining,
+	}
+	if invoice.Customer != nil {
+		state.CustomerID = invoice.Customer.ID
+	}
+	if invoice.Parent != nil && invoice.Parent.SubscriptionDetails != nil && invoice.Parent.SubscriptionDetails.Subscription != nil {
+		state.SubscriptionID = invoice.Parent.SubscriptionDetails.Subscription.ID
+	}
+	if invoice.StatusTransitions != nil && invoice.StatusTransitions.FinalizedAt > 0 {
+		state.FinalizedAt = time.Unix(invoice.StatusTransitions.FinalizedAt, 0).UTC()
+	}
+	return state, nil
+}
+
+func (c *client) CreateInvoiceItem(ctx context.Context, input CreateInvoiceItemInput) (*InvoiceItem, error) {
+	if input.IdempotencyKey == "" || input.AllocationKey == "" {
+		return nil, errMissingIdempotencyKey
+	}
+	if input.CustomerID == "" || input.SubscriptionID == "" || input.InvoiceID == "" {
+		return nil, errors.New("customer, subscription, and invoice ids are required")
+	}
+	if input.AmountCents <= 0 {
+		return nil, errors.New("invoice item amount must be positive")
+	}
+	if input.PeriodStart.IsZero() || !input.PeriodEnd.After(input.PeriodStart) {
+		return nil, errors.New("invoice item period is invalid")
+	}
+
+	params := new(stripesdk.InvoiceItemCreateParams)
+	params.Amount = new(input.AmountCents)
+	params.Currency = stripesdk.String(string(stripesdk.CurrencyUSD))
+	params.Customer = stripesdk.String(input.CustomerID)
+	params.Subscription = stripesdk.String(input.SubscriptionID)
+	params.Invoice = stripesdk.String(input.InvoiceID)
+	params.Description = stripesdk.String(input.Description)
+	params.Discountable = new(false)
+	params.Period = &stripesdk.InvoiceItemCreatePeriodParams{
+		Start: new(input.PeriodStart.Unix()),
+		End:   new(input.PeriodEnd.Add(-time.Second).Unix()),
+	}
+	params.Metadata = map[string]string{allocationMetadataKey: input.AllocationKey}
+	params.SetIdempotencyKey(input.IdempotencyKey)
+
+	item, err := c.api.createInvoiceItem(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("create Stripe invoice item: %w", err)
+	}
+	if item == nil || item.ID == "" {
+		return nil, errors.New("create Stripe invoice item: empty response")
+	}
+	return &InvoiceItem{
+		ID:          item.ID,
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}, nil
+}
+
+func (c *client) CreateCreditNote(ctx context.Context, input CreateCreditNoteInput) (*CreditNote, error) {
+	if input.IdempotencyKey == "" || input.AllocationKey == "" {
+		return nil, errMissingIdempotencyKey
+	}
+	if input.InvoiceID == "" {
+		return nil, errors.New("invoice id is required")
+	}
+	if input.AmountCents <= 0 || input.CreditAmountCents < 0 || input.CreditAmountCents > input.AmountCents {
+		return nil, errors.New("credit note amount is invalid")
+	}
+
+	params := new(stripesdk.CreditNoteCreateParams)
+	params.Invoice = stripesdk.String(input.InvoiceID)
+	params.Amount = new(input.AmountCents)
+	if input.CreditAmountCents > 0 {
+		params.CreditAmount = new(input.CreditAmountCents)
+	}
+	params.EmailType = stripesdk.String("none")
+	params.Memo = stripesdk.String(input.Description)
+	params.Metadata = map[string]string{allocationMetadataKey: input.AllocationKey}
+	params.Reason = stripesdk.String(string(stripesdk.CreditNoteReasonOrderChange))
+	params.SetIdempotencyKey(input.IdempotencyKey)
+
+	note, err := c.api.createCreditNote(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("create Stripe credit note: %w", err)
+	}
+	if note == nil || note.ID == "" {
+		return nil, errors.New("create Stripe credit note: empty response")
+	}
+	return &CreditNote{
+		ID:          note.ID,
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}, nil
+}
+
+func (c *client) FindInvoiceItem(ctx context.Context, input FindInvoiceAllocationInput) (*InvoiceItem, error) {
+	if input.InvoiceID == "" || input.AllocationKey == "" || input.AmountCents <= 0 {
+		return nil, errors.New("invoice id, allocation key, and positive amount are required")
+	}
+	params := new(stripesdk.InvoiceItemListParams)
+	params.Invoice = stripesdk.String(input.InvoiceID)
+	params.Limit = stripesdk.Int64(100)
+	for item, err := range c.api.listInvoiceItems(ctx, params) {
+		if err != nil {
+			return nil, fmt.Errorf("list Stripe invoice items: %w", err)
+		}
+		if item == nil || item.Metadata[allocationMetadataKey] != input.AllocationKey {
+			continue
+		}
+		invoiceID := ""
+		if item.Invoice != nil {
+			invoiceID = item.Invoice.ID
+		}
+		if invoiceID != input.InvoiceID || item.Currency != stripesdk.CurrencyUSD || item.Amount != input.AmountCents {
+			return nil, errors.New("stripe invoice item allocation metadata matches different financial data")
+		}
+		return &InvoiceItem{ID: item.ID, InvoiceID: invoiceID, Currency: string(item.Currency), AmountCents: item.Amount}, nil
+	}
+	return nil, nil
+}
+
+func (c *client) FindCreditNote(ctx context.Context, input FindInvoiceAllocationInput) (*CreditNote, error) {
+	if input.InvoiceID == "" || input.AllocationKey == "" || input.AmountCents <= 0 {
+		return nil, errors.New("invoice id, allocation key, and positive amount are required")
+	}
+	params := new(stripesdk.CreditNoteListParams)
+	params.Invoice = stripesdk.String(input.InvoiceID)
+	params.Limit = stripesdk.Int64(100)
+	for note, err := range c.api.listCreditNotes(ctx, params) {
+		if err != nil {
+			return nil, fmt.Errorf("list Stripe credit notes: %w", err)
+		}
+		if note == nil || note.Metadata[allocationMetadataKey] != input.AllocationKey {
+			continue
+		}
+		invoiceID := ""
+		if note.Invoice != nil {
+			invoiceID = note.Invoice.ID
+		}
+		if invoiceID != input.InvoiceID || note.Currency != stripesdk.CurrencyUSD || note.Amount != input.AmountCents {
+			return nil, errors.New("stripe credit note allocation metadata matches different financial data")
+		}
+		return &CreditNote{ID: note.ID, InvoiceID: invoiceID, Currency: string(note.Currency), AmountCents: note.Amount}, nil
+	}
+	return nil, nil
+}
+
 func (c *client) VerifyWebhook(payload []byte, signature string) (*WebhookEvent, error) {
 	if !IsConfigured(c.webhookSecret) {
 		return nil, fmt.Errorf("verify Stripe webhook: %w", ErrWebhookNotConfigured)
@@ -526,6 +804,38 @@ func (s *stubClient) CreateMeterEvent(ctx context.Context, _ CreateMeterEventInp
 func (s *stubClient) GetMeterEventSummary(ctx context.Context, _ GetMeterEventSummaryInput) (float64, error) {
 	s.logger.DebugContext(ctx, "stub Stripe meter event summary skipped")
 	return 0, nil
+}
+
+func (s *stubClient) GetInvoice(context.Context, string) (*InvoiceState, error) {
+	return nil, errors.New("retrieve Stripe invoice is unavailable locally")
+}
+
+func (s *stubClient) CreateInvoiceItem(ctx context.Context, input CreateInvoiceItemInput) (*InvoiceItem, error) {
+	s.logger.DebugContext(ctx, "stub Stripe invoice item skipped")
+	return &InvoiceItem{
+		ID:          "ii_local_stub",
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}, nil
+}
+
+func (s *stubClient) CreateCreditNote(ctx context.Context, input CreateCreditNoteInput) (*CreditNote, error) {
+	s.logger.DebugContext(ctx, "stub Stripe credit note skipped")
+	return &CreditNote{
+		ID:          "cn_local_stub",
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}, nil
+}
+
+func (s *stubClient) FindInvoiceItem(context.Context, FindInvoiceAllocationInput) (*InvoiceItem, error) {
+	return nil, nil
+}
+
+func (s *stubClient) FindCreditNote(context.Context, FindInvoiceAllocationInput) (*CreditNote, error) {
+	return nil, nil
 }
 
 func (s *stubClient) VerifyWebhook(_ []byte, _ string) (*WebhookEvent, error) {

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -98,6 +98,14 @@ type fakeStripeAPI struct {
 	meterEventParams       *stripesdk.BillingMeterEventCreateParams
 	meterSummaryParams     *stripesdk.BillingMeterEventSummaryListParams
 	meterSummaries         []*stripesdk.BillingMeterEventSummary
+	invoiceRetrieveParams  *stripesdk.InvoiceRetrieveParams
+	invoice                *stripesdk.Invoice
+	invoiceItemParams      *stripesdk.InvoiceItemCreateParams
+	invoiceItemListParams  *stripesdk.InvoiceItemListParams
+	invoiceItems           []*stripesdk.InvoiceItem
+	creditNoteParams       *stripesdk.CreditNoteCreateParams
+	creditNoteListParams   *stripesdk.CreditNoteListParams
+	creditNotes            []*stripesdk.CreditNote
 	calls                  int
 	err                    error
 }
@@ -132,6 +140,60 @@ func (f *fakeStripeAPI) listMeterEventSummaries(_ context.Context, params *strip
 	return func(yield func(*stripesdk.BillingMeterEventSummary, error) bool) {
 		for _, summary := range f.meterSummaries {
 			if !yield(summary, nil) {
+				return
+			}
+		}
+		if f.err != nil {
+			yield(nil, f.err)
+		}
+	}
+}
+
+func (f *fakeStripeAPI) retrieveInvoice(_ context.Context, _ string, params *stripesdk.InvoiceRetrieveParams) (*stripesdk.Invoice, error) {
+	f.calls++
+	f.invoiceRetrieveParams = params
+	return f.invoice, f.err
+}
+
+func (f *fakeStripeAPI) createInvoiceItem(_ context.Context, params *stripesdk.InvoiceItemCreateParams) (*stripesdk.InvoiceItem, error) {
+	f.calls++
+	f.invoiceItemParams = params
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &stripesdk.InvoiceItem{ID: "ii_test"}, nil
+}
+
+func (f *fakeStripeAPI) listInvoiceItems(_ context.Context, params *stripesdk.InvoiceItemListParams) stripesdk.Seq2[*stripesdk.InvoiceItem, error] {
+	f.calls++
+	f.invoiceItemListParams = params
+	return func(yield func(*stripesdk.InvoiceItem, error) bool) {
+		for _, item := range f.invoiceItems {
+			if !yield(item, nil) {
+				return
+			}
+		}
+		if f.err != nil {
+			yield(nil, f.err)
+		}
+	}
+}
+
+func (f *fakeStripeAPI) createCreditNote(_ context.Context, params *stripesdk.CreditNoteCreateParams) (*stripesdk.CreditNote, error) {
+	f.calls++
+	f.creditNoteParams = params
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &stripesdk.CreditNote{ID: "cn_test"}, nil
+}
+
+func (f *fakeStripeAPI) listCreditNotes(_ context.Context, params *stripesdk.CreditNoteListParams) stripesdk.Seq2[*stripesdk.CreditNote, error] {
+	f.calls++
+	f.creditNoteListParams = params
+	return func(yield func(*stripesdk.CreditNote, error) bool) {
+		for _, note := range f.creditNotes {
+			if !yield(note, nil) {
 				return
 			}
 		}
@@ -486,6 +548,173 @@ func TestWritesWrapStripeErrors(t *testing.T) {
 	})
 	require.ErrorIs(t, err, apiErr)
 	require.ErrorContains(t, err, "create Stripe Checkout session")
+}
+
+func TestGetInvoiceMapsSubscriptionPeriodAndState(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, 0)
+	finalized := end.Add(72 * time.Hour)
+	api := &fakeStripeAPI{invoice: &stripesdk.Invoice{
+		ID:              "in_placeholder",
+		Customer:        &stripesdk.Customer{ID: "cus_placeholder"},
+		Currency:        stripesdk.CurrencyUSD,
+		BillingReason:   stripesdk.InvoiceBillingReasonSubscriptionCycle,
+		Status:          stripesdk.InvoiceStatusOpen,
+		PeriodStart:     start.Unix(),
+		PeriodEnd:       end.Unix(),
+		AmountRemaining: 1234,
+		Parent: &stripesdk.InvoiceParent{SubscriptionDetails: &stripesdk.InvoiceParentSubscriptionDetails{
+			Subscription: &stripesdk.Subscription{ID: "sub_placeholder"},
+		}},
+		StatusTransitions: &stripesdk.InvoiceStatusTransitions{FinalizedAt: finalized.Unix()},
+	}}
+
+	state, err := (&client{api: api}).GetInvoice(t.Context(), "in_placeholder")
+	require.NoError(t, err)
+	require.Equal(t, &InvoiceState{
+		ID:                 "in_placeholder",
+		CustomerID:         "cus_placeholder",
+		SubscriptionID:     "sub_placeholder",
+		Currency:           "usd",
+		BillingReason:      "subscription_cycle",
+		Status:             "open",
+		ServicePeriodStart: start,
+		ServicePeriodEnd:   end,
+		FinalizedAt:        finalized,
+		AmountRemaining:    1234,
+	}, state)
+	require.Len(t, api.invoiceRetrieveParams.Expand, 1)
+	require.Equal(t, "parent.subscription_details.subscription", stripesdk.StringValue(api.invoiceRetrieveParams.Expand[0]))
+}
+
+func TestCreateInvoiceItemUsesExactFinancialIdentity(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	api := &fakeStripeAPI{}
+	item, err := (&client{api: api}).CreateInvoiceItem(t.Context(), CreateInvoiceItemInput{
+		CustomerID:     "cus_placeholder",
+		SubscriptionID: "sub_placeholder",
+		InvoiceID:      "in_placeholder",
+		Description:    "OpenRouter chat usage",
+		AmountCents:    1001,
+		PeriodStart:    start,
+		PeriodEnd:      end,
+		AllocationKey:  "allocation_placeholder",
+		IdempotencyKey: "openrouter:<ORG_ID>:2026-07-01:1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, &InvoiceItem{ID: "ii_test", InvoiceID: "in_placeholder", Currency: "usd", AmountCents: 1001}, item)
+	params := api.invoiceItemParams
+	require.EqualValues(t, 1001, stripesdk.Int64Value(params.Amount))
+	require.Equal(t, "usd", stripesdk.StringValue(params.Currency))
+	require.Equal(t, "cus_placeholder", stripesdk.StringValue(params.Customer))
+	require.Equal(t, "sub_placeholder", stripesdk.StringValue(params.Subscription))
+	require.Equal(t, "in_placeholder", stripesdk.StringValue(params.Invoice))
+	require.Equal(t, "OpenRouter chat usage", stripesdk.StringValue(params.Description))
+	require.False(t, stripesdk.BoolValue(params.Discountable))
+	require.Equal(t, start.Unix(), stripesdk.Int64Value(params.Period.Start))
+	require.Equal(t, end.Add(-time.Second).Unix(), stripesdk.Int64Value(params.Period.End))
+	require.Equal(t, "allocation_placeholder", params.Metadata[allocationMetadataKey])
+	require.Equal(t, "openrouter:<ORG_ID>:2026-07-01:1", stripesdk.StringValue(params.IdempotencyKey))
+}
+
+func TestCreateCreditNoteUsesCustomerBalanceForPostPaymentCredit(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	note, err := (&client{api: api}).CreateCreditNote(t.Context(), CreateCreditNoteInput{
+		InvoiceID:         "in_placeholder",
+		Description:       "OpenRouter usage correction",
+		AmountCents:       250,
+		CreditAmountCents: 200,
+		AllocationKey:     "allocation_placeholder",
+		IdempotencyKey:    "openrouter:<ORG_ID>:2026-07-01:2",
+	})
+	require.NoError(t, err)
+	require.Equal(t, &CreditNote{ID: "cn_test", InvoiceID: "in_placeholder", Currency: "usd", AmountCents: 250}, note)
+	params := api.creditNoteParams
+	require.Equal(t, "in_placeholder", stripesdk.StringValue(params.Invoice))
+	require.EqualValues(t, 250, stripesdk.Int64Value(params.Amount))
+	require.EqualValues(t, 200, stripesdk.Int64Value(params.CreditAmount))
+	require.Equal(t, "none", stripesdk.StringValue(params.EmailType))
+	require.Equal(t, "OpenRouter usage correction", stripesdk.StringValue(params.Memo))
+	require.Equal(t, "order_change", stripesdk.StringValue(params.Reason))
+	require.Equal(t, "allocation_placeholder", params.Metadata[allocationMetadataKey])
+	require.Equal(t, "openrouter:<ORG_ID>:2026-07-01:2", stripesdk.StringValue(params.IdempotencyKey))
+}
+
+func TestFindInvoiceAllocationValidatesFinancialData(t *testing.T) {
+	t.Parallel()
+
+	invoice := &stripesdk.Invoice{ID: "in_placeholder"}
+	tests := []struct {
+		name      string
+		item      *stripesdk.InvoiceItem
+		note      *stripesdk.CreditNote
+		findNote  bool
+		wantID    string
+		wantError string
+	}{
+		{
+			name:   "invoice item match",
+			item:   &stripesdk.InvoiceItem{ID: "ii_placeholder", Invoice: invoice, Currency: stripesdk.CurrencyUSD, Amount: 125, Metadata: map[string]string{allocationMetadataKey: "allocation_placeholder"}},
+			wantID: "ii_placeholder",
+		},
+		{
+			name:      "invoice item amount mismatch",
+			item:      &stripesdk.InvoiceItem{ID: "ii_placeholder", Invoice: invoice, Currency: stripesdk.CurrencyUSD, Amount: 124, Metadata: map[string]string{allocationMetadataKey: "allocation_placeholder"}},
+			wantError: "different financial data",
+		},
+		{
+			name:     "credit note match",
+			note:     &stripesdk.CreditNote{ID: "cn_placeholder", Invoice: invoice, Currency: stripesdk.CurrencyUSD, Amount: 125, Metadata: map[string]string{allocationMetadataKey: "allocation_placeholder"}},
+			findNote: true,
+			wantID:   "cn_placeholder",
+		},
+		{
+			name:      "credit note invoice mismatch",
+			note:      &stripesdk.CreditNote{ID: "cn_placeholder", Invoice: &stripesdk.Invoice{ID: "in_other"}, Currency: stripesdk.CurrencyUSD, Amount: 125, Metadata: map[string]string{allocationMetadataKey: "allocation_placeholder"}},
+			findNote:  true,
+			wantError: "different financial data",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			api := &fakeStripeAPI{invoiceItems: []*stripesdk.InvoiceItem{test.item}, creditNotes: []*stripesdk.CreditNote{test.note}}
+			input := FindInvoiceAllocationInput{InvoiceID: "in_placeholder", AllocationKey: "allocation_placeholder", AmountCents: 125}
+			var id string
+			if test.findNote {
+				found, err := (&client{api: api}).FindCreditNote(t.Context(), input)
+				if found != nil {
+					id = found.ID
+				}
+				if test.wantError != "" {
+					require.ErrorContains(t, err, test.wantError)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, "in_placeholder", stripesdk.StringValue(api.creditNoteListParams.Invoice))
+			} else {
+				found, err := (&client{api: api}).FindInvoiceItem(t.Context(), input)
+				if found != nil {
+					id = found.ID
+				}
+				if test.wantError != "" {
+					require.ErrorContains(t, err, test.wantError)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, "in_placeholder", stripesdk.StringValue(api.invoiceItemListParams.Invoice))
+			}
+			require.Equal(t, test.wantID, id)
+		})
+	}
 }
 
 func TestVerifyWebhook(t *testing.T) {

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -676,8 +676,8 @@ func TestFindInvoiceAllocationValidatesFinancialData(t *testing.T) {
 			wantID:   "cn_placeholder",
 		},
 		{
-			name:      "credit note invoice mismatch",
-			note:      &stripesdk.CreditNote{ID: "cn_placeholder", Invoice: &stripesdk.Invoice{ID: "in_other"}, Currency: stripesdk.CurrencyUSD, Amount: 125, Metadata: map[string]string{allocationMetadataKey: "allocation_placeholder"}},
+			name:      "credit note amount mismatch",
+			note:      &stripesdk.CreditNote{ID: "cn_placeholder", Invoice: invoice, Currency: stripesdk.CurrencyUSD, Amount: 124, Metadata: map[string]string{allocationMetadataKey: "allocation_placeholder"}},
 			findNote:  true,
 			wantError: "different financial data",
 		},

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -118,6 +118,26 @@ func (c *checkoutStripeClient) GetMeterEventSummary(context.Context, stripeclien
 	return 0, errors.New("not implemented")
 }
 
+func (c *checkoutStripeClient) GetInvoice(context.Context, string) (*stripeclient.InvoiceState, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *checkoutStripeClient) CreateInvoiceItem(context.Context, stripeclient.CreateInvoiceItemInput) (*stripeclient.InvoiceItem, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *checkoutStripeClient) CreateCreditNote(context.Context, stripeclient.CreateCreditNoteInput) (*stripeclient.CreditNote, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *checkoutStripeClient) FindInvoiceItem(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.InvoiceItem, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *checkoutStripeClient) FindCreditNote(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.CreditNote, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (c *checkoutStripeClient) VerifyWebhook([]byte, string) (*stripeclient.WebhookEvent, error) {
 	return nil, errors.New("not implemented")
 }

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -589,3 +589,52 @@ FROM stripe_invoice_allocations
 WHERE organization_id = @organization_id
   AND source_kind = 'tum_cycle'
 ORDER BY source_period_start, seq;
+
+-- name: GetPaygInvoiceIdentity :one
+SELECT
+    billing_metadata.stripe_customer_id
+  , billing_metadata.stripe_subscription_id
+  , billing_metadata.stripe_billing_cycle_anchor
+  , organization_metadata.gram_account_type
+FROM billing_metadata
+JOIN organization_metadata
+  ON organization_metadata.id = billing_metadata.organization_id
+WHERE billing_metadata.organization_id = @organization_id;
+
+-- name: UpsertStripeInvoice :one
+INSERT INTO stripe_invoices (
+    stripe_invoice_id
+  , organization_id
+  , stripe_customer_id
+  , stripe_subscription_id
+  , service_period_start
+  , service_period_end
+  , invoice_state
+  , finalized_at
+) VALUES (
+    @stripe_invoice_id
+  , @organization_id
+  , @stripe_customer_id
+  , @stripe_subscription_id
+  , @service_period_start
+  , @service_period_end
+  , @invoice_state
+  , @finalized_at
+)
+ON CONFLICT (stripe_invoice_id) DO UPDATE
+SET
+    invoice_state = EXCLUDED.invoice_state
+  , finalized_at = EXCLUDED.finalized_at
+  , updated_at = clock_timestamp()
+WHERE stripe_invoices.organization_id = EXCLUDED.organization_id
+  AND stripe_invoices.stripe_customer_id = EXCLUDED.stripe_customer_id
+  AND stripe_invoices.stripe_subscription_id = EXCLUDED.stripe_subscription_id
+  AND stripe_invoices.service_period_start = EXCLUDED.service_period_start
+  AND stripe_invoices.service_period_end = EXCLUDED.service_period_end
+RETURNING stripe_invoice_id;
+
+-- name: ListStripeInvoicesFixture :many
+SELECT *
+FROM stripe_invoices
+WHERE organization_id = @organization_id
+ORDER BY service_period_start, stripe_invoice_id;

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -595,11 +595,18 @@ SELECT
     billing_metadata.stripe_customer_id
   , billing_metadata.stripe_subscription_id
   , billing_metadata.stripe_billing_cycle_anchor
+  , billing_metadata.stripe_checkout_session_id
   , organization_metadata.gram_account_type
 FROM billing_metadata
 JOIN organization_metadata
   ON organization_metadata.id = billing_metadata.organization_id
 WHERE billing_metadata.organization_id = @organization_id;
+
+-- name: SetStripeCheckoutSessionFixture :exec
+-- Test-only fixture for invoice/checkout webhook ordering.
+UPDATE billing_metadata
+SET stripe_checkout_session_id = @stripe_checkout_session_id
+WHERE organization_id = @organization_id;
 
 -- name: UpsertStripeInvoice :one
 INSERT INTO stripe_invoices (

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -42,6 +42,19 @@ type BillingMetadatum struct {
 	UpdatedAt              pgtype.Timestamptz
 }
 
+type StripeInvoice struct {
+	StripeInvoiceID      string
+	OrganizationID       pgtype.Text
+	StripeCustomerID     string
+	StripeSubscriptionID string
+	ServicePeriodStart   pgtype.Timestamptz
+	ServicePeriodEnd     pgtype.Timestamptz
+	InvoiceState         string
+	FinalizedAt          pgtype.Timestamptz
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
 type StripeInvoiceAllocation struct {
 	ID                      uuid.UUID
 	OrganizationID          pgtype.Text

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -720,6 +720,7 @@ SELECT
     billing_metadata.stripe_customer_id
   , billing_metadata.stripe_subscription_id
   , billing_metadata.stripe_billing_cycle_anchor
+  , billing_metadata.stripe_checkout_session_id
   , organization_metadata.gram_account_type
 FROM billing_metadata
 JOIN organization_metadata
@@ -731,6 +732,7 @@ type GetPaygInvoiceIdentityRow struct {
 	StripeCustomerID         pgtype.Text
 	StripeSubscriptionID     pgtype.Text
 	StripeBillingCycleAnchor pgtype.Timestamptz
+	StripeCheckoutSessionID  pgtype.Text
 	GramAccountType          string
 }
 
@@ -741,6 +743,7 @@ func (q *Queries) GetPaygInvoiceIdentity(ctx context.Context, organizationID str
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
 		&i.StripeBillingCycleAnchor,
+		&i.StripeCheckoutSessionID,
 		&i.GramAccountType,
 	)
 	return i, err
@@ -1452,6 +1455,23 @@ func (q *Queries) PrepareStripeCheckoutIntent(ctx context.Context, arg PrepareSt
 		&i.ReuseExistingIntent,
 	)
 	return i, err
+}
+
+const setStripeCheckoutSessionFixture = `-- name: SetStripeCheckoutSessionFixture :exec
+UPDATE billing_metadata
+SET stripe_checkout_session_id = $1
+WHERE organization_id = $2
+`
+
+type SetStripeCheckoutSessionFixtureParams struct {
+	StripeCheckoutSessionID pgtype.Text
+	OrganizationID          string
+}
+
+// Test-only fixture for invoice/checkout webhook ordering.
+func (q *Queries) SetStripeCheckoutSessionFixture(ctx context.Context, arg SetStripeCheckoutSessionFixtureParams) error {
+	_, err := q.db.Exec(ctx, setStripeCheckoutSessionFixture, arg.StripeCheckoutSessionID, arg.OrganizationID)
+	return err
 }
 
 const setStripeSubscriptionFixture = `-- name: SetStripeSubscriptionFixture :exec

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -715,6 +715,37 @@ func (q *Queries) GetPaygActivationState(ctx context.Context, organizationID str
 	return i, err
 }
 
+const getPaygInvoiceIdentity = `-- name: GetPaygInvoiceIdentity :one
+SELECT
+    billing_metadata.stripe_customer_id
+  , billing_metadata.stripe_subscription_id
+  , billing_metadata.stripe_billing_cycle_anchor
+  , organization_metadata.gram_account_type
+FROM billing_metadata
+JOIN organization_metadata
+  ON organization_metadata.id = billing_metadata.organization_id
+WHERE billing_metadata.organization_id = $1
+`
+
+type GetPaygInvoiceIdentityRow struct {
+	StripeCustomerID         pgtype.Text
+	StripeSubscriptionID     pgtype.Text
+	StripeBillingCycleAnchor pgtype.Timestamptz
+	GramAccountType          string
+}
+
+func (q *Queries) GetPaygInvoiceIdentity(ctx context.Context, organizationID string) (GetPaygInvoiceIdentityRow, error) {
+	row := q.db.QueryRow(ctx, getPaygInvoiceIdentity, organizationID)
+	var i GetPaygInvoiceIdentityRow
+	err := row.Scan(
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
+		&i.StripeBillingCycleAnchor,
+		&i.GramAccountType,
+	)
+	return i, err
+}
+
 const getTUMMeterReportTotals = `-- name: GetTUMMeterReportTotals :one
 SELECT
     COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state = 'confirmed'), 0)::bigint AS confirmed_tokens
@@ -926,6 +957,44 @@ func (q *Queries) ListStaleTUMMeterReportCycles(ctx context.Context, arg ListSta
 			&i.CycleEnd,
 			&i.StripeCustomerID,
 			&i.AbsenceObservedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listStripeInvoicesFixture = `-- name: ListStripeInvoicesFixture :many
+SELECT stripe_invoice_id, organization_id, stripe_customer_id, stripe_subscription_id, service_period_start, service_period_end, invoice_state, finalized_at, created_at, updated_at
+FROM stripe_invoices
+WHERE organization_id = $1
+ORDER BY service_period_start, stripe_invoice_id
+`
+
+func (q *Queries) ListStripeInvoicesFixture(ctx context.Context, organizationID pgtype.Text) ([]StripeInvoice, error) {
+	rows, err := q.db.Query(ctx, listStripeInvoicesFixture, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []StripeInvoice
+	for rows.Next() {
+		var i StripeInvoice
+		if err := rows.Scan(
+			&i.StripeInvoiceID,
+			&i.OrganizationID,
+			&i.StripeCustomerID,
+			&i.StripeSubscriptionID,
+			&i.ServicePeriodStart,
+			&i.ServicePeriodEnd,
+			&i.InvoiceState,
+			&i.FinalizedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1592,4 +1661,64 @@ func (q *Queries) UpsertBillingMetadata(ctx context.Context, arg UpsertBillingMe
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const upsertStripeInvoice = `-- name: UpsertStripeInvoice :one
+INSERT INTO stripe_invoices (
+    stripe_invoice_id
+  , organization_id
+  , stripe_customer_id
+  , stripe_subscription_id
+  , service_period_start
+  , service_period_end
+  , invoice_state
+  , finalized_at
+) VALUES (
+    $1
+  , $2
+  , $3
+  , $4
+  , $5
+  , $6
+  , $7
+  , $8
+)
+ON CONFLICT (stripe_invoice_id) DO UPDATE
+SET
+    invoice_state = EXCLUDED.invoice_state
+  , finalized_at = EXCLUDED.finalized_at
+  , updated_at = clock_timestamp()
+WHERE stripe_invoices.organization_id = EXCLUDED.organization_id
+  AND stripe_invoices.stripe_customer_id = EXCLUDED.stripe_customer_id
+  AND stripe_invoices.stripe_subscription_id = EXCLUDED.stripe_subscription_id
+  AND stripe_invoices.service_period_start = EXCLUDED.service_period_start
+  AND stripe_invoices.service_period_end = EXCLUDED.service_period_end
+RETURNING stripe_invoice_id
+`
+
+type UpsertStripeInvoiceParams struct {
+	StripeInvoiceID      string
+	OrganizationID       pgtype.Text
+	StripeCustomerID     string
+	StripeSubscriptionID string
+	ServicePeriodStart   pgtype.Timestamptz
+	ServicePeriodEnd     pgtype.Timestamptz
+	InvoiceState         string
+	FinalizedAt          pgtype.Timestamptz
+}
+
+func (q *Queries) UpsertStripeInvoice(ctx context.Context, arg UpsertStripeInvoiceParams) (string, error) {
+	row := q.db.QueryRow(ctx, upsertStripeInvoice,
+		arg.StripeInvoiceID,
+		arg.OrganizationID,
+		arg.StripeCustomerID,
+		arg.StripeSubscriptionID,
+		arg.ServicePeriodStart,
+		arg.ServicePeriodEnd,
+		arg.InvoiceState,
+		arg.FinalizedAt,
+	)
+	var stripe_invoice_id string
+	err := row.Scan(&stripe_invoice_id)
+	return stripe_invoice_id, err
 }

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -181,8 +181,13 @@ func (s *Service) currentStripeInvoice(ctx context.Context, event *stripeclient.
 	if err != nil {
 		return nil, oops.E(oops.CodeUnavailable, err, "failed to retrieve current Stripe invoice").LogWarn(ctx, s.logger)
 	}
-	if state == nil || state.ID != event.ObjectID || state.CustomerID == "" || state.CustomerID != event.CustomerID || state.SubscriptionID == "" || state.ServicePeriodStart.IsZero() || !state.ServicePeriodEnd.After(state.ServicePeriodStart) {
+	if state == nil || state.ID != event.ObjectID || state.CustomerID == "" || state.CustomerID != event.CustomerID {
 		return nil, oops.E(oops.CodeBadRequest, nil, "Stripe invoice identifiers do not match current state").LogWarn(ctx, s.logger)
+	}
+	if state.BillingReason == "subscription_create" || state.BillingReason == "subscription_cycle" {
+		if state.SubscriptionID == "" || state.ServicePeriodStart.IsZero() || !state.ServicePeriodEnd.After(state.ServicePeriodStart) {
+			return nil, oops.E(oops.CodeBadRequest, nil, "Stripe subscription invoice identifiers do not match current state").LogWarn(ctx, s.logger)
+		}
 	}
 	return state, nil
 }
@@ -244,12 +249,6 @@ func (s *Service) recordStripeInvoice(ctx context.Context, tx pgx.Tx, organizati
 	if invoice == nil {
 		return false, errors.New("missing current Stripe invoice state")
 	}
-	if invoice.Currency != "usd" {
-		return false, fmt.Errorf("unsupported Stripe invoice currency %q", invoice.Currency)
-	}
-	if !invoice.ServicePeriodStart.Equal(invoice.ServicePeriodStart.Truncate(24*time.Hour)) || !invoice.ServicePeriodEnd.Equal(invoice.ServicePeriodEnd.Truncate(24*time.Hour)) {
-		return false, errors.New("stripe invoice service period is not UTC-day aligned")
-	}
 	switch invoice.BillingReason {
 	case "subscription_create", "subscription_cycle":
 	default:
@@ -261,16 +260,28 @@ func (s *Service) recordStripeInvoice(ctx context.Context, tx pgx.Tx, organizati
 	if err != nil {
 		return false, fmt.Errorf("read PAYG invoice identity: %w", err)
 	}
+	if !identity.StripeCustomerID.Valid || identity.StripeCustomerID.String != event.CustomerID {
+		return false, errors.New("stripe invoice customer does not belong to the organization")
+	}
 	if identity.GramAccountType != "payg" {
+		if identity.StripeCheckoutSessionID.Valid {
+			return false, errors.New("PAYG Checkout activation has not committed")
+		}
 		return false, nil
 	}
-	if !identity.StripeCustomerID.Valid || identity.StripeCustomerID.String != event.CustomerID || !identity.StripeSubscriptionID.Valid || identity.StripeSubscriptionID.String != invoice.SubscriptionID || !identity.StripeBillingCycleAnchor.Valid {
+	if !identity.StripeSubscriptionID.Valid || identity.StripeSubscriptionID.String != invoice.SubscriptionID || !identity.StripeBillingCycleAnchor.Valid {
 		return false, errors.New("stripe invoice does not belong to active PAYG billing")
 	}
 	if invoice.ServicePeriodStart.Before(identity.StripeBillingCycleAnchor.Time.UTC()) {
 		// Checkout can create a zero-dollar free stub before the first paid
 		// midnight. It is intentionally outside pass-through billing.
 		return false, nil
+	}
+	if invoice.Currency != "usd" {
+		return false, fmt.Errorf("unsupported Stripe invoice currency %q", invoice.Currency)
+	}
+	if !invoice.ServicePeriodStart.Equal(invoice.ServicePeriodStart.Truncate(24*time.Hour)) || !invoice.ServicePeriodEnd.Equal(invoice.ServicePeriodEnd.Truncate(24*time.Hour)) {
+		return false, errors.New("stripe invoice service period is not UTC-day aligned")
 	}
 
 	_, err = q.UpsertStripeInvoice(ctx, repo.UpsertStripeInvoiceParams{

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -185,7 +185,10 @@ func (s *Service) currentStripeInvoice(ctx context.Context, event *stripeclient.
 		return nil, oops.E(oops.CodeBadRequest, nil, "Stripe invoice identifiers do not match current state").LogWarn(ctx, s.logger)
 	}
 	if state.BillingReason == "subscription_create" || state.BillingReason == "subscription_cycle" {
-		if state.SubscriptionID == "" || state.ServicePeriodStart.IsZero() || !state.ServicePeriodEnd.After(state.ServicePeriodStart) {
+		if state.SubscriptionID == "" || state.ServicePeriodStart.IsZero() {
+			return nil, oops.E(oops.CodeBadRequest, nil, "Stripe subscription invoice identifiers do not match current state").LogWarn(ctx, s.logger)
+		}
+		if state.BillingReason == "subscription_cycle" && !state.ServicePeriodEnd.After(state.ServicePeriodStart) {
 			return nil, oops.E(oops.CodeBadRequest, nil, "Stripe subscription invoice identifiers do not match current state").LogWarn(ctx, s.logger)
 		}
 	}
@@ -271,6 +274,11 @@ func (s *Service) recordStripeInvoice(ctx context.Context, tx pgx.Tx, organizati
 	}
 	if !identity.StripeSubscriptionID.Valid || identity.StripeSubscriptionID.String != invoice.SubscriptionID || !identity.StripeBillingCycleAnchor.Valid {
 		return false, errors.New("stripe invoice does not belong to active PAYG billing")
+	}
+	if invoice.BillingReason == "subscription_create" && !invoice.ServicePeriodEnd.After(invoice.ServicePeriodStart) {
+		// Stripe's immediate first subscription invoice has no prior service
+		// period. It carries no usage and must not enter pass-through billing.
+		return false, nil
 	}
 	if invoice.ServicePeriodStart.Before(identity.StripeBillingCycleAnchor.Time.UTC()) {
 		// Checkout can create a zero-dollar free stub before the first paid

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -38,7 +39,7 @@ type stripeWebhookResult struct {
 	newlyEnabledFeatures []productfeatures.Feature
 }
 
-type stripeWebhookHandler func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error)
+type stripeWebhookHandler func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error)
 
 func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
@@ -85,11 +86,28 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		logger.InfoContext(ctx, "skipping duplicate Stripe webhook event")
 		return nil
 	}
+	if event.Type == "invoice.created" {
+		_, err := repo.New(s.db).GetBillingMetadataOrganizationByStripeCustomerID(ctx, pgtype.Text{String: event.CustomerID, Valid: true})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			logger.WarnContext(ctx, "skipping Stripe webhook event for an unknown customer")
+			return nil
+		case err != nil:
+			return oops.E(oops.CodeUnexpected, err, "failed to resolve Stripe webhook customer").LogError(ctx, logger)
+		}
+	}
 
 	var checkoutState *stripeclient.CheckoutSessionState
+	var invoiceState *stripeclient.InvoiceState
 	checkoutEligible := true
 	if event.Type == "checkout.session.completed" {
 		checkoutState, checkoutEligible, err = s.currentCheckoutSession(ctx, event)
+		if err != nil {
+			return err
+		}
+	}
+	if event.Type == "invoice.created" {
+		invoiceState, err = s.currentStripeInvoice(ctx, event)
 		if err != nil {
 			return err
 		}
@@ -139,7 +157,7 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		return nil
 	}
 
-	result, err := s.stripeHandler(ctx, logger, tx, organizationID, event, checkoutState)
+	result, err := s.stripeHandler(ctx, logger, tx, organizationID, event, checkoutState, invoiceState)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to handle Stripe webhook event").LogError(ctx, logger)
 	}
@@ -153,6 +171,20 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 	}
 
 	return nil
+}
+
+func (s *Service) currentStripeInvoice(ctx context.Context, event *stripeclient.WebhookEvent) (*stripeclient.InvoiceState, error) {
+	if event.ObjectID == "" {
+		return nil, oops.E(oops.CodeBadRequest, nil, "invalid Stripe invoice identifier").LogWarn(ctx, s.logger)
+	}
+	state, err := s.stripeClient.GetInvoice(ctx, event.ObjectID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnavailable, err, "failed to retrieve current Stripe invoice").LogWarn(ctx, s.logger)
+	}
+	if state == nil || state.ID != event.ObjectID || state.CustomerID == "" || state.CustomerID != event.CustomerID || state.SubscriptionID == "" || state.ServicePeriodStart.IsZero() || !state.ServicePeriodEnd.After(state.ServicePeriodStart) {
+		return nil, oops.E(oops.CodeBadRequest, nil, "Stripe invoice identifiers do not match current state").LogWarn(ctx, s.logger)
+	}
+	return state, nil
 }
 
 func (s *Service) currentCheckoutSession(ctx context.Context, event *stripeclient.WebhookEvent) (*stripeclient.CheckoutSessionState, bool, error) {
@@ -186,18 +218,75 @@ func (s *Service) currentCheckoutSession(ctx context.Context, event *stripeclien
 	}
 }
 
-func (s *Service) serviceStripeWebhookHandler(ctx context.Context, logger *slog.Logger, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+func (s *Service) serviceStripeWebhookHandler(ctx context.Context, logger *slog.Logger, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState, invoice *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 	switch event.Type {
 	case "checkout.session.completed":
 		return s.activatePaygCheckout(ctx, tx, organizationID, event, checkout)
 	case "invoice.created":
-		logger.InfoContext(ctx, "received Stripe invoice creation")
+		recorded, err := s.recordStripeInvoice(ctx, tx, organizationID, event, invoice)
+		if err != nil {
+			return stripeWebhookResult{}, err
+		}
+		if recorded {
+			logger.InfoContext(ctx, "recorded Stripe invoice creation")
+		} else {
+			logger.InfoContext(ctx, "skipped non-billable Stripe invoice creation")
+		}
 	case "invoice.payment_failed":
 		logger.InfoContext(ctx, "received Stripe invoice payment failure")
 	case "customer.subscription.deleted":
 		logger.InfoContext(ctx, "received Stripe subscription deletion")
 	}
 	return stripeWebhookResult{newlyEnabledFeatures: nil}, nil
+}
+
+func (s *Service) recordStripeInvoice(ctx context.Context, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, invoice *stripeclient.InvoiceState) (bool, error) {
+	if invoice == nil {
+		return false, errors.New("missing current Stripe invoice state")
+	}
+	if invoice.Currency != "usd" {
+		return false, fmt.Errorf("unsupported Stripe invoice currency %q", invoice.Currency)
+	}
+	if !invoice.ServicePeriodStart.Equal(invoice.ServicePeriodStart.Truncate(24*time.Hour)) || !invoice.ServicePeriodEnd.Equal(invoice.ServicePeriodEnd.Truncate(24*time.Hour)) {
+		return false, errors.New("stripe invoice service period is not UTC-day aligned")
+	}
+	switch invoice.BillingReason {
+	case "subscription_create", "subscription_cycle":
+	default:
+		return false, nil
+	}
+
+	q := repo.New(tx)
+	identity, err := q.GetPaygInvoiceIdentity(ctx, organizationID)
+	if err != nil {
+		return false, fmt.Errorf("read PAYG invoice identity: %w", err)
+	}
+	if identity.GramAccountType != "payg" {
+		return false, nil
+	}
+	if !identity.StripeCustomerID.Valid || identity.StripeCustomerID.String != event.CustomerID || !identity.StripeSubscriptionID.Valid || identity.StripeSubscriptionID.String != invoice.SubscriptionID || !identity.StripeBillingCycleAnchor.Valid {
+		return false, errors.New("stripe invoice does not belong to active PAYG billing")
+	}
+	if invoice.ServicePeriodStart.Before(identity.StripeBillingCycleAnchor.Time.UTC()) {
+		// Checkout can create a zero-dollar free stub before the first paid
+		// midnight. It is intentionally outside pass-through billing.
+		return false, nil
+	}
+
+	_, err = q.UpsertStripeInvoice(ctx, repo.UpsertStripeInvoiceParams{
+		StripeInvoiceID:      invoice.ID,
+		OrganizationID:       pgtype.Text{String: organizationID, Valid: true},
+		StripeCustomerID:     invoice.CustomerID,
+		StripeSubscriptionID: invoice.SubscriptionID,
+		ServicePeriodStart:   pgtype.Timestamptz{Time: invoice.ServicePeriodStart.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+		ServicePeriodEnd:     pgtype.Timestamptz{Time: invoice.ServicePeriodEnd.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+		InvoiceState:         invoice.Status,
+		FinalizedAt:          pgtype.Timestamptz{Time: invoice.FinalizedAt.UTC(), InfinityModifier: pgtype.Finite, Valid: !invoice.FinalizedAt.IsZero()},
+	})
+	if err != nil {
+		return false, fmt.Errorf("record Stripe invoice: %w", err)
+	}
+	return true, nil
 }
 
 func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -40,6 +40,9 @@ type fakeStripeWebhookClient struct {
 	verify        func([]byte, string) (*stripeclient.WebhookEvent, error)
 	checkout      *stripeclient.CheckoutSessionState
 	checkoutError error
+	invoice       *stripeclient.InvoiceState
+	invoiceError  error
+	invoiceCalls  atomic.Int32
 	verifyCalls   atomic.Int32
 }
 
@@ -85,6 +88,27 @@ func (f *fakeStripeWebhookClient) GetMeterEventSummary(context.Context, stripecl
 	return 0, errors.New("not implemented")
 }
 
+func (f *fakeStripeWebhookClient) GetInvoice(context.Context, string) (*stripeclient.InvoiceState, error) {
+	f.invoiceCalls.Add(1)
+	return f.invoice, f.invoiceError
+}
+
+func (f *fakeStripeWebhookClient) CreateInvoiceItem(context.Context, stripeclient.CreateInvoiceItemInput) (*stripeclient.InvoiceItem, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeStripeWebhookClient) CreateCreditNote(context.Context, stripeclient.CreateCreditNoteInput) (*stripeclient.CreditNote, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeStripeWebhookClient) FindInvoiceItem(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.InvoiceItem, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeStripeWebhookClient) FindCreditNote(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.CreditNote, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (f *fakeStripeWebhookClient) VerifyWebhook(payload []byte, signature string) (*stripeclient.WebhookEvent, error) {
 	f.verifyCalls.Add(1)
 	return f.verify(payload, signature)
@@ -94,7 +118,7 @@ func (f *fakeStripeWebhookClient) Catalog() stripeclient.Catalog {
 	return stripeclient.Catalog{PriceIDTUM: "", MeterIDTUM: "", MeterEventName: ""}
 }
 
-func testStripeWebhookHandler(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+func testStripeWebhookHandler(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 	return stripeWebhookResult{newlyEnabledFeatures: nil}, nil
 }
 
@@ -118,6 +142,16 @@ func newStripeWebhookService(t *testing.T, customerID string, handler stripeWebh
 	require.NoError(t, err)
 
 	client := &fakeStripeWebhookClient{
+		invoice: &stripeclient.InvoiceState{
+			ID:                 "invoice_placeholder",
+			CustomerID:         customerID,
+			SubscriptionID:     "subscription_placeholder",
+			Currency:           "usd",
+			BillingReason:      "subscription_cycle",
+			Status:             "draft",
+			ServicePeriodStart: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			ServicePeriodEnd:   time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC),
+		},
 		verify: func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
 			return &stripeclient.WebhookEvent{
 				ID:         "event_placeholder",
@@ -153,6 +187,48 @@ func stripeWebhookReceiptCount(t *testing.T, db *pgxpool.Pool) int {
 	count, err := repo.New(db).CountStripeWebhookReceiptsFixture(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	return int(count)
+}
+
+func configurePaygInvoiceIdentity(t *testing.T, service *Service, subscriptionID string, billingCycleAnchor time.Time) {
+	t.Helper()
+
+	queries := repo.New(service.db)
+	_, err := queries.ActivatePaygBillingMetadata(t.Context(), repo.ActivatePaygBillingMetadataParams{
+		StripeSubscriptionID:     pgtype.Text{String: subscriptionID, Valid: true},
+		StripeBillingCycleAnchor: pgtype.Timestamptz{Time: billingCycleAnchor.UTC(), Valid: true},
+		BillingCycleAnchorDay:    int32(billingCycleAnchor.UTC().Day()),
+		OrganizationID:           stripeWebhookOrganizationID,
+		StripeCustomerID:         pgtype.Text{String: "customer_placeholder", Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, queries.ActivatePaygOrganization(t.Context(), stripeWebhookOrganizationID))
+	service.stripeHandler = service.serviceStripeWebhookHandler
+}
+
+func configureInvoiceWebhook(t *testing.T, service *Service, eventID string, invoice *stripeclient.InvoiceState) *fakeStripeWebhookClient {
+	t.Helper()
+
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	client.invoice = invoice
+	client.verify = func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+		return &stripeclient.WebhookEvent{
+			ID:         eventID,
+			Type:       "invoice.created",
+			Created:    time.Now().UTC(),
+			ObjectID:   invoice.ID,
+			CustomerID: "customer_placeholder",
+		}, nil
+	}
+	return client
+}
+
+func stripeInvoices(t *testing.T, db *pgxpool.Pool) []repo.StripeInvoice {
+	t.Helper()
+
+	invoices, err := repo.New(db).ListStripeInvoicesFixture(t.Context(), pgtype.Text{String: stripeWebhookOrganizationID, Valid: true})
+	require.NoError(t, err)
+	return invoices
 }
 
 func paygSchedulingIntentCount(t *testing.T, db *pgxpool.Pool) int {
@@ -331,12 +407,22 @@ func TestStripeWebhookAcknowledgesEventsWithoutDispatch(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+			service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 				t.Fatal("handler must not run")
 				return stripeWebhookResult{}, nil
 			})
 			client, ok := service.stripeClient.(*fakeStripeWebhookClient)
 			require.True(t, ok)
+			client.invoice = &stripeclient.InvoiceState{
+				ID:                 "object_placeholder",
+				CustomerID:         test.customerID,
+				SubscriptionID:     "subscription_placeholder",
+				Currency:           "usd",
+				BillingReason:      "subscription_cycle",
+				Status:             "draft",
+				ServicePeriodStart: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+				ServicePeriodEnd:   time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC),
+			}
 			client.verify = func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
 				return &stripeclient.WebhookEvent{
 					ID:         "event_" + strings.ReplaceAll(test.name, " ", "_"),
@@ -348,6 +434,7 @@ func TestStripeWebhookAcknowledgesEventsWithoutDispatch(t *testing.T) {
 			}
 			require.Equal(t, http.StatusOK, serveStripeWebhook(service, "{}").Code)
 			require.Zero(t, stripeWebhookReceiptCount(t, db))
+			require.Zero(t, client.invoiceCalls.Load())
 		})
 	}
 }
@@ -356,7 +443,7 @@ func TestStripeWebhookSequentialDuplicateDispatchesOnce(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		return stripeWebhookResult{}, nil
 	})
@@ -374,7 +461,7 @@ func TestStripeWebhookConcurrentDuplicateDispatchesOnce(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	var enterOnce sync.Once
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		enterOnce.Do(func() { close(entered) })
 		<-release
@@ -404,7 +491,7 @@ func TestStripeWebhookConcurrentDistinctEventsForSameCustomerDoNotSerialize(t *t
 			close(release)
 		}
 	}()
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		<-release
 		return stripeWebhookResult{}, nil
@@ -414,7 +501,7 @@ func TestStripeWebhookConcurrentDistinctEventsForSameCustomerDoNotSerialize(t *t
 	client.verify = func(payload []byte, _ string) (*stripeclient.WebhookEvent, error) {
 		return &stripeclient.WebhookEvent{
 			ID:         "event_" + string(payload),
-			Type:       "invoice.created",
+			Type:       "invoice.payment_failed",
 			ObjectID:   "invoice_" + string(payload),
 			CustomerID: "customer_placeholder",
 		}, nil
@@ -438,7 +525,7 @@ func TestStripeWebhookHandlerFailureRollsBackForRetry(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		if calls.Add(1) == 1 {
 			return stripeWebhookResult{}, errors.New("transient handler failure")
 		}
@@ -449,6 +536,295 @@ func TestStripeWebhookHandlerFailureRollsBackForRetry(t *testing.T) {
 	require.Zero(t, stripeWebhookReceiptCount(t, db))
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "retry").Code)
 	require.EqualValues(t, 2, calls.Load())
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+}
+
+func TestStripeInvoiceCreatedPersistsImmutableBillingIdentity(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		state       string
+		finalizedAt time.Time
+	}{
+		{name: "draft", state: "draft"},
+		{name: "open", state: "open", finalizedAt: periodStart.Add(2 * time.Hour)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+			configurePaygInvoiceIdentity(t, service, "subscription_placeholder", periodStart)
+			invoice := &stripeclient.InvoiceState{
+				ID:                 "invoice_" + test.name,
+				CustomerID:         "customer_placeholder",
+				SubscriptionID:     "subscription_placeholder",
+				Currency:           "usd",
+				BillingReason:      "subscription_cycle",
+				Status:             test.state,
+				ServicePeriodStart: periodStart,
+				ServicePeriodEnd:   periodEnd,
+				FinalizedAt:        test.finalizedAt,
+			}
+			configureInvoiceWebhook(t, service, "event_"+test.name, invoice)
+
+			recorder := serveStripeWebhook(service, test.name)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+			rows := stripeInvoices(t, db)
+			require.Len(t, rows, 1)
+			row := rows[0]
+			require.Equal(t, invoice.ID, row.StripeInvoiceID)
+			require.Equal(t, stripeWebhookOrganizationID, row.OrganizationID.String)
+			require.True(t, row.OrganizationID.Valid)
+			require.Equal(t, invoice.CustomerID, row.StripeCustomerID)
+			require.Equal(t, invoice.SubscriptionID, row.StripeSubscriptionID)
+			require.True(t, periodStart.Equal(row.ServicePeriodStart.Time))
+			require.True(t, periodEnd.Equal(row.ServicePeriodEnd.Time))
+			require.Equal(t, test.state, row.InvoiceState)
+			if test.finalizedAt.IsZero() {
+				require.False(t, row.FinalizedAt.Valid)
+			} else {
+				require.True(t, row.FinalizedAt.Valid)
+				require.True(t, test.finalizedAt.Equal(row.FinalizedAt.Time))
+			}
+		})
+	}
+}
+
+func TestStripeInvoiceCreatedStoresCurrentStateForDelayedEvent(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	finalizedAt := periodStart.Add(3 * time.Hour)
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygInvoiceIdentity(t, service, "subscription_placeholder", periodStart)
+	client := configureInvoiceWebhook(t, service, "event_delayed_invoice", &stripeclient.InvoiceState{
+		ID:                 "invoice_delayed",
+		CustomerID:         "customer_placeholder",
+		SubscriptionID:     "subscription_placeholder",
+		Currency:           "usd",
+		BillingReason:      "subscription_cycle",
+		Status:             "open",
+		ServicePeriodStart: periodStart,
+		ServicePeriodEnd:   periodEnd,
+		FinalizedAt:        finalizedAt,
+	})
+	client.verify = func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+		return &stripeclient.WebhookEvent{
+			ID:         "event_delayed_invoice",
+			Type:       "invoice.created",
+			Created:    periodStart.Add(-24 * time.Hour),
+			ObjectID:   "invoice_delayed",
+			CustomerID: "customer_placeholder",
+		}, nil
+	}
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "stale-event-payload").Code)
+	rows := stripeInvoices(t, db)
+	require.Len(t, rows, 1)
+	require.Equal(t, "open", rows[0].InvoiceState)
+	require.True(t, finalizedAt.Equal(rows[0].FinalizedAt.Time))
+}
+
+func TestStripeInvoiceRetrievalFailureRetriesWithoutReceipt(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygInvoiceIdentity(t, service, "subscription_placeholder", periodStart)
+	client := configureInvoiceWebhook(t, service, "event_invoice_retrieval_retry", &stripeclient.InvoiceState{
+		ID:                 "invoice_retrieval_retry",
+		CustomerID:         "customer_placeholder",
+		SubscriptionID:     "subscription_placeholder",
+		Currency:           "usd",
+		BillingReason:      "subscription_cycle",
+		Status:             "draft",
+		ServicePeriodStart: periodStart,
+		ServicePeriodEnd:   periodStart.AddDate(0, 1, 0),
+	})
+	client.invoiceError = errors.New("Stripe retrieval unavailable")
+
+	require.Equal(t, http.StatusServiceUnavailable, serveStripeWebhook(service, "first").Code)
+	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Empty(t, stripeInvoices(t, db))
+	require.EqualValues(t, 1, client.invoiceCalls.Load())
+
+	client.invoiceError = nil
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "retry").Code)
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Len(t, stripeInvoices(t, db), 1)
+	require.EqualValues(t, 2, client.invoiceCalls.Load())
+}
+
+func TestStripeInvoiceCreatedDurablyIgnoresNonBillableInvoices(t *testing.T) {
+	t.Parallel()
+
+	anchor := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		billingReason string
+		periodStart   time.Time
+		periodEnd     time.Time
+	}{
+		{
+			name:          "free pre-anchor stub",
+			billingReason: "subscription_create",
+			periodStart:   anchor.AddDate(0, -1, 0),
+			periodEnd:     anchor,
+		},
+		{
+			name:          "unsupported billing reason",
+			billingReason: "manual",
+			periodStart:   anchor,
+			periodEnd:     anchor.AddDate(0, 1, 0),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+			configurePaygInvoiceIdentity(t, service, "subscription_placeholder", anchor)
+			configureInvoiceWebhook(t, service, "event_"+strings.ReplaceAll(test.name, " ", "_"), &stripeclient.InvoiceState{
+				ID:                 "invoice_" + strings.ReplaceAll(test.name, " ", "_"),
+				CustomerID:         "customer_placeholder",
+				SubscriptionID:     "subscription_placeholder",
+				Currency:           "usd",
+				BillingReason:      test.billingReason,
+				Status:             "draft",
+				ServicePeriodStart: test.periodStart,
+				ServicePeriodEnd:   test.periodEnd,
+			})
+
+			require.Equal(t, http.StatusOK, serveStripeWebhook(service, test.name).Code)
+			require.Empty(t, stripeInvoices(t, db))
+			require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+		})
+	}
+}
+
+func TestStripeInvoiceCreatedRejectsMismatchedFinancialIdentity(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		wantStatus int
+		mutate     func(*stripeclient.InvoiceState)
+	}{
+		{
+			name:       "wrong customer",
+			wantStatus: http.StatusBadRequest,
+			mutate:     func(invoice *stripeclient.InvoiceState) { invoice.CustomerID = "customer_other" },
+		},
+		{
+			name:       "wrong subscription",
+			wantStatus: http.StatusInternalServerError,
+			mutate:     func(invoice *stripeclient.InvoiceState) { invoice.SubscriptionID = "subscription_other" },
+		},
+		{
+			name:       "wrong currency",
+			wantStatus: http.StatusInternalServerError,
+			mutate:     func(invoice *stripeclient.InvoiceState) { invoice.Currency = "eur" },
+		},
+		{
+			name:       "unaligned period",
+			wantStatus: http.StatusInternalServerError,
+			mutate: func(invoice *stripeclient.InvoiceState) {
+				invoice.ServicePeriodStart = invoice.ServicePeriodStart.Add(time.Hour)
+				invoice.ServicePeriodEnd = invoice.ServicePeriodEnd.Add(time.Hour)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+			configurePaygInvoiceIdentity(t, service, "subscription_placeholder", periodStart)
+			invoice := &stripeclient.InvoiceState{
+				ID:                 "invoice_" + strings.ReplaceAll(test.name, " ", "_"),
+				CustomerID:         "customer_placeholder",
+				SubscriptionID:     "subscription_placeholder",
+				Currency:           "usd",
+				BillingReason:      "subscription_cycle",
+				Status:             "draft",
+				ServicePeriodStart: periodStart,
+				ServicePeriodEnd:   periodEnd,
+			}
+			test.mutate(invoice)
+			configureInvoiceWebhook(t, service, "event_"+strings.ReplaceAll(test.name, " ", "_"), invoice)
+
+			require.Equal(t, test.wantStatus, serveStripeWebhook(service, test.name).Code)
+			require.Empty(t, stripeInvoices(t, db))
+			require.Zero(t, stripeWebhookReceiptCount(t, db))
+		})
+	}
+}
+
+func TestStripeInvoiceIDCannotRebindImmutableIdentity(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygInvoiceIdentity(t, service, "subscription_placeholder", periodStart)
+	invoice := &stripeclient.InvoiceState{
+		ID:                 "invoice_immutable",
+		CustomerID:         "customer_placeholder",
+		SubscriptionID:     "subscription_placeholder",
+		Currency:           "usd",
+		BillingReason:      "subscription_cycle",
+		Status:             "draft",
+		ServicePeriodStart: periodStart,
+		ServicePeriodEnd:   periodEnd,
+	}
+	configureInvoiceWebhook(t, service, "event_immutable_first", invoice)
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
+
+	rebound := *invoice
+	rebound.ServicePeriodStart = periodEnd
+	rebound.ServicePeriodEnd = periodEnd.AddDate(0, 1, 0)
+	configureInvoiceWebhook(t, service, "event_immutable_second", &rebound)
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "second").Code)
+
+	rows := stripeInvoices(t, db)
+	require.Len(t, rows, 1)
+	require.True(t, periodStart.Equal(rows[0].ServicePeriodStart.Time))
+	require.True(t, periodEnd.Equal(rows[0].ServicePeriodEnd.Time))
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+}
+
+func TestStripeInvoiceExactReplaySkipsCurrentStateRetrieval(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygInvoiceIdentity(t, service, "subscription_placeholder", periodStart)
+	client := configureInvoiceWebhook(t, service, "event_invoice_exact_replay", &stripeclient.InvoiceState{
+		ID:                 "invoice_exact_replay",
+		CustomerID:         "customer_placeholder",
+		SubscriptionID:     "subscription_placeholder",
+		Currency:           "usd",
+		BillingReason:      "subscription_cycle",
+		Status:             "draft",
+		ServicePeriodStart: periodStart,
+		ServicePeriodEnd:   periodStart.AddDate(0, 1, 0),
+	})
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
+	require.EqualValues(t, 1, client.invoiceCalls.Load())
+
+	client.invoiceError = errors.New("Stripe retrieval unavailable")
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "replay").Code)
+	require.EqualValues(t, 1, client.invoiceCalls.Load())
+	require.Len(t, stripeInvoices(t, db), 1)
 	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
 }
 

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -669,20 +669,26 @@ func TestStripeInvoiceCreatedDurablyIgnoresNonBillableInvoices(t *testing.T) {
 	tests := []struct {
 		name          string
 		billingReason string
+		currency      string
+		subscription  string
 		periodStart   time.Time
 		periodEnd     time.Time
 	}{
 		{
 			name:          "free pre-anchor stub",
 			billingReason: "subscription_create",
-			periodStart:   anchor.AddDate(0, -1, 0),
+			currency:      "usd",
+			subscription:  "subscription_placeholder",
+			periodStart:   anchor.AddDate(0, -1, 0).Add(9*time.Hour + 17*time.Minute),
 			periodEnd:     anchor,
 		},
 		{
 			name:          "unsupported billing reason",
 			billingReason: "manual",
-			periodStart:   anchor,
-			periodEnd:     anchor.AddDate(0, 1, 0),
+			currency:      "eur",
+			subscription:  "",
+			periodStart:   time.Time{},
+			periodEnd:     time.Time{},
 		},
 	}
 	for _, test := range tests {
@@ -694,8 +700,8 @@ func TestStripeInvoiceCreatedDurablyIgnoresNonBillableInvoices(t *testing.T) {
 			configureInvoiceWebhook(t, service, "event_"+strings.ReplaceAll(test.name, " ", "_"), &stripeclient.InvoiceState{
 				ID:                 "invoice_" + strings.ReplaceAll(test.name, " ", "_"),
 				CustomerID:         "customer_placeholder",
-				SubscriptionID:     "subscription_placeholder",
-				Currency:           "usd",
+				SubscriptionID:     test.subscription,
+				Currency:           test.currency,
 				BillingReason:      test.billingReason,
 				Status:             "draft",
 				ServicePeriodStart: test.periodStart,
@@ -707,6 +713,37 @@ func TestStripeInvoiceCreatedDurablyIgnoresNonBillableInvoices(t *testing.T) {
 			require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
 		})
 	}
+}
+
+func TestStripeInvoiceCreatedRetriesUntilCheckoutActivationCommits(t *testing.T) {
+	t.Parallel()
+
+	periodStart := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	require.NoError(t, repo.New(db).SetStripeCheckoutSessionFixture(t.Context(), repo.SetStripeCheckoutSessionFixtureParams{
+		StripeCheckoutSessionID: pgtype.Text{String: "checkout_placeholder", Valid: true},
+		OrganizationID:          stripeWebhookOrganizationID,
+	}))
+	configureInvoiceWebhook(t, service, "event_before_activation", &stripeclient.InvoiceState{
+		ID:                 "invoice_before_activation",
+		CustomerID:         "customer_placeholder",
+		SubscriptionID:     "subscription_placeholder",
+		Currency:           "usd",
+		BillingReason:      "subscription_cycle",
+		Status:             "draft",
+		ServicePeriodStart: periodStart,
+		ServicePeriodEnd:   periodStart.AddDate(0, 1, 0),
+	})
+	service.stripeHandler = service.serviceStripeWebhookHandler
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "before-activation").Code)
+	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Empty(t, stripeInvoices(t, db))
+
+	configurePaygInvoiceIdentity(t, service, "subscription_placeholder", periodStart)
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "after-activation").Code)
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Len(t, stripeInvoices(t, db), 1)
 }
 
 func TestStripeInvoiceCreatedRejectsMismatchedFinancialIdentity(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -683,6 +683,14 @@ func TestStripeInvoiceCreatedDurablyIgnoresNonBillableInvoices(t *testing.T) {
 			periodEnd:     anchor,
 		},
 		{
+			name:          "zero-length first subscription invoice",
+			billingReason: "subscription_create",
+			currency:      "usd",
+			subscription:  "subscription_placeholder",
+			periodStart:   anchor.Add(-time.Second),
+			periodEnd:     anchor.Add(-time.Second),
+		},
+		{
 			name:          "unsupported billing reason",
 			billingReason: "manual",
 			currency:      "eur",

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -687,8 +687,8 @@ func TestStripeInvoiceCreatedDurablyIgnoresNonBillableInvoices(t *testing.T) {
 			billingReason: "subscription_create",
 			currency:      "usd",
 			subscription:  "subscription_placeholder",
-			periodStart:   anchor.Add(-time.Second),
-			periodEnd:     anchor.Add(-time.Second),
+			periodStart:   anchor,
+			periodEnd:     anchor,
 		},
 		{
 			name:          "unsupported billing reason",


### PR DESCRIPTION
## Summary

- persist and validate canonical Stripe subscription invoices for PAYG billing periods
- freeze Other inference spend after 48 hours and create one cents-exact signed carry after the 72-hour observation window
- deliver durable invoice-item and credit-note allocations with tenant-scoped claims, reconciliation, safe draft rebinding, and long-outage recovery
- route TUM carry allocations through the same dispatcher without coupling them to inference-spend collection health

## Testing

- `mise exec -- go test ./server/internal/background/activities ./server/internal/background ./server/internal/usage ./server/internal/thirdparty/stripe ./server/internal/thirdparty/openrouter ./server/cmd/gram -count=1`
- `mise lint:server`
- `mise run build:server --readonly`
- `mise run gen:sqlc-server`
- `git diff --check`

## Stack

- depends on #5345
- Linear: DNO-844
