### PR TITLE
fix: validate Stripe sandbox billing lifecycle

### DIFF
--- a/.changeset/accept-compatible-stripe-webhooks.md
+++ b/.changeset/accept-compatible-stripe-webhooks.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Accept Stripe webhook events from newer API versions within the SDK's compatible release train.

--- a/.mise-tasks/stripe/setup.mts
+++ b/.mise-tasks/stripe/setup.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --disable-warning=ExperimentalWarning --experimental-strip-types
 
-//MISE description="Provision and validate the Stripe sandbox TUM meter and metered price, then save the catalog config to mise.local.toml"
+//MISE description="Provision and validate Stripe sandbox billing objects and initialize the local webhook secret"
 
 // Idempotent: the meter is keyed on its event name and the price on its
 // lookup key, so re-running against a sandbox that already has the objects
@@ -160,6 +160,27 @@ async function resolveSecretKey(): Promise<{ key: string; prompted: boolean }> {
   return { key: entered, prompted: true };
 }
 
+async function resolveWebhookSecret(key: string): Promise<string> {
+  const listener = await $({
+    nothrow: true,
+    quiet: true,
+    env: { ...process.env, STRIPE_API_KEY: key },
+  })`stripe listen --print-secret --skip-update`;
+  const output = `${listener.stdout}\n${listener.stderr}`;
+  const secret = output.match(/whsec_[A-Za-z0-9]+/)?.[0];
+  if (listener.exitCode !== 0 || !secret) {
+    const details = output
+      .replaceAll(key, "<redacted>")
+      .replace(/(?:sk|rk)_(?:test|live)_[A-Za-z0-9_]+/g, "<redacted>")
+      .replace(/whsec_[A-Za-z0-9]+/g, "<redacted>")
+      .trim();
+    throw new Error(
+      `Initialize Stripe CLI webhook listener secret failed${details ? `: ${details}` : "."}`,
+    );
+  }
+  return secret;
+}
+
 async function findMeter(
   key: string,
   status: "active" | "inactive",
@@ -317,10 +338,14 @@ async function main() {
     ["recurring.meter", price.recurring?.meter, meter.id],
   ]);
 
