### PR TITLE
fix: record an audit entry when a trial is extended

### DIFF
--- a/.changeset/audit-trial-extension.md
+++ b/.changeset/audit-trial-extension.md
@@ -1,0 +1,11 @@
+---
+"server": patch
+---
+
+Extending an enterprise trial now writes an entry to the organization's audit
+feed, so it is no longer the one trial lifecycle event that leaves no trace
+alongside a trial being armed, demoted and re-armed. The entry names the
+Speakeasy team rather than the operator who acted, and carries the end date the
+trial held before the extension, the end date it holds now, and the number of
+days applied. The write and the entry commit together, so an extension can never
+land silently.

--- a/.changeset/audit-trial-extension.md
+++ b/.changeset/audit-trial-extension.md
@@ -1,5 +1,6 @@
 ---
 "server": patch
+"dashboard": patch
 ---
 
 Extending an enterprise trial now writes an entry to the organization's audit
@@ -9,3 +10,7 @@ Speakeasy team rather than the operator who acted, and carries the end date the
 trial held before the extension, the end date it holds now, and the number of
 days applied. The write and the entry commit together, so an extension can never
 land silently.
+
+The activity log reads the new entry as "extended enterprise trial", alongside
+the "started", "ended" and "restarted" entries it already gives the rest of the
+trial lifecycle.

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -75,6 +75,7 @@ export const AUDIT_ACTIONS = [
   "organization:device_agent_configuration_updated",
   "organization:enterprise_trial_armed",
   "organization:enterprise_trial_demoted",
+  "organization:enterprise_trial_extended",
   "organization:enterprise_trial_rearmed",
   "organization:hooks_fail_open_disabled",
   "organization:hooks_fail_open_enabled",
@@ -367,6 +368,8 @@ export function staticActionPhrase(action: AuditAction): string {
       return "started enterprise trial";
     case "organization:enterprise_trial_demoted":
       return "ended enterprise trial";
+    case "organization:enterprise_trial_extended":
+      return "extended enterprise trial";
     case "organization:enterprise_trial_rearmed":
       return "restarted enterprise trial";
 

--- a/server/internal/admin/extendtrial_test.go
+++ b/server/internal/admin/extendtrial_test.go
@@ -182,6 +182,9 @@ func TestExtendTrial_OrganizationWithNoTrialRow(t *testing.T) {
 
 	_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_no_trial", Days: 3})
 	requireOopsCode(t, err, oops.CodeConflict)
+	// Extend and re-arm share one rejection helper, so each has to name its own
+	// message or the two can be swapped without a test noticing.
+	require.ErrorContains(t, err, "organization has no running enterprise trial to extend")
 
 	// Extend moves an end date; it must never be a way to arm a trial that was
 	// never granted, which is the auth flow's job.

--- a/server/internal/admin/extendtrial_test.go
+++ b/server/internal/admin/extendtrial_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"testing"
 	"time"
@@ -11,8 +12,14 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
 	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
 	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
@@ -413,4 +420,144 @@ func TestExtendTrial_ExtensionsAccumulate(t *testing.T) {
 	after := readTrial(t, ctx, conn, "org_ext_twice")
 	require.WithinDuration(t, seededEndsAt.Add(8*24*time.Hour), after.EndsAt.Time, time.Second,
 		"a second extension must build on the first")
+}
+
+func TestExtendTrial_WritesAnAuditEntry(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// id, name and slug all differ, so an assertion on one cannot pass on
+	// another. The seeded end date is ten days out and the extension is three,
+	// so the two dates in the metadata are far apart and neither is now().
+	seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_audit", name: "org_ext_audit Name", slug: "org_ext_audit-slug", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_audit", endsAt: seededEndsAt})
+	before := readTrial(t, ctx, conn, "org_ext_audit")
+
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{
+		SessionID:   "session-ext-audit",
+		Email:       "operator@example.test",
+		OIDCSubject: "oidc-subject-ext-audit",
+		Name:        "Test Operator",
+		HD:          "example.test",
+	})
+
+	countBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended)
+	require.NoError(t, err)
+
+	_, err = svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_audit", Days: 3})
+	require.NoError(t, err)
+
+	countAfter, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended)
+	require.NoError(t, err)
+	require.Equal(t, countBefore+1, countAfter, "an extension must leave a trace in the organization's feed")
+
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended)
+	require.NoError(t, err)
+	require.Equal(t, "organization", entry.SubjectType)
+	require.Equal(t, "org_ext_audit", entry.SubjectID)
+	require.Equal(t, "org_ext_audit Name", entry.SubjectDisplay, "the customer's feed must name the organization, not only its id")
+	require.Equal(t, "org_ext_audit-slug", entry.SubjectSlug)
+	require.NotNil(t, entry.ActorDisplayName, "the entry must name who extended the trial")
+	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
+
+	var metadata struct {
+		ExtendedByDays      int       `json:"extended_by_days"`
+		PreviousTrialEndsAt time.Time `json:"previous_trial_ends_at"`
+		TrialEndsAt         time.Time `json:"trial_ends_at"`
+	}
+	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
+	require.Equal(t, 3, metadata.ExtendedByDays)
+
+	// The two dates the database wrote, in the order they happened. Reading them
+	// back to front would describe a trial that was cut short.
+	after := readTrial(t, ctx, conn, "org_ext_audit")
+	require.WithinDuration(t, before.EndsAt.Time, metadata.PreviousTrialEndsAt, 0, "the entry must carry the end date the row held before the extension")
+	require.WithinDuration(t, after.EndsAt.Time, metadata.TrialEndsAt, 0, "the entry must carry the end date the row holds now")
+	require.True(t, metadata.TrialEndsAt.After(metadata.PreviousTrialEndsAt), "an extension must read forwards")
+
+	// The trial lifecycle event; any other would deliver this to nobody.
+	_, err = audittestrepo.New(conn).GetLatestOutboxPayloadByOrg(ctx, audittestrepo.GetLatestOutboxPayloadByOrgParams{
+		OrganizationID: "org_ext_audit",
+		EventType:      string(events.OrganizationEnterpriseTrialV1.EventType()),
+	})
+	require.NoError(t, err, "an extension must enqueue an outbox entry on the enterprise trial event")
+}
+
+func TestExtendTrial_AuditEntryNamesTheTeamAndNotTheOperator(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_actor", name: "Actor Co", slug: "ext-actor", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_actor", endsAt: time.Now().UTC().Add(10 * 24 * time.Hour)})
+
+	const operatorEmail = "operator@example.test"
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{
+		SessionID:   "session-ext-actor",
+		Email:       operatorEmail,
+		OIDCSubject: "oidc-subject-ext-actor",
+		Name:        "Test Operator",
+		HD:          "example.test",
+	})
+
+	_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_actor", Days: 3})
+	require.NoError(t, err)
+
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended)
+	require.NoError(t, err)
+
+	// The customer reads this feed, so a Speakeasy action carries the collective
+	// label. The read-side mask cannot reach this entry: it matches an actor id
+	// against a Gram user, and an admin session has an OIDC subject instead.
+	require.NotNil(t, entry.ActorDisplayName)
+	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
+
+	// Without this, an entry naming nobody at all would satisfy the one above.
+	require.Equal(t, "oidc-subject-ext-actor", entry.ActorID,
+		"the entry must still record which operator acted, in the field the customer's feed does not render")
+	require.Equal(t, "user", entry.ActorType)
+
+	for name, field := range map[string]string{
+		"actor display name": conv.PtrValOr(entry.ActorDisplayName, ""),
+		"actor id":           entry.ActorID,
+		"subject display":    entry.SubjectDisplay,
+		"subject slug":       entry.SubjectSlug,
+		"metadata":           string(entry.Metadata),
+		"before snapshot":    string(entry.BeforeSnapshot),
+		"after snapshot":     string(entry.AfterSnapshot),
+	} {
+		require.NotContains(t, field, operatorEmail, "the operator's email must not reach the customer's audit feed through the %s", name)
+	}
+}
+
+// TestExtendTrial_AFailedAuditEntryRollsBackTheExtension pins that the write and
+// its entry commit together. An extension that outlived a failed entry would
+// leave the feed silent, which is the whole point of this slice.
+func TestExtendTrial_AFailedAuditEntryRollsBackTheExtension(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_atomic", name: "Atomic Co", slug: "ext-atomic", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_atomic", endsAt: seededEndsAt})
+	before := readTrial(t, ctx, conn, "org_ext_atomic")
+
+	// Failing the audit insert deterministically, from outside the handler. The
+	// test owns its database, so the constraint reaches no other test.
+	require.NoError(t, audittest.RejectAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended))
+
+	_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_atomic", Days: 3})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+
+	after := readTrial(t, ctx, conn, "org_ext_atomic")
+	require.Equal(t, before.EndsAt.Time, after.EndsAt.Time,
+		"an extension whose audit entry failed must not survive: was %s, now %s", before.EndsAt.Time, after.EndsAt.Time)
+	require.Equal(t, before.UpdatedAt.Time, after.UpdatedAt.Time)
+
+	count, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended)
+	require.NoError(t, err)
+	require.Zero(t, count)
 }

