### PR TITLE
feat(admin): create an organization from the organizations list

### DIFF
--- a/.changeset/admin-create-organization-client.md
+++ b/.changeset/admin-create-organization-client.md
@@ -24,6 +24,8 @@ A refused name leaves the dialog open with the name still in it and the server's
 reason beside it, because a rejected name is one the operator wants to edit
 rather than retype. A deployment with no WorkOS configuration refuses this way
 too, so it reports that it cannot create organizations instead of failing
-silently. While a create is in flight, the confirm button, the cancel button, the
+silently. A refusal also leaves the list as it found it, so pressing Create while
+the list is still loading cannot leave the table saying there are no
+organizations. While a create is in flight, the confirm button, the cancel button, the
 close control and the Escape key are all held, so one press creates one
 organization.

--- a/.changeset/admin-create-organization-client.md
+++ b/.changeset/admin-create-organization-client.md
@@ -1,0 +1,29 @@
+---
+"admin": patch
+---
+
+Platform admins can now create an organization from the organizations list. The
+endpoint shipped without a caller, so opening an organization still meant leaving
+Gram for the WorkOS dashboard. A Create organization button sits at the end of
+the toolbar, takes a name, and creates the organization.
+
+What it creates is deliberately plain: no members, not whitelisted, no trial, and
+on the free tier. The server validates the name exactly as self-serve signup
+validates it, so an operator cannot name an organization something a customer
+could not have named it.
+
+The list is fetched again after a create rather than having the new row written
+into the page on screen. Where that row belongs depends on the sort, the filters
+and the page the operator is on, so putting it anywhere by hand would put it
+somewhere the server would not have. For the same reason the confirmation names
+the organization that was created and says the list may not show it: a list
+filtered to running trials is right to leave a new free-tier organization out,
+and the operator still needs to be told the write landed.
+
+A refused name leaves the dialog open with the name still in it and the server's
+reason beside it, because a rejected name is one the operator wants to edit
+rather than retype. A deployment with no WorkOS configuration refuses this way
+too, so it reports that it cannot create organizations instead of failing
+silently. While a create is in flight, the confirm button, the cancel button, the
+close control and the Escape key are all held, so one press creates one
+organization.

--- a/client/admin/src/pages/organizations/CreateOrganization.test.tsx
+++ b/client/admin/src/pages/organizations/CreateOrganization.test.tsx
@@ -55,10 +55,14 @@ const CREATED: AdminOrganization = {
   updated_at: "2026-01-02T00:00:00Z",
 };
 
-// Subscribes to the same list entry the page's table does, so an invalidation
-// is observable here as another call rather than as a spy on the cache.
+// A filtered page, not the bare key the component invalidates. The operator can
+// be on any filter and any page when they create, so a probe on the same key the
+// component names would leave that claim undefended: narrowing the invalidation,
+// or making it exact, would keep passing.
+const PROBE_PARAMS = { q: "placeholder", account_types: ["free"] };
+
 function ListProbe(): React.JSX.Element {
-  const { data } = useQuery(organizationsListQuery());
+  const { data } = useQuery(organizationsListQuery(PROBE_PARAMS));
   return <span data-testid="rows">{data?.organizations.length ?? -1}</span>;
 }
 