+  const webhookSecret = await resolveWebhookSecret(key);
+  log.success("Initialized the Stripe CLI webhook signing secret.");
+
   const settings: Record<string, string> = {
     STRIPE_PRICE_ID_TUM: price.id,
     STRIPE_METER_ID_TUM: meter.id,
     STRIPE_METER_EVENT_NAME: METER_EVENT_NAME,
+    STRIPE_WEBHOOK_SECRET: webhookSecret,
   };
   if (prompted) {
     settings.STRIPE_API_KEY = key;
@@ -335,13 +360,29 @@ async function main() {
 
   log.info(
     [
-      "Manual follow-ups (dashboard-only settings, not settable via API):",
-      "  - Billing → Revenue recovery: use 8 Smart Retry attempts over 2 weeks,",
-      "    then cancel the subscription after retries are exhausted.",
-      "  - Billing → Invoices: set a 72-hour finalization grace period for this metered price.",
-      "  - Customer emails: enable failed-payment, finalized-invoice, and receipt emails.",
-      "  - Webhooks: once the webhook route exists, run `stripe listen --forward-to` against it",
-      "    and put the printed whsec_… value in mise.local.toml as STRIPE_WEBHOOK_SECRET.",
+      "Start webhook forwarding for this worktree in a separate terminal:",
+      '  if test "${STRIPE_API_KEY:-}" = unset; then unset STRIPE_API_KEY; fi',
+      '  stripe listen --skip-verify --forward-to "$GRAM_SERVER_URL/rpc/stripe.webhook"',
+    ].join("\n"),
+  );
+
+  log.info(
+    [
+      "Finish Stripe Dashboard setup before sandbox validation:",
+      "",
+      "1. Configure subscription Smart Retries",
+      "   Billing → Revenue recovery → Retries",
+      "   - Under Card payments, click Manage.",
+      "   - Select Smart Retries: 8 retries within 2 weeks.",
+      "   - Set Subscription status to cancel the subscription.",
+      "   - Leave Invoice status as leave the invoice past-due; it applies to one-off invoices.",
+      "   - Save the settings.",
+      "",
+      "2. Configure the metered invoice grace period",
+      "   Settings → Billing → Invoices → Invoice finalization grace period",
+      "   - Click Add rule and set Invoice finalization delay to 72 hours.",
+      "   - Add both conditions: Has a metered price and Invoice is from a subscription cycle.",
+      "   - Save the rule.",
     ].join("\n"),
   );
 

--- a/.mise-tasks/stripe/setup.mts
+++ b/.mise-tasks/stripe/setup.mts
@@ -362,7 +362,7 @@ async function main() {
     [
       "Start webhook forwarding for this worktree in a separate terminal:",
       '  if test "${STRIPE_API_KEY:-}" = unset; then unset STRIPE_API_KEY; fi',
-      '  stripe listen --skip-verify --forward-to "$GRAM_SERVER_URL/rpc/stripe.webhook"',
+      '  stripe listen --latest --skip-verify --forward-to "$GRAM_SERVER_URL/rpc/stripe.webhook"',
     ].join("\n"),
   );
 

--- a/docs/runbooks/stripe-m3-sandbox-validation.md
+++ b/docs/runbooks/stripe-m3-sandbox-validation.md
@@ -200,8 +200,8 @@ Confirm the test output covers all of these checkpoints:
 - the +48-hour TUM baseline freezes once, the closed-period event timestamp is
   `cycle_end - 1 second`, and a post-freeze difference becomes one signed
   carry-forward allocation after +72 hours;
-- only in-period chat spend is allocated; internal-key and pre-period spend is
-  excluded;
+- only in-period Other inference spend is allocated; Security inference and
+  pre-period spend are excluded;
 - exact decimal sums are converted to minor units once per cumulative period;
 - positive corrections become a later invoice item and negative corrections
   become a credit note, without duplicate delivery after replay;
@@ -235,7 +235,7 @@ SQL
 
 The sum of confirmed TUM deltas must equal the frozen billed baseline for the
 closed period. Initial OpenRouter allocation cents plus signed carry cents must
-equal the exact final cumulative chat-spend cents. Every confirmed external ID
+equal the exact final cumulative Other inference-spend cents. Every confirmed external ID
 must resolve to the same customer, subscription, invoice period, currency, and
 amount in Stripe.
 
@@ -247,8 +247,8 @@ Cancel the current sandbox subscription. Wait for
 - Gram is `free` and not admitted;
 - the stored subscription ID and exact Stripe anchor are cleared, while the
   Stripe customer remains;
-- the chat key is disabled locally and upstream;
-- the internal key is unchanged.
+- the Other inference key is disabled locally and upstream;
+- the Security inference key is unchanged.
 
 Use the deterministic lifecycle test above to replay the exact signed event and
 confirm receipt, audit, metric, and upstream effects do not repeat. In the
@@ -256,8 +256,8 @@ sandbox, deliver a deletion for an old subscription after completing a new
 Checkout and confirm the replacement remains active.
 
 Complete Checkout again with the same customer. The PAYG activation event must
-cause current-state reconciliation to re-enable the same chat key with its
-PAYG limit; the internal key remains untouched.
+cause current-state reconciliation to re-enable the same Other inference key
+with its PAYG limit; the Security inference key remains untouched.
 
 The voluntary cancellation proves Gram's terminal event behavior. Separately,
 confirm the sandbox Dashboard still has the required Smart Retries end action:

--- a/docs/runbooks/stripe-m3-sandbox-validation.md
+++ b/docs/runbooks/stripe-m3-sandbox-validation.md
@@ -1,0 +1,283 @@
+# Stripe M3 Sandbox Validation
+
+Use this runbook to validate PAYG conversion, metering, invoice allocation, and
+subscription loss in a Stripe sandbox. Run it twice from a clean test clock.
+Keep the two run IDs and the command output in the internal rollout record.
+
+This runbook never uses production Stripe objects. Do not paste customer,
+organization, project, email, or spend data into commits, pull requests, or CI
+logs. Use only synthetic values and placeholders such as `<ORG_ID>`.
+
+## What the clocks control
+
+Stripe test clocks advance Stripe objects only. They do not advance Gram's
+Postgres clock, Temporal clock, worker schedules, or activity `Now` inputs.
+The sandbox portion below validates real Stripe subscription and invoice state.
+The deterministic Gram tests use explicit timestamps to validate the +48-hour
+and +72-hour state transitions without waiting three days.
+
+Stripe advances a clock asynchronously. After every advance, poll until its
+status is `ready` before inspecting invoices or subscriptions. Test-clock
+objects are omitted from unscoped list calls, so retrieve them by clock,
+customer, subscription, or exact object ID.
+
+References:
+
+- [Stripe test-clock API workflow](https://docs.stripe.com/billing/testing/test-clocks/api-advanced-usage)
+- [Usage-based invoice finalization grace periods](https://docs.stripe.com/billing/subscriptions/usage-based/configure-grace-period)
+- [Smart Retries](https://docs.stripe.com/billing/revenue-recovery/smart-retries)
+
+## Prerequisites
+
+1. Use a Stripe sandbox with a test-mode secret key. Never use an `sk_live_` or
+   `rk_live_` key.
+2. Start the Docker daemon and prepare the local stack. In Cursor Cloud, start
+   Docker with `sudo service docker start`; on macOS, use Docker Desktop.
+
+   ```sh
+   ./zero --agent
+   ```
+
+3. Configure and validate the Stripe meter, metered price, and local webhook
+   signing secret:
+
+   ```sh
+   mise set --prompt --file mise.local.toml STRIPE_API_KEY
+   mise run stripe:setup
+   ```
+
+4. In the Stripe sandbox Dashboard, verify these account settings:
+
+   - the PAYG price is monthly, metered, USD, and attached to the configured
+     TUM meter;
+   - invoice finalization has a 72-hour rule for metered subscription-cycle
+     invoices;
+   - Smart Retries uses 8 attempts within 2 weeks and cancels the subscription
+     after the last failed attempt.
+
+5. Restart `server`, then forward sandbox webhooks to Gram in a separate
+   terminal. The setup task already saved the listener signing secret to
+   ignored `mise.local.toml`.
+
+   ```sh
+   pitchfork restart server
+   if test "${STRIPE_API_KEY:-}" = unset; then unset STRIPE_API_KEY; fi
+   stripe listen --skip-verify \
+     --forward-to "$GRAM_SERVER_URL/rpc/stripe.webhook"
+   ```
+
+6. Create a synthetic Gram organization through the local dashboard. Record
+   its ID and slug only in your shell or the internal rollout record:
+
+   ```sh
+   export M3_ORG_ID='<ORG_ID>'
+   export M3_ORG_SLUG='<ORG_SLUG>'
+   ```
+
+## Create a clocked Stripe customer
+
+Choose a UTC timestamp before the next midnight and export it as Unix seconds.
+Create the clock, then create a customer on that clock. The standard Stripe
+test payment method is sandbox-only.
+
+```sh
+export M3_CLOCK_START='<UNIX_SECONDS>'
+
+M3_CLOCK_ID="$({
+  curl --fail --silent --show-error https://api.stripe.com/v1/test_helpers/test_clocks \
+    -u "$STRIPE_API_KEY:" \
+    -d frozen_time="$M3_CLOCK_START" \
+    -d name='Gram M3 validation'
+} | jq -r .id)"
+export M3_CLOCK_ID
+
+M3_CUSTOMER_ID="$({
+  curl --fail --silent --show-error https://api.stripe.com/v1/customers \
+    -u "$STRIPE_API_KEY:" \
+    -d test_clock="$M3_CLOCK_ID" \
+    -d payment_method=pm_card_visa \
+    -d 'invoice_settings[default_payment_method]'=pm_card_visa
+} | jq -r .id)"
+export M3_CUSTOMER_ID
+```
+
+Associate the synthetic organization with this customer before opening
+Checkout. This is sandbox setup, not a production application path.
+
+```sh
+psql "$GRAM_DATABASE_URL" \
+  -v org_id="$M3_ORG_ID" \
+  -v customer_id="$M3_CUSTOMER_ID" <<'SQL'
+INSERT INTO billing_metadata (organization_id, stripe_customer_id)
+VALUES (:'org_id', :'customer_id')
+ON CONFLICT (organization_id) DO UPDATE
+SET stripe_customer_id = EXCLUDED.stripe_customer_id,
+    updated_at = clock_timestamp();
+SQL
+```
+
+## Convert to PAYG and verify the paid anchor
+
+1. Open `http://localhost:5173/<ORG_SLUG>/billing` as an organization admin.
+2. Start PAYG Checkout and complete it with the sandbox card.
+3. Wait for `checkout.session.completed` to reach the local webhook listener.
+4. Query the durable projection:
+
+   ```sh
+   psql "$GRAM_DATABASE_URL" \
+     -v org_id="$M3_ORG_ID" \
+     -c "SELECT om.gram_account_type, om.whitelisted,
+                bm.stripe_customer_id, bm.stripe_subscription_id,
+                bm.stripe_billing_cycle_anchor
+         FROM organization_metadata om
+         JOIN billing_metadata bm ON bm.organization_id = om.id
+         WHERE om.id = :'org_id'"
+   ```
+
+The organization must be `payg` and admitted, the customer must be unchanged,
+and the first paid anchor must be the next `00:00:00Z`. A checkout completed
+before that boundary produces only a free Stripe stub; no trial-window or
+pre-anchor usage belongs to the paid period.
+
+Retrieve the exact subscription rather than using an unscoped list request:
+
+```sh
+export M3_SUBSCRIPTION_ID='<SUBSCRIPTION_ID_FROM_DATABASE>'
+curl --fail --silent --show-error \
+  "https://api.stripe.com/v1/subscriptions/$M3_SUBSCRIPTION_ID" \
+  -u "$STRIPE_API_KEY:" | jq '{id,status,billing_cycle_anchor,test_clock}'
+```
+
+Advance the Stripe clock to the paid anchor, poll until ready, then advance one
+monthly interval and poll again. Confirm the next subscription-cycle invoice
+uses midnight UTC service-period bounds and remains draft under the 72-hour
+metered grace rule.
+
+```sh
+wait_for_m3_clock() {
+  while true; do
+    status="$({
+      curl --fail --silent --show-error \
+        "https://api.stripe.com/v1/test_helpers/test_clocks/$M3_CLOCK_ID" \
+        -u "$STRIPE_API_KEY:"
+    } | jq -r .status)"
+    test "$status" = ready && break
+    sleep 2
+  done
+}
+
+curl --fail --silent --show-error \
+  "https://api.stripe.com/v1/test_helpers/test_clocks/$M3_CLOCK_ID/advance" \
+  -u "$STRIPE_API_KEY:" \
+  -d frozen_time='<NEXT_UTC_MIDNIGHT_UNIX_SECONDS>'
+wait_for_m3_clock
+
+curl --fail --silent --show-error \
+  "https://api.stripe.com/v1/test_helpers/test_clocks/$M3_CLOCK_ID/advance" \
+  -u "$STRIPE_API_KEY:" \
+  -d frozen_time='<NEXT_MONTHLY_ANCHOR_UNIX_SECONDS>'
+wait_for_m3_clock
+```
+
+## Validate Gram's explicit-time billing transitions
+
+Run the deterministic acceptance suites. They seed synthetic Postgres state,
+invoke the real activities and webhook handler with explicit timestamps, and
+use fake remote boundaries so CI never needs Stripe credentials.
+
+```sh
+mise exec -- go test ./server/internal/usage \
+  -run 'TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle|TestStripeCheckout' -count=1
+
+mise exec -- go test ./server/internal/background/activities \
+  -run 'TestM3FreezeObservationAndCarrySettlementLifecycle|TestReportTUMUsageToStripe' -count=1
+```
+
+Confirm the test output covers all of these checkpoints:
+
+- paid periods start at midnight UTC and exclude the free stub;
+- durable TUM intents use signed database-derived deltas and stable IDs;
+- the +48-hour TUM baseline freezes once, the closed-period event timestamp is
+  `cycle_end - 1 second`, and a post-freeze difference becomes one signed
+  carry-forward allocation after +72 hours;
+- only in-period chat spend is allocated; internal-key and pre-period spend is
+  excluded;
+- exact decimal sums are converted to minor units once per cumulative period;
+- positive corrections become a later invoice item and negative corrections
+  become a credit note, without duplicate delivery after replay;
+- ambiguous meter and allocation writes stay on the same idempotency identity
+  inside 24 hours and reconcile before a replacement identity is used.
+
+For the sandbox run, compare the same durable records to Stripe by exact object
+ID. Do not use unscoped list endpoints.
+
+```sh
+psql "$GRAM_DATABASE_URL" -v org_id="$M3_ORG_ID" <<'SQL'
+SELECT cycle_start, cycle_end, tum_tokens, billed_tum_tokens,
+       billed_frozen_at, finalized_at
+FROM billing_cycle_usage
+WHERE organization_id = :'org_id'
+ORDER BY cycle_start;
+
+SELECT source_kind, source_key, seq, source_snapshot_usd, amount_usd,
+       delivery_state, stripe_invoice_item_id, stripe_credit_note_id
+FROM stripe_invoice_allocations
+WHERE organization_id = :'org_id'
+ORDER BY source_period_start, source_key, seq;
+
+SELECT stripe_identifier, delta_tokens, event_timestamp,
+       delivery_state, confirmed_at
+FROM stripe_meter_reports
+WHERE organization_id = :'org_id'
+ORDER BY event_timestamp, seq;
+SQL
+```
+
+The sum of confirmed TUM deltas must equal the frozen billed baseline for the
+closed period. Initial OpenRouter allocation cents plus signed carry cents must
+equal the exact final cumulative chat-spend cents. Every confirmed external ID
+must resolve to the same customer, subscription, invoice period, currency, and
+amount in Stripe.
+
+## Validate subscription loss and recovery
+
+Cancel the current sandbox subscription. Wait for
+`customer.subscription.deleted`, then verify:
+
+- Gram is `free` and not admitted;
+- the stored subscription ID and exact Stripe anchor are cleared, while the
+  Stripe customer remains;
+- the chat key is disabled locally and upstream;
+- the internal key is unchanged.
+
+Use the deterministic lifecycle test above to replay the exact signed event and
+confirm receipt, audit, metric, and upstream effects do not repeat. In the
+sandbox, deliver a deletion for an old subscription after completing a new
+Checkout and confirm the replacement remains active.
+
+Complete Checkout again with the same customer. The PAYG activation event must
+cause current-state reconciliation to re-enable the same chat key with its
+PAYG limit; the internal key remains untouched.
+
+The voluntary cancellation proves Gram's terminal event behavior. Separately,
+confirm the sandbox Dashboard still has the required Smart Retries end action:
+8 attempts within 2 weeks, then cancel. Stripe owns the retry schedule and
+customer retry emails; Gram reacts only to the terminal deletion.
+
+## Cleanup and mandatory repetition
+
+Delete the test clock. Stripe also deletes its associated sandbox objects.
+
+```sh
+curl --fail --silent --show-error -X DELETE \
+  "https://api.stripe.com/v1/test_helpers/test_clocks/$M3_CLOCK_ID" \
+  -u "$STRIPE_API_KEY:"
+```
+
+Delete the synthetic Gram organization through the normal local administration
+path. Do not reuse its billing rows for the second run.
+
+Repeat the complete runbook with a new clock, customer, and synthetic Gram
+organization. The second run must require no manual database repair and must
+produce the same invariants. File a discrepancy before expanding beyond the
+internal sandbox cohort.

--- a/docs/runbooks/stripe-m3-sandbox-validation.md
+++ b/docs/runbooks/stripe-m3-sandbox-validation.md
@@ -235,7 +235,8 @@ SQL
 
 The sum of confirmed TUM deltas must equal the frozen billed baseline for the
 closed period. Initial OpenRouter allocation cents plus signed carry cents must
-equal the exact final cumulative Other inference-spend cents. Every confirmed external ID
+equal the exact final cumulative Other inference spend cents. Every confirmed
+external ID
 must resolve to the same customer, subscription, invoice period, currency, and
 amount in Stripe.
 

--- a/docs/runbooks/stripe-m3-sandbox-validation.md
+++ b/docs/runbooks/stripe-m3-sandbox-validation.md
@@ -62,7 +62,7 @@ References:
    ```sh
    pitchfork restart server
    if test "${STRIPE_API_KEY:-}" = unset; then unset STRIPE_API_KEY; fi
-   stripe listen --skip-verify \
+   stripe listen --latest --skip-verify \
      --forward-to "$GRAM_SERVER_URL/rpc/stripe.webhook"
    ```
 

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
@@ -20,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
 type allocationStripeMock struct {
@@ -822,4 +824,101 @@ func TestSettleStripeInvoiceAllocations_RefusesVoidCreditDestination(t *testing.
 	err := activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(24 * time.Hour)})
 	require.ErrorContains(t, err, `status "void" does not support credit notes`)
 	require.Empty(t, stripe.creditInputs)
+}
+
+func TestM3FreezeObservationAndCarrySettlementLifecycle(t *testing.T) {
+	t.Parallel()
+
+	anchor := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	reporter, meterStripe, db, organizationID := setupTUMStripeReporter(t, "m3_freeze_carry_lifecycle", "payg", anchor)
+	cycleEnd := anchor.AddDate(0, 1, 0)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 2_000_000, nil)
+
+	allocationStripe := &allocationStripeMock{invoices: make(map[string]*stripeclient.InvoiceState)}
+	allocator := activities.NewSettleStripeInvoiceAllocations(testenv.NewLogger(t), db, allocationStripe)
+	addStripeInvoice(t, db, allocationStripe, organizationID, "invoice_original", anchor, cycleEnd, "draft", 0)
+	addStripeInvoice(t, db, allocationStripe, organizationID, "invoice_carry", cycleEnd, cycleEnd.AddDate(0, 1, 0), "draft", 0)
+	createChatKeyAt(t, db, organizationID, anchor.Add(-time.Hour))
+	putDailySpend(t, db, organizationID, anchor, "1.005000")
+
+	meterStripe.On("CreateMeterEvent", mock.Anything, mock.MatchedBy(func(input stripeclient.CreateMeterEventInput) bool {
+		return input.Value == 2_000_000 && input.Timestamp.Equal(cycleEnd.Add(-time.Second)) && input.IdempotencyKey != ""
+	})).Return(nil).Once()
+	freezeAt := cycleEnd.Add(48 * time.Hour)
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             freezeAt,
+	}))
+	require.NoError(t, allocator.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: freezeAt}))
+
+	finalizedAt := cycleEnd.Add(72 * time.Hour)
+	upsertTUMCycle(t, db, organizationID, anchor, cycleEnd, 2_100_000, &finalizedAt)
+	putDailySpend(t, db, organizationID, anchor, "1.255000")
+	_, err := usagerepo.New(db).UpsertStripeInvoice(t.Context(), usagerepo.UpsertStripeInvoiceParams{
+		StripeInvoiceID:      "invoice_original",
+		OrganizationID:       pgtype.Text{String: organizationID, Valid: true},
+		StripeCustomerID:     "cus_" + organizationID,
+		StripeSubscriptionID: "sub_" + organizationID,
+		ServicePeriodStart:   pgtype.Timestamptz{Time: anchor, InfinityModifier: pgtype.Finite, Valid: true},
+		ServicePeriodEnd:     pgtype.Timestamptz{Time: cycleEnd, InfinityModifier: pgtype.Finite, Valid: true},
+		InvoiceState:         "open",
+		FinalizedAt:          pgtype.Timestamptz{Time: cycleEnd.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+	allocationStripe.invoices["invoice_original"].Status = "open"
+	allocationStripe.invoices["invoice_original"].FinalizedAt = cycleEnd.Add(time.Hour)
+
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             finalizedAt,
+	}))
+	require.NoError(t, allocator.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: finalizedAt}))
+
+	// Re-running both deterministic passes proves the immutable final source is
+	// allocated once even after the observation window has closed.
+	replayAt := finalizedAt.Add(24 * time.Hour)
+	require.NoError(t, reporter.Do(t.Context(), activities.ReportTUMUsageToStripeInput{
+		OrganizationIDs: []string{organizationID},
+		Now:             replayAt,
+	}))
+	require.NoError(t, allocator.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: replayAt}))
+
+	cycles, err := usagerepo.New(db).ListBillingCycleUsage(t.Context(), organizationID)
+	require.NoError(t, err)
+	require.Len(t, cycles, 1)
+	require.Equal(t, int64(2_000_000), cycles[0].BilledTumTokens.Int64)
+	require.Equal(t, int64(2_100_000), cycles[0].TumTokens)
+
+	tumCarries, err := usagerepo.New(db).ListTUMCarryAllocationsFixture(t.Context(), pgtype.Text{String: organizationID, Valid: true})
+	require.NoError(t, err)
+	require.Len(t, tumCarries, 1)
+	require.Equal(t, int64(100_000), tumCarries[0].DeltaTokens.Int64)
+	require.Equal(t, "0.040000", numericString(t, tumCarries[0].AmountUsd))
+
+	allocations := listAllocationFixtures(t, db, organizationID)
+	amountsBySource := make(map[string][]string)
+	for _, allocation := range allocations {
+		require.Equal(t, "confirmed", allocation.DeliveryState)
+		amount := numericString(t, allocation.AmountUsd)
+		if amount == "0.250000" || amount == "0.040000" {
+			require.Equal(t, "invoice_carry", allocation.DestinationInvoiceID.String)
+		}
+		if amount != "0" {
+			amountsBySource[allocation.SourceKind] = append(amountsBySource[allocation.SourceKind], amount)
+		}
+	}
+	require.ElementsMatch(t, []string{"1.010000", "0.250000"}, amountsBySource["openrouter_daily_spend"])
+	require.Equal(t, []string{"0.040000"}, amountsBySource["tum_cycle"])
+
+	require.Len(t, allocationStripe.itemInputs, 3)
+	itemCents := make([]int64, 0, len(allocationStripe.itemInputs))
+	for _, input := range allocationStripe.itemInputs {
+		itemCents = append(itemCents, input.AmountCents)
+		if input.AmountCents == 25 || input.AmountCents == 4 {
+			require.Equal(t, "invoice_carry", input.InvoiceID)
+		}
+	}
+	require.ElementsMatch(t, []int64{101, 25, 4}, itemCents)
+	require.Empty(t, allocationStripe.creditInputs)
+	meterStripe.AssertExpectations(t)
 }

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -714,9 +714,6 @@ func (c *client) VerifyWebhook(payload []byte, signature string) (*WebhookEvent,
 	if err != nil {
 		return nil, fmt.Errorf("verify Stripe webhook: %w", err)
 	}
-	if event.APIVersion != stripesdk.APIVersion {
-		return nil, fmt.Errorf("verify Stripe webhook: expected API version %s, got %s", stripesdk.APIVersion, event.APIVersion)
-	}
 
 	var objectID string
 	var customerID string

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -710,7 +710,11 @@ func (c *client) VerifyWebhook(payload []byte, signature string) (*WebhookEvent,
 		return nil, fmt.Errorf("verify Stripe webhook: %w", ErrWebhookNotConfigured)
 	}
 
-	event, err := stripewebhook.ConstructEvent(payload, signature, c.webhookSecret)
+	event, err := stripewebhook.ConstructEventWithOptions(payload, signature, c.webhookSecret, stripewebhook.ConstructEventOptions{
+		Tolerance:                0,
+		IgnoreTolerance:          false,
+		IgnoreAPIVersionMismatch: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("verify Stripe webhook: %w", err)
 	}

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -84,12 +84,6 @@ func TestIsConfigured(t *testing.T) {
 	require.True(t, IsConfigured("sk_test_placeholder"))
 }
 
-func TestSDKPinsExpectedAPIVersion(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "2026-03-25.dahlia", stripesdk.APIVersion)
-}
-
 type fakeStripeAPI struct {
 	customerParams         *stripesdk.CustomerCreateParams
 	checkoutSessionParams  *stripesdk.CheckoutSessionCreateParams
@@ -932,34 +926,25 @@ func TestVerifyWebhookRejectsReplayedTimestamp(t *testing.T) {
 	require.NotErrorIs(t, err, ErrWebhookNotConfigured)
 }
 
-func TestVerifyWebhookAcceptsNewerVersionInSDKReleaseTrain(t *testing.T) {
+func TestVerifyWebhookAcceptsSignedEventsAcrossAPIVersions(t *testing.T) {
 	t.Parallel()
 
-	const secret = "whsec_test"
-	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
-		Payload: webhookPayload(t, "2026-07-29.dahlia", time.Now(), map[string]any{"id": "in_test"}),
-		Secret:  secret,
-	})
-	c := &client{webhookSecret: secret}
+	for _, apiVersion := range []string{"2025-09-30.clover", "2026-07-29.dahlia", "2099-01-01.future"} {
+		t.Run(apiVersion, func(t *testing.T) {
+			t.Parallel()
 
-	event, err := c.VerifyWebhook(signed.Payload, signed.Header)
-	require.NoError(t, err)
-	require.Equal(t, "in_test", event.ObjectID)
-}
+			const secret = "whsec_test"
+			signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
+				Payload: webhookPayload(t, apiVersion, time.Now(), map[string]any{"id": "in_test"}),
+				Secret:  secret,
+			})
+			c := &client{webhookSecret: secret}
 
-func TestVerifyWebhookRejectsIncompatibleReleaseTrain(t *testing.T) {
-	t.Parallel()
-
-	const secret = "whsec_test"
-	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
-		Payload: webhookPayload(t, "2025-09-30.clover", time.Now(), map[string]any{"id": "in_test"}),
-		Secret:  secret,
-	})
-	c := &client{webhookSecret: secret}
-
-	_, err := c.VerifyWebhook(signed.Payload, signed.Header)
-	require.ErrorContains(t, err, "expects API version "+stripesdk.APIVersion)
-	require.NotErrorIs(t, err, ErrWebhookNotConfigured)
+			event, err := c.VerifyWebhook(signed.Payload, signed.Header)
+			require.NoError(t, err)
+			require.Equal(t, "in_test", event.ObjectID)
+		})
+	}
 }
 
 func TestStubClientIsSafeToCall(t *testing.T) {

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -932,18 +932,33 @@ func TestVerifyWebhookRejectsReplayedTimestamp(t *testing.T) {
 	require.NotErrorIs(t, err, ErrWebhookNotConfigured)
 }
 
-func TestVerifyWebhookRejectsWrongAPIVersion(t *testing.T) {
+func TestVerifyWebhookAcceptsNewerVersionInSDKReleaseTrain(t *testing.T) {
 	t.Parallel()
 
 	const secret = "whsec_test"
 	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
-		Payload: webhookPayload(t, "2026-05-27.dahlia", time.Now(), map[string]any{"id": "in_test"}),
+		Payload: webhookPayload(t, "2026-07-29.dahlia", time.Now(), map[string]any{"id": "in_test"}),
+		Secret:  secret,
+	})
+	c := &client{webhookSecret: secret}
+
+	event, err := c.VerifyWebhook(signed.Payload, signed.Header)
+	require.NoError(t, err)
+	require.Equal(t, "in_test", event.ObjectID)
+}
+
+func TestVerifyWebhookRejectsIncompatibleReleaseTrain(t *testing.T) {
+	t.Parallel()
+
+	const secret = "whsec_test"
+	signed := stripewebhook.GenerateTestSignedPayload(&stripewebhook.UnsignedPayload{
+		Payload: webhookPayload(t, "2025-09-30.clover", time.Now(), map[string]any{"id": "in_test"}),
 		Secret:  secret,
 	})
 	c := &client{webhookSecret: secret}
 
 	_, err := c.VerifyWebhook(signed.Payload, signed.Header)
-	require.ErrorContains(t, err, "expected API version "+stripesdk.APIVersion)
+	require.ErrorContains(t, err, "expects API version "+stripesdk.APIVersion)
 	require.NotErrorIs(t, err, ErrWebhookNotConfigured)
 }
 

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -169,7 +169,6 @@ func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
 		_, err := keys.CreateOpenRouterAPIKey(t.Context(), openrouterrepo.CreateOpenRouterAPIKeyParams{
 			OrganizationID: m3OrganizationID,
 			KeyType:        string(keyType),
-			Key:            pgtype.Text{String: "key_placeholder_" + string(keyType), Valid: true},
 			KeyEncrypted:   pgtype.Text{},
 			KeyHash:        "hash_placeholder_" + string(keyType),
 			MonthlyCredits: 70,

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -1,0 +1,290 @@
+package usage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+	"github.com/speakeasy-api/gram/server/internal/usage"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+const (
+	m3OrganizationID = "org_billing_validation"
+	m3CustomerID     = "customer_placeholder"
+)
+
+type m3StripeWebhookClient struct {
+	event    stripeclient.WebhookEvent
+	checkout stripeclient.CheckoutSessionState
+}
+
+func (*m3StripeWebhookClient) CreateCustomer(context.Context, stripeclient.CreateCustomerInput) (*stripeclient.Customer, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*m3StripeWebhookClient) CreateCheckoutSession(context.Context, stripeclient.CreateCheckoutSessionInput) (*stripeclient.CheckoutSession, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *m3StripeWebhookClient) GetCheckoutSession(context.Context, string) (*stripeclient.CheckoutSessionState, error) {
+	state := c.checkout
+	return &state, nil
+}
+
+func (*m3StripeWebhookClient) CreateMeterEvent(context.Context, stripeclient.CreateMeterEventInput) error {
+	return errors.New("not implemented")
+}
+
+func (*m3StripeWebhookClient) GetMeterEventSummary(context.Context, stripeclient.GetMeterEventSummaryInput) (float64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (*m3StripeWebhookClient) GetInvoice(context.Context, string) (*stripeclient.InvoiceState, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*m3StripeWebhookClient) CreateInvoiceItem(context.Context, stripeclient.CreateInvoiceItemInput) (*stripeclient.InvoiceItem, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*m3StripeWebhookClient) CreateCreditNote(context.Context, stripeclient.CreateCreditNoteInput) (*stripeclient.CreditNote, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*m3StripeWebhookClient) FindInvoiceItem(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.InvoiceItem, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*m3StripeWebhookClient) FindCreditNote(context.Context, stripeclient.FindInvoiceAllocationInput) (*stripeclient.CreditNote, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *m3StripeWebhookClient) VerifyWebhook([]byte, string) (*stripeclient.WebhookEvent, error) {
+	event := c.event
+	return &event, nil
+}
+
+func (*m3StripeWebhookClient) Catalog() stripeclient.Catalog {
+	return stripeclient.Catalog{PriceIDTUM: "", MeterIDTUM: "", MeterEventName: ""}
+}
+
+type m3OpenRouterProvisioner struct {
+	db           openrouterrepo.DBTX
+	disableCalls []openrouter.KeyType
+	refreshCalls []openrouter.KeyType
+}
+
+func (*m3OpenRouterProvisioner) ProvisionAPIKey(context.Context, string, openrouter.KeyType) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (p *m3OpenRouterProvisioner) RefreshAPIKeyLimit(ctx context.Context, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
+	key, err := openrouterrepo.New(p.db).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
+		OrganizationID: organizationID,
+		KeyType:        string(keyType),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("get OpenRouter API key: %w", err)
+	}
+	refreshed, err := openrouterrepo.New(p.db).UpdateOpenRouterKey(ctx, openrouterrepo.UpdateOpenRouterKeyParams{
+		MonthlyCredits: int64(*limit),
+		KeyHash:        key.KeyHash,
+		Reinstate:      key.Disabled,
+		OrganizationID: organizationID,
+		KeyType:        string(keyType),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("update OpenRouter API key: %w", err)
+	}
+	p.refreshCalls = append(p.refreshCalls, keyType)
+	return int(refreshed.MonthlyCredits), nil
+}
+
+func (p *m3OpenRouterProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {
+	p.disableCalls = append(p.disableCalls, keyType)
+	if err := openrouterrepo.New(p.db).DisableOpenRouterAPIKey(ctx, openrouterrepo.DisableOpenRouterAPIKeyParams{
+		OrganizationID: organizationID,
+		KeyType:        string(keyType),
+	}); err != nil {
+		return fmt.Errorf("disable OpenRouter API key: %w", err)
+	}
+	return nil
+}
+
+func (*m3OpenRouterProvisioner) GetCreditsUsed(context.Context, string, openrouter.KeyType) (float64, int, error) {
+	return 0, 0, errors.New("not implemented")
+}
+
+func (*m3OpenRouterProvisioner) GetKeyUsage(context.Context, string) (float64, *int64, error) {
+	return 0, nil, errors.New("not implemented")
+}
+
+func (*m3OpenRouterProvisioner) ReconcileMonthlyCredits(context.Context, string, openrouter.KeyType, int64, *int64) (int64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (*m3OpenRouterProvisioner) GetModelUsage(context.Context, string, string, openrouter.KeyType) (*openrouter.ModelUsage, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	db, err := usage.CloneM3BillingValidationDatabase(t, "m3_subscription_lifecycle")
+	require.NoError(t, err)
+
+	require.NoError(t, orgrepo.New(db).CreateOrganizationMetadata(t.Context(), orgrepo.CreateOrganizationMetadataParams{
+		ID:   m3OrganizationID,
+		Name: "Billing Validation Organization",
+		Slug: "billing-validation",
+	}))
+	require.NoError(t, authz.SeedSystemRoleGrants(t.Context(), db, m3OrganizationID))
+	require.NoError(t, usagerepo.New(db).CreateStripeBillingMetadataFixture(t.Context(), usagerepo.CreateStripeBillingMetadataFixtureParams{
+		OrganizationID:   m3OrganizationID,
+		StripeCustomerID: pgtype.Text{String: m3CustomerID, Valid: true},
+	}))
+
+	keys := openrouterrepo.New(db)
+	for _, keyType := range openrouter.AllKeyTypes {
+		_, err := keys.CreateOpenRouterAPIKey(t.Context(), openrouterrepo.CreateOpenRouterAPIKeyParams{
+			OrganizationID: m3OrganizationID,
+			KeyType:        string(keyType),
+			Key:            pgtype.Text{String: "key_placeholder_" + string(keyType), Valid: true},
+			KeyEncrypted:   pgtype.Text{},
+			KeyHash:        "hash_placeholder_" + string(keyType),
+			MonthlyCredits: 70,
+		})
+		require.NoError(t, err)
+	}
+
+	stripe := &m3StripeWebhookClient{}
+	provisioner := &m3OpenRouterProvisioner{db: db, disableCalls: nil, refreshCalls: nil}
+	service, metrics := usage.NewM3StripeWebhookService(t, db, stripe)
+	mux := goahttp.NewMuxer()
+	usage.Attach(mux, service)
+
+	serve := func(body string) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/rpc/stripe.webhook", strings.NewReader(body))
+		request.Header.Set("Stripe-Signature", "signature_placeholder")
+		mux.ServeHTTP(recorder, request)
+		require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+	checkout := func(eventID, subscriptionID string, anchor time.Time) {
+		stripe.event = stripeclient.WebhookEvent{
+			ID:             eventID,
+			Type:           "checkout.session.completed",
+			Created:        anchor.Add(-time.Hour),
+			ObjectID:       "checkout_" + eventID,
+			CustomerID:     m3CustomerID,
+			SubscriptionID: subscriptionID,
+		}
+		stripe.checkout = stripeclient.CheckoutSessionState{
+			ID:                     stripe.event.ObjectID,
+			Status:                 "complete",
+			CustomerID:             m3CustomerID,
+			SubscriptionID:         subscriptionID,
+			SubscriptionCustomerID: m3CustomerID,
+			SubscriptionStatus:     "active",
+			BillingCycleAnchor:     anchor,
+		}
+		serve(eventID)
+	}
+	deleted := func(eventID, subscriptionID string) {
+		stripe.event = stripeclient.WebhookEvent{
+			ID:         eventID,
+			Type:       "customer.subscription.deleted",
+			Created:    time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC),
+			ObjectID:   subscriptionID,
+			CustomerID: m3CustomerID,
+		}
+		serve(eventID)
+	}
+	keyState := func(keyType openrouter.KeyType) openrouterrepo.OpenrouterApiKey {
+		key, err := keys.GetOpenRouterAPIKey(t.Context(), openrouterrepo.GetOpenRouterAPIKeyParams{
+			OrganizationID: m3OrganizationID,
+			KeyType:        string(keyType),
+		})
+		require.NoError(t, err)
+		return key
+	}
+
+	firstAnchor := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	checkout("event_initial_checkout", "subscription_initial", firstAnchor)
+	deleted("event_subscription_loss", "subscription_initial")
+	require.EqualValues(t, 1, metrics.SubscriptionLosses())
+	require.True(t, keyState(openrouter.KeyTypeChat).Disabled)
+	require.False(t, keyState(openrouter.KeyTypeInternal).Disabled)
+
+	reconciler := activities.NewReconcilePaygOpenRouterChatKey(logger, db, provisioner)
+	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
+		OrganizationID: m3OrganizationID,
+		DesiredState:   openrouter.KeyDesiredStateDisabled,
+	}))
+	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat}, provisioner.disableCalls)
+	require.Empty(t, provisioner.refreshCalls)
+
+	secondAnchor := time.Date(2026, time.October, 2, 0, 0, 0, 0, time.UTC)
+	checkout("event_recheckout", "subscription_replacement", secondAnchor)
+	require.True(t, keyState(openrouter.KeyTypeChat).Disabled, "recheckout commits before the durable wake-up is consumed")
+	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
+		OrganizationID: m3OrganizationID,
+		DesiredState:   openrouter.KeyDesiredStateEnabled,
+	}))
+	require.False(t, keyState(openrouter.KeyTypeChat).Disabled)
+	require.False(t, keyState(openrouter.KeyTypeInternal).Disabled)
+	require.Equal(t, "hash_placeholder_chat", keyState(openrouter.KeyTypeChat).KeyHash)
+	require.Equal(t, "hash_placeholder_internal", keyState(openrouter.KeyTypeInternal).KeyHash)
+
+	deleted("event_stale_subscription_loss", "subscription_initial")
+	serve("exact replay")
+	require.EqualValues(t, 1, metrics.SubscriptionLosses(), "stale and replayed deletions do not repeat the metric")
+	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
+		OrganizationID: m3OrganizationID,
+		DesiredState:   openrouter.KeyDesiredStateDisabled,
+	}))
+
+	metadata, err := usagerepo.New(db).GetBillingMetadata(t.Context(), m3OrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "subscription_replacement", metadata.StripeSubscriptionID.String)
+	require.True(t, metadata.StripeBillingCycleAnchor.Valid)
+	require.True(t, secondAnchor.Equal(metadata.StripeBillingCycleAnchor.Time))
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), m3OrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "payg", organization.GramAccountType)
+	require.True(t, organization.Whitelisted)
+	require.False(t, keyState(openrouter.KeyTypeChat).Disabled)
+	require.False(t, keyState(openrouter.KeyTypeInternal).Disabled)
+	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat}, provisioner.disableCalls)
+	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat}, provisioner.refreshCalls)
+
+	receipts, err := usagerepo.New(db).CountStripeWebhookReceiptsFixture(t.Context(), m3OrganizationID)
+	require.NoError(t, err)
+	require.EqualValues(t, 4, receipts)
+	activations, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, activations)
+	deactivations, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygDeactivated)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deactivations)
+}

