### PR TITLE
feat: send PAYG lifecycle emails

### DIFF
--- a/.changeset/payg-trial-and-access-emails.md
+++ b/.changeset/payg-trial-and-access-emails.md
@@ -1,0 +1,7 @@
+---
+"server": patch
+---
+
+Send an idempotent reminder three days before an eligible trial ends, and notify
+PAYG billing contacts when subscription loss or an eligible trial demotion
+pauses access. Both emails re-check current billing state before delivery.

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -34,6 +34,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background"
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -487,9 +488,13 @@ func newStreamsCommand() *cli.Command {
 
 			svixRelayHandler := svixrelay.NewHandler(logger, meterProvider, db, svixClient)
 			paygKeyRefreshHandler := usage.NewPaygKeyRefreshHandler(logger, openRouterKeyRefresher)
+			billingNotificationHandler := billingnotifications.NewEventHandler(logger, &background.TemporalBillingEmailScheduler{TemporalEnv: temporalEnv})
 			webhookEventHandler := streams.HandlerFunc[*webhooksv1.Event](func(ctx context.Context, event *webhooksv1.Event, metadata gcp.MessageMetadata) error {
 				if err := paygKeyRefreshHandler.Handle(ctx, event, metadata); err != nil {
 					return fmt.Errorf("schedule PAYG key refresh: %w", err)
+				}
+				if err := billingNotificationHandler.Handle(ctx, event, metadata); err != nil {
+					return fmt.Errorf("schedule billing notification: %w", err)
 				}
 				return svixRelayHandler.Handle(ctx, event, metadata)
 			})

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -490,13 +490,17 @@ func newStreamsCommand() *cli.Command {
 			paygKeyRefreshHandler := usage.NewPaygKeyRefreshHandler(logger, openRouterKeyRefresher)
 			billingNotificationHandler := billingnotifications.NewEventHandler(logger, &background.TemporalBillingEmailScheduler{TemporalEnv: temporalEnv})
 			webhookEventHandler := streams.HandlerFunc[*webhooksv1.Event](func(ctx context.Context, event *webhooksv1.Event, metadata gcp.MessageMetadata) error {
+				var handlerErrors []error
+				if err := svixRelayHandler.Handle(ctx, event, metadata); err != nil {
+					handlerErrors = append(handlerErrors, fmt.Errorf("relay webhook event to Svix: %w", err))
+				}
 				if err := paygKeyRefreshHandler.Handle(ctx, event, metadata); err != nil {
-					return fmt.Errorf("schedule PAYG key refresh: %w", err)
+					handlerErrors = append(handlerErrors, fmt.Errorf("schedule PAYG key refresh: %w", err))
 				}
 				if err := billingNotificationHandler.Handle(ctx, event, metadata); err != nil {
-					return fmt.Errorf("schedule billing notification: %w", err)
+					handlerErrors = append(handlerErrors, fmt.Errorf("schedule billing notification: %w", err))
 				}
-				return svixRelayHandler.Handle(ctx, event, metadata)
+				return errors.Join(handlerErrors...)
 			})
 
 			pingLogLevel := conv.Ternary(c.String("environment") == "local", slog.LevelInfo, slog.LevelDebug)

--- a/server/internal/background/access_paused_email.go
+++ b/server/internal/background/access_paused_email.go
@@ -11,13 +11,27 @@ import (
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
 const (
-	accessPausedEmailWorkflowIDPrefix   = "v1:access-paused-email"
-	accessPausedEmailWorkflowRunTimeout = 7 * 24 * time.Hour
+	accessPausedEmailWorkflowIDPrefix              = "v1:access-paused-email"
+	accessPausedEmailWorkflowRunTimeout            = 7 * 24 * time.Hour
+	accessPausedEmailRetryInitialInterval          = 5 * time.Second
+	accessPausedEmailRetryMaximumInterval          = time.Minute
+	accessPausedEmailRetryBackoffCoefficient       = 2
+	accessPausedEmailRetryMaximumAttempts    int32 = 12
 )
+
+func accessPausedEmailRetryPolicy() *temporal.RetryPolicy {
+	return &temporal.RetryPolicy{
+		InitialInterval:    accessPausedEmailRetryInitialInterval,
+		MaximumInterval:    accessPausedEmailRetryMaximumInterval,
+		BackoffCoefficient: accessPausedEmailRetryBackoffCoefficient,
+		MaximumAttempts:    accessPausedEmailRetryMaximumAttempts,
+	}
+}
 
 type TemporalBillingEmailScheduler struct {
 	TemporalEnv *tenvironment.Environment
@@ -48,10 +62,11 @@ func (s *TemporalBillingEmailScheduler) ScheduleAccessPaused(ctx context.Context
 func AccessPausedEmailWorkflow(ctx workflow.Context, input billingnotifications.SendAccessPausedInput) error {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: trialLifecycleEmailActivityTimeout,
-		RetryPolicy:         trialReminderRetryPolicy(),
+		RetryPolicy:         accessPausedEmailRetryPolicy(),
 	})
 	var a *Activities
 	if err := workflow.ExecuteActivity(ctx, a.SendAccessPausedEmail, input).Get(ctx, nil); err != nil {
+		workflow.GetLogger(ctx).Error("access paused email delivery failed", "organization_id", input.OrganizationID, "event_id", input.EventID, "error", err)
 		return fmt.Errorf("send access paused email: %w", err)
 	}
 	return nil

--- a/server/internal/background/access_paused_email.go
+++ b/server/internal/background/access_paused_email.go
@@ -1,0 +1,58 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
+	tenvironment "github.com/speakeasy-api/gram/server/internal/temporal"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	accessPausedEmailWorkflowIDPrefix   = "v1:access-paused-email"
+	accessPausedEmailWorkflowRunTimeout = 7 * 24 * time.Hour
+)
+
+type TemporalBillingEmailScheduler struct {
+	TemporalEnv *tenvironment.Environment
+}
+
+var _ billingnotifications.AccessPausedScheduler = (*TemporalBillingEmailScheduler)(nil)
+
+func (s *TemporalBillingEmailScheduler) ScheduleAccessPaused(ctx context.Context, input billingnotifications.SendAccessPausedInput) error {
+	if s == nil || s.TemporalEnv == nil {
+		return fmt.Errorf("temporal environment is not configured")
+	}
+	_, err := s.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    fmt.Sprintf("%s:%s", accessPausedEmailWorkflowIDPrefix, input.EventID),
+		TaskQueue:             string(s.TemporalEnv.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+		WorkflowRunTimeout:    accessPausedEmailWorkflowRunTimeout,
+	}, AccessPausedEmailWorkflow, input)
+	if err != nil {
+		var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+		if errors.As(err, &alreadyStarted) {
+			return nil
+		}
+		return fmt.Errorf("enqueue access paused email workflow: %w", err)
+	}
+	return nil
+}
+
+func AccessPausedEmailWorkflow(ctx workflow.Context, input billingnotifications.SendAccessPausedInput) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: trialLifecycleEmailActivityTimeout,
+		RetryPolicy:         trialReminderRetryPolicy(),
+	})
+	var a *Activities
+	if err := workflow.ExecuteActivity(ctx, a.SendAccessPausedEmail, input).Get(ctx, nil); err != nil {
+		return fmt.Errorf("send access paused email: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/access_paused_email_test.go
+++ b/server/internal/background/access_paused_email_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 )
 
-func TestAccessPausedEmailWorkflowRetriesBeyondLegacyAttemptLimit(t *testing.T) {
+func TestAccessPausedEmailWorkflowStopsAfterBoundedRetries(t *testing.T) {
 	t.Parallel()
 
 	var suite testsuite.WorkflowTestSuite
@@ -21,10 +21,8 @@ func TestAccessPausedEmailWorkflowRetriesBeyondLegacyAttemptLimit(t *testing.T) 
 	var attempts atomic.Int32
 	env.RegisterActivityWithOptions(
 		func(context.Context, billingnotifications.SendAccessPausedInput) error {
-			if attempts.Add(1) <= trialLifecycleEmailRetryMaximumAttempts {
-				return errors.New("email service unavailable")
-			}
-			return nil
+			attempts.Add(1)
+			return errors.New("email service unavailable")
 		},
 		activity.RegisterOptions{Name: "SendAccessPausedEmail"},
 	)
@@ -35,6 +33,6 @@ func TestAccessPausedEmailWorkflowRetriesBeyondLegacyAttemptLimit(t *testing.T) 
 		Kind:           billingnotifications.AccessPausedSubscriptionLoss,
 	})
 
-	require.NoError(t, env.GetWorkflowError())
-	require.Equal(t, trialLifecycleEmailRetryMaximumAttempts+1, attempts.Load())
+	require.ErrorContains(t, env.GetWorkflowError(), "send access paused email")
+	require.Equal(t, accessPausedEmailRetryMaximumAttempts, attempts.Load())
 }

