### PR TITLE
fix: stop retrying AI usage polls in-run when the provider is down

### DIFF
--- a/.changeset/ai-poll-provider-outage-classification.md
+++ b/.changeset/ai-poll-provider-outage-classification.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Classify AI integration poll failures caused by provider outages (persistent 429/5xx or transport errors) so they skip the in-run Temporal retries and defer to the schedule-level failure backoff, and surface the provider's final HTTP status and error body when the guardian retry client exhausts its budget instead of the opaque "giving up" message.

--- a/server/internal/background/activities/poll_ai_data.go
+++ b/server/internal/background/activities/poll_ai_data.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,13 +34,18 @@ const ErrTypeAIUsagePollFailed = "AIUsagePollFailed"
 // aiUsagePollFailureDetails is the structured details payload attached to
 // ErrTypeAIUsagePollFailed application errors.
 type aiUsagePollFailureDetails struct {
-	ConfigID     string                      `json:"config_id"`
-	Provider     string                      `json:"provider,omitempty"`
-	Attempt      int32                       `json:"attempt"`
-	MaxAttempts  int32                       `json:"max_attempts"`
-	NonRetryable bool                        `json:"non_retryable"`
-	Stages       []stageFailureDetail        `json:"stages,omitempty"`
-	Progress     aiintegrations.SyncProgress `json:"progress,omitempty"`
+	ConfigID     string `json:"config_id"`
+	Provider     string `json:"provider,omitempty"`
+	Attempt      int32  `json:"attempt"`
+	MaxAttempts  int32  `json:"max_attempts"`
+	NonRetryable bool   `json:"non_retryable"`
+	// ProviderUnavailable marks failures caused by a provider outage
+	// (persistent 429/5xx or transport errors): non-retryable within the
+	// run because the schedule-level backoff owns the retry cadence, not
+	// because the failure is permanent.
+	ProviderUnavailable bool                        `json:"provider_unavailable,omitempty"`
+	Stages              []stageFailureDetail        `json:"stages,omitempty"`
+	Progress            aiintegrations.SyncProgress `json:"progress,omitempty"`
 }
 
 type stageFailureDetail struct {
@@ -145,29 +151,31 @@ func (p *PollAIData) Do(ctx context.Context, input string) (err error) {
 		}
 
 		attempt := activity.GetInfo(ctx).Attempt
-		nonRetryable := pollRejectedByProvider(err)
+		rejected := pollRejectedByProvider(err)
+		unavailable := pollProviderUnavailable(err)
 
 		// Temporal records failures, but that's not visible to the user. We
 		// record the failure on the last attempt — or immediately when
-		// retrying can't help, e.g. a rejected api key — so it's visible to
-		// the user in the dashboard.
-		if attempt >= PollUsageMaxAttempts || nonRetryable {
+		// retrying within this run can't help: a rejected api key, or a
+		// provider outage whose retry cadence the schedule-level backoff
+		// already owns — so it's visible to the user in the dashboard.
+		if attempt >= PollUsageMaxAttempts || rejected || unavailable {
 			recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			defer cancel()
 
 			// Provider rejections are permanent until the user fixes the
 			// integration, so after a few of them in a row the schedule is
-			// auto-paused instead of re-enqueued forever. Retryable failures
-			// never pause: the schedule keeps polling, at a cadence that
-			// backs off with the failure streak.
-			pauseAfter := conv.Ternary[int32](nonRetryable, aiintegrations.AutoPauseAfterRejectedPolls, 0)
+			// auto-paused instead of re-enqueued forever. Other failures —
+			// including provider outages — never pause: the schedule keeps
+			// polling, at a cadence that backs off with the failure streak.
+			pauseAfter := conv.Ternary[int32](rejected, aiintegrations.AutoPauseAfterRejectedPolls, 0)
 			shareableErr := shareablePollError(schedule, err)
 			if recordErr := p.integrations.RecordSchedulePollFailure(recordCtx, cfg.ID, schedule, endTime, shareableErr, pauseAfter); recordErr != nil {
 				err = errors.Join(err, fmt.Errorf("record ai integration schedule failure: %w", recordErr))
 			}
 		}
 
-		err = newPollFailureError(cfg.ID, cfg.Provider, attempt, nonRetryable, err)
+		err = newPollFailureError(cfg.ID, cfg.Provider, attempt, rejected, unavailable, err)
 	}()
 
 	switch schedule {
@@ -249,6 +257,18 @@ func shareablePollError(schedule string, cause error) error {
 	var contentErr *aiintegrations.CodexCostContentError
 	if errors.As(cause, &contentErr) {
 		return oops.E(oops.CodeUnexpected, cause, "%s", contentErr.ShareableMessage())
+	}
+
+	// A spent retry budget means the provider kept answering with retryable
+	// statuses or transport errors — an outage, not a configuration problem.
+	// Say so, with the last status when one was seen, instead of the generic
+	// schedule message.
+	var exhausted *guardian.RetriesExhaustedError
+	if errors.As(cause, &exhausted) {
+		if exhausted.StatusCode != 0 {
+			return oops.E(oops.CodeUnavailable, cause, "provider api is temporarily unavailable (HTTP %d); the sync will back off and retry", exhausted.StatusCode)
+		}
+		return oops.E(oops.CodeUnavailable, cause, "provider api is unreachable; the sync will back off and retry")
 	}
 
 	var cursorErr *cursorapi.HTTPError
@@ -343,19 +363,51 @@ func pollRejectedByProvider(err error) bool {
 	return false
 }
 
+// pollProviderUnavailable reports whether the poll failed because the
+// provider was unavailable: the HTTP client's whole retry budget was spent
+// on retryable statuses or transport errors, or a throttling/server status
+// surfaced directly. Retrying inside the Temporal run cannot outlast an
+// outage — the schedule-level failure backoff owns that cadence — so these
+// skip the remaining activity attempts. Unlike a provider rejection, an
+// outage ends on its own, so it never counts toward auto-pausing.
+func pollProviderUnavailable(err error) bool {
+	var exhausted *guardian.RetriesExhaustedError
+	if errors.As(err, &exhausted) {
+		return true
+	}
+	statusUnavailable := func(status int) bool {
+		return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
+	}
+	var cursorErr *cursorapi.HTTPError
+	if errors.As(err, &cursorErr) {
+		return statusUnavailable(cursorErr.StatusCode)
+	}
+	var anthropicErr *anthropicapi.HTTPError
+	if errors.As(err, &anthropicErr) {
+		return statusUnavailable(anthropicErr.StatusCode)
+	}
+	var codexErr *codexapi.HTTPError
+	if errors.As(err, &codexErr) {
+		return statusUnavailable(codexErr.StatusCode)
+	}
+	return false
+}
+
 // newPollFailureError wraps a poll failure in a typed Temporal application
 // error. The details payload surfaces the provider, attempt count, per-stage
 // failures, and run progress in the Temporal UI; the cause chain is kept
 // intact for errors.Is/errors.As callers.
-func newPollFailureError(configID uuid.UUID, provider string, attempt int32, nonRetryable bool, cause error) error {
+func newPollFailureError(configID uuid.UUID, provider string, attempt int32, rejected bool, providerUnavailable bool, cause error) error {
+	nonRetryable := rejected || providerUnavailable
 	details := aiUsagePollFailureDetails{
-		ConfigID:     configID.String(),
-		Provider:     provider,
-		Attempt:      attempt,
-		MaxAttempts:  PollUsageMaxAttempts,
-		NonRetryable: nonRetryable,
-		Stages:       nil,
-		Progress:     nil,
+		ConfigID:            configID.String(),
+		Provider:            provider,
+		Attempt:             attempt,
+		MaxAttempts:         PollUsageMaxAttempts,
+		NonRetryable:        nonRetryable,
+		ProviderUnavailable: providerUnavailable,
+		Stages:              nil,
+		Progress:            nil,
 	}
 
 	var syncErr *aiintegrations.SyncError

--- a/server/internal/background/activities/poll_ai_data.go
+++ b/server/internal/background/activities/poll_ai_data.go
@@ -376,13 +376,17 @@ func pollRejectedByProvider(err error) bool {
 // skip the remaining activity attempts. Unlike a provider rejection, an
 // outage ends on its own, so it never counts toward auto-pausing.
 func pollProviderUnavailable(err error) bool {
-	// A canceled or expired activity context is our side giving up, not the
-	// provider failing; those must keep the normal retry path.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
+	// A throttling or server status is affirmative outage evidence and is
+	// checked first: a multi-stage sync can carry a timed-out sibling stage
+	// next to the outage (newSyncError drops only Canceled stages), and the
+	// sibling must not mask it.
 	if pollUnavailableHTTPStatus(err) != 0 {
 		return true
+	}
+	// Otherwise a canceled or expired activity context is our side giving
+	// up, not the provider failing; those must keep the normal retry path.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
 	}
 	var exhausted *guardian.RetriesExhaustedError
 	if errors.As(err, &exhausted) {

--- a/server/internal/background/activities/poll_ai_data.go
+++ b/server/internal/background/activities/poll_ai_data.go
@@ -152,7 +152,10 @@ func (p *PollAIData) Do(ctx context.Context, input string) (err error) {
 
 		attempt := activity.GetInfo(ctx).Attempt
 		rejected := pollRejectedByProvider(err)
-		unavailable := pollProviderUnavailable(err)
+		// A multi-stage sync can carry both a rejection and an outage;
+		// the rejection wins so the auto-pause path and the actionable
+		// message stay in charge.
+		unavailable := !rejected && pollProviderUnavailable(err)
 
 		// Temporal records failures, but that's not visible to the user. We
 		// record the failure on the last attempt — or immediately when
@@ -259,18 +262,6 @@ func shareablePollError(schedule string, cause error) error {
 		return oops.E(oops.CodeUnexpected, cause, "%s", contentErr.ShareableMessage())
 	}
 
-	// A spent retry budget means the provider kept answering with retryable
-	// statuses or transport errors — an outage, not a configuration problem.
-	// Say so, with the last status when one was seen, instead of the generic
-	// schedule message.
-	var exhausted *guardian.RetriesExhaustedError
-	if errors.As(cause, &exhausted) {
-		if exhausted.StatusCode != 0 {
-			return oops.E(oops.CodeUnavailable, cause, "provider api is temporarily unavailable (HTTP %d); the sync will back off and retry", exhausted.StatusCode)
-		}
-		return oops.E(oops.CodeUnavailable, cause, "provider api is unreachable; the sync will back off and retry")
-	}
-
 	var cursorErr *cursorapi.HTTPError
 	if errors.As(cause, &cursorErr) && cursorErr.StatusCode == 401 {
 		return oops.E(oops.CodeUnauthorized, cause, "cursor rejected the configured api key")
@@ -311,6 +302,20 @@ func shareablePollError(schedule string, cause error) error {
 				return oops.E(oops.CodeNotFound, cause, "codex cloud workspace not found or compliance api access not enabled")
 			}
 		}
+	}
+
+	// A provider outage — a throttling or server status answered directly
+	// or on the final attempt of a spent retry budget — is transient, not a
+	// configuration problem. Say so, with the status when one was seen,
+	// instead of the generic schedule message. Checked after the provider
+	// rejection cases: a multi-stage sync can carry both a rejection and an
+	// outage, and the rejection is the actionable one.
+	if status := pollUnavailableHTTPStatus(cause); status != 0 {
+		return oops.E(oops.CodeUnavailable, cause, "provider api is temporarily unavailable (HTTP %d); the sync will back off and retry", status)
+	}
+	var exhausted *guardian.RetriesExhaustedError
+	if errors.As(cause, &exhausted) {
+		return oops.E(oops.CodeUnavailable, cause, "provider api is unreachable; the sync will back off and retry")
 	}
 
 	// An interior oops boundary already chose a safe public message and code
@@ -371,26 +376,56 @@ func pollRejectedByProvider(err error) bool {
 // skip the remaining activity attempts. Unlike a provider rejection, an
 // outage ends on its own, so it never counts toward auto-pausing.
 func pollProviderUnavailable(err error) bool {
-	var exhausted *guardian.RetriesExhaustedError
-	if errors.As(err, &exhausted) {
+	// A canceled or expired activity context is our side giving up, not the
+	// provider failing; those must keep the normal retry path.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if pollUnavailableHTTPStatus(err) != 0 {
 		return true
 	}
+	var exhausted *guardian.RetriesExhaustedError
+	if errors.As(err, &exhausted) {
+		// Repeated transport failures with no response affirm an outage. A
+		// single response-less attempt means the retry policy refused to
+		// retry (TLS verification, redirect policy, resilience denial) —
+		// not evidence the provider is down.
+		return exhausted.StatusCode == 0 && exhausted.Attempts > 1
+	}
+	return false
+}
+
+// pollUnavailableHTTPStatus returns the throttling or server status a
+// provider answered with — directly, via cursor's typed rate limit, or on
+// the final attempt of a spent retry budget — or zero when the failure
+// carries no such status. Shared by the outage classification and the
+// org-visible message so the two cannot disagree about what counts as an
+// outage.
+func pollUnavailableHTTPStatus(err error) int {
 	statusUnavailable := func(status int) bool {
 		return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 	}
+	var exhausted *guardian.RetriesExhaustedError
+	if errors.As(err, &exhausted) && statusUnavailable(exhausted.StatusCode) {
+		return exhausted.StatusCode
+	}
+	var rateLimited *cursorapi.RateLimitError
+	if errors.As(err, &rateLimited) {
+		return http.StatusTooManyRequests
+	}
 	var cursorErr *cursorapi.HTTPError
-	if errors.As(err, &cursorErr) {
-		return statusUnavailable(cursorErr.StatusCode)
+	if errors.As(err, &cursorErr) && statusUnavailable(cursorErr.StatusCode) {
+		return cursorErr.StatusCode
 	}
 	var anthropicErr *anthropicapi.HTTPError
-	if errors.As(err, &anthropicErr) {
-		return statusUnavailable(anthropicErr.StatusCode)
+	if errors.As(err, &anthropicErr) && statusUnavailable(anthropicErr.StatusCode) {
+		return anthropicErr.StatusCode
 	}
 	var codexErr *codexapi.HTTPError
-	if errors.As(err, &codexErr) {
-		return statusUnavailable(codexErr.StatusCode)
+	if errors.As(err, &codexErr) && statusUnavailable(codexErr.StatusCode) {
+		return codexErr.StatusCode
 	}
-	return false
+	return 0
 }
 
 // newPollFailureError wraps a poll failure in a typed Temporal application

--- a/server/internal/background/activities/poll_ai_data_test.go
+++ b/server/internal/background/activities/poll_ai_data_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"go.temporal.io/sdk/testsuite"
 
 	"github.com/speakeasy-api/gram/server/internal/aiintegrations"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	anthropicapi "github.com/speakeasy-api/gram/server/internal/thirdparty/anthropic"
 	codexapi "github.com/speakeasy-api/gram/server/internal/thirdparty/codex"
@@ -57,6 +59,102 @@ func TestPollRejectedByProviderMatchesPermanentProviderFailures(t *testing.T) {
 	require.True(t, pollRejectedByProvider(&codexapi.HTTPError{StatusCode: 404, Status: "404 Not Found"}))
 	require.False(t, pollRejectedByProvider(&codexapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
 	require.False(t, pollRejectedByProvider(errors.New("network timeout")))
+}
+
+func TestPollProviderUnavailableMatchesOutages(t *testing.T) {
+	t.Parallel()
+
+	// A spent HTTP retry budget is the canonical outage signal, including
+	// when the transport wrapped it in a *url.Error and a sync stage wrapped
+	// that again.
+	exhausted := &guardian.RetriesExhaustedError{
+		Method:     "GET",
+		URL:        "https://api.chatgpt.com/v1/compliance/organizations/org-x/logs",
+		Attempts:   5,
+		StatusCode: 500,
+		Body:       `{"error":"boom"}`,
+		Err:        nil,
+	}
+	require.True(t, pollProviderUnavailable(exhausted))
+	wrapped := fmt.Errorf("sync codex cost data: %w", &aiintegrations.SyncError{
+		Op: "sync codex costs",
+		Stages: []aiintegrations.SyncStageError{{
+			Stage: "import_cost_logs",
+			Err:   fmt.Errorf("fetch codex_compliance upper bound: %w", &url.Error{Op: "Get", URL: "https://api.chatgpt.com", Err: exhausted}),
+		}},
+		Progress: nil,
+	})
+	require.True(t, pollProviderUnavailable(wrapped))
+
+	// Direct throttling/server statuses count too; rejections and unknown
+	// errors do not.
+	require.True(t, pollProviderUnavailable(&codexapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
+	require.True(t, pollProviderUnavailable(&anthropicapi.HTTPError{StatusCode: 429, Status: "429 Too Many Requests"}))
+	require.True(t, pollProviderUnavailable(&cursorapi.HTTPError{StatusCode: 500, Status: "500 Internal Server Error"}))
+	require.False(t, pollProviderUnavailable(&codexapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}))
+	require.False(t, pollProviderUnavailable(&anthropicapi.HTTPError{StatusCode: 404, Status: "404 Not Found"}))
+	require.False(t, pollProviderUnavailable(errors.New("json decode failed")))
+}
+
+func TestNewPollFailureErrorMarksProviderOutagesNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	configID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	cause := fmt.Errorf("sync codex cost data: %w", &guardian.RetriesExhaustedError{
+		Method:     "GET",
+		URL:        "https://api.chatgpt.com/v1/compliance/organizations/org-x/logs",
+		Attempts:   5,
+		StatusCode: 500,
+		Body:       `{"error":"boom"}`,
+		Err:        nil,
+	})
+
+	err := newPollFailureError(configID, aiintegrations.ProviderCodexCompliance, 1, false, true, cause)
+
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.True(t, appErr.NonRetryable())
+	require.Contains(t, appErr.Message(), "last status 500")
+
+	var details aiUsagePollFailureDetails
+	require.NoError(t, appErr.Details(&details))
+	require.True(t, details.NonRetryable)
+	require.True(t, details.ProviderUnavailable)
+}
+
+func TestShareablePollErrorClassifiesProviderOutage(t *testing.T) {
+	t.Parallel()
+
+	cause := fmt.Errorf("sync codex cost data: %w", &guardian.RetriesExhaustedError{
+		Method:     "GET",
+		URL:        "https://api.chatgpt.com/v1/compliance/organizations/org-x/logs",
+		Attempts:   5,
+		StatusCode: 500,
+		Body:       `{"error":"internal secret detail"}`,
+		Err:        nil,
+	})
+
+	err := shareablePollError(aiintegrations.ScheduleCodexCompliance, cause)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnavailable, shareable.Code)
+	require.Contains(t, err.Error(), "temporarily unavailable (HTTP 500)")
+	require.NotContains(t, err.Error(), "internal secret detail")
+
+	// Exhaustion without a response reports unreachability instead.
+	noResponse := &guardian.RetriesExhaustedError{
+		Method:     "",
+		URL:        "",
+		Attempts:   5,
+		StatusCode: 0,
+		Body:       "",
+		Err:        errors.New("dial tcp: connection refused"),
+	}
+	err = shareablePollError(aiintegrations.ScheduleCodexCompliance, noResponse)
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnavailable, shareable.Code)
+	require.Contains(t, err.Error(), "unreachable")
+	require.NotContains(t, err.Error(), "dial tcp")
 }
 
 func TestPollRejectedByProviderSeesThroughWrappedSyncErrors(t *testing.T) {
@@ -109,7 +207,7 @@ func TestNewPollFailureErrorCarriesStageAndProgressDetails(t *testing.T) {
 	}
 	cause := fmt.Errorf("sync anthropic compliance data: %w", syncErr)
 
-	err := newPollFailureError(configID, aiintegrations.ProviderAnthropicCompliance, 5, false, cause)
+	err := newPollFailureError(configID, aiintegrations.ProviderAnthropicCompliance, 5, false, false, cause)
 
 	var appErr *temporal.ApplicationError
 	require.ErrorAs(t, err, &appErr)
@@ -184,6 +282,7 @@ func TestNewPollFailureErrorKeepsStageContextAroundShareableStageErrors(t *testi
 		aiintegrations.ProviderCodexCompliance,
 		5,
 		false,
+		false,
 		cause,
 	)
 
@@ -209,6 +308,7 @@ func TestNewPollFailureErrorExpandsShareableCauses(t *testing.T) {
 		aiintegrations.ProviderCodexCompliance,
 		5,
 		false,
+		false,
 		cause,
 	)
 
@@ -224,7 +324,7 @@ func TestNewPollFailureErrorMarksAuthFailuresNonRetryable(t *testing.T) {
 	configID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	cause := fmt.Errorf("fetch cursor usage window: %w", &cursorapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"})
 
-	err := newPollFailureError(configID, aiintegrations.ProviderCursor, 1, true, cause)
+	err := newPollFailureError(configID, aiintegrations.ProviderCursor, 1, true, false, cause)
 
 	var appErr *temporal.ApplicationError
 	require.ErrorAs(t, err, &appErr)
@@ -278,6 +378,7 @@ func TestCustomerPollErrorClassifiesCodexContentFailuresWithoutPayload(t *testin
 			uuid.MustParse("33333333-3333-3333-3333-333333333333"),
 			aiintegrations.ProviderCodexCompliance,
 			5,
+			false,
 			false,
 			internalErr,
 		)

--- a/server/internal/background/activities/poll_ai_data_test.go
+++ b/server/internal/background/activities/poll_ai_data_test.go
@@ -86,14 +86,79 @@ func TestPollProviderUnavailableMatchesOutages(t *testing.T) {
 	})
 	require.True(t, pollProviderUnavailable(wrapped))
 
-	// Direct throttling/server statuses count too; rejections and unknown
-	// errors do not.
+	// Repeated response-less transport failures affirm an outage; a single
+	// response-less attempt means the retry policy refused to retry (TLS
+	// verification, redirect policy, resilience denial) and stays on the
+	// normal retry path.
+	require.True(t, pollProviderUnavailable(&guardian.RetriesExhaustedError{
+		Method: "GET", URL: "https://api.chatgpt.com", Attempts: 3, StatusCode: 0, Body: "", Err: errors.New("dial tcp: connection refused"),
+	}))
+	require.False(t, pollProviderUnavailable(&guardian.RetriesExhaustedError{
+		Method: "", URL: "", Attempts: 1, StatusCode: 0, Body: "", Err: errors.New("tls: failed to verify certificate"),
+	}))
+
+	// Caller-side aborts are never outages, wherever they sit in the chain.
+	require.False(t, pollProviderUnavailable(fmt.Errorf("sync codex cost data: %w", context.Canceled)))
+	require.False(t, pollProviderUnavailable(fmt.Errorf("sync codex cost data: %w", context.DeadlineExceeded)))
+
+	// Direct throttling/server statuses count too — including cursor's
+	// typed rate limit, which never becomes an HTTPError; rejections and
+	// unknown errors do not.
 	require.True(t, pollProviderUnavailable(&codexapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
 	require.True(t, pollProviderUnavailable(&anthropicapi.HTTPError{StatusCode: 429, Status: "429 Too Many Requests"}))
 	require.True(t, pollProviderUnavailable(&cursorapi.HTTPError{StatusCode: 500, Status: "500 Internal Server Error"}))
+	require.True(t, pollProviderUnavailable(&cursorapi.RateLimitError{Status: "429 Too Many Requests", RetryAfter: time.Minute, Page: 2}))
 	require.False(t, pollProviderUnavailable(&codexapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}))
 	require.False(t, pollProviderUnavailable(&anthropicapi.HTTPError{StatusCode: 404, Status: "404 Not Found"}))
 	require.False(t, pollProviderUnavailable(errors.New("json decode failed")))
+}
+
+func TestShareablePollErrorClassifiesDirectProviderStatuses(t *testing.T) {
+	t.Parallel()
+
+	// A direct 5xx (cursor's client has no HTTP-level retries) must produce
+	// the same outage message as a spent retry budget, not the generic
+	// schedule fallback.
+	err := shareablePollError(aiintegrations.ScheduleCursor, fmt.Errorf("fetch cursor usage window: %w",
+		&cursorapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnavailable, shareable.Code)
+	require.Contains(t, err.Error(), "temporarily unavailable (HTTP 503)")
+
+	err = shareablePollError(aiintegrations.ScheduleCursor, fmt.Errorf("fetch cursor usage window: %w",
+		&cursorapi.RateLimitError{Status: "429 Too Many Requests", RetryAfter: time.Minute, Page: 1}))
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnavailable, shareable.Code)
+	require.Contains(t, err.Error(), "temporarily unavailable (HTTP 429)")
+}
+
+func TestShareablePollErrorPrefersRejectionOverOutage(t *testing.T) {
+	t.Parallel()
+
+	// A multi-stage sync can fail with both a rejected api key and an
+	// exhausted retry budget; the rejection is the actionable message and
+	// must win over the transient-outage one.
+	cause := fmt.Errorf("sync codex cost data: %w", &aiintegrations.SyncError{
+		Op: "sync codex costs",
+		Stages: []aiintegrations.SyncStageError{
+			{
+				Stage: "import_cost_logs",
+				Err:   fmt.Errorf("download log: %w", &guardian.RetriesExhaustedError{Method: "GET", URL: "https://api.chatgpt.com", Attempts: 5, StatusCode: 500, Body: "", Err: nil}),
+			},
+			{
+				Stage: "import_cost_logs",
+				Err:   fmt.Errorf("list logs: %w", &codexapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}),
+			},
+		},
+		Progress: nil,
+	})
+
+	err := shareablePollError(aiintegrations.ScheduleCodexCompliance, cause)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnauthorized, shareable.Code)
+	require.Contains(t, err.Error(), "codex compliance rejected the configured api key")
 }
 
 func TestNewPollFailureErrorMarksProviderOutagesNonRetryable(t *testing.T) {

--- a/server/internal/background/activities/poll_ai_data_test.go
+++ b/server/internal/background/activities/poll_ai_data_test.go
@@ -101,6 +101,18 @@ func TestPollProviderUnavailableMatchesOutages(t *testing.T) {
 	require.False(t, pollProviderUnavailable(fmt.Errorf("sync codex cost data: %w", context.Canceled)))
 	require.False(t, pollProviderUnavailable(fmt.Errorf("sync codex cost data: %w", context.DeadlineExceeded)))
 
+	// ...but a timed-out sibling stage must not mask affirmative outage
+	// evidence in a composite failure (newSyncError keeps DeadlineExceeded
+	// stages).
+	require.True(t, pollProviderUnavailable(fmt.Errorf("sync codex cost data: %w", &aiintegrations.SyncError{
+		Op: "sync codex costs",
+		Stages: []aiintegrations.SyncStageError{
+			{Stage: "import_cost_logs", Err: fmt.Errorf("download log: %w", context.DeadlineExceeded)},
+			{Stage: "import_cost_logs", Err: fmt.Errorf("list logs: %w", &guardian.RetriesExhaustedError{Method: "GET", URL: "https://api.chatgpt.com", Attempts: 5, StatusCode: 500, Body: "", Err: nil})},
+		},
+		Progress: nil,
+	})))
+
 	// Direct throttling/server statuses count too — including cursor's
 	// typed rate limit, which never becomes an HTTPError; rejections and
 	// unknown errors do not.

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -115,12 +115,15 @@ type RetryConfig struct {
 // only a few fields need to be overridden.
 func DefaultRetryConfig() *RetryConfig {
 	return &RetryConfig{
-		WaitMin:      1 * time.Second,
-		WaitMax:      30 * time.Second,
-		MaxAttempts:  4,
-		CheckRetry:   retryablehttp.DefaultRetryPolicy,
-		Backoff:      retryablehttp.DefaultBackoff,
-		ErrorHandler: nil,
+		WaitMin:     1 * time.Second,
+		WaitMax:     30 * time.Second,
+		MaxAttempts: 4,
+		CheckRetry:  retryablehttp.DefaultRetryPolicy,
+		Backoff:     retryablehttp.DefaultBackoff,
+		// Exhausted retries surface as *RetriesExhaustedError so callers
+		// keep the final attempt's status and body instead of the opaque
+		// "giving up" message that discards the response.
+		ErrorHandler: retriesExhaustedErrorHandler,
 		PrepareRetry: nil,
 	}
 }

--- a/server/internal/guardian/retry.go
+++ b/server/internal/guardian/retry.go
@@ -1,25 +1,35 @@
 package guardian
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // retriesExhaustedBodyLimit bounds how much of the final response body a
 // RetriesExhaustedError captures. Provider error bodies are small JSON
 // documents; anything larger is truncated so the error stays loggable.
-const retriesExhaustedBodyLimit = 1000
+const retriesExhaustedBodyLimit = 1024
 
 // RetriesExhaustedError is returned by clients built with a retry config
-// once the whole retry budget is spent. Unlike retryablehttp's default
+// when the client gives up on a request. Unlike retryablehttp's default
 // "giving up" error, it preserves what the final attempt actually saw — the
 // HTTP status and a snippet of the response body, or the transport error —
 // so callers can tell a provider outage (persistent 429/5xx) from a
 // misconfigured request without re-issuing it. The http.Client transport
 // wraps it in a *url.Error; match with errors.As.
+//
+// Attempts counts attempts actually made: a value of 1 means the retry
+// policy refused to retry at all (e.g. a TLS verification failure or a
+// resilience denial), not that the budget ran out — check it before
+// treating the error as evidence of a persistent upstream failure. Context
+// cancellation and deadline expiry are never wrapped in this type.
 type RetriesExhaustedError struct {
-	// Method and URL identify the request that ran out of retries.
+	// Method and URL identify the request that was given up on. URL has
+	// any userinfo password redacted.
 	Method string
 	URL    string
 	// Attempts is the number of attempts made before giving up.
@@ -27,8 +37,10 @@ type RetriesExhaustedError struct {
 	// StatusCode is the HTTP status of the final attempt, or zero when the
 	// final attempt failed before receiving a response.
 	StatusCode int
-	// Body is a truncated snippet of the final attempt's response body,
-	// empty when no response was received.
+	// Body is a truncated snippet of the final attempt's response body with
+	// control characters replaced, empty when no response was received. It
+	// is upstream-controlled content: safe to log, but do not surface it to
+	// end users without an explicit decision to.
 	Body string
 	// Err is the transport error from the final attempt, if any.
 	Err error
@@ -53,10 +65,25 @@ func (e *RetriesExhaustedError) Error() string {
 
 func (e *RetriesExhaustedError) Unwrap() error { return e.Err }
 
-// retriesExhaustedErrorHandler converts retry exhaustion into a
-// *RetriesExhaustedError. retryablehttp hands the handler the final
-// response un-drained, so the handler owns closing it.
+// retriesExhaustedErrorHandler converts a given-up request into a
+// *RetriesExhaustedError. retryablehttp invokes the handler on every
+// failing exit from Do — exhausted budgets, but also first-attempt aborts
+// where the retry policy declined to retry — and hands it the final
+// response un-drained, so the handler owns closing it. Caveat for future
+// configs: if PrepareRetry is ever set and fails, retryablehttp has already
+// drained and closed the response it passes here, so Body reads empty and
+// StatusCode may be stale; no current config sets PrepareRetry.
 func retriesExhaustedErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	// A canceled or expired context is the caller aborting, not the
+	// upstream failing; pass it through so cancellation never masquerades
+	// as an upstream error.
+	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, err
+	}
+
 	exhausted := &RetriesExhaustedError{
 		Method:     "",
 		URL:        "",
@@ -67,11 +94,23 @@ func retriesExhaustedErrorHandler(resp *http.Response, err error, numTries int) 
 	}
 	if resp != nil {
 		exhausted.Method = resp.Request.Method
-		exhausted.URL = resp.Request.URL.String()
+		exhausted.URL = resp.Request.URL.Redacted()
 		exhausted.StatusCode = resp.StatusCode
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, retriesExhaustedBodyLimit))
 		_ = resp.Body.Close()
-		exhausted.Body = string(body)
+		exhausted.Body = printableBodySnippet(body)
 	}
 	return nil, exhausted
+}
+
+// printableBodySnippet makes an upstream body safe to embed in a
+// single-line error string: control characters (including newlines) become
+// spaces and invalid UTF-8 is replaced during the conversion.
+func printableBodySnippet(body []byte) string {
+	return strings.Map(func(r rune) rune {
+		if r < ' ' || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, string(body))
 }

--- a/server/internal/guardian/retry.go
+++ b/server/internal/guardian/retry.go
@@ -1,0 +1,77 @@
+package guardian
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// retriesExhaustedBodyLimit bounds how much of the final response body a
+// RetriesExhaustedError captures. Provider error bodies are small JSON
+// documents; anything larger is truncated so the error stays loggable.
+const retriesExhaustedBodyLimit = 1000
+
+// RetriesExhaustedError is returned by clients built with a retry config
+// once the whole retry budget is spent. Unlike retryablehttp's default
+// "giving up" error, it preserves what the final attempt actually saw — the
+// HTTP status and a snippet of the response body, or the transport error —
+// so callers can tell a provider outage (persistent 429/5xx) from a
+// misconfigured request without re-issuing it. The http.Client transport
+// wraps it in a *url.Error; match with errors.As.
+type RetriesExhaustedError struct {
+	// Method and URL identify the request that ran out of retries.
+	Method string
+	URL    string
+	// Attempts is the number of attempts made before giving up.
+	Attempts int
+	// StatusCode is the HTTP status of the final attempt, or zero when the
+	// final attempt failed before receiving a response.
+	StatusCode int
+	// Body is a truncated snippet of the final attempt's response body,
+	// empty when no response was received.
+	Body string
+	// Err is the transport error from the final attempt, if any.
+	Err error
+}
+
+func (e *RetriesExhaustedError) Error() string {
+	msg := fmt.Sprintf("giving up after %d attempt(s)", e.Attempts)
+	if e.Method != "" {
+		msg = fmt.Sprintf("%s %s %s", e.Method, e.URL, msg)
+	}
+	if e.StatusCode != 0 {
+		msg = fmt.Sprintf("%s: last status %d", msg, e.StatusCode)
+		if e.Body != "" {
+			msg = fmt.Sprintf("%s: %s", msg, e.Body)
+		}
+	}
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %s", msg, e.Err)
+	}
+	return msg
+}
+
+func (e *RetriesExhaustedError) Unwrap() error { return e.Err }
+
+// retriesExhaustedErrorHandler converts retry exhaustion into a
+// *RetriesExhaustedError. retryablehttp hands the handler the final
+// response un-drained, so the handler owns closing it.
+func retriesExhaustedErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	exhausted := &RetriesExhaustedError{
+		Method:     "",
+		URL:        "",
+		Attempts:   numTries,
+		StatusCode: 0,
+		Body:       "",
+		Err:        err,
+	}
+	if resp != nil {
+		exhausted.Method = resp.Request.Method
+		exhausted.URL = resp.Request.URL.String()
+		exhausted.StatusCode = resp.StatusCode
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, retriesExhaustedBodyLimit))
+		_ = resp.Body.Close()
+		exhausted.Body = string(body)
+	}
+	return nil, exhausted
+}

--- a/server/internal/guardian/retry_test.go
+++ b/server/internal/guardian/retry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +52,65 @@ func TestClient_RetriesExhausted_PreservesFinalStatusAndBody(t *testing.T) {
 	require.Contains(t, exhausted.Body, "export pipeline wedged")
 	require.Contains(t, err.Error(), "giving up after 3 attempt(s)")
 	require.Contains(t, err.Error(), "last status 500")
+}
+
+func TestClient_ContextCancellationIsNotWrappedAsExhaustion(t *testing.T) {
+	t.Parallel()
+
+	// The handler stalls until the client abandons the request; unblocking
+	// on the request context keeps server.Close from waiting on it.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	client := policy.Client(guardian.WithRetryConfig(fastRetryConfig()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	var exhausted *guardian.RetriesExhaustedError
+	require.NotErrorAs(t, err, &exhausted, "caller-side aborts must not look like retry exhaustion")
+}
+
+func TestClient_RetriesExhausted_RedactsPasswordAndControlChars(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("line one\nline two\x07"))
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	client := policy.Client(guardian.WithRetryConfig(fastRetryConfig()))
+
+	authedURL := strings.Replace(server.URL, "http://", "http://user:hunter2@", 1)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, authedURL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+	require.Error(t, err)
+
+	var exhausted *guardian.RetriesExhaustedError
+	require.ErrorAs(t, err, &exhausted)
+	require.NotContains(t, exhausted.Error(), "hunter2")
+	require.Equal(t, "line one line two ", exhausted.Body)
 }
 
 func TestClient_RetriesExhausted_TransportFailureHasNoStatus(t *testing.T) {

--- a/server/internal/guardian/retry_test.go
+++ b/server/internal/guardian/retry_test.go
@@ -1,0 +1,113 @@
+package guardian_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func fastRetryConfig() *guardian.RetryConfig {
+	cfg := guardian.DefaultRetryConfig()
+	cfg.WaitMin = time.Millisecond
+	cfg.WaitMax = 5 * time.Millisecond
+	cfg.MaxAttempts = 2
+	return cfg
+}
+
+func TestClient_RetriesExhausted_PreservesFinalStatusAndBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"export pipeline wedged","request_id":"req_123"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	client := policy.Client(guardian.WithRetryConfig(fastRetryConfig()))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/logs", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+	require.Error(t, err)
+
+	var exhausted *guardian.RetriesExhaustedError
+	require.ErrorAs(t, err, &exhausted)
+	require.Equal(t, http.StatusInternalServerError, exhausted.StatusCode)
+	require.Equal(t, 3, exhausted.Attempts)
+	require.Contains(t, exhausted.Body, "export pipeline wedged")
+	require.Contains(t, err.Error(), "giving up after 3 attempt(s)")
+	require.Contains(t, err.Error(), "last status 500")
+}
+
+func TestClient_RetriesExhausted_TransportFailureHasNoStatus(t *testing.T) {
+	t.Parallel()
+
+	// A server that is already closed yields a connection error on every
+	// attempt, so exhaustion happens without ever seeing a response.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	client := policy.Client(guardian.WithRetryConfig(fastRetryConfig()))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+	require.Error(t, err)
+
+	var exhausted *guardian.RetriesExhaustedError
+	require.ErrorAs(t, err, &exhausted)
+	require.Equal(t, 0, exhausted.StatusCode)
+	require.Empty(t, exhausted.Body)
+	require.Error(t, exhausted.Err)
+}
+
+func TestClient_CustomErrorHandlerStillWins(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	sentinel := errors.New("custom handler ran")
+	cfg := fastRetryConfig()
+	cfg.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, sentinel
+	}
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	client := policy.Client(guardian.WithRetryConfig(cfg))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+	require.ErrorIs(t, err, sentinel)
+}


### PR DESCRIPTION
Tonight's `pollaidata` activity-failure burst (monitor 304557077) was one org's `codex_compliance` sync hitting persistent HTTP 500s from the provider's compliance API. Nothing was wrong on our side, but two of our behaviors made it noisy and opaque:

1. **The final response was discarded on retry exhaustion.** guardian's retryablehttp client returned the stock `giving up after N attempt(s)` error with no status code and no body, so no diagnostic surface could say _why_ the provider was failing.
2. **A provider outage burned the whole Temporal retry budget.** Each poll run retried the activity 5x (each attempt itself carrying the HTTP client's inner retries), inflating the activity-failure metric ~5x and paging on-call for something no one can action, while the schedule-level failure backoff (#5285) already owns the retry cadence.

## Changes

- **guardian**: retry exhaustion now surfaces a typed `RetriesExhaustedError` carrying the final attempt's status code and up to 1KB of the response body (provider error bodies include their error message and request id — the thing you need to escalate an outage). Wired as the default `ErrorHandler` for `DefaultRetryConfig()`; hand-rolled `WithRetryConfig` configs keep their explicit behavior. Error stays non-nil with a compatible message shape, and the response is still consumed and closed.
- **PollAIData**: new `pollProviderUnavailable` classification (retries exhausted, or a direct 429/5xx from any provider's typed HTTP error). Such failures now fail the activity once instead of 5 times, record the poll failure immediately so the backoff engages from the first failing run, persist a clean org-visible message ("provider api is temporarily unavailable (HTTP 500); the sync will back off and retry"), and never count toward auto-pause — outages end on their own, unlike key rejections, which still pause. The Temporal failure details gain a `provider_unavailable` flag.

Net effect on an outage like tonight's: ~1 activity failure per backoff window instead of 12+/30m, so the failure-burst monitor stays quiet for upstream outages while still firing for genuine Gram-side bugs (which keep the full 5-attempt retry).

## Testing

- New guardian tests run a real always-500 server and a dead listener through the retry client, asserting the typed error carries status/body (or neither), and that an explicit custom `ErrorHandler` still wins.
- New activity tests cover the classifier (including the error wrapped through `url.Error` and `SyncError`), the once-only non-retryable wrapping with details flag, and the shareable outage message (asserting the raw provider body does not leak into the org-visible error).
- Full `guardian`, `background/activities`, `aiintegrations`, and `thirdparty/...` suites pass; `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops in-run retries for usage polls when the provider is unavailable and preserves the last HTTP status/body on retry exhaustion. This cuts noisy failures during outages, defers retries to the schedule backoff, and improves diagnostics.

- `guardian`: exhausted retries return `RetriesExhaustedError` with the final status and up to 1KB of body; control chars sanitized and URL passwords redacted. Context cancellations/deadlines pass through unchanged. Default via `DefaultRetryConfig()`; a custom `ErrorHandler` set with `WithRetryConfig` still wins.
- Poll activity: classifies provider-unavailable failures (persistent 429/5xx, including `cursorapi` rate limits, or a spent retry budget; repeated transport failures only if multiple attempts) as non-retryable within the run, records the failure immediately so schedule backoff applies, and never counts toward auto-pause. Precedence: provider rejection beats outage for pause/messaging; outage evidence beats a timed-out sibling stage; cancellations/deadlines are not outages. Temporal details include `provider_unavailable`. User-facing message: “temporarily unavailable (HTTP N)” or “unreachable,” without leaking bodies.

<sup>Written for commit 8334e41e4747071e221a0431f6245de09440423f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