--- a/server/internal/usage/m3_test_exports_test.go
+++ b/server/internal/usage/m3_test_exports_test.go
@@ -1,0 +1,53 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+)
+
+type M3StripeWebhookMetrics struct {
+	subscriptionLosses atomic.Int64
+}
+
+func (*M3StripeWebhookMetrics) RecordInvoicePaymentFailed(context.Context) {}
+
+func (m *M3StripeWebhookMetrics) RecordSubscriptionLost(context.Context) {
+	m.subscriptionLosses.Add(1)
+}
+
+func (m *M3StripeWebhookMetrics) SubscriptionLosses() int64 {
+	return m.subscriptionLosses.Load()
+}
+
+func CloneM3BillingValidationDatabase(t *testing.T, name string) (*pgxpool.Pool, error) {
+	t.Helper()
+	db, err := infra.CloneTestDatabase(t, name)
+	if err != nil {
+		return nil, fmt.Errorf("clone M3 billing validation database: %w", err)
+	}
+	return db, nil
+}
+
+func NewM3StripeWebhookService(t *testing.T, db *pgxpool.Pool, stripeClient stripeclient.Client) (*Service, *M3StripeWebhookMetrics) {
+	t.Helper()
+	metrics := &M3StripeWebhookMetrics{}
+	service := &Service{
+		logger:          testenv.NewLogger(t),
+		db:              db,
+		auditLogger:     audit.NewLogger(),
+		stripeClient:    stripeClient,
+		stripeHandler:   nil,
+		stripeMetrics:   metrics,
+		productFeatures: nil,
+	}
+	service.stripeHandler = service.serviceStripeWebhookHandler
+	return service, metrics
+}


### PR DESCRIPTION
## Summary

- extend `mise run stripe:setup` to provision and validate the Stripe billing catalog, initialize a stable local webhook signing secret, and print the remaining Dashboard-only policy steps
- accept correctly signed Stripe webhooks across API-version drift while retaining signature and timestamp verification
- add a repeatable sandbox runbook for conversion, midnight anchors, metering, invoice allocation, subscription loss, and recovery
- add deterministic lifecycle and +48/+72 settlement coverage using Security inference and Other inference terminology

## Testing

- `mise run stripe:setup`
- `mise exec -- go test ./server/internal/usage ./server/internal/background/activities ./server/internal/background ./server/internal/thirdparty/stripe ./server/internal/thirdparty/openrouter -count=1`
- `mise lint:server`
- `mise build:server --readonly`
- `git diff --check`

## Stack

- depends on #5363
- Linear: DNO-848
