### PR TITLE
feat(admin): set the account type on many organizations from the list

### DIFF
--- a/.changeset/admin-bulk-account-type-client.md
+++ b/.changeset/admin-bulk-account-type-client.md
@@ -1,0 +1,22 @@
+---
+"admin": patch
+---
+
+Let a platform admin set one account type on many organizations at once. Ticking
+rows in the organizations list turns the strip above the table into a bulk
+control: it counts what is ticked, offers the account types the server accepts,
+and reads the count and the target type back in a confirmation before anything is
+written. Nothing is written until that confirmation is accepted.
+
+The ids come from the ticked rows and from nowhere else. There is no field that
+takes an id, because the write matches an id case-sensitively while the list
+search matches case-insensitively: an id pasted in the wrong case would come back
+as missing while the row it names sat on screen.
+
+An id the server matched no organization to is named on screen after the write,
+by the organization the operator ticked, rather than being counted silently as
+done. The selection is dropped whenever the rows change under it, so an account
+type cannot be set on a record that scrolled out of view.
+
+Row selection is opt-in for the shared admin table. A page that does not ask for
+it renders exactly as before.

--- a/.changeset/admin-bulk-account-type-client.md
+++ b/.changeset/admin-bulk-account-type-client.md
@@ -15,8 +15,8 @@ as missing while the row it names sat on screen.
 
 An id the server matched no organization to is named on screen after the write,
 by the organization the operator ticked, rather than being counted silently as
-done. The selection is dropped whenever the rows change under it, so an account
-type cannot be set on a record that scrolled out of view.
+done. The selection is dropped whenever the operator pages, sorts or filters, so
+an account type cannot be set on a record that scrolled out of view.
 
 Row selection is opt-in for the shared admin table. A page that does not ask for
 it renders exactly as before. The checkbox column is pinned to the left edge, the

--- a/.changeset/admin-bulk-account-type-client.md
+++ b/.changeset/admin-bulk-account-type-client.md
@@ -19,4 +19,6 @@ done. The selection is dropped whenever the rows change under it, so an account
 type cannot be set on a record that scrolled out of view.
 
 Row selection is opt-in for the shared admin table. A page that does not ask for
-it renders exactly as before.
+it renders exactly as before. The checkbox column is pinned to the left edge, the
+way the actions column is pinned to the right, because the list is wider than the
+window and the control that picks rows would otherwise scroll out of reach.

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -69,7 +69,7 @@ export type DataTableInstance<T extends RowData> = ReactTable<
   T
 >;
 
-export const SELECT_COLUMN_ID = "select";
+const SELECT_COLUMN_ID = "select";
 
 // Mirrors the pin a page puts on a trailing actions column. `w-px` shrinks the
 // column to the checkbox, so the pin does not read as a gutter, and the header

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -71,6 +71,11 @@ export type DataTableInstance<T extends RowData> = ReactTable<
 
 export const SELECT_COLUMN_ID = "select";
 
+// Mirrors the pin a page puts on a trailing actions column. `w-px` shrinks the
+// column to the checkbox, so the pin does not read as a gutter, and the header
+// row is already `z-10`, so this stays under it.
+const PINNED_LEFT = "sticky left-0 z-1 w-px";
+
 /**
  * The opt-in select column: a checkbox per row and one in the header that ticks
  * and unticks the rows the table is currently holding.
@@ -93,7 +98,17 @@ export function selectColumn<T extends RowData>({
   const column = createColumnHelper<DataTableFeatures, T>();
   return column.display({
     id: SELECT_COLUMN_ID,
-    meta: { label: "Select" },
+    meta: {
+      label: "Select",
+      // Pinned, because an admin list is wider than the window: measured at
+      // 1440 down to 768, the checkbox scrolls off the left edge while a pinned
+      // actions column keeps its place. A table whose purpose is picking rows
+      // cannot let the control that picks them leave the screen.
+      headClassName: cn(PINNED_LEFT, "bg-muted"),
+      // Inherited, so the pinned cell repaints with the row rather than reading
+      // as a flat stripe over a highlighted row's own colour.
+      cellClassName: cn(PINNED_LEFT, "bg-inherit"),
+    },
     // Hiding it would strand a selection the operator could no longer see or
     // undo, the same reason the row controls opt out.
     enableHiding: false,

--- a/client/admin/src/components/data-table.tsx
+++ b/client/admin/src/components/data-table.tsx
@@ -1,9 +1,12 @@
 // oxlint-disable react/only-export-components -- compound component (Object.assign) pattern
 import {
   columnVisibilityFeature,
+  createColumnHelper,
   FlexRender,
   metaHelper,
+  rowSelectionFeature,
   tableFeatures,
+  type DisplayColumnDef,
   type ReactTable,
   type Row,
   type RowData,
@@ -11,6 +14,7 @@ import {
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -32,12 +36,14 @@ import {
  */
 
 /**
- * Per-column classes, carried on the column definition because the header and
- * the body cell are rendered here rather than by the page.
+ * Per-column classes, because the header and the body cell are rendered here
+ * rather than by the page, and the name a column lists itself under when its
+ * header is not a string.
  */
 export type DataTableColumnMeta = {
   headClassName?: string;
   cellClassName?: string;
+  label?: string;
 };
 
 /**
@@ -46,9 +52,13 @@ export type DataTableColumnMeta = {
  * Column visibility gates `row.getVisibleCells`, `column.getIsVisible` and
  * `column.getCanHide`, which this wrapper and its header both call. A table
  * with no Columns control still registers it for that reason.
+ *
+ * Row selection is registered here and drawn nowhere: it adds no column and no
+ * state until a table asks for one by putting `selectColumn` in its columns.
  */
 export const dataTableFeatures = tableFeatures({
   columnVisibilityFeature,
+  rowSelectionFeature,
   columnMeta: metaHelper<DataTableColumnMeta>(),
 });
 
@@ -58,6 +68,61 @@ export type DataTableInstance<T extends RowData> = ReactTable<
   DataTableFeatures,
   T
 >;
+
+export const SELECT_COLUMN_ID = "select";
+
+/**
+ * The opt-in select column: a checkbox per row and one in the header that ticks
+ * and unticks the rows the table is currently holding.
+ *
+ * Opt in by putting it first in a page's columns. A page that leaves it out
+ * gets no checkbox anywhere, which is why this is a column rather than
+ * something the wrapper draws on its own.
+ *
+ * Both labels are the caller's, because a checkbox has no text of its own and
+ * "Select row" repeated down a table tells a screen reader nothing about which
+ * record it is on.
+ */
+export function selectColumn<T extends RowData>({
+  allLabel,
+  rowLabel,
+}: {
+  allLabel: string;
+  rowLabel: (row: T) => string;
+}): DisplayColumnDef<DataTableFeatures, T, unknown> {
+  const column = createColumnHelper<DataTableFeatures, T>();
+  return column.display({
+    id: SELECT_COLUMN_ID,
+    meta: { label: "Select" },
+    // Hiding it would strand a selection the operator could no longer see or
+    // undo, the same reason the row controls opt out.
+    enableHiding: false,
+    header: ({ table }) => (
+      <Checkbox
+        aria-label={allLabel}
+        // Mixed rather than unchecked while only some rows are ticked. It is
+        // the state ARIA has for this, and the next press clears rather than
+        // extends, which an unchecked box would misstate.
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(checked) => {
+          table.toggleAllPageRowsSelected(checked === true);
+        }}
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        aria-label={rowLabel(row.original)}
+        checked={row.getIsSelected()}
+        onCheckedChange={(checked) => {
+          row.toggleSelected(checked === true);
+        }}
+      />
+    ),
+  });
+}
 
 export type TableCellPadding = "condensed" | "normal" | "spacious";
 

--- a/client/admin/src/components/ui/checkbox.tsx
+++ b/client/admin/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { CheckIcon } from "lucide-react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -201,6 +201,16 @@ export function invalidateOrganizationStats(qc: QueryClient): void {
   void qc.invalidateQueries({ queryKey: organizationsStatsQuery.queryKey });
 }
 
+// For a write that answers with ids rather than records, so there is nothing to
+// put in the cache. Both keys and the whole of each: the operator can act on
+// rows from any page under any filter.
+export function invalidateOrganizations(qc: QueryClient): Promise<void> {
+  return Promise.all([
+    qc.invalidateQueries({ queryKey: organizationsListQuery().queryKey }),
+    qc.invalidateQueries({ queryKey: [ORGANIZATION_KEY] }),
+  ]).then(() => undefined);
+}
+
 export function projectQuery(
   idOrSlug: string,
 ): AdminQuery<AdminProjectDetail, readonly ["gram-admin-project", string]> {

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -106,6 +106,30 @@ export function organizationMembersQuery(
   });
 }
 
