### PR TITLE
fix(remotemcp): model MCP payloads as types that carry what they don't model

### DIFF
--- a/server/internal/remotemcp/proxy/json_object.go
+++ b/server/internal/remotemcp/proxy/json_object.go
@@ -7,17 +7,11 @@ import (
 	"strings"
 )
 
-// object is a JSON object held as its members, used by the wire types in wire.go
-// to read and write a payload without committing to a fixed set of member names.
+// object preserves unmodeled members of JSON objects the proxy mutates.
 type object map[string]json.RawMessage
 
-// decodeObject decodes payload as a JSON object. An empty payload decodes to an
-// empty object, so a setter can populate a member on a payload the peer omitted
-// entirely.
-//
-// A JSON `null` is rejected rather than silently accepted: unmarshaling it into a
-// map sets the map to nil instead of failing, which would turn every subsequent
-// member write into a panic.
+// decodeObject treats an empty payload as an empty object and rejects null so the
+// returned map is always writable.
 func decodeObject(payload json.RawMessage) (object, error) {
 	members := object{}
 	if len(payload) == 0 {
@@ -34,9 +28,6 @@ func decodeObject(payload json.RawMessage) (object, error) {
 	return members, nil
 }
 
-// encode re-encodes the object. Member order is not preserved, and a payload that
-// repeated a member name has already collapsed to the single value Go's decoder
-// kept — see the package comment in wire.go for why that is deliberate.
 func (o object) encode() (json.RawMessage, error) {
 	encoded, err := json.Marshal(o)
 	if err != nil {
@@ -46,54 +37,22 @@ func (o object) encode() (json.RawMessage, error) {
 	return encoded, nil
 }
 
-// Caching hints on a list result, added in MCP 2026-07-28. See
-// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching.
 const (
 	cacheScopeMember = "cacheScope"
 	ttlMsMember      = "ttlMs"
 
-	// cacheScopePrivate confines a cached result to the authorization context
-	// that fetched it. The spec's counterpart, "public", declares the result
-	// free of user-specific data and lets any client, shared gateway, or
-	// caching proxy serve it to any user — explicitly across access tokens, and
-	// explicitly for results from an authenticated endpoint.
 	cacheScopePrivate = `"private"`
 
-	// ttlMsStale tells the client to treat the result as immediately stale. The
-	// spec defines 0 as exactly that, and defines an absent ttlMs as defaulting
-	// to it.
 	ttlMsStale = `0`
 )
 
-// confineToCaller marks a list result the proxy has filtered for one caller as
-// cacheable only within that caller's authorization context.
-//
-// A filtered list is user-specific by construction even when the upstream's own
-// inventory was not, so relaying the upstream's `cacheScope: "public"` would
-// authorize any cache between Gram and the model to serve one caller's permitted
-// tools to a different caller — the sharing that scope permits and that the spec
-// names as a security consideration. "private" is the scope the spec calls
-// correct for "filtered list results that vary per user".
-//
-// The TTL goes to zero for a related reason: the upstream's TTL describes how
-// long its own inventory stays fresh, which says nothing about how long Gram's
-// filtering of it does. A revoked grant changes the correct answer at once and
-// Gram cannot invalidate a cache the client already holds. Call-time
-// authorization stops a withdrawn tool from being executed but not from being
-// listed, and not listing it is what the filter is for.
-//
-// Both are set only when the upstream sent a caching hint at all. An upstream on
-// an older revision sends neither member, and a client on that revision has no
-// caching to authorize — introducing members the revision in effect does not
-// define would be Gram inventing wire fields rather than carrying them.
+// confineToCaller prevents caller-specific results from being shared or retained
+// after authorization changes. It rewrites only caching hints the upstream sent.
 func (o object) confineToCaller() {
 	_, hasScope := o[cacheScopeMember]
 	_, hasTTL := o[ttlMsMember]
 
-	// A case-variant alias would be read in place of the value written below by
-	// any parser that folds member names, leaving the result still marked
-	// publicly cacheable. An alias also counts as the upstream having sent a
-	// hint, so its presence still triggers the confinement.
+	// Remove aliases that case-folding parsers could prefer over the confined values.
 	for name := range o {
 		switch {
 		case name == cacheScopeMember || name == ttlMsMember:

--- a/server/internal/remotemcp/proxy/json_object.go
+++ b/server/internal/remotemcp/proxy/json_object.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // object is a JSON object held as its members, used by the wire types in wire.go
@@ -88,6 +89,23 @@ const (
 func (o object) confineToCaller() {
 	_, hasScope := o[cacheScopeMember]
 	_, hasTTL := o[ttlMsMember]
+
+	// A case-variant alias would be read in place of the value written below by
+	// any parser that folds member names, leaving the result still marked
+	// publicly cacheable. An alias also counts as the upstream having sent a
+	// hint, so its presence still triggers the confinement.
+	for name := range o {
+		switch {
+		case name == cacheScopeMember || name == ttlMsMember:
+		case strings.EqualFold(name, cacheScopeMember):
+			hasScope = true
+			delete(o, name)
+		case strings.EqualFold(name, ttlMsMember):
+			hasTTL = true
+			delete(o, name)
+		}
+	}
+
 	if !hasScope && !hasTTL {
 		return
 	}

--- a/server/internal/remotemcp/proxy/json_object.go
+++ b/server/internal/remotemcp/proxy/json_object.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// object is a JSON object held as its members, used by the wire types in wire.go
+// to read and write a payload without committing to a fixed set of member names.
+type object map[string]json.RawMessage
+
+// decodeObject decodes payload as a JSON object. An empty payload decodes to an
+// empty object, so a setter can populate a member on a payload the peer omitted
+// entirely.
+//
+// A JSON `null` is rejected rather than silently accepted: unmarshaling it into a
+// map sets the map to nil instead of failing, which would turn every subsequent
+// member write into a panic.
+func decodeObject(payload json.RawMessage) (object, error) {
+	members := object{}
+	if len(payload) == 0 {
+		return members, nil
+	}
+
+	if err := json.Unmarshal(payload, &members); err != nil {
+		return nil, fmt.Errorf("decode payload as a JSON object: %w", err)
+	}
+	if members == nil {
+		return nil, errors.New("payload is null, not a JSON object")
+	}
+
+	return members, nil
+}
+
+// encode re-encodes the object. Member order is not preserved, and a payload that
+// repeated a member name has already collapsed to the single value Go's decoder
+// kept — see the package comment in wire.go for why that is deliberate.
+func (o object) encode() (json.RawMessage, error) {
+	encoded, err := json.Marshal(o)
+	if err != nil {
+		return nil, fmt.Errorf("encode JSON object: %w", err)
+	}
+
+	return encoded, nil
+}
+
+// Caching hints on a list result, added in MCP 2026-07-28. See
+// https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching.
+const (
+	cacheScopeMember = "cacheScope"
+	ttlMsMember      = "ttlMs"
+
+	// cacheScopePrivate confines a cached result to the authorization context
+	// that fetched it. The spec's counterpart, "public", declares the result
+	// free of user-specific data and lets any client, shared gateway, or
+	// caching proxy serve it to any user — explicitly across access tokens, and
+	// explicitly for results from an authenticated endpoint.
+	cacheScopePrivate = `"private"`
+
+	// ttlMsStale tells the client to treat the result as immediately stale. The
+	// spec defines 0 as exactly that, and defines an absent ttlMs as defaulting
+	// to it.
+	ttlMsStale = `0`
+)
+
+// confineToCaller marks a list result the proxy has filtered for one caller as
+// cacheable only within that caller's authorization context.
+//
+// A filtered list is user-specific by construction even when the upstream's own
+// inventory was not, so relaying the upstream's `cacheScope: "public"` would
+// authorize any cache between Gram and the model to serve one caller's permitted
+// tools to a different caller — the sharing that scope permits and that the spec
+// names as a security consideration. "private" is the scope the spec calls
+// correct for "filtered list results that vary per user".
+//
+// The TTL goes to zero for a related reason: the upstream's TTL describes how
+// long its own inventory stays fresh, which says nothing about how long Gram's
+// filtering of it does. A revoked grant changes the correct answer at once and
+// Gram cannot invalidate a cache the client already holds. Call-time
+// authorization stops a withdrawn tool from being executed but not from being
+// listed, and not listing it is what the filter is for.
+//
+// Both are set only when the upstream sent a caching hint at all. An upstream on
+// an older revision sends neither member, and a client on that revision has no
+// caching to authorize — introducing members the revision in effect does not
+// define would be Gram inventing wire fields rather than carrying them.
+func (o object) confineToCaller() {
+	_, hasScope := o[cacheScopeMember]
+	_, hasTTL := o[ttlMsMember]
+	if !hasScope && !hasTTL {
+		return
+	}
+
+	o[cacheScopeMember] = json.RawMessage(cacheScopePrivate)
+	o[ttlMsMember] = json.RawMessage(ttlMsStale)
+}

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -2295,7 +2294,7 @@ func TestProxy_Post_ToolsListResponse_LaterInterceptorObservesEarlierMutation(t 
 	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
 		&mutatingToolsListResponseInterceptor{
 			name: "filter-to-one",
-			toolsFn: func(tools []*mcp.Tool) []*mcp.Tool {
+			toolsFn: func(tools []*proxy.Tool) []*proxy.Tool {
 				return tools[:1]
 			},
 		},
@@ -2330,8 +2329,8 @@ func TestProxy_Post_ToolsListResponse_MutationThenRejection_DiscardsMutation(t *
 	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
 		&mutatingToolsListResponseInterceptor{
 			name: "mutate-then-pass",
-			toolsFn: func(_ []*mcp.Tool) []*mcp.Tool {
-				return []*mcp.Tool{{Name: "should_not_reach_client", InputSchema: map[string]any{}}}
+			toolsFn: func(_ []*proxy.Tool) []*proxy.Tool {
+				return []*proxy.Tool{{Name: "should_not_reach_client"}}
 			},
 		},
 		&mutatingToolsListResponseInterceptor{
@@ -2364,7 +2363,7 @@ func TestProxy_Post_ToolsListResponse_SetTools_EmptyArrayWhenAllFiltered(t *test
 	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
 		&mutatingToolsListResponseInterceptor{
 			name:    "deny-all",
-			toolsFn: func(_ []*mcp.Tool) []*mcp.Tool { return []*mcp.Tool{} },
+			toolsFn: func(_ []*proxy.Tool) []*proxy.Tool { return []*proxy.Tool{} },
 		},
 	}
 
@@ -2399,7 +2398,7 @@ func TestProxy_Post_ToolsListResponse_SetTools_OnErrorResponse_SurfacesAs5xx(t *
 	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
 		&mutatingToolsListResponseInterceptor{
 			name:    "blind-filter",
-			toolsFn: func(_ []*mcp.Tool) []*mcp.Tool { return nil },
+			toolsFn: func(_ []*proxy.Tool) []*proxy.Tool { return nil },
 		},
 	}
 
@@ -2409,40 +2408,6 @@ func TestProxy_Post_ToolsListResponse_SetTools_OnErrorResponse_SurfacesAs5xx(t *
 	rr := httptest.NewRecorder()
 	err := p.Post(rr, req)
 	require.Error(t, err, "MutationError must surface as a server-side error, not a rejection envelope")
-	require.Contains(t, err.Error(), "mutation", "error chain must identify the failure as a mutation anomaly")
-	require.Empty(t, rr.Body.String(), "the proxy must not commit a JSON-RPC body when surfacing a 5xx")
-}
-
-func TestProxy_Post_ToolsListResponse_SetTools_MarshalFailureSurfacesAs5xx(t *testing.T) {
-	t.Parallel()
-
-	// Force a marshal failure inside SetTools by handing it an
-	// unmarshalable InputSchema (channels cannot be JSON-encoded). The
-	// setter must reject with a *MutationError before any state on the
-	// typed view or wire bytes changes, and the proxy must surface that
-	// as a 5xx rather than a JSON-RPC rejection envelope.
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, toolsListResponseThreeTools)
-	}))
-	t.Cleanup(upstream.Close)
-
-	p := newProxyForTest(t, upstream.URL)
-	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
-		&mutatingToolsListResponseInterceptor{
-			name: "inject-unmarshalable-schema",
-			toolsFn: func(_ []*mcp.Tool) []*mcp.Tool {
-				return []*mcp.Tool{{Name: "broken", InputSchema: make(chan int)}}
-			},
-		},
-	}
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(toolsListRequest))
-	req.Header.Set("Content-Type", "application/json")
-
-	rr := httptest.NewRecorder()
-	err := p.Post(rr, req)
-	require.Error(t, err, "marshal failure must surface as a server-side error, not a rejection envelope")
 	require.Contains(t, err.Error(), "mutation", "error chain must identify the failure as a mutation anomaly")
 	require.Empty(t, rr.Body.String(), "the proxy must not commit a JSON-RPC body when surfacing a 5xx")
 }
@@ -2463,7 +2428,7 @@ func TestProxy_Post_ToolsListResponse_SetTools_NilToolsNormalizesToEmptyArray(t 
 	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
 		&mutatingToolsListResponseInterceptor{
 			name:    "deny-all-via-nil",
-			toolsFn: func(_ []*mcp.Tool) []*mcp.Tool { return nil },
+			toolsFn: func(_ []*proxy.Tool) []*proxy.Tool { return nil },
 		},
 	}
 
@@ -2489,7 +2454,7 @@ func TestProxy_Post_ToolsListResponse_SetTools_RewritesRelayedBody_JSONPath(t *t
 	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
 		&mutatingToolsListResponseInterceptor{
 			name: "keep-only-tool-b",
-			toolsFn: func(tools []*mcp.Tool) []*mcp.Tool {
+			toolsFn: func(tools []*proxy.Tool) []*proxy.Tool {
 				kept := tools[:0]
 				for _, t := range tools {
 					if t.Name == "tool_b" {
@@ -2605,7 +2570,7 @@ func TestProxy_Post_ToolsListResponse_SetTools_RewritesRelayedEvent_SSEPath(t *t
 	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
 		&mutatingToolsListResponseInterceptor{
 			name: "keep-only-tool-a",
-			toolsFn: func(tools []*mcp.Tool) []*mcp.Tool {
+			toolsFn: func(tools []*proxy.Tool) []*proxy.Tool {
 				kept := tools[:0]
 				for _, t := range tools {
 					if t.Name == "tool_a" {

--- a/server/internal/remotemcp/proxy/resources_list_response.go
+++ b/server/internal/remotemcp/proxy/resources_list_response.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // ResourcesListResponse is a "resources/list"-specific view over the remote
@@ -30,12 +29,12 @@ type ResourcesListResponse struct {
 	// Result is the decoded resources/list result when upstream returned a
 	// JSON-RPC success response. Mutually exclusive with Error — exactly one
 	// of Result and Error is non-nil.
-	Result *mcp.ListResourcesResult
+	Result *ResourcesListResult
 }
 
 // resourcesListResponseFromRemoteMessage returns a ResourcesListResponse view
 // over msg if msg carries a JSON-RPC response whose payload decodes cleanly
-// as either a [mcp.ListResourcesResult] or a [jsonrpc.Error]. Anything else
+// as either a [ResourcesListResult] or a [jsonrpc.Error]. Anything else
 // returns ok=false so the typed interceptor loop is skipped. Decoding
 // failures do not abort the proxy; the response is relayed to the user
 // unchanged.
@@ -68,11 +67,7 @@ func resourcesListResponseFromRemoteMessage(request *ResourcesListRequest, msg *
 		return resp, true
 	}
 
-	result := &mcp.ListResourcesResult{
-		Meta:       nil,
-		NextCursor: "",
-		Resources:  nil,
-	}
+	result := &ResourcesListResult{Resources: nil, NextCursor: "", extras: nil}
 	if err := json.Unmarshal(rpcResp.Result, result); err != nil {
 		return nil, false
 	}
@@ -108,7 +103,7 @@ func resourcesListResponseFromRemoteMessage(request *ResourcesListRequest, msg *
 // [*MutationError] at the interceptor return path and surfaces it as an
 // HTTP 5xx via [oops.E] with [oops.CodeUnexpected] rather than as a
 // user-facing JSON-RPC rejection.
-func (r *ResourcesListResponse) SetResources(resources []*mcp.Resource) error {
+func (r *ResourcesListResponse) SetResources(resources []*Resource) error {
 	if r.Result == nil {
 		return &MutationError{Op: "set resources", Cause: errors.New("response carries an error, not a result")}
 	}
@@ -117,22 +112,16 @@ func (r *ResourcesListResponse) SetResources(resources []*mcp.Resource) error {
 		return &MutationError{Op: "set resources", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Response", r.RemoteMessage.Message)}
 	}
 
-	if resources == nil {
-		resources = []*mcp.Resource{}
-	}
-
-	// Stage the mutation against a temporary copy of Result so a marshal
-	// failure can't leave the typed view's Resources desynced from the
-	// underlying wire bytes. Only commit (assign to Result.Resources,
-	// rpcResp.Result, dirty) once marshaling has succeeded.
-	staged := *r.Result
+	staged := r.Result.clone()
 	staged.Resources = resources
-	payload, err := json.Marshal(&staged)
+	staged.confineToCaller()
+
+	payload, err := json.Marshal(staged)
 	if err != nil {
-		return &MutationError{Op: "set resources", Cause: fmt.Errorf("marshal mutated ListResourcesResult: %w", err)}
+		return &MutationError{Op: "set resources", Cause: fmt.Errorf("encode mutated resources/list result: %w", err)}
 	}
 
-	r.Result.Resources = resources
+	*r.Result = staged
 	rpcResp.Result = payload
 	r.RemoteMessage.dirty = true
 	return nil

--- a/server/internal/remotemcp/proxy/resources_list_response_interceptor_test.go
+++ b/server/internal/remotemcp/proxy/resources_list_response_interceptor_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 )
 
@@ -45,7 +43,7 @@ func (m *mockResourcesListResponseInterceptor) InterceptResourcesListResponse(_ 
 // "mutate-then-reject" composition.
 type mutatingResourcesListResponseInterceptor struct {
 	name        string
-	resourcesFn func([]*mcp.Resource) []*mcp.Resource
+	resourcesFn func([]*proxy.Resource) []*proxy.Resource
 	err         error
 }
 
@@ -53,7 +51,7 @@ func (m *mutatingResourcesListResponseInterceptor) Name() string { return m.name
 
 func (m *mutatingResourcesListResponseInterceptor) InterceptResourcesListResponse(_ context.Context, list *proxy.ResourcesListResponse) error {
 	if m.resourcesFn != nil {
-		var current []*mcp.Resource
+		var current []*proxy.Resource
 		if list.Result != nil {
 			current = list.Result.Resources
 		}

--- a/server/internal/remotemcp/proxy/resources_test.go
+++ b/server/internal/remotemcp/proxy/resources_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
@@ -189,7 +188,7 @@ func TestProxy_Post_ResourcesListResponse_SetResources_RewritesRelayedBody(t *te
 	p.ResourcesListResponseInterceptors = []proxy.ResourcesListResponseInterceptor{
 		&mutatingResourcesListResponseInterceptor{
 			name: "keep-only-a",
-			resourcesFn: func(resources []*mcp.Resource) []*mcp.Resource {
+			resourcesFn: func(resources []*proxy.Resource) []*proxy.Resource {
 				kept := resources[:0]
 				for _, r := range resources {
 					if r.URI == "file:///a" {
@@ -227,7 +226,7 @@ func TestProxy_Post_ResourcesListResponse_SetResources_EmptyArrayWhenAllFiltered
 	p.ResourcesListResponseInterceptors = []proxy.ResourcesListResponseInterceptor{
 		&mutatingResourcesListResponseInterceptor{
 			name: "drop-all",
-			resourcesFn: func(_ []*mcp.Resource) []*mcp.Resource {
+			resourcesFn: func(_ []*proxy.Resource) []*proxy.Resource {
 				return nil
 			},
 		},

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -90,15 +90,33 @@ func (r *ToolsCallRequest) SetArguments(arguments json.RawMessage) error {
 		return &MutationError{Op: "set arguments", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Request", r.UserRequest.JSONRPCMessages[0])}
 	}
 
-	// Stage the mutation against a temporary copy of Params so a marshal
-	// failure can't leave the typed view's Arguments desynced from the
-	// underlying wire bytes. Only commit (assign to Params.Arguments,
-	// rpcReq.Params, dirty) once marshaling has succeeded.
-	staged := *r.Params
-	staged.Arguments = arguments
-	payload, err := json.Marshal(&staged)
+	// Only the `arguments` member is rewritten; every other member the client
+	// sent travels on untouched, including the ones the vendored SDK's
+	// CallToolParamsRaw does not model. Under MCP 2026-07-28 those include a
+	// multi round-trip retry's `requestState` and `inputResponses`, which a
+	// re-marshal of the struct would strand.
+	params, err := decodeObject(rpcReq.Params)
 	if err != nil {
-		return &MutationError{Op: "set arguments", Cause: fmt.Errorf("marshal mutated CallToolParamsRaw: %w", err)}
+		return &MutationError{Op: "set arguments", Cause: err}
+	}
+	// Gram authorized this call against the decoded `name`. Carrying a case-fold
+	// alias of it onward would let an exact-key upstream execute a different tool
+	// than the one authorized, and for a request the safe answer is to refuse
+	// rather than to pick one.
+	if err := requireUnambiguousInvocation(params, "name"); err != nil {
+		return &MutationError{Op: "set arguments", Cause: err}
+	}
+	if len(arguments) == 0 {
+		// The SDK struct spells the member `omitempty`, so clearing it removes
+		// the member rather than writing an explicit null.
+		delete(params, "arguments")
+	} else {
+		params["arguments"] = arguments
+	}
+
+	payload, err := params.encode()
+	if err != nil {
+		return &MutationError{Op: "set arguments", Cause: err}
 	}
 
 	r.Params.Arguments = arguments

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -90,22 +90,12 @@ func (r *ToolsCallRequest) SetArguments(arguments json.RawMessage) error {
 		return &MutationError{Op: "set arguments", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Request", r.UserRequest.JSONRPCMessages[0])}
 	}
 
-	// Only the `arguments` member is rewritten; every other member the client
-	// sent travels on untouched, including the ones the vendored SDK's
-	// CallToolParamsRaw does not model. Under MCP 2026-07-28 those include a
-	// multi round-trip retry's `requestState` and `inputResponses`, which a
-	// re-marshal of the struct would strand.
+	// Mutate the raw params so fields unknown to the vendored SDK survive.
 	params, err := decodeObject(rpcReq.Params)
 	if err != nil {
 		return &MutationError{Op: "set arguments", Cause: err}
 	}
-	// Gram authorized this call against the decoded `name`. Carrying a case-fold
-	// alias of it onward would let an exact-key upstream execute a different tool
-	// than the one authorized, and for a request the safe answer is to refuse
-	// rather than to pick one.
-	// A RejectError rather than a MutationError: the payload is invalid client
-	// input, so the caller gets a JSON-RPC rejection instead of a 5xx blamed on
-	// the proxy.
+	// Reject aliases that could make upstream invoke a different tool than Gram authorized.
 	if err := requireUnambiguousInvocation(params, "name"); err != nil {
 		return &RejectError{
 			Code:    RejectCodeInvalidParams,
@@ -114,8 +104,7 @@ func (r *ToolsCallRequest) SetArguments(arguments json.RawMessage) error {
 		}
 	}
 	if len(arguments) == 0 {
-		// The SDK struct spells the member `omitempty`, so clearing it removes
-		// the member rather than writing an explicit null.
+		// Match CallToolParamsRaw's omitempty behavior.
 		delete(params, "arguments")
 	} else {
 		params["arguments"] = arguments

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -103,8 +103,15 @@ func (r *ToolsCallRequest) SetArguments(arguments json.RawMessage) error {
 	// alias of it onward would let an exact-key upstream execute a different tool
 	// than the one authorized, and for a request the safe answer is to refuse
 	// rather than to pick one.
+	// A RejectError rather than a MutationError: the payload is invalid client
+	// input, so the caller gets a JSON-RPC rejection instead of a 5xx blamed on
+	// the proxy.
 	if err := requireUnambiguousInvocation(params, "name"); err != nil {
-		return &MutationError{Op: "set arguments", Cause: err}
+		return &RejectError{
+			Code:    RejectCodeInvalidParams,
+			Message: "ambiguous tools/call params: " + err.Error(),
+			Data:    nil,
+		}
 	}
 	if len(arguments) == 0 {
 		// The SDK struct spells the member `omitempty`, so clearing it removes

--- a/server/internal/remotemcp/proxy/tools_list_field_preservation_test.go
+++ b/server/internal/remotemcp/proxy/tools_list_field_preservation_test.go
@@ -1,0 +1,471 @@
+package proxy_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+// upstreamToolsListWithUnmodelledMembers is a tools/list result from an upstream
+// on a protocol revision newer than the vendored SDK: it carries `resultType`
+// (required of every result from 2026-07-28 onward), the `ttlMs`/`cacheScope`
+// caching hints that revision added to list results, and a per-tool member
+// nothing in this repo models.
+const upstreamToolsListWithUnmodelledMembers = `{"jsonrpc":"2.0","id":9,"result":{` +
+	`"resultType":"complete",` +
+	`"tools":[` +
+	`{"name":"keep","inputSchema":{"type":"object"},"x-vendor-extension":"kept"},` +
+	`{"name":"drop","inputSchema":{"type":"object"}}` +
+	`],` +
+	`"nextCursor":"cursor-1",` +
+	`"ttlMs":60000,` +
+	`"cacheScope":"public"` +
+	`}}`
+
+const toolsListRequestBody = `{"jsonrpc":"2.0","id":9,"method":"tools/list","params":{}}`
+
+func postJSON(t *testing.T, p interface {
+	Post(http.ResponseWriter, *http.Request) error
+}, body string,
+) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rr := httptest.NewRecorder()
+	if err := p.Post(rr, req); err != nil {
+		return rr, fmt.Errorf("proxy post: %w", err)
+	}
+	return rr, nil
+}
+
+func upstreamServing(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(upstream.Close)
+
+	return upstream
+}
+
+// keepNamed returns a filter that keeps the tools whose name appears in names.
+func keepNamed(names ...string) func([]*proxy.Tool) []*proxy.Tool {
+	wanted := make(map[string]bool, len(names))
+	for _, n := range names {
+		wanted[n] = true
+	}
+
+	return func(tools []*proxy.Tool) []*proxy.Tool {
+		kept := make([]*proxy.Tool, 0, len(tools))
+		for _, tool := range tools {
+			if wanted[tool.Name] {
+				kept = append(kept, tool)
+			}
+		}
+		return kept
+	}
+}
+
+func resultMembers(t *testing.T, body string) map[string]json.RawMessage {
+	t.Helper()
+
+	var envelope struct {
+		Result map[string]json.RawMessage `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &envelope), "body: %s", body)
+
+	return envelope.Result
+}
+
+func filteringProxy(t *testing.T, upstreamBody string, keep func([]*proxy.Tool) []*proxy.Tool) *proxy.Proxy {
+	t.Helper()
+
+	p := newProxyForTest(t, upstreamServing(t, upstreamBody).URL)
+	p.ToolsListResponseInterceptors = []proxy.ToolsListResponseInterceptor{
+		&mutatingToolsListResponseInterceptor{name: "filter", toolsFn: keep, err: nil},
+	}
+
+	return p
+}
+
+// TestProxy_Post_ToolsListFilterKeepsUnmodelledMembers is the regression test for
+// a client rejecting a relayed tools/list with "missing required resultType".
+// Filtering the tool array must not disturb the members around it, nor the
+// members of the tools that survive.
+func TestProxy_Post_ToolsListFilterKeepsUnmodelledMembers(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t, upstreamToolsListWithUnmodelledMembers, keepNamed("keep"))
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	members := resultMembers(t, rr.Body.String())
+	require.JSONEq(t, `"complete"`, string(members["resultType"]), "resultType must survive the filter")
+	require.JSONEq(t, `"cursor-1"`, string(members["nextCursor"]), "the pagination cursor must survive the filter")
+
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(members["tools"], &tools))
+	require.Len(t, tools, 1, "the filter must still have dropped the unauthorized tool")
+	require.JSONEq(t, `"keep"`, string(tools[0]["name"]))
+	require.JSONEq(t, `{"type":"object"}`, string(tools[0]["inputSchema"]),
+		"a member Gram does not model must survive on the tool that carries it")
+	require.JSONEq(t, `"kept"`, string(tools[0]["x-vendor-extension"]),
+		"a vendor member must survive on the tool that carries it")
+}
+
+// TestProxy_Post_ToolsListWithoutMutationRelaysVerbatim pins the untouched path:
+// with no mutating interceptor the proxy must not re-encode at all.
+func TestProxy_Post_ToolsListWithoutMutationRelaysVerbatim(t *testing.T) {
+	t.Parallel()
+
+	p := newProxyForTest(t, upstreamServing(t, upstreamToolsListWithUnmodelledMembers).URL)
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+	//nolint:testifylint // Byte identity is the invariant, not JSON equivalence: JSONEq would also pass a re-encode, which is what this rules out.
+	require.Equal(t, upstreamToolsListWithUnmodelledMembers, rr.Body.String(),
+		"an unmutated response must relay byte-for-byte")
+}
+
+// TestProxy_Post_ToolsListInjectedToolCarriesNothing pins that the setter still
+// takes tools, not a filter mask: a caller may hand back a tool it constructed,
+// which simply carries no members of its own.
+func TestProxy_Post_ToolsListInjectedToolCarriesNothing(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t, upstreamToolsListWithUnmodelledMembers, func(tools []*proxy.Tool) []*proxy.Tool {
+		return append(keepNamed("keep")(tools), &proxy.Tool{Name: "injected"})
+	})
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(resultMembers(t, rr.Body.String())["tools"], &tools))
+	require.Len(t, tools, 2)
+	require.JSONEq(t, `"keep"`, string(tools[0]["name"]))
+	require.JSONEq(t, `"kept"`, string(tools[0]["x-vendor-extension"]), "the upstream's tool keeps its members")
+	require.JSONEq(t, `"injected"`, string(tools[1]["name"]))
+	require.Len(t, tools[1], 1, "a constructed tool carries only what it was given")
+}
+
+// TestProxy_Post_ToolsListRenamedToolKeepsItsOtherMembers pins that editing a
+// modeled field rewrites that member and leaves the rest of the tool alone —
+// the property that makes the carried members live on the object.
+func TestProxy_Post_ToolsListRenamedToolKeepsItsOtherMembers(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t, upstreamToolsListWithUnmodelledMembers, func(tools []*proxy.Tool) []*proxy.Tool {
+		kept := keepNamed("keep")(tools)
+		kept[0].Name = "renamed"
+		return kept
+	})
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(resultMembers(t, rr.Body.String())["tools"], &tools))
+	require.Len(t, tools, 1)
+	require.JSONEq(t, `"renamed"`, string(tools[0]["name"]), "the edit must reach the client")
+	require.JSONEq(t, `"kept"`, string(tools[0]["x-vendor-extension"]),
+		"editing one member must not drop the others")
+}
+
+// TestProxy_Post_ToolsListFilterConfinesCacheToCaller covers the one member the
+// filter rewrites beyond the tool array. Relaying an upstream's public cache
+// scope on a per-caller list would let any cache between Gram and the model serve
+// one caller's tools to another.
+func TestProxy_Post_ToolsListFilterConfinesCacheToCaller(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t, upstreamToolsListWithUnmodelledMembers, keepNamed("keep"))
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	members := resultMembers(t, rr.Body.String())
+	require.JSONEq(t, `"private"`, string(members["cacheScope"]),
+		"a per-caller filtered list must not stay publicly cacheable")
+	require.JSONEq(t, `0`, string(members["ttlMs"]),
+		"Gram cannot promise freshness for a list it filtered on policy it can revoke")
+}
+
+// TestProxy_Post_ToolsListFilterInventsNoCacheHints pins the other half of that
+// rule: an upstream on a revision without caching hints must not have one
+// introduced on its behalf.
+func TestProxy_Post_ToolsListFilterInventsNoCacheHints(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t,
+		`{"jsonrpc":"2.0","id":9,"result":{"tools":[{"name":"keep","inputSchema":{"type":"object"}}]}}`,
+		keepNamed("keep"))
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	members := resultMembers(t, rr.Body.String())
+	require.NotContains(t, members, "cacheScope")
+	require.NotContains(t, members, "ttlMs")
+}
+
+// TestProxy_Post_ToolsListEmptyFilterKeepsResultMembers covers the filter that
+// removes everything: the array must be present and empty, and the members
+// around it intact.
+func TestProxy_Post_ToolsListEmptyFilterKeepsResultMembers(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t, upstreamToolsListWithUnmodelledMembers, keepNamed())
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	members := resultMembers(t, rr.Body.String())
+	require.JSONEq(t, `[]`, string(members["tools"]))
+	require.JSONEq(t, `"complete"`, string(members["resultType"]))
+	require.JSONEq(t, `"cursor-1"`, string(members["nextCursor"]))
+}
+
+// TestProxy_Post_ToolsListFilterCollapsesRepeatedMemberNames is the safety
+// property behind carrying members by content rather than by byte identity.
+// Parsers disagree on a repeated member name — Go keeps the last, first-wins
+// parsers are common — so relaying both onward would let Gram authorize one tool
+// while a peer downstream reads another.
+func TestProxy_Post_ToolsListFilterCollapsesRepeatedMemberNames(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t,
+		`{"jsonrpc":"2.0","id":9,"result":{"tools":[{"name":"first","name":"second","inputSchema":{}}]}}`,
+		keepNamed("second"))
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	body := rr.Body.String()
+	require.NotContains(t, body, `"first"`, "the value Gram did not authorize must not reach the client")
+	require.Contains(t, body, `"second"`, "the value Gram authorized is the one relayed")
+	require.Equal(t, 1, strings.Count(body, `"name"`), "the repeated member must be emitted once")
+}
+
+// TestProxy_Post_ToolsListFilterDropsCaseVariantOfModelledMember pins the other
+// parser-differential case. Go matches a struct field to a member
+// case-insensitively while the protocol matches keys exactly, so carrying both
+// `name` and `Name` would leave Gram having authorized one and a
+// case-insensitive peer reading the other.
+func TestProxy_Post_ToolsListFilterDropsCaseVariantOfModelledMember(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t,
+		`{"jsonrpc":"2.0","id":9,"result":{"tools":[{"name":"authorized","Name":"shadow","inputSchema":{}}]}}`,
+		keepNamed("authorized"))
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(resultMembers(t, rr.Body.String())["tools"], &tools))
+	require.Len(t, tools, 1)
+	require.JSONEq(t, `"authorized"`, string(tools[0]["name"]), "the client sees the name Gram authorized")
+	require.NotContains(t, tools[0], "Name", "the case variant must not be carried alongside it")
+}
+
+// TestProxy_Post_ToolsListNullResultRelaysUntouched covers a JSON null result.
+// It is not a list Gram can filter, so no typed view is built, the interceptors
+// do not run, and the payload relays as it arrived — rather than panicking on a
+// nil member map.
+func TestProxy_Post_ToolsListNullResultRelaysUntouched(t *testing.T) {
+	t.Parallel()
+
+	const nullResult = `{"jsonrpc":"2.0","id":9,"result":null}`
+	p := filteringProxy(t, nullResult, keepNamed())
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+	//nolint:testifylint // Byte identity is the point: nothing decoded, so nothing re-encoded.
+	require.Equal(t, nullResult, rr.Body.String())
+}
+
+// TestProxy_Post_ToolsListFilterKeepsUnmodelledAnnotationMembers pins that the
+// guarantee holds one level down. Gram reads four annotation hints; a hint it does
+// not model must survive on the annotations object that carries it, and must not
+// be readable one way by Gram and another way downstream.
+func TestProxy_Post_ToolsListFilterKeepsUnmodelledAnnotationMembers(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t,
+		`{"jsonrpc":"2.0","id":9,"result":{"tools":[{"name":"keep","inputSchema":{},`+
+			`"annotations":{"readOnlyHint":true,"x-vendor-hint":"kept","destructiveHint":false}}]}}`,
+		keepNamed("keep"))
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(resultMembers(t, rr.Body.String())["tools"], &tools))
+	require.Len(t, tools, 1)
+
+	var annotations map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(tools[0]["annotations"], &annotations))
+	require.JSONEq(t, `true`, string(annotations["readOnlyHint"]))
+	require.JSONEq(t, `false`, string(annotations["destructiveHint"]),
+		"an explicitly-false hint must stay explicitly false")
+	require.JSONEq(t, `"kept"`, string(annotations["x-vendor-hint"]),
+		"an annotation member Gram does not model must survive")
+}
+
+// TestProxy_Post_ToolsListNullToolRelaysUntouched covers `tools: [null]`. It is
+// not a list Gram can authorize per tool, so no typed view is built and the
+// payload relays as it arrived rather than reaching a filter that would
+// dereference the null.
+func TestProxy_Post_ToolsListNullToolRelaysUntouched(t *testing.T) {
+	t.Parallel()
+
+	const nullTool = `{"jsonrpc":"2.0","id":9,"result":{"tools":[null]}}`
+	p := filteringProxy(t, nullTool, keepNamed())
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+	//nolint:testifylint // Byte identity is the point: nothing decoded, so nothing re-encoded.
+	require.Equal(t, nullTool, rr.Body.String())
+}
+
+// TestProxy_Post_ToolsCallRewriteRefusesAmbiguousToolName is the request-side
+// counterpart to dropping case variants on a response. Gram authorizes a
+// tools/call against the decoded name, and Go decodes `Name` into the same field
+// as `name`, so a body carrying both could be authorized as one tool and executed
+// as another by an exact-key upstream. For a request the safe answer is to refuse
+// rather than to pick one.
+func TestProxy_Post_ToolsCallRewriteRefusesAmbiguousToolName(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.ToolsCallRequestInterceptors = []proxy.ToolsCallRequestInterceptor{
+		&mutatingToolsCallRequestInterceptor{
+			name:   "scrub-arguments",
+			argsFn: func(json.RawMessage) json.RawMessage { return json.RawMessage(`{}`) },
+			err:    nil,
+		},
+	}
+
+	_, err := postJSON(t, p,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"denied","Name":"allowed","arguments":{}}}`)
+	require.Error(t, err, "an ambiguous invocation must not be rewritten and forwarded")
+	require.Equal(t, int32(0), hits.Load(), "the ambiguous payload must never reach the upstream")
+}
+
+// TestProxy_Post_ResourcesListFilterKeepsUnmodelledMembers covers the sibling
+// view, which shares the commit pathway.
+func TestProxy_Post_ResourcesListFilterKeepsUnmodelledMembers(t *testing.T) {
+	t.Parallel()
+
+	p := newProxyForTest(t, upstreamServing(t, `{"jsonrpc":"2.0","id":9,"result":{`+
+		`"resultType":"complete",`+
+		`"resources":[{"uri":"file:///keep","name":"keep","x-vendor-extension":"kept"},{"uri":"file:///drop","name":"drop"}],`+
+		`"ttlMs":60000,`+
+		`"cacheScope":"public"`+
+		`}}`).URL)
+	p.ResourcesListResponseInterceptors = []proxy.ResourcesListResponseInterceptor{
+		&mutatingResourcesListResponseInterceptor{
+			name: "keep-only-keep",
+			resourcesFn: func(resources []*proxy.Resource) []*proxy.Resource {
+				kept := make([]*proxy.Resource, 0, len(resources))
+				for _, resource := range resources {
+					if resource.Name == "keep" {
+						kept = append(kept, resource)
+					}
+				}
+				return kept
+			},
+			err: nil,
+		},
+	}
+
+	rr, err := postJSON(t, p, `{"jsonrpc":"2.0","id":9,"method":"resources/list","params":{}}`)
+	require.NoError(t, err)
+
+	members := resultMembers(t, rr.Body.String())
+	require.JSONEq(t, `"complete"`, string(members["resultType"]))
+	require.JSONEq(t, `"private"`, string(members["cacheScope"]))
+	require.JSONEq(t, `0`, string(members["ttlMs"]))
+
+	var resources []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(members["resources"], &resources))
+	require.Len(t, resources, 1)
+	require.JSONEq(t, `"kept"`, string(resources[0]["x-vendor-extension"]))
+}
+
+// TestProxy_Post_ToolsCallArgumentRewriteKeepsOtherParams covers the
+// request-side commit. A multi round-trip retry carries `inputResponses` and
+// `requestState` alongside `arguments`; dropping either strands the round trip.
+func TestProxy_Post_ToolsCallArgumentRewriteKeepsOtherParams(t *testing.T) {
+	t.Parallel()
+
+	var forwarded atomic.Pointer[string]
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seen := string(body)
+		forwarded.Store(&seen)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.ToolsCallRequestInterceptors = []proxy.ToolsCallRequestInterceptor{
+		&mutatingToolsCallRequestInterceptor{
+			name:   "scrub-arguments",
+			argsFn: func(json.RawMessage) json.RawMessage { return json.RawMessage(`{"scrubbed":true}`) },
+			err:    nil,
+		},
+	}
+
+	_, err := postJSON(t, p, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{`+
+		`"name":"do_thing",`+
+		`"arguments":{"secret":"strip me"},`+
+		`"requestState":"AEAD-protected blob",`+
+		`"inputResponses":{"github_login":{"action":"accept"}}`+
+		`}}`)
+	require.NoError(t, err)
+
+	seen := forwarded.Load()
+	require.NotNil(t, seen)
+
+	var envelope struct {
+		Params map[string]json.RawMessage `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(*seen), &envelope))
+	require.JSONEq(t, `{"scrubbed":true}`, string(envelope.Params["arguments"]), "the rewrite must reach upstream")
+	require.JSONEq(t, `"do_thing"`, string(envelope.Params["name"]))
+	require.JSONEq(t, `"AEAD-protected blob"`, string(envelope.Params["requestState"]),
+		"multi round-trip state must survive an argument rewrite")
+	require.JSONEq(t, `{"github_login":{"action":"accept"}}`, string(envelope.Params["inputResponses"]),
+		"multi round-trip responses must survive an argument rewrite")
+}

--- a/server/internal/remotemcp/proxy/tools_list_field_preservation_test.go
+++ b/server/internal/remotemcp/proxy/tools_list_field_preservation_test.go
@@ -15,11 +15,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 )
 
-// upstreamToolsListWithUnmodelledMembers is a tools/list result from an upstream
-// on a protocol revision newer than the vendored SDK: it carries `resultType`
-// (required of every result from 2026-07-28 onward), the `ttlMs`/`cacheScope`
-// caching hints that revision added to list results, and a per-tool member
-// nothing in this repo models.
 const upstreamToolsListWithUnmodelledMembers = `{"jsonrpc":"2.0","id":9,"result":{` +
 	`"resultType":"complete",` +
 	`"tools":[` +
@@ -63,7 +58,6 @@ func upstreamServing(t *testing.T, body string) *httptest.Server {
 	return upstream
 }
 
-// keepNamed returns a filter that keeps the tools whose name appears in names.
 func keepNamed(names ...string) func([]*proxy.Tool) []*proxy.Tool {
 	wanted := make(map[string]bool, len(names))
 	for _, n := range names {
@@ -103,10 +97,6 @@ func filteringProxy(t *testing.T, upstreamBody string, keep func([]*proxy.Tool) 
 	return p
 }
 
-// TestProxy_Post_ToolsListFilterKeepsUnmodelledMembers is the regression test for
-// a client rejecting a relayed tools/list with "missing required resultType".
-// Filtering the tool array must not disturb the members around it, nor the
-// members of the tools that survive.
 func TestProxy_Post_ToolsListFilterKeepsUnmodelledMembers(t *testing.T) {
 	t.Parallel()
 
@@ -130,8 +120,6 @@ func TestProxy_Post_ToolsListFilterKeepsUnmodelledMembers(t *testing.T) {
 		"a vendor member must survive on the tool that carries it")
 }
 
-// TestProxy_Post_ToolsListWithoutMutationRelaysVerbatim pins the untouched path:
-// with no mutating interceptor the proxy must not re-encode at all.
 func TestProxy_Post_ToolsListWithoutMutationRelaysVerbatim(t *testing.T) {
 	t.Parallel()
 
@@ -139,14 +127,11 @@ func TestProxy_Post_ToolsListWithoutMutationRelaysVerbatim(t *testing.T) {
 
 	rr, err := postJSON(t, p, toolsListRequestBody)
 	require.NoError(t, err)
-	//nolint:testifylint // Byte identity is the invariant, not JSON equivalence: JSONEq would also pass a re-encode, which is what this rules out.
+	//nolint:testifylint // This assertion requires byte identity, not JSON equivalence.
 	require.Equal(t, upstreamToolsListWithUnmodelledMembers, rr.Body.String(),
 		"an unmutated response must relay byte-for-byte")
 }
 
-// TestProxy_Post_ToolsListInjectedToolCarriesNothing pins that the setter still
-// takes tools, not a filter mask: a caller may hand back a tool it constructed,
-// which simply carries no members of its own.
 func TestProxy_Post_ToolsListInjectedToolCarriesNothing(t *testing.T) {
 	t.Parallel()
 
@@ -166,9 +151,6 @@ func TestProxy_Post_ToolsListInjectedToolCarriesNothing(t *testing.T) {
 	require.Len(t, tools[1], 1, "a constructed tool carries only what it was given")
 }
 
-// TestProxy_Post_ToolsListRenamedToolKeepsItsOtherMembers pins that editing a
-// modeled field rewrites that member and leaves the rest of the tool alone —
-// the property that makes the carried members live on the object.
 func TestProxy_Post_ToolsListRenamedToolKeepsItsOtherMembers(t *testing.T) {
 	t.Parallel()
 
@@ -189,10 +171,6 @@ func TestProxy_Post_ToolsListRenamedToolKeepsItsOtherMembers(t *testing.T) {
 		"editing one member must not drop the others")
 }
 
-// TestProxy_Post_ToolsListFilterConfinesCacheToCaller covers the one member the
-// filter rewrites beyond the tool array. Relaying an upstream's public cache
-// scope on a per-caller list would let any cache between Gram and the model serve
-// one caller's tools to another.
 func TestProxy_Post_ToolsListFilterConfinesCacheToCaller(t *testing.T) {
 	t.Parallel()
 
@@ -208,9 +186,6 @@ func TestProxy_Post_ToolsListFilterConfinesCacheToCaller(t *testing.T) {
 		"Gram cannot promise freshness for a list it filtered on policy it can revoke")
 }
 
-// TestProxy_Post_ToolsListFilterInventsNoCacheHints pins the other half of that
-// rule: an upstream on a revision without caching hints must not have one
-// introduced on its behalf.
 func TestProxy_Post_ToolsListFilterInventsNoCacheHints(t *testing.T) {
 	t.Parallel()
 
@@ -226,9 +201,6 @@ func TestProxy_Post_ToolsListFilterInventsNoCacheHints(t *testing.T) {
 	require.NotContains(t, members, "ttlMs")
 }
 
-// TestProxy_Post_ToolsListEmptyFilterKeepsResultMembers covers the filter that
-// removes everything: the array must be present and empty, and the members
-// around it intact.
 func TestProxy_Post_ToolsListEmptyFilterKeepsResultMembers(t *testing.T) {
 	t.Parallel()
 
@@ -243,11 +215,6 @@ func TestProxy_Post_ToolsListEmptyFilterKeepsResultMembers(t *testing.T) {
 	require.JSONEq(t, `"cursor-1"`, string(members["nextCursor"]))
 }
 
-// TestProxy_Post_ToolsListFilterCollapsesRepeatedMemberNames is the safety
-// property behind carrying members by content rather than by byte identity.
-// Parsers disagree on a repeated member name — Go keeps the last, first-wins
-// parsers are common — so relaying both onward would let Gram authorize one tool
-// while a peer downstream reads another.
 func TestProxy_Post_ToolsListFilterCollapsesRepeatedMemberNames(t *testing.T) {
 	t.Parallel()
 
@@ -264,11 +231,6 @@ func TestProxy_Post_ToolsListFilterCollapsesRepeatedMemberNames(t *testing.T) {
 	require.Equal(t, 1, strings.Count(body, `"name"`), "the repeated member must be emitted once")
 }
 
-// TestProxy_Post_ToolsListFilterDropsCaseVariantOfModelledMember pins the other
-// parser-differential case. Go matches a struct field to a member
-// case-insensitively while the protocol matches keys exactly, so carrying both
-// `name` and `Name` would leave Gram having authorized one and a
-// case-insensitive peer reading the other.
 func TestProxy_Post_ToolsListFilterDropsCaseVariantOfModelledMember(t *testing.T) {
 	t.Parallel()
 
@@ -286,10 +248,6 @@ func TestProxy_Post_ToolsListFilterDropsCaseVariantOfModelledMember(t *testing.T
 	require.NotContains(t, tools[0], "Name", "the case variant must not be carried alongside it")
 }
 
-// TestProxy_Post_ToolsListNullResultRelaysUntouched covers a JSON null result.
-// It is not a list Gram can filter, so no typed view is built, the interceptors
-// do not run, and the payload relays as it arrived — rather than panicking on a
-// nil member map.
 func TestProxy_Post_ToolsListNullResultRelaysUntouched(t *testing.T) {
 	t.Parallel()
 
@@ -298,14 +256,10 @@ func TestProxy_Post_ToolsListNullResultRelaysUntouched(t *testing.T) {
 
 	rr, err := postJSON(t, p, toolsListRequestBody)
 	require.NoError(t, err)
-	//nolint:testifylint // Byte identity is the point: nothing decoded, so nothing re-encoded.
+	//nolint:testifylint // This assertion requires byte identity, not JSON equivalence.
 	require.Equal(t, nullResult, rr.Body.String())
 }
 
-// TestProxy_Post_ToolsListFilterDropsCaseVariantCacheHints pins that confining a
-// filtered list actually confines it. A case-variant alias of a cache hint would
-// be read in place of the value Gram writes by any parser that folds member
-// names, leaving a per-caller result still marked publicly cacheable.
 func TestProxy_Post_ToolsListFilterDropsCaseVariantCacheHints(t *testing.T) {
 	t.Parallel()
 
@@ -325,10 +279,6 @@ func TestProxy_Post_ToolsListFilterDropsCaseVariantCacheHints(t *testing.T) {
 	require.NotContains(t, members, "TtlMs")
 }
 
-// TestProxy_Post_ToolsListNullArrayRelaysUntouched covers an explicitly null tool
-// array. It decodes to an empty list without error, so a mutation would emit it
-// as [] — normalising the upstream's malformed payload on exactly the paths that
-// filter, and relaying it untouched on the rest. Every path relays instead.
 func TestProxy_Post_ToolsListNullArrayRelaysUntouched(t *testing.T) {
 	t.Parallel()
 
@@ -337,13 +287,10 @@ func TestProxy_Post_ToolsListNullArrayRelaysUntouched(t *testing.T) {
 
 	rr, err := postJSON(t, p, toolsListRequestBody)
 	require.NoError(t, err)
-	//nolint:testifylint // Byte identity is the point: nothing decoded, so nothing re-encoded.
+	//nolint:testifylint // This assertion requires byte identity, not JSON equivalence.
 	require.Equal(t, nullArray, rr.Body.String())
 }
 
-// TestProxy_Post_ToolsCallAmbiguousNameIsRejectedNotErrored pins the error class.
-// An ambiguous invocation is invalid client input, so the caller gets a JSON-RPC
-// rejection rather than a 5xx blamed on the proxy.
 func TestProxy_Post_ToolsCallAmbiguousNameIsRejectedNotErrored(t *testing.T) {
 	t.Parallel()
 
@@ -374,10 +321,6 @@ func TestProxy_Post_ToolsCallAmbiguousNameIsRejectedNotErrored(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "ambiguous tools/call params")
 }
 
-// TestProxy_Post_ToolsListFilterKeepsUnmodelledAnnotationMembers pins that the
-// guarantee holds one level down. Gram reads four annotation hints; a hint it does
-// not model must survive on the annotations object that carries it, and must not
-// be readable one way by Gram and another way downstream.
 func TestProxy_Post_ToolsListFilterKeepsUnmodelledAnnotationMembers(t *testing.T) {
 	t.Parallel()
 
@@ -402,10 +345,6 @@ func TestProxy_Post_ToolsListFilterKeepsUnmodelledAnnotationMembers(t *testing.T
 		"an annotation member Gram does not model must survive")
 }
 
-// TestProxy_Post_ToolsListNullToolRelaysUntouched covers `tools: [null]`. It is
-// not a list Gram can authorize per tool, so no typed view is built and the
-// payload relays as it arrived rather than reaching a filter that would
-// dereference the null.
 func TestProxy_Post_ToolsListNullToolRelaysUntouched(t *testing.T) {
 	t.Parallel()
 
@@ -414,7 +353,7 @@ func TestProxy_Post_ToolsListNullToolRelaysUntouched(t *testing.T) {
 
 	rr, err := postJSON(t, p, toolsListRequestBody)
 	require.NoError(t, err)
-	//nolint:testifylint // Byte identity is the point: nothing decoded, so nothing re-encoded.
+	//nolint:testifylint // This assertion requires byte identity, not JSON equivalence.
 	require.Equal(t, nullTool, rr.Body.String())
 }
 
@@ -457,9 +396,6 @@ func TestProxy_Post_ResourcesListFilterKeepsUnmodelledMembers(t *testing.T) {
 	require.JSONEq(t, `"kept"`, string(resources[0]["x-vendor-extension"]))
 }
 
-// TestProxy_Post_ToolsCallArgumentRewriteKeepsOtherParams covers the
-// request-side commit. A multi round-trip retry carries `inputResponses` and
-// `requestState` alongside `arguments`; dropping either strands the round trip.
 func TestProxy_Post_ToolsCallArgumentRewriteKeepsOtherParams(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotemcp/proxy/tools_list_field_preservation_test.go
+++ b/server/internal/remotemcp/proxy/tools_list_field_preservation_test.go
@@ -302,6 +302,78 @@ func TestProxy_Post_ToolsListNullResultRelaysUntouched(t *testing.T) {
 	require.Equal(t, nullResult, rr.Body.String())
 }
 
+// TestProxy_Post_ToolsListFilterDropsCaseVariantCacheHints pins that confining a
+// filtered list actually confines it. A case-variant alias of a cache hint would
+// be read in place of the value Gram writes by any parser that folds member
+// names, leaving a per-caller result still marked publicly cacheable.
+func TestProxy_Post_ToolsListFilterDropsCaseVariantCacheHints(t *testing.T) {
+	t.Parallel()
+
+	p := filteringProxy(t,
+		`{"jsonrpc":"2.0","id":9,"result":{"tools":[{"name":"keep","inputSchema":{}}],`+
+			`"CacheScope":"public","TtlMs":60000}}`,
+		keepNamed("keep"))
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+
+	members := resultMembers(t, rr.Body.String())
+	require.JSONEq(t, `"private"`, string(members["cacheScope"]),
+		"an aliased hint still counts as the upstream having sent one")
+	require.JSONEq(t, `0`, string(members["ttlMs"]))
+	require.NotContains(t, members, "CacheScope", "the alias must not survive alongside the confined value")
+	require.NotContains(t, members, "TtlMs")
+}
+
+// TestProxy_Post_ToolsListNullArrayRelaysUntouched covers an explicitly null tool
+// array. It decodes to an empty list without error, so a mutation would emit it
+// as [] — normalising the upstream's malformed payload on exactly the paths that
+// filter, and relaying it untouched on the rest. Every path relays instead.
+func TestProxy_Post_ToolsListNullArrayRelaysUntouched(t *testing.T) {
+	t.Parallel()
+
+	const nullArray = `{"jsonrpc":"2.0","id":9,"result":{"tools":null}}`
+	p := filteringProxy(t, nullArray, keepNamed())
+
+	rr, err := postJSON(t, p, toolsListRequestBody)
+	require.NoError(t, err)
+	//nolint:testifylint // Byte identity is the point: nothing decoded, so nothing re-encoded.
+	require.Equal(t, nullArray, rr.Body.String())
+}
+
+// TestProxy_Post_ToolsCallAmbiguousNameIsRejectedNotErrored pins the error class.
+// An ambiguous invocation is invalid client input, so the caller gets a JSON-RPC
+// rejection rather than a 5xx blamed on the proxy.
+func TestProxy_Post_ToolsCallAmbiguousNameIsRejectedNotErrored(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.ToolsCallRequestInterceptors = []proxy.ToolsCallRequestInterceptor{
+		&mutatingToolsCallRequestInterceptor{
+			name:   "scrub-arguments",
+			argsFn: func(json.RawMessage) json.RawMessage { return json.RawMessage(`{}`) },
+			err:    nil,
+		},
+	}
+
+	rr, err := postJSON(t, p,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"denied","Name":"allowed","arguments":{}}}`)
+	require.NoError(t, err, "invalid client input must not surface as a proxy error")
+	require.Equal(t, int32(0), hits.Load(), "the ambiguous payload must never reach the upstream")
+	require.Contains(t, rr.Body.String(), "-32602", "the caller gets an invalid-params rejection")
+	require.Contains(t, rr.Body.String(), "ambiguous tools/call params")
+}
+
 // TestProxy_Post_ToolsListFilterKeepsUnmodelledAnnotationMembers pins that the
 // guarantee holds one level down. Gram reads four annotation hints; a hint it does
 // not model must survive on the annotations object that carries it, and must not
@@ -346,42 +418,6 @@ func TestProxy_Post_ToolsListNullToolRelaysUntouched(t *testing.T) {
 	require.Equal(t, nullTool, rr.Body.String())
 }
 
-// TestProxy_Post_ToolsCallRewriteRefusesAmbiguousToolName is the request-side
-// counterpart to dropping case variants on a response. Gram authorizes a
-// tools/call against the decoded name, and Go decodes `Name` into the same field
-// as `name`, so a body carrying both could be authorized as one tool and executed
-// as another by an exact-key upstream. For a request the safe answer is to refuse
-// rather than to pick one.
-func TestProxy_Post_ToolsCallRewriteRefusesAmbiguousToolName(t *testing.T) {
-	t.Parallel()
-
-	var hits atomic.Int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hits.Add(1)
-		_, _ = io.Copy(io.Discard, r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":4,"result":{"content":[]}}`))
-	}))
-	t.Cleanup(upstream.Close)
-
-	p := newProxyForTest(t, upstream.URL)
-	p.ToolsCallRequestInterceptors = []proxy.ToolsCallRequestInterceptor{
-		&mutatingToolsCallRequestInterceptor{
-			name:   "scrub-arguments",
-			argsFn: func(json.RawMessage) json.RawMessage { return json.RawMessage(`{}`) },
-			err:    nil,
-		},
-	}
-
-	_, err := postJSON(t, p,
-		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"denied","Name":"allowed","arguments":{}}}`)
-	require.Error(t, err, "an ambiguous invocation must not be rewritten and forwarded")
-	require.Equal(t, int32(0), hits.Load(), "the ambiguous payload must never reach the upstream")
-}
-
-// TestProxy_Post_ResourcesListFilterKeepsUnmodelledMembers covers the sibling
-// view, which shares the commit pathway.
 func TestProxy_Post_ResourcesListFilterKeepsUnmodelledMembers(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotemcp/proxy/tools_list_response.go
+++ b/server/internal/remotemcp/proxy/tools_list_response.go
@@ -68,9 +68,6 @@ func toolsListResponseFromRemoteMessage(request *ToolsListRequest, msg *RemoteMe
 		return resp, true
 	}
 
-	// A payload that does not decode as a tools/list result leaves ok=false, so
-	// the typed loop is skipped and the response relays to the user unchanged.
-	// That includes a `null` result, which carries no tools to filter.
 	result := &ToolsListResult{Tools: nil, NextCursor: "", extras: nil}
 	if err := json.Unmarshal(rpcResp.Result, result); err != nil {
 		return nil, false
@@ -116,9 +113,7 @@ func (r *ToolsListResponse) SetTools(tools []*Tool) error {
 		return &MutationError{Op: "set tools", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Response", r.RemoteMessage.Message)}
 	}
 
-	// Staged on a clone so a failure cannot leave the wire disagreeing with the
-	// typed view: confining the cache scope writes to the carried members, which
-	// the live result would otherwise share.
+	// Stage cache-hint changes so marshal failure leaves the typed view untouched.
 	staged := r.Result.clone()
 	staged.Tools = tools
 	staged.confineToCaller()

--- a/server/internal/remotemcp/proxy/tools_list_response.go
+++ b/server/internal/remotemcp/proxy/tools_list_response.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // ToolsListResponse is a "tools/list"-specific view over the remote message
@@ -30,12 +29,12 @@ type ToolsListResponse struct {
 	// Result is the decoded tools/list result when upstream returned a
 	// JSON-RPC success response. Mutually exclusive with Error — exactly one
 	// of Result and Error is non-nil.
-	Result *mcp.ListToolsResult
+	Result *ToolsListResult
 }
 
 // toolsListResponseFromRemoteMessage returns a ToolsListResponse view over
 // msg if msg carries a JSON-RPC response whose payload decodes cleanly as
-// either a [mcp.ListToolsResult] or a [jsonrpc.Error]. Anything else
+// either a [ToolsListResult] or a [jsonrpc.Error]. Anything else
 // returns ok=false so the typed interceptor loop is skipped. Decoding
 // failures do not abort the proxy; the response is relayed to the user
 // unchanged.
@@ -43,6 +42,7 @@ type ToolsListResponse struct {
 // Used by both the buffered JSON path and the SSE-terminal path. In both
 // cases msg.Message is already a *jsonrpc.Response decoded from the wire;
 // the helper just re-decodes its payload as a tools/list shape.
+
 func toolsListResponseFromRemoteMessage(request *ToolsListRequest, msg *RemoteMessage) (*ToolsListResponse, bool) {
 	if request == nil || msg == nil {
 		return nil, false
@@ -68,11 +68,10 @@ func toolsListResponseFromRemoteMessage(request *ToolsListRequest, msg *RemoteMe
 		return resp, true
 	}
 
-	result := &mcp.ListToolsResult{
-		Meta:       nil,
-		NextCursor: "",
-		Tools:      nil,
-	}
+	// A payload that does not decode as a tools/list result leaves ok=false, so
+	// the typed loop is skipped and the response relays to the user unchanged.
+	// That includes a `null` result, which carries no tools to filter.
+	result := &ToolsListResult{Tools: nil, NextCursor: "", extras: nil}
 	if err := json.Unmarshal(rpcResp.Result, result); err != nil {
 		return nil, false
 	}
@@ -108,7 +107,7 @@ func toolsListResponseFromRemoteMessage(request *ToolsListRequest, msg *RemoteMe
 // detects [*MutationError] at the interceptor return path and surfaces
 // it as an HTTP 5xx via [oops.E] with [oops.CodeUnexpected] rather than
 // as a user-facing JSON-RPC rejection.
-func (r *ToolsListResponse) SetTools(tools []*mcp.Tool) error {
+func (r *ToolsListResponse) SetTools(tools []*Tool) error {
 	if r.Result == nil {
 		return &MutationError{Op: "set tools", Cause: errors.New("response carries an error, not a result")}
 	}
@@ -117,22 +116,19 @@ func (r *ToolsListResponse) SetTools(tools []*mcp.Tool) error {
 		return &MutationError{Op: "set tools", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Response", r.RemoteMessage.Message)}
 	}
 
-	if tools == nil {
-		tools = []*mcp.Tool{}
-	}
-
-	// Stage the mutation against a temporary copy of Result so a marshal
-	// failure can't leave the typed view's Tools desynced from the
-	// underlying wire bytes. Only commit (assign to Result.Tools,
-	// rpcResp.Result, dirty) once marshaling has succeeded.
-	staged := *r.Result
+	// Staged on a clone so a failure cannot leave the wire disagreeing with the
+	// typed view: confining the cache scope writes to the carried members, which
+	// the live result would otherwise share.
+	staged := r.Result.clone()
 	staged.Tools = tools
-	payload, err := json.Marshal(&staged)
+	staged.confineToCaller()
+
+	payload, err := json.Marshal(staged)
 	if err != nil {
-		return &MutationError{Op: "set tools", Cause: fmt.Errorf("marshal mutated ListToolsResult: %w", err)}
+		return &MutationError{Op: "set tools", Cause: fmt.Errorf("encode mutated tools/list result: %w", err)}
 	}
 
-	r.Result.Tools = tools
+	*r.Result = staged
 	rpcResp.Result = payload
 	r.RemoteMessage.dirty = true
 	return nil

--- a/server/internal/remotemcp/proxy/tools_list_response_interceptor_test.go
+++ b/server/internal/remotemcp/proxy/tools_list_response_interceptor_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 )
 
@@ -46,7 +44,7 @@ func (m *mockToolsListResponseInterceptor) InterceptToolsListResponse(_ context.
 // composition.
 type mutatingToolsListResponseInterceptor struct {
 	name    string
-	toolsFn func([]*mcp.Tool) []*mcp.Tool
+	toolsFn func([]*proxy.Tool) []*proxy.Tool
 	err     error
 }
 
@@ -54,7 +52,7 @@ func (m *mutatingToolsListResponseInterceptor) Name() string { return m.name }
 
 func (m *mutatingToolsListResponseInterceptor) InterceptToolsListResponse(_ context.Context, list *proxy.ToolsListResponse) error {
 	if m.toolsFn != nil {
-		var current []*mcp.Tool
+		var current []*proxy.Tool
 		if list.Result != nil {
 			current = list.Result.Tools
 		}

--- a/server/internal/remotemcp/proxy/wire.go
+++ b/server/internal/remotemcp/proxy/wire.go
@@ -9,44 +9,10 @@ import (
 	"strings"
 )
 
-// The types here model the MCP payloads the proxy mutates. They exist instead of
-// the vendored modelcontextprotocol/go-sdk structs because a struct commits its
-// author's opinion about which members exist, and committing a mutation through
-// one publishes that opinion as Gram's: every member the SDK version does not
-// model is deleted in transit. MCP 2026-07-28 requires `resultType` on every
-// result and clients validate it, so a member Gram drops makes Gram the
-// non-compliant party for a payload the upstream got right — and the proxy is a
-// pass-through on protocol version, so the revision being validated against is
-// the one the client and the upstream settled between themselves, not one Gram
-// picked.
-//
-// Each type models the members Gram itself reads and carries every other member
-// of the same object, so a decode/encode round trip reproduces the payload.
-// Carried members live on the object that owns them, which is what makes
-// filtering a list preserve each surviving item's own members with no bookkeeping
-// on the side, and a nested object that Gram reads into is modeled by a type of
-// its own so the same guarantee holds one level down.
-//
-// Adding a field is how Gram takes a dependency on a member. Anything not listed
-// travels through untouched, which is the point.
-//
-// Two things are deliberately not preserved, because preserving them would make
-// the payload mean different things to different readers:
-//
-//   - A repeated member name collapses to the single value Go's decoder kept.
-//     Parsers disagree here — Go keeps the last, first-wins parsers are common —
-//     so relaying both onward would let Gram authorize one tool while a peer
-//     downstream reads another.
-//   - A member whose name differs from a modeled one only by case is dropped.
-//     Go matches a struct field to a member case-insensitively while the protocol
-//     matches keys exactly, so carrying both `name` and `Name` would leave Gram
-//     having authorized one value and a case-insensitive peer reading the other.
-//
-// Member order is not preserved either, but that carries no meaning. Byte-for-byte
-// relay remains the behaviour whenever nothing mutates, which never decodes at all.
-
-// extrasOnly returns the members of a decoded object that the modeled names do
-// not claim, dropping each modeled name and any case-fold alias of it.
+// These wire types preserve members that Gram does not model, allowing newer MCP
+// payloads to survive mutations. Duplicate and case-folded names are collapsed so
+// Gram and downstream parsers cannot disagree about authorized values. Messages
+// that are not mutated bypass these types and relay byte-for-byte.
 func extrasOnly(members object, modeled ...string) object {
 	extras := make(object, len(members))
 	maps.Copy(extras, members)
@@ -63,9 +29,6 @@ func extrasOnly(members object, modeled ...string) object {
 	return extras
 }
 
-// mergeModeled writes the carried extras and then the modeled members into one
-// object, dropping any extra that case-fold collides with a modeled name so the
-// emitted object cannot read differently to a case-insensitive parser.
 func mergeModeled(extras object, modeled object) (json.RawMessage, error) {
 	names := make([]string, 0, len(modeled))
 	for name := range modeled {
@@ -78,10 +41,7 @@ func mergeModeled(extras object, modeled object) (json.RawMessage, error) {
 	return out.encode()
 }
 
-// ToolAnnotations is a tool's annotation hints. Gram matches annotation-scoped
-// grants against the four the spec defines; anything else an upstream attaches is
-// carried. Absent and explicitly-false hints are both nil, so a caller cannot
-// mistake "not declared" for "declared false".
+// ToolAnnotations contains the hints Gram evaluates and preserves unknown members.
 type ToolAnnotations struct {
 	ReadOnlyHint    *bool
 	DestructiveHint *bool
@@ -143,18 +103,12 @@ func (a ToolAnnotations) MarshalJSON() ([]byte, error) {
 	return mergeModeled(a.extras, modeled)
 }
 
-// Tool is a tools/list entry. Gram reads a tool's name to authorize it, its
-// annotation hints to match annotation-scoped grants, and carries its input
-// schema so a caller can construct a usable replacement; everything else —
-// description, output schema, title, icons, `_meta`, vendor extensions — is
-// carried opaquely.
+// Tool is a tools/list entry that preserves members Gram does not model.
 type Tool struct {
-	// Name identifies the tool and is what Gram authorizes against, so it is
-	// read exact-key rather than through a case-insensitive struct match.
+	// Name identifies the tool for authorization.
 	Name string
 
-	// InputSchema is the tool's declared parameter schema, kept as the bytes the
-	// peer sent so no schema dialect or numeric formatting is reinterpreted.
+	// InputSchema preserves the peer's raw schema encoding.
 	InputSchema json.RawMessage
 
 	// Annotations is nil when the tool declared none.
@@ -214,9 +168,7 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 	return mergeModeled(t.extras, modeled)
 }
 
-// ToolsListResult is a tools/list result. Gram reads the tool array and the
-// pagination cursor; every other member — `resultType`, the caching hints,
-// `_meta`, vendor extensions — is carried.
+// ToolsListResult preserves unmodeled members of a tools/list result.
 type ToolsListResult struct {
 	Tools      []*Tool
 	NextCursor string
@@ -233,10 +185,7 @@ func (r *ToolsListResult) UnmarshalJSON(data []byte) error {
 
 	var next ToolsListResult
 	if raw, ok := members["tools"]; ok {
-		// An explicit null decodes to an empty list without error, which a
-		// mutation would then emit as [] — normalising the upstream's malformed
-		// payload on exactly the paths that happen to filter, and relaying it
-		// untouched on the rest. Refuse the view instead, so every path relays.
+		// Reject null so mutation cannot silently normalize it to [].
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return errors.New("tools is null, not an array")
 		}
@@ -244,8 +193,7 @@ func (r *ToolsListResult) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("decode tools: %w", err)
 		}
 	}
-	// A null entry would reach every reader of the list as a tool with no name,
-	// so it is refused here rather than guarded at each of them.
+	// Reject null entries before authorization code dereferences them.
 	for idx, tool := range next.Tools {
 		if tool == nil {
 			return fmt.Errorf("tool %d is null", idx)
@@ -266,7 +214,7 @@ func (r *ToolsListResult) UnmarshalJSON(data []byte) error {
 func (r ToolsListResult) MarshalJSON() ([]byte, error) {
 	tools := r.Tools
 	if tools == nil {
-		// MCP list results carry an array, never null.
+		// MCP requires an array.
 		tools = []*Tool{}
 	}
 	encodedTools, err := json.Marshal(tools)
@@ -286,8 +234,7 @@ func (r ToolsListResult) MarshalJSON() ([]byte, error) {
 	return mergeModeled(r.extras, modeled)
 }
 
-// Resource is a resources/list entry. Gram reads a resource's uri and name;
-// everything else is carried.
+// Resource is a resources/list entry that preserves members Gram does not model.
 type Resource struct {
 	URI  string
 	Name string
@@ -333,8 +280,7 @@ func (r Resource) MarshalJSON() ([]byte, error) {
 	return mergeModeled(r.extras, object{"uri": uri, "name": name})
 }
 
-// ResourcesListResult is a resources/list result, modeled like
-// [ToolsListResult].
+// ResourcesListResult preserves unmodeled members of a resources/list result.
 type ResourcesListResult struct {
 	Resources  []*Resource
 	NextCursor string
@@ -351,10 +297,7 @@ func (r *ResourcesListResult) UnmarshalJSON(data []byte) error {
 
 	var next ResourcesListResult
 	if raw, ok := members["resources"]; ok {
-		// An explicit null decodes to an empty list without error, which a
-		// mutation would then emit as [] — normalising the upstream's malformed
-		// payload on exactly the paths that happen to filter, and relaying it
-		// untouched on the rest. Refuse the view instead, so every path relays.
+		// Reject null so mutation cannot silently normalize it to [].
 		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 			return errors.New("resources is null, not an array")
 		}
@@ -401,16 +344,10 @@ func (r ResourcesListResult) MarshalJSON() ([]byte, error) {
 	return mergeModeled(r.extras, modeled)
 }
 
-// confineToCaller marks a list result the proxy has filtered for one caller as
-// cacheable only within that caller's authorization context. See the identically
-// named method on [object] for why.
 func (r *ToolsListResult) confineToCaller() { r.extras.confineToCaller() }
 
-// confineToCaller mirrors [ToolsListResult.confineToCaller].
 func (r *ResourcesListResult) confineToCaller() { r.extras.confineToCaller() }
 
-// clone returns a copy whose carried members can be mutated without touching the
-// original's, so a setter can stage a mutation and abandon it on failure.
 func (r ToolsListResult) clone() ToolsListResult {
 	r.extras = maps.Clone(r.extras)
 	if r.extras == nil {
@@ -420,7 +357,6 @@ func (r ToolsListResult) clone() ToolsListResult {
 	return r
 }
 
-// clone mirrors [ToolsListResult.clone].
 func (r ResourcesListResult) clone() ResourcesListResult {
 	r.extras = maps.Clone(r.extras)
 	if r.extras == nil {
@@ -430,17 +366,8 @@ func (r ResourcesListResult) clone() ResourcesListResult {
 	return r
 }
 
-// requireUnambiguousInvocation rejects a request payload whose members would
-// identify a different operation to a peer than the one Gram authorized.
-//
-// Gram authorizes a tools/call against the decoded `name` and then forwards the
-// payload, so a body carrying both `name` and a case-fold alias of it can be
-// authorized as one tool and executed as another by an exact-key upstream.
-// Dropping the alias is the right answer for a response Gram is filtering, but
-// not for a request: silently changing which tool is invoked is worse than
-// refusing to invoke one. Callers surface this as a [*RejectError] carrying
-// [RejectCodeInvalidParams] — the payload is invalid client input, so the caller
-// gets a JSON-RPC rejection rather than a 5xx blamed on the proxy.
+// requireUnambiguousInvocation rejects aliases that could make upstream invoke a
+// different tool than Gram authorized.
 func requireUnambiguousInvocation(members object, modeled ...string) error {
 	for _, name := range modeled {
 		if _, ok := members[name]; !ok {

--- a/server/internal/remotemcp/proxy/wire.go
+++ b/server/internal/remotemcp/proxy/wire.go
@@ -1,0 +1,439 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+)
+
+// The types here model the MCP payloads the proxy mutates. They exist instead of
+// the vendored modelcontextprotocol/go-sdk structs because a struct commits its
+// author's opinion about which members exist, and committing a mutation through
+// one publishes that opinion as Gram's: every member the SDK version does not
+// model is deleted in transit. MCP 2026-07-28 requires `resultType` on every
+// result and clients validate it, so a member Gram drops makes Gram the
+// non-compliant party for a payload the upstream got right — and the proxy is a
+// pass-through on protocol version, so the revision being validated against is
+// the one the client and the upstream settled between themselves, not one Gram
+// picked.
+//
+// Each type models the members Gram itself reads and carries every other member
+// of the same object, so a decode/encode round trip reproduces the payload.
+// Carried members live on the object that owns them, which is what makes
+// filtering a list preserve each surviving item's own members with no bookkeeping
+// on the side, and a nested object that Gram reads into is modeled by a type of
+// its own so the same guarantee holds one level down.
+//
+// Adding a field is how Gram takes a dependency on a member. Anything not listed
+// travels through untouched, which is the point.
+//
+// Two things are deliberately not preserved, because preserving them would make
+// the payload mean different things to different readers:
+//
+//   - A repeated member name collapses to the single value Go's decoder kept.
+//     Parsers disagree here — Go keeps the last, first-wins parsers are common —
+//     so relaying both onward would let Gram authorize one tool while a peer
+//     downstream reads another.
+//   - A member whose name differs from a modeled one only by case is dropped.
+//     Go matches a struct field to a member case-insensitively while the protocol
+//     matches keys exactly, so carrying both `name` and `Name` would leave Gram
+//     having authorized one value and a case-insensitive peer reading the other.
+//
+// Member order is not preserved either, but that carries no meaning. Byte-for-byte
+// relay remains the behaviour whenever nothing mutates, which never decodes at all.
+
+// extrasOnly returns the members of a decoded object that the modeled names do
+// not claim, dropping each modeled name and any case-fold alias of it.
+func extrasOnly(members object, modeled ...string) object {
+	extras := make(object, len(members))
+	maps.Copy(extras, members)
+
+	for _, name := range modeled {
+		delete(extras, name)
+		for carried := range extras {
+			if strings.EqualFold(carried, name) {
+				delete(extras, carried)
+			}
+		}
+	}
+
+	return extras
+}
+
+// mergeModeled writes the carried extras and then the modeled members into one
+// object, dropping any extra that case-fold collides with a modeled name so the
+// emitted object cannot read differently to a case-insensitive parser.
+func mergeModeled(extras object, modeled object) (json.RawMessage, error) {
+	names := make([]string, 0, len(modeled))
+	for name := range modeled {
+		names = append(names, name)
+	}
+
+	out := extrasOnly(extras, names...)
+	maps.Copy(out, modeled)
+
+	return out.encode()
+}
+
+// ToolAnnotations is a tool's annotation hints. Gram matches annotation-scoped
+// grants against the four the spec defines; anything else an upstream attaches is
+// carried. Absent and explicitly-false hints are both nil, so a caller cannot
+// mistake "not declared" for "declared false".
+type ToolAnnotations struct {
+	ReadOnlyHint    *bool
+	DestructiveHint *bool
+	IdempotentHint  *bool
+	OpenWorldHint   *bool
+
+	extras object
+}
+
+var annotationMembers = []string{"readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (a *ToolAnnotations) UnmarshalJSON(data []byte) error {
+	members, err := decodeObject(data)
+	if err != nil {
+		return fmt.Errorf("decode tool annotations: %w", err)
+	}
+
+	var next ToolAnnotations
+	for name, target := range map[string]**bool{
+		"readOnlyHint":    &next.ReadOnlyHint,
+		"destructiveHint": &next.DestructiveHint,
+		"idempotentHint":  &next.IdempotentHint,
+		"openWorldHint":   &next.OpenWorldHint,
+	} {
+		raw, ok := members[name]
+		if !ok {
+			continue
+		}
+		if err := json.Unmarshal(raw, target); err != nil {
+			return fmt.Errorf("decode annotation %q: %w", name, err)
+		}
+	}
+	next.extras = extrasOnly(members, annotationMembers...)
+
+	*a = next
+	return nil
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (a ToolAnnotations) MarshalJSON() ([]byte, error) {
+	modeled := object{}
+	for name, value := range map[string]*bool{
+		"readOnlyHint":    a.ReadOnlyHint,
+		"destructiveHint": a.DestructiveHint,
+		"idempotentHint":  a.IdempotentHint,
+		"openWorldHint":   a.OpenWorldHint,
+	} {
+		if value == nil {
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("encode annotation %q: %w", name, err)
+		}
+		modeled[name] = encoded
+	}
+
+	return mergeModeled(a.extras, modeled)
+}
+
+// Tool is a tools/list entry. Gram reads a tool's name to authorize it, its
+// annotation hints to match annotation-scoped grants, and carries its input
+// schema so a caller can construct a usable replacement; everything else —
+// description, output schema, title, icons, `_meta`, vendor extensions — is
+// carried opaquely.
+type Tool struct {
+	// Name identifies the tool and is what Gram authorizes against, so it is
+	// read exact-key rather than through a case-insensitive struct match.
+	Name string
+
+	// InputSchema is the tool's declared parameter schema, kept as the bytes the
+	// peer sent so no schema dialect or numeric formatting is reinterpreted.
+	InputSchema json.RawMessage
+
+	// Annotations is nil when the tool declared none.
+	Annotations *ToolAnnotations
+
+	extras object
+}
+
+var toolMembers = []string{"name", "inputSchema", "annotations"}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (t *Tool) UnmarshalJSON(data []byte) error {
+	members, err := decodeObject(data)
+	if err != nil {
+		return fmt.Errorf("decode tool: %w", err)
+	}
+
+	var next Tool
+	if raw, ok := members["name"]; ok {
+		if err := json.Unmarshal(raw, &next.Name); err != nil {
+			return fmt.Errorf("decode tool name: %w", err)
+		}
+	}
+	if raw, ok := members["inputSchema"]; ok {
+		next.InputSchema = raw
+	}
+	if raw, ok := members["annotations"]; ok {
+		if err := json.Unmarshal(raw, &next.Annotations); err != nil {
+			return fmt.Errorf("decode tool annotations: %w", err)
+		}
+	}
+	next.extras = extrasOnly(members, toolMembers...)
+
+	*t = next
+	return nil
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (t Tool) MarshalJSON() ([]byte, error) {
+	name, err := json.Marshal(t.Name)
+	if err != nil {
+		return nil, fmt.Errorf("encode tool name: %w", err)
+	}
+
+	modeled := object{"name": name}
+	if len(t.InputSchema) > 0 {
+		modeled["inputSchema"] = t.InputSchema
+	}
+	if t.Annotations != nil {
+		encoded, err := json.Marshal(*t.Annotations)
+		if err != nil {
+			return nil, fmt.Errorf("encode tool annotations: %w", err)
+		}
+		modeled["annotations"] = encoded
+	}
+
+	return mergeModeled(t.extras, modeled)
+}
+
+// ToolsListResult is a tools/list result. Gram reads the tool array and the
+// pagination cursor; every other member — `resultType`, the caching hints,
+// `_meta`, vendor extensions — is carried.
+type ToolsListResult struct {
+	Tools      []*Tool
+	NextCursor string
+
+	extras object
+}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (r *ToolsListResult) UnmarshalJSON(data []byte) error {
+	members, err := decodeObject(data)
+	if err != nil {
+		return fmt.Errorf("decode tools/list result: %w", err)
+	}
+
+	var next ToolsListResult
+	if raw, ok := members["tools"]; ok {
+		if err := json.Unmarshal(raw, &next.Tools); err != nil {
+			return fmt.Errorf("decode tools: %w", err)
+		}
+	}
+	// A null entry would reach every reader of the list as a tool with no name,
+	// so it is refused here rather than guarded at each of them.
+	for idx, tool := range next.Tools {
+		if tool == nil {
+			return fmt.Errorf("tool %d is null", idx)
+		}
+	}
+	if raw, ok := members["nextCursor"]; ok {
+		if err := json.Unmarshal(raw, &next.NextCursor); err != nil {
+			return fmt.Errorf("decode nextCursor: %w", err)
+		}
+	}
+	next.extras = extrasOnly(members, "tools", "nextCursor")
+
+	*r = next
+	return nil
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (r ToolsListResult) MarshalJSON() ([]byte, error) {
+	tools := r.Tools
+	if tools == nil {
+		// MCP list results carry an array, never null.
+		tools = []*Tool{}
+	}
+	encodedTools, err := json.Marshal(tools)
+	if err != nil {
+		return nil, fmt.Errorf("encode tools: %w", err)
+	}
+
+	modeled := object{"tools": encodedTools}
+	if r.NextCursor != "" {
+		cursor, err := json.Marshal(r.NextCursor)
+		if err != nil {
+			return nil, fmt.Errorf("encode nextCursor: %w", err)
+		}
+		modeled["nextCursor"] = cursor
+	}
+
+	return mergeModeled(r.extras, modeled)
+}
+
+// Resource is a resources/list entry. Gram reads a resource's uri and name;
+// everything else is carried.
+type Resource struct {
+	URI  string
+	Name string
+
+	extras object
+}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (r *Resource) UnmarshalJSON(data []byte) error {
+	members, err := decodeObject(data)
+	if err != nil {
+		return fmt.Errorf("decode resource: %w", err)
+	}
+
+	var next Resource
+	if raw, ok := members["uri"]; ok {
+		if err := json.Unmarshal(raw, &next.URI); err != nil {
+			return fmt.Errorf("decode resource uri: %w", err)
+		}
+	}
+	if raw, ok := members["name"]; ok {
+		if err := json.Unmarshal(raw, &next.Name); err != nil {
+			return fmt.Errorf("decode resource name: %w", err)
+		}
+	}
+	next.extras = extrasOnly(members, "uri", "name")
+
+	*r = next
+	return nil
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (r Resource) MarshalJSON() ([]byte, error) {
+	uri, err := json.Marshal(r.URI)
+	if err != nil {
+		return nil, fmt.Errorf("encode resource uri: %w", err)
+	}
+	name, err := json.Marshal(r.Name)
+	if err != nil {
+		return nil, fmt.Errorf("encode resource name: %w", err)
+	}
+
+	return mergeModeled(r.extras, object{"uri": uri, "name": name})
+}
+
+// ResourcesListResult is a resources/list result, modeled like
+// [ToolsListResult].
+type ResourcesListResult struct {
+	Resources  []*Resource
+	NextCursor string
+
+	extras object
+}
+
+// UnmarshalJSON implements [json.Unmarshaler].
+func (r *ResourcesListResult) UnmarshalJSON(data []byte) error {
+	members, err := decodeObject(data)
+	if err != nil {
+		return fmt.Errorf("decode resources/list result: %w", err)
+	}
+
+	var next ResourcesListResult
+	if raw, ok := members["resources"]; ok {
+		if err := json.Unmarshal(raw, &next.Resources); err != nil {
+			return fmt.Errorf("decode resources: %w", err)
+		}
+	}
+	for idx, resource := range next.Resources {
+		if resource == nil {
+			return fmt.Errorf("resource %d is null", idx)
+		}
+	}
+	if raw, ok := members["nextCursor"]; ok {
+		if err := json.Unmarshal(raw, &next.NextCursor); err != nil {
+			return fmt.Errorf("decode nextCursor: %w", err)
+		}
+	}
+	next.extras = extrasOnly(members, "resources", "nextCursor")
+
+	*r = next
+	return nil
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (r ResourcesListResult) MarshalJSON() ([]byte, error) {
+	resources := r.Resources
+	if resources == nil {
+		resources = []*Resource{}
+	}
+	encodedResources, err := json.Marshal(resources)
+	if err != nil {
+		return nil, fmt.Errorf("encode resources: %w", err)
+	}
+
+	modeled := object{"resources": encodedResources}
+	if r.NextCursor != "" {
+		cursor, err := json.Marshal(r.NextCursor)
+		if err != nil {
+			return nil, fmt.Errorf("encode nextCursor: %w", err)
+		}
+		modeled["nextCursor"] = cursor
+	}
+
+	return mergeModeled(r.extras, modeled)
+}
+
+// confineToCaller marks a list result the proxy has filtered for one caller as
+// cacheable only within that caller's authorization context. See the identically
+// named method on [object] for why.
+func (r *ToolsListResult) confineToCaller() { r.extras.confineToCaller() }
+
+// confineToCaller mirrors [ToolsListResult.confineToCaller].
+func (r *ResourcesListResult) confineToCaller() { r.extras.confineToCaller() }
+
+// clone returns a copy whose carried members can be mutated without touching the
+// original's, so a setter can stage a mutation and abandon it on failure.
+func (r ToolsListResult) clone() ToolsListResult {
+	r.extras = maps.Clone(r.extras)
+	if r.extras == nil {
+		r.extras = object{}
+	}
+
+	return r
+}
+
+// clone mirrors [ToolsListResult.clone].
+func (r ResourcesListResult) clone() ResourcesListResult {
+	r.extras = maps.Clone(r.extras)
+	if r.extras == nil {
+		r.extras = object{}
+	}
+
+	return r
+}
+
+// requireUnambiguousInvocation rejects a request payload whose members would
+// identify a different operation to a peer than the one Gram authorized.
+//
+// Gram authorizes a tools/call against the decoded `name` and then forwards the
+// payload, so a body carrying both `name` and a case-fold alias of it can be
+// authorized as one tool and executed as another by an exact-key upstream.
+// Dropping the alias is the right answer for a response Gram is filtering, but
+// not for a request: silently changing which tool is invoked is worse than
+// refusing to invoke one. Callers surface this as a mutation failure.
+func requireUnambiguousInvocation(members object, modeled ...string) error {
+	for _, name := range modeled {
+		if _, ok := members[name]; !ok {
+			continue
+		}
+		for carried := range members {
+			if carried != name && strings.EqualFold(carried, name) {
+				return fmt.Errorf("members %q and %q differ only by case", name, carried)
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/internal/remotemcp/proxy/wire.go
+++ b/server/internal/remotemcp/proxy/wire.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -231,6 +233,13 @@ func (r *ToolsListResult) UnmarshalJSON(data []byte) error {
 
 	var next ToolsListResult
 	if raw, ok := members["tools"]; ok {
+		// An explicit null decodes to an empty list without error, which a
+		// mutation would then emit as [] — normalising the upstream's malformed
+		// payload on exactly the paths that happen to filter, and relaying it
+		// untouched on the rest. Refuse the view instead, so every path relays.
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return errors.New("tools is null, not an array")
+		}
 		if err := json.Unmarshal(raw, &next.Tools); err != nil {
 			return fmt.Errorf("decode tools: %w", err)
 		}
@@ -342,6 +351,13 @@ func (r *ResourcesListResult) UnmarshalJSON(data []byte) error {
 
 	var next ResourcesListResult
 	if raw, ok := members["resources"]; ok {
+		// An explicit null decodes to an empty list without error, which a
+		// mutation would then emit as [] — normalising the upstream's malformed
+		// payload on exactly the paths that happen to filter, and relaying it
+		// untouched on the rest. Refuse the view instead, so every path relays.
+		if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return errors.New("resources is null, not an array")
+		}
 		if err := json.Unmarshal(raw, &next.Resources); err != nil {
 			return fmt.Errorf("decode resources: %w", err)
 		}

--- a/server/internal/remotemcp/proxy/wire.go
+++ b/server/internal/remotemcp/proxy/wire.go
@@ -438,7 +438,9 @@ func (r ResourcesListResult) clone() ResourcesListResult {
 // authorized as one tool and executed as another by an exact-key upstream.
 // Dropping the alias is the right answer for a response Gram is filtering, but
 // not for a request: silently changing which tool is invoked is worse than
-// refusing to invoke one. Callers surface this as a mutation failure.
+// refusing to invoke one. Callers surface this as a [*RejectError] carrying
+// [RejectCodeInvalidParams] — the payload is invalid client input, so the caller
+// gets a JSON-RPC rejection rather than a 5xx blamed on the proxy.
 func requireUnambiguousInvocation(members object, modeled ...string) error {
 	for _, name := range modeled {
 		if _, ok := members[name]; !ok {

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 )
@@ -64,16 +62,22 @@ func (i *ToolsListMCPConnectFilterInterceptor) Name() string {
 // challenge-log entry for the batch, not N), and rebuilds the tool
 // slice in input order keeping only authorized entries.
 //
-// When the response carries no tools the interceptor is a no-op. An
-// empty filtered result is a valid outcome — the caller has access to
-// nothing in this server — and is committed via [SetTools] as an empty
-// array.
+// An empty filtered result is a valid outcome — the caller has access to nothing
+// in this server — and is committed via [proxy.ToolsListResponse.SetTools] as an
+// empty array. A page that arrives with no tools is still committed rather than
+// skipped: SetTools confines a filtered result to the calling authorization
+// context, and the spec requires one cache scope across every page of a list
+// request, so skipping would leave an empty page publicly cacheable while its
+// siblings are not.
 func (i *ToolsListMCPConnectFilterInterceptor) InterceptToolsListResponse(ctx context.Context, list *proxy.ToolsListResponse) error {
 	if i.authz == nil || list == nil || list.Result == nil {
 		return nil
 	}
 	tools := list.Result.Tools
 	if len(tools) == 0 {
+		if err := list.SetTools(tools); err != nil {
+			return fmt.Errorf("commit empty tools/list page: %w", err)
+		}
 		return nil
 	}
 
@@ -100,7 +104,7 @@ func (i *ToolsListMCPConnectFilterInterceptor) InterceptToolsListResponse(ctx co
 		return fmt.Errorf("filter mcp:connect tools: %w", err)
 	}
 
-	allowed := make([]*mcp.Tool, 0, len(tools))
+	allowed := make([]*proxy.Tool, 0, len(tools))
 	for idx, t := range tools {
 		if matched[idx] {
 			allowed = append(allowed, t)

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
@@ -1,11 +1,11 @@
 package remotemcp_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -16,30 +16,28 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-// newToolsListResponse constructs a typed view with the given tools and
-// a fresh RemoteMessage backing the SetTools setter. The RemoteMessage
-// carries a *jsonrpc.Response whose Result is set to a marshaled
-// ListToolsResult so SetTools can re-marshal cleanly.
-func newToolsListResponse(t *testing.T, tools []*mcp.Tool) *proxy.ToolsListResponse {
+// newToolsListResponse constructs a typed view whose result was decoded from wire
+// bytes, so it carries the members [proxy.ToolsListResponse.SetTools] preserves.
+func newToolsListResponse(t *testing.T, tools []*proxy.Tool) *proxy.ToolsListResponse {
 	t.Helper()
 
-	result := &mcp.ListToolsResult{
-		Meta:       nil,
-		NextCursor: "",
-		Tools:      tools,
-	}
-	rpcResp := &jsonrpc.Response{
-		ID:     jsonrpc.ID{},
-		Result: nil,
-		Error:  nil,
-	}
+	payload, err := json.Marshal(&proxy.ToolsListResult{Tools: tools, NextCursor: ""})
+	require.NoError(t, err)
+
+	result := &proxy.ToolsListResult{Tools: nil, NextCursor: ""}
+	require.NoError(t, json.Unmarshal(payload, result))
+
 	return &proxy.ToolsListResponse{
 		Error: nil,
 		RemoteMessage: &proxy.RemoteMessage{
 			UserHTTPRequest:    nil,
 			RemoteHTTPRequest:  nil,
 			RemoteHTTPResponse: nil,
-			Message:            rpcResp,
+			Message: &jsonrpc.Response{
+				ID:     jsonrpc.ID{},
+				Result: payload,
+				Error:  nil,
+			},
 		},
 		Request: nil,
 		Result:  result,
@@ -59,9 +57,9 @@ func TestToolsListMCPConnectFilterInterceptor_NilEnginePassesThrough(t *testing.
 	// A nil engine must not panic; pass the response through unchanged.
 	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(nil, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
-	resp := newToolsListResponse(t, []*mcp.Tool{
-		{Name: "tool_a", InputSchema: map[string]any{}},
-		{Name: "tool_b", InputSchema: map[string]any{}},
+	resp := newToolsListResponse(t, []*proxy.Tool{
+		{Name: "tool_a"},
+		{Name: "tool_b"},
 	})
 	require.NoError(t, interceptor.InterceptToolsListResponse(t.Context(), resp))
 	require.Len(t, resp.Result.Tools, 2, "nil engine must leave the tools array unchanged")
@@ -82,10 +80,10 @@ func TestToolsListMCPConnectFilterInterceptor_KeepsOnlyGrantedTools(t *testing.T
 
 	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
-	resp := newToolsListResponse(t, []*mcp.Tool{
-		{Name: "search_tickets", InputSchema: map[string]any{}},
-		{Name: "delete_ticket", InputSchema: map[string]any{}},
-		{Name: "update_ticket", InputSchema: map[string]any{}},
+	resp := newToolsListResponse(t, []*proxy.Tool{
+		{Name: "search_tickets"},
+		{Name: "delete_ticket"},
+		{Name: "update_ticket"},
 	})
 	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
 
@@ -105,9 +103,9 @@ func TestToolsListMCPConnectFilterInterceptor_EmptyArrayWhenNoGrantsMatch(t *tes
 
 	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
-	resp := newToolsListResponse(t, []*mcp.Tool{
-		{Name: "tool_a", InputSchema: map[string]any{}},
-		{Name: "tool_b", InputSchema: map[string]any{}},
+	resp := newToolsListResponse(t, []*proxy.Tool{
+		{Name: "tool_a"},
+		{Name: "tool_b"},
 	})
 	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
 	require.Empty(t, resp.Result.Tools)
@@ -136,11 +134,11 @@ func TestToolsListMCPConnectFilterInterceptor_PreservesInputOrderInFilteredResul
 
 	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
-	resp := newToolsListResponse(t, []*mcp.Tool{
-		{Name: "tool_a", InputSchema: map[string]any{}},
-		{Name: "tool_b", InputSchema: map[string]any{}},
-		{Name: "tool_c", InputSchema: map[string]any{}},
-		{Name: "tool_d", InputSchema: map[string]any{}},
+	resp := newToolsListResponse(t, []*proxy.Tool{
+		{Name: "tool_a"},
+		{Name: "tool_b"},
+		{Name: "tool_c"},
+		{Name: "tool_d"},
 	})
 	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
 
@@ -203,9 +201,9 @@ func TestToolsListMCPConnectFilterInterceptor_FiltersByDisposition(t *testing.T)
 	}}
 	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
 
-	resp := newToolsListResponse(t, []*mcp.Tool{
-		{Name: "list_items", InputSchema: map[string]any{}},
-		{Name: "delete_item", InputSchema: map[string]any{}},
+	resp := newToolsListResponse(t, []*proxy.Tool{
+		{Name: "list_items"},
+		{Name: "delete_item"},
 	})
 	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
 
@@ -232,8 +230,8 @@ func TestToolsListMCPConnectFilterInterceptor_ResolverErrorFailsClosed(t *testin
 	resolver := fakeToolDispositionResolver{err: errors.New("metadata store unavailable")}
 	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
 
-	resp := newToolsListResponse(t, []*mcp.Tool{
-		{Name: "list_items", InputSchema: map[string]any{}},
+	resp := newToolsListResponse(t, []*proxy.Tool{
+		{Name: "list_items"},
 	})
 	err := interceptor.InterceptToolsListResponse(ctx, resp)
 	require.Error(t, err)
@@ -263,9 +261,9 @@ func TestToolsListMCPConnectFilterInterceptor_KeepsUnclassifiedGrantedTool(t *te
 	resolver := fakeToolDispositionResolver{dispositions: map[string]string{"tool_b": "destructive"}}
 	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
 
-	resp := newToolsListResponse(t, []*mcp.Tool{
-		{Name: "tool_a", InputSchema: map[string]any{}},
-		{Name: "tool_b", InputSchema: map[string]any{}},
+	resp := newToolsListResponse(t, []*proxy.Tool{
+		{Name: "tool_a"},
+		{Name: "tool_b"},
 	})
 	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
 


### PR DESCRIPTION
## Summary

A client on MCP 2026-07-28 fails against a Gram-hosted MCP server that fronts a third-party MCP server:

```
Reconnected to <server>, but fetching tools failed: Invalid result for tools/list:
missing required resultType — servers implementing protocol revision 2026-07-28
MUST include it (the absent-means-complete bridge applies only to earlier-revision
servers)
```

`resultType` (SEP-2322) is required on every result from 2026-07-28 onward; the absent-means-complete bridge applies only to servers on earlier revisions. The upstream sends it and Gram deletes it in transit.

## Root cause

The proxy's typed views decode a relayed payload into a `modelcontextprotocol/go-sdk` struct, and every setter committed a mutation by re-marshaling that struct back over the wire payload:

```go
staged := *r.Result
staged.Tools = tools
payload, err := json.Marshal(&staged)   // ListToolsResult models _meta, nextCursor, tools
rpcResp.Result = payload                // every other upstream member: gone
```

`mcp.ListToolsResult` in v1.6.1 has no `resultType`, no `ttlMs`, no `cacheScope` — the SDK has no 2026-07-28 support at all. The proxy is deliberately a pass-through on protocol version (the client and the upstream settle a revision between themselves), so the client validates the relayed payload against what the *upstream* answered. A member Gram drops makes Gram the non-compliant party for a payload the upstream got right.

Only private-visibility servers filter `tools/list`, which is why this reproduces for some callers of an endpoint and not others: with nothing to commit, `dirty` stays false and the upstream's bytes relay untouched.

The same pattern was in `SetResources` and in `SetArguments`, where it also dropped multi round-trip `requestState` and `inputResponses` from `tools/call` params.

## Change

The payloads the proxy mutates now have Gram-owned types (`wire.go`) that model the members Gram itself reads and **carry every other member of the same object**, so a decode/encode round trip reproduces the payload:

```go
type ToolsListResult struct {
    Tools      []*Tool
    NextCursor string
    extras     object // resultType, ttlMs, cacheScope, _meta, vendor members
}

type Tool struct {
    Name        string
    InputSchema json.RawMessage
    Annotations *ToolAnnotations
    extras      object // description, outputSchema, title, icons, _meta, vendor members
}
```

`ToolAnnotations` models the four hints the spec defines and carries the rest, so the guarantee holds one level down too. Adding a field is how Gram takes a dependency on a member; anything not listed is nobody's business here.

Because the carried members live on **the object that owns them**, filtering a list preserves each surviving tool's own members with no bookkeeping on the side, and a tool a caller constructs simply carries none. `SetTools` and `SetResources` keep their shape — the RBAC filter is unchanged apart from its slice type (+11/-7).

### Two things are deliberately not preserved

Preserving them would let the payload mean different things to different readers:

- **A repeated member name** collapses to the value Go's decoder kept. Parsers disagree — Go keeps the last, first-wins parsers are common — so relaying both would let Gram authorize one tool while a peer downstream reads another.
- **A member differing from a modeled one only by case** is dropped. Go matches a struct field case-insensitively while the protocol matches keys exactly, so carrying both `name` and `Name` would leave Gram having authorized one value and a case-insensitive peer reading the other.

On a **request** that second case is refused rather than resolved: Gram authorizes a `tools/call` against the decoded name and then forwards the payload, so silently choosing which of two spellings to invoke is worse than refusing to invoke anything.

### Two more things fall out

- **`null` payloads.** A JSON `null` unmarshals into a map by setting it to nil rather than failing, so a filter reaching the commit would have written to a nil map and panicked. A null result, null params, and a null tool in the array are all refused at decode, leaving the payload to relay as it arrived.
- **Cache scope on a filtered list.** Gram rewrites a list precisely when it has filtered the inventory for one caller, so relaying an upstream's `cacheScope: "public"` would authorize any cache between Gram and the model to serve one caller's tools to another — the sharing that scope permits and that the spec names as a security consideration. The scope becomes `"private"` (what the spec names for filtered per-user lists) and `ttlMs` goes to zero, because the upstream's TTL describes how long *its* inventory stays fresh and says nothing about Gram's filtering of it, which a revoked grant changes at once in a cache Gram cannot invalidate. Neither member is introduced where the upstream sent none, and empty pages are committed too, since the spec requires one cache scope across every page of a list request.

Marshalers take value receivers so a payload marshaled by value cannot silently fall back to reflection and emit Go field names instead of the wire shape.

## Validated against the real upstream

Confirmed end to end on the preview, through a private remote-MCP-backed server fronting Linear:

```
result members : ['_meta', 'cacheScope', 'resultType', 'tools', 'ttlMs']
resultType     : "complete"
cacheScope     : "private"
ttlMs          : 0
tool count     : 63
```

- Linear genuinely emits `resultType: "complete"` — it is on 2026-07-28 and validates the request envelope, rejecting a probe that omitted `io.modelcontextprotocol/clientCapabilities`. This was the one link previously inferred rather than observed.
- The relayed result carries it through the RBAC filter.
- `cacheScope: "private"` and `ttlMs: 0` are Gram's own values rather than Linear's, which is the proof that the mutation path actually ran — precisely where the old code re-marshalled through `mcp.ListToolsResult` and destroyed all three members.

## Testing

End-to-end through the real proxy path (`httptest` upstream → `Proxy.Post` → recorded bytes): unmodelled members survive a filter at the result, tool, and annotation levels; an unmutated response relays byte-identically; an injected tool carries only what it was given and a renamed tool keeps its other members; cursor-bearing and empty filters keep their surrounding members; public cache scope becomes private with a zeroed TTL and no hint is invented where the upstream sent none; a repeated member name collapses to the value Gram authorized and a case variant is dropped; an ambiguous `tools/call` invocation is refused and never forwarded; `resources/list` behaves the same; MRT `requestState`/`inputResponses` survive an argument rewrite; `null` result, `null` params and a `null` tool all fail closed without panicking.

`mise lint:server` and the full `./server/internal/remotemcp/...` suite pass.

## Notes for review

- **`SetTools` keeps its signature but changes its element type**, `[]*mcp.Tool` → `[]*proxy.Tool`. Callers on other branches need the type swap and, where they read annotations, `tool.Annotations` is now `*proxy.ToolAnnotations` with `*bool` hints rather than the SDK's mixed shape. The consent-tool-filtering branch has one such call site.
- Designed and reviewed across four rounds with codex `gpt-5.6-sol`. Two earlier iterations of this PR were discarded: one kept each item's original bytes and compared canonical marshals to detect in-place edits, the other pushed callers onto raw maps and a `KeepTools(keep []bool)` mask. Both are gone — the reconciliation and the mask existed only because the payload's unmodelled members had nowhere to live.

## Deliberately out of scope

Adjacent 2026-07-28 gaps found while tracing this, left for focused follow-ups because they are version-negotiation or authorization changes rather than relay fidelity:

- The mirrored `Mcp-Method`/`Mcp-Name` headers the revision added are forwarded upstream unvalidated while Gram authorizes the body, so a caller can send a permitted tool name in the body carrying a withheld one in the header for a routing intermediary to act on. The spec requires any server that reads the body to reject the mismatch — and also to *require* those headers and to check `MCP-Protocol-Version` against body `_meta`, so a complete fix is version-aware and belongs on its own.
- Relatedly, a `tools/call` whose params repeat `name` is authorized on Go's last-wins value and forwarded verbatim when no interceptor mutates it, so a first-wins peer could execute the other. Pre-existing, and needs a rejection hook rather than a commit-path guard.
- Gram's own hosted toolset surface answers `2025-03-26` unconditionally and dispatches `tools/list` with no version gate and no `initialize` required, so a 2026-07-28-only client gets a result with no `resultType` and rejects it — same symptom, different cause. Verified locally; it also emits `"tools":null` where the spec requires an array.
- The `initialize` PostHog analytics never fire for clients on 2026-07-28, which has no `initialize`.
- Usage and billing interceptors count an MRT interim `tools/call` result as a completed call.