--- a/server/internal/background/access_paused_email_test.go
+++ b/server/internal/background/access_paused_email_test.go
@@ -1,0 +1,40 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
+)
+
+func TestAccessPausedEmailWorkflowRetriesBeyondLegacyAttemptLimit(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	var attempts atomic.Int32
+	env.RegisterActivityWithOptions(
+		func(context.Context, billingnotifications.SendAccessPausedInput) error {
+			if attempts.Add(1) <= trialLifecycleEmailRetryMaximumAttempts {
+				return errors.New("email service unavailable")
+			}
+			return nil
+		},
+		activity.RegisterOptions{Name: "SendAccessPausedEmail"},
+	)
+
+	env.ExecuteWorkflow(AccessPausedEmailWorkflow, billingnotifications.SendAccessPausedInput{
+		EventID:        "<EVENT_ID>",
+		OrganizationID: "<ORGANIZATION_ID>",
+		Kind:           billingnotifications.AccessPausedSubscriptionLoss,
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, trialLifecycleEmailRetryMaximumAttempts+1, attempts.Load())
+}

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -32,6 +32,7 @@ import (
 	spend_rules "github.com/speakeasy-api/gram/server/internal/background/activities/spend_rules"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	"github.com/speakeasy-api/gram/server/internal/businessmemory"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat"
@@ -164,6 +165,7 @@ type Activities struct {
 	remoteSessionRefresh            *activities.RemoteSessionRefresh
 	demoteExpiredTrials             *activities.DemoteExpiredTrials
 	trialEmails                     *trialemails.Service
+	billingNotifications            *billingnotifications.Service
 }
 
 func NewActivities(
@@ -372,8 +374,14 @@ func NewActivities(
 		publishOutbox:                   publish_outbox.New(logger, tracerProvider, meterProvider, db, publishers.Outbox),
 		pluginPublisher:                 activities.NewPluginPublisher(logger, db, pluginPublisher),
 		listSpendRuleOrgs:               spend_rules.NewListOrgs(logger, db),
-		demoteExpiredTrials:             activities.NewDemoteExpiredTrials(logger, db, openrouterProvisioner, auditLogger, trialEmailsService),
-		evaluateOrgSpendRules:           spend_rules.NewEvaluateOrg(logger, tracerProvider, db, spendRulesCH, cacheAdapter, features),
+		demoteExpiredTrials: activities.NewDemoteExpiredTrials(
+			logger,
+			db,
+			openrouterProvisioner,
+			auditLogger,
+			&TemporalTrialEmailNotifier{TemporalEnv: temporalEnv},
+		),
+		evaluateOrgSpendRules: spend_rules.NewEvaluateOrg(logger, tracerProvider, db, spendRulesCH, cacheAdapter, features),
 		// The judge draws on the same per-(org, model) bucket and the same
 		// completion client as every other platform judge, so efficacy scoring
 		// cannot outspend the org's key behind their backs.
@@ -388,6 +396,7 @@ func NewActivities(
 		skillSuggestionAnalyzer: skillSuggestionAnalyzer,
 		remoteSessionRefresh:    remoteSessionRefresh,
 		trialEmails:             trialEmailsService,
+		billingNotifications:    billingnotifications.NewService(logger, db, emailService, features, siteURL),
 		// The judges draw on the same per-(org, model) bucket and the same
 		// completion client as every other platform judge, so chat analysis
 		// cannot outspend the org's key behind their backs.
@@ -424,6 +433,38 @@ func (a *Activities) SendTrialLifecycleEmail(ctx context.Context, input TrialLif
 	default:
 		return fmt.Errorf("unsupported trial lifecycle email kind %q", input.Kind)
 	}
+}
+
+func (a *Activities) ResolveTrialEndingReminder(ctx context.Context, organizationID string) (billingnotifications.TrialReminderState, error) {
+	if a.billingNotifications == nil {
+		return billingnotifications.TrialReminderState{}, fmt.Errorf("billing notification service is not configured")
+	}
+	state, err := a.billingNotifications.ResolveTrialReminder(ctx, organizationID)
+	if err != nil {
+		return billingnotifications.TrialReminderState{}, fmt.Errorf("resolve trial reminder: %w", err)
+	}
+	return state, nil
+}
+
+func (a *Activities) SendTrialEndingSoonEmail(ctx context.Context, input billingnotifications.SendTrialEndingSoonInput) (billingnotifications.SendTrialEndingSoonResult, error) {
+	if a.billingNotifications == nil {
+		return billingnotifications.SendTrialEndingSoonResult{}, fmt.Errorf("billing notification service is not configured")
+	}
+	result, err := a.billingNotifications.SendTrialEndingSoon(ctx, input)
+	if err != nil {
+		return billingnotifications.SendTrialEndingSoonResult{}, fmt.Errorf("send trial ending soon notification: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) SendAccessPausedEmail(ctx context.Context, input billingnotifications.SendAccessPausedInput) error {
+	if a.billingNotifications == nil {
+		return fmt.Errorf("billing notification service is not configured")
+	}
+	if err := a.billingNotifications.SendAccessPaused(ctx, input); err != nil {
+		return fmt.Errorf("send access paused notification: %w", err)
+	}
+	return nil
 }
 
 func (a *Activities) ProcessWorkOSOrganizationEvents(ctx context.Context, params activities.ProcessWorkOSOrganizationEventsParams) (*activities.ProcessWorkOSOrganizationEventsResult, error) {

--- a/server/internal/background/activities/billing_recipients.go
+++ b/server/internal/background/activities/billing_recipients.go
@@ -2,22 +2,16 @@ package activities
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/access/repo"
-	"github.com/speakeasy-api/gram/server/internal/authz"
-	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 )
 
 // recipientEmailIdempotencyKey keeps recipient-aware Loops keys under its
 // 100-character limit and makes address deduplication case-insensitive.
 func recipientEmailIdempotencyKey(recipient string, parts ...string) string {
-	parts = append(parts, strings.ToLower(recipient))
-	digest := sha256.Sum256([]byte(strings.Join(parts, ":")))
-	return hex.EncodeToString(digest[:])
+	return billingnotifications.RecipientIdempotencyKey(recipient, parts...)
 }
 
 func resolveBillingNotificationRecipients(
@@ -27,22 +21,9 @@ func resolveBillingNotificationRecipients(
 	accountType string,
 	configuredEmail *string,
 ) ([]string, error) {
-	switch billing.Tier(accountType) {
-	case billing.TierEnterprise:
-		if configuredEmail == nil {
-			return nil, nil
-		}
-		return []string{*configuredEmail}, nil
-	case billing.TierPayg:
-		if configuredEmail != nil {
-			return []string{*configuredEmail}, nil
-		}
-		recipients, err := authz.ResolveOrganizationAdminEmails(ctx, db, organizationID)
-		if err != nil {
-			return recipients, fmt.Errorf("resolve PAYG organization administrator recipients: %w", err)
-		}
-		return recipients, nil
-	default:
-		return nil, nil
+	recipients, err := billingnotifications.ResolveRecipients(ctx, db, organizationID, accountType, configuredEmail)
+	if err != nil {
+		return recipients, fmt.Errorf("resolve billing notification recipients: %w", err)
 	}
+	return recipients, nil
 }

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -24,7 +24,7 @@ type DemoteExpiredTrials struct {
 	repo       *trialsrepo.Queries
 	openRouter openrouter.Provisioner
 	audit      *audit.Logger
-	trial      trialemails.Notifier
+	notifier   trialemails.Notifier
 }
 
 func NewDemoteExpiredTrials(
@@ -32,19 +32,15 @@ func NewDemoteExpiredTrials(
 	db *pgxpool.Pool,
 	openRouterProvisioner openrouter.Provisioner,
 	auditLogger *audit.Logger,
-	trialNotifier trialemails.Notifier,
+	notifier trialemails.Notifier,
 ) *DemoteExpiredTrials {
-	if trialNotifier == nil {
-		trialNotifier = trialemails.NoopNotifier{}
-	}
-
 	return &DemoteExpiredTrials{
 		logger:     logger.With(attr.SlogComponent("demote_expired_trials")),
 		db:         db,
 		repo:       trialsrepo.New(db),
 		openRouter: openRouterProvisioner,
 		audit:      auditLogger,
-		trial:      trialNotifier,
+		notifier:   notifier,
 	}
 }
 
@@ -73,14 +69,10 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	trial, err := tx.MarkTrialDemoted(ctx, args.OrganizationID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		// A conversion, a completed demotion, or a re-arm (ends_at moved
-		// forward, stamps cleared) landed between the list and this write.
-		// Only a closed trial should drop out of the Loops sequence.
+		// A conversion or a manual reinstatement landed between the list and
+		// this write. The organization is no longer ours to demote.
 		d.logger.InfoContext(ctx, "expired trial changed before demotion",
 			attr.SlogOrganizationID(args.OrganizationID))
-		if err := d.notifyTrialInactiveIfClosed(ctx, args.OrganizationID); err != nil {
-			return err
-		}
 		return nil
 	case err != nil:
 		return fmt.Errorf("mark trial demoted: %w", err)
@@ -122,30 +114,11 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	if err := dbtx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit trial demotion: %w", err)
 	}
+	if d.notifier != nil {
+		if err := d.notifier.TrialInactive(ctx, args.OrganizationID); err != nil {
+			d.logger.ErrorContext(ctx, "notify inactive trial after demotion", attr.SlogOrganizationID(args.OrganizationID), attr.SlogError(err))
+		}
+	}
 
-	d.notifyTrialInactive(ctx, args.OrganizationID)
 	return nil
-}
-
-func (d *DemoteExpiredTrials) notifyTrialInactiveIfClosed(ctx context.Context, organizationID string) error {
-	// GetActiveTrial is the armed-trial predicate. Re-read it immediately
-	// before Loops so a re-arm that landed after MarkTrialDemoted's
-	// ErrNoRows keeps trialActive. Lookup errors fail the activity so
-	// Temporal retries; notifier errors stay logged-only.
-	_, err := d.repo.GetActiveTrial(ctx, organizationID)
-	switch {
-	case err == nil:
-		return nil
-	case errors.Is(err, pgx.ErrNoRows):
-		d.notifyTrialInactive(ctx, organizationID)
-		return nil
-	default:
-		return fmt.Errorf("revalidate trial before inactive notify: %w", err)
-	}
-}
-
-func (d *DemoteExpiredTrials) notifyTrialInactive(ctx context.Context, organizationID string) {
-	if err := d.trial.TrialInactive(ctx, organizationID); err != nil {
-		d.logger.ErrorContext(ctx, "failed to notify trial inactive", attr.SlogError(err), attr.SlogOrganizationID(organizationID))
-	}
 }

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -17,6 +17,7 @@ import (
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
@@ -41,28 +42,11 @@ func (p *trialProvisioner) DisableAPIKey(_ context.Context, orgID string, keyTyp
 	return nil
 }
 
-type fakeTrialNotifier struct {
-	inactive    []string
-	inactiveErr error
-}
-
-func (f *fakeTrialNotifier) TrialStarted(context.Context, string) error { return nil }
-
-func (f *fakeTrialNotifier) AdminAdded(context.Context, string, string) error {
-	return nil
-}
-
-func (f *fakeTrialNotifier) TrialInactive(_ context.Context, organizationID string) error {
-	f.inactive = append(f.inactive, organizationID)
-	return f.inactiveErr
-}
-
 type trialTestInstance struct {
 	conn        *pgxpool.Pool
 	trials      *trialsrepo.Queries
 	orgs        *orgrepo.Queries
 	provisioner *trialProvisioner
-	notifier    *fakeTrialNotifier
 	activity    *activities.DemoteExpiredTrials
 }
 
@@ -75,25 +59,25 @@ func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
 	require.NoError(t, err)
 
 	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), disabled: nil, failWith: nil}
-	notifier := &fakeTrialNotifier{}
 
 	return ctx, &trialTestInstance{
 		conn:        conn,
 		trials:      trialsrepo.New(conn),
 		orgs:        orgrepo.New(conn),
 		provisioner: provisioner,
-		notifier:    notifier,
 		activity: activities.NewDemoteExpiredTrials(
 			testenv.NewLogger(t),
 			conn,
 			provisioner,
 			audit.NewLogger(),
-			notifier,
+			trialemails.NoopNotifier{},
 		),
 	}
 }
 
-func newOrg(t *testing.T, ctx context.Context, ti *trialTestInstance) string {
+// newTrialOrg creates an enterprise organization that is whitelisted for the
+// duration of its trial, which is the state signup leaves behind.
+func newTrialOrg(t *testing.T, ctx context.Context, ti *trialTestInstance, endsAt time.Time) string {
 	t.Helper()
 
 	orgID := "org-" + uuid.NewString()[:8]
@@ -112,16 +96,7 @@ func newOrg(t *testing.T, ctx context.Context, ti *trialTestInstance) string {
 		GramAccountType: "enterprise",
 	}))
 
-	return orgID
-}
-
-// newTrialOrg creates an enterprise organization that is whitelisted for the
-// duration of its trial, which is the state signup leaves behind.
-func newTrialOrg(t *testing.T, ctx context.Context, ti *trialTestInstance, endsAt time.Time) string {
-	t.Helper()
-
-	orgID := newOrg(t, ctx, ti)
-	err := ti.trials.CreateTrial(ctx, trialsrepo.CreateTrialParams{
+	err = ti.trials.CreateTrial(ctx, trialsrepo.CreateTrialParams{
 		OrganizationID: orgID,
 		Tier:           "enterprise",
 		EndsAt:         pgtype.Timestamptz{Time: endsAt, InfinityModifier: pgtype.Finite, Valid: true},
@@ -157,7 +132,6 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	require.True(t, trial.DemotedAt.Valid)
 
 	require.ElementsMatch(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.disabled)
-	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)
@@ -224,7 +198,6 @@ func TestDemoteExpiredTrials_DemoteSkipsTrialConvertedAfterListing(t *testing.T)
 	require.False(t, trial.DemotedAt.Valid)
 
 	require.Empty(t, ti.provisioner.disabled, "a trial that converted keeps its keys")
-	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 }
 
 // Temporal retries a failed activity, so a second demotion of the same trial
@@ -253,7 +226,6 @@ func TestDemoteExpiredTrials_DemoteIsIdempotent(t *testing.T) {
 	again, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)
 	require.Equal(t, after, again)
-	require.Equal(t, []string{orgID, orgID}, ti.notifier.inactive)
 }
 
 // The lockdown runs inside the demotion transaction on purpose: a stamped
@@ -280,57 +252,4 @@ func TestDemoteExpiredTrials_KeyLockdownFailureLeavesTrialArmed(t *testing.T) {
 	due, err := ti.activity.List(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{orgID}, due)
-	require.Empty(t, ti.notifier.inactive)
-}
-
-func TestDemoteExpiredTrials_DemoteSkipsActiveUnexpiredTrialEmails(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTrialTestInstance(t)
-	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(24*time.Hour).UTC())
-
-	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
-
-	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
-	require.NoError(t, err)
-	require.Equal(t, "enterprise", org.GramAccountType)
-	require.True(t, org.Whitelisted)
-	require.Empty(t, ti.notifier.inactive)
-}
-
-func TestDemoteExpiredTrials_DemoteAlreadyDemotedWithFutureEndsAtStillNotifies(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTrialTestInstance(t)
-	orgID := newOrg(t, ctx, ti)
-	now := time.Now().UTC()
-	require.NoError(t, ti.trials.InsertTrialFixture(ctx, trialsrepo.InsertTrialFixtureParams{
-		OrganizationID: orgID,
-		CreatedAt:      pgtype.Timestamptz{Time: now.Add(-48 * time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
-		EndsAt:         pgtype.Timestamptz{Time: now.Add(24 * time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
-		ConvertedAt:    pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
-		DemotedAt:      pgtype.Timestamptz{Time: now.Add(-time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
-	}))
-
-	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
-
-	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
-	require.NoError(t, err)
-	require.Equal(t, "enterprise", org.GramAccountType)
-	require.Equal(t, []string{orgID}, ti.notifier.inactive)
-}
-
-func TestDemoteExpiredTrials_TrialInactiveFailureDoesNotFailDemotion(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTrialTestInstance(t)
-	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
-	ti.notifier.inactiveErr = errors.New("loops unavailable")
-
-	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
-
-	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
-	require.NoError(t, err)
-	require.Equal(t, "free", org.GramAccountType)
-	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 }

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -17,7 +17,6 @@ import (
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
-	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
@@ -29,6 +28,23 @@ type trialProvisioner struct {
 
 	disabled []string
 	failWith error
+}
+
+type recordingTrialNotifier struct {
+	inactive []string
+}
+
+func (n *recordingTrialNotifier) TrialStarted(context.Context, string) error {
+	return nil
+}
+
+func (n *recordingTrialNotifier) AdminAdded(context.Context, string, string) error {
+	return nil
+}
+
+func (n *recordingTrialNotifier) TrialInactive(_ context.Context, organizationID string) error {
+	n.inactive = append(n.inactive, organizationID)
+	return nil
 }
 
 var _ openrouter.Provisioner = (*trialProvisioner)(nil)
@@ -47,6 +63,7 @@ type trialTestInstance struct {
 	trials      *trialsrepo.Queries
 	orgs        *orgrepo.Queries
 	provisioner *trialProvisioner
+	notifier    *recordingTrialNotifier
 	activity    *activities.DemoteExpiredTrials
 }
 
@@ -59,18 +76,20 @@ func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
 	require.NoError(t, err)
 
 	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), disabled: nil, failWith: nil}
+	notifier := &recordingTrialNotifier{inactive: nil}
 
 	return ctx, &trialTestInstance{
 		conn:        conn,
 		trials:      trialsrepo.New(conn),
 		orgs:        orgrepo.New(conn),
 		provisioner: provisioner,
+		notifier:    notifier,
 		activity: activities.NewDemoteExpiredTrials(
 			testenv.NewLogger(t),
 			conn,
 			provisioner,
 			audit.NewLogger(),
-			trialemails.NoopNotifier{},
+			notifier,
 		),
 	}
 }
@@ -132,6 +151,7 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	require.True(t, trial.DemotedAt.Valid)
 
 	require.ElementsMatch(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.disabled)
+	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)
@@ -198,6 +218,7 @@ func TestDemoteExpiredTrials_DemoteSkipsTrialConvertedAfterListing(t *testing.T)
 	require.False(t, trial.DemotedAt.Valid)
 
 	require.Empty(t, ti.provisioner.disabled, "a trial that converted keeps its keys")
+	require.Empty(t, ti.notifier.inactive, "a no-op demotion must not publish trial inactivity")
 }
 
 // Temporal retries a failed activity, so a second demotion of the same trial
@@ -226,6 +247,7 @@ func TestDemoteExpiredTrials_DemoteIsIdempotent(t *testing.T) {
 	again, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)
 	require.Equal(t, after, again)
+	require.Equal(t, []string{orgID}, ti.notifier.inactive, "a retried demotion notifies exactly once")
 }
 
 // The lockdown runs inside the demotion transaction on purpose: a stamped
@@ -252,4 +274,5 @@ func TestDemoteExpiredTrials_KeyLockdownFailureLeavesTrialArmed(t *testing.T) {
 	due, err := ti.activity.List(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{orgID}, due)
+	require.Empty(t, ti.notifier.inactive, "a rolled-back demotion must not publish trial inactivity")
 }

--- a/server/internal/background/trial_emails.go
+++ b/server/internal/background/trial_emails.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	tenvironment "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	"go.temporal.io/api/enums/v1"
@@ -16,11 +17,13 @@ import (
 const (
 	trialLifecycleEmailWorkflowIDPrefix              = "v1:trial-lifecycle-email"
 	trialLifecycleEmailActivityTimeout               = 5 * time.Minute
-	trialLifecycleEmailWorkflowRunTimeout            = 30 * time.Minute
+	trialLifecycleEmailWorkflowRunTimeout            = 180 * 24 * time.Hour
 	trialLifecycleEmailRetryInitialInterval          = 5 * time.Second
 	trialLifecycleEmailRetryMaximumInterval          = time.Minute
 	trialLifecycleEmailRetryBackoffCoefficient       = 2.0
 	trialLifecycleEmailRetryMaximumAttempts    int32 = 5
+	trialReminderRetryInitialInterval                = 30 * time.Second
+	trialReminderRetryMaximumInterval                = 30 * time.Minute
 )
 
 func trialLifecycleEmailRetryPolicy() *temporal.RetryPolicy {
@@ -29,6 +32,15 @@ func trialLifecycleEmailRetryPolicy() *temporal.RetryPolicy {
 		MaximumInterval:    trialLifecycleEmailRetryMaximumInterval,
 		BackoffCoefficient: trialLifecycleEmailRetryBackoffCoefficient,
 		MaximumAttempts:    trialLifecycleEmailRetryMaximumAttempts,
+	}
+}
+
+func trialReminderRetryPolicy() *temporal.RetryPolicy {
+	return &temporal.RetryPolicy{
+		InitialInterval:    trialReminderRetryInitialInterval,
+		MaximumInterval:    trialReminderRetryMaximumInterval,
+		BackoffCoefficient: trialLifecycleEmailRetryBackoffCoefficient,
+		MaximumAttempts:    0,
 	}
 }
 
@@ -120,7 +132,43 @@ func TrialLifecycleEmailWorkflow(ctx workflow.Context, input TrialLifecycleEmail
 
 	var a *Activities
 	if err := workflow.ExecuteActivity(ctx, a.SendTrialLifecycleEmail, input).Get(ctx, nil); err != nil {
-		return fmt.Errorf("send trial lifecycle email: %w", err)
+		if input.Kind != TrialStartedEmailKind {
+			return fmt.Errorf("send trial lifecycle email: %w", err)
+		}
+		workflow.GetLogger(ctx).Error("legacy trial lifecycle email failed; continuing to T-3 reminder", "error", err)
 	}
-	return nil
+	if input.Kind != TrialStartedEmailKind {
+		return nil
+	}
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: trialLifecycleEmailActivityTimeout,
+		RetryPolicy:         trialReminderRetryPolicy(),
+	})
+
+	for {
+		var state billingnotifications.TrialReminderState
+		if err := workflow.ExecuteActivity(ctx, a.ResolveTrialEndingReminder, input.OrganizationID).Get(ctx, &state); err != nil {
+			return fmt.Errorf("resolve trial ending reminder: %w", err)
+		}
+		if !state.Active {
+			return nil
+		}
+		if wait := state.SendAt.Sub(workflow.Now(ctx)); wait > 0 {
+			if err := workflow.Sleep(ctx, wait); err != nil {
+				return fmt.Errorf("wait for trial ending reminder: %w", err)
+			}
+		}
+
+		var result billingnotifications.SendTrialEndingSoonResult
+		if err := workflow.ExecuteActivity(ctx, a.SendTrialEndingSoonEmail, billingnotifications.SendTrialEndingSoonInput{
+			OrganizationID: input.OrganizationID,
+			TrialCreatedAt: state.TrialCreatedAt,
+			TrialEndsAt:    state.TrialEndsAt,
+		}).Get(ctx, &result); err != nil {
+			return fmt.Errorf("send trial ending soon email: %w", err)
+		}
+		if !result.Reschedule {
+			return nil
+		}
+	}
 }

--- a/server/internal/background/trial_emails.go
+++ b/server/internal/background/trial_emails.go
@@ -24,6 +24,7 @@ const (
 	trialLifecycleEmailRetryMaximumAttempts    int32 = 5
 	trialReminderRetryInitialInterval                = 30 * time.Second
 	trialReminderRetryMaximumInterval                = 30 * time.Minute
+	trialReminderTimerChunk                          = 30 * 24 * time.Hour
 )
 
 func trialLifecycleEmailRetryPolicy() *temporal.RetryPolicy {
@@ -68,6 +69,10 @@ type TrialLifecycleEmailInput struct {
 
 	// UserID identifies the administrator affected by an admin-added event.
 	UserID string `json:"user_id,omitempty"`
+
+	// ReminderOnly is carried across ContinueAsNew after the immediate lifecycle
+	// synchronization has completed.
+	ReminderOnly bool `json:"reminder_only,omitempty"`
 }
 
 // TemporalTrialEmailNotifier enqueues trial email work without performing the
@@ -84,6 +89,7 @@ func (n *TemporalTrialEmailNotifier) TrialStarted(ctx context.Context, organizat
 		Kind:           TrialStartedEmailKind,
 		OrganizationID: organizationID,
 		UserID:         "",
+		ReminderOnly:   false,
 	})
 }
 
@@ -92,6 +98,7 @@ func (n *TemporalTrialEmailNotifier) AdminAdded(ctx context.Context, organizatio
 		Kind:           AdminAddedEmailKind,
 		OrganizationID: organizationID,
 		UserID:         userID,
+		ReminderOnly:   false,
 	})
 }
 
@@ -100,6 +107,7 @@ func (n *TemporalTrialEmailNotifier) TrialInactive(ctx context.Context, organiza
 		Kind:           TrialInactiveEmailKind,
 		OrganizationID: organizationID,
 		UserID:         "",
+		ReminderOnly:   false,
 	})
 }
 
@@ -131,44 +139,52 @@ func TrialLifecycleEmailWorkflow(ctx workflow.Context, input TrialLifecycleEmail
 	})
 
 	var a *Activities