@@ -151,7 +155,9 @@ describe("creating an organization", () => {
   it("sends the name and closes", async () => {
     await open();
     type("Placeholder New");
-    submitForm();
+    // The button itself, once. Everything else here drives the form, so an
+    // inert primary control would otherwise go unnoticed.
+    fireEvent.click(submitButton());
 
     await waitFor(() => {
       expect(mocks.createOrganization).toHaveBeenCalledWith({
@@ -164,16 +170,35 @@ describe("creating an organization", () => {
   });
 
   it("names the organization it created, on screen and out loud", async () => {
+    // The server normalises the name it stores and answers with what it
+    // stored, so the two differ here on purpose: an assertion against a
+    // fixture that echoes the field would hold nothing.
+    mocks.createOrganization.mockResolvedValue({
+      ...CREATED,
+      name: "Placeholder New",
+    });
     await open();
-    type("Placeholder New");
+    type("placeholder    new");
     submitForm();
 
-    // From the response, not from the field: the server normalises the name.
     await screen.findByText(/Created Placeholder New\./);
+    expect(screen.queryByText(/placeholder    new/)).toBeNull();
     await waitFor(() => {
       expect(announce).toHaveBeenCalledWith(
         expect.stringContaining("Created Placeholder New."),
       );
+    });
+  });
+
+  it("clears the page's failure banner", async () => {
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    // A re-enable that failed reports in a banner on the page, and every
+    // sibling write clears it when the next one lands.
+    await waitFor(() => {
+      expect(showFailure).toHaveBeenCalledWith(null);
     });
   });
 
@@ -184,7 +209,14 @@ describe("creating an organization", () => {
 
     // The record is free tier with no trial, so a filtered list can be right
     // to leave it out and the confirmation cannot be "look at the table".
-    await screen.findByText(/may not show it under the current filters/);
+    const line = await screen.findByText(
+      /may not show it under the current filters/,
+    );
+    // The line is truncated in a row that also holds a search box and the
+    // filter chips, and the caveat is the half that gets clipped. This is an
+    // attribute assertion: happy-dom lays nothing out and cannot say what is
+    // on screen.
+    expect(line.getAttribute("title")).toBe(line.textContent);
   });
 
   it("trims the name before sending it", async () => {
@@ -241,6 +273,13 @@ describe("an empty name", () => {
     expect(mocks.createOrganization).not.toHaveBeenCalled();
   });
 
+  it("is marked required on the field", async () => {
+    await open();
+    // The submit is disabled until there is a name, and a disabled control is
+    // no explanation. This is what a screen reader has to go on.
+    expect(nameField().required).toBe(true);
+  });
+
   it("leaves the submit disabled", async () => {
     await open();
     expect(submitButton().disabled).toBe(true);
@@ -248,6 +287,36 @@ describe("an empty name", () => {
     expect(submitButton().disabled).toBe(true);
     type("Placeholder New");
     expect(submitButton().disabled).toBe(false);
+  });
+});
+
+describe("cancelling", () => {
+  it("gives the keyboard back to the trigger", async () => {
+    await open();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Radix restores through the trigger, which is why this dialog needs no
+    // focus rescue of its own. Restoration runs on a timeout, so this waits.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Create organization" }),
+      );
+    });
+  });
+
+  it("sends nothing", async () => {
+    await open();
+    type("Placeholder New");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Cancel sits inside the form, so losing type="button" would make it
+    // submit: the button that abandons the write would create the
+    // organization.
+    expect(mocks.createOrganization).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });
 
@@ -330,6 +399,21 @@ describe("a refusal", () => {
     expect(nameField().value).toBe("Placeholder New");
   });
 
+  it("marks the field invalid and points it at the reason", async () => {
+    mocks.createOrganization.mockRejectedValue(refusal(REASON));
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    const alert = await screen.findByRole("alert");
+    const field = nameField();
+    expect(field.getAttribute("aria-invalid")).toBe("true");
+    // The operator tabs back to edit the rejected name, and the alert has
+    // already fired by then.
+    expect(field.getAttribute("aria-describedby")).toBe(alert.id);
+    expect(alert.id).toBeTruthy();
+  });
+
   it("reports nothing as created", async () => {
     mocks.createOrganization.mockRejectedValue(refusal(REASON));
     await open();
@@ -359,6 +443,24 @@ describe("a refusal", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });
+  });
+
+  it("does not sit beside the previous create's confirmation", async () => {
+    await open();
+    type("Placeholder New");
+    submitForm();
+    await screen.findByText(/Created Placeholder New\./);
+
+    mocks.createOrganization.mockRejectedValue(refusal(REASON));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create organization" }),
+    );
+    await screen.findByRole("dialog");
+
+    // Opening the dialog again is the operator saying the last create is
+    // done with. Leaving it up would put a success and a refusal on screen
+    // together.
+    expect(screen.queryByText(/Created Placeholder New\./)).toBeNull();
   });
 
   it("is not still showing when the dialog is reopened", async () => {

--- a/client/admin/src/pages/organizations/CreateOrganization.test.tsx
+++ b/client/admin/src/pages/organizations/CreateOrganization.test.tsx
@@ -1,0 +1,381 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { organizationQuery, organizationsListQuery } from "@/lib/adminQueries";
+import {
+  GramAdminError,
+  type AdminOrganization,
+  type CreateOrganizationRequest,
+  type ListOrganizationsResult,
+} from "@/lib/gramAdminApi";
+import { renderWithApp } from "@/test/harness";
+
+import { CreateOrganization } from "./CreateOrganization";
+
+// A synchronous read straight after a click misses TanStack Query's pending
+// state: its notify manager schedules on a macrotask. Every assertion about a
+// write in flight below goes through findBy* or waitFor for that reason.
+
+const mocks = vi.hoisted(() => ({
+  createOrganization:
+    vi.fn<(body: CreateOrganizationRequest) => Promise<AdminOrganization>>(),
+  listOrganizations: vi.fn<() => Promise<ListOrganizationsResult>>(),
+  getOrganization: vi.fn<(idOrSlug: string) => Promise<AdminOrganization>>(),
+  getOrganizationStats: vi.fn(),
+}));
+
+// The write and the reads it stales. errorMessage stays real, because what the
+// operator is told about a refusal is the subject of several of these tests.
+vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
+  return {
+    ...actual,
+    createOrganization: mocks.createOrganization,
+    listOrganizations: mocks.listOrganizations,
+    getOrganization: mocks.getOrganization,
+    getOrganizationStats: mocks.getOrganizationStats,
+  };
+});
+
+const CREATED: AdminOrganization = {
+  id: "org_placeholder_new",
+  name: "Placeholder New",
+  slug: "placeholder-new",
+  account_type: "free",
+  whitelisted: false,
+  member_count: 0,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+};
+
+// Subscribes to the same list entry the page's table does, so an invalidation
+// is observable here as another call rather than as a spy on the cache.
+function ListProbe(): React.JSX.Element {
+  const { data } = useQuery(organizationsListQuery());
+  return <span data-testid="rows">{data?.organizations.length ?? -1}</span>;
+}
+
+// Reads the detail entry the write fills in, by slug. Disabled, so it never
+// fetches: whatever it shows came out of the cache.
+function DetailProbe({ idOrSlug }: { idOrSlug: string }): React.JSX.Element {
+  const { data } = useQuery({ ...organizationQuery(idOrSlug), enabled: false });
+  return <span data-testid="detail">{data?.name ?? ""}</span>;
+}
+
+const announce = vi.fn<(text: string) => void>();
+const showFailure = vi.fn<(text: string | null) => void>();
+const REPORTER = { announce, showFailure };
+
+async function open(extra?: React.ReactNode): Promise<void> {
+  await renderWithApp(
+    <>
+      <CreateOrganization reporter={REPORTER} />
+      {extra}
+    </>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Create organization" }));
+  await screen.findByRole("dialog");
+}
+
+function nameField(): HTMLInputElement {
+  return screen.getByLabelText("Organization name") as HTMLInputElement;
+}
+
+function submitButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /^(Create|Creating\.\.\.)$/ });
+}
+
+// The form rather than the button: Enter in the field submits it too, so this
+// is the path a guard on the button alone does not cover.
+function submitForm(): void {
+  const form = screen.getByRole("dialog").querySelector("form");
+  if (!form) throw new Error("the dialog has no form");
+  fireEvent.submit(form);
+}
+
+function type(value: string): void {
+  fireEvent.change(nameField(), { target: { value } });
+}
+
+// A refusal that carries a readable body, which is what a deployment with no
+// WorkOS configuration answers with.
+function refusal(message: string): GramAdminError {
+  return new GramAdminError(422, { message }, "Unprocessable Entity");
+}
+
+// A write held open, so the pending state can be read before it lands.
+function deferred(): {
+  resolve: (org: AdminOrganization) => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: (org: AdminOrganization) => void;
+  let reject!: (error: Error) => void;
+  mocks.createOrganization.mockReturnValue(
+    new Promise<AdminOrganization>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    }),
+  );
+  return { resolve, reject };
+}
+
+beforeEach(() => {
+  mocks.createOrganization.mockReset();
+  mocks.createOrganization.mockResolvedValue(CREATED);
+  mocks.listOrganizations.mockReset();
+  mocks.listOrganizations.mockResolvedValue({ organizations: [] });
+  mocks.getOrganization.mockReset();
+  mocks.getOrganization.mockResolvedValue(CREATED);
+  announce.mockReset();
+  showFailure.mockReset();
+  mocks.getOrganizationStats.mockReset();
+  mocks.getOrganizationStats.mockResolvedValue({
+    total: 0,
+    created_last_7_days: 0,
+    trials_ending_soon: 0,
+    disabled: 0,
+    disabled_last_7_days: 0,
+  });
+});
+
+afterEach(cleanup);
+
+describe("creating an organization", () => {
+  it("sends the name and closes", async () => {
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    await waitFor(() => {
+      expect(mocks.createOrganization).toHaveBeenCalledWith({
+        name: "Placeholder New",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("names the organization it created, on screen and out loud", async () => {
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    // From the response, not from the field: the server normalises the name.
+    await screen.findByText(/Created Placeholder New\./);
+    await waitFor(() => {
+      expect(announce).toHaveBeenCalledWith(
+        expect.stringContaining("Created Placeholder New."),
+      );
+    });
+  });
+
+  it("says the new row may not be on the page", async () => {
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    // The record is free tier with no trial, so a filtered list can be right
+    // to leave it out and the confirmation cannot be "look at the table".
+    await screen.findByText(/may not show it under the current filters/);
+  });
+
+  it("trims the name before sending it", async () => {
+    await open();
+    type("  Placeholder New  ");
+    submitForm();
+
+    await waitFor(() => {
+      expect(mocks.createOrganization).toHaveBeenCalledWith({
+        name: "Placeholder New",
+      });
+    });
+  });
+
+  it("refetches the list", async () => {
+    await open(<ListProbe />);
+    await waitFor(() => {
+      expect(mocks.listOrganizations).toHaveBeenCalledTimes(1);
+    });
+
+    // The new record belongs wherever the sort, the filter and the cursor put
+    // it, so the page is fetched again rather than patched.
+    mocks.listOrganizations.mockResolvedValue({ organizations: [CREATED] });
+    type("Placeholder New");
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rows").textContent).toBe("1");
+    });
+  });
+
+  it("fills the detail cache under the slug", async () => {
+    await open(<DetailProbe idOrSlug={CREATED.slug} />);
+    type("Placeholder New");
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail").textContent).toBe(CREATED.name);
+    });
+    expect(mocks.getOrganization).not.toHaveBeenCalled();
+  });
+});
+
+describe("an empty name", () => {
+  it("does not reach the server", async () => {
+    await open();
+    submitForm();
+    type("   ");
+    submitForm();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mocks.createOrganization).not.toHaveBeenCalled();
+  });
+
+  it("leaves the submit disabled", async () => {
+    await open();
+    expect(submitButton().disabled).toBe(true);
+    type("   ");
+    expect(submitButton().disabled).toBe(true);
+    type("Placeholder New");
+    expect(submitButton().disabled).toBe(false);
+  });
+});
+
+describe("a write in flight", () => {
+  it("sends one request however many times it is submitted", async () => {
+    const write = deferred();
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    await waitFor(() => {
+      expect(mocks.createOrganization).toHaveBeenCalledTimes(1);
+    });
+    submitForm();
+    submitForm();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mocks.createOrganization).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      write.resolve(CREATED);
+    });
+  });
+
+  it("disables both buttons and the close control", async () => {
+    const write = deferred();
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    await waitFor(() => {
+      expect(submitButton().disabled).toBe(true);
+    });
+    expect(submitButton().textContent).toBe("Creating...");
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect((cancel as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+
+    await act(async () => {
+      write.resolve(CREATED);
+    });
+  });
+
+  it("does not close on Escape", async () => {
+    const write = deferred();
+    await open();
+    type("Placeholder New");
+    submitForm();
+    await waitFor(() => {
+      expect(mocks.createOrganization).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+
+    await act(async () => {
+      write.resolve(CREATED);
+    });
+  });
+});
+
+describe("a refusal", () => {
+  const REASON =
+    "this server has no WorkOS configuration, so it cannot create organizations";
+
+  it("stays open holding the reason and the name", async () => {
+    mocks.createOrganization.mockRejectedValue(refusal(REASON));
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toBe(REASON);
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+    // A rejected name is one the operator wants to edit, not retype.
+    expect(nameField().value).toBe("Placeholder New");
+  });
+
+  it("reports nothing as created", async () => {
+    mocks.createOrganization.mockRejectedValue(refusal(REASON));
+    await open();
+    type("Placeholder New");
+    submitForm();
+
+    await screen.findByRole("alert");
+    expect(screen.queryByText(/^Created /)).toBeNull();
+    expect(announce).not.toHaveBeenCalled();
+  });
+
+  it("can be submitted again after an edit", async () => {
+    mocks.createOrganization.mockRejectedValueOnce(refusal(REASON));
+    await open();
+    type("Placeholder New");
+    submitForm();
+    await screen.findByRole("alert");
+
+    type("Placeholder Newer");
+    submitForm();
+
+    await waitFor(() => {
+      expect(mocks.createOrganization).toHaveBeenLastCalledWith({
+        name: "Placeholder Newer",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("is not still showing when the dialog is reopened", async () => {
+    mocks.createOrganization.mockRejectedValue(refusal(REASON));
+    await open();
+    type("Placeholder New");
+    submitForm();
+    await screen.findByRole("alert");
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create organization" }),
+    );
+    await screen.findByRole("dialog");
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(nameField().value).toBe("");
+  });
+});

--- a/client/admin/src/pages/organizations/CreateOrganization.tsx
+++ b/client/admin/src/pages/organizations/CreateOrganization.tsx
@@ -1,0 +1,178 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useId, useState, type FormEvent, type JSX } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  cancelOrganizationFetches,
+  invalidateOrganizationStats,
+  organizationQuery,
+  organizationsListQuery,
+} from "@/lib/adminQueries";
+import {
+  createOrganization,
+  errorMessage,
+  type AdminOrganization,
+  type CreateOrganizationRequest,
+} from "@/lib/gramAdminApi";
+
+import type { WriteReporter } from "./OrganizationActions";
+
+/**
+ * Creates one organization from a name.
+ *
+ * What the server makes is deliberately plain: no members, not whitelisted, no
+ * trial, free tier. It also normalises the name, so the confirmation is worded
+ * from the response rather than from what was typed.
+ */
+export function CreateOrganization({
+  reporter,
+}: {
+  // Handed down rather than taken from context: this control is drawn above the
+  // table by the page that owns the live region, not from inside a row.
+  reporter: WriteReporter;
+}): JSX.Element {
+  const { announce } = reporter;
+  const qc = useQueryClient();
+  const nameField = useId();
+
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  // What the toolbar shows after a create lands. Spoken through the page's live
+  // region instead, which is the one region on this page.
+  const [created, setCreated] = useState("");
+
+  const create = useMutation({
+    mutationFn: (body: CreateOrganizationRequest) => createOrganization(body),
+    // A list read already in flight was asked before this write and lands
+    // after it, so it would answer the refetch below with pre-write rows.
+    onMutate: () => cancelOrganizationFetches(qc),
+    onSuccess: (org: AdminOrganization) => {
+      setOpen(false);
+      setName("");
+      // Named, because the row itself is not proof: the record is free tier
+      // with no trial, so a list filtered to running trials correctly does not
+      // show it, and the sort and the cursor decide the rest.
+      const done = `Created ${org.name}. The list may not show it under the current filters.`;
+      setCreated(done);
+      announce(done);
+
+      // The detail route takes either, and the response carries both, so
+      // opening the new organization paints without a fetch first.
+      qc.setQueryData(organizationQuery(org.id).queryKey, org);
+      if (org.slug) qc.setQueryData(organizationQuery(org.slug).queryKey, org);
+
+      // Invalidated rather than written into the page on screen. Where the new
+      // row belongs depends on the sort, the filter and the cursor, none of
+      // which this control can evaluate, so splicing it in would put it
+      // somewhere the server would not have.
+      invalidateOrganizationStats(qc);
+      return qc.invalidateQueries({
+        queryKey: organizationsListQuery().queryKey,
+      });
+    },
+    // The cancelled read has nothing to replace it, so the strip would keep
+    // three dashes until something else asked.
+    onError: () => invalidateOrganizationStats(qc),
+  });
+
+  // The server normalises surrounding and repeated whitespace away and answers
+  // with what it stored, so the trim only decides what counts as empty and
+  // keeps the request the same as the check.
+  const trimmed = name.trim();
+  const canSubmit = trimmed !== "" && !create.isPending;
+
+  const submit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    // Not the button's `disabled` alone: Enter in the field submits the form,
+    // and a second press while the first write is open would create a second
+    // organization.
+    if (!canSubmit) return;
+    create.mutate({ name: trimmed });
+  };
+
+  return (
+    <>
+      {/* Read as well as heard. The created row need not appear on the page, so
+          without this a sighted operator has no account of the write at all. */}
+      <span className="text-muted-foreground min-w-0 truncate text-xs">
+        {created}
+      </span>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          // Escape and the overlay both come through here, and neither may
+          // take the dialog away from a write that is still open.
+          if (!next && create.isPending) return;
+          if (next) {
+            setName("");
+            create.reset();
+          }
+          setOpen(next);
+        }}
+      >
+        <DialogTrigger asChild>
+          <Button size="sm">Create organization</Button>
+        </DialogTrigger>
+        <DialogContent showCloseButton={!create.isPending}>
+          <form onSubmit={submit}>
+            <DialogHeader>
+              <DialogTitle>Create an organization</DialogTitle>
+              <DialogDescription>
+                It is created with no members, no trial and the free account
+                type. Members are invited from the organization itself.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="my-4 grid gap-2">
+              <label htmlFor={nameField} className="text-sm font-medium">
+                Organization name
+              </label>
+              <Input
+                id={nameField}
+                value={name}
+                autoComplete="off"
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+
+            {/* A modal takes the rest of the page out of the accessibility
+                tree, the page's live region included, so a refusal the operator
+                is looking at needs its own. The name stays in the field: a
+                rejected name is one they want to edit, not retype. */}
+            {create.error && (
+              <p role="alert" className="text-destructive text-sm">
+                {errorMessage(create.error)}
+              </p>
+            )}
+
+            <DialogFooter className="mt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={create.isPending}
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={!canSubmit}>
+                {create.isPending ? "Creating..." : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/client/admin/src/pages/organizations/CreateOrganization.tsx
+++ b/client/admin/src/pages/organizations/CreateOrganization.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   cancelOrganizationFetches,
+  invalidateOrganizations,
   invalidateOrganizationStats,
   organizationQuery,
   organizationsListQuery,
@@ -30,9 +31,8 @@ import type { WriteReporter } from "./OrganizationActions";
 /**
  * Creates one organization from a name.
  *
- * What the server makes is deliberately plain: no members, not whitelisted, no
- * trial, free tier. It also normalises the name, so the confirmation is worded
- * from the response rather than from what was typed.
+ * The confirmation is worded from the response, because the server normalises
+ * the name it stores.
  */
 export function CreateOrganization({
   reporter,
@@ -41,14 +41,15 @@ export function CreateOrganization({
   // table by the page that owns the live region, not from inside a row.
   reporter: WriteReporter;
 }): JSX.Element {
-  const { announce } = reporter;
+  const { announce, showFailure } = reporter;
   const qc = useQueryClient();
   const nameField = useId();
+  const messageID = useId();
 
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
-  // What the toolbar shows after a create lands. Spoken through the page's live
-  // region instead, which is the one region on this page.
+  // What the toolbar shows after a create lands. It is spoken through the
+  // page's region, which is the only live region on this page.
   const [created, setCreated] = useState("");
 
   const create = useMutation({
@@ -57,45 +58,45 @@ export function CreateOrganization({
     // after it, so it would answer the refetch below with pre-write rows.
     onMutate: () => cancelOrganizationFetches(qc),
     onSuccess: (org: AdminOrganization) => {
-      setOpen(false);
-      setName("");
-      // Named, because the row itself is not proof: the record is free tier
-      // with no trial, so a list filtered to running trials correctly does not
-      // show it, and the sort and the cursor decide the rest.
+      // Named, because the row is not proof: a filtered list is right to leave
+      // a new free-tier organization out.
       const done = `Created ${org.name}. The list may not show it under the current filters.`;
       setCreated(done);
       announce(done);
+      // Ahead of the close, so the order the two reach the accessibility tree
+      // in is never a question.
+      setOpen(false);
+      setName("");
+      // The page's banner belongs to the last write that failed, and this one
+      // succeeded. Every sibling write clears it the same way.
+      showFailure(null);
 
       // The detail route takes either, and the response carries both, so
       // opening the new organization paints without a fetch first.
       qc.setQueryData(organizationQuery(org.id).queryKey, org);
       if (org.slug) qc.setQueryData(organizationQuery(org.slug).queryKey, org);
 
-      // Invalidated rather than written into the page on screen. Where the new
-      // row belongs depends on the sort, the filter and the cursor, none of
-      // which this control can evaluate, so splicing it in would put it
-      // somewhere the server would not have.
+      // Invalidated rather than spliced into the page on screen: the sort, the
+      // filters and the cursor decide where the new row belongs.
       invalidateOrganizationStats(qc);
       return qc.invalidateQueries({
         queryKey: organizationsListQuery().queryKey,
       });
     },
-    // The cancelled read has nothing to replace it, so the strip would keep
-    // three dashes until something else asked.
-    onError: () => invalidateOrganizationStats(qc),
+    // Everything onMutate cancelled. A cancelled read reverts and nothing
+    // restarts it, so the table would report no organizations at all.
+    onError: () => invalidateOrganizations(qc),
   });
 
-  // The server normalises surrounding and repeated whitespace away and answers
-  // with what it stored, so the trim only decides what counts as empty and
-  // keeps the request the same as the check.
+  // The server normalises whitespace itself, so the trim only decides what
+  // counts as empty and keeps the request the same as the check.
   const trimmed = name.trim();
   const canSubmit = trimmed !== "" && !create.isPending;
 
   const submit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     // Not the button's `disabled` alone: Enter in the field submits the form,
-    // and a second press while the first write is open would create a second
-    // organization.
+    // so a second press mid-write would create a second organization.
     if (!canSubmit) return;
     create.mutate({ name: trimmed });
   };
@@ -104,7 +105,10 @@ export function CreateOrganization({
     <>
       {/* Read as well as heard. The created row need not appear on the page, so
           without this a sighted operator has no account of the write at all. */}
-      <span className="text-muted-foreground min-w-0 truncate text-xs">
+      <span
+        title={created}
+        className="text-muted-foreground min-w-0 truncate text-xs"
+      >
         {created}
       </span>
 
@@ -117,6 +121,9 @@ export function CreateOrganization({
           if (next) {
             setName("");
             create.reset();
+            // The last create's confirmation would otherwise sit beside this
+            // one's refusal.
+            setCreated("");
           }
           setOpen(next);
         }}
@@ -124,6 +131,9 @@ export function CreateOrganization({
         <DialogTrigger asChild>
           <Button size="sm">Create organization</Button>
         </DialogTrigger>
+        {/* No focus rescue, unlike the dialogs in OrganizationActions.tsx:
+            those have no trigger to restore through and this one is mounted
+            for the life of the page. */}
         <DialogContent showCloseButton={!create.isPending}>
           <form onSubmit={submit}>
             <DialogHeader>
@@ -141,17 +151,25 @@ export function CreateOrganization({
               <Input
                 id={nameField}
                 value={name}
+                required
                 autoComplete="off"
+                aria-invalid={Boolean(create.error)}
+                // The alert fires once. An operator who tabs back to edit the
+                // rejected name would otherwise be told nothing at all.
+                aria-describedby={create.error ? messageID : undefined}
                 onChange={(event) => setName(event.target.value)}
               />
             </div>
 
-            {/* A modal takes the rest of the page out of the accessibility
-                tree, the page's live region included, so a refusal the operator
-                is looking at needs its own. The name stays in the field: a
-                rejected name is one they want to edit, not retype. */}
+            {/* Assertive and beside the field it belongs to, which is where
+                the operator is. The name stays put: a rejected name is one they
+                want to edit, not retype. */}
             {create.error && (
-              <p role="alert" className="text-destructive text-sm">
+              <p
+                id={messageID}
+                role="alert"
+                className="text-destructive text-sm"
+              >
                 {errorMessage(create.error)}
               </p>
             )}

--- a/client/admin/src/pages/organizations/Toolbar.tsx
+++ b/client/admin/src/pages/organizations/Toolbar.tsx
@@ -27,7 +27,9 @@ import { cn } from "@/lib/utils";
 import type { OrganizationsSearch } from "@/routes/organizations.index";
 
 import { useApplyFilters } from "./applyFilters";
+import { CreateOrganization } from "./CreateOrganization";
 import { FilterSheet } from "./FilterSheet";
+import type { WriteReporter } from "./OrganizationActions";
 
 const ROUTE_ID = "/organizations/";
 const SEARCH_DEBOUNCE_MS = 300;
@@ -38,9 +40,16 @@ type ToolbarProps = {
    * the debounce reached no URL, so the box has nothing else to notice by.
    */
   searchCleared: number;
+  // Passed straight through to the create control. This row sits outside the
+  // provider the row menu reads, and the live region it speaks through belongs
+  // to the page.
+  reporter: WriteReporter;
 };
 
-export function Toolbar({ searchCleared }: ToolbarProps): JSX.Element {
+export function Toolbar({
+  searchCleared,
+  reporter,
+}: ToolbarProps): JSX.Element {
   const search = useSearch({ from: ROUTE_ID });
   const navigate = useNavigate({ from: ROUTE_ID });
 
@@ -168,6 +177,11 @@ export function Toolbar({ searchCleared }: ToolbarProps): JSX.Element {
           if (group) triggers.current[group]?.focus();
         }}
       />
+
+      {/* Last in the row and the only filled control in it, so it reads as the
+          page's primary action rather than another way to narrow the list. */}
+      <span className="min-w-0 flex-1" />
+      <CreateOrganization reporter={reporter} />
     </div>
   );
 }

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -71,6 +71,8 @@ const mocks = vi.hoisted(() => ({
         body: BulkUpdateAccountTypeRequest,
       ) => Promise<BulkUpdateAccountTypeResult>
     >(),
+  createOrganization:
+    vi.fn<(body: { name: string }) => Promise<AdminOrganization>>(),
 }));
 
 // Only the endpoints this page's route tree reaches are replaced. The rest of
@@ -91,6 +93,7 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     enableOrganization: mocks.enableOrganization,
     extendTrial: mocks.extendTrial,
     bulkUpdateAccountType: mocks.bulkUpdateAccountType,
+    createOrganization: mocks.createOrganization,
   };
 });
 
@@ -413,6 +416,10 @@ beforeEach(() => {
   mocks.bulkUpdateAccountType.mockReset();
   mocks.bulkUpdateAccountType.mockImplementation(({ ids }) =>
     Promise.resolve({ updated_ids: [...ids].reverse(), missing_ids: [] }),
+  );
+  mocks.createOrganization.mockReset();
+  mocks.createOrganization.mockImplementation(({ name }) =>
+    Promise.resolve({ ...CREATED_ORG, name }),
   );
 });
 
@@ -3656,6 +3663,104 @@ describe("organizations list bulk account type", () => {
     expect(
       screen.getAllByRole("menuitem").map((item) => item.textContent),
     ).toEqual([...ACCOUNT_TYPE_OPTIONS]);
+  });
+});
+
+// A record neither row on the page carries, and free tier with no trial, which
+// is what the create endpoint makes.
+const CREATED_ORG: AdminOrganization = {
+  id: "org_placeholder_three",
+  name: "Placeholder Three",
+  slug: "placeholder-three",
+  account_type: "free",
+  whitelisted: false,
+  member_count: 0,
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+};
+
+// The control's own behaviour is covered in CreateOrganization.test.tsx. These
+// two are about the page: that it draws the control at all, and that what the
+// control says reaches the one live region, which is the whole reason the
+// announcement is routed through the page rather than spoken locally.
+describe("organizations list create organization", () => {
+  it("offers the create control in the toolbar", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    const control = screen.getByRole("button", { name: "Create organization" });
+    // In the search box's own row, not the strip inside the table: this is the
+    // page's action rather than the table's. The row is the search box's
+    // grandparent, and walking up from the box rather than down from the page
+    // keeps the assertion off every other container on it.
+    const row = screen
+      .getByLabelText("Search organizations")
+      .closest("div")?.parentElement;
+    expect(row?.contains(control)).toBe(true);
+  });
+
+  it("announces a created organization through the page's live region", async () => {
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    await screen.findByRole("link", { name: FIRST_ORG.name });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create organization" }),
+    );
+    fireEvent.change(await screen.findByLabelText("Organization name"), {
+      target: { value: CREATED_ORG.name },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    });
+
+    // The region itself, not a spy on the reporter. A control that announced
+    // into its own region, or into nothing, would pass every test in the
+    // component's own file and fail this one.
+    await waitFor(() => {
+      expect(announcement()).toContain(`Created ${CREATED_ORG.name}.`);
+    });
+  });
+});
+
+// The write cancels every organization read in flight before it goes out, and
+// this control is pressable while the page's first list read is still open: the
+// toolbar is drawn whether or not the rows have arrived. A cancelled read
+// reverts and nothing restarts it, so a refused create can leave the table on
+// its loading state with no request outstanding.
+describe("organizations list create organization: a refusal", () => {
+  it("leaves the list fetching rather than cancelled", async () => {
+    let releaseList!: (result: ListOrganizationsResult) => void;
+    mocks.listOrganizations.mockReturnValueOnce(
+      new Promise<ListOrganizationsResult>((resolve) => {
+        releaseList = resolve;
+      }),
+    );
+
+    await renderRouteTree(routeTree, { initialPath: "/organizations" });
+    expect(screen.getByText("Loading...")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create organization" }),
+    );
+    fireEvent.change(await screen.findByLabelText("Organization name"), {
+      target: { value: CREATED_ORG.name },
+    });
+    mocks.createOrganization.mockRejectedValueOnce(
+      new GramAdminError(422, { message: "no" }, "Unprocessable Entity"),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    });
+    await screen.findByRole("alert");
+
+    // The read the write cancelled is dead: React Query drops its answer, so
+    // the rows can only arrive from a request made after the failure.
+    releaseList({ organizations: ORGS });
+    // An open Radix modal hides the rest of the page from the accessibility
+    // tree, so the rows are unreachable by role until the operator is out of
+    // the dialog. Closing it is their next move anyway.
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await screen.findByRole("link", { name: FIRST_ORG.name });
   });
 });
 

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -421,7 +421,7 @@ export function OrganizationsList(): JSX.Element {
               while the operator scrolls the rows they lead to. */}
           <StatStrip />
 
-          <Toolbar searchCleared={searchCleared} />
+          <Toolbar searchCleared={searchCleared} reporter={writeReporter} />
         </FiltersApplied.Provider>
 
         {/* A failed refetch keeps the previous rows, so the failure has to show


### PR DESCRIPTION
A platform admin can now create an organization from the organizations list, without leaving it.

Closes AGE-3238. Client half of the endpoint added in #5297.

## What it does

A **Create organization** control sits in the toolbar above the table. It opens a dialog that takes one field, the name, and reports what the server made: no members, no trial, free account type.

Three decisions are worth stating, because each rules out something a reader might expect:

**The confirmation is worded from the response, not from what was typed.** The server normalises the name, so the operator sees what was actually stored.

**The confirmation says the new row may not appear.** The record is free tier with no trial, so a list filtered to running trials correctly does not show it, and the sort and cursor decide the rest. Saying "created" while the table appears unchanged would otherwise read as a failure.

**The created organization invalidates the list rather than being spliced into the page on screen.** Where the new row belongs depends on the sort, the filter and the cursor, none of which this control can evaluate, so splicing it in would put it somewhere the server would not have. This deliberately differs from the row actions, which repaint an existing row from the response.

## A defect the review round found

The first commit cancelled any list read already in flight, because a read asked before the write but landing after it would answer the refetch with pre-write rows. On the refusal path it then restored only the stats cache and not the list.

That is reachable, and the symptom is worse than a stalled spinner. The toolbar renders outside the page's loading path, so **Create is pressable while the very first list read is still in flight.** Cancelling that read reverts it to a state with no data and no fetch outstanding, so the table renders **"No organizations found"**: an active lie, on an account that has organizations, until something else happens to ask again. A refused name is the ordinary failure here, not an exotic one.

The second commit restores what the cancel took. This was reproduced with a probe before it was fixed, and is now held by a test that fails on both the previous shape and on removing the handler entirely.

The same `onError` shape exists on the sibling write hooks, and the bulk hook has no `onError` at all. Those are deliberately **not** touched here, and are filed separately.

## Verification

Re-run independently of the authoring session:

| Gate | Result |
| --- | --- |
| `aube run -F admin type-check` | 0 |
| `aube run -F admin lint:oxlint` | 0 |
| `aube run -F admin test` | 0, 14 files, 389 tests |

A four-lens review round ran before this PR: mutation and coverage, correctness and cache semantics, accessibility and keyboard, and scope and hygiene. 30 invented mutations, with 5 canaries all surviving, so the harness was sound rather than falsely all-killing.

Its most useful finding was that the original tests could not see the feature at all. The create control could be **deleted from the toolbar entirely** and all 380 tests still passed, and the announcement path could be replaced with a no-op with the same result: the suite proved only that a mock function had been called. Both are now held by tests that render the real page and assert on the page's own live region rather than on a spy. Applying that mutation by hand against the final tip fails three named tests.

Accessibility fixes from the same round: the refusal is now tied to the field with `aria-invalid` and `aria-describedby`, the field is marked required, and the page's failure banner is cleared on success like every sibling write.

A comment claiming that a modal removes the page's live region from the accessibility tree was **false** and has been corrected. `aria-hidden` explicitly exempts live regions, and Radix's dialog takes that path. The `role="alert"` it justified is still correct, for a different reason: it is assertive and sits with the field.

## Where the tests stop

Two limits, stated rather than implied. `happy-dom` performs no layout, so nothing here proves geometry, visibility or scroll behaviour. And removing `preventDefault()` from the submit handler survives the suite, because the harness does not perform native form submission; that is a property of the environment and is not worth a test that pretends otherwise.

One further claim was investigated and **could not be reproduced**: that focus survives the pending window only because removing the close button triggers a mutation-based refocus. Three probes returned identical results with and without it. It may still hold in a real browser, so only the verifiable half was written down.

Client-only change. No `server/design` or `server/gen` change, so no SDK regeneration is required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create an organization from the organizations list without leaving the page. Previously the endpoint had no caller and admins had to use WorkOS; now a toolbar action opens a name-only dialog, creates a free, no-trial org, and refreshes the list.

- Button sits at the end of the organizations toolbar; dialog requires a name, trims whitespace, and announces success via the page’s live region using the server-normalized name. The confirmation notes the new row may not appear under current filters.
- On success, seeds the organization detail cache by id and slug, invalidates org list and stats, and clears any page-level failure banner. The list is refetched rather than spliced to respect sort/filter/cursor.
- On refusal, the dialog stays open with the server’s reason beside the field; the field is marked invalid and described by the alert. Opening the dialog clears the previous success message.
- While the write is in flight, submit/cancel/close/Escape are disabled to prevent duplicates.
- Fixes a cancelation bug: if a create fails after canceling an in-flight list read, the list is now invalidated and refetched instead of leaving the table in a false “No organizations found” state.

**Linear: AGE-3238**
- Completes the client half by adding the caller and meeting the acceptance intent: admins can submit a name and, after the call returns, the list is refetched (visibility depends on filters).

<sup>Written for commit f1769d9dd24d03d2fb4532d9df2cf4ad22df6596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