+// Every cache a write to an organization can stale, listed once. Cancelling and
+// invalidating read the same list, so a key added here reaches both: a key added
+// to one of them alone is the stale row this file exists to prevent.
+const ORGANIZATION_CACHES: readonly QueryKey[] = [
+  organizationsListQuery().queryKey,
+  // The whole detail key rather than one organization's, and that is the point
+  // rather than laziness. `writeOrganizationToCache` writes the record under its
+  // id and under its slug, the row links by slug wherever there is one, and the
+  // slug is not known at the moment a write goes out: it arrives with the
+  // response the write has not made yet. Naming the id alone would leave the
+  // entry the operator actually opened free to answer late and put the record
+  // back.
+  //
+  // Touching another organization's detail entry costs that page a refetch and
+  // nothing else, and only one detail query is ever in flight from here.
+  [ORGANIZATION_KEY],
+  // Measured: an invalidation cannot refire a stats fetch that is already
+  // running. React Query joins the open request instead of starting a second
+  // one, and its pre-write answer clears the invalidated flag as it lands. So
+  // the cancel has to come first, and `invalidateOrganizationStats` covers the
+  // write paths that end without one.
+  organizationsStatsQuery.queryKey,
+];
+
 // Called before a write goes out, because a read already in flight outlives it.
 // React Query commits whatever a request answers whenever it lands, so a list
 // fetch that started before the write returns the row in its old state
@@ -120,23 +144,9 @@ export function organizationMembersQuery(
 // Cancelling rather than awaiting, because the answer is already stale: it was
 // asked before the write the operator just made.
 export function cancelOrganizationFetches(qc: QueryClient): Promise<void> {
-  return Promise.all([
-    qc.cancelQueries({ queryKey: organizationsListQuery().queryKey }),
-    // The whole detail key rather than one organization's, and that is the
-    // point rather than laziness. `writeOrganizationToCache` writes the record
-    // under its id and under its slug, the row links by slug wherever there is
-    // one, and the slug is not known here: it arrives with the response the
-    // write has not made yet. Cancelling the id alone would leave the entry the
-    // operator actually opened free to answer late and put the record back.
-    //
-    // Cancelling another organization's detail fetch costs that page a refetch
-    // and nothing else, and only one detail query is ever in flight from here.
-    qc.cancelQueries({ queryKey: [ORGANIZATION_KEY] }),
-    // Measured: the invalidation below cannot refire a fetch that is already
-    // running. React Query joins the open request instead of starting a second
-    // one, and its pre-write answer clears the invalidated flag as it lands.
-    qc.cancelQueries({ queryKey: organizationsStatsQuery.queryKey }),
-  ]).then(() => undefined);
+  return Promise.all(
+    ORGANIZATION_CACHES.map((queryKey) => qc.cancelQueries({ queryKey })),
+  ).then(() => undefined);
 }
 
 // Every admin write answers with the organization in its new state, so the
@@ -202,13 +212,12 @@ export function invalidateOrganizationStats(qc: QueryClient): void {
 }
 
 // For a write that answers with ids rather than records, so there is nothing to
-// put in the cache. Both keys and the whole of each: the operator can act on
+// put in the cache. Every key and the whole of each: the operator can act on
 // rows from any page under any filter.
 export function invalidateOrganizations(qc: QueryClient): Promise<void> {
-  return Promise.all([
-    qc.invalidateQueries({ queryKey: organizationsListQuery().queryKey }),
-    qc.invalidateQueries({ queryKey: [ORGANIZATION_KEY] }),
-  ]).then(() => undefined);
+  return Promise.all(
+    ORGANIZATION_CACHES.map((queryKey) => qc.invalidateQueries({ queryKey })),
+  ).then(() => undefined);
 }
 
 export function projectQuery(

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   GramAdminError,
+  bulkUpdateAccountType,
   disableOrganization,
   enableOrganization,
   errorMessage,
@@ -212,6 +213,39 @@ describe("the organization write endpoints", () => {
       method: "POST",
       contentType: "application/json",
       body: { id: ORG.id, days: 30 },
+    });
+  });
+
+  it("posts the ids and one account type to the bulk path", async () => {
+    const answer = {
+      updated_ids: [ORG.id],
+      missing_ids: ["org_placeholder_two"],
+    };
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(answer), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    // The only write here that answers with ids rather than a record, so the
+    // two lists have to come back out of the client whole.
+    await expect(
+      bulkUpdateAccountType({
+        ids: [ORG.id, "org_placeholder_two"],
+        account_type: "enterprise",
+      }),
+    ).resolves.toEqual(answer);
+
+    expect(requestOf(fetch)).toEqual({
+      path: "/admin/organizations.bulkUpdateAccountType",
+      method: "POST",
+      contentType: "application/json",
+      body: {
+        ids: [ORG.id, "org_placeholder_two"],
+        account_type: "enterprise",
+      },
     });
   });
 

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -309,6 +309,34 @@ export function updateOrganization(
   });
 }
 
+export type BulkUpdateAccountTypeRequest = {
+  ids: string[];
+  account_type: string;
+};
+
+// `updated_ids` is a set: the server states no order, so nothing may index into
+// it or line it up against the request. `missing_ids` was not written, and a
+// caller that drops it reports the write as having done more than it did.
+export type BulkUpdateAccountTypeResult = {
+  updated_ids: string[];
+  missing_ids: string[];
+};
+
+// One statement for every id: an id that matches nothing comes back in
+// missing_ids rather than failing the batch.
+export function bulkUpdateAccountType(
+  body: BulkUpdateAccountTypeRequest,
+): Promise<BulkUpdateAccountTypeResult> {
+  return gramAdminFetch<BulkUpdateAccountTypeResult>(
+    "/admin/organizations.bulkUpdateAccountType",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
 export type OrganizationRequest = {
   id: string;
 };

--- a/client/admin/src/pages/OrganizationDetail.test.tsx
+++ b/client/admin/src/pages/OrganizationDetail.test.tsx
@@ -187,6 +187,23 @@ describe("organization detail", () => {
     ]);
   });
 