-	if err := workflow.ExecuteActivity(ctx, a.SendTrialLifecycleEmail, input).Get(ctx, nil); err != nil {
-		if input.Kind != TrialStartedEmailKind {
-			return fmt.Errorf("send trial lifecycle email: %w", err)
+	if !input.ReminderOnly {
+		if err := workflow.ExecuteActivity(ctx, a.SendTrialLifecycleEmail, input).Get(ctx, nil); err != nil {
+			if input.Kind != TrialStartedEmailKind {
+				return fmt.Errorf("send trial lifecycle email: %w", err)
+			}
+			workflow.GetLogger(ctx).Error("legacy trial lifecycle email failed; continuing to T-3 reminder", "error", err)
 		}
-		workflow.GetLogger(ctx).Error("legacy trial lifecycle email failed; continuing to T-3 reminder", "error", err)
 	}
 	if input.Kind != TrialStartedEmailKind {
 		return nil
 	}
+	input.ReminderOnly = true
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: trialLifecycleEmailActivityTimeout,
 		RetryPolicy:         trialReminderRetryPolicy(),
 	})
 
-	for {
-		var state billingnotifications.TrialReminderState
-		if err := workflow.ExecuteActivity(ctx, a.ResolveTrialEndingReminder, input.OrganizationID).Get(ctx, &state); err != nil {
-			return fmt.Errorf("resolve trial ending reminder: %w", err)
-		}
-		if !state.Active {
-			return nil
-		}
-		if wait := state.SendAt.Sub(workflow.Now(ctx)); wait > 0 {
-			if err := workflow.Sleep(ctx, wait); err != nil {
-				return fmt.Errorf("wait for trial ending reminder: %w", err)
+	var state billingnotifications.TrialReminderState
+	if err := workflow.ExecuteActivity(ctx, a.ResolveTrialEndingReminder, input.OrganizationID).Get(ctx, &state); err != nil {
+		return fmt.Errorf("resolve trial ending reminder: %w", err)
+	}
+	if !state.Active {
+		return nil
+	}
+	if wait := state.SendAt.Sub(workflow.Now(ctx)); wait > 0 {
+		if wait > trialReminderTimerChunk {
+			if err := workflow.Sleep(ctx, trialReminderTimerChunk); err != nil {
+				return fmt.Errorf("wait to recheck trial ending reminder: %w", err)
 			}
+			return workflow.NewContinueAsNewError(ctx, TrialLifecycleEmailWorkflow, input)
 		}
-
-		var result billingnotifications.SendTrialEndingSoonResult
-		if err := workflow.ExecuteActivity(ctx, a.SendTrialEndingSoonEmail, billingnotifications.SendTrialEndingSoonInput{
-			OrganizationID: input.OrganizationID,
-			TrialCreatedAt: state.TrialCreatedAt,
-			TrialEndsAt:    state.TrialEndsAt,
-		}).Get(ctx, &result); err != nil {
-			return fmt.Errorf("send trial ending soon email: %w", err)
-		}
-		if !result.Reschedule {
-			return nil
+		if err := workflow.Sleep(ctx, wait); err != nil {
+			return fmt.Errorf("wait for trial ending reminder: %w", err)
 		}
 	}
+
+	var result billingnotifications.SendTrialEndingSoonResult
+	if err := workflow.ExecuteActivity(ctx, a.SendTrialEndingSoonEmail, billingnotifications.SendTrialEndingSoonInput{
+		OrganizationID: input.OrganizationID,
+		TrialCreatedAt: state.TrialCreatedAt,
+		TrialEndsAt:    state.TrialEndsAt,
+	}).Get(ctx, &result); err != nil {
+		return fmt.Errorf("send trial ending soon email: %w", err)
+	}
+	if result.Reschedule {
+		return workflow.NewContinueAsNewError(ctx, TrialLifecycleEmailWorkflow, input)
+	}
+	return nil
 }

--- a/server/internal/background/trial_emails_test.go
+++ b/server/internal/background/trial_emails_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 )
 
 func trialLifecycleEmailRetryBudget() time.Duration {
@@ -48,6 +50,7 @@ func TestTrialLifecycleEmailWorkflowDispatchesAdminAdded(t *testing.T) {
 		Kind:           AdminAddedEmailKind,
 		OrganizationID: "<ORGANIZATION_ID>",
 		UserID:         "<USER_ID>",
+		ReminderOnly:   false,
 	}
 	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, input)
 
@@ -75,6 +78,8 @@ func TestTrialLifecycleEmailWorkflowRetriesActivity(t *testing.T) {
 	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{
 		Kind:           AdminAddedEmailKind,
 		OrganizationID: "<ORGANIZATION_ID>",
+		UserID:         "",
+		ReminderOnly:   false,
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -102,7 +107,7 @@ func TestTrialLifecycleEmailWorkflowKeepsReminderAfterLegacySyncFailure(t *testi
 		activity.RegisterOptions{Name: "ResolveTrialEndingReminder"},
 	)
 
-	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{Kind: TrialStartedEmailKind, OrganizationID: "<ORGANIZATION_ID>", UserID: ""})
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{Kind: TrialStartedEmailKind, OrganizationID: "<ORGANIZATION_ID>", UserID: "", ReminderOnly: false})
 
 	require.NoError(t, env.GetWorkflowError())
 	require.Equal(t, trialLifecycleEmailRetryMaximumAttempts, attempts.Load())
@@ -146,6 +151,8 @@ func TestTrialLifecycleEmailWorkflowWaitsUntilThreeDaysBeforeEnd(t *testing.T) {
 	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{
 		Kind:           TrialStartedEmailKind,
 		OrganizationID: "<ORGANIZATION_ID>",
+		UserID:         "",
+		ReminderOnly:   false,
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -162,7 +169,6 @@ func TestTrialLifecycleEmailWorkflowRetimesExtendedTrial(t *testing.T) {
 	createdAt := now.Add(-24 * time.Hour)
 	firstEnd := now.Add(4 * 24 * time.Hour)
 	extendedEnd := now.Add(8 * 24 * time.Hour)
-	var resolves atomic.Int32
 	var sends atomic.Int32
 
 	env.RegisterActivityWithOptions(
@@ -171,32 +177,90 @@ func TestTrialLifecycleEmailWorkflowRetimesExtendedTrial(t *testing.T) {
 	)
 	env.RegisterActivityWithOptions(
 		func(context.Context, string) (billingnotifications.TrialReminderState, error) {
-			endsAt := firstEnd
-			if resolves.Add(1) > 1 {
-				endsAt = extendedEnd
-			}
 			return billingnotifications.TrialReminderState{
 				Active:         true,
 				TrialCreatedAt: createdAt,
-				TrialEndsAt:    endsAt,
-				SendAt:         endsAt.Add(-72 * time.Hour),
+				TrialEndsAt:    firstEnd,
+				SendAt:         firstEnd.Add(-72 * time.Hour),
 			}, nil
 		},
 		activity.RegisterOptions{Name: "ResolveTrialEndingReminder"},
 	)
 	env.RegisterActivityWithOptions(
 		func(context.Context, billingnotifications.SendTrialEndingSoonInput) (billingnotifications.SendTrialEndingSoonResult, error) {
-			if sends.Add(1) == 1 {
-				return billingnotifications.SendTrialEndingSoonResult{Reschedule: true}, nil
-			}
-			return billingnotifications.SendTrialEndingSoonResult{}, nil
+			sends.Add(1)
+			return billingnotifications.SendTrialEndingSoonResult{Reschedule: true}, nil
 		},
 		activity.RegisterOptions{Name: "SendTrialEndingSoonEmail"},
 	)
 
-	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{Kind: TrialStartedEmailKind, OrganizationID: "<ORGANIZATION_ID>", UserID: ""})
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{Kind: TrialStartedEmailKind, OrganizationID: "<ORGANIZATION_ID>", UserID: "", ReminderOnly: false})
 
+	var continueErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &continueErr)
+	var nextInput TrialLifecycleEmailInput
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueErr.Input, &nextInput))
+	require.True(t, nextInput.ReminderOnly)
+	require.Equal(t, int32(1), sends.Load())
+
+	env = suite.NewTestWorkflowEnvironment()
+	env.RegisterActivityWithOptions(
+		func(context.Context, string) (billingnotifications.TrialReminderState, error) {
+			return billingnotifications.TrialReminderState{
+				Active:         true,
+				TrialCreatedAt: createdAt,
+				TrialEndsAt:    extendedEnd,
+				SendAt:         extendedEnd.Add(-72 * time.Hour),
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ResolveTrialEndingReminder"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, billingnotifications.SendTrialEndingSoonInput) (billingnotifications.SendTrialEndingSoonResult, error) {
+			sends.Add(1)
+			return billingnotifications.SendTrialEndingSoonResult{}, nil
+		},
+		activity.RegisterOptions{Name: "SendTrialEndingSoonEmail"},
+	)
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, nextInput)
 	require.NoError(t, env.GetWorkflowError())
 	require.Equal(t, int32(2), sends.Load())
-	require.True(t, extendedEnd.Add(-72*time.Hour).Equal(env.Now()))
+}
+
+func TestTrialLifecycleEmailWorkflowChunksLongReminderTimer(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	now := env.Now().UTC()
+	trialEndsAt := now.Add(90 * 24 * time.Hour)
+	var lifecycleCalls atomic.Int32
+	env.RegisterActivityWithOptions(
+		func(context.Context, TrialLifecycleEmailInput) error {
+			lifecycleCalls.Add(1)
+			return nil
+		},
+		activity.RegisterOptions{Name: "SendTrialLifecycleEmail"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, string) (billingnotifications.TrialReminderState, error) {
+			return billingnotifications.TrialReminderState{
+				Active:         true,
+				TrialCreatedAt: now,
+				TrialEndsAt:    trialEndsAt,
+				SendAt:         trialEndsAt.Add(-72 * time.Hour),
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ResolveTrialEndingReminder"},
+	)
+
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{Kind: TrialStartedEmailKind, OrganizationID: "<ORGANIZATION_ID>", UserID: "", ReminderOnly: false})
+
+	var continueErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &continueErr)
+	var nextInput TrialLifecycleEmailInput
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueErr.Input, &nextInput))
+	require.True(t, nextInput.ReminderOnly)
+	require.Equal(t, int32(1), lifecycleCalls.Load())
+	require.True(t, now.Add(trialReminderTimerChunk).Equal(env.Now()))
 }

