### PR TITLE
fix: hide per-row false positive action for non-judge Watchdog findings

### DIFF
--- a/.changeset/watchdog-evidence-single-action.md
+++ b/.changeset/watchdog-evidence-single-action.md
@@ -1,0 +1,10 @@
+---
+"dashboard": patch
+---
+
+Watchdog signal drawer evidence rows now offer a single action each. Judge
+findings keep the False positive button — they cannot be excluded, since their
+rule id covers the whole detector. Every other detector's rows now show only
+Exclude, where they previously offered both actions side by side, which made
+one-off false-positive dismissal the path of least resistance over creating a
+reviewed exclusion rule.

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -123,6 +123,9 @@ function EvidenceRow({
   // behind it instead of a redaction chip over content that may not exist.
   // Judge findings also can't be excluded (their rule id is a constant for
   // the whole detector), so the row offers only false-positive dismissal.
+  // Every other detector gets only Exclude: exclusion rules are the reviewed
+  // dismissal path for pattern detectors, and offering both actions side by
+  // side made per-row false-positive marking the path of least resistance.
   const judge = isJudgeSource(result.source);
   return (
     <div className="border-border overflow-hidden rounded-md border">
@@ -163,7 +166,15 @@ function EvidenceRow({
           {(result.confidence ?? 0).toFixed(2)})
         </Text>
         <span className="flex shrink-0 gap-1">
-          {!judge && (
+          {judge ? (
+            <Button
+              variant="tertiary"
+              size="sm"
+              onClick={() => onDismiss(result)}
+            >
+              <Button.Text>False positive</Button.Text>
+            </Button>
+          ) : (
             <Button
               variant="tertiary"
               size="sm"
@@ -172,13 +183,6 @@ function EvidenceRow({
               <Button.Text>Exclude</Button.Text>
             </Button>
           )}
-          <Button
-            variant="tertiary"
-            size="sm"
-            onClick={() => onDismiss(result)}
-          >
-            <Button.Text>False positive</Button.Text>
-          </Button>
         </span>
       </div>
     </div>


### PR DESCRIPTION
## What

In the Watchdog signal drawer, evidence rows for pattern-detector findings (presidio, gitleaks, custom rules, ...) no longer show a per-row **False positive** button. Each row now offers exactly one action:

- Judge findings (`llm_judge`, `prompt_injection`): **False positive** (unchanged — they cannot be excluded, their rule id covers the whole detector).
- Every other detector: **Exclude** only.

## Why

Non-judge rows offered both actions side by side, making one-off false-positive dismissal the path of least resistance over creating a reviewed exclusion rule — the intended dismissal path for pattern detectors.

## Notes

- Signal-level actions were already gated this way (judge signals → "Mark all as false positive", others → "Create exclusion rule"); this aligns the per-row actions with them.
- Scope is the signal drawer only; the Risk Events list and chat transcript are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes evidence rows in the Watchdog signal drawer single-action. Non-judge findings now show only Exclude (previously Exclude + False positive); judge findings still show only False positive and cannot be excluded, aligning row actions with signal-level behavior and steering pattern-detector dismissals through exclusions.

**Review notes**
- Scope: signal drawer only; Risk Events list and chat transcript unchanged.
- UI-only change in `client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx`; no backend impact.
- Verify judge sources (`llm_judge`, `prompt_injection`) render False positive; all other detectors render Exclude.
- Adds changeset: `dashboard` patch.
- No migration required.

<sup>Written for commit 0587b9250c266d0e185fe7c2904143923a117c10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