--- a/server/internal/admin/extendtrial_test.go
+++ b/server/internal/admin/extendtrial_test.go
@@ -590,8 +590,11 @@ func TestExtendTrial_ASecondExtensionThatUnblocksOntoAnExtendedTrialSucceeds(t *
 	ctx, svc, conn := newTestAdminService(t)
 
 	// Close enough that it expires while the second call is blocked, far enough
-	// that the first call still finds a running trial.
-	seededEndsAt := time.Now().UTC().Add(2 * time.Second)
+	// that the first call still finds a running trial. Five seconds is the budget
+	// for two round trips and a BeginTx on a loaded box, plus any drift between
+	// this process's clock and the database's, and it sets the test's runtime
+	// because the wait below runs it out.
+	seededEndsAt := time.Now().UTC().Add(5 * time.Second)
 	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_race", name: "Race Co", slug: "ext-race", accountType: "enterprise", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_race", endsAt: seededEndsAt})
 

--- a/server/internal/admin/extendtrial_test.go
+++ b/server/internal/admin/extendtrial_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
@@ -459,6 +461,12 @@ func TestExtendTrial_WritesAnAuditEntry(t *testing.T) {
 	require.Equal(t, "org_ext_audit", entry.SubjectID)
 	require.Equal(t, "org_ext_audit Name", entry.SubjectDisplay, "the customer's feed must name the organization, not only its id")
 	require.Equal(t, "org_ext_audit-slug", entry.SubjectSlug)
+
+	// A trial belongs to the organization, not to one of its projects. There is
+	// no foreign key here, so a project id that is set but names nothing would
+	// insert and then hide the entry behind the feed's project filter.
+	require.False(t, entry.ProjectID.Valid, "a trial extension must not be scoped to a project")
+
 	require.NotNil(t, entry.ActorDisplayName, "the entry must name who extended the trial")
 	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
 
@@ -521,6 +529,7 @@ func TestExtendTrial_AuditEntryNamesTheTeamAndNotTheOperator(t *testing.T) {
 
 	for name, field := range map[string]string{
 		"actor display name": conv.PtrValOr(entry.ActorDisplayName, ""),
+		"actor slug":         entry.ActorSlug,
 		"actor id":           entry.ActorID,
 		"subject display":    entry.SubjectDisplay,
 		"subject slug":       entry.SubjectSlug,
@@ -560,4 +569,108 @@ func TestExtendTrial_AFailedAuditEntryRollsBackTheExtension(t *testing.T) {
 	count, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended)
 	require.NoError(t, err)
 	require.Zero(t, count)
+}
+
+// TestExtendTrial_ASecondExtensionThatUnblocksOntoAnExtendedTrialSucceeds is the
+// concurrency case the CTE created. Two operators extend the same trial in its
+// last moments: the first holds a row lock, the second blocks behind it, and the
+// seeded end date passes while it waits. By the time the second one unblocks the
+// trial has two more weeks on it, so the only correct answer is another
+// extension. A conflict here would tell an operator there is no running trial to
+// extend, about a trial that was just extended in front of them.
+//
+// The predicates therefore have to be evaluated by the locking read, which
+// re-evaluates against the newest row version once it unblocks. Left on the
+// outer UPDATE they run against the statement's own snapshot, which under READ
+// COMMITTED still shows the pre-extension row, and a row skipped by the qual
+// never reaches the recheck.
+func TestExtendTrial_ASecondExtensionThatUnblocksOntoAnExtendedTrialSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// Close enough that it expires while the second call is blocked, far enough
+	// that the first call still finds a running trial.
+	seededEndsAt := time.Now().UTC().Add(2 * time.Second)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_race", name: "Race Co", slug: "ext-race", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_race", endsAt: seededEndsAt})
+
+	// The first operator extends by a fortnight and holds the transaction open.
+	first := testenv.BeginTx(t, ctx, conn)
+	extended, err := trialsRepo.New(first).ExtendTrial(ctx, trialsRepo.ExtendTrialParams{
+		OrganizationID: "org_ext_race",
+		ExtendByDays:   14,
+	})
+	require.NoError(t, err)
+
+	second := make(chan error, 1)
+	go func() {
+		_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_race", Days: 3})
+		second <- err
+	}()
+
+	testenv.WaitForBlockedBackend(t, ctx, conn)
+
+	// The database's own clock, not the test process's: the seeded date has to
+	// have passed where the predicate is evaluated.
+	require.Eventually(t, func() bool {
+		clock, err := testrepo.New(conn).GetTransactionClockFixture(ctx)
+		return err == nil && clock.TransactionNow.Time.After(seededEndsAt)
+	}, 30*time.Second, 50*time.Millisecond, "expected the seeded end date to pass while the second extension was blocked")
+
+	select {
+	case err := <-second:
+		t.Fatalf("the second extension must still be blocked on the first, got %v", err)
+	default:
+	}
+
+	require.NoError(t, first.Commit(ctx))
+
+	require.NoError(t, <-second,
+		"an extension that unblocks onto a trial another operator just extended must not be reported as a conflict")
+
+	after := readTrial(t, ctx, conn, "org_ext_race")
+	require.WithinDuration(t, extended.EndsAt.Time.Add(3*24*time.Hour), after.EndsAt.Time, time.Second,
+		"the second extension must build on the first: first landed on %s, row now holds %s", extended.EndsAt.Time, after.EndsAt.Time)
+
+	// This is what the lock buys. FOR UPDATE returns the row version it waited
+	// for; a plain read returns the one its own snapshot shows, and the entry
+	// would claim the trial had been running only to the seeded date.
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialExtended)
+	require.NoError(t, err)
+
+	var metadata struct {
+		PreviousTrialEndsAt time.Time `json:"previous_trial_ends_at"`
+	}
+	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
+	require.WithinDuration(t, extended.EndsAt.Time, metadata.PreviousTrialEndsAt, 0,
+		"the entry must carry the date the first extension left the row on")
+}
+
+// TestExtendTrial_ADatabaseFailureIsNotReportedAsAConflict pins the branch that
+// tells pgx.ErrNoRows apart from every other error the extend query can answer.
+// Collapsing the two would tell an operator whose connection dropped, or whose
+// statement deadlocked, that the organization has no running trial to extend,
+// and would log nothing about the real fault.
+func TestExtendTrial_ADatabaseFailureIsNotReportedAsAConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	// A trial that is running in every respect, so a conflict here could only
+	// come from the handler collapsing the error, never from the guard.
+	seededEndsAt := time.Now().UTC().Add(10 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_ext_dberr", name: "DB Err Co", slug: "ext-dberr", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_ext_dberr", endsAt: seededEndsAt})
+	before := readTrial(t, ctx, conn, "org_ext_dberr")
+
+	// Failing the write deterministically, from outside the handler, with an
+	// error that is emphatically not a missing row.
+	testenv.RejectWritesTo(t, ctx, conn, "trials")
+
+	_, err := svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: "org_ext_dberr", Days: 3})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+
+	after := readTrial(t, ctx, conn, "org_ext_dberr")
+	require.Equal(t, before.EndsAt.Time, after.EndsAt.Time, "a failed extension must not move ends_at")
 }

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -721,10 +721,12 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		// rejectExtension reads on the pool, so this connection goes back before
-		// it asks for a second one. The deferred rollback is idempotent.
+		// rejectTrialChange reads on the pool, so this connection goes back
+		// before it asks for a second one. The deferred rollback is idempotent.
 		_ = tx.Rollback(ctx)