--- a/server/internal/background/trial_emails_test.go
+++ b/server/internal/background/trial_emails_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
@@ -72,11 +73,130 @@ func TestTrialLifecycleEmailWorkflowRetriesActivity(t *testing.T) {
 	)
 
 	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{
-		Kind:           TrialStartedEmailKind,
+		Kind:           AdminAddedEmailKind,
 		OrganizationID: "<ORGANIZATION_ID>",
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	require.Equal(t, int32(3), attempts.Load())
+}
+
+func TestTrialLifecycleEmailWorkflowKeepsReminderAfterLegacySyncFailure(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	var attempts atomic.Int32
+	env.RegisterActivityWithOptions(
+		func(context.Context, TrialLifecycleEmailInput) error {
+			attempts.Add(1)
+			return errors.New("legacy workflow unavailable")
+		},
+		activity.RegisterOptions{Name: "SendTrialLifecycleEmail"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, string) (billingnotifications.TrialReminderState, error) {
+			return billingnotifications.TrialReminderState{Active: false, TrialCreatedAt: time.Time{}, TrialEndsAt: time.Time{}, SendAt: time.Time{}}, nil
+		},
+		activity.RegisterOptions{Name: "ResolveTrialEndingReminder"},
+	)
+
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{Kind: TrialStartedEmailKind, OrganizationID: "<ORGANIZATION_ID>", UserID: ""})
+
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, trialLifecycleEmailRetryMaximumAttempts, attempts.Load())
+}
+
+func TestTrialLifecycleEmailWorkflowWaitsUntilThreeDaysBeforeEnd(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	now := env.Now().UTC()
+	trialCreatedAt := now.Add(-24 * time.Hour)
+	trialEndsAt := now.Add(7 * 24 * time.Hour)
+	var sentAt time.Time
+
+	env.RegisterActivityWithOptions(
+		func(context.Context, TrialLifecycleEmailInput) error { return nil },
+		activity.RegisterOptions{Name: "SendTrialLifecycleEmail"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, string) (billingnotifications.TrialReminderState, error) {
+			return billingnotifications.TrialReminderState{
+				Active:         true,
+				TrialCreatedAt: trialCreatedAt,
+				TrialEndsAt:    trialEndsAt,
+				SendAt:         trialEndsAt.Add(-72 * time.Hour),
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ResolveTrialEndingReminder"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, input billingnotifications.SendTrialEndingSoonInput) (billingnotifications.SendTrialEndingSoonResult, error) {
+			sentAt = env.Now()
+			require.Equal(t, trialCreatedAt, input.TrialCreatedAt)
+			require.Equal(t, trialEndsAt, input.TrialEndsAt)
+			return billingnotifications.SendTrialEndingSoonResult{}, nil
+		},
+		activity.RegisterOptions{Name: "SendTrialEndingSoonEmail"},
+	)
+
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{
+		Kind:           TrialStartedEmailKind,
+		OrganizationID: "<ORGANIZATION_ID>",
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.True(t, trialEndsAt.Add(-72*time.Hour).Equal(sentAt))
+}
+
+func TestTrialLifecycleEmailWorkflowRetimesExtendedTrial(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	now := env.Now().UTC()
+	createdAt := now.Add(-24 * time.Hour)
+	firstEnd := now.Add(4 * 24 * time.Hour)
+	extendedEnd := now.Add(8 * 24 * time.Hour)
+	var resolves atomic.Int32
+	var sends atomic.Int32
+
+	env.RegisterActivityWithOptions(
+		func(context.Context, TrialLifecycleEmailInput) error { return nil },
+		activity.RegisterOptions{Name: "SendTrialLifecycleEmail"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, string) (billingnotifications.TrialReminderState, error) {
+			endsAt := firstEnd
+			if resolves.Add(1) > 1 {
+				endsAt = extendedEnd
+			}
+			return billingnotifications.TrialReminderState{
+				Active:         true,
+				TrialCreatedAt: createdAt,
+				TrialEndsAt:    endsAt,
+				SendAt:         endsAt.Add(-72 * time.Hour),
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ResolveTrialEndingReminder"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, billingnotifications.SendTrialEndingSoonInput) (billingnotifications.SendTrialEndingSoonResult, error) {
+			if sends.Add(1) == 1 {
+				return billingnotifications.SendTrialEndingSoonResult{Reschedule: true}, nil
+			}
+			return billingnotifications.SendTrialEndingSoonResult{}, nil
+		},
+		activity.RegisterOptions{Name: "SendTrialEndingSoonEmail"},
+	)
+
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{Kind: TrialStartedEmailKind, OrganizationID: "<ORGANIZATION_ID>", UserID: ""})
+
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, int32(2), sends.Load())
+	require.True(t, extendedEnd.Add(-72*time.Hour).Equal(env.Now()))
 }

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -481,6 +481,9 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.ListExpiredTrials)
 	temporalWorker.RegisterActivity(activities.DemoteExpiredTrial)
 	temporalWorker.RegisterActivity(activities.SendTrialLifecycleEmail)
