### PR TITLE
feat: re-arm per-key PAYG inference alerts

### DIFF
--- a/.changeset/rearm-payg-spend-alerts.md
+++ b/.changeset/rearm-payg-spend-alerts.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+---
+
+Re-arm PAYG inference spend alerts after an explicit cap change while preserving
+deduplication when reconciled OpenRouter limits fluctuate.

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -740,7 +740,7 @@ func (d *devProvisioner) GetCreditsUsed(_ context.Context, _ string, _ openroute
 func (d *devProvisioner) GetKeyUsage(_ context.Context, _ string) (float64, *int64, error) {
 	return 0, nil, fmt.Errorf("not implemented in bench")
 }
-func (d *devProvisioner) ReconcileMonthlyCredits(_ context.Context, _ string, _ openrouter.KeyType, currentLimit int64, _ *int64) (int64, error) {
+func (d *devProvisioner) ReconcileMonthlyCredits(_ context.Context, _ string, _ openrouter.KeyType, currentLimit int64, _ int64, _ *int64) (int64, error) {
 	return currentLimit, nil
 }
 func (d *devProvisioner) GetModelUsage(_ context.Context, _ string, _ string, _ openrouter.KeyType) (*openrouter.ModelUsage, error) {

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -294,7 +294,7 @@ func (d *devProvisioner) GetCreditsUsed(_ context.Context, _ string, _ openroute
 func (d *devProvisioner) GetKeyUsage(_ context.Context, _ string) (float64, *int64, error) {
 	return 0, nil, fmt.Errorf("not implemented in bench")
 }
-func (d *devProvisioner) ReconcileMonthlyCredits(_ context.Context, _ string, _ openrouter.KeyType, currentLimit int64, _ *int64) (int64, error) {
+func (d *devProvisioner) ReconcileMonthlyCredits(_ context.Context, _ string, _ openrouter.KeyType, currentLimit int64, _ int64, _ *int64) (int64, error) {
 	return currentLimit, nil
 }
 func (d *devProvisioner) GetModelUsage(_ context.Context, _ string, _ string, _ openrouter.KeyType) (*openrouter.ModelUsage, error) {

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -338,7 +338,7 @@ func NewActivities(
 		weeklyUsageSummary:              activities.NewWeeklyUsageSummary(logger, db, chConn, emailService, siteURL),
 		forwardTokenUsageToPostHog:      activities.NewForwardTokenUsageToPostHog(logger, db, posthogClient, cacheAdapter),
 		refreshOpenRouterKey:            activities.NewRefreshOpenRouterKey(logger, db, openrouterProvisioner),
-		setOpenRouterSpendCap:           activities.NewSetOpenRouterSpendCap(logger, db, openrouterProvisioner, auditLogger),
+		setOpenRouterSpendCap:           activities.NewSetOpenRouterSpendCap(logger, db, openrouterProvisioner, auditLogger, cacheAdapter),
 		reconcilePaygOpenRouterChatKey:  activities.NewReconcilePaygOpenRouterChatKey(logger, db, openrouterProvisioner),
 		transitionDeployment:            activities.NewTransitionDeployment(logger, db),
 		validateDeployment:              activities.NewValidateDeployment(logger, db, billingRepo),

--- a/server/internal/background/activities/openrouter_credits_alerts.go
+++ b/server/internal/background/activities/openrouter_credits_alerts.go
@@ -8,17 +8,21 @@ import (
 	"strconv"
 	"time"
 
+	redisCache "github.com/go-redis/cache/v9"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	auditrepo "github.com/speakeasy-api/gram/server/internal/audit/repo"
 	repo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/email"
 	"github.com/speakeasy-api/gram/server/internal/modelkeys"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usage"
 )
 
@@ -117,6 +121,7 @@ type MaybeSendOpenRouterCreditsAlerts struct {
 	logger       *slog.Logger
 	db           *pgxpool.Pool
 	repo         *repo.Queries
+	auditRepo    *auditrepo.Queries
 	cache        cache.Cache
 	emails       *email.Service
 	alertsSent   metric.Int64Counter
@@ -159,6 +164,7 @@ func NewMaybeSendOpenRouterCreditsAlerts(
 		logger:       componentLogger,
 		db:           db,
 		repo:         repo.New(db),
+		auditRepo:    auditrepo.New(db),
 		cache:        cacheAdapter,
 		emails:       emails,
 		alertsSent:   sent,
@@ -166,16 +172,26 @@ func NewMaybeSendOpenRouterCreditsAlerts(
 	}
 }
 
+// openRouterCreditsAlertGenerationKey stores the explicit cap-change operation
+// that owns the current alert ladder. Reconciliation never writes this key, so
+// upstream/local limit flaps cannot re-arm alerts.
+func openRouterCreditsAlertGenerationKey(orgID string, keyType openrouter.KeyType) string {
+	return fmt.Sprintf("openrouter-credits-alert-generation:%s:%s", orgID, keyType)
+}
+
 // openRouterCreditsAlertKey is the Redis dedup key for one org's crossed
 // threshold. The calendar month and the credit limit are deliberately NOT part
 // of the key: monthly re-arming comes from the reservation's TTL expiring
 // shortly after the cycle ends (see openRouterCreditsAlertGrace), and keying on
-// the limit would let the limit flapping between the upstream and DB-cached
-// values (when ReconcileMonthlyCredits fails) mint duplicate alerts for one
-// unchanged usage state. The trade-off: raising the cap mid-month does not
-// re-arm already-sent thresholds until the next month.
-func openRouterCreditsAlertKey(orgID string, keyType openrouter.KeyType, threshold int) string {
-	return fmt.Sprintf("openrouter-credits-alert:%s:%s:%d", orgID, keyType, threshold)
+// the limit would let reconciliation flaps mint duplicate alerts. A successful
+// explicit cap change rotates generation instead. The empty-generation shape
+// is the legacy key, preserving reservations that predate generation tracking.
+func openRouterCreditsAlertKey(orgID string, keyType openrouter.KeyType, threshold int, generation string) string {
+	key := fmt.Sprintf("openrouter-credits-alert:%s:%s:%d", orgID, keyType, threshold)
+	if generation != "" {
+		key += ":" + generation
+	}
+	return key
 }
 
 // openRouterCreditsAlertCycle keeps provider idempotency on the prior month
@@ -192,9 +208,54 @@ func openRouterCreditsAlertRecipientKey(idempotencyKey string) string {
 // openRouterCreditsAlertCandidate is one (org, key type) pair that crossed a
 // threshold this tick and holds a fresh dedup reservation.
 type openRouterCreditsAlertCandidate struct {
-	orgID     string
-	keyType   openrouter.KeyType
-	threshold int
+	orgID           string
+	keyType         openrouter.KeyType
+	threshold       int
+	generation      string
+	generationAware bool
+	creditLimit     int64
+}
+
+type openRouterCreditsAlertGeneration struct {
+	OperationID    string `json:"operation_id"`
+	MonthlyCredits int64  `json:"monthly_credits"`
+}
+
+var errOpenRouterCreditsAlertGenerationChanged = errors.New("openrouter credits alert generation changed")
+
+func (a *MaybeSendOpenRouterCreditsAlerts) readGeneration(
+	ctx context.Context,
+	orgID string,
+	keyType openrouter.KeyType,
+	restoreCache bool,
+) (openRouterCreditsAlertGeneration, error) {
+	var generation openRouterCreditsAlertGeneration
+	err := a.cache.Get(ctx, openRouterCreditsAlertGenerationKey(orgID, keyType), &generation)
+	if errors.Is(err, redisCache.ErrCacheMiss) {
+		latest, err := a.auditRepo.GetLatestOpenRouterSpendCapAuditOperation(ctx, auditrepo.GetLatestOpenRouterSpendCapAuditOperationParams{
+			OrganizationID: orgID,
+			SubjectID:      urn.NewOpenRouterAPIKey(orgID, string(keyType)).ID,
+		})
+		if err != nil {
+			return openRouterCreditsAlertGeneration{OperationID: "", MonthlyCredits: 0}, fmt.Errorf("read durable OpenRouter credits alert generation: %w", err)
+		}
+		generation := openRouterCreditsAlertGeneration{
+			OperationID:    latest.OperationID,
+			MonthlyCredits: latest.MonthlyCredits,
+		}
+		if restoreCache {
+			now := time.Now().UTC()
+			_, cycleEnd := usage.CurrentBillingCycle(now, 1)
+			if err := a.cache.Set(ctx, openRouterCreditsAlertGenerationKey(orgID, keyType), generation, cycleEnd.Sub(now)+openRouterCreditsAlertGrace); err != nil {
+				return openRouterCreditsAlertGeneration{OperationID: "", MonthlyCredits: 0}, fmt.Errorf("restore OpenRouter credits alert generation cache: %w", err)
+			}
+		}
+		return generation, nil
+	}
+	if err != nil {
+		return openRouterCreditsAlertGeneration{OperationID: "", MonthlyCredits: 0}, fmt.Errorf("read OpenRouter credits alert generation: %w", err)
+	}
+	return generation, nil
 }
 
 func (a *MaybeSendOpenRouterCreditsAlerts) Do(ctx context.Context, metrics []OpenRouterCreditsMetric) error {
@@ -208,13 +269,31 @@ func (a *MaybeSendOpenRouterCreditsAlerts) Do(ctx context.Context, metrics []Ope
 		if _, ok := openRouterCreditsAlertConfigs[keyType]; !ok {
 			continue
 		}
-		if threshold := highestCrossedOpenRouterCreditsThreshold(m.CreditsUsed, m.CreditLimit); threshold != 0 {
-			candidates = append(candidates, openRouterCreditsAlertCandidate{
-				orgID:     m.OrganizationID,
-				keyType:   keyType,
-				threshold: threshold,
-			})
+		threshold := highestCrossedOpenRouterCreditsThreshold(m.CreditsUsed, m.CreditLimit)
+		if threshold == 0 {
+			continue
 		}
+
+		generationAware := m.AccountType == string(billing.TierPayg)
+		generation := openRouterCreditsAlertGeneration{OperationID: "", MonthlyCredits: 0}
+		if generationAware {
+			loadedGeneration, err := a.readGeneration(ctx, m.OrganizationID, keyType, false)
+			if err != nil {
+				a.logger.ErrorContext(ctx, "read openrouter credits alert generation",
+					attr.SlogOrganizationID(m.OrganizationID), attr.SlogOpenRouterKeyType(string(keyType)), attr.SlogError(err))
+				a.recordFailure(ctx, m.OrganizationID, keyType)
+				continue
+			}
+			generation = loadedGeneration
+		}
+		candidates = append(candidates, openRouterCreditsAlertCandidate{
+			orgID:           m.OrganizationID,
+			keyType:         keyType,
+			threshold:       threshold,
+			generation:      generation.OperationID,
+			generationAware: generationAware,
+			creditLimit:     m.CreditLimit,
+		})
 	}
 	if len(candidates) == 0 {
 		return nil
@@ -226,7 +305,7 @@ func (a *MaybeSendOpenRouterCreditsAlerts) Do(ctx context.Context, metrics []Ope
 	// reservation is extended to month length only after a successful send.
 	pending := make([]openRouterCreditsAlertCandidate, 0, len(candidates))
 	for _, c := range candidates {
-		won, err := a.cache.Add(ctx, openRouterCreditsAlertKey(c.orgID, c.keyType, c.threshold), openRouterCreditsAlertRetryTTL)
+		won, err := a.cache.Add(ctx, openRouterCreditsAlertKey(c.orgID, c.keyType, c.threshold, c.generation), openRouterCreditsAlertRetryTTL)
 		if err != nil {
 			a.logger.ErrorContext(ctx, "failed to reserve openrouter credits alert",
 				attr.SlogOrganizationID(c.orgID), attr.SlogOpenRouterKeyType(string(c.keyType)), attr.SlogError(err))
@@ -303,27 +382,90 @@ func (a *MaybeSendOpenRouterCreditsAlerts) Do(ctx context.Context, metrics []Ope
 			continue
 		}
 
-		deliveryErrors := []error{audience.err}
-		for _, recipient := range audience.recipients {
-			if err := a.sendOne(ctx, c, r.OrganizationName, recipient, now); err != nil {
-				deliveryErrors = append(deliveryErrors, err)
+		deliver := func(queries *repo.Queries) error {
+			// Cap writes and alert delivery share one per-org/key lock. The final
+			// generation check therefore orders an in-flight poll either wholly
+			// before the cap change, or skips it after the new ladder is installed.
+			if c.generationAware {
+				generation, err := a.readGeneration(ctx, c.orgID, c.keyType, true)
+				if err != nil {
+					return err
+				}
+				if generation.OperationID != c.generation {
+					return errOpenRouterCreditsAlertGenerationChanged
+				}
+				if generation.OperationID != "" && generation.MonthlyCredits != c.creditLimit {
+					currentLimit, err := queries.GetOpenRouterInferenceKeyLimit(ctx, repo.GetOpenRouterInferenceKeyLimitParams{
+						OrganizationID: c.orgID,
+						KeyType:        string(c.keyType),
+					})
+					if err != nil {
+						return fmt.Errorf("read current OpenRouter inference cap: %w", err)
+					}
+					if currentLimit != c.creditLimit {
+						return errOpenRouterCreditsAlertGenerationChanged
+					}
+
+					generation.MonthlyCredits = currentLimit
+					now := time.Now().UTC()
+					_, cycleEnd := usage.CurrentBillingCycle(now, 1)
+					if err := a.cache.Set(ctx, openRouterCreditsAlertGenerationKey(c.orgID, c.keyType), generation, cycleEnd.Sub(now)+openRouterCreditsAlertGrace); err != nil {
+						return fmt.Errorf("rebase OpenRouter credits alert generation: %w", err)
+					}
+				}
 			}
+
+			deliveryErrors := []error{audience.err}
+			for _, recipient := range audience.recipients {
+				if err := a.sendOne(ctx, c, r.OrganizationName, recipient, now); err != nil {
+					deliveryErrors = append(deliveryErrors, err)
+				}
+			}
+			if err := errors.Join(deliveryErrors...); err != nil {
+				return err
+			}
+
+			// Finalize the org-level reservation only after the full audience has
+			// accepted the send. Provider idempotency keys make a partial retry safe.
+			_, cycleEnd := usage.CurrentBillingCycle(now, 1)
+			ttl := cycleEnd.Sub(now) + openRouterCreditsAlertGrace
+			expireCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+			defer cancel()
+			if err := a.cache.Expire(expireCtx, openRouterCreditsAlertKey(c.orgID, c.keyType, c.threshold, c.generation), ttl); err != nil {
+				logger.ErrorContext(expireCtx, "failed to extend openrouter credits alert reservation", attr.SlogError(err))
+			}
+			// A generation must outlive every reservation created beneath it. If it
+			// expired first, the next poll would fall back to the legacy namespace
+			// and could resend the same threshold during the current cycle.
+			if c.generation != "" {
+				if err := a.cache.Expire(expireCtx, openRouterCreditsAlertGenerationKey(c.orgID, c.keyType), ttl); err != nil {
+					logger.ErrorContext(expireCtx, "failed to extend openrouter credits alert generation", attr.SlogError(err))
+				}
+			}
+			return nil
 		}
-		if err := errors.Join(deliveryErrors...); err != nil {
-			logger.ErrorContext(ctx, "failed to deliver openrouter credits alert audience", attr.SlogError(err))
+
+		var deliveryErr error
+		if c.generationAware {
+			deliveryErr = withOpenRouterKeyBillingLock(ctx, a.logger, a.db, c.orgID, c.keyType, func(queries *repo.Queries) error {
+				return deliver(queries)
+			})
+		} else {
+			deliveryErr = deliver(nil)
+		}
+		if errors.Is(deliveryErr, errOpenRouterCreditsAlertGenerationChanged) {
+			logger.InfoContext(ctx, "skipping stale OpenRouter credits alert generation")
+			if err := a.cache.Delete(ctx, openRouterCreditsAlertKey(c.orgID, c.keyType, c.threshold, c.generation)); err != nil {
+				logger.ErrorContext(ctx, "release stale OpenRouter credits alert reservation", attr.SlogError(err))
+				a.recordFailure(ctx, c.orgID, c.keyType)
+			}
+			continue
+		}
+		if deliveryErr != nil {
+			logger.ErrorContext(ctx, "failed to deliver openrouter credits alert audience", attr.SlogError(deliveryErr))
 			a.recordFailure(ctx, c.orgID, c.keyType)
 			continue
 		}
-
-		// Finalize the org-level reservation only after the full audience has
-		// accepted the send. Provider idempotency keys make a partial retry safe.
-		_, cycleEnd := usage.CurrentBillingCycle(now, 1)
-		ttl := cycleEnd.Sub(now) + openRouterCreditsAlertGrace
-		expireCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		if err := a.cache.Expire(expireCtx, openRouterCreditsAlertKey(c.orgID, c.keyType, c.threshold), ttl); err != nil {
-			logger.ErrorContext(expireCtx, "failed to extend openrouter credits alert reservation", attr.SlogError(err))
-		}
-		cancel()
 	}
 
 	return nil
@@ -346,7 +488,11 @@ func (a *MaybeSendOpenRouterCreditsAlerts) sendOne(
 		strconv.Itoa(c.threshold),
 		c.threshold >= 100,
 	)
-	idempotencyKey := recipientEmailIdempotencyKey(recipient, "openrouter-credits-alert", c.orgID, string(c.keyType), strconv.Itoa(c.threshold), openRouterCreditsAlertCycle(now))
+	idempotencyParts := []string{"openrouter-credits-alert", c.orgID, string(c.keyType), strconv.Itoa(c.threshold), openRouterCreditsAlertCycle(now)}
+	if c.generation != "" {
+		idempotencyParts = append(idempotencyParts, c.generation)
+	}
+	idempotencyKey := recipientEmailIdempotencyKey(recipient, idempotencyParts...)
 	recipientKey := openRouterCreditsAlertRecipientKey(idempotencyKey)
 	won, err := a.cache.Add(ctx, recipientKey, openRouterCreditsAlertRecipientRetryTTL)
 	if err != nil {

--- a/server/internal/background/activities/openrouter_credits_alerts_internal_test.go
+++ b/server/internal/background/activities/openrouter_credits_alerts_internal_test.go
@@ -5,7 +5,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
+
+func OpenRouterCreditsAlertGenerationKeyForTest(orgID string, keyType openrouter.KeyType) string {
+	return openRouterCreditsAlertGenerationKey(orgID, keyType)
+}
 
 func TestHighestCrossedOpenRouterCreditsThreshold_Ladder(t *testing.T) {
 	t.Parallel()
@@ -50,4 +56,19 @@ func TestOpenRouterCreditsAlertCycleStaysStableThroughRolloverGrace(t *testing.T
 	require.Equal(t, "2026-07", openRouterCreditsAlertCycle(time.Date(2026, time.July, 31, 23, 30, 0, 0, time.UTC)))
 	require.Equal(t, "2026-07", openRouterCreditsAlertCycle(time.Date(2026, time.August, 1, 0, 30, 0, 0, time.UTC)))
 	require.Equal(t, "2026-08", openRouterCreditsAlertCycle(time.Date(2026, time.August, 3, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestOpenRouterCreditsAlertKeyPreservesLegacyReservationsUntilCapChange(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		"openrouter-credits-alert:org_placeholder:chat:90",
+		openRouterCreditsAlertKey("org_placeholder", "chat", 90, ""),
+	)
+	require.Equal(
+		t,
+		"openrouter-credits-alert:org_placeholder:chat:90:operation_placeholder",
+		openRouterCreditsAlertKey("org_placeholder", "chat", 90, "operation_placeholder"),
+	)
 }

--- a/server/internal/background/activities/openrouter_credits_alerts_test.go
+++ b/server/internal/background/activities/openrouter_credits_alerts_test.go
@@ -3,7 +3,9 @@ package activities_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -23,12 +26,22 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 func setupOpenRouterCreditsAlertsTest(t *testing.T, dbName string) (*activities.MaybeSendOpenRouterCreditsAlerts, *pgxpool.Pool, *captureLoopsClient, cache.Cache) {
+	t.Helper()
+	return setupOpenRouterCreditsAlertsTestWithCache(t, dbName, nil)
+}
+
+func setupOpenRouterCreditsAlertsTestWithCache(
+	t *testing.T,
+	dbName string,
+	wrap func(cache.Cache) cache.Cache,
+) (*activities.MaybeSendOpenRouterCreditsAlerts, *pgxpool.Pool, *captureLoopsClient, cache.Cache) {
 	t.Helper()
 
 	conn, err := infra.CloneTestDatabase(t, dbName)
@@ -37,7 +50,10 @@ func setupOpenRouterCreditsAlertsTest(t *testing.T, dbName string) (*activities.
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
+	var cacheAdapter cache.Cache = cache.NewRedisCacheAdapter(redisClient)
+	if wrap != nil {
+		cacheAdapter = wrap(cacheAdapter)
+	}
 	captured := &captureLoopsClient{sent: nil, failNext: 0}
 	act := activities.NewMaybeSendOpenRouterCreditsAlerts(
 		testenv.NewLogger(t),
@@ -51,6 +67,57 @@ func setupOpenRouterCreditsAlertsTest(t *testing.T, dbName string) (*activities.
 	)
 
 	return act, conn, captured, cacheAdapter
+}
+
+type captureAlertExpireCache struct {
+	cache.Cache
+	mu      sync.Mutex
+	expires map[string]time.Duration
+}
+
+type rotateAlertGenerationAfterReservationCache struct {
+	cache.Cache
+	orgID      string
+	generation spendCapAlertGenerationFixture
+	once       sync.Once
+}
+
+func (c *rotateAlertGenerationAfterReservationCache) Add(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+	won, err := c.Cache.Add(ctx, key, ttl)
+	if err != nil {
+		return false, fmt.Errorf("reserve alert before generation rotation: %w", err)
+	}
+	if won {
+		c.once.Do(func() {
+			err = c.Set(
+				ctx,
+				activities.OpenRouterCreditsAlertGenerationKeyForTest(c.orgID, openrouter.KeyTypeChat),
+				c.generation,
+				24*time.Hour,
+			)
+		})
+		if err != nil {
+			return false, fmt.Errorf("rotate alert generation after reservation: %w", err)
+		}
+	}
+	return won, nil
+}
+
+func (c *captureAlertExpireCache) Expire(ctx context.Context, key string, ttl time.Duration) error {
+	c.mu.Lock()
+	c.expires[key] = ttl
+	c.mu.Unlock()
+	if err := c.Cache.Expire(ctx, key, ttl); err != nil {
+		return fmt.Errorf("expire captured alert key: %w", err)
+	}
+	return nil
+}
+
+func (c *captureAlertExpireCache) ttl(key string) (time.Duration, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ttl, ok := c.expires[key]
+	return ttl, ok
 }
 
 // createAlertOrg provisions an org with billing metadata. A non-empty
@@ -156,6 +223,32 @@ func deleteAlertReservation(t *testing.T, ctx context.Context, cacheAdapter cach
 	require.NoError(t, cacheAdapter.Delete(ctx, key))
 }
 
+func setAlertGeneration(t *testing.T, ctx context.Context, cacheAdapter cache.Cache, orgID string, generation string, monthlyCredits int64) {
+	t.Helper()
+	setAlertGenerationForKey(t, ctx, cacheAdapter, orgID, openrouter.KeyTypeChat, generation, monthlyCredits)
+}
+
+func setAlertGenerationForKey(t *testing.T, ctx context.Context, cacheAdapter cache.Cache, orgID string, keyType openrouter.KeyType, generation string, monthlyCredits int64) {
+	t.Helper()
+	key := activities.OpenRouterCreditsAlertGenerationKeyForTest(orgID, keyType)
+	require.NoError(t, cacheAdapter.Set(ctx, key, spendCapAlertGenerationFixture{
+		OperationID:    generation,
+		MonthlyCredits: monthlyCredits,
+	}, 24*time.Hour))
+}
+
+func createAlertInferenceKey(t *testing.T, ctx context.Context, db *pgxpool.Pool, orgID string, keyType openrouter.KeyType, monthlyCredits int64) {
+	t.Helper()
+	_, err := openrouterrepo.New(db).CreateOpenRouterAPIKey(ctx, openrouterrepo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+		KeyEncrypted:   pgtype.Text{},
+		KeyHash:        "hash_placeholder",
+		MonthlyCredits: monthlyCredits,
+	})
+	require.NoError(t, err)
+}
+
 func internalCreditsMetric(orgID string, used float64, limit int64) activities.OpenRouterCreditsMetric {
 	m := chatCreditsMetric(orgID, used, limit)
 	m.KeyType = string(openrouter.KeyTypeInternal)
@@ -194,6 +287,58 @@ func TestMaybeSendOpenRouterCreditsAlerts_SendsHighestCrossedThreshold(t *testin
 	// Re-running the same tick must not re-alert the same threshold.
 	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{chatCreditsMetric(orgID, 92, 100)}))
 	require.Len(t, captured.Sent(), 1, "threshold alerts fire once per month")
+}
+
+func TestMaybeSendOpenRouterCreditsAlerts_ExtendsGenerationWithReservation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	var capturedCache *captureAlertExpireCache
+	act, conn, _, cacheAdapter := setupOpenRouterCreditsAlertsTestWithCache(t, "openrouter_credits_alert_generation_ttl", func(base cache.Cache) cache.Cache {
+		capturedCache = &captureAlertExpireCache{Cache: base, expires: map[string]time.Duration{}}
+		return capturedCache
+	})
+	orgID, _ := createAlertOrgWithAccountType(t, ctx, conn, "billing@example.com", "", billing.TierPayg)
+	setAlertGeneration(t, ctx, cacheAdapter, orgID, "operation_placeholder", 100)
+
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 60, 100)}))
+
+	reservationKey := fmt.Sprintf("openrouter-credits-alert:%s:chat:50:operation_placeholder", orgID)
+	reservationTTL, ok := capturedCache.ttl(reservationKey)
+	require.True(t, ok)
+	generationTTL, ok := capturedCache.ttl(spendCapGenerationKey(orgID))
+	require.True(t, ok)
+	require.Equal(t, reservationTTL, generationTTL)
+}
+
+func TestMaybeSendOpenRouterCreditsAlerts_SkipsGenerationChangedAfterReservation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	var rotatingCache *rotateAlertGenerationAfterReservationCache
+	act, conn, captured, cacheAdapter := setupOpenRouterCreditsAlertsTestWithCache(t, "openrouter_credits_alert_generation_race", func(base cache.Cache) cache.Cache {
+		rotatingCache = &rotateAlertGenerationAfterReservationCache{
+			Cache: base,
+			generation: spendCapAlertGenerationFixture{
+				OperationID:    "operation_new_placeholder",
+				MonthlyCredits: 100,
+			},
+		}
+		return rotatingCache
+	})
+	orgID, _ := createAlertOrgWithAccountType(t, ctx, conn, "billing@example.com", "", billing.TierPayg)
+	rotatingCache.orgID = orgID
+	setAlertGeneration(t, ctx, cacheAdapter, orgID, "operation_old_placeholder", 100)
+
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 60, 100)}))
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, cacheAdapter.Get(
+		ctx,
+		activities.OpenRouterCreditsAlertGenerationKeyForTest(orgID, openrouter.KeyTypeChat),
+		&generation,
+	))
+	require.Equal(t, "operation_new_placeholder", generation.OperationID, "the test must prove the simulated rotation succeeded")
+	require.Empty(t, captured.Sent(), "a poll reserved under the old generation must not send after cap rotation")
 }
 
 func TestMaybeSendOpenRouterCreditsAlerts_ExhaustedFlagsExhaustion(t *testing.T) {
@@ -268,6 +413,145 @@ func TestMaybeSendOpenRouterCreditsAlerts_KeyTypesAlertIndependently(t *testing.
 	require.Len(t, sent, 3, "the internal key's next threshold fires independently")
 	require.Equal(t, internalCreditsTemplateID, sent[2].TransactionalID)
 	require.Equal(t, "75", sent[2].DataVariables["threshold_percent"])
+}
+
+func TestMaybeSendOpenRouterCreditsAlerts_CapChangeRearmsAdjustedLadder(t *testing.T) {
+	t.Parallel()
+
+	for _, keyType := range openrouter.AllKeyTypes {
+		t.Run(string(keyType), func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			act, conn, captured, cacheAdapter := setupOpenRouterCreditsAlertsTest(t, "openrouter_credits_alert_cap_rearm_"+string(keyType))
+			orgID, _ := createAlertOrgWithAccountType(t, ctx, conn, "billing@example.test", "", billing.TierPayg)
+			metric := func(used float64, limit int64) activities.OpenRouterCreditsMetric {
+				value := paygCreditsMetric(orgID, used, limit)
+				value.KeyType = string(keyType)
+				return value
+			}
+
+			require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{metric(95, 100)}))
+			setAlertGenerationForKey(t, ctx, cacheAdapter, orgID, keyType, "operation_raised_cap_placeholder", 200)
+
+			// The raised 200-credit cap drops current usage below the first threshold.
+			// Each threshold then fires once as usage crosses the adjusted ladder.
+			for _, used := range []float64{99, 100, 150, 180, 200, 200} {
+				require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{metric(used, 200)}))
+			}
+
+			sent := captured.Sent()
+			require.Len(t, sent, 5)
+			thresholds := make([]string, 0, len(sent))
+			for _, message := range sent {
+				thresholds = append(thresholds, message.DataVariables["threshold_percent"])
+			}
+			require.Equal(t, []string{"90", "50", "75", "90", "100"}, thresholds)
+			require.NotEqual(t, sent[0].IdempotencyKey, sent[3].IdempotencyKey,
+				"the provider must accept the re-armed 90%% alert within its idempotency window")
+		})
+	}
+}
+
+func TestMaybeSendOpenRouterCreditsAlerts_SkipsMetricCollectedBeforeCapChange(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	act, conn, captured, cacheAdapter := setupOpenRouterCreditsAlertsTest(t, "openrouter_credits_alert_stale_metric")
+	orgID, _ := createAlertOrgWithAccountType(t, ctx, conn, "billing@example.test", "", billing.TierPayg)
+	setAlertGeneration(t, ctx, cacheAdapter, orgID, "operation_raised_cap_placeholder", 200)
+	createAlertInferenceKey(t, ctx, conn, orgID, openrouter.KeyTypeChat, 200)
+
+	// This snapshot crossed 90% under the old cap, but arrived after the new
+	// generation was installed. It must not send or reserve the new ladder.
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 95, 100)}))
+	require.Empty(t, captured.Sent())
+
+	// A fresh snapshot under the new cap can still claim the same threshold.
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 180, 200)}))
+	sent := captured.Sent()
+	require.Len(t, sent, 1)
+	require.Equal(t, "90", sent[0].DataVariables["threshold_percent"])
+}
+
+func TestMaybeSendOpenRouterCreditsAlerts_RebasesGenerationAfterUpstreamReconciliation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	act, conn, captured, cacheAdapter := setupOpenRouterCreditsAlertsTest(t, "openrouter_credits_alert_reconciled_cap")
+	orgID, _ := createAlertOrgWithAccountType(t, ctx, conn, "billing@example.test", "", billing.TierPayg)
+	setAlertGeneration(t, ctx, cacheAdapter, orgID, "operation_original_placeholder", 100)
+	createAlertInferenceKey(t, ctx, conn, orgID, openrouter.KeyTypeChat, 200)
+
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 180, 200)}))
+	require.Len(t, captured.Sent(), 1)
+
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, cacheAdapter.Get(ctx, activities.OpenRouterCreditsAlertGenerationKeyForTest(orgID, openrouter.KeyTypeChat), &generation))
+	require.Equal(t, "operation_original_placeholder", generation.OperationID)
+	require.EqualValues(t, 200, generation.MonthlyCredits)
+}
+
+func TestMaybeSendOpenRouterCreditsAlerts_RecoversGenerationFromAuditAfterCacheLoss(t *testing.T) {
+	t.Parallel()
+
+	for _, keyType := range openrouter.AllKeyTypes {
+		t.Run(string(keyType), func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			act, conn, captured, cacheAdapter := setupOpenRouterCreditsAlertsTest(t, "openrouter_credits_alert_generation_recovery_"+string(keyType))
+			orgID, _ := createAlertOrgWithAccountType(t, ctx, conn, "billing@example.test", "", billing.TierPayg)
+			operationID := "operation_durable_placeholder"
+			require.NoError(t, audit.NewLogger().LogOpenRouterAPIKeySetSpendCap(ctx, conn, audit.LogOpenRouterAPIKeySetSpendCapEvent{
+				OrganizationID:      orgID,
+				Actor:               urn.NewPrincipal(urn.PrincipalTypeUser, "user_placeholder"),
+				ActorDisplayName:    nil,
+				ActorSlug:           nil,
+				OpenRouterAPIKeyURN: urn.NewOpenRouterAPIKey(orgID, string(keyType)),
+				KeyType:             string(keyType),
+				OperationIdentifier: operationID,
+				OpenRouterAPIKeySnapshotBefore: &audit.OpenRouterAPIKeySpendCapSnapshot{
+					MonthlyCredits: 100,
+				},
+				OpenRouterAPIKeySnapshotAfter: &audit.OpenRouterAPIKeySpendCapSnapshot{
+					MonthlyCredits: 200,
+				},
+			}))
+
+			metric := paygCreditsMetric(orgID, 180, 200)
+			metric.KeyType = string(keyType)
+			require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{metric}))
+			first := captured.Sent()
+			require.Len(t, first, 1)
+
+			// Simulate loss of all Redis state for this delivery. The durable audit
+			// row must restore the same provider idempotency key for either key type.
+			require.NoError(t, cacheAdapter.Delete(ctx, activities.OpenRouterCreditsAlertGenerationKeyForTest(orgID, keyType)))
+			require.NoError(t, cacheAdapter.Delete(ctx, fmt.Sprintf("openrouter-credits-alert:%s:%s:90:%s", orgID, keyType, operationID)))
+			require.NoError(t, cacheAdapter.Delete(ctx, "openrouter-credits-alert-recipient:"+first[0].IdempotencyKey))
+			require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{metric}))
+
+			sent := captured.Sent()
+			require.Len(t, sent, 2)
+			require.Equal(t, sent[0].IdempotencyKey, sent[1].IdempotencyKey)
+		})
+	}
+}
+
+func TestMaybeSendOpenRouterCreditsAlerts_ReconcileLimitFlapDoesNotRearm(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	act, conn, captured, cacheAdapter := setupOpenRouterCreditsAlertsTest(t, "openrouter_credits_alert_limit_flap")
+	orgID, _ := createAlertOrgWithAccountType(t, ctx, conn, "billing@example.test", "", billing.TierPayg)
+	setAlertGeneration(t, ctx, cacheAdapter, orgID, "operation_stable_cap_placeholder", 100)
+
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 95, 100)}))
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 95, 200)}))
+	require.NoError(t, act.Do(ctx, []activities.OpenRouterCreditsMetric{paygCreditsMetric(orgID, 95, 100)}))
+
+	require.Len(t, captured.Sent(), 1, "the same generation must survive an upstream/local limit flap")
 }
 
 func TestMaybeSendOpenRouterCreditsAlerts_SkipsWithoutAlertEmail(t *testing.T) {

--- a/server/internal/background/activities/openrouter_credits_metrics.go
+++ b/server/internal/background/activities/openrouter_credits_metrics.go
@@ -131,7 +131,7 @@ func (c *CollectOpenRouterCreditsMetrics) Do(ctx context.Context, args CollectOp
 				if err != nil {
 					return fmt.Errorf("fetch openrouter key usage: %w", err)
 				}
-				effectiveLimit, err := dbProvisioner.ReconcileMonthlyCreditsWithDB(gctx, conn, row.OrganizationID, keyType, currentKey.MonthlyCredits, upstreamLimit)
+				effectiveLimit, err := dbProvisioner.ReconcileMonthlyCreditsWithDB(gctx, conn, row.OrganizationID, keyType, currentKey.MonthlyCredits, currentKey.UpdatedAt.Time.UnixMicro(), upstreamLimit)
 				if err != nil {
 					return fmt.Errorf("reconcile openrouter monthly credits: %w", err)
 				}

--- a/server/internal/background/activities/openrouter_key_billing_lock.go
+++ b/server/internal/background/activities/openrouter_key_billing_lock.go
@@ -18,7 +18,20 @@ import (
 type openRouterKeyBillingDBProvisioner interface {
 	RefreshAPIKeyLimitWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, *int) (int, error)
 	DisableAPIKeyWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType) error
-	ReconcileMonthlyCreditsWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, int64, *int64) (int64, error)
+	ReconcileMonthlyCreditsWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, int64, int64, *int64) (int64, error)
+}
+
+func withOpenRouterKeyBillingLock(
+	ctx context.Context,
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+	organizationID string,
+	keyType openrouter.KeyType,
+	operation func(*repo.Queries) error,
+) error {
+	return withOpenRouterKeyBillingConnectionLock(ctx, logger, db, organizationID, keyType, func(_ *pgxpool.Conn, queries *repo.Queries) error {
+		return operation(queries)
+	})
 }
 
 func withOpenRouterKeyBillingConnectionLock(

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -73,6 +73,13 @@ LEFT JOIN openrouter_api_keys chat_key
  AND chat_key.deleted IS FALSE
 WHERE organization_metadata.id = @organization_id;
 
+-- name: GetOpenRouterInferenceKeyLimit :one
+SELECT monthly_credits
+FROM openrouter_api_keys
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE;
+
 -- name: SetPaygOpenRouterChatKeyProjectionFixture :exec
 WITH updated_organization AS (
   UPDATE organization_metadata
@@ -110,6 +117,7 @@ SELECT
     om.gram_account_type,
     k.key_type,
     k.monthly_credits,
+    (extract(epoch FROM k.updated_at) * 1000000)::bigint AS limit_generation,
     k.key_encrypted AS api_key_encrypted
 FROM organization_metadata om
 JOIN openrouter_api_keys k ON k.organization_id = om.id

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -72,8 +72,8 @@ func (m *mockPaygChatKeyProvisioner) GetKeyUsage(ctx context.Context, apiKey str
 	return used, limit, args.Error(2)
 }
 
-func (m *mockPaygChatKeyProvisioner) ReconcileMonthlyCredits(ctx context.Context, organizationID string, keyType openrouter.KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
-	args := m.Called(ctx, organizationID, keyType, currentLimit, upstreamLimit)
+func (m *mockPaygChatKeyProvisioner) ReconcileMonthlyCredits(ctx context.Context, organizationID string, keyType openrouter.KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
+	args := m.Called(ctx, organizationID, keyType, currentLimit, currentGeneration, upstreamLimit)
 	credits, ok := args.Get(0).(int64)
 	if !ok {
 		panic("mock monthly credits value is not an int64")
@@ -81,8 +81,8 @@ func (m *mockPaygChatKeyProvisioner) ReconcileMonthlyCredits(ctx context.Context
 	return credits, args.Error(1)
 }
 
-func (m *mockPaygChatKeyProvisioner) ReconcileMonthlyCreditsWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
-	return m.ReconcileMonthlyCredits(ctx, organizationID, keyType, currentLimit, upstreamLimit)
+func (m *mockPaygChatKeyProvisioner) ReconcileMonthlyCreditsWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
+	return m.ReconcileMonthlyCredits(ctx, organizationID, keyType, currentLimit, currentGeneration, upstreamLimit)
 }
 
 func (m *mockPaygChatKeyProvisioner) GetModelUsage(ctx context.Context, generationID string, organizationID string, keyType openrouter.KeyType) (*openrouter.ModelUsage, error) {

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -983,6 +983,7 @@ SELECT
     om.gram_account_type,
     k.key_type,
     k.monthly_credits,
+    (extract(epoch FROM k.updated_at) * 1000000)::bigint AS limit_generation,
     k.key_encrypted AS api_key_encrypted
 FROM organization_metadata om
 JOIN openrouter_api_keys k ON k.organization_id = om.id
@@ -999,6 +1000,7 @@ type GetOpenRouterCreditsMonitoringTargetsRow struct {
 	GramAccountType  string
 	KeyType          string
 	MonthlyCredits   int64
+	LimitGeneration  int64
 	ApiKeyEncrypted  pgtype.Text
 }
 
@@ -1025,6 +1027,7 @@ func (q *Queries) GetOpenRouterCreditsMonitoringTargets(ctx context.Context, acc
 			&i.GramAccountType,
 			&i.KeyType,
 			&i.MonthlyCredits,
+			&i.LimitGeneration,
 			&i.ApiKeyEncrypted,
 		); err != nil {
 			return nil, err
@@ -1087,6 +1090,26 @@ func (q *Queries) GetOpenRouterDailySpendRecoveryStartDay(ctx context.Context, a
 	var recovery_start_day pgtype.Date
 	err := row.Scan(&recovery_start_day)
 	return recovery_start_day, err
+}
+
+const getOpenRouterInferenceKeyLimit = `-- name: GetOpenRouterInferenceKeyLimit :one
+SELECT monthly_credits
+FROM openrouter_api_keys
+WHERE organization_id = $1
+  AND key_type = $2
+  AND deleted IS FALSE
+`
+
+type GetOpenRouterInferenceKeyLimitParams struct {
+	OrganizationID string
+	KeyType        string
+}
+
+func (q *Queries) GetOpenRouterInferenceKeyLimit(ctx context.Context, arg GetOpenRouterInferenceKeyLimitParams) (int64, error) {
+	row := q.db.QueryRow(ctx, getOpenRouterInferenceKeyLimit, arg.OrganizationID, arg.KeyType)
+	var monthly_credits int64
+	err := row.Scan(&monthly_credits)
+	return monthly_credits, err
 }
 
 const getPaygOpenRouterChatKeyProjection = `-- name: GetPaygOpenRouterChatKeyProjection :one

--- a/server/internal/background/activities/set_openrouter_spend_cap.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap.go
@@ -14,12 +14,14 @@ import (
 	auditrepo "github.com/speakeasy-api/gram/server/internal/audit/repo"
 	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usage"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 )
@@ -39,14 +41,22 @@ type SetOpenRouterSpendCap struct {
 	db         *pgxpool.Pool
 	openRouter openrouter.Provisioner
 	audit      openRouterSpendCapAuditLogger
+	cache      cache.Cache
 }
 
-func NewSetOpenRouterSpendCap(logger *slog.Logger, db *pgxpool.Pool, openRouter openrouter.Provisioner, auditLogger openRouterSpendCapAuditLogger) *SetOpenRouterSpendCap {
+func NewSetOpenRouterSpendCap(
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+	openRouter openrouter.Provisioner,
+	auditLogger openRouterSpendCapAuditLogger,
+	cacheAdapter cache.Cache,
+) *SetOpenRouterSpendCap {
 	return &SetOpenRouterSpendCap{
 		logger:     logger,
 		db:         db,
 		openRouter: openRouter,
 		audit:      auditLogger,
+		cache:      cacheAdapter,
 	}
 }
 
@@ -90,7 +100,8 @@ func (s *SetOpenRouterSpendCap) Do(ctx context.Context, args SetOpenRouterSpendC
 
 func (s *SetOpenRouterSpendCap) setLocked(ctx context.Context, conn *pgxpool.Conn, queries *activitiesrepo.Queries, args SetOpenRouterSpendCapArgs, keyType openrouter.KeyType) error {
 	subject := urn.NewOpenRouterAPIKey(args.OrganizationID, string(keyType))
-	recorded, err := auditrepo.New(conn).HasOpenRouterSpendCapAuditOperation(ctx, auditrepo.HasOpenRouterSpendCapAuditOperationParams{
+	auditQueries := auditrepo.New(conn)
+	recorded, err := auditQueries.HasOpenRouterSpendCapAuditOperation(ctx, auditrepo.HasOpenRouterSpendCapAuditOperationParams{
 		OrganizationID: args.OrganizationID,
 		SubjectID:      subject.ID,
 		OperationID:    args.OperationID,
@@ -99,7 +110,16 @@ func (s *SetOpenRouterSpendCap) setLocked(ctx context.Context, conn *pgxpool.Con
 		return fmt.Errorf("check spend-cap audit operation: %w", err)
 	}
 	if recorded {
-		return nil
+		latest, err := auditQueries.GetLatestOpenRouterSpendCapAuditOperation(ctx, auditrepo.GetLatestOpenRouterSpendCapAuditOperationParams{
+			OrganizationID: args.OrganizationID,
+			SubjectID:      subject.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("check latest spend-cap audit operation: %w", err)
+		}
+		if latest.OperationID != args.OperationID || latest.MonthlyCredits != int64(args.Limit) {
+			return nil
+		}
 	}
 
 	key, err := openrouterrepo.New(conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
@@ -107,10 +127,19 @@ func (s *SetOpenRouterSpendCap) setLocked(ctx context.Context, conn *pgxpool.Con
 		KeyType:        string(keyType),
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
+		if recorded {
+			return nil
+		}
 		return fmt.Errorf("%s key must be provisioned before setting its inference cap", keyType)
 	}
 	if err != nil {
 		return fmt.Errorf("read %s key before setting inference cap: %w", keyType, err)
+	}
+	if recorded {
+		// A cache failure after the durable cap mutation must be repairable on
+		// activity retry. The latest-audit check above prevents an older operation
+		// from replacing a newer generation.
+		return s.rearmCreditsAlertsIfCurrent(ctx, conn, queries, args, keyType)
 	}
 	before := key.MonthlyCredits
 	applied := false
@@ -215,7 +244,7 @@ func (s *SetOpenRouterSpendCap) setLocked(ctx context.Context, conn *pgxpool.Con
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
-	auditQueries := auditrepo.New(dbtx)
+	auditQueries = auditrepo.New(dbtx)
 	recorded, err = auditQueries.HasOpenRouterSpendCapAuditOperation(ctx, auditrepo.HasOpenRouterSpendCapAuditOperationParams{
 		OrganizationID: args.OrganizationID,
 		SubjectID:      subject.ID,
@@ -246,6 +275,55 @@ func (s *SetOpenRouterSpendCap) setLocked(ctx context.Context, conn *pgxpool.Con
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit spend-cap audit transaction: %w", err)
+	}
+
+	return s.rearmCreditsAlertsIfCurrent(ctx, conn, queries, args, keyType)
+}
+
+func (s *SetOpenRouterSpendCap) rearmCreditsAlertsIfCurrent(
+	ctx context.Context,
+	conn *pgxpool.Conn,
+	queries *activitiesrepo.Queries,
+	args SetOpenRouterSpendCapArgs,
+	keyType openrouter.KeyType,
+) error {
+	projection, err := queries.GetPaygOpenRouterChatKeyProjection(ctx, args.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("read billing state before re-arming inference alerts: %w", err)
+	}
+	hasSubscription := projection.StripeSubscriptionID.Valid && projection.StripeSubscriptionID.String != ""
+	if projection.GramAccountType != string(billing.TierPayg) || !hasSubscription {
+		return nil
+	}
+	key, err := openrouterrepo.New(conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
+		OrganizationID: args.OrganizationID,
+		KeyType:        string(keyType),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s key before re-arming inference alerts: %w", keyType, err)
+	}
+	if key.Disabled {
+		return nil
+	}
+	return s.rearmCreditsAlerts(ctx, args, keyType)
+}
+
+func (s *SetOpenRouterSpendCap) rearmCreditsAlerts(ctx context.Context, args SetOpenRouterSpendCapArgs, keyType openrouter.KeyType) error {
+	now := time.Now().UTC()
+	_, cycleEnd := usage.CurrentBillingCycle(now, 1)
+	if err := s.cache.Set(
+		ctx,
+		openRouterCreditsAlertGenerationKey(args.OrganizationID, keyType),
+		openRouterCreditsAlertGeneration{
+			OperationID:    args.OperationID,
+			MonthlyCredits: int64(args.Limit),
+		},
+		cycleEnd.Sub(now)+openRouterCreditsAlertGrace,
+	); err != nil {
+		return fmt.Errorf("re-arm OpenRouter %s credits alerts: %w", keyType, err)
 	}
 	return nil
 }

--- a/server/internal/background/activities/set_openrouter_spend_cap_test.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	redislib "github.com/go-redis/cache/v9"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -21,12 +22,14 @@ import (
 	auditrepo "github.com/speakeasy-api/gram/server/internal/audit/repo"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
 type failFirstSpendCapAuditLogger struct {
@@ -40,6 +43,26 @@ type spendCapHeartbeatFixture struct {
 	ObservedKeyUpdatedAt time.Time
 	AppliedKeyUpdatedAt  time.Time
 	Applied              bool
+}
+
+type spendCapAlertGenerationFixture struct {
+	OperationID    string `json:"operation_id"`
+	MonthlyCredits int64  `json:"monthly_credits"`
+}
+
+type failFirstSpendCapGenerationCache struct {
+	cache.Cache
+	calls atomic.Int32
+}
+
+func (c *failFirstSpendCapGenerationCache) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
+	if c.calls.Add(1) == 1 {
+		return errors.New("cache unavailable")
+	}
+	if err := c.Cache.Set(ctx, key, value, ttl); err != nil {
+		return fmt.Errorf("set spend-cap alert generation: %w", err)
+	}
+	return nil
 }
 
 func (l *failFirstSpendCapAuditLogger) LogOpenRouterAPIKeySetSpendCap(
@@ -103,7 +126,8 @@ func TestSetOpenRouterSpendCapTargetsSecurityInferenceKey(t *testing.T) {
 		}))
 	}).Return(75, nil).Once()
 
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger())
+	cacheAdapter := newSpendCapActivityCache(t)
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), cacheAdapter)
 	args := spendCapActivityArgs("operation_internal_placeholder", organizationID, 75)
 	args.KeyType = string(openrouter.KeyTypeInternal)
 
@@ -117,6 +141,14 @@ func TestSetOpenRouterSpendCapTargetsSecurityInferenceKey(t *testing.T) {
 	entry, err := audittest.LatestAuditLogByAction(t.Context(), db, audit.ActionOpenRouterAPIKeySetSpendCap)
 	require.NoError(t, err)
 	require.Equal(t, "Security inference cap", entry.SubjectDisplay)
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, cacheAdapter.Get(
+		t.Context(),
+		activities.OpenRouterCreditsAlertGenerationKeyForTest(organizationID, openrouter.KeyTypeInternal),
+		&generation,
+	))
+	require.Equal(t, "operation_internal_placeholder", generation.OperationID)
+	require.EqualValues(t, 75, generation.MonthlyCredits)
 }
 
 func spendCapActivityArgs(operationID, organizationID string, limit int) activities.SetOpenRouterSpendCapArgs {
@@ -128,6 +160,17 @@ func spendCapActivityArgs(operationID, organizationID string, limit int) activit
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, "user_placeholder"),
 		ActorDisplayName: nil,
 	}
+}
+
+func newSpendCapActivityCache(t *testing.T) cache.Cache {
+	t.Helper()
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	return cache.NewRedisCacheAdapter(redisClient)
+}
+
+func spendCapGenerationKey(organizationID string) string {
+	return activities.OpenRouterCreditsAlertGenerationKeyForTest(organizationID, openrouter.KeyTypeChat)
 }
 
 func TestSetOpenRouterSpendCapRechecksActiveTrialBeforePatch(t *testing.T) {
@@ -149,7 +192,7 @@ func TestSetOpenRouterSpendCapRechecksActiveTrialBeforePatch(t *testing.T) {
 		DemotedAt:      pgtype.Timestamptz{},
 	}))
 
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger())
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), newSpendCapActivityCache(t))
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestActivityEnvironment()
 	env.RegisterActivity(setter.Do)
@@ -185,7 +228,8 @@ func TestSetOpenRouterSpendCapRetryPreservesOriginalAuditSnapshot(t *testing.T) 
 	}).Return(600, nil).Once()
 
 	auditLogger := &failFirstSpendCapAuditLogger{delegate: audit.NewLogger()}
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, auditLogger)
+	cacheAdapter := newSpendCapActivityCache(t)
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, auditLogger, cacheAdapter)
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
@@ -211,6 +255,10 @@ func TestSetOpenRouterSpendCapRetryPreservesOriginalAuditSnapshot(t *testing.T) 
 	require.NoError(t, err)
 	require.EqualValues(t, 250, before["monthly_credits"])
 	require.EqualValues(t, 600, after["monthly_credits"])
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, cacheAdapter.Get(t.Context(), spendCapGenerationKey(organizationID), &generation))
+	require.Equal(t, "operation_retry_placeholder", generation.OperationID)
+	require.EqualValues(t, 600, generation.MonthlyCredits)
 }
 
 func TestSetOpenRouterSpendCapRetryCompletesAuditAfterBillingStateChanges(t *testing.T) {
@@ -254,7 +302,7 @@ func TestSetOpenRouterSpendCapRetryCompletesAuditAfterBillingStateChanges(t *tes
 			})
 		},
 	}
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, auditLogger)
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, auditLogger, newSpendCapActivityCache(t))
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
@@ -312,7 +360,7 @@ func TestSetOpenRouterSpendCapRetryReappliesWhenOriginalValueEqualsRequestedLimi
 		}))
 	}).Return(600, nil).Once()
 
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger())
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), newSpendCapActivityCache(t))
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestActivityEnvironment()
 	env.RegisterActivity(setter.Do)
@@ -348,7 +396,7 @@ func TestSetOpenRouterSpendCapRetryAuditsWhenAppliedHeartbeatWasLost(t *testing.
 		KeyType:        string(openrouter.KeyTypeChat),
 	}))
 
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger())
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), newSpendCapActivityCache(t))
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestActivityEnvironment()
 	env.RegisterActivity(setter.Do)
@@ -400,7 +448,7 @@ func TestSetOpenRouterSpendCapRetryAuditsAfterMirrorReconciliationAdvancesGenera
 		KeyType:        string(openrouter.KeyTypeChat),
 	}))
 
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger())
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), newSpendCapActivityCache(t))
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestActivityEnvironment()
 	env.RegisterActivity(setter.Do)
@@ -429,7 +477,7 @@ func TestSetOpenRouterSpendCapRetryRejectsMissingAppliedGeneration(t *testing.T)
 	)
 	createSpendCapActivityKey(t, db, organizationID, 100)
 
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger())
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), newSpendCapActivityCache(t))
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestActivityEnvironment()
 	env.RegisterActivity(setter.Do)
@@ -491,7 +539,8 @@ func TestSetOpenRouterSpendCapRetryDoesNotOverwriteNewerUnauditedOperation(t *te
 	require.NoError(t, err)
 
 	firstAuditLogger := &failFirstSpendCapAuditLogger{delegate: audit.NewLogger()}
-	firstSetter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, firstAuditLogger)
+	cacheAdapter := newSpendCapActivityCache(t)
+	firstSetter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, firstAuditLogger, cacheAdapter)
 	var suite testsuite.WorkflowTestSuite
 	firstEnv := suite.NewTestActivityEnvironment()
 	firstEnv.RegisterActivity(firstSetter.Do)
@@ -504,7 +553,7 @@ func TestSetOpenRouterSpendCapRetryDoesNotOverwriteNewerUnauditedOperation(t *te
 	require.NoError(t, err)
 
 	secondAuditLogger := &failFirstSpendCapAuditLogger{delegate: audit.NewLogger()}
-	secondSetter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, secondAuditLogger)
+	secondSetter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, secondAuditLogger, cacheAdapter)
 	secondEnv := suite.NewTestActivityEnvironment()
 	secondEnv.RegisterActivity(secondSetter.Do)
 	_, err = secondEnv.ExecuteActivity(secondSetter.Do, spendCapActivityArgs("operation_second_placeholder", organizationID, 700))
@@ -557,6 +606,10 @@ func TestSetOpenRouterSpendCapRetryDoesNotOverwriteNewerUnauditedOperation(t *te
 	require.NoError(t, err)
 	require.EqualValues(t, 600, before["monthly_credits"])
 	require.EqualValues(t, 700, after["monthly_credits"])
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, cacheAdapter.Get(t.Context(), spendCapGenerationKey(organizationID), &generation))
+	require.Equal(t, "operation_second_placeholder", generation.OperationID)
+	require.EqualValues(t, 700, generation.MonthlyCredits)
 }
 
 func TestSetOpenRouterSpendCapSerializesConcurrentOperations(t *testing.T) {
@@ -606,7 +659,8 @@ func TestSetOpenRouterSpendCapSerializesConcurrentOperations(t *testing.T) {
 		updateLimit(args, 700)
 	}).Return(700, nil).Once()
 
-	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger())
+	cacheAdapter := newSpendCapActivityCache(t)
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), cacheAdapter)
 	run := func(args activities.SetOpenRouterSpendCapArgs) error {
 		var suite testsuite.WorkflowTestSuite
 		env := suite.NewTestActivityEnvironment()
@@ -650,4 +704,167 @@ func TestSetOpenRouterSpendCapSerializesConcurrentOperations(t *testing.T) {
 	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOpenRouterAPIKeySetSpendCap)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, count)
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, cacheAdapter.Get(t.Context(), spendCapGenerationKey(organizationID), &generation))
+	require.Equal(t, "operation_second_placeholder", generation.OperationID)
+	require.EqualValues(t, 700, generation.MonthlyCredits)
+}
+
+func TestSetOpenRouterSpendCapRetryRepairsAlertGeneration(t *testing.T) {
+	t.Parallel()
+
+	_, provisioner, db, organizationID := setupPaygChatKeyReconciler(
+		t,
+		"payg",
+		pgtype.Text{String: "subscription_placeholder", Valid: true},
+	)
+	createSpendCapActivityKey(t, db, organizationID, 100)
+	provisioner.On(
+		"RefreshAPIKeyLimit",
+		mock.Anything,
+		organizationID,
+		openrouter.KeyTypeChat,
+		mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 600 }),
+	).Run(func(args mock.Arguments) {
+		ctx, ok := args.Get(0).(context.Context)
+		require.True(t, ok)
+		require.NoError(t, openrouterrepo.New(db).UpdateOpenRouterKeyMonthlyCredits(ctx, openrouterrepo.UpdateOpenRouterKeyMonthlyCreditsParams{
+			MonthlyCredits: 600,
+			OrganizationID: organizationID,
+			KeyType:        string(openrouter.KeyTypeChat),
+		}))
+	}).Return(600, nil).Once()
+
+	redisCache := newSpendCapActivityCache(t)
+	generationCache := &failFirstSpendCapGenerationCache{Cache: redisCache}
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), generationCache)
+	run := func() error {
+		var suite testsuite.WorkflowTestSuite
+		env := suite.NewTestActivityEnvironment()
+		env.RegisterActivity(setter.Do)
+		_, err := env.ExecuteActivity(setter.Do, spendCapActivityArgs("operation_cache_retry_placeholder", organizationID, 600))
+		if err != nil {
+			return fmt.Errorf("execute spend-cap activity: %w", err)
+		}
+		return nil
+	}
+
+	require.ErrorContains(t, run(), "re-arm OpenRouter chat credits alerts")
+	// Reconciliation can update the local mirror independently. The durable
+	// latest explicit operation still owns alert generation repair.
+	require.NoError(t, openrouterrepo.New(db).UpdateOpenRouterKeyMonthlyCredits(t.Context(), openrouterrepo.UpdateOpenRouterKeyMonthlyCreditsParams{
+		MonthlyCredits: 700,
+		OrganizationID: organizationID,
+		KeyType:        string(openrouter.KeyTypeChat),
+	}))
+	require.NoError(t, run())
+	provisioner.AssertExpectations(t)
+	require.EqualValues(t, 2, generationCache.calls.Load())
+
+	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOpenRouterAPIKeySetSpendCap)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count, "the cache retry must not duplicate the audit event")
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, redisCache.Get(t.Context(), spendCapGenerationKey(organizationID), &generation))
+	require.Equal(t, "operation_cache_retry_placeholder", generation.OperationID)
+	require.EqualValues(t, 600, generation.MonthlyCredits)
+}
+
+func TestSetOpenRouterSpendCapStaleRetryCannotReplaceNewerSameLimitGeneration(t *testing.T) {
+	t.Parallel()
+
+	_, provisioner, db, organizationID := setupPaygChatKeyReconciler(
+		t,
+		"payg",
+		pgtype.Text{String: "subscription_placeholder", Valid: true},
+	)
+	createSpendCapActivityKey(t, db, organizationID, 100)
+	provisioner.On(
+		"RefreshAPIKeyLimit",
+		mock.Anything,
+		organizationID,
+		openrouter.KeyTypeChat,
+		mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 600 }),
+	).Run(func(args mock.Arguments) {
+		ctx, ok := args.Get(0).(context.Context)
+		require.True(t, ok)
+		require.NoError(t, openrouterrepo.New(db).UpdateOpenRouterKeyMonthlyCredits(ctx, openrouterrepo.UpdateOpenRouterKeyMonthlyCreditsParams{
+			MonthlyCredits: 600,
+			OrganizationID: organizationID,
+			KeyType:        string(openrouter.KeyTypeChat),
+		}))
+	}).Return(600, nil).Twice()
+
+	redisCache := newSpendCapActivityCache(t)
+	generationCache := &failFirstSpendCapGenerationCache{Cache: redisCache}
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), generationCache)
+	run := func(operationID string) error {
+		var suite testsuite.WorkflowTestSuite
+		env := suite.NewTestActivityEnvironment()
+		env.RegisterActivity(setter.Do)
+		_, err := env.ExecuteActivity(setter.Do, spendCapActivityArgs(operationID, organizationID, 600))
+		if err != nil {
+			return fmt.Errorf("execute spend-cap activity: %w", err)
+		}
+		return nil
+	}
+
+	require.ErrorContains(t, run("operation_first_placeholder"), "re-arm OpenRouter chat credits alerts")
+	require.NoError(t, run("operation_second_placeholder"))
+	require.NoError(t, run("operation_first_placeholder"))
+	provisioner.AssertExpectations(t)
+
+	var generation spendCapAlertGenerationFixture
+	require.NoError(t, redisCache.Get(t.Context(), spendCapGenerationKey(organizationID), &generation))
+	require.Equal(t, "operation_second_placeholder", generation.OperationID)
+	require.EqualValues(t, 600, generation.MonthlyCredits)
+}
+
+func TestSetOpenRouterSpendCapRecordedRetryNoopsWhenKeyIsDisabled(t *testing.T) {
+	t.Parallel()
+
+	_, provisioner, db, organizationID := setupPaygChatKeyReconciler(
+		t,
+		"payg",
+		pgtype.Text{String: "subscription_placeholder", Valid: true},
+	)
+	createSpendCapActivityKey(t, db, organizationID, 100)
+	provisioner.On(
+		"RefreshAPIKeyLimit",
+		mock.Anything,
+		organizationID,
+		openrouter.KeyTypeChat,
+		mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 600 }),
+	).Run(func(args mock.Arguments) {
+		ctx, ok := args.Get(0).(context.Context)
+		require.True(t, ok)
+		require.NoError(t, openrouterrepo.New(db).UpdateOpenRouterKeyMonthlyCredits(ctx, openrouterrepo.UpdateOpenRouterKeyMonthlyCreditsParams{
+			MonthlyCredits: 600,
+			OrganizationID: organizationID,
+			KeyType:        string(openrouter.KeyTypeChat),
+		}))
+	}).Return(600, nil).Once()
+
+	redisCache := newSpendCapActivityCache(t)
+	generationCache := &failFirstSpendCapGenerationCache{Cache: redisCache}
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), generationCache)
+	args := spendCapActivityArgs("operation_loss_placeholder", organizationID, 600)
+	run := func() error {
+		var suite testsuite.WorkflowTestSuite
+		env := suite.NewTestActivityEnvironment()
+		env.RegisterActivity(setter.Do)
+		_, err := env.ExecuteActivity(setter.Do, args)
+		if err != nil {
+			return fmt.Errorf("execute spend-cap activity: %w", err)
+		}
+		return nil
+	}
+
+	require.ErrorContains(t, run(), "re-arm OpenRouter chat credits alerts")
+	require.NoError(t, usagerepo.New(db).DisablePaygOpenRouterChatKey(t.Context(), organizationID))
+	require.NoError(t, run())
+	provisioner.AssertExpectations(t)
+
+	var generation spendCapAlertGenerationFixture
+	require.ErrorIs(t, redisCache.Get(t.Context(), spendCapGenerationKey(organizationID), &generation), redislib.ErrCacheMiss)
 }

--- a/server/internal/modelkeys/setup_test.go
+++ b/server/internal/modelkeys/setup_test.go
@@ -80,7 +80,7 @@ func (p *stubProvisioner) GetKeyUsage(ctx context.Context, apiKey string) (float
 	return 0, nil, p.usageErr
 }
 
-func (p *stubProvisioner) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType openrouter.KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
+func (p *stubProvisioner) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType openrouter.KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
 	return currentLimit, nil
 }
 

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -128,7 +128,7 @@ func (s *stubProvisioner) GetKeyUsage(ctx context.Context, apiKey string) (float
 	return s.usage, s.usageLimit, nil
 }
 
-func (s *stubProvisioner) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType openrouter.KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
+func (s *stubProvisioner) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType openrouter.KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
 	return currentLimit, nil
 }
 

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -350,6 +350,102 @@ func TestRefreshAPIKeyLimit_NilPreservesEachPaygInferenceCap(t *testing.T) {
 	}
 }
 
+func TestReconcileMonthlyCredits_UncappedUpstreamClearsMirror(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+
+	effective, err := provisioner.ReconcileMonthlyCredits(ctx, orgID, KeyTypeChat, before.MonthlyCredits, before.UpdatedAt.Time.UnixMicro(), nil)
+	require.NoError(t, err)
+	require.Zero(t, effective, "an uncapped provider key has no enforceable alert denominator")
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.Zero(t, row.MonthlyCredits, "the local display mirror must follow provider authority")
+}
+
+func TestReconcileMonthlyCredits_DoesNotOverwriteConcurrentCapChange(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+
+	const newerCap = int64(250)
+	require.NoError(t, queries.UpdateOpenRouterKeyMonthlyCredits(ctx, repo.UpdateOpenRouterKeyMonthlyCreditsParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		MonthlyCredits: newerCap,
+	}))
+
+	effective, err := provisioner.ReconcileMonthlyCredits(ctx, orgID, KeyTypeChat, before.MonthlyCredits, before.UpdatedAt.Time.UnixMicro(), nil)
+	require.NoError(t, err)
+	require.Equal(t, newerCap, effective)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.Equal(t, newerCap, row.MonthlyCredits)
+}
+
+func TestReconcileMonthlyCredits_DetectsSameValueCapOperation(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+
+	// A user can deliberately save the same numeric cap. The write generation,
+	// not just the number, makes that operation newer than this poll.
+	require.NoError(t, queries.UpdateOpenRouterKeyMonthlyCredits(ctx, repo.UpdateOpenRouterKeyMonthlyCreditsParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		MonthlyCredits: before.MonthlyCredits,
+	}))
+
+	effective, err := provisioner.ReconcileMonthlyCredits(ctx, orgID, KeyTypeChat, before.MonthlyCredits, before.UpdatedAt.Time.UnixMicro(), nil)
+	require.NoError(t, err)
+	require.Equal(t, before.MonthlyCredits, effective)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.Equal(t, before.MonthlyCredits, row.MonthlyCredits)
+}
+
 func TestRefreshAPIKeyLimit_NilPreservesDisabledKeyAfterTierTransition(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -54,12 +54,12 @@ func (o *Development) GetKeyUsage(ctx context.Context, apiKey string) (float64, 
 	return 12.5, nil, nil // arbitrary local number; unlimited dev key
 }
 
-func (o *Development) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
+func (o *Development) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
 	return currentLimit, nil
 }
 
-func (o *Development) ReconcileMonthlyCreditsWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
-	return o.ReconcileMonthlyCredits(ctx, orgID, keyType, currentLimit, upstreamLimit)
+func (o *Development) ReconcileMonthlyCreditsWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
+	return o.ReconcileMonthlyCredits(ctx, orgID, keyType, currentLimit, currentGeneration, upstreamLimit)
 }
 
 func (o *Development) GetModelUsage(ctx context.Context, generationID string, orgID string, keyType KeyType) (*ModelUsage, error) {

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -305,13 +305,15 @@ type Provisioner interface {
 	GetKeyUsage(ctx context.Context, apiKey string) (used float64, limit *int64, err error)
 
 	// ReconcileMonthlyCredits compares upstreamLimit against the caller-supplied
-	// currentLimit (the DB-cached value) and writes the upstream value to the
+	// currentLimit and currentGeneration from the DB snapshot and writes the upstream value to the
 	// openrouter_api_keys row when they diverge. It is a DB-only reconciliation
 	// — it does NOT call OpenRouter — and is intended to self-heal drift
 	// introduced by out-of-band edits on the OpenRouter dashboard. A nil
-	// upstreamLimit (unlimited key) is treated as a no-op. Returns the
-	// effective limit the caller should use for the current tick.
-	ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, upstreamLimit *int64) (int64, error)
+	// upstreamLimit means unlimited and is mirrored as zero. The conditional
+	// write never overwrites a cap operation committed after that snapshot,
+	// including one that deliberately writes the same numeric limit.
+	// Returns the effective limit the caller should use for the current tick.
+	ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error)
 
 	// GetModelUsage fetches generation usage by ID. Normal completion paths use
 	// inline usage; this is only a fallback for streams closed before the final
@@ -713,19 +715,8 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 		limit = int(key.MonthlyCredits)
 	}
 
-	// A key with no recorded ceiling reports the policy amount rather than a
-	// ceiling of nothing.
-	if limit <= 0 {
-		org, err := o.orgRepo.GetOrganizationMetadata(ctx, orgID)
-		if err != nil {
-			return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
-		}
-
-		limit = o.defaultLimitForOrg(ctx, o.db, org)
-	}
-
 	if errors.Is(keyErr, pgx.ErrNoRows) {
-		return 0, limit, nil // the key doesn't exist yet
+		return 0, 0, nil // the key doesn't exist yet
 	}
 	if keyErr != nil {
 		return 0, 0, fmt.Errorf("read openrouter key for usage: %w", keyErr)
@@ -798,34 +789,52 @@ func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, *
 // ReconcileMonthlyCredits self-heals drift in the locally cached monthly limit
 // after an out-of-band change on the OpenRouter dashboard. See the
 // Provisioner interface doc for the full contract.
-func (o *OpenRouter) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
-	return o.reconcileMonthlyCredits(ctx, o.db, orgID, keyType, currentLimit, upstreamLimit)
+func (o *OpenRouter) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
+	return o.reconcileMonthlyCredits(ctx, o.db, orgID, keyType, currentLimit, currentGeneration, upstreamLimit)
 }
 
 // ReconcileMonthlyCreditsWithDB is ReconcileMonthlyCredits using db for the
 // mirror write. Credits polling holds the same per-key advisory lock across
 // its upstream read and this write, so a stale observation cannot race a cap
 // operation and erase its applied generation.
-func (o *OpenRouter) ReconcileMonthlyCreditsWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
-	return o.reconcileMonthlyCredits(ctx, db, orgID, keyType, currentLimit, upstreamLimit)
+func (o *OpenRouter) ReconcileMonthlyCreditsWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
+	return o.reconcileMonthlyCredits(ctx, db, orgID, keyType, currentLimit, currentGeneration, upstreamLimit)
 }
 
-func (o *OpenRouter) reconcileMonthlyCredits(ctx context.Context, db DBTX, orgID string, keyType KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
-	if upstreamLimit == nil {
-		return currentLimit, nil
+func (o *OpenRouter) reconcileMonthlyCredits(ctx context.Context, db DBTX, orgID string, keyType KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
+	// A nil upstream limit means the provider key is uncapped, not that the
+	// last local mirror is still authoritative. Mirror that as zero so cap
+	// meters and threshold alerts cannot claim an unenforced limit.
+	newLimit := int64(0)
+	if upstreamLimit != nil {
+		newLimit = *upstreamLimit
 	}
-
-	newLimit := *upstreamLimit
 	if newLimit == currentLimit {
 		return currentLimit, nil
 	}
 
-	if err := repo.New(db).UpdateOpenRouterKeyMonthlyCredits(ctx, repo.UpdateOpenRouterKeyMonthlyCreditsParams{
-		OrganizationID: orgID,
-		KeyType:        string(keyType.OrDefault()),
-		MonthlyCredits: newLimit,
-	}); err != nil {
+	keyRepo := repo.New(db)
+	updated, err := keyRepo.CompareAndSetOpenRouterKeyMonthlyCredits(ctx, repo.CompareAndSetOpenRouterKeyMonthlyCreditsParams{
+		OrganizationID:        orgID,
+		KeyType:               string(keyType.OrDefault()),
+		MonthlyCredits:        newLimit,
+		CurrentMonthlyCredits: currentLimit,
+		CurrentGeneration:     currentGeneration,
+	})
+	if err != nil {
 		return currentLimit, fmt.Errorf("reconcile openrouter monthly credits: %w", err)
+	}
+	if updated == 0 {
+		// A concurrent cap change won the compare-and-set. Read its value instead
+		// of overwriting it with the stale provider observation.
+		key, readErr := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+			OrganizationID: orgID,
+			KeyType:        string(keyType.OrDefault()),
+		})
+		if readErr != nil {
+			return currentLimit, fmt.Errorf("read concurrently updated openrouter monthly credits: %w", readErr)
+		}
+		return key.MonthlyCredits, nil
 	}
 
 	o.logger.InfoContext(ctx, "reconciled openrouter monthly credits from upstream",

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -59,3 +59,15 @@ SET monthly_credits = @monthly_credits,
 WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE;
+
+-- name: CompareAndSetOpenRouterKeyMonthlyCredits :execrows
+-- Reconciles an upstream observation only while the local mirror still equals
+-- what the caller observed. A concurrent explicit cap change wins this CAS.
+UPDATE openrouter_api_keys
+SET monthly_credits = @monthly_credits,
+    updated_at = GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND monthly_credits = @current_monthly_credits
+  AND (extract(epoch FROM updated_at) * 1000000)::bigint = @current_generation::bigint
+  AND deleted IS FALSE;

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -11,6 +11,41 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const compareAndSetOpenRouterKeyMonthlyCredits = `-- name: CompareAndSetOpenRouterKeyMonthlyCredits :execrows
+UPDATE openrouter_api_keys
+SET monthly_credits = $1,
+    updated_at = GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+WHERE organization_id = $2
+  AND key_type = $3
+  AND monthly_credits = $4
+  AND (extract(epoch FROM updated_at) * 1000000)::bigint = $5::bigint
+  AND deleted IS FALSE
+`
+
+type CompareAndSetOpenRouterKeyMonthlyCreditsParams struct {
+	MonthlyCredits        int64
+	OrganizationID        string
+	KeyType               string
+	CurrentMonthlyCredits int64
+	CurrentGeneration     int64
+}
+
+// Reconciles an upstream observation only while the local mirror still equals
+// what the caller observed. A concurrent explicit cap change wins this CAS.
+func (q *Queries) CompareAndSetOpenRouterKeyMonthlyCredits(ctx context.Context, arg CompareAndSetOpenRouterKeyMonthlyCreditsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, compareAndSetOpenRouterKeyMonthlyCredits,
+		arg.MonthlyCredits,
+		arg.OrganizationID,
+		arg.KeyType,
+		arg.CurrentMonthlyCredits,
+		arg.CurrentGeneration,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const createOpenRouterAPIKey = `-- name: CreateOpenRouterAPIKey :one
 INSERT INTO openrouter_api_keys (
     organization_id

--- a/server/internal/thirdparty/openrouter/trial_credits_test.go
+++ b/server/internal/thirdparty/openrouter/trial_credits_test.go
@@ -268,10 +268,10 @@ func TestGetCreditsUsed_ReportsKeyLimitOverTierDefault(t *testing.T) {
 	require.Equal(t, raised, reported, "the reported ceiling must follow the key, not the account type")
 }
 
-// TestGetCreditsUsed_ZeroKeyLimitFallsBackToPolicy covers the keys minted
-// before the monthly_credits column carried a value. Those rows hold zero, and
-// reporting it would tell the customer they have no credits at all.
-func TestGetCreditsUsed_ZeroKeyLimitFallsBackToPolicy(t *testing.T) {
+// TestGetCreditsUsed_ZeroKeyLimitReportsUncapped covers a provider key whose
+// authoritative limit is unlimited. Zero is the local representation of that
+// absence, not a request to invent the account-type default.
+func TestGetCreditsUsed_ZeroKeyLimitReportsUncapped(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -290,6 +290,5 @@ func TestGetCreditsUsed_ZeroKeyLimitFallsBackToPolicy(t *testing.T) {
 
 	_, reported, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
 	require.NoError(t, err)
-	require.Equal(t, wantEnterpriseLimit, reported,
-		"a key with no recorded ceiling must report the account-type amount")
+	require.Zero(t, reported, "a key with no provider ceiling must report no cap")
 }

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -77,7 +77,7 @@ func (m *mockProvisioner) GetKeyUsage(ctx context.Context, apiKey string) (float
 	return 0, nil, nil
 }
 
-func (m *mockProvisioner) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
+func (m *mockProvisioner) ReconcileMonthlyCredits(ctx context.Context, orgID string, keyType KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
 	return currentLimit, nil
 }
 

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -176,7 +176,7 @@ func (*recordingOpenRouterProvisioner) GetKeyUsage(context.Context, string) (flo
 	return 0, nil, fmt.Errorf("not implemented")
 }
 
-func (*recordingOpenRouterProvisioner) ReconcileMonthlyCredits(context.Context, string, openrouter.KeyType, int64, *int64) (int64, error) {
+func (*recordingOpenRouterProvisioner) ReconcileMonthlyCredits(context.Context, string, openrouter.KeyType, int64, int64, *int64) (int64, error) {
 	return 0, fmt.Errorf("not implemented")
 }
 

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -158,12 +158,12 @@ func (*m3OpenRouterProvisioner) GetKeyUsage(context.Context, string) (float64, *
 	return 0, nil, errors.New("not implemented")
 }
 
-func (*m3OpenRouterProvisioner) ReconcileMonthlyCredits(context.Context, string, openrouter.KeyType, int64, *int64) (int64, error) {
+func (*m3OpenRouterProvisioner) ReconcileMonthlyCredits(context.Context, string, openrouter.KeyType, int64, int64, *int64) (int64, error) {
 	return 0, errors.New("not implemented")
 }
 
-func (p *m3OpenRouterProvisioner) ReconcileMonthlyCreditsWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, currentLimit int64, upstreamLimit *int64) (int64, error) {
-	return p.ReconcileMonthlyCredits(ctx, organizationID, keyType, currentLimit, upstreamLimit)
+func (p *m3OpenRouterProvisioner) ReconcileMonthlyCreditsWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
+	return p.ReconcileMonthlyCredits(ctx, organizationID, keyType, currentLimit, currentGeneration, upstreamLimit)
 }
 
 func (*m3OpenRouterProvisioner) GetModelUsage(context.Context, string, string, openrouter.KeyType) (*openrouter.ModelUsage, error) {


### PR DESCRIPTION
## Summary

- rotate an independent alert generation after each successful inference-cap change
- include the generation in organization, recipient, and provider idempotency so same-month thresholds can fire again without reconciliation duplicates
- preserve separate Security inference and Other inference alert ladders while excluding BYOK provider keys
- revalidate generations under the per-key lock so stale in-flight reservations cannot send after a cap change

## Testing

- focused background activity and workflow tests
- `mise lint:server`
- `git diff --check`

## Stack

- depends on #5368
- Linear: DNO-847