-		return nil, s.rejectExtension(ctx, logger, payload.ID)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID,
+			"look up organization after unextended trial",
+			"organization has no running enterprise trial to extend")
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "extend trial").LogError(ctx, logger)
 	}
@@ -768,16 +770,22 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial extension")
 }
 
-// rejectExtension turns an unextended trial into the error the operator should
-// act on. There are two causes and only the second is a conflict: the
-// organization does not exist at all, or it exists and its trial cannot be
-// extended. Disable and enable both answer not-found for an id that matches
-// nothing, so an operator who pastes one bad id must not be told to go and look
-// at a trial by this endpoint alone.
+// rejectTrialChange turns a trial write that touched no row into the error the
+// operator should act on. There are two causes and only the second is a
+// conflict: the organization does not exist at all, or it exists and its trial
+// is in the wrong state. Disable and enable both answer not-found for an id that
+// matches nothing, so an operator who pastes one bad id must not be told to go
+// and look at a trial by this endpoint alone.
+//
+// The organization existing means the trial is what blocks the write: converted,
+// demoted, expired, or never granted. Which one is not the operator's business,
+// and arming a trial that was never granted is the auth flow's job rather than
+// this endpoint's. failed_precondition would read better than conflict, but the
+// admin service does not declare it, so it would leave as a 500.
 //
 // The lookup is on the failure path only, and runs on the pool because the
-// caller's transaction is about to be rolled back.
-func (s *Service) rejectExtension(ctx context.Context, logger *slog.Logger, organizationID string) error {
+// caller's transaction is already rolled back.
+func (s *Service) rejectTrialChange(ctx context.Context, logger *slog.Logger, organizationID string, lookupContext string, conflictMessage string) error {
 	_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
 		ID:        organizationID,
 		AllowSlug: false,
@@ -788,16 +796,10 @@ func (s *Service) rejectExtension(ctx context.Context, logger *slog.Logger, orga
 	case lookupErr != nil:
 		// Falling through to the conflict here would report a trial state we
 		// never managed to read.
-		return oops.E(oops.CodeUnexpected, lookupErr, "look up organization after unextended trial").LogError(ctx, logger)
+		return oops.E(oops.CodeUnexpected, lookupErr, "%s", lookupContext).LogError(ctx, logger)
 	}
 
-	// The organization exists, so it is the trial that blocks the write:
-	// converted, demoted, expired, or never granted. Which one is not the
-	// operator's business, and arming a trial that was never granted is the
-	// auth flow's job rather than this endpoint's. failed_precondition would
-	// read better than conflict, but the admin service does not declare it,
-	// so it would leave as a 500.
-	return oops.E(oops.CodeConflict, nil, "organization has no running enterprise trial to extend")
+	return oops.E(oops.CodeConflict, nil, "%s", conflictMessage)
 }
 
 // CreateOrganization creates an organization in WorkOS and then in Gram.
@@ -958,7 +960,12 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, s.rejectRearm(ctx, logger, payload.ID)
+		// rejectTrialChange reads on the pool, so this connection goes back
+		// before it asks for a second one. The deferred rollback is idempotent.
+		_ = tx.Rollback(ctx)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID,
+			"look up organization after unrearmed trial",
+			"organization has no demoted enterprise trial to re-arm")
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "re-arm trial").LogError(ctx, logger)
 	}
@@ -1004,25 +1011,6 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	)
 
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial re-arm")
-}
-
-// rejectRearm turns a zero-row re-arm into the error the operator should act
-// on: a pasted wrong id must report a missing organization, not a trial state.
-func (s *Service) rejectRearm(ctx context.Context, logger *slog.Logger, organizationID string) error {
-	_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
-		ID:        organizationID,
-		AllowSlug: false,
-	})
-	switch {
-	case errors.Is(lookupErr, pgx.ErrNoRows):
-		return oops.C(oops.CodeNotFound)
-	case lookupErr != nil:
-		// Falling through would report a trial state we never managed to read.
-		return oops.E(oops.CodeUnexpected, lookupErr, "look up organization after unrearmed trial").LogError(ctx, logger)
-	}
-
-	// Which of the three reasons applies is not the operator's business.
-	return oops.E(oops.CodeConflict, nil, "organization has no demoted enterprise trial to re-arm")
 }
 
 // reviveTrialKeys brings every platform key the organization holds back up, and

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -726,10 +726,8 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 		return nil, oops.E(oops.CodeUnexpected, err, "extend trial").LogError(ctx, logger)
 	}
 