+	temporalWorker.RegisterActivity(activities.ResolveTrialEndingReminder)
+	temporalWorker.RegisterActivity(activities.SendTrialEndingSoonEmail)
+	temporalWorker.RegisterActivity(activities.SendAccessPausedEmail)
 	// Skill efficacy activities — the database steps run on the main queue and
 	// only the judged publication goes to the dedicated worker.
 	temporalWorker.RegisterActivity(activities.skillEfficacyScorer.EnqueueSkillEfficacyPage)
@@ -596,6 +599,7 @@ func NewTemporalWorker(
 	// Trial expiry workflows
 	temporalWorker.RegisterWorkflow(DemoteExpiredTrialsWorkflow)
 	temporalWorker.RegisterWorkflow(TrialLifecycleEmailWorkflow)
+	temporalWorker.RegisterWorkflow(AccessPausedEmailWorkflow)
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
 			logger.ErrorContext(context.Background(), "failed to add platform usage metrics schedule", attr.SlogError(err))

--- a/server/internal/billingnotifications/handler.go
+++ b/server/internal/billingnotifications/handler.go
@@ -31,11 +31,17 @@ func NewEventHandler(logger *slog.Logger, scheduler AccessPausedScheduler) *Even
 
 func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gcp.MessageMetadata) error {
 	if event == nil {
+		h.logger.ErrorContext(ctx, "dropping nil billing notification event")
 		return nil
 	}
 	eventID := event.GetEventId()
 	organizationID := event.GetOrganizationId()
 	if eventID == "" || organizationID == "" {
+		h.logger.ErrorContext(ctx, "dropping invalid billing notification event",
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogOutboxPublicID(eventID),
+			attr.SlogEvent(event.GetEventType()),
+		)
 		return nil
 	}
 
@@ -59,6 +65,12 @@ func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gc
 		expectedAction = audit.ActionOrganizationEnterpriseTrialDemoted
 	}
 	if audit.Action(payload.Action) != expectedAction || payload.OrganizationID != organizationID || payload.SubjectID != organizationID || payload.SubjectType != "organization" {
+		if audit.Action(payload.Action) == expectedAction {
+			h.logger.ErrorContext(ctx, "dropping mismatched billing notification event",
+				attr.SlogOrganizationID(organizationID),
+				attr.SlogOutboxPublicID(eventID),
+			)
+		}
 		return nil
 	}
 	if h.scheduler == nil {

--- a/server/internal/billingnotifications/handler.go
+++ b/server/internal/billingnotifications/handler.go
@@ -1,0 +1,75 @@
+package billingnotifications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+)
+
+type AccessPausedScheduler interface {
+	ScheduleAccessPaused(context.Context, SendAccessPausedInput) error
+}
+
+type EventHandler struct {
+	logger    *slog.Logger
+	scheduler AccessPausedScheduler
+}
+
+func NewEventHandler(logger *slog.Logger, scheduler AccessPausedScheduler) *EventHandler {
+	return &EventHandler{
+		logger:    logger.With(attr.SlogComponent("billing-notification-events")),
+		scheduler: scheduler,
+	}
+}
+
+func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gcp.MessageMetadata) error {
+	if event == nil {
+		return nil
+	}
+	eventID := event.GetEventId()
+	organizationID := event.GetOrganizationId()
+	if eventID == "" || organizationID == "" {
+		return nil
+	}
+
+	var kind AccessPausedKind
+	switch event.GetEventType() {
+	case string(events.OrganizationBillingV1.EventType()):
+		kind = AccessPausedSubscriptionLoss
+	case string(events.OrganizationEnterpriseTrialV1.EventType()):
+		kind = AccessPausedTrialDemotion
+	default:
+		return nil
+	}
+
+	var payload events.AuditLogCreatedPayloadV1
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		h.logger.ErrorContext(ctx, "dropping unreadable billing notification event", attr.SlogOutboxPublicID(eventID), attr.SlogError(err))
+		return nil
+	}
+	expectedAction := audit.ActionOrganizationPaygDeactivated
+	if kind == AccessPausedTrialDemotion {
+		expectedAction = audit.ActionOrganizationEnterpriseTrialDemoted
+	}
+	if audit.Action(payload.Action) != expectedAction || payload.OrganizationID != organizationID || payload.SubjectID != organizationID || payload.SubjectType != "organization" {
+		return nil
+	}
+	if h.scheduler == nil {
+		return fmt.Errorf("access paused scheduler is unavailable")
+	}
+	if err := h.scheduler.ScheduleAccessPaused(ctx, SendAccessPausedInput{
+		EventID:        eventID,
+		OrganizationID: organizationID,
+		Kind:           kind,
+	}); err != nil {
+		return fmt.Errorf("schedule access paused email: %w", err)
+	}
+	return nil
+}