+  it("draws no checkbox on a table that did not ask for one", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+    await screen.findByRole("link", { name: PROJECT.name });
+
+    // Row selection is opt-in, and it is opted into by putting the select
+    // column in a page's own column list. The shared table registers the
+    // feature for every page that uses it, and a feature that drew a column of
+    // its own would put one here, where nothing reads a selection.
+    expect(screen.queryAllByRole("checkbox")).toEqual([]);
+
+    await selectTab("Members");
+    await screen.findByRole("cell", { name: MEMBER.email });
+    expect(screen.queryAllByRole("checkbox")).toEqual([]);
+  });
+
   it("renders every members cell out of the record that produced it", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,

--- a/client/admin/src/pages/organizations/BulkAccountType.tsx
+++ b/client/admin/src/pages/organizations/BulkAccountType.tsx
@@ -1,0 +1,171 @@
+import { useRef, useState, type JSX } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ACCOUNT_TYPE_OPTIONS, type AccountType } from "@/lib/accountTypes";
+import { errorMessage, type AdminOrganization } from "@/lib/gramAdminApi";
+
+import type { WriteReporter } from "./OrganizationActions";
+import { useBulkUpdateAccountType } from "./rowActions";
+
+function organizationCount(count: number): string {
+  return `${count} ${count === 1 ? "organization" : "organizations"}`;
+}
+
+/**
+ * Sets one account type on every ticked organization.
+ *
+ * The ids come from the ticked rows and from nowhere else. The write matches an
+ * id case-sensitively and the list search matches case-insensitively, so an
+ * operator who pasted an id in the wrong case can find the row, and a field
+ * they could type that id back into would report it missing while the row sat
+ * on screen in front of them. There is no such field here and there must not
+ * be one.
+ */
+export function BulkAccountType({
+  selected,
+  reporter,
+  onDone,
+}: {
+  selected: AdminOrganization[];
+  // Handed down rather than taken from context: this control is drawn by the
+  // page that owns both surfaces, not from inside a table cell.
+  reporter: WriteReporter;
+  // Called after a write lands, so the page drops a selection that has already
+  // been acted on.
+  onDone: () => void;
+}): JSX.Element {
+  const { announce, showFailure } = reporter;
+  // The type the operator picked, and the whole of what the dialog is open
+  // for. Nothing is written until they confirm it.
+  const [pending, setPending] = useState<AccountType>();
+  const trigger = useRef<HTMLButtonElement>(null);
+
+  const bulk = useBulkUpdateAccountType();
+
+  const run = (accountType: AccountType): void => {
+    const ids = selected.map((org) => org.id);
+    bulk.mutate(
+      { ids, account_type: accountType },
+      {
+        onSuccess: (result) => {
+          setPending(undefined);
+          // Named from the ticked rows, because the answer carries ids and the
+          // operator picked names. An id the selection cannot name is reported
+          // as itself rather than dropped.
+          const names = new Map(selected.map((org) => [org.id, org.name]));
+          const missing = result.missing_ids.map((id) => names.get(id) ?? id);
+          const done = `${organizationCount(result.updated_ids.length)} set to ${accountType}.`;
+          // A bulk write that quietly did less than it said is worse than one
+          // that failed, so what was not written is shown as well as spoken.
+          const report = missing.length
+            ? `${done} ${organizationCount(missing.length)} matched nothing and were left unchanged: ${missing.join(", ")}.`
+            : null;
+          showFailure(report);
+          announce(report ?? done);
+          onDone();
+        },
+        // The dialog stays open holding the reason, because that is where the
+        // operator is looking.
+        onError: (error) =>
+          announce(`Could not set the account type: ${errorMessage(error)}`),
+      },
+    );
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button ref={trigger} variant="outline" size="xs">
+            Set account type
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {ACCOUNT_TYPE_OPTIONS.map((option) => (
+            <DropdownMenuItem
+              key={option}
+              // Opens the confirmation and writes nothing. The count is the
+              // thing an operator gets wrong, and this is the last place they
+              // can read it back before every ticked row changes.
+              onSelect={() => {
+                bulk.reset();
+                setPending(option);
+              }}
+            >
+              {option}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {pending !== undefined && (
+        <Dialog
+          open
+          onOpenChange={(next) => {
+            if (!next && !bulk.isPending) setPending(undefined);
+          }}
+        >
+          <DialogContent
+            onCloseAutoFocus={(event) => {
+              // The control is gone once a write has cleared the selection, and
+              // there is nowhere better to put the keyboard then.
+              const control = trigger.current;
+              if (!control?.isConnected) return;
+              event.preventDefault();
+              control.focus();
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>
+                Set {organizationCount(selected.length)} to {pending}?
+              </DialogTitle>
+              <DialogDescription>
+                Every ticked organization changes account type. Nothing else
+                about them changes.
+              </DialogDescription>
+            </DialogHeader>
+            {/* A modal takes the rest of the page out of the accessibility
+                tree, the live region included, so a failure the operator is
+                looking at needs its own. */}
+            {bulk.error && (
+              <p role="alert" className="text-destructive text-sm">
+                {errorMessage(bulk.error)}
+              </p>
+            )}
+            <DialogFooter>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={bulk.isPending}
+                onClick={() => setPending(undefined)}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                disabled={bulk.isPending}
+                onClick={() => run(pending)}
+              >
+                {bulk.isPending ? "Setting..." : `Set to ${pending}`}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/client/admin/src/pages/organizations/BulkAccountType.tsx
+++ b/client/admin/src/pages/organizations/BulkAccountType.tsx
@@ -39,6 +39,7 @@ export function BulkAccountType({
   selected,
   reporter,
   onDone,
+  rescueFocus,
 }: {
   selected: AdminOrganization[];
   // Handed down rather than taken from context: this control is drawn by the
@@ -47,6 +48,9 @@ export function BulkAccountType({
   // Called after a write lands, so the page drops a selection that has already
   // been acted on.
   onDone: () => void;
+  // Where the keyboard goes when that dropped selection has taken this control
+  // off the page with it.
+  rescueFocus: () => void;
 }): JSX.Element {
   const { announce, showFailure } = reporter;
   // The type the operator picked, and the whole of what the dialog is open
@@ -64,15 +68,18 @@ export function BulkAccountType({
         onSuccess: (result) => {
           setPending(undefined);
           // Named from the ticked rows, because the answer carries ids and the
-          // operator picked names. An id the selection cannot name is reported
-          // as itself rather than dropped.
+          // operator picked names. The fallback is cheap defence only: the ids
+          // that come back are a subset of the ones the selection sent.
           const names = new Map(selected.map((org) => [org.id, org.name]));
           const missing = result.missing_ids.map((id) => names.get(id) ?? id);
           const done = `${organizationCount(result.updated_ids.length)} set to ${accountType}.`;
           // A bulk write that quietly did less than it said is worse than one
           // that failed, so what was not written is shown as well as spoken.
+          //
+          // "stayed unchanged" rather than "were left unchanged", so the verb
+          // reads at one organization as well as at many.
           const report = missing.length
-            ? `${done} ${organizationCount(missing.length)} matched nothing and were left unchanged: ${missing.join(", ")}.`
+            ? `${done} ${organizationCount(missing.length)} matched nothing and stayed unchanged: ${missing.join(", ")}.`
             : null;
           showFailure(report);
           announce(report ?? done);
@@ -120,13 +127,15 @@ export function BulkAccountType({
           }}
         >
           <DialogContent
+            showCloseButton={!bulk.isPending}
             onCloseAutoFocus={(event) => {
-              // The control is gone once a write has cleared the selection, and
-              // there is nowhere better to put the keyboard then.
-              const control = trigger.current;
-              if (!control?.isConnected) return;
               event.preventDefault();
-              control.focus();
+              // The trigger goes off the page with the selection a landed write
+              // clears, and Radix hands focus to the body then. The list is the
+              // one thing still under the operator's hand.
+              const control = trigger.current;
+              if (control) control.focus();
+              else rescueFocus();
             }}
           >
             <DialogHeader>

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { Column, RowData } from "@tanstack/react-table";
 import { SearchIcon } from "lucide-react";
-import { useEffect, useRef, useState, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX, type ReactNode } from "react";
 
 import type {
   DataTableFeatures,
@@ -180,12 +180,22 @@ export function Toolbar({ searchCleared }: ToolbarProps): JSX.Element {
 export function TableActionBar<T extends RowData>({
   table,
   onColumnToggled,
+  bulkActions,
 }: {
   table: DataTableInstance<T>;
   // Told after a toggle lands, so a page that overrides what this menu writes
   // can answer a request the menu cannot satisfy on its own.
   onColumnToggled?: (columnId: string, label: string) => void;
+  // Shown in place of "Nothing selected", so the strip keeps its height and no
+  // row moves under the pointer. A table with no select column never has a
+  // selection, so it never shows these.
+  bulkActions?: ReactNode;
 }): JSX.Element {
+  // The row model, not the selection state: the state is a map of row ids and
+  // it can name a row this page no longer holds, which would count a record
+  // that is not on screen and not in what the bulk action sends.
+  const selectedCount = table.getSelectedRowModel().rows.length;
+
   // Read off the table rather than walked a second time here, so the menu
   // cannot disagree with the table about how many columns are left.
   //
@@ -199,7 +209,23 @@ export function TableActionBar<T extends RowData>({
 
   return (
     <div className="flex items-center gap-3 border-b px-3 py-2">
-      <span className="text-muted-foreground text-xs">Nothing selected</span>
+      {selectedCount === 0 ? (
+        <span className="text-muted-foreground text-xs">Nothing selected</span>
+      ) : (
+        <>
+          {/* The bar is generic over the record, so the count is bare here and
+              the confirmation names what is being counted. */}
+          <span className="text-xs">{selectedCount} selected</span>
+          {bulkActions}
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => table.resetRowSelection()}
+          >
+            Clear selection
+          </Button>
+        </>
+      )}
       <span className="flex-1" />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -246,10 +272,12 @@ export function TableActionBar<T extends RowData>({
 }
 
 // A header is a renderable in general, and only a string carries a label a
-// screen reader can announce here. The id is the readable fallback.
+// screen reader can announce here. A column drawing a control instead names
+// itself through its meta, and the id is the readable fallback.
 function columnLabel<T extends RowData>(
   column: Column<DataTableFeatures, T>,
 ): string {
-  const { header } = column.columnDef;
+  const { header, meta } = column.columnDef;
+  if (meta?.label) return meta.label;
   return typeof header === "string" ? header : column.id;
 }

--- a/client/admin/src/pages/organizations/columns.tsx
+++ b/client/admin/src/pages/organizations/columns.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { createColumnHelper } from "@tanstack/react-table";
 
-import type { DataTableFeatures } from "@/components/data-table";
+import { selectColumn, type DataTableFeatures } from "@/components/data-table";
 import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { badgeTone } from "@/lib/badgeTone";
@@ -21,6 +21,13 @@ const PINNED_RIGHT = "sticky right-0 z-1 w-px";
 // table does not rebuild its column model on every render. The header of each
 // column doubles as its label in the Columns control.
 export const ORG_COLUMNS = column.columns([
+  // Leftmost, so the checkbox is the first thing on the row and the first tab
+  // stop in it. The bulk actions above the table are the only thing that reads
+  // the selection, and this is the only way to make one.
+  selectColumn<AdminOrganization>({
+    allLabel: "Select every organization on this page",
+    rowLabel: (org) => `Select ${org.name}`,
+  }),
   column.accessor("name", {
     header: "Name",
     // The link, not the row, carries the keyboard path and the accessible

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -3083,13 +3083,42 @@ describe("organizations list bulk account type", () => {
 
     // The select column is leftmost and the actions column is pinned to the
     // right edge, so the keyboard has to walk the row the way the eye does:
-    // checkbox, then the record, then what can be done to it. The widths and
-    // the pin itself are geometry, and happy-dom lays nothing out, so this is
-    // the order and not the placement.
+    // checkbox, then the record, then what can be done to it. happy-dom lays
+    // nothing out, so this is the order and not the placement.
     expect(tabStopBefore(link)).toBe(rowCheckbox(FIRST_ORG.name));
     expect(tabStopBefore(await peekTrigger(FIRST_ORG.name))).not.toBe(
       rowCheckbox(FIRST_ORG.name),
     );
+  });
+
+  it("pins the select column to the left edge, in both the header and the rows", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // The list is wider than the window at every width an operator uses, so an
+    // unpinned checkbox scrolls off the left while the actions column holds the
+    // right. A table whose purpose is picking rows cannot hide the control that
+    // picks them. happy-dom lays nothing out, so these read the classes that
+    // carry the pin; the measurement is in the browser.
+    for (const control of [
+      screen.getByRole("checkbox", {
+        name: "Select every organization on this page",
+      }),
+      rowCheckbox(FIRST_ORG.name),
+    ]) {
+      const pinned = control.closest("th,td");
+      expect(pinned?.classList.contains("sticky")).toBe(true);
+      expect(pinned?.classList.contains("left-0")).toBe(true);
+      expect(pinned?.classList.contains("z-1")).toBe(true);
+      // The table is `w-full`, so a column that did not shrink to the checkbox
+      // would take a share of the freed width and read as an empty gutter.
+      expect(pinned?.classList.contains("w-px")).toBe(true);
+      // Opaque, or the cells sliding under it show through.
+      expect(
+        pinned?.classList.contains("bg-muted") ||
+          pinned?.classList.contains("bg-inherit"),
+      ).toBe(true);
+    }
   });
 
   it("leaves the row's own controls alone when a checkbox is ticked", async () => {

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -406,8 +406,10 @@ beforeEach(() => {
   mocks.extendTrial.mockImplementation(({ id }) =>
     Promise.resolve({ ...orgByID(id), trial_ends_at: EXTENDED_TRIAL_END }),
   );
-  // Everything the request asked for, and nothing missing. A test about the
-  // ids the server could not find says so itself.
+  // Everything the request asked for, and nothing missing. The reversal guards
+  // nothing on its own, because only the length of this array is ever read;
+  // "names the organizations the server could not find" is the test that holds
+  // the reporting, by answering a different set from the one it was sent.
   mocks.bulkUpdateAccountType.mockReset();
   mocks.bulkUpdateAccountType.mockImplementation(({ ids }) =>
     Promise.resolve({ updated_ids: [...ids].reverse(), missing_ids: [] }),
@@ -3100,25 +3102,28 @@ describe("organizations list bulk account type", () => {
     // right. A table whose purpose is picking rows cannot hide the control that
     // picks them. happy-dom lays nothing out, so these read the classes that
     // carry the pin; the measurement is in the browser.
-    for (const control of [
-      screen.getByRole("checkbox", {
+    const head = screen
+      .getByRole("checkbox", {
         name: "Select every organization on this page",
-      }),
-      rowCheckbox(FIRST_ORG.name),
-    ]) {
-      const pinned = control.closest("th,td");
+      })
+      .closest("th");
+    const cell = rowCheckbox(FIRST_ORG.name).closest("td");
+
+    for (const pinned of [head, cell]) {
       expect(pinned?.classList.contains("sticky")).toBe(true);
       expect(pinned?.classList.contains("left-0")).toBe(true);
       expect(pinned?.classList.contains("z-1")).toBe(true);
       // The table is `w-full`, so a column that did not shrink to the checkbox
       // would take a share of the freed width and read as an empty gutter.
       expect(pinned?.classList.contains("w-px")).toBe(true);
-      // Opaque, or the cells sliding under it show through.
-      expect(
-        pinned?.classList.contains("bg-muted") ||
-          pinned?.classList.contains("bg-inherit"),
-      ).toBe(true);
     }
+
+    // Each element's own colour, and not the other's. The header's grey painted
+    // down the column would cover the rows sliding under it and stop the hover
+    // and peek highlight dead at the checkbox.
+    expect(head?.classList.contains("bg-muted")).toBe(true);
+    expect(cell?.classList.contains("bg-inherit")).toBe(true);
+    expect(cell?.classList.contains("bg-muted")).toBe(false);
   });
 
   it("leaves the row's own controls alone when a checkbox is ticked", async () => {
@@ -3394,10 +3399,36 @@ describe("organizations list bulk account type", () => {
     // than off what was asked for.
     const banner = await screen.findByRole("alert");
     expect(banner.textContent).toContain("1 organization set to enterprise.");
+    // The verb has to agree at one as well as at many, and the noun is already
+    // counted, so the sentence cannot branch on the count twice.
     expect(banner.textContent).toContain(
-      `1 organization matched nothing and were left unchanged: ${SECOND_ORG.name}.`,
+      `1 organization matched nothing and stayed unchanged: ${SECOND_ORG.name}.`,
     );
     expect(announcement()).toBe(banner.textContent?.replace("Dismiss", ""));
+  });
+
+  it("names every organization the server could not find, not just the first", async () => {
+    mocks.bulkUpdateAccountType.mockImplementation(() =>
+      Promise.resolve({
+        updated_ids: [],
+        missing_ids: [SECOND_ORG.id, FIRST_ORG.id],
+      }),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    await tick(SECOND_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    await confirm("enterprise");
+
+    // The same sentence at two, so the wording cannot be fixed at one count by
+    // breaking it at the other. The order is the answer's, not the selection's.
+    const banner = await screen.findByRole("alert");
+    expect(banner.textContent).toContain("0 organizations set to enterprise.");
+    expect(banner.textContent).toContain(
+      `2 organizations matched nothing and stayed unchanged: ${SECOND_ORG.name}, ${FIRST_ORG.name}.`,
+    );
   });
 
   it("reports nothing missing when every id landed", async () => {
@@ -3432,10 +3463,13 @@ describe("organizations list bulk account type", () => {
     await screen.findByRole("dialog");
     await confirm("enterprise");
 
+    // As an alert, not merely as text: the modal takes the page's live region
+    // out of the accessibility tree, so this role is the only thing that speaks
+    // the refusal to an operator who cannot see it.
     const dialog = screen.getByRole("dialog");
-    expect(
-      within(dialog).getByText("account_type is not allowed"),
-    ).toBeTruthy();
+    expect(within(dialog).getByRole("alert").textContent).toBe(
+      "account_type is not allowed",
+    );
     // Nothing was written, so the selection the operator would retry with is
     // still there.
     fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
@@ -3485,6 +3519,80 @@ describe("organizations list bulk account type", () => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });
     expect(document.activeElement).toBe(bulkTrigger());
+  });
+
+  it("puts the keyboard on the list when the write takes that control away", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    await confirm("enterprise");
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    // A landed write clears the selection, which takes the trigger the dialog
+    // opened from off the page. Dropped on the body instead, the next Tab
+    // restarts at the top of the document, nowhere near the rows just written.
+    expect(
+      screen.queryByRole("button", { name: "Set account type" }),
+    ).toBeNull();
+    expect(document.activeElement).toBe(
+      screen.getByRole("region", { name: "Organizations table" }),
+    );
+  });
+
+  it("shuts the dialog's own controls while the write is in flight", async () => {
+    let land = (): void => {};
+    mocks.bulkUpdateAccountType.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          land = () =>
+            resolve({ updated_ids: [FIRST_ORG.id], missing_ids: [] });
+        }),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    // Held open on purpose: every other test resolves the write inside the same
+    // act, so nothing else ever observes this state.
+    await confirm("enterprise");
+
+    const dialog = screen.getByRole("dialog");
+    const setting = await within(dialog).findByRole("button", {
+      name: "Setting...",
+    });
+    expect(setting.hasAttribute("disabled")).toBe(true);
+    // Cancel too: a write already sent cannot be called back by closing the
+    // dialog it was sent from.
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Cancel" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    // The close control goes rather than sitting there live beside a greyed
+    // Cancel, doing nothing when it is pressed.
+    expect(within(dialog).queryByRole("button", { name: "Close" })).toBeNull();
+
+    // A press and an Escape a macrotask later, which is as fast as an operator
+    // can be. Neither may reach the endpoint or take the dialog down.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.click(setting);
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(mocks.bulkUpdateAccountType.mock.calls).toHaveLength(1);
+    expect(screen.getByRole("dialog")).toBe(dialog);
+
+    await act(async () => {
+      land();
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
   });
 
   it("lets the operator pick a different type after cancelling", async () => {

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -3165,6 +3165,34 @@ describe("organizations list bulk account type", () => {
     expect(screen.getByText("Nothing selected")).toBeTruthy();
   });
 
+  it("clears the selection when a platform total opens the rows behind it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    fireEvent.click(screen.getByRole("button", { name: /^Disabled/ }));
+
+    // A stat cell replaces the filters, so the rows under the selection are a
+    // different set from the one the operator ticked. It reaches the selection
+    // through the search in the URL, the same way the filter sheet does.
+    await waitFor(() => {
+      expect(screen.getByText("Nothing selected")).toBeTruthy();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Set account type" }),
+    ).toBeNull();
+
+    // The strip is a sibling above the bar the bulk control lives in, so a
+    // selection swaps that bar's contents and leaves the totals alone. Document
+    // order, not layout: happy-dom lays nothing out.
+    const strip = screen.getByRole("group", { name: "Platform totals" });
+    await tick(FIRST_ORG.name);
+    expect(screen.getByRole("group", { name: "Platform totals" })).toBe(strip);
+    expect(
+      strip.compareDocumentPosition(bulkTrigger()) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("does not bring the selection back when the operator pages back", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -29,6 +29,8 @@ import {
   TRIAL_STATES,
   type AdminOrganization,
   type AdminOrganizationStats,
+  type BulkUpdateAccountTypeRequest,
+  type BulkUpdateAccountTypeResult,
   type ListOrganizationsParams,
   type ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
@@ -63,6 +65,12 @@ const mocks = vi.hoisted(() => ({
     vi.fn<(body: { id: string }) => Promise<AdminOrganization>>(),
   extendTrial:
     vi.fn<(body: { id: string; days: number }) => Promise<AdminOrganization>>(),
+  bulkUpdateAccountType:
+    vi.fn<
+      (
+        body: BulkUpdateAccountTypeRequest,
+      ) => Promise<BulkUpdateAccountTypeResult>
+    >(),
 }));
 
 // Only the endpoints this page's route tree reaches are replaced. The rest of
@@ -82,6 +90,7 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     disableOrganization: mocks.disableOrganization,
     enableOrganization: mocks.enableOrganization,
     extendTrial: mocks.extendTrial,
+    bulkUpdateAccountType: mocks.bulkUpdateAccountType,
   };
 });
 
@@ -396,6 +405,12 @@ beforeEach(() => {
   mocks.extendTrial.mockReset();
   mocks.extendTrial.mockImplementation(({ id }) =>
     Promise.resolve({ ...orgByID(id), trial_ends_at: EXTENDED_TRIAL_END }),
+  );
+  // Everything the request asked for, and nothing missing. A test about the
+  // ids the server could not find says so itself.
+  mocks.bulkUpdateAccountType.mockReset();
+  mocks.bulkUpdateAccountType.mockImplementation(({ ids }) =>
+    Promise.resolve({ updated_ids: [...ids].reverse(), missing_ids: [] }),
   );
 });
 
@@ -1004,6 +1019,8 @@ describe("organizations list", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      // The select column's header is a checkbox, so it carries no text.
+      "",
       "Name",
       "Slug",
       "Type",
@@ -1019,6 +1036,8 @@ describe("organizations list", () => {
         .getAllByRole("cell")
         .map((cell) => cell.textContent),
     ).toEqual([
+      // The select checkbox is named on the control, not in the cell.
+      "",
       FIRST_ORG.name,
       FIRST_ORG.slug,
       FIRST_ORG.account_type,
@@ -1159,7 +1178,7 @@ describe("organizations list peek", () => {
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Slug", "Type", "Actions"]);
+    ).toEqual(["", "Name", "Slug", "Type", "Actions"]);
   });
 
   it("takes the trial column down with the rest while it is open", async () => {
@@ -1288,13 +1307,14 @@ describe("organizations list peek", () => {
     await peekOn(FIRST_ORG.name);
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Type", "Actions"]);
+    ).toEqual(["", "Name", "Type", "Actions"]);
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      "",
       "Name",
       "Type",
       "Members",
@@ -1322,7 +1342,7 @@ describe("organizations list peek", () => {
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Slug", "Type", "Actions"]);
+    ).toEqual(["", "Name", "Slug", "Type", "Actions"]);
     expect(screen.getByRole("link", { name: FIRST_ORG.name })).toBeTruthy();
 
     fireEvent.keyDown(peekPanel(), { key: "Escape" });
@@ -1386,6 +1406,8 @@ describe("organizations list peek", () => {
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
     ).toEqual([
+      // The select column's header is a checkbox, so it carries no text.
+      "",
       "Name",
       "Slug",
       "Type",
@@ -2910,22 +2932,587 @@ describe("organizations list actions column", () => {
 // The bar takes a table, so the last-column case is reachable here by handing
 // it a two column table rather than by clicking seven items shut through a
 // menu that closes each time.
+describe("organizations list bulk account type", () => {
+  // Every id the operator can act on comes from a ticked row, so the tests
+  // reach the rows the way an operator does: through the checkbox named for
+  // the organization it is on. There is no field anywhere here that takes an
+  // id, and there must not be one: the write matches an id case-sensitively
+  // and the search matches case-insensitively, so a typed id can name a row
+  // that is on screen and still come back missing.
+  function selectAll(): HTMLElement {
+    return screen.getByRole("checkbox", {
+      name: "Select every organization on this page",
+    });
+  }
+
+  function rowCheckbox(name: string): HTMLElement {
+    return screen.getByRole("checkbox", { name: `Select ${name}` });
+  }
+
+  async function tick(name: string): Promise<void> {
+    fireEvent.click(
+      await screen.findByRole("checkbox", {
+        name: `Select ${name}`,
+      }),
+    );
+  }
+
+  function bulkTrigger(): HTMLElement {
+    return screen.getByRole("button", { name: "Set account type" });
+  }
+
+  // The two halves of the action, kept apart on purpose: picking a type opens
+  // the confirmation and writes nothing, and confirming is what writes.
+  function pick(type: string): void {
+    openOn(bulkTrigger());
+    fireEvent.click(screen.getByRole("menuitem", { name: type }));
+  }
+
+  async function confirm(type: string): Promise<void> {
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: `Set to ${type}` }));
+    });
+  }
+
+  function dialogTitle(): string {
+    return (
+      within(screen.getByRole("dialog")).getByRole("heading").textContent ?? ""
+    );
+  }
+
+  function lastBulkRequest(): BulkUpdateAccountTypeRequest {
+    const call = mocks.bulkUpdateAccountType.mock.calls.at(-1);
+    if (!call?.[0]) throw new Error("nothing was sent to the bulk endpoint");
+    return call[0];
+  }
+
+  it("says nothing is selected until a row is ticked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+    // The action appears with the selection. Offering it against nothing would
+    // be offering a request the server refuses: the payload takes one id at
+    // least.
+    expect(
+      screen.queryByRole("button", { name: "Set account type" }),
+    ).toBeNull();
+  });
+
+  it("counts the rows the operator ticked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    expect(screen.getByText("1 selected")).toBeTruthy();
+
+    await tick(SECOND_ORG.name);
+    expect(screen.getByText("2 selected")).toBeTruthy();
+    expect(screen.queryByText("Nothing selected")).toBeNull();
+  });
+
+  // The strip swaps its contents in place. happy-dom performs no layout, so
+  // nothing here can prove the strip keeps its height; what it can prove is
+  // that the control the height is set by is in both states. The geometry is
+  // checked in a browser.
+  it("keeps the Columns control in the strip in both states", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+    const bar = screen.getByText("Nothing selected").parentElement;
+    if (!bar) throw new Error("the strip has no element");
+    expect(within(bar).getByRole("button", { name: "Columns" })).toBeTruthy();
+
+    await tick(FIRST_ORG.name);
+
+    const selectedBar = screen.getByText("1 selected").parentElement;
+    expect(selectedBar).toBe(bar);
+    expect(within(bar).getByRole("button", { name: "Columns" })).toBeTruthy();
+  });
+
+  it("ticks every row on the page from the header checkbox", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    fireEvent.click(selectAll());
+
+    expect(screen.getByText(`${ORGS.length} selected`)).toBeTruthy();
+    for (const org of ORGS) {
+      expect(rowCheckbox(org.name).getAttribute("aria-checked")).toBe("true");
+    }
+  });
+
+  it("unticks every row on the page from the header checkbox", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    fireEvent.click(selectAll());
+    fireEvent.click(selectAll());
+
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+    expect(rowCheckbox(FIRST_ORG.name).getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  it("reports the header checkbox as mixed while only some rows are ticked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+
+    // Not "false". The next press clears rather than extends, and an unchecked
+    // box states the opposite to whoever cannot see the count beside it.
+    expect(selectAll().getAttribute("aria-checked")).toBe("mixed");
+  });
+
+  it("leaves the list where it is when a checkbox is ticked", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    // The checkbox sits inside a row that opens the organization when it is
+    // clicked. A row handler that answered this one would take the operator
+    // off the list at the moment they started building a selection.
+    await tick(FIRST_ORG.name);
+
+    expect(router.state.location.pathname).toBe("/organizations");
+    expect(screen.getByText("1 selected")).toBeTruthy();
+  });
+
+  it("puts the row's checkbox ahead of everything else in it", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    const link = await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // The select column is leftmost and the actions column is pinned to the
+    // right edge, so the keyboard has to walk the row the way the eye does:
+    // checkbox, then the record, then what can be done to it. The widths and
+    // the pin itself are geometry, and happy-dom lays nothing out, so this is
+    // the order and not the placement.
+    expect(tabStopBefore(link)).toBe(rowCheckbox(FIRST_ORG.name));
+    expect(tabStopBefore(await peekTrigger(FIRST_ORG.name))).not.toBe(
+      rowCheckbox(FIRST_ORG.name),
+    );
+  });
+
+  it("leaves the row's own controls alone when a checkbox is ticked", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    await tick(FIRST_ORG.name);
+
+    // The actions column carries peek and the row menu in one pinned cell. A
+    // checkbox press that reached either would open a panel or a menu over the
+    // list the operator is building a selection in.
+    expect(
+      screen.queryByRole("complementary", { name: "Organization peek" }),
+    ).toBeNull();
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.getByText("1 selected")).toBeTruthy();
+  });
+
+  it("clears the selection when the operator pages", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    // A selection that survives a page is a selection the operator cannot see.
+    // The count would still read 1 and the row it names would be off screen.
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+  });
+
+  it("does not bring the selection back when the operator pages back", async () => {
+    mocks.listOrganizations.mockImplementation((params) =>
+      Promise.resolve(
+        params?.cursor
+          ? { organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    const next = await screen.findByRole("button", { name: "Next" });
+    await waitFor(() => {
+      expect(next.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(next);
+    await screen.findByRole("link", { name: NEXT_PAGE_ORG.name });
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous" }));
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    // The page the selection was made on is back, so a selection that was only
+    // hidden by the page change rather than dropped shows up again here. The
+    // pager is component state and stays out of the URL, which is why watching
+    // the URL alone is not enough.
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+    expect(rowCheckbox(FIRST_ORG.name).getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  it("clears the selection when a filter is applied", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+
+    await openFilters("Status");
+    await chooseFilter("Status", "Disabled");
+    applyFilters();
+
+    await waitFor(() => {
+      expect(lastListParams().disabled_states).toEqual(["disabled"]);
+    });
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+  });
+
+  it("clears the selection when the sort changes", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    await tick(FIRST_ORG.name);
+
+    // The sort is in the URL and not in the list request, so a page that
+    // watched only the request would keep a selection across a reorder.
+    await act(async () => {
+      await router.navigate({
+        to: "/organizations",
+        search: { sort: "name", dir: "asc" },
+      });
+    });
+
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+  });
+
+  it("clears the selection when the search term changes", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+
+    await tick(FIRST_ORG.name);
+
+    await act(async () => {
+      await router.navigate({ to: "/organizations", search: { q: "acme" } });
+    });
+
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+  });
+
+  it("unticks one row and keeps the rest", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    fireEvent.click(selectAll());
+    await tick(SECOND_ORG.name);
+
+    // The second press on a ticked row clears that row, so a checkbox that
+    // only ever ticked would leave the operator no way back short of clearing
+    // the whole selection.
+    expect(screen.getByText(`${ORGS.length - 1} selected`)).toBeTruthy();
+    expect(rowCheckbox(SECOND_ORG.name).getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  it("drops the selection when the operator clears it by hand", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+    expect(mocks.bulkUpdateAccountType).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing until the operator confirms", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    await tick(SECOND_ORG.name);
+    pick("enterprise");
+
+    // The whole point of the confirmation. A control that wrote on the pick
+    // would have changed both records by now, and the dialog below would be a
+    // decoration over a write that had already happened.
+    await screen.findByRole("dialog");
+    expect(mocks.bulkUpdateAccountType).not.toHaveBeenCalled();
+  });
+
+  it("names the count and the target type in the confirmation", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    await tick(SECOND_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+
+    // The count is the thing an operator gets wrong, and the type is the thing
+    // they picked. Both are read back before anything is written.
+    expect(dialogTitle()).toBe("Set 2 organizations to enterprise?");
+  });
+
+  it("counts one organization in the singular", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("free");
+    await screen.findByRole("dialog");
+
+    expect(dialogTitle()).toBe("Set 1 organization to free?");
+  });
+
+  it("sends the ticked ids and the picked type, and nothing else", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    await tick(TRIALLING_ORG.name);
+    pick("pro");
+    await screen.findByRole("dialog");
+    await confirm("pro");
+
+    // Two of the three rows on the page, so a request built from the rows
+    // rather than from the selection fails here. The ids are compared as a set
+    // for the same reason the answer is read as one.
+    const sent = lastBulkRequest();
+    expect([...sent.ids].sort()).toEqual(
+      [FIRST_ORG.id, TRIALLING_ORG.id].sort(),
+    );
+    expect(sent.account_type).toBe("pro");
+  });
+
+  it("writes nothing when the operator cancels", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(mocks.bulkUpdateAccountType).not.toHaveBeenCalled();
+    // The selection is what the operator built. Cancelling the write is not
+    // asking to build it again.
+    expect(screen.getByText("1 selected")).toBeTruthy();
+  });
+
+  it("clears the selection once the write lands", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    await tick(SECOND_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    await confirm("enterprise");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    // A selection that outlives the write it was made for is a second write
+    // one press away, against rows that already carry the type.
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+    expect(announcement()).toBe("2 organizations set to enterprise.");
+  });
+
+  it("asks for the list again once the write lands", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+    const before = mocks.listOrganizations.mock.calls.length;
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    await confirm("enterprise");
+
+    // The answer carries ids, not records, so there is nothing to repaint the
+    // rows from. Without the invalidation the table keeps showing the type the
+    // operator just changed.
+    await waitFor(() => {
+      expect(mocks.listOrganizations.mock.calls.length).toBeGreaterThan(before);
+    });
+  });
+
+  it("names the organizations the server could not find", async () => {
+    mocks.bulkUpdateAccountType.mockImplementation(({ ids }) =>
+      Promise.resolve({
+        updated_ids: ids.filter((id) => id !== SECOND_ORG.id),
+        missing_ids: [SECOND_ORG.id],
+      }),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    await tick(SECOND_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    await confirm("enterprise");
+
+    // Shown as well as spoken. A bulk write that quietly did less than it said
+    // is worse than one that failed, and the count comes off the answer rather
+    // than off what was asked for.
+    const banner = await screen.findByRole("alert");
+    expect(banner.textContent).toContain("1 organization set to enterprise.");
+    expect(banner.textContent).toContain(
+      `1 organization matched nothing and were left unchanged: ${SECOND_ORG.name}.`,
+    );
+    expect(announcement()).toBe(banner.textContent?.replace("Dismiss", ""));
+  });
+
+  it("reports nothing missing when every id landed", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("free");
+    await screen.findByRole("dialog");
+    await confirm("free");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    // No banner at all: nothing went missing, and a banner that always shows
+    // teaches the operator to ignore the one that matters.
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(announcement()).toBe("1 organization set to free.");
+  });
+
+  it("keeps the dialog open holding the reason when the server refuses", async () => {
+    mocks.bulkUpdateAccountType.mockRejectedValue(
+      new GramAdminError(
+        400,
+        { name: "invalid", message: "account_type is not allowed" },
+        "gram admin 400 Bad Request",
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    await confirm("enterprise");
+
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByText("account_type is not allowed"),
+    ).toBeTruthy();
+    // Nothing was written, so the selection the operator would retry with is
+    // still there.
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(screen.getByText("1 selected")).toBeTruthy();
+  });
+
+  it("does not carry a refused write's reason into the next one", async () => {
+    mocks.bulkUpdateAccountType.mockRejectedValue(
+      new GramAdminError(
+        400,
+        { name: "invalid", message: "account_type is not allowed" },
+        "gram admin 400 Bad Request",
+      ),
+    );
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    await confirm("enterprise");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    pick("free");
+
+    // The reason belongs to the write that was refused. A dialog that opened
+    // holding it would be telling the operator their next write had already
+    // failed.
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).queryByRole("alert")).toBeNull();
+  });
+
+  it("gives the keyboard back to the control the dialog opened from", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(document.activeElement).toBe(bulkTrigger());
+  });
+
+  it("lets the operator pick a different type after cancelling", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    pick("enterprise");
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    pick("free");
+    await screen.findByRole("dialog");
+
+    // The dialog reads the type off the pick that opened it, not off the first
+    // one the operator ever made.
+    expect(dialogTitle()).toBe("Set 1 organization to free?");
+    await confirm("free");
+    expect(lastBulkRequest().account_type).toBe("free");
+  });
+
+  it("offers every account type the server takes and no other", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+
+    await tick(FIRST_ORG.name);
+    openOn(bulkTrigger());
+
+    // ACCOUNT_TYPE_OPTIONS mirrors constants.AccountTypes, which is the enum
+    // the payload declares. An option outside it is a request the generated
+    // decoder refuses before the handler ever sees it.
+    expect(
+      screen.getAllByRole("menuitem").map((item) => item.textContent),
+    ).toEqual([...ACCOUNT_TYPE_OPTIONS]);
+  });
+});
+
 describe("TableActionBar", () => {
   // Destructured off the tuple rather than off a slice, which widens each
   // element back to a bare column definition.
-  const [FIRST, SECOND, THIRD] = ORG_COLUMNS;
+  // Position, not an id lookup, for the select column: leftmost is the claim.
+  const [SELECT, FIRST, SECOND, THIRD] = ORG_COLUMNS;
   // Found by id rather than by position, so a column added after it does not
   // quietly become the one these cases are about.
   const ACTIONS = ORG_COLUMNS.find((definition) => definition.id === "actions");
-  if (!FIRST || !SECOND || !THIRD || !ACTIONS) {
-    throw new Error("ORG_COLUMNS needs three data columns and an actions one");
+  if (!SELECT || !FIRST || !SECOND || !THIRD || !ACTIONS) {
+    throw new Error(
+      "ORG_COLUMNS needs a select column, three data ones and an actions one",
+    );
   }
 
   // Sliced, so the array carries the element type useTable asks for. Two data
   // columns for the cases about the bar's own two rules, and the control
   // column beside one of them for the cases where a column that cannot be
   // hidden is in the count.
-  const MENU_COLUMNS = ORG_COLUMNS.slice(0, 2);
+  const MENU_COLUMNS = ORG_COLUMNS.slice(1, 3);
   const WITH_ACTIONS_COLUMN: typeof MENU_COLUMNS = [ACTIONS, FIRST];
   // A second opt-out column, so the rule still has to count hideable columns
   // rather than visible ones when more than one of them cannot be hidden.
@@ -3133,6 +3720,20 @@ describe("TableActionBar", () => {
     // The opt-out is per column, so the menu still works around it.
     fireEvent.click(itemFor(SECOND.header));
     expect(onVisibilityChange).toHaveBeenCalled();
+  });
+
+  it("names the select column in the menu and locks it", () => {
+    const { onVisibilityChange } = openColumnsMenu({}, [SELECT, FIRST, SECOND]);
+
+    // Its header draws a checkbox rather than text, so there is no name to
+    // read off it and the menu would otherwise list it by its raw id.
+    const item = screen.getByRole("menuitemcheckbox", { name: "Select" });
+
+    // Hiding it would take away the only way to make a selection, and leave
+    // the bar above the table offering an action against nothing.
+    fireEvent.click(item);
+    expect(onVisibilityChange).not.toHaveBeenCalled();
+    expect(item.getAttribute("aria-disabled")).toBe("true");
   });
 });
 

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -155,9 +155,11 @@ export function OrganizationsList(): JSX.Element {
     setPager({ filters, stack: [] });
   }
 
-  // Cleared whenever the rows change under it: a selection the operator can no
-  // longer see is how an account type gets set on a record nobody looked at.
-  // The whole search, because the sort is in the URL and it reorders the page.
+  // Cleared whenever the operator changes the view: a selection carried across
+  // a page, a sort or a filter is how an account type gets set on a record
+  // nobody looked at. The whole search, because the sort is in the URL and it
+  // reorders the page. A refetch that changes rows under a still view keeps the
+  // selection, and the row model is what stops a dropped row being written to.
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const viewKey = `${JSON.stringify(search)}|${pager.cursor ?? ""}`;
   const [selectionView, setSelectionView] = useState(viewKey);
@@ -283,6 +285,12 @@ export function OrganizationsList(): JSX.Element {
       ?.querySelector<HTMLElement>(PEEK_TRIGGER_SELECTOR)
       ?.focus();
   }, [peekTookTheKeyboard]);
+
+  // The same landing place the peek rescue above uses, handed to the bulk
+  // dialog because its own trigger leaves the page with the selection.
+  const focusList = useCallback((): void => {
+    scrollBox.current?.focus();
+  }, []);
 
   const closePeek = useCallback((): void => {
     const trigger = peekedRow.current?.querySelector<HTMLElement>(
@@ -482,6 +490,7 @@ export function OrganizationsList(): JSX.Element {
                         selected={selectedOrgs}
                         reporter={writeReporter}
                         onDone={() => setRowSelection({})}
+                        rescueFocus={focusList}
                       />
                     }
                   />

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -1,6 +1,10 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearch } from "@tanstack/react-router";
-import { useTable, type ColumnVisibilityState } from "@tanstack/react-table";
+import {
+  useTable,
+  type ColumnVisibilityState,
+  type RowSelectionState,
+} from "@tanstack/react-table";
 import {
   useCallback,
   useEffect,
@@ -22,6 +26,7 @@ import {
 } from "@/lib/gramAdminApi";
 import { cn } from "@/lib/utils";
 
+import { BulkAccountType } from "./BulkAccountType";
 import { ORG_COLUMNS } from "./columns";
 import { WriteReportProvider } from "./OrganizationActions";
 import { PeekPanel } from "./PeekPanel";
@@ -150,6 +155,17 @@ export function OrganizationsList(): JSX.Element {
     setPager({ filters, stack: [] });
   }
 
+  // Cleared whenever the rows change under it: a selection the operator can no
+  // longer see is how an account type gets set on a record nobody looked at.
+  // The whole search, because the sort is in the URL and it reorders the page.
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const viewKey = `${JSON.stringify(search)}|${pager.cursor ?? ""}`;
+  const [selectionView, setSelectionView] = useState(viewKey);
+  if (selectionView !== viewKey) {
+    setSelectionView(viewKey);
+    setRowSelection({});
+  }
+
   const { data, isLoading, isError, error, isPlaceholderData } = useQuery({
     ...organizationsListQuery({
       ...listParams,
@@ -213,11 +229,18 @@ export function OrganizationsList(): JSX.Element {
     // Without this a row is keyed by its index, and React reuses those keys
     // across a page change and across a filter change.
     getRowId: (org) => org.id,
-    state: { columnVisibility: effectiveVisibility },
+    state: { columnVisibility: effectiveVisibility, rowSelection },
     onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
   });
 
   const rows = table.getRowModel().rows;
+
+  // The rows themselves, not the ids: the bulk action names the organizations
+  // the server could not find, and only the ticked rows carry those names.
+  const selectedOrgs = table
+    .getSelectedRowModel()
+    .rows.map((row) => row.original);
 
   // findIndex, not table.getRow: getRow throws once a page change drops the id.
   const peekedIndex = peekedId ? rows.findIndex((r) => r.id === peekedId) : -1;
@@ -454,6 +477,13 @@ export function OrganizationsList(): JSX.Element {
                   <TableActionBar
                     table={table}
                     onColumnToggled={handleColumnToggled}
+                    bulkActions={
+                      <BulkAccountType
+                        selected={selectedOrgs}
+                        reporter={writeReporter}
+                        onDone={() => setRowSelection({})}
+                      />
+                    }
                   />
 
                   <div

--- a/client/admin/src/pages/organizations/rowActions.tsx
+++ b/client/admin/src/pages/organizations/rowActions.tsx
@@ -8,15 +8,19 @@ import { useCallback } from "react";
 
 import {
   cancelOrganizationFetches,
+  invalidateOrganizations,
   invalidateOrganizationStats,
   organizationQuery,
   writeOrganizationToCache,
 } from "@/lib/adminQueries";
 import {
+  bulkUpdateAccountType,
   disableOrganization,
   enableOrganization,
   extendTrial,
   type AdminOrganization,
+  type BulkUpdateAccountTypeRequest,
+  type BulkUpdateAccountTypeResult,
   type ExtendTrialRequest,
   type TrialState,
 } from "@/lib/gramAdminApi";
@@ -102,6 +106,22 @@ export function useEnableOrganization(): OrganizationWrite<string> {
     onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org) => writeOrganizationToCache(qc, org),
     onError: () => invalidateOrganizationStats(qc),
+  });
+}
+
+// The one write that does not answer with a record, so it invalidates rather
+// than repainting from the response: the answer is two lists of ids.
+export function useBulkUpdateAccountType(): UseMutationResult<
+  BulkUpdateAccountTypeResult,
+  Error,
+  BulkUpdateAccountTypeRequest
+> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: BulkUpdateAccountTypeRequest) =>
+      bulkUpdateAccountType(body),
+    onMutate: () => cancelOrganizationFetches(qc),
+    onSuccess: () => invalidateOrganizations(qc),
   });
 }
 


### PR DESCRIPTION
Setting one account type on twenty organizations meant opening twenty detail pages. This adds the client half of the bulk endpoint that shipped in #5342, so a platform admin can do it from the list.

Closes AGE-3193.

## What it does

Ticking rows in the organizations list turns the strip above the table into a bulk control. It counts what is ticked, offers the three account types the server accepts, and reads the count and the target type back in a confirmation. Nothing is written until that confirmation is accepted.

Row selection is opt-in for the shared admin table. A page that does not include the new `selectColumn` in its column list has no selection and renders exactly as it did before.

## Decisions worth a reviewer's attention

**There is no field that takes an id, and that is load-bearing.** The write matches an id case-sensitively while the list search does not, so an id pasted in the wrong case would come back reported as missing while the row it names sat on screen. Selection-only removes that class of confusion rather than handling it.

**An unmatched id is named, not counted.** The server answers with the ids it wrote and the ids that matched nothing. The dialog names the missing ones using the organization the operator ticked, so a stale row is visible rather than silently folded into the done count.

**The selection is dropped when the view key changes**, which is the search, the sort, the filters and the cursor, and again once a write lands. A background refetch that changes rows keeps the selection; the safety property holds through the row model rather than through that line.

**The checkbox column is pinned to the left edge.** Measured in a browser at 1440, 1280, 1024 and 768, the list overflows at every one of them, so scrolling right to reach the pinned actions column took the checkbox off the left edge. The header carries `bg-muted` and the body cells carry `bg-inherit`, so a pinned cell repaints with its row rather than reading as a flat stripe over a highlighted row.

**The checkbox primitive is the stock shadcn one**, copied from the dashboard and built on the `radix-ui` package already installed here. Nothing was added to the lockfile.

## Stated limits

**A ticked row carries no row-level highlight.** `ui/table.tsx` ships `data-[state=selected]:bg-muted`, but the shared row never sets `data-state` from the selection and the page's own row class would win regardless. Deliberately left out: the checkbox is now pinned to the left edge so it is visible for every row at every scroll position, and adding a selected colour means deciding how it composes with the hover and peek colours, which is a table-wide design call rather than part of this slice.

**One leg of "no stale id can reach the write" rests on source reading, not on a test.** `getSelectedRowModel()` intersects the selection map with the rows the table currently holds, so an id left in state after the rows change cannot reach the request. That was confirmed by reading table-core 9.0.0. The mutation that would prove it could not be expressed against the v9 accessor, so no test holds it.

**happy-dom performs no layout**, so no test here proves the pinned column is where it looks. The pinning assertions are class assertions and say so.

## Verification

Three gates from the worktree, each re-run by me rather than taken from the builder's report: `type-check` 0, `lint:oxlint` 0, `test` 0 with 12 files and 329 tests.

A review round ran against a byte-identical mirror and returned nine items, all applied in the second commit. The two that mattered:

- **The pin's only assertion could not tell the header from the cell.** It was disjunctive, and the same loop applied it to both elements, so painting the whole first column with the header's muted grey survived all 326 tests. It now asserts per element. I applied that mutation by hand on the final tree: exactly one test failed, `pins the select column to the left edge, in both the header and the rows`, and the file was byte-identical after revert.
- **Focus was dropped on the floor after a successful write.** The dialog closed with `document.activeElement` on `document.body`, so the next Tab restarted at the top of the document. It now lands on the existing labelled scroll region, which was built for exactly this case when a peeked record leaves the list.

The dialog's whole in-flight state was also unmeasured: four separate guards survived removal because every test resolved the write inside the same `act()`. Measured with a deferred promise, the guards were all correct and no product defect existed, so this PR adds the one test that holds them rather than a fix. `DialogContent` does take `showCloseButton` in this version, so the close control now leaves while the write is in flight rather than sitting live beside a greyed-out Cancel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set one account type on many organizations directly from the list, replacing per‑org edits. Selection is page‑scoped and ids only come from ticked rows to avoid case‑mismatch errors.

- Opt‑in row selection via `selectColumn` in `components/data-table.tsx` (pinned left, tri‑state header checkbox, cannot be hidden), using a `Checkbox` built on `radix-ui` with `@tanstack/react-table`. Pages without `selectColumn` render unchanged.
- Organizations list: `BulkAccountType.tsx` adds “Set account type” with a confirm dialog that names the count and target type; options come from `ACCOUNT_TYPE_OPTIONS`. While pending, dialog controls disable and the close button hides; on success it clears the selection, announces the result, focuses the list, and shows any missing ids by organization name.
- API client: `bulkUpdateAccountType` posts `{ ids, account_type }` to `/admin/organizations.bulkUpdateAccountType` and returns `{ updated_ids, missing_ids }`.
- Caching: pre‑write cancels and post‑write invalidates are unified via one `ORGANIZATION_CACHES` list; `invalidateOrganizations` refreshes list, detail, and stats queries.
- Selection behavior: resets on search/sort/filter/pager changes and after a write (background refetches preserve it). `TableActionBar` shows bulk actions and “Clear selection.” To enable elsewhere, place `selectColumn` first and pass `bulkActions` to `TableActionBar`.

Connects to Linear AGE-3193. Scope: page‑scoped id slice only; “Select all across pages” is not included.

<sup>Written for commit f4e2b8cd37aaad56e766175e2f3ea17536b71f84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