-	// The audit entry is the customer's, so it has to name the organization
-	// rather than only its id. Re-arm gets those columns back from a write it
-	// already makes; extend writes nothing on organization_metadata, so it reads
-	// them, inside the transaction the entry commits with.
+	// The customer's feed names the organization, not only its id, and extend
+	// writes nothing on organization_metadata to get those columns back from.
 	organization, err := repo.New(tx).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
 		ID:        payload.ID,
 		AllowSlug: false,
@@ -774,8 +772,8 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 // nothing, so an operator who pastes one bad id must not be told to go and look
 // at a trial by this endpoint alone.
 //
-// The lookup is on the failure path only, and runs on the pool rather than the
-// caller's transaction, which is already unusable by the time it is reached.
+// The lookup is on the failure path only, and runs on the pool because the
+// caller's transaction is about to be rolled back.
 func (s *Service) rejectExtension(ctx context.Context, logger *slog.Logger, organizationID string) error {
 	_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
 		ID:        organizationID,

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -707,45 +707,96 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 		return nil, oops.E(oops.CodeInvalid, nil, "days must be between %d and %d", constants.MinTrialExtensionDays, constants.MaxTrialExtensionDays)
 	}
 
-	rows, err := trialsRepo.New(s.db).ExtendTrial(ctx, trialsRepo.ExtendTrialParams{
+	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin trial extension transaction").LogError(ctx, logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	extended, err := trialsRepo.New(tx).ExtendTrial(ctx, trialsRepo.ExtendTrialParams{
 		OrganizationID: payload.ID,
 		ExtendByDays:   int32(payload.Days),
 	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "extend trial").LogError(ctx, s.logger)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, s.rejectExtension(ctx, logger, payload.ID)
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "extend trial").LogError(ctx, logger)
 	}
-	// Zero rows has two causes that mean different things to the operator, and
-	// only the second is a conflict: the organization does not exist at all, or
-	// it exists and its trial cannot be extended. Disable and enable both answer
-	// not-found for an id that matches nothing, so an operator who pastes one bad
-	// id must not be told to go and look at a trial by this endpoint alone.
-	//
-	// The lookup is on the failure path only, so the happy path still costs one
-	// write and one read.
-	if rows == 0 {
-		_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
-			ID:        payload.ID,
-			AllowSlug: false,
-		})
-		switch {
-		case errors.Is(lookupErr, pgx.ErrNoRows):
-			return nil, oops.C(oops.CodeNotFound)
-		case lookupErr != nil:
-			// Falling through to the conflict here would report a trial state we
-			// never managed to read.
-			return nil, oops.E(oops.CodeUnexpected, lookupErr, "look up organization after unextended trial").LogError(ctx, s.logger)
-		}
 
-		// The organization exists, so it is the trial that blocks the write:
-		// converted, demoted, expired, or never granted. Which one is not the
-		// operator's business, and arming a trial that was never granted is the
-		// auth flow's job rather than this endpoint's. failed_precondition would
-		// read better than conflict, but the admin service does not declare it,
-		// so it would leave as a 500.
-		return nil, oops.E(oops.CodeConflict, nil, "organization has no running enterprise trial to extend")
+	// The audit entry is the customer's, so it has to name the organization
+	// rather than only its id. Re-arm gets those columns back from a write it
+	// already makes; extend writes nothing on organization_metadata, so it reads
+	// them, inside the transaction the entry commits with.
+	organization, err := repo.New(tx).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
+		ID:        payload.ID,
+		AllowSlug: false,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "read organization for trial extension").LogError(ctx, logger)
 	}