--- a/server/internal/billingnotifications/handler_test.go
+++ b/server/internal/billingnotifications/handler_test.go
@@ -1,0 +1,79 @@
+package billingnotifications
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type captureAccessPausedScheduler struct {
+	inputs []SendAccessPausedInput
+}
+
+func (s *captureAccessPausedScheduler) ScheduleAccessPaused(_ context.Context, input SendAccessPausedInput) error {
+	s.inputs = append(s.inputs, input)
+	return nil
+}
+
+func billingNotificationEvent(t *testing.T, eventType string, action audit.Action) *webhooksv1.Event {
+	t.Helper()
+	organizationID := "<ORGANIZATION_ID>"
+	eventID := "<EVENT_ID>"
+	createdAt := "2026-08-15T12:00:00Z"
+	payload, err := json.Marshal(map[string]string{
+		"organization_id": organizationID,
+		"action":          string(action),
+		"subject_id":      organizationID,
+		"subject_type":    "organization",
+	})
+	require.NoError(t, err)
+	return webhooksv1.Event_builder{
+		EventId:        &eventID,
+		OrganizationId: &organizationID,
+		EventType:      &eventType,
+		Payload:        payload,
+		CreatedAt:      &createdAt,
+	}.Build()
+}
+
+func TestEventHandlerSchedulesOnlyAccessPausedTransitions(t *testing.T) {
+	t.Parallel()
+	scheduler := &captureAccessPausedScheduler{}
+	handler := NewEventHandler(testenv.NewLogger(t), scheduler)
+	metadata := gcp.MessageMetadata{ID: "<MESSAGE_ID>", Attributes: nil, DeliveryAttempt: nil}
+
+	require.NoError(t, handler.Handle(t.Context(), billingNotificationEvent(t, string(events.OrganizationBillingV1.EventType()), audit.ActionOrganizationPaygDeactivated), metadata))
+	require.NoError(t, handler.Handle(t.Context(), billingNotificationEvent(t, string(events.OrganizationEnterpriseTrialV1.EventType()), audit.ActionOrganizationEnterpriseTrialDemoted), metadata))
+	require.Len(t, scheduler.inputs, 2)
+	require.Equal(t, AccessPausedSubscriptionLoss, scheduler.inputs[0].Kind)
+	require.Equal(t, AccessPausedTrialDemotion, scheduler.inputs[1].Kind)
+
+	require.NoError(t, handler.Handle(t.Context(), billingNotificationEvent(t, string(events.OrganizationBillingV1.EventType()), audit.ActionOrganizationPaygActivated), metadata))
+	require.Len(t, scheduler.inputs, 2)
+}
+
+func TestEventHandlerDropsMismatchedEnvelope(t *testing.T) {
+	t.Parallel()
+	scheduler := &captureAccessPausedScheduler{}
+	handler := NewEventHandler(testenv.NewLogger(t), scheduler)
+	event := billingNotificationEvent(t, string(events.OrganizationBillingV1.EventType()), audit.ActionOrganizationPaygDeactivated)
+	payload, err := json.Marshal(map[string]string{
+		"organization_id": "<OTHER_ORGANIZATION_ID>",
+		"action":          string(audit.ActionOrganizationPaygDeactivated),
+		"subject_id":      "<OTHER_ORGANIZATION_ID>",
+		"subject_type":    "organization",
+	})
+	require.NoError(t, err)
+	event.SetPayload(payload)
+
+	require.NoError(t, handler.Handle(t.Context(), event, gcp.MessageMetadata{ID: "<MESSAGE_ID>", Attributes: nil, DeliveryAttempt: nil}))
+	require.Empty(t, scheduler.inputs)
+}

--- a/server/internal/billingnotifications/recipients.go
+++ b/server/internal/billingnotifications/recipients.go
@@ -1,0 +1,43 @@
+package billingnotifications
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+)
+
+// RecipientIdempotencyKey keeps recipient-aware provider keys short and makes
+// address identity case-insensitive.
+func RecipientIdempotencyKey(recipient string, parts ...string) string {
+	parts = append(parts, strings.ToLower(recipient))
+	digest := sha256.Sum256([]byte(strings.Join(parts, ":")))
+	return hex.EncodeToString(digest[:])
+}
+
+// ResolveRecipients applies the product billing-email policy for one tier.
+func ResolveRecipients(ctx context.Context, db repo.DBTX, organizationID, accountType string, configuredEmail *string) ([]string, error) {
+	switch billing.Tier(accountType) {
+	case billing.TierEnterprise:
+		if configuredEmail == nil {
+			return nil, nil
+		}
+		return []string{*configuredEmail}, nil
+	case billing.TierPayg:
+		if configuredEmail != nil {
+			return []string{*configuredEmail}, nil
+		}
+		recipients, err := authz.ResolveOrganizationAdminEmails(ctx, db, organizationID)
+		if err != nil {
+			return recipients, fmt.Errorf("resolve PAYG organization administrator recipients: %w", err)
+		}
+		return recipients, nil
+	default:
+		return nil, nil
+	}
+}

--- a/server/internal/billingnotifications/service.go
+++ b/server/internal/billingnotifications/service.go
@@ -1,0 +1,222 @@
+package billingnotifications
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/email"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+const trialEndingSoonLeadTime = 72 * time.Hour
+
+type Sender interface {
+	SendIdempotent(context.Context, string, string, email.Template) error
+}
+
+type Service struct {
+	logger   *slog.Logger
+	db       *pgxpool.Pool
+	sender   Sender
+	features feature.Provider
+	siteURL  *url.URL
+}
+
+func NewService(logger *slog.Logger, db *pgxpool.Pool, sender Sender, features feature.Provider, siteURL *url.URL) *Service {
+	return &Service{
+		logger:   logger.With(attr.SlogComponent("billing-notifications")),
+		db:       db,
+		sender:   sender,
+		features: features,
+		siteURL:  siteURL,
+	}
+}
+
+type TrialReminderState struct {
+	Active         bool
+	TrialCreatedAt time.Time
+	TrialEndsAt    time.Time
+	SendAt         time.Time
+}
+
+func (s *Service) ResolveTrialReminder(ctx context.Context, organizationID string) (TrialReminderState, error) {
+	trial, err := trialsrepo.New(s.db).GetActiveTrial(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return TrialReminderState{Active: false, TrialCreatedAt: time.Time{}, TrialEndsAt: time.Time{}, SendAt: time.Time{}}, nil
+	}
+	if err != nil {
+		return TrialReminderState{}, fmt.Errorf("get active trial: %w", err)
+	}
+
+	metadata, err := usagerepo.New(s.db).GetBillingMetadata(ctx, organizationID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return TrialReminderState{}, fmt.Errorf("get billing metadata: %w", err)
+	}
+	if err == nil && metadata.StripeSubscriptionID.Valid {
+		return TrialReminderState{Active: false, TrialCreatedAt: time.Time{}, TrialEndsAt: time.Time{}, SendAt: time.Time{}}, nil
+	}
+
+	return TrialReminderState{
+		Active:         true,
+		TrialCreatedAt: trial.CreatedAt.Time,
+		TrialEndsAt:    trial.EndsAt.Time,
+		SendAt:         trial.EndsAt.Time.Add(-trialEndingSoonLeadTime),
+	}, nil
+}
+
+type SendTrialEndingSoonInput struct {
+	OrganizationID string
+	TrialCreatedAt time.Time
+	TrialEndsAt    time.Time
+}
+
+type SendTrialEndingSoonResult struct {
+	Reschedule bool
+}
+
+func (s *Service) SendTrialEndingSoon(ctx context.Context, input SendTrialEndingSoonInput) (SendTrialEndingSoonResult, error) {
+	state, err := s.ResolveTrialReminder(ctx, input.OrganizationID)
+	if err != nil || !state.Active {
+		return SendTrialEndingSoonResult{}, err
+	}
+	if !state.TrialCreatedAt.Equal(input.TrialCreatedAt) || !state.TrialEndsAt.Equal(input.TrialEndsAt) {
+		return SendTrialEndingSoonResult{Reschedule: true}, nil
+	}
+
+	organization, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, input.OrganizationID)
+	if err != nil {
+		return SendTrialEndingSoonResult{}, fmt.Errorf("get organization: %w", err)
+	}
+	configuredEmail, err := s.configuredEmail(ctx, input.OrganizationID)
+	if err != nil {
+		return SendTrialEndingSoonResult{}, err
+	}
+	recipients, err := ResolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
+	if err != nil {
+		return SendTrialEndingSoonResult{}, err
+	}
+
+	template := email.TrialEndingSoon{
+		OrganizationName: organization.Name,
+		TrialEndDate:     state.TrialEndsAt.UTC().Format("January 2, 2006"),
+		ActionURL:        s.siteURL.JoinPath(organization.Slug, "billing").String(),
+	}
+	var sendErrors []error
+	for _, recipient := range recipients {
+		key := RecipientIdempotencyKey(recipient, "trial-ending-soon", input.OrganizationID, state.TrialCreatedAt.UTC().Format(time.RFC3339Nano), state.TrialEndsAt.UTC().Format(time.RFC3339Nano))
+		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
+			s.logger.ErrorContext(ctx, "send trial ending soon email", attr.SlogOrganizationID(input.OrganizationID), attr.SlogError(err))
+			sendErrors = append(sendErrors, err)
+		}
+	}
+	return SendTrialEndingSoonResult{}, errors.Join(sendErrors...)
+}
+
+type AccessPausedKind string
+
+const (
+	AccessPausedSubscriptionLoss AccessPausedKind = "subscription-loss"
+	AccessPausedTrialDemotion    AccessPausedKind = "trial-demotion"
+)
+
+type SendAccessPausedInput struct {
+	EventID        string
+	OrganizationID string
+	Kind           AccessPausedKind
+}
+
+func (s *Service) SendAccessPaused(ctx context.Context, input SendAccessPausedInput) error {
+	switch input.Kind {
+	case AccessPausedSubscriptionLoss, AccessPausedTrialDemotion:
+	case "":
+		return fmt.Errorf("access paused kind is required")
+	default:
+		return fmt.Errorf("unsupported access paused kind %q", input.Kind)
+	}
+
+	organization, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, input.OrganizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get organization: %w", err)
+	}
+	if organization.GramAccountType != "free" || organization.Whitelisted {
+		return nil
+	}
+
+	metadata, err := usagerepo.New(s.db).GetBillingMetadata(ctx, input.OrganizationID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get billing metadata: %w", err)
+	}
+	if err == nil && metadata.StripeSubscriptionID.Valid {
+		return nil
+	}
+
+	if input.Kind == AccessPausedTrialDemotion {
+		trial, trialErr := trialsrepo.New(s.db).GetTrial(ctx, input.OrganizationID)
+		if errors.Is(trialErr, pgx.ErrNoRows) || (trialErr == nil && (!trial.DemotedAt.Valid || trial.ConvertedAt.Valid)) {
+			return nil
+		}
+		if trialErr != nil {
+			return fmt.Errorf("get demoted trial: %w", trialErr)
+		}
+		if s.features == nil {
+			return nil
+		}
+		enabled, flagErr := s.features.IsFlagEnabled(ctx, feature.FlagPaygSelfServeBilling, input.OrganizationID, feature.OrgProjectGroups(organization.Slug, ""))
+		if flagErr != nil || !enabled {
+			if flagErr != nil {
+				s.logger.WarnContext(ctx, "evaluate PAYG email rollout", attr.SlogOrganizationID(input.OrganizationID), attr.SlogError(flagErr))
+			}
+			return nil
+		}
+	}
+
+	configuredEmail, err := s.configuredEmail(ctx, input.OrganizationID)
+	if err != nil {
+		return err
+	}
+	recipients, err := ResolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
+	if err != nil {
+		return err
+	}
+	template := email.AccessPaused{
+		OrganizationName: organization.Name,
+		ActionURL:        s.siteURL.JoinPath(organization.Slug).String(),
+	}
+	var sendErrors []error
+	for _, recipient := range recipients {
+		key := RecipientIdempotencyKey(recipient, "access-paused", input.EventID)
+		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
+			s.logger.ErrorContext(ctx, "send access paused email", attr.SlogOrganizationID(input.OrganizationID), attr.SlogOutboxPublicID(input.EventID), attr.SlogError(err))
+			sendErrors = append(sendErrors, err)
+		}
+	}
+	return errors.Join(sendErrors...)
+}
+
+func (s *Service) configuredEmail(ctx context.Context, organizationID string) (*string, error) {
+	metadata, err := usagerepo.New(s.db).GetBillingMetadata(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get billing metadata: %w", err)
+	}
+	if !metadata.AlertEmail.Valid {
+		return nil, nil
+	}
+	return &metadata.AlertEmail.String, nil
+}