+
+	actor, operatorEmail := adminActor(ctx)
+	if err := s.audit.LogOrganizationEnterpriseTrialExtended(ctx, tx, audit.LogOrganizationEnterpriseTrialExtendedEvent{
+		OrganizationID: payload.ID,
+		Actor:          actor,
+		// The customer reads this feed, so the entry carries the team label
+		// rather than the operator's email. adminActor says why.
+		ActorDisplayName:    conv.PtrEmpty(audit.SpeakeasyTeamActorLabel),
+		ActorSlug:           nil,
+		OrganizationName:    organization.Name,
+		OrganizationSlug:    organization.Slug,
+		ExtendedByDays:      payload.Days,
+		PreviousTrialEndsAt: extended.PreviousEndsAt.Time,
+		TrialEndsAt:         extended.EndsAt.Time,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log trial extension").LogError(ctx, logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit trial extension").LogError(ctx, logger)
+	}
+
+	// Speakeasy-only, and the only place the email meets the entry's subject.
+	logger.InfoContext(ctx, "extended enterprise trial",
+		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
+	)
 
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial extension")
+}
+
+// rejectExtension turns an unextended trial into the error the operator should
+// act on. There are two causes and only the second is a conflict: the
+// organization does not exist at all, or it exists and its trial cannot be
+// extended. Disable and enable both answer not-found for an id that matches
+// nothing, so an operator who pastes one bad id must not be told to go and look
+// at a trial by this endpoint alone.
+//
+// The lookup is on the failure path only, and runs on the pool rather than the
+// caller's transaction, which is already unusable by the time it is reached.
+func (s *Service) rejectExtension(ctx context.Context, logger *slog.Logger, organizationID string) error {
+	_, lookupErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
+		ID:        organizationID,
+		AllowSlug: false,
+	})
+	switch {
+	case errors.Is(lookupErr, pgx.ErrNoRows):
+		return oops.C(oops.CodeNotFound)
+	case lookupErr != nil:
+		// Falling through to the conflict here would report a trial state we
+		// never managed to read.
+		return oops.E(oops.CodeUnexpected, lookupErr, "look up organization after unextended trial").LogError(ctx, logger)
+	}
+
+	// The organization exists, so it is the trial that blocks the write:
+	// converted, demoted, expired, or never granted. Which one is not the
+	// operator's business, and arming a trial that was never granted is the
+	// auth flow's job rather than this endpoint's. failed_precondition would
+	// read better than conflict, but the admin service does not declare it,
+	// so it would leave as a 500.
+	return oops.E(oops.CodeConflict, nil, "organization has no running enterprise trial to extend")
 }
 
 // CreateOrganization creates an organization in WorkOS and then in Gram.

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -721,6 +721,9 @@ func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPaylo
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
+		// rejectExtension reads on the pool, so this connection goes back before
+		// it asks for a second one. The deferred rollback is idempotent.
+		_ = tx.Rollback(ctx)
 		return nil, s.rejectExtension(ctx, logger, payload.ID)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "extend trial").LogError(ctx, logger)

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -772,6 +772,7 @@ func TestRearmTrial_AuditEntryNamesTheTeamAndNotTheOperator(t *testing.T) {
 	// The subject is opaque, so it is not the email in another shape.
 	for name, field := range map[string]string{
 		"actor display name": conv.PtrValOr(entry.ActorDisplayName, ""),
+		"actor slug":         entry.ActorSlug,
 		"actor id":           entry.ActorID,
 		"subject display":    entry.SubjectDisplay,
 		"subject slug":       entry.SubjectSlug,

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -523,6 +523,9 @@ func TestRearmTrial_OrganizationWithNoTrialRow(t *testing.T) {
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_no_trial", Days: 14})
 	requireOopsCode(t, err, oops.CodeConflict)
+	// Extend and re-arm share one rejection helper, so each has to name its own
+	// message or the two can be swapped without a test noticing.
+	require.ErrorContains(t, err, "organization has no demoted enterprise trial to re-arm")
 
 	// Re-arm must never be a way to grant a trial; that is the auth flow's job.
 	_, err = trialsRepo.New(conn).GetTrial(ctx, "org_rearm_no_trial")

--- a/server/internal/audit/audittest/helpers.go
+++ b/server/internal/audit/audittest/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -82,4 +83,24 @@ func DecodeAuditData(payload []byte) (map[string]any, error) {
 	}
 
 	return snapshot, nil
+}
+
+// RejectAction makes every audit insert for one action fail, so a caller can
+// prove that its mutation and its entry commit together.
+//
+// It alters the schema, so it is only sound in a test that owns its database,
+// and it can be called once per database. There is no seam inside the Logger to
+// fail instead: it holds no state.
+func RejectAction(ctx context.Context, dbtx repo.DBTX, action audit.Action) error {
+	literal := strings.ReplaceAll(string(action), "'", "''")
+	stmt := fmt.Sprintf(
+		"ALTER TABLE audit_logs ADD CONSTRAINT audittest_reject_action CHECK (action <> '%s')",
+		literal,
+	)
+
+	if _, err := dbtx.Exec(ctx, stmt); err != nil {
+		return fmt.Errorf("reject audit action %s: %w", action, err)
+	}
+
+	return nil
 }

--- a/server/internal/audit/audittest/helpers.go
+++ b/server/internal/audit/audittest/helpers.go
@@ -25,13 +25,16 @@ type LogRecord struct {
 	ActorType        string
 	ActorDisplayName *string
 	ActorDisplay     string
-	SubjectID        string
-	SubjectType      string
-	SubjectDisplay   string
-	SubjectSlug      string
-	Metadata         []byte
-	BeforeSnapshot   []byte
-	AfterSnapshot    []byte
+	// The feed returns this alongside the display name, and the staff mask
+	// clears it only for an actor id that resolves to a Gram user.
+	ActorSlug      string
+	SubjectID      string
+	SubjectType    string
+	SubjectDisplay string
+	SubjectSlug    string
+	Metadata       []byte
+	BeforeSnapshot []byte
+	AfterSnapshot  []byte
 }
 
 func LatestAuditLogByAction(ctx context.Context, dbtx repo.DBTX, action audit.Action) (LogRecord, error) {
@@ -48,6 +51,7 @@ func LatestAuditLogByAction(ctx context.Context, dbtx repo.DBTX, action audit.Ac
 		ActorType:        row.ActorType,
 		ActorDisplayName: conv.FromPGText[string](row.ActorDisplayName),
 		ActorDisplay:     conv.PtrValOr(conv.FromPGText[string](row.ActorDisplayName), ""),
+		ActorSlug:        conv.PtrValOr(conv.FromPGText[string](row.ActorSlug), ""),
 		SubjectID:        row.SubjectID,
 		SubjectType:      row.SubjectType,
 		SubjectDisplay:   conv.PtrValOr(conv.FromPGText[string](row.SubjectDisplayName), ""),

--- a/server/internal/audit/audittest/queries.sql
+++ b/server/internal/audit/audittest/queries.sql
@@ -6,6 +6,7 @@ SELECT
   actor_id,
   actor_type,
   actor_display_name,
+  actor_slug,
   subject_id,
   subject_type,
   subject_display_name,

--- a/server/internal/audit/audittest/repo/queries.sql.go
+++ b/server/internal/audit/audittest/repo/queries.sql.go
@@ -45,6 +45,7 @@ SELECT
   actor_id,
   actor_type,
   actor_display_name,
+  actor_slug,
   subject_id,
   subject_type,
   subject_display_name,
@@ -65,6 +66,7 @@ type GetLatestAuditLogByActionRow struct {
 	ActorID            string
 	ActorType          string
 	ActorDisplayName   pgtype.Text
+	ActorSlug          pgtype.Text
 	SubjectID          string
 	SubjectType        string
 	SubjectDisplayName pgtype.Text
@@ -84,6 +86,7 @@ func (q *Queries) GetLatestAuditLogByAction(ctx context.Context, action string) 
 		&i.ActorID,
 		&i.ActorType,
 		&i.ActorDisplayName,
+		&i.ActorSlug,
 		&i.SubjectID,
 		&i.SubjectType,
 		&i.SubjectDisplayName,

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -431,8 +431,9 @@ func (l *Logger) LogOrganizationEnterpriseTrialRearmed(ctx context.Context, dbtx
 }
 
 // LogOrganizationEnterpriseTrialExtendedEvent records an operator moving a
-// running trial's end date forward. Both dates are carried because the day count
-// alone cannot be turned back into the date the trial used to end.
+// running trial's end date forward. Both dates are carried so the entry never
+// depends on inverting the calendar-day arithmetic, which is exact only while
+// every session runs in UTC.
 type LogOrganizationEnterpriseTrialExtendedEvent struct {
 	OrganizationID string
 

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -30,6 +30,8 @@ const (
 	ActionOrganizationEnterpriseTrialDemoted Action = "organization:enterprise_trial_demoted"
 
 	ActionOrganizationEnterpriseTrialRearmed Action = "organization:enterprise_trial_rearmed"
+
+	ActionOrganizationEnterpriseTrialExtended Action = "organization:enterprise_trial_extended"
 )
 
 type LogOrganizationInviteCreateEvent struct {
@@ -399,6 +401,60 @@ func (l *Logger) LogOrganizationEnterpriseTrialRearmed(ctx context.Context, dbtx
 	metadata, err := marshalAuditPayload(map[string]any{
 		"account_type":  event.AccountType,
 		"trial_ends_at": event.TrialEndsAt,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.OrganizationID,
+		SubjectType:        "organization",
+		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.OrganizationSlug),
+
+		Metadata:       metadata,
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationEnterpriseTrialV1})
+}
+
+// LogOrganizationEnterpriseTrialExtendedEvent records an operator moving a
+// running trial's end date forward. Both dates are carried because the day count
+// alone cannot be turned back into the date the trial used to end.
+type LogOrganizationEnterpriseTrialExtendedEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	OrganizationName string
+	OrganizationSlug string
+
+	ExtendedByDays      int
+	PreviousTrialEndsAt time.Time
+	TrialEndsAt         time.Time
+}
+
+func (l *Logger) LogOrganizationEnterpriseTrialExtended(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialExtendedEvent) error {
+	action := ActionOrganizationEnterpriseTrialExtended
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"extended_by_days":       event.ExtendedByDays,
+		"previous_trial_ends_at": event.PreviousTrialEndsAt,
+		"trial_ends_at":          event.TrialEndsAt,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -45,7 +45,7 @@ var (
 	OpenRouterAPIKeyV1                     = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.openrouter_api_key_event_v1", "Emitted when changes to the organization's platform OpenRouter key are made")
 	OrganizationHooksFailOpenV1            = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_hooks_fail_open_event_v1", "Emitted when the organization's hooks fail-open setting is toggled")
 	OrganizationDeviceAgentConfigurationV1 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_device_agent_configuration_event_v1", "Emitted when the organization's device-agent configuration is changed")
-	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, demoted, or re-armed")
+	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed")
 	OrganizationInviteV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_invite_event_v1", "Emitted when changes to organization invites are made")
 	OrganizationWebhooksV1                 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_webhooks_event_v1", "Emitted when changes to organization webhooks are made")
 	OtelForwardingV1                       = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.otel_forwarding_event_v1", "Emitted when changes to OTEL forwarding configs are made")

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -1626,7 +1626,7 @@ webhooks:
                 required: true
     audit_log.organization_enterprise_trial_event_v1:
         post:
-            description: Emitted when the organization's enterprise trial is armed, demoted, or re-armed
+            description: Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed
             operationId: audit_log.organization_enterprise_trial_event_v1
             requestBody:
                 content:

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -76,6 +77,50 @@ func NewMeterProvider(t *testing.T) metric.MeterProvider {
 	t.Helper()
 
 	return metricnoop.NewMeterProvider()
+}
+
+// WaitForBlockedBackend blocks until some backend in this database is waiting
+// on a lock another one holds. A concurrency test needs it to know its second
+// connection has really blocked: a sleep long enough to be safe would still let
+// a slow start pass the test for the wrong reason.
+//
+// The query is raw because pg_stat_activity is a system view sqlc's catalog does
+// not carry, and it is scoped to the current database because the Postgres
+// instance is shared with every other package's cloned test databases. It reads
+// pg_stat_activity rather than pg_locks because a backend queued behind a row
+// lock waits on a transactionid lock, whose pg_locks row has no database.
+func WaitForBlockedBackend(t *testing.T, ctx context.Context, conn *pgxpool.Pool) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		var blocked int64
+		err := conn.QueryRow(ctx, `
+			SELECT count(*)
+			FROM pg_stat_activity
+			WHERE datname = current_database()
+			  AND wait_event_type = 'Lock'
+		`).Scan(&blocked)
+
+		return err == nil && blocked > 0
+	}, 30*time.Second, 10*time.Millisecond, "expected a backend to block on a lock")
+}
+
+// RejectWritesTo makes every insert and update on one table fail with a check
+// constraint violation, so a caller can prove how its handler reports a database
+// error that is not pgx.ErrNoRows. NOT VALID leaves the rows already there
+// alone, so fixtures seeded beforehand stay readable.
+//
+// It alters the schema, so it is only sound in a test that owns its database,
+// and it can be called once per table per database.
+func RejectWritesTo(t *testing.T, ctx context.Context, conn *pgxpool.Pool, table string) {
+	t.Helper()
+
+	name := pgx.Identifier{"testenv_reject_writes_" + table}.Sanitize()
+	stmt := "ALTER TABLE " + pgx.Identifier{table}.Sanitize() +
+		" ADD CONSTRAINT " + name + " CHECK (false) NOT VALID"
+
+	_, err := conn.Exec(ctx, stmt)
+	require.NoError(t, err)
 }
 
 // BeginTx starts a transaction that's rolled back on test cleanup, so tests

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -90,8 +90,15 @@ RETURNING *;
 -- The previous ends_at comes back from a CTE that reads the row before the
 -- update rather than from subtracting the interval afterwards: the calendar-day
 -- arithmetic above has no exact inverse across a daylight saving boundary, and
--- the audit entry has to carry the date the row actually held. The UPDATE joins
--- the CTE so the locking read runs first, as DemoteOrganizationToFree does.
+-- the audit entry has to carry the date the row actually held.
+--
+-- Every condition sits on the locking read and the UPDATE keeps only the join.
+-- That placement is load-bearing under READ COMMITTED. FOR UPDATE re-evaluates
+-- its own conditions against the newest row version once it stops waiting on a
+-- competing writer; the UPDATE's scan cannot, because a row its snapshot already
+-- rejects is skipped before the lock is ever taken. With the conditions on the
+-- UPDATE, a second operator extending a trial in its last moments unblocks onto
+-- a row that just gained two weeks and is told there is no running trial.
 --
 -- The three conditions are not equally load-bearing today, and it is worth
 -- saying which is which:
@@ -122,6 +129,9 @@ WITH previous AS (
     SELECT trials.organization_id, trials.ends_at
     FROM trials
     WHERE trials.organization_id = @organization_id
+      AND trials.converted_at IS NULL
+      AND trials.demoted_at IS NULL
+      AND trials.ends_at > clock_timestamp()
     FOR UPDATE
 )
 UPDATE trials
@@ -129,9 +139,6 @@ SET ends_at = trials.ends_at + make_interval(days => @extend_by_days::int),
     updated_at = clock_timestamp()
 FROM previous
 WHERE trials.organization_id = previous.organization_id
-  AND trials.converted_at IS NULL
-  AND trials.demoted_at IS NULL
-  AND trials.ends_at > clock_timestamp()
 RETURNING previous.ends_at AS previous_ends_at, trials.ends_at;
 
 -- name: RearmTrial :one

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -67,7 +67,7 @@ WHERE organization_id = @organization_id
   AND demoted_at IS NULL
 RETURNING *;
 
--- name: ExtendTrial :execrows
+-- name: ExtendTrial :one
 -- Operator-initiated extension. The interval is added to the existing ends_at
 -- rather than to the current time: "give them another two weeks" means two weeks
 -- on top of whatever the trial has left, and adding to now would silently
@@ -82,10 +82,16 @@ RETURNING *;
 -- session TimeZone has to revisit them.
 --
 -- Only a running trial can be extended, and the conditions that define running
--- are here rather than in the handler so the database enforces them. Zero rows
+-- are here rather than in the handler so the database enforces them. No row
 -- means either that the trial cannot be extended or that the organization does
--- not exist at all; the two share a row count but not an operator action, so the
--- handler tells them apart with a follow-up read rather than merging them.
+-- not exist at all; the two share an empty result but not an operator action, so
+-- the handler tells them apart with a follow-up read rather than merging them.
+--
+-- The previous ends_at comes back from a CTE that reads the row before the
+-- update rather than from subtracting the interval afterwards: the calendar-day
+-- arithmetic above has no exact inverse across a daylight saving boundary, and
+-- the audit entry has to carry the date the row actually held. The UPDATE joins
+-- the CTE so the locking read runs first, as DemoteOrganizationToFree does.
 --
 -- The three conditions are not equally load-bearing today, and it is worth
 -- saying which is which:
@@ -112,13 +118,21 @@ RETURNING *;
 --     afterwards should not have silently lost the ability to extend in between,
 --     and a trial that keeps expiring during the investigation punishes the
 --     investigation.
+WITH previous AS (
+    SELECT trials.organization_id, trials.ends_at
+    FROM trials
+    WHERE trials.organization_id = @organization_id
+    FOR UPDATE
+)
 UPDATE trials
-SET ends_at = ends_at + make_interval(days => @extend_by_days::int),
+SET ends_at = trials.ends_at + make_interval(days => @extend_by_days::int),
     updated_at = clock_timestamp()
-WHERE organization_id = @organization_id
-  AND converted_at IS NULL
-  AND demoted_at IS NULL
-  AND ends_at > clock_timestamp();
+FROM previous
+WHERE trials.organization_id = previous.organization_id
+  AND trials.converted_at IS NULL
+  AND trials.demoted_at IS NULL
+  AND trials.ends_at > clock_timestamp()
+RETURNING previous.ends_at AS previous_ends_at, trials.ends_at;
 
 -- name: RearmTrial :one
 -- Operator-initiated reinstatement of a demoted trial. Returns the tier the

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -67,6 +67,9 @@ WITH previous AS (
     SELECT trials.organization_id, trials.ends_at
     FROM trials
     WHERE trials.organization_id = $2
+      AND trials.converted_at IS NULL
+      AND trials.demoted_at IS NULL
+      AND trials.ends_at > clock_timestamp()
     FOR UPDATE
 )
 UPDATE trials
@@ -74,9 +77,6 @@ SET ends_at = trials.ends_at + make_interval(days => $1::int),
     updated_at = clock_timestamp()
 FROM previous
 WHERE trials.organization_id = previous.organization_id
-  AND trials.converted_at IS NULL
-  AND trials.demoted_at IS NULL
-  AND trials.ends_at > clock_timestamp()
 RETURNING previous.ends_at AS previous_ends_at, trials.ends_at
 `
 
@@ -112,8 +112,15 @@ type ExtendTrialRow struct {
 // The previous ends_at comes back from a CTE that reads the row before the
 // update rather than from subtracting the interval afterwards: the calendar-day
 // arithmetic above has no exact inverse across a daylight saving boundary, and
-// the audit entry has to carry the date the row actually held. The UPDATE joins
-// the CTE so the locking read runs first, as DemoteOrganizationToFree does.
+// the audit entry has to carry the date the row actually held.
+//
+// Every condition sits on the locking read and the UPDATE keeps only the join.
+// That placement is load-bearing under READ COMMITTED. FOR UPDATE re-evaluates
+// its own conditions against the newest row version once it stops waiting on a
+// competing writer; the UPDATE's scan cannot, because a row its snapshot already
+// rejects is skipped before the lock is ever taken. With the conditions on the
+// UPDATE, a second operator extending a trial in its last moments unblocks onto
+// a row that just gained two weeks and is told there is no running trial.
 //
 // The three conditions are not equally load-bearing today, and it is worth
 // saying which is which:

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -62,19 +62,32 @@ func (q *Queries) DemoteOrganizationToFree(ctx context.Context, organizationID s
 	return i, err
 }
 
-const extendTrial = `-- name: ExtendTrial :execrows
+const extendTrial = `-- name: ExtendTrial :one
+WITH previous AS (
+    SELECT trials.organization_id, trials.ends_at
+    FROM trials
+    WHERE trials.organization_id = $2
+    FOR UPDATE
+)
 UPDATE trials
-SET ends_at = ends_at + make_interval(days => $1::int),
+SET ends_at = trials.ends_at + make_interval(days => $1::int),
     updated_at = clock_timestamp()
-WHERE organization_id = $2
-  AND converted_at IS NULL
-  AND demoted_at IS NULL
-  AND ends_at > clock_timestamp()
+FROM previous
+WHERE trials.organization_id = previous.organization_id
+  AND trials.converted_at IS NULL
+  AND trials.demoted_at IS NULL
+  AND trials.ends_at > clock_timestamp()
+RETURNING previous.ends_at AS previous_ends_at, trials.ends_at
 `
 
 type ExtendTrialParams struct {
 	ExtendByDays   int32
 	OrganizationID string
+}
+
+type ExtendTrialRow struct {
+	PreviousEndsAt pgtype.Timestamptz
+	EndsAt         pgtype.Timestamptz
 }
 
 // Operator-initiated extension. The interval is added to the existing ends_at
@@ -91,10 +104,16 @@ type ExtendTrialParams struct {
 // session TimeZone has to revisit them.
 //
 // Only a running trial can be extended, and the conditions that define running
-// are here rather than in the handler so the database enforces them. Zero rows
+// are here rather than in the handler so the database enforces them. No row
 // means either that the trial cannot be extended or that the organization does
-// not exist at all; the two share a row count but not an operator action, so the
-// handler tells them apart with a follow-up read rather than merging them.
+// not exist at all; the two share an empty result but not an operator action, so
+// the handler tells them apart with a follow-up read rather than merging them.
+//
+// The previous ends_at comes back from a CTE that reads the row before the
+// update rather than from subtracting the interval afterwards: the calendar-day
+// arithmetic above has no exact inverse across a daylight saving boundary, and
+// the audit entry has to carry the date the row actually held. The UPDATE joins
+// the CTE so the locking read runs first, as DemoteOrganizationToFree does.
 //
 // The three conditions are not equally load-bearing today, and it is worth
 // saying which is which:
@@ -121,12 +140,11 @@ type ExtendTrialParams struct {
 //     afterwards should not have silently lost the ability to extend in between,
 //     and a trial that keeps expiring during the investigation punishes the
 //     investigation.
-func (q *Queries) ExtendTrial(ctx context.Context, arg ExtendTrialParams) (int64, error) {
-	result, err := q.db.Exec(ctx, extendTrial, arg.ExtendByDays, arg.OrganizationID)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+func (q *Queries) ExtendTrial(ctx context.Context, arg ExtendTrialParams) (ExtendTrialRow, error) {
+	row := q.db.QueryRow(ctx, extendTrial, arg.ExtendByDays, arg.OrganizationID)
+	var i ExtendTrialRow
+	err := row.Scan(&i.PreviousEndsAt, &i.EndsAt)
+	return i, err
 }
 
 const getActiveTrial = `-- name: GetActiveTrial :one


### PR DESCRIPTION
Extending an enterprise trial was the one trial lifecycle event that left no trace in the organization's audit feed, and fixing that uncovered a concurrency defect in the extend query itself.

Closes AGE-3212.

## What changed

Three commits, each readable on its own.

**`fix: record an audit entry when a trial is extended`.** Arming, demoting and re-arming a trial all write an audit entry. Extending did not. `ExtendTrial` now runs in a transaction and writes the entry alongside the update, so an extension that lands cannot leave the feed silent. The entry carries the Speakeasy team label rather than the operator, as re-arm already does, and records the end date the row held before the extension, the end date it holds now, and the day count applied.

The query now returns the row rather than a row count, and captures the previous `ends_at` from a CTE read rather than by subtracting the interval afterwards. Calendar-day arithmetic has no exact inverse across a daylight saving boundary.

**`fix: evaluate the extend-trial guard on the locking read`.** See below. This is the part worth a reviewer's attention.

**`fix: widen the race test's seed window to five seconds`.** Flake prevention, measured rather than guessed.

## The concurrency defect

A second operator extending a trial in its last moments was told the organization had no running trial to extend, about a trial that had just gained two weeks in front of them.

The CTE locked on `organization_id` alone and left the three running-trial conditions on the outer `UPDATE`. Under READ COMMITTED that scan evaluates them against its own snapshot, which still shows the row as it was before the competing transaction committed, and **a row the snapshot rejects is skipped before the lock is ever taken**, so the EvalPlanQual recheck never runs. `FOR UPDATE` does re-evaluate its own conditions against the newest row version once it stops waiting.

So all three conditions move onto the locking read and the `UPDATE` keeps only the join. That placement is load-bearing, not cosmetic.

A two-connection test pins the case. It also pins that the previous end date on the audit entry is the one the competing extension left behind, not the one this statement's snapshot saw.

Reviewers may want to check one thing in particular: the outer `UPDATE` now carries only `trials.organization_id = previous.organization_id`, which would fan out across every historical row if an organization could have more than one trial. It cannot. `trials_pkey PRIMARY KEY (organization_id)` in `server/database/schema.sql` is one row per organization and is the only key on the table.

## Known limits, stated rather than hidden

- **An extend arriving while a competing re-arm holds the lock returns a conflict without blocking**, because the CTE's snapshot rejects the demoted row before the lock is taken. The answer is still "no running trial" about a trial that was just re-armed. This is not a regression in either direction: the pre-CTE single-statement form behaved the same way, for the same reason, so this restores the earlier latency behaviour. It is the ordinary READ COMMITTED property that a statement answers from its start-time snapshot, and it is strictly milder than the defect being fixed, where the statement waited, observed a changed world, and still answered from the stale one. Removing it would mean giving up the predicate placement this commit exists to establish.
- **`WaitForBlockedBackend` is imprecise as a shared primitive.** It matches any backend in the database waiting on a lock, not a specific backend or query. That is sound here, because the database is per-test and only two connections are active, but a future caller with other concurrent activity would get a false positive, including a caller that used `RejectWritesTo` on the same database. The two helpers are safe together today only because no test calls both.
- **`RejectWritesTo` has no timeout on its `ACCESS EXCLUSIVE` acquisition.** It would block rather than fail if a caller held a lock on the table. That terminates at the test binary's timeout rather than never, since the context is the test's own.
- **The two new helpers sit in `server/internal/testenv`, which is imported by every test package.** They are additive and hold no global state. glint's `notestingrawsql` rule fires only on `_test.go` files, so they genuinely cannot live in a test file, and neither query is expressible through sqlc: `pg_stat_activity` is not in the catalog, and the `ALTER TABLE` has a dynamic identifier. A test-support package local to admin would fit `RejectWritesTo` better, since it has exactly one caller, but that is a new package for one function.

## A client file in a server change

`client/dashboard/src/lib/audit-actions.ts` is in this diff deliberately. Adding an audit action constant on the server without the matching dashboard entry renders the entry through the unknown-action fallback, so the customer's feed reads "Speakeasy Team enterprised trial extended". The parity test that guards this was already red on the branch, and it lives on the client side of a paths filter that a server-only diff does not trip, so CI would not have caught it.

## Verification

Re-run independently of the authoring session, on the final tip:

| Gate | Result |
| --- | --- |
| `mise run build:server` | 0 |
| `mise run lint:server` | 0 |
| `go test -count=1` over admin, audit, trials, outbox | 0 |
| `go test -count=1 ./internal/admin/...` on the final commit | 0, 21.6s |

A review round of four reviewers ran before this PR, with a second focused pass over the fix batch: 44 mutations, 33 killed, 10 canaries all survived, plus one anti-canary that correctly died. The audit sweeps that prove an operator's email never reaches a customer's feed now enumerate `ActorSlug`, which they could not do before, and the same blind spot has been closed on the re-arm sweep.

The seed-window change was measured rather than assumed: 2.08s to 5.08s for the isolated test, but the admin package is about 20.2s at either value, because the test is `t.Parallel()` and is nowhere near the critical path. The cost is real only for a developer running that single test by name, and zero on the shard that actually flakes.

No schema or migration change, and no `server/design` or `server/gen` change, so no SDK regeneration is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records an audit entry when extending an enterprise trial and hardens concurrency and rejection-path behavior. Previously, extend wrote no audit, evaluated guards on the UPDATE snapshot, and performed a reject lookup while holding a failed transaction; now `ExtendTrial` runs in a transaction, evaluates guards on a locking read, returns previous/new `ends_at`, logs the event, and rolls back before the not-found lookup. Addresses Linear `AGE-3212`.

- Evaluates running-trial guards in a CTE `FOR UPDATE` read; the outer UPDATE now only joins on `organization_id`, preventing stale-snapshot skips under READ COMMITTED. A second extension that unblocks after another extension now succeeds, and the audit metadata’s previous end date comes from the locking read.
- Writes `organization:enterprise_trial_extended` with the Speakeasy team label, the prior and new `ends_at`, and the day count; emits `OrganizationEnterpriseTrialV1` and adds the action to the dashboard phrase map.
- Shares a `rejectTrialChange` helper between extend and re-arm; both roll back the failed transaction before the organization lookup and assert distinct conflict messages, avoiding pool contention on rejections.
- Changes the extend query to return row data (previous and new `ends_at`) instead of a row count; captures the prior date from the locking read to avoid DST inversion.
- Adds focused tests and small helpers (`WaitForBlockedBackend`, `RejectWritesTo`), and includes `ActorSlug` in audit test reads; widens the race window for stability.
- No schema or migration changes; no SDK regeneration.

<sup>Written for commit db5d7fe4413596accd3847a55f7d6ba1e26fcaae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