--- a/server/internal/billingnotifications/service.go
+++ b/server/internal/billingnotifications/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/email"
 	"github.com/speakeasy-api/gram/server/internal/feature"
@@ -26,20 +27,22 @@ type Sender interface {
 }
 
 type Service struct {
-	logger   *slog.Logger
-	db       *pgxpool.Pool
-	sender   Sender
-	features feature.Provider
-	siteURL  *url.URL
+	logger            *slog.Logger
+	db                *pgxpool.Pool
+	sender            Sender
+	features          feature.Provider
+	siteURL           *url.URL
+	resolveRecipients func(context.Context, accessrepo.DBTX, string, string, *string) ([]string, error)
 }
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sender Sender, features feature.Provider, siteURL *url.URL) *Service {
 	return &Service{
-		logger:   logger.With(attr.SlogComponent("billing-notifications")),
-		db:       db,
-		sender:   sender,
-		features: features,
-		siteURL:  siteURL,
+		logger:            logger.With(attr.SlogComponent("billing-notifications")),
+		db:                db,
+		sender:            sender,
+		features:          features,
+		siteURL:           siteURL,
+		resolveRecipients: ResolveRecipients,
 	}
 }
 
@@ -102,17 +105,17 @@ func (s *Service) SendTrialEndingSoon(ctx context.Context, input SendTrialEnding
 	if err != nil {
 		return SendTrialEndingSoonResult{}, err
 	}
-	recipients, err := ResolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
-	if err != nil {
-		return SendTrialEndingSoonResult{}, err
-	}
+	recipients, resolutionErr := s.resolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
 
 	template := email.TrialEndingSoon{
 		OrganizationName: organization.Name,
 		TrialEndDate:     state.TrialEndsAt.UTC().Format("January 2, 2006"),
 		ActionURL:        s.siteURL.JoinPath(organization.Slug, "billing").String(),
 	}
-	var sendErrors []error
+	sendErrors := make([]error, 0, len(recipients)+1)
+	if resolutionErr != nil {
+		sendErrors = append(sendErrors, resolutionErr)
+	}
 	for _, recipient := range recipients {
 		key := RecipientIdempotencyKey(recipient, "trial-ending-soon", input.OrganizationID, state.TrialCreatedAt.UTC().Format(time.RFC3339Nano), state.TrialEndsAt.UTC().Format(time.RFC3339Nano))
 		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
@@ -188,15 +191,15 @@ func (s *Service) SendAccessPaused(ctx context.Context, input SendAccessPausedIn
 	if err != nil {
 		return err
 	}
-	recipients, err := ResolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
-	if err != nil {
-		return err
-	}
+	recipients, resolutionErr := s.resolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
 	template := email.AccessPaused{
 		OrganizationName: organization.Name,
 		ActionURL:        s.siteURL.JoinPath(organization.Slug).String(),
 	}
-	var sendErrors []error
+	sendErrors := make([]error, 0, len(recipients)+1)
+	if resolutionErr != nil {
+		sendErrors = append(sendErrors, resolutionErr)
+	}
 	for _, recipient := range recipients {
 		key := RecipientIdempotencyKey(recipient, "access-paused", input.EventID)
 		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {

--- a/server/internal/billingnotifications/service_test.go
+++ b/server/internal/billingnotifications/service_test.go
@@ -2,6 +2,7 @@ package billingnotifications
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"sync"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/email"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -144,4 +146,51 @@ func TestSendAccessPausedSubscriptionLossDoesNotDependOnRolloutFlag(t *testing.T
 	}))
 	require.Len(t, sender.sends, 1)
 	require.Equal(t, "billing@example.test", sender.sends[0].recipient)
+}
+
+func TestSendTrialEndingSoonDeliversResolvedRecipientsBeforeReturningResolutionError(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "enterprise", true)
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, trialsrepo.New(service.db).InsertTrialFixture(t.Context(), trialsrepo.InsertTrialFixtureParams{
+		OrganizationID: organizationID,
+		Tier:           "enterprise",
+		CreatedAt:      pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		EndsAt:         pgtype.Timestamptz{Time: now.Add(7 * 24 * time.Hour), Valid: true},
+		ConvertedAt:    pgtype.Timestamptz{},
+		DemotedAt:      pgtype.Timestamptz{},
+	}))
+	resolutionErr := errors.New("one administrator could not be resolved")
+	service.resolveRecipients = func(context.Context, accessrepo.DBTX, string, string, *string) ([]string, error) {
+		return []string{"resolved@example.test"}, resolutionErr
+	}
+	state, err := service.ResolveTrialReminder(t.Context(), organizationID)
+	require.NoError(t, err)
+
+	_, err = service.SendTrialEndingSoon(t.Context(), SendTrialEndingSoonInput{
+		OrganizationID: organizationID,
+		TrialCreatedAt: state.TrialCreatedAt,
+		TrialEndsAt:    state.TrialEndsAt,
+	})
+	require.ErrorIs(t, err, resolutionErr)
+	require.Len(t, sender.sends, 1)
+	require.Equal(t, "resolved@example.test", sender.sends[0].recipient)
+}
+
+func TestSendAccessPausedDeliversResolvedRecipientsBeforeReturningResolutionError(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "free", false)
+	resolutionErr := errors.New("one administrator could not be resolved")
+	service.resolveRecipients = func(context.Context, accessrepo.DBTX, string, string, *string) ([]string, error) {
+		return []string{"resolved@example.test"}, resolutionErr
+	}
+
+	err := service.SendAccessPaused(t.Context(), SendAccessPausedInput{
+		EventID:        "event-placeholder",
+		OrganizationID: organizationID,
+		Kind:           AccessPausedSubscriptionLoss,
+	})
+	require.ErrorIs(t, err, resolutionErr)
+	require.Len(t, sender.sends, 1)
+	require.Equal(t, "resolved@example.test", sender.sends[0].recipient)
 }

--- a/server/internal/billingnotifications/service_test.go
+++ b/server/internal/billingnotifications/service_test.go
@@ -1,0 +1,147 @@
+package billingnotifications
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/email"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+type capturedEmail struct {
+	recipient string
+	key       string
+	template  email.Template
+}
+
+type captureSender struct {
+	mu    sync.Mutex
+	sends []capturedEmail
+}
+
+func (s *captureSender) SendIdempotent(_ context.Context, recipient, key string, template email.Template) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sends = append(s.sends, capturedEmail{recipient: recipient, key: key, template: template})
+	return nil
+}
+
+func newNotificationTestService(t *testing.T, accountType string, whitelisted bool) (*Service, *captureSender, string) {
+	t.Helper()
+	db, err := testInfra.CloneTestDatabase(t, "billing_notifications")
+	require.NoError(t, err)
+	organizationID := "org-billing-notifications"
+	_, err = orgrepo.New(db).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Example Organization",
+		Slug:        "example-org",
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{Bool: whitelisted, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, orgrepo.New(db).SetAccountType(t.Context(), orgrepo.SetAccountTypeParams{
+		ID:              organizationID,
+		GramAccountType: accountType,
+	}))
+	sender := &captureSender{}
+	flags := new(feature.InMemory)
+	siteURL, err := url.Parse("https://app.example.test")
+	require.NoError(t, err)
+	return NewService(testenv.NewLogger(t), db, sender, flags, siteURL), sender, organizationID
+}
+
+func TestSendTrialEndingSoonUsesConfiguredBillingEmailAndStableTrialIdentity(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "enterprise", true)
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, trialsrepo.New(service.db).InsertTrialFixture(t.Context(), trialsrepo.InsertTrialFixtureParams{
+		OrganizationID: organizationID,
+		Tier:           "enterprise",
+		CreatedAt:      pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		EndsAt:         pgtype.Timestamptz{Time: now.Add(7 * 24 * time.Hour), Valid: true},
+		ConvertedAt:    pgtype.Timestamptz{},
+		DemotedAt:      pgtype.Timestamptz{},
+	}))
+	_, err := usagerepo.New(service.db).UpsertBillingEmail(t.Context(), usagerepo.UpsertBillingEmailParams{
+		OrganizationID: organizationID,
+		AlertEmail:     pgtype.Text{String: "billing@example.test", Valid: true},
+	})
+	require.NoError(t, err)
+
+	state, err := service.ResolveTrialReminder(t.Context(), organizationID)
+	require.NoError(t, err)
+	require.True(t, state.Active)
+	require.Equal(t, state.TrialEndsAt.Add(-72*time.Hour), state.SendAt)
+	result, err := service.SendTrialEndingSoon(t.Context(), SendTrialEndingSoonInput{
+		OrganizationID: organizationID,
+		TrialCreatedAt: state.TrialCreatedAt,
+		TrialEndsAt:    state.TrialEndsAt,
+	})
+	require.NoError(t, err)
+	require.False(t, result.Reschedule)
+	require.Len(t, sender.sends, 1)
+	require.Equal(t, "billing@example.test", sender.sends[0].recipient)
+	require.Len(t, sender.sends[0].key, 64)
+	template, ok := sender.sends[0].template.(email.TrialEndingSoon)
+	require.True(t, ok)
+	require.Equal(t, "https://app.example.test/example-org/billing", template.ActionURL)
+}
+
+func TestSendAccessPausedTrialDemotionFailsClosedAndUsesOrganizationGate(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "free", false)
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, trialsrepo.New(service.db).InsertTrialFixture(t.Context(), trialsrepo.InsertTrialFixtureParams{
+		OrganizationID: organizationID,
+		Tier:           "enterprise",
+		CreatedAt:      pgtype.Timestamptz{Time: now.Add(-15 * 24 * time.Hour), Valid: true},
+		EndsAt:         pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+		ConvertedAt:    pgtype.Timestamptz{},
+		DemotedAt:      pgtype.Timestamptz{Time: now, Valid: true},
+	}))
+	_, err := usagerepo.New(service.db).UpsertBillingEmail(t.Context(), usagerepo.UpsertBillingEmailParams{
+		OrganizationID: organizationID,
+		AlertEmail:     pgtype.Text{String: "billing@example.test", Valid: true},
+	})
+	require.NoError(t, err)
+	input := SendAccessPausedInput{EventID: "event-placeholder", OrganizationID: organizationID, Kind: AccessPausedTrialDemotion}
+
+	require.NoError(t, service.SendAccessPaused(t.Context(), input))
+	require.Empty(t, sender.sends)
+	flags, ok := service.features.(*feature.InMemory)
+	require.True(t, ok)
+	flags.SetFlag(feature.FlagPaygSelfServeBilling, organizationID, true)
+	require.NoError(t, service.SendAccessPaused(t.Context(), input))
+	require.Len(t, sender.sends, 1)
+	template, ok := sender.sends[0].template.(email.AccessPaused)
+	require.True(t, ok)
+	require.Equal(t, "https://app.example.test/example-org", template.ActionURL)
+}
+
+func TestSendAccessPausedSubscriptionLossDoesNotDependOnRolloutFlag(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "free", false)
+	_, err := usagerepo.New(service.db).UpsertBillingEmail(t.Context(), usagerepo.UpsertBillingEmailParams{
+		OrganizationID: organizationID,
+		AlertEmail:     pgtype.Text{String: "billing@example.test", Valid: true},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, service.SendAccessPaused(t.Context(), SendAccessPausedInput{
+		EventID:        "event-placeholder",
+		OrganizationID: organizationID,
+		Kind:           AccessPausedSubscriptionLoss,
+	}))
+	require.Len(t, sender.sends, 1)
+	require.Equal(t, "billing@example.test", sender.sends[0].recipient)
+}

--- a/server/internal/billingnotifications/setup_test.go
+++ b/server/internal/billingnotifications/setup_test.go
@@ -1,0 +1,25 @@
+package billingnotifications
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var testInfra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	environment, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+	}
+	testInfra = environment
+	code := m.Run()
+	if err := cleanup(); err != nil {
+		log.Fatalf("clean up test infrastructure: %v", err)
+	}
+	os.Exit(code)
+}

--- a/server/internal/email/loops/access_paused.lmx
+++ b/server/internal/email/loops/access_paused.lmx
@@ -1,0 +1,22 @@
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
+</Columns>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">BILLING · ACCESS PAUSED</Strong></Paragraph>
+<H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Your organization’s access is paused.</H1>
+<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">Access to Gram for {data.organization_name} is paused because there is no active subscription. Start pay as you go to restore access.</Paragraph>
+<Button href="{data.action_url}" paddingRight="40" paddingBottom="48" paddingLeft="40">Start pay as you go →</Button>
+<Divider />
+<Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this operational email because this address receives billing notifications for {data.organization_name}.</Paragraph>
+</Section>

--- a/server/internal/email/loops/manifest.json
+++ b/server/internal/email/loops/manifest.json
@@ -6,6 +6,13 @@
     "reply_to_email": "gram@speakeasy.com"
   },
   "templates": {
+    "access_paused": {
+      "managed_name": "gram.transactional.v2.access_paused",
+      "subject": "Access paused for {data.organization_name}",
+      "preview_text": "Start pay as you go to restore access.",
+      "source": "access_paused.lmx",
+      "variables": ["organization_name", "action_url"]
+    },
     "access_request": {
       "managed_name": "gram.transactional.v2.access_request",
       "subject": "Access requested for {data.organization_name}",
@@ -52,6 +59,13 @@
         "inviter_email",
         "organization_name"
       ]
+    },
+    "trial_ending_soon": {
+      "managed_name": "gram.transactional.v2.trial_ending_soon",
+      "subject": "Your Gram trial ends on {data.trial_end_date}",
+      "preview_text": "Set up billing to keep access for {data.organization_name}.",
+      "source": "trial_ending_soon.lmx",
+      "variables": ["organization_name", "trial_end_date", "action_url"]
     },
     "tum_usage_overage": {
       "managed_name": "gram.transactional.v2.tum_usage_overage",

--- a/server/internal/email/loops/trial_ending_soon.lmx
+++ b/server/internal/email/loops/trial_ending_soon.lmx
@@ -1,0 +1,26 @@
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
+</Columns>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">TRIAL · 3 DAYS REMAINING</Strong></Paragraph>
+<H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Your trial ends soon.</H1>
+<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">The Gram trial for {data.organization_name} ends on {data.trial_end_date}. Set up billing to keep access after the trial.</Paragraph>
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">TRIAL END DATE</Strong></Paragraph>
+  <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">{data.trial_end_date}</Text></Paragraph>
+</Section>
+<Button href="{data.action_url}" paddingTop="32" paddingRight="40" paddingBottom="48" paddingLeft="40">Set up billing →</Button>
+<Divider />
+<Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this operational email because this address receives billing notifications for {data.organization_name}.</Paragraph>
+</Section>

--- a/server/internal/email/template_access_paused.go
+++ b/server/internal/email/template_access_paused.go
@@ -1,0 +1,19 @@
+package email
+
+type AccessPaused struct {
+	OrganizationName string
+	ActionURL        string
+}
+
+func (AccessPaused) Key() TemplateKey {
+	return TemplateKeyAccessPaused
+}
+
+func (AccessPaused) AddToAudience() bool { return false }
+
+func (t AccessPaused) Variables() map[string]string {
+	return map[string]string{
+		"organization_name": t.OrganizationName,
+		"action_url":        t.ActionURL,
+	}
+}

--- a/server/internal/email/template_access_paused_test.go
+++ b/server/internal/email/template_access_paused_test.go
@@ -1,0 +1,23 @@
+package email
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessPaused_Contract(t *testing.T) {
+	t.Parallel()
+
+	tmpl := AccessPaused{
+		OrganizationName: "Example Organization",
+		ActionURL:        "https://app.getgram.ai/example/billing",
+	}
+
+	require.Equal(t, TemplateKeyAccessPaused, tmpl.Key())
+	require.Equal(t, map[string]string{
+		"organization_name": "Example Organization",
+		"action_url":        "https://app.getgram.ai/example/billing",
+	}, tmpl.Variables())
+	require.False(t, tmpl.AddToAudience())
+}

--- a/server/internal/email/template_trial_ending_soon.go
+++ b/server/internal/email/template_trial_ending_soon.go
@@ -1,0 +1,21 @@
+package email
+
+type TrialEndingSoon struct {
+	OrganizationName string
+	TrialEndDate     string
+	ActionURL        string
+}
+
+func (TrialEndingSoon) Key() TemplateKey {
+	return TemplateKeyTrialEndingSoon
+}
+
+func (TrialEndingSoon) AddToAudience() bool { return false }
+
+func (t TrialEndingSoon) Variables() map[string]string {
+	return map[string]string{
+		"organization_name": t.OrganizationName,
+		"trial_end_date":    t.TrialEndDate,
+		"action_url":        t.ActionURL,
+	}
+}

--- a/server/internal/email/template_trial_ending_soon_test.go
+++ b/server/internal/email/template_trial_ending_soon_test.go
@@ -1,0 +1,25 @@
+package email
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrialEndingSoon_Contract(t *testing.T) {
+	t.Parallel()
+
+	tmpl := TrialEndingSoon{
+		OrganizationName: "Example Organization",
+		TrialEndDate:     "August 18, 2026",
+		ActionURL:        "https://app.getgram.ai/example/billing",
+	}
+
+	require.Equal(t, TemplateKeyTrialEndingSoon, tmpl.Key())
+	require.Equal(t, map[string]string{
+		"organization_name": "Example Organization",
+		"trial_end_date":    "August 18, 2026",
+		"action_url":        "https://app.getgram.ai/example/billing",
+	}, tmpl.Variables())
+	require.False(t, tmpl.AddToAudience())
+}

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -36,6 +36,8 @@ const (
 	TemplateKeyCustomDomainUnhealthy     TemplateKey = "custom_domain_unhealthy"
 	TemplateKeyWeeklyUsageSummary        TemplateKey = "weekly_usage_summary"
 	TemplateKeyAccessRequest             TemplateKey = "access_request"
+	TemplateKeyTrialEndingSoon           TemplateKey = "trial_ending_soon"
+	TemplateKeyAccessPaused              TemplateKey = "access_paused"
 )
 
 var (
@@ -120,4 +122,6 @@ var RegisteredTemplates = []Template{
 	CustomDomainUnhealthy{Email: "", Domain: "", IssueMessage: "", DomainLink: ""},
 	WeeklyUsageSummary{OrganizationName: "", CycleEndDate: "", DaysRemaining: "", CycleElapsedPercent: "", TotalTokens: "", PreviousTotalTokens: "", TotalChangePercent: "", ViewUsageURL: ""},
 	AccessRequest{RequesterName: "", OrganizationName: "", ManageAccessLink: ""},
+	TrialEndingSoon{OrganizationName: "", TrialEndDate: "", ActionURL: ""},
+	AccessPaused{OrganizationName: "", ActionURL: ""},
 }

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -32,7 +32,9 @@ func TestParseTemplateIDs_ValidatesCompleteRegistry(t *testing.T) {
 		"openrouter_internal_credits_threshold":"id-6",
 		"custom_domain_unhealthy":"id-7",
 		"weekly_usage_summary":"id-8",
-		"access_request":"id-9"
+		"access_request":"id-9",
+		"trial_ending_soon":"id-10",
+		"access_paused":"id-11"
 	}`)
 	require.NoError(t, err)
 	require.NoError(t, ids.ValidateRegistered())


### PR DESCRIPTION
## Summary

- add typed Loops templates for trial-ending and access-paused notifications
- schedule the trial reminder at T-3 with current-state suppression and extension-aware re-timing
- deliver access-paused notifications from committed billing/trial audit events with durable Temporal retries
- route both notifications to the configured billing address or effective organization admins

## Verification

- `mise exec -- go run ./server/cmd/sync-loops-email-templates --validate-only`
- `mise lint:server`
- `mise build:server`
- `mise exec -- go test ./server/internal/billingnotifications ./server/internal/email/... ./server/internal/background/... ./server/cmd/gram/... -count=1`

Linear: DNO-842

Stacked on #5366.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends PAYG lifecycle emails: a T-3 trial-ending reminder and an access-paused notice. Previously none; now delivery runs in Temporal with per-recipient idempotency and bounded retries, validates audit envelopes, re-checks billing state at send time, and never blocks trial demotion or subscription revocation. Meets Linear DNO-842 §13 email matrix.

- Adds `billingnotifications` service for recipient resolution (configured billing email or all PAYG admins), idempotency keys, and send logic; exposes activities `ResolveTrialEndingReminder`, `SendTrialEndingSoonEmail`, `SendAccessPausedEmail`; registers Loops templates `trial_ending_soon` and `access_paused`.
- Trial workflow: schedules the T-3 reminder, suppresses when a subscription exists, retimes on extensions, keeps the reminder after legacy sync failure, chunks long waits via continue-as-new; workflow run timeout is 180 days.
- Access paused: introduces `AccessPausedEmailWorkflow`; sends only for free, non-whitelisted orgs with no active subscription; trial-demotion path gated by `feature.FlagPaygSelfServeBilling`; subscription-loss path is ungated.
- Webhooks: adds a `streams` handler that validates envelopes and enqueues access-paused emails for `OrganizationBillingV1` (subscription loss) and `OrganizationEnterpriseTrialV1` (trial demotion); aggregates handler errors with `errors.Join`.
- Worker: registers new activities and workflows; trial demotion no longer emits inactive notifications on no-op or rollback.

**Rollout**
- Sync templates: mise exec -- go run ./server/cmd/sync-loops-email-templates
- Enable `feature.FlagPaygSelfServeBilling` to allow access-paused emails on trial demotion.

<sup>Written for commit ade309c64883e7a752174f27a28d14082872c084. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

