### PR TITLE
feat(server): attribute platform mcp writes to their acting surface

### DIFF
--- a/server/internal/platformmcp/adapters.go
+++ b/server/internal/platformmcp/adapters.go
@@ -76,6 +76,7 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (Prin
 	}
 
 	return Principal{
+		Surface:        SurfacePlatformMCP,
 		UserID:         subject.ID,
 		OrganizationID: session.OrganizationID,
 		ConnectionID:   session.ConnectionID.String(),
@@ -114,7 +115,7 @@ func (s *LiveOrganizationSelector) EligibleOrganizations(ctx context.Context, us
 	}
 	options := make([]OrganizationOption, 0, len(organizations))
 	for _, organization := range organizations {
-		if err := s.authorizer.RequireLiveOrgAdmin(ctx, Principal{UserID: userID, OrganizationID: organization.ID, ConnectionID: "", Generation: "", ClientID: ""}); err != nil {
+		if err := s.authorizer.RequireLiveOrgAdmin(ctx, Principal{UserID: userID, OrganizationID: organization.ID, ConnectionID: "", Generation: "", ClientID: "", Surface: SurfacePlatformMCP}); err != nil {
 			if isAuthorizationDenied(err) {
 				continue
 			}

--- a/server/internal/platformmcp/distribution_service.go
+++ b/server/internal/platformmcp/distribution_service.go
@@ -127,7 +127,7 @@ func (s *DistributionService) Distribute(ctx context.Context, principal Principa
 		return Distribution{}, ErrDistributionInvalid
 	}
 
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return Distribution{}, ErrDistributionInvalid
 	}
@@ -253,7 +253,7 @@ func (s *DistributionService) Remove(ctx context.Context, principal Principal, i
 		return Distribution{}, ErrDistributionInvalid
 	}
 
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return Distribution{}, ErrDistributionInvalid
 	}

--- a/server/internal/platformmcp/feedback.go
+++ b/server/internal/platformmcp/feedback.go
@@ -72,7 +72,7 @@ func (s *FeedbackService) Submit(ctx context.Context, principal Principal, input
 		return FeedbackResult{}, err
 	}
 
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return FeedbackResult{}, ErrFeedbackInvalid
 	}

--- a/server/internal/platformmcp/feedback_integration_test.go
+++ b/server/internal/platformmcp/feedback_integration_test.go
@@ -65,7 +65,7 @@ WHERE id = $1`, created.TrackingID).Scan(
 		&stored.ExpiresAt,
 	)
 	require.NoError(t, err)
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	require.NoError(t, err)
 	require.Equal(t, principal.OrganizationID, stored.OrganizationID)
 	require.Equal(t, connectionID, stored.ConnectionID)
@@ -104,7 +104,7 @@ func TestFeedbackServiceEnforcesConnectionLimitAndRejectsReplacedGeneration(t *t
 	require.ErrorIs(t, err, ErrFeedbackRateLimited)
 
 	freshPrincipal, _ := seedRegistrationLifecycle(t, ctx, conn)
-	connectionID, _, err := principalConnection(freshPrincipal)
+	connectionID, _, err := parseConnection(freshPrincipal)
 	require.NoError(t, err)
 	_, err = platformrepo.New(conn).RotatePlatformMCPConnectionGeneration(ctx, platformrepo.RotatePlatformMCPConnectionGenerationParams{
 		ActiveGeneration: uuid.New(),

--- a/server/internal/platformmcp/lifecycle.go
+++ b/server/internal/platformmcp/lifecycle.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -91,7 +92,7 @@ func (s *RegistrationStore) IssueSetupHandoff(ctx context.Context, principal Pri
 	if s == nil || s.db == nil {
 		return IssuedSetupHandoff{}, ErrUnavailable
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return IssuedSetupHandoff{}, err
 	}
@@ -182,7 +183,7 @@ func (s *RegistrationStore) ConsumeSetupHandoff(ctx context.Context, principal P
 	if s == nil || s.db == nil {
 		return SetupHandoff{}, ErrUnavailable
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return SetupHandoff{}, err
 	}
@@ -247,7 +248,7 @@ func (s *RegistrationStore) BeginProviderSetup(ctx context.Context, principal Pr
 	if s == nil || s.db == nil {
 		return ProviderSetupResult{}, ErrUnavailable
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return ProviderSetupResult{}, err
 	}
@@ -318,7 +319,7 @@ func (s *RegistrationStore) ProbeProviderReadiness(ctx context.Context, principa
 	if s == nil || s.db == nil {
 		return Readiness{}, ErrUnavailable
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return Readiness{}, err
 	}
@@ -378,7 +379,7 @@ func (s *RegistrationStore) GetProviderReadiness(ctx context.Context, principal 
 	if s == nil || s.db == nil {
 		return Readiness{}, false, ErrUnavailable
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return Readiness{}, false, err
 	}
@@ -416,7 +417,7 @@ func (s *RegistrationStore) RecordReadiness(ctx context.Context, principal Princ
 	if s == nil || s.db == nil {
 		return Readiness{}, ErrUnavailable
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return Readiness{}, err
 	}
@@ -512,7 +513,7 @@ func (s *RegistrationStore) recordSetupFailure(ctx context.Context, principal Pr
 }
 
 func recordSetupMilestone(ctx context.Context, q *platformrepo.Queries, principal Principal, registration platformrepo.PlatformMcpCatalogRegistration, handoffID uuid.UUID, milestone string) error {
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return err
 	}
@@ -542,6 +543,10 @@ func isSetupMilestone(value string) bool {
 	}
 }
 
+// lifecycleRegistration resolves a registration the caller is entitled to act
+// on. Ownership matches the real user; a caller holding an OAuth connection
+// additionally has its generation checked live, which a connectionless surface
+// has no equivalent of and is instead authorized on every call upstream.
 func lifecycleRegistration(ctx context.Context, q *platformrepo.Queries, principal Principal, projectID, registrationID uuid.UUID) (platformrepo.PlatformMcpCatalogRegistration, error) {
 	connectionID, generation, err := principalConnection(principal)
 	if err != nil {
@@ -553,6 +558,7 @@ func lifecycleRegistration(ctx context.Context, q *platformrepo.Queries, princip
 		ProjectID:            projectID,
 		ConnectionID:         connectionID,
 		ConnectionGeneration: generation,
+		UserID:               conv.ToPGText(principal.UserID),
 		SubjectUrn:           userSubjectURN(principal.UserID),
 	})
 	if err != nil {

--- a/server/internal/platformmcp/onboarding.go
+++ b/server/internal/platformmcp/onboarding.go
@@ -241,7 +241,7 @@ func (s *OnboardingService) RecordCatalogExplored(ctx context.Context, principal
 	if s == nil || s.db == nil {
 		return ErrUnavailable
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func (s *OnboardingService) recordLifecycleMilestone(ctx context.Context, princi
 	if s == nil || s.db == nil || projectID == uuid.Nil || registrationID == uuid.Nil {
 		return ErrOnboardingInvalid
 	}
-	connectionID, generation, err := principalConnection(principal)
+	connectionID, generation, err := parseConnection(principal)
 	if err != nil {
 		return err
 	}

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -455,30 +455,48 @@ SELECT pg_advisory_xact_lock(
 );
 
 -- name: GetPlatformMCPOperationReceipt :one
+-- Idempotency belongs to the real user, not to a connection: reauthorization
+-- mints a new connection generation and must not let the same key replay a
+-- create. Receipts written before user_id existed carry only a connection, so
+-- they are still matched through its subject.
 SELECT receipt.*
 FROM platform_mcp_operation_receipts AS receipt
-JOIN platform_mcp_connections AS connection
+LEFT JOIN platform_mcp_connections AS connection
   ON connection.id = receipt.connection_id
  AND connection.organization_id = receipt.organization_id
 WHERE receipt.organization_id = @organization_id
-  AND connection.subject_urn = @subject_urn
   AND receipt.project_id = @project_id
   AND receipt.operation = @operation
   AND receipt.idempotency_key = @idempotency_key
+  AND (
+    receipt.user_id = @user_id
+    OR (receipt.user_id IS NULL AND connection.subject_urn = @subject_urn)
+  )
 ORDER BY receipt.created_at DESC, receipt.id DESC
 LIMIT 1;
 
 -- name: DeleteExpiredPlatformMCPOperationReceipt :execrows
+-- Matches GetPlatformMCPOperationReceipt exactly. A receipt this cannot reach
+-- never expires, and its idempotency key stays unusable for that user.
 DELETE FROM platform_mcp_operation_receipts AS receipt
-USING platform_mcp_connections AS connection
-WHERE receipt.connection_id = connection.id
-  AND receipt.organization_id = connection.organization_id
-  AND receipt.organization_id = @organization_id
-  AND connection.subject_urn = @subject_urn
+WHERE receipt.organization_id = @organization_id
   AND receipt.project_id = @project_id
   AND receipt.operation = @operation
   AND receipt.idempotency_key = @idempotency_key
-  AND receipt.expires_at <= clock_timestamp();
+  AND receipt.expires_at <= clock_timestamp()
+  AND (
+    receipt.user_id = @user_id
+    OR (
+      receipt.user_id IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM platform_mcp_connections AS connection
+        WHERE connection.id = receipt.connection_id
+          AND connection.organization_id = receipt.organization_id
+          AND connection.subject_urn = @subject_urn
+      )
+    )
+  );
 
 -- name: CreatePlatformMCPOperationReceipt :one
 INSERT INTO platform_mcp_operation_receipts (
@@ -487,6 +505,8 @@ INSERT INTO platform_mcp_operation_receipts (
     registration_id,
     connection_id,
     connection_generation,
+    user_id,
+    acting_surface,
     operation,
     idempotency_key,
     input_hash,
@@ -499,6 +519,8 @@ INSERT INTO platform_mcp_operation_receipts (
     @registration_id,
     @connection_id,
     @connection_generation,
+    @user_id,
+    @acting_surface,
     @operation,
     @idempotency_key,
     @input_hash,
@@ -594,15 +616,21 @@ WHERE id = @id
 
 -- name: GetPlatformMCPCatalogRegistrationForLifecycle :one
 -- Registrations are project desired state, not permanently owned by the OAuth
--- client that originally created them. Lifecycle actions require the current
--- active Platform connection to belong to that same user subject.
+-- client that originally created them. Lifecycle actions require the caller to
+-- be the same user that created the registration.
+--
+-- A caller acting through an OAuth connection must additionally present a
+-- live, unrevoked generation. A surface that holds no connection — the project
+-- assistant acts under assistant identity — passes a null connection and is
+-- authorized on every call upstream instead. Ownership still matches on the
+-- real user, so a null connection widens nothing.
 SELECT registration.*
 FROM platform_mcp_catalog_registrations AS registration
-JOIN platform_mcp_connections AS created_connection
+LEFT JOIN platform_mcp_connections AS created_connection
   ON created_connection.id = registration.connection_id
  AND created_connection.organization_id = registration.organization_id
-JOIN platform_mcp_connections AS current_connection
-  ON current_connection.id = @connection_id
+LEFT JOIN platform_mcp_connections AS current_connection
+  ON current_connection.id = sqlc.narg(connection_id)
  AND current_connection.organization_id = registration.organization_id
 JOIN projects AS project
   ON project.id = registration.project_id
@@ -612,10 +640,19 @@ WHERE registration.id = @registration_id
   AND registration.organization_id = @organization_id
   AND registration.project_id = @project_id
   AND registration.deleted IS FALSE
-  AND created_connection.subject_urn = @subject_urn
-  AND current_connection.subject_urn = @subject_urn
-  AND current_connection.active_generation = @connection_generation
-  AND current_connection.revoked_at IS NULL;
+  AND (
+    registration.user_id = @user_id
+    OR (registration.user_id IS NULL AND created_connection.subject_urn = @subject_urn)
+  )
+  AND (
+    sqlc.narg(connection_id) IS NULL
+    OR (
+      current_connection.id IS NOT NULL
+      AND current_connection.subject_urn = @subject_urn
+      AND current_connection.active_generation = sqlc.narg(connection_generation)
+      AND current_connection.revoked_at IS NULL
+    )
+  );
 
 -- name: CreatePlatformMCPCatalogRegistration :one
 INSERT INTO platform_mcp_catalog_registrations (
@@ -626,7 +663,9 @@ INSERT INTO platform_mcp_catalog_registrations (
     catalog_reference,
     status,
     connection_id,
-    connection_generation
+    connection_generation,
+    user_id,
+    acting_surface
 ) VALUES (
     @organization_id,
     @project_id,
@@ -635,7 +674,9 @@ INSERT INTO platform_mcp_catalog_registrations (
     @catalog_reference,
     @status,
     @connection_id,
-    @connection_generation
+    @connection_generation,
+    @user_id,
+    @acting_surface
 )
 RETURNING *;
 

--- a/server/internal/platformmcp/registration.go
+++ b/server/internal/platformmcp/registration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -68,15 +69,18 @@ type ResolvedProject struct {
 }
 
 type OperationReceipt struct {
-	ID                   uuid.UUID
-	RegistrationID       uuid.NullUUID
-	Status               string
-	ResultCode           string
-	InputHash            string
-	ExpiresAt            time.Time
-	Replayed             bool
-	ConnectionID         uuid.UUID
-	ConnectionGeneration uuid.UUID
+	ID             uuid.UUID
+	RegistrationID uuid.NullUUID
+	Status         string
+	ResultCode     string
+	InputHash      string
+	ExpiresAt      time.Time
+	Replayed       bool
+	// Invalid when the receipt was written by a surface with no OAuth
+	// connection. Unwrapping these to a bare uuid.Nil would be read downstream
+	// as "connection missing" rather than "no connection applies".
+	ConnectionID         uuid.NullUUID
+	ConnectionGeneration uuid.NullUUID
 }
 
 // RegistrationStoreConfig carries values whose production defaults require
@@ -264,8 +268,11 @@ func (s *RegistrationStore) BeginReceipt(ctx context.Context, principal Principa
 	if err := q.LockPlatformMCPOperationReceipt(ctx, lock); err != nil {
 		return OperationReceipt{}, fmt.Errorf("lock platform mcp registration receipt: %w", err)
 	}
+	// Matched on the real user; SubjectUrn only reaches receipts written
+	// before user_id existed, which carry a connection instead.
 	receiptLookup := platformrepo.GetPlatformMCPOperationReceiptParams{
 		OrganizationID: principal.OrganizationID,
+		UserID:         conv.ToPGText(principal.UserID),
 		SubjectUrn:     userSubjectURN(principal.UserID),
 		ProjectID:      project.ID,
 		Operation:      operationRegisterCatalogMCP,
@@ -293,8 +300,10 @@ func (s *RegistrationStore) BeginReceipt(ctx context.Context, principal Principa
 		OrganizationID:       principal.OrganizationID,
 		ProjectID:            project.ID,
 		RegistrationID:       uuid.NullUUID{},
-		ConnectionID:         uuid.NullUUID{UUID: connectionID, Valid: true},
-		ConnectionGeneration: uuid.NullUUID{UUID: generation, Valid: true},
+		ConnectionID:         connectionID,
+		ConnectionGeneration: generation,
+		UserID:               conv.ToPGText(principal.UserID),
+		ActingSurface:        conv.ToPGText(string(principal.surface())),
 		Operation:            operationRegisterCatalogMCP,
 		IdempotencyKey:       request.IdempotencyKey,
 		InputHash:            request.InputHash,
@@ -349,6 +358,7 @@ func (s *RegistrationStore) ConvergeRegistration(ctx context.Context, principal 
 	}
 	storedReceipt, err := q.GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
 		OrganizationID: receiptLock.OrganizationID,
+		UserID:         conv.ToPGText(principal.UserID),
 		SubjectUrn:     receiptLock.SubjectUrn,
 		ProjectID:      project.ID,
 		Operation:      receiptLock.Operation,
@@ -444,8 +454,10 @@ func (s *RegistrationStore) ConvergeRegistration(ctx context.Context, principal 
 			CatalogProvider:      request.CatalogProvider,
 			CatalogReference:     request.CatalogReference,
 			Status:               registrationStatusPending,
-			ConnectionID:         uuid.NullUUID{UUID: connectionID, Valid: true},
-			ConnectionGeneration: uuid.NullUUID{UUID: generation, Valid: true},
+			ConnectionID:         connectionID,
+			ConnectionGeneration: generation,
+			UserID:               conv.ToPGText(principal.UserID),
+			ActingSurface:        conv.ToPGText(string(principal.surface())),
 		})
 		if err != nil {
 			return OperationReceipt{}, fmt.Errorf("create platform mcp catalog registration: %w", err)
@@ -515,6 +527,7 @@ func (s *RegistrationStore) CompleteRegistration(ctx context.Context, principal 
 	}
 	storedReceipt, err := q.GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
 		OrganizationID: receiptLock.OrganizationID,
+		UserID:         conv.ToPGText(principal.UserID),
 		SubjectUrn:     receiptLock.SubjectUrn,
 		ProjectID:      project.ID,
 		Operation:      receiptLock.Operation,
@@ -655,8 +668,8 @@ func (s *RegistrationStore) CompleteRegistration(ctx context.Context, principal 
 	}
 	if err := q.RecordPlatformMCPRegistrationSucceeded(ctx, platformrepo.RecordPlatformMCPRegistrationSucceededParams{
 		OrganizationID:       principal.OrganizationID,
-		ConnectionID:         uuid.NullUUID{UUID: connectionID, Valid: true},
-		ConnectionGeneration: uuid.NullUUID{UUID: generation, Valid: true},
+		ConnectionID:         connectionID,
+		ConnectionGeneration: generation,
 		ProjectID:            uuid.NullUUID{UUID: project.ID, Valid: true},
 		McpKey:               registration.CatalogProvider + ":" + registration.CatalogReference,
 		AttemptID:            uuid.NullUUID{UUID: registration.ID, Valid: true},
@@ -835,7 +848,22 @@ func validateCatalogRegistrationRequest(principal Principal, project ResolvedPro
 	return nil
 }
 
-func principalConnection(principal Principal) (uuid.UUID, uuid.UUID, error) {
+// principalConnection resolves the caller's OAuth connection, if it has one.
+// A principal with no connection — the project assistant acts under assistant
+// identity — yields two invalid NullUUIDs rather than an error: the row it
+// writes is attributed by user and acting surface instead.
+func principalConnection(principal Principal) (uuid.NullUUID, uuid.NullUUID, error) {
+	if !principal.HasConnection() {
+		return uuid.NullUUID{}, uuid.NullUUID{}, nil
+	}
+	connectionID, generation, err := parseConnection(principal)
+	if err != nil {
+		return uuid.NullUUID{}, uuid.NullUUID{}, err
+	}
+	return uuid.NullUUID{UUID: connectionID, Valid: true}, uuid.NullUUID{UUID: generation, Valid: true}, nil
+}
+
+func parseConnection(principal Principal) (uuid.UUID, uuid.UUID, error) {
 	connectionID, err := uuid.Parse(principal.ConnectionID)
 	if err != nil {
 		return uuid.Nil, uuid.Nil, fmt.Errorf("parse platform mcp registration connection: %w", err)
@@ -860,8 +888,8 @@ func operationReceiptFromRow(row platformrepo.PlatformMcpOperationReceipt, repla
 		InputHash:            row.InputHash,
 		ExpiresAt:            row.ExpiresAt.Time,
 		Replayed:             replayed,
-		ConnectionID:         row.ConnectionID.UUID,
-		ConnectionGeneration: row.ConnectionGeneration.UUID,
+		ConnectionID:         row.ConnectionID,
+		ConnectionGeneration: row.ConnectionGeneration,
 	}
 }
 

--- a/server/internal/platformmcp/registration_integration_test.go
+++ b/server/internal/platformmcp/registration_integration_test.go
@@ -103,6 +103,7 @@ func TestRegistrationStoreEnforcesActiveRegistrationCap(t *testing.T) {
 
 	storedDeniedReceipt, err := platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
 		OrganizationID: principal.OrganizationID,
+		UserID:         conv.ToPGText(principal.UserID),
 		SubjectUrn:     userSubjectURN(principal.UserID),
 		ProjectID:      project.ID,
 		Operation:      operationRegisterCatalogMCP,
@@ -352,6 +353,7 @@ func TestRegistrationStoreCompleteRegistrationConvergesPrivateComponents(t *test
 
 	storedReceipt, err := platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
 		OrganizationID: principal.OrganizationID,
+		UserID:         conv.ToPGText(principal.UserID),
 		SubjectUrn:     userSubjectURN(principal.UserID),
 		ProjectID:      project.ID,
 		Operation:      operationRegisterCatalogMCP,
@@ -804,4 +806,59 @@ func seedRegistrationEligibleCohort(t *testing.T, ctx context.Context, conn *pgx
 		Slug:        "cohort-endpoint-" + uuid.NewString()[:8],
 	})
 	require.NoError(t, err)
+}
+
+// The project assistant holds no OAuth connection. Its writes must still land,
+// attributed to the real user and its acting surface, and must still replay
+// idempotently — the property that breaks first if a read path joins through
+// the connection it does not have.
+func TestRegistrationStoreWritesWithoutAConnection(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_registration_no_connection")
+	require.NoError(t, err)
+
+	connected, project := seedRegistrationLifecycle(t, ctx, conn)
+	assistant := Principal{
+		UserID:         connected.UserID,
+		OrganizationID: connected.OrganizationID,
+		ConnectionID:   "",
+		Generation:     "",
+		ClientID:       "gram-project-assistant",
+		Surface:        SurfaceProjectAssistant,
+	}
+	require.False(t, assistant.HasConnection())
+
+	store, err := NewRegistrationStore(conn, RegistrationStoreConfig{ActiveRegistrationCap: 5})
+	require.NoError(t, err)
+
+	request := registrationRequest(project, "assistant-registered", "assistant-key")
+	receipt, err := store.BeginReceipt(ctx, assistant, project, request, time.Now().UTC())
+	require.NoError(t, err, "an assistant write must not require an OAuth connection")
+	require.False(t, receipt.ConnectionID.Valid, "no connection applies, which is not the same as a zero uuid")
+
+	receipt, err = store.ConvergeRegistration(ctx, assistant, project, request, receipt)
+	require.NoError(t, err)
+	receipt, err = store.CompleteRegistrationWithRemoteURL(ctx, assistant, project, request, receipt, "https://reviewed.example.test/assistant")
+	require.NoError(t, err)
+	require.True(t, receipt.RegistrationID.Valid)
+
+	stored, err := platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
+		OrganizationID: assistant.OrganizationID,
+		UserID:         conv.ToPGText(assistant.UserID),
+		SubjectUrn:     userSubjectURN(assistant.UserID),
+		ProjectID:      project.ID,
+		Operation:      operationRegisterCatalogMCP,
+		IdempotencyKey: request.IdempotencyKey,
+	})
+	require.NoError(t, err, "a connection-less receipt must still be readable, or its idempotency key is poisoned")
+	require.False(t, stored.ConnectionID.Valid)
+	require.Equal(t, assistant.UserID, stored.UserID.String)
+	require.Equal(t, string(SurfaceProjectAssistant), stored.ActingSurface.String)
+
+	replay, err := store.BeginReceipt(ctx, assistant, project, request, time.Now().UTC())
+	require.NoError(t, err, "replaying the same key must return the original receipt, not a unique violation")
+	require.True(t, replay.Replayed)
+	require.Equal(t, receipt.ID, replay.ID)
 }

--- a/server/internal/platformmcp/registration_test.go
+++ b/server/internal/platformmcp/registration_test.go
@@ -117,3 +117,32 @@ func TestUserSubjectURN(t *testing.T) {
 
 	require.Equal(t, "user:user-id", userSubjectURN("user-id"))
 }
+
+// Half a connection is an incomplete identity, not an absent one. Taking the
+// connection-less path for it would record a user-attributed write against a
+// connection the caller never proved, and would violate the database's own
+// pair constraint.
+func TestPrincipalConnectionRejectsAHalfPopulatedPair(t *testing.T) {
+	t.Parallel()
+
+	full := Principal{UserID: "user", OrganizationID: "org", ConnectionID: uuid.NewString(), Generation: uuid.NewString()}
+	connectionID, generation, err := principalConnection(full)
+	require.NoError(t, err)
+	require.True(t, connectionID.Valid)
+	require.True(t, generation.Valid)
+
+	none := Principal{UserID: "user", OrganizationID: "org"}
+	connectionID, generation, err = principalConnection(none)
+	require.NoError(t, err, "a surface with no connection is legitimate")
+	require.False(t, connectionID.Valid)
+	require.False(t, generation.Valid)
+
+	for _, incomplete := range []Principal{
+		{UserID: "user", OrganizationID: "org", ConnectionID: uuid.NewString()},
+		{UserID: "user", OrganizationID: "org", Generation: uuid.NewString()},
+	} {
+		require.True(t, incomplete.HasConnection(), "either half is a claim to a connection")
+		_, _, err := principalConnection(incomplete)
+		require.Error(t, err, "an incomplete connection identity must not be treated as connection-less")
+	}
+}

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -464,7 +464,9 @@ INSERT INTO platform_mcp_catalog_registrations (
     catalog_reference,
     status,
     connection_id,
-    connection_generation
+    connection_generation,
+    user_id,
+    acting_surface
 ) VALUES (
     $1,
     $2,
@@ -473,7 +475,9 @@ INSERT INTO platform_mcp_catalog_registrations (
     $5,
     $6,
     $7,
-    $8
+    $8,
+    $9,
+    $10
 )
 RETURNING id, organization_id, project_id, source_kind, catalog_provider, catalog_reference, status, remote_mcp_server_id, remote_mcp_server_owned, user_session_issuer_id, user_session_issuer_owned, mcp_server_id, mcp_server_owned, mcp_endpoint_id, mcp_endpoint_owned, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at, deleted_at, deleted
 `
@@ -487,6 +491,8 @@ type CreatePlatformMCPCatalogRegistrationParams struct {
 	Status               string
 	ConnectionID         uuid.NullUUID
 	ConnectionGeneration uuid.NullUUID
+	UserID               pgtype.Text
+	ActingSurface        pgtype.Text
 }
 
 func (q *Queries) CreatePlatformMCPCatalogRegistration(ctx context.Context, arg CreatePlatformMCPCatalogRegistrationParams) (PlatformMcpCatalogRegistration, error) {
@@ -499,6 +505,8 @@ func (q *Queries) CreatePlatformMCPCatalogRegistration(ctx context.Context, arg 
 		arg.Status,
 		arg.ConnectionID,
 		arg.ConnectionGeneration,
+		arg.UserID,
+		arg.ActingSurface,
 	)
 	var i PlatformMcpCatalogRegistration
 	err := row.Scan(
@@ -877,6 +885,8 @@ INSERT INTO platform_mcp_operation_receipts (
     registration_id,
     connection_id,
     connection_generation,
+    user_id,
+    acting_surface,
     operation,
     idempotency_key,
     input_hash,
@@ -894,7 +904,9 @@ INSERT INTO platform_mcp_operation_receipts (
     $8,
     $9,
     $10,
-    $11
+    $11,
+    $12,
+    $13
 )
 RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, expires_at, created_at, updated_at
 `
@@ -905,6 +917,8 @@ type CreatePlatformMCPOperationReceiptParams struct {
 	RegistrationID       uuid.NullUUID
 	ConnectionID         uuid.NullUUID
 	ConnectionGeneration uuid.NullUUID
+	UserID               pgtype.Text
+	ActingSurface        pgtype.Text
 	Operation            string
 	IdempotencyKey       string
 	InputHash            string
@@ -920,6 +934,8 @@ func (q *Queries) CreatePlatformMCPOperationReceipt(ctx context.Context, arg Cre
 		arg.RegistrationID,
 		arg.ConnectionID,
 		arg.ConnectionGeneration,
+		arg.UserID,
+		arg.ActingSurface,
 		arg.Operation,
 		arg.IdempotencyKey,
 		arg.InputHash,
@@ -1168,32 +1184,45 @@ func (q *Queries) DeleteExpiredPlatformMCPFeedback(ctx context.Context, organiza
 
 const deleteExpiredPlatformMCPOperationReceipt = `-- name: DeleteExpiredPlatformMCPOperationReceipt :execrows
 DELETE FROM platform_mcp_operation_receipts AS receipt
-USING platform_mcp_connections AS connection
-WHERE receipt.connection_id = connection.id
-  AND receipt.organization_id = connection.organization_id
-  AND receipt.organization_id = $1
-  AND connection.subject_urn = $2
-  AND receipt.project_id = $3
-  AND receipt.operation = $4
-  AND receipt.idempotency_key = $5
+WHERE receipt.organization_id = $1
+  AND receipt.project_id = $2
+  AND receipt.operation = $3
+  AND receipt.idempotency_key = $4
   AND receipt.expires_at <= clock_timestamp()
+  AND (
+    receipt.user_id = $5
+    OR (
+      receipt.user_id IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM platform_mcp_connections AS connection
+        WHERE connection.id = receipt.connection_id
+          AND connection.organization_id = receipt.organization_id
+          AND connection.subject_urn = $6
+      )
+    )
+  )
 `
 
 type DeleteExpiredPlatformMCPOperationReceiptParams struct {
 	OrganizationID string
-	SubjectUrn     string
 	ProjectID      uuid.UUID
 	Operation      string
 	IdempotencyKey string
+	UserID         pgtype.Text
+	SubjectUrn     string
 }
 
+// Matches GetPlatformMCPOperationReceipt exactly. A receipt this cannot reach
+// never expires, and its idempotency key stays unusable for that user.
 func (q *Queries) DeleteExpiredPlatformMCPOperationReceipt(ctx context.Context, arg DeleteExpiredPlatformMCPOperationReceiptParams) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteExpiredPlatformMCPOperationReceipt,
 		arg.OrganizationID,
-		arg.SubjectUrn,
 		arg.ProjectID,
 		arg.Operation,
 		arg.IdempotencyKey,
+		arg.UserID,
+		arg.SubjectUrn,
 	)
 	if err != nil {
 		return 0, err
@@ -1821,10 +1850,10 @@ func (q *Queries) GetPlatformMCPCatalogRegistrationByID(ctx context.Context, arg
 const getPlatformMCPCatalogRegistrationForLifecycle = `-- name: GetPlatformMCPCatalogRegistrationForLifecycle :one
 SELECT registration.id, registration.organization_id, registration.project_id, registration.source_kind, registration.catalog_provider, registration.catalog_reference, registration.status, registration.remote_mcp_server_id, registration.remote_mcp_server_owned, registration.user_session_issuer_id, registration.user_session_issuer_owned, registration.mcp_server_id, registration.mcp_server_owned, registration.mcp_endpoint_id, registration.mcp_endpoint_owned, registration.connection_id, registration.connection_generation, registration.user_id, registration.acting_surface, registration.created_at, registration.updated_at, registration.deleted_at, registration.deleted
 FROM platform_mcp_catalog_registrations AS registration
-JOIN platform_mcp_connections AS created_connection
+LEFT JOIN platform_mcp_connections AS created_connection
   ON created_connection.id = registration.connection_id
  AND created_connection.organization_id = registration.organization_id
-JOIN platform_mcp_connections AS current_connection
+LEFT JOIN platform_mcp_connections AS current_connection
   ON current_connection.id = $1
  AND current_connection.organization_id = registration.organization_id
 JOIN projects AS project
@@ -1835,30 +1864,47 @@ WHERE registration.id = $2
   AND registration.organization_id = $3
   AND registration.project_id = $4
   AND registration.deleted IS FALSE
-  AND created_connection.subject_urn = $5
-  AND current_connection.subject_urn = $5
-  AND current_connection.active_generation = $6
-  AND current_connection.revoked_at IS NULL
+  AND (
+    registration.user_id = $5
+    OR (registration.user_id IS NULL AND created_connection.subject_urn = $6)
+  )
+  AND (
+    $1 IS NULL
+    OR (
+      current_connection.id IS NOT NULL
+      AND current_connection.subject_urn = $6
+      AND current_connection.active_generation = $7
+      AND current_connection.revoked_at IS NULL
+    )
+  )
 `
 
 type GetPlatformMCPCatalogRegistrationForLifecycleParams struct {
-	ConnectionID         uuid.UUID
+	ConnectionID         uuid.NullUUID
 	RegistrationID       uuid.UUID
 	OrganizationID       string
 	ProjectID            uuid.UUID
+	UserID               pgtype.Text
 	SubjectUrn           string
-	ConnectionGeneration uuid.UUID
+	ConnectionGeneration uuid.NullUUID
 }
 
 // Registrations are project desired state, not permanently owned by the OAuth
-// client that originally created them. Lifecycle actions require the current
-// active Platform connection to belong to that same user subject.
+// client that originally created them. Lifecycle actions require the caller to
+// be the same user that created the registration.
+//
+// A caller acting through an OAuth connection must additionally present a
+// live, unrevoked generation. A surface that holds no connection — the project
+// assistant acts under assistant identity — passes a null connection and is
+// authorized on every call upstream instead. Ownership still matches on the
+// real user, so a null connection widens nothing.
 func (q *Queries) GetPlatformMCPCatalogRegistrationForLifecycle(ctx context.Context, arg GetPlatformMCPCatalogRegistrationForLifecycleParams) (PlatformMcpCatalogRegistration, error) {
 	row := q.db.QueryRow(ctx, getPlatformMCPCatalogRegistrationForLifecycle,
 		arg.ConnectionID,
 		arg.RegistrationID,
 		arg.OrganizationID,
 		arg.ProjectID,
+		arg.UserID,
 		arg.SubjectUrn,
 		arg.ConnectionGeneration,
 	)
@@ -2144,33 +2190,42 @@ func (q *Queries) GetPlatformMCPOnboardingSelectedProject(ctx context.Context, a
 const getPlatformMCPOperationReceipt = `-- name: GetPlatformMCPOperationReceipt :one
 SELECT receipt.id, receipt.organization_id, receipt.project_id, receipt.registration_id, receipt.connection_id, receipt.connection_generation, receipt.user_id, receipt.acting_surface, receipt.operation, receipt.idempotency_key, receipt.input_hash, receipt.status, receipt.result_code, receipt.expires_at, receipt.created_at, receipt.updated_at
 FROM platform_mcp_operation_receipts AS receipt
-JOIN platform_mcp_connections AS connection
+LEFT JOIN platform_mcp_connections AS connection
   ON connection.id = receipt.connection_id
  AND connection.organization_id = receipt.organization_id
 WHERE receipt.organization_id = $1
-  AND connection.subject_urn = $2
-  AND receipt.project_id = $3
-  AND receipt.operation = $4
-  AND receipt.idempotency_key = $5
+  AND receipt.project_id = $2
+  AND receipt.operation = $3
+  AND receipt.idempotency_key = $4
+  AND (
+    receipt.user_id = $5
+    OR (receipt.user_id IS NULL AND connection.subject_urn = $6)
+  )
 ORDER BY receipt.created_at DESC, receipt.id DESC
 LIMIT 1
 `
 
 type GetPlatformMCPOperationReceiptParams struct {
 	OrganizationID string
-	SubjectUrn     string
 	ProjectID      uuid.UUID
 	Operation      string
 	IdempotencyKey string
+	UserID         pgtype.Text
+	SubjectUrn     string
 }
 
+// Idempotency belongs to the real user, not to a connection: reauthorization
+// mints a new connection generation and must not let the same key replay a
+// create. Receipts written before user_id existed carry only a connection, so
+// they are still matched through its subject.
 func (q *Queries) GetPlatformMCPOperationReceipt(ctx context.Context, arg GetPlatformMCPOperationReceiptParams) (PlatformMcpOperationReceipt, error) {
 	row := q.db.QueryRow(ctx, getPlatformMCPOperationReceipt,
 		arg.OrganizationID,
-		arg.SubjectUrn,
 		arg.ProjectID,
 		arg.Operation,
 		arg.IdempotencyKey,
+		arg.UserID,
+		arg.SubjectUrn,
 	)
 	var i PlatformMcpOperationReceipt
 	err := row.Scan(

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -27,12 +27,49 @@ var (
 	ErrUnavailable  = errors.New("platform mcp unavailable")
 )
 
+// ActingSurface names the surface a call arrives through. Audit has to be able
+// to tell an agent-driven change from a dashboard change made by the same
+// user, and reviewing a runaway agent's burst of activity depends on it.
+type ActingSurface string
+
+const (
+	// SurfacePlatformMCP is the OAuth-authenticated Platform MCP endpoint.
+	SurfacePlatformMCP ActingSurface = "platform_mcp"
+	// SurfaceProjectAssistant is the project assistant runtime, which acts
+	// under assistant identity and holds no OAuth connection.
+	SurfaceProjectAssistant ActingSurface = "project_assistant"
+	// SurfaceDashboard is an authenticated dashboard session completing work a
+	// Platform MCP flow started, such as a provider setup handoff.
+	SurfaceDashboard ActingSurface = "dashboard"
+)
+
+// Principal is the identity a Platform MCP call acts under.
+//
+// ConnectionID and Generation are empty for a surface with no OAuth
+// connection. UserID and OrganizationID are always present: authorization,
+// idempotency, and audit are keyed on the real user, not on the connection,
+// so a call without a connection is attributable exactly as well as one with.
 type Principal struct {
 	UserID         string
 	OrganizationID string
 	ConnectionID   string
 	Generation     string
 	ClientID       string
+	Surface        ActingSurface
+}
+
+// HasConnection reports whether this principal carries an OAuth connection.
+func (p Principal) HasConnection() bool {
+	return p.ConnectionID != "" && p.Generation != ""
+}
+
+// surface defaults an unset surface to the external endpoint, which is the
+// only surface that existed before this field.
+func (p Principal) surface() ActingSurface {
+	if p.Surface == "" {
+		return SurfacePlatformMCP
+	}
+	return p.Surface
 }
 
 type Authenticator interface {

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -45,10 +45,14 @@ const (
 
 // Principal is the identity a Platform MCP call acts under.
 //
-// ConnectionID and Generation are empty for a surface with no OAuth
-// connection. UserID and OrganizationID are always present: authorization,
-// idempotency, and audit are keyed on the real user, not on the connection,
-// so a call without a connection is attributable exactly as well as one with.
+// ConnectionID and Generation are empty together for a surface with no OAuth
+// connection, and present together otherwise — the same invariant the
+// connection columns carry in the database.
+//
+// OrganizationID is always present. UserID is present for every surface that
+// writes, because authorization, idempotency, and audit are keyed on the real
+// user rather than on the connection; that is what makes a connection-less
+// call attributable exactly as well as one with a connection.
 type Principal struct {
 	UserID         string
 	OrganizationID string
@@ -58,9 +62,14 @@ type Principal struct {
 	Surface        ActingSurface
 }
 
-// HasConnection reports whether this principal carries an OAuth connection.
+// HasConnection reports whether this principal claims an OAuth connection.
+//
+// Either half counts as a claim. A principal presenting one half has an
+// incomplete identity rather than no connection, and must fail strict parsing
+// instead of silently taking the connection-less path — which would record a
+// user-attributed write for a connection the caller could not prove.
 func (p Principal) HasConnection() bool {
-	return p.ConnectionID != "" && p.Generation != ""
+	return p.ConnectionID != "" || p.Generation != ""
 }
 
 // surface defaults an unset surface to the external endpoint, which is the

--- a/server/internal/platformmcp/setup_http.go
+++ b/server/internal/platformmcp/setup_http.go
@@ -37,6 +37,7 @@ func (s *DashboardSetupService) StartDashboardSetup(ctx context.Context, userID,
 	}
 
 	principal := Principal{
+		Surface:        SurfaceDashboard,
 		UserID:         userID,
 		OrganizationID: organizationID,
 		ConnectionID:   "",

--- a/server/internal/platformtools/platform/tools.go
+++ b/server/internal/platformtools/platform/tools.go
@@ -24,7 +24,7 @@ func principalFromContext(ctx context.Context) (platformmcp.Principal, error) {
 	}
 	return platformmcp.Principal{
 		Surface:        platformmcp.SurfaceProjectAssistant,
-		UserID:         "",
+		UserID:         authCtx.UserID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ConnectionID:   "",
 		Generation:     "",

--- a/server/internal/platformtools/platform/tools.go
+++ b/server/internal/platformtools/platform/tools.go
@@ -23,6 +23,7 @@ func principalFromContext(ctx context.Context) (platformmcp.Principal, error) {
 		return platformmcp.Principal{}, fmt.Errorf("platform tools require organization auth context")
 	}
 	return platformmcp.Principal{
+		Surface:        platformmcp.SurfaceProjectAssistant,
 		UserID:         "",
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ConnectionID:   "",


### PR DESCRIPTION
## What

Makes Platform MCP writes attributable to the surface that made them, so a surface without an OAuth connection — the project assistant — can write at all.

Stacked on #5304, which adds the columns. **Merge that first**; this PR's base is that branch.

## Why

Platform MCP writes are connection-scoped today. `platform_mcp_catalog_registrations` and `platform_mcp_operation_receipts` reference `platform_mcp_connections` by foreign key, and receipt idempotency is keyed by connection.

The RFC is explicit that the assistant does not have one:

> Project Assistant continues to use its own assistant identity and audience rather than an external user's OAuth connection.

So an assistant-originated registration fails — today with `invalid UUID length: 17`, parsing the synthetic connection id the bridge invents, and behind that on the foreign key.

The RFC also specifies idempotency independently of the connection:

> Persist receipts for 24 hours by organization + real user + operation + exact project/target + key, independent of connection generation, so reauthorization cannot replay a create.

## Read paths first

The ordering matters because the failure is silent rather than loud. Nothing may write a null connection until these change:

- `GetPlatformMCPOperationReceipt` and `DeleteExpiredPlatformMCPOperationReceipt` matched receipts by joining `platform_mcp_connections`. A receipt with no connection is invisible to both, so `BeginReceipt` falls through to an insert, the new partial unique index rejects it, and — because the expiry reclaim joins the same way — the row never expires. That idempotency key would stay unusable for that user, permanently. Both now match on `user_id`, keeping the connection subject as a fallback for receipts written before `user_id` existed.
- `GetPlatformMCPCatalogRegistrationForLifecycle` inner-joined both the creating connection and the caller's current one, which would hide a connection-less registration from every lifecycle action. Ownership now matches the real user. The live-generation and revocation checks still apply, but only to a caller that actually holds a connection; a connection-less surface is authorized upstream on every call instead, and ownership still matches on the user, so nothing is widened.

## Write path

- `Principal` carries an `ActingSurface` — `platform_mcp`, `project_assistant`, or `dashboard` — and reports whether it holds a connection. Every construction site sets its real surface.
- `principalConnection` returns null ids for a surface with no connection. `parseConnection` stays strict for the paths whose tables still require one: distribution, feedback, and onboarding milestones. Those remain connection-only until their tables get the same treatment.
- Registrations and receipts record `user_id` and `acting_surface`.
- `OperationReceipt.ConnectionID` / `ConnectionGeneration` are `uuid.NullUUID`. Previously the row's value was unwrapped and its `Valid` flag discarded, so a connection-less receipt would replay as `uuid.Nil` — which `provider_adapter.go` treats as a missing connection. This was raised by cubic on #5304 and is fixed here, in the change that first makes the state reachable.

## Test

`TestRegistrationStoreWritesWithoutAConnection` drives a connection-less principal through begin → converge → complete, reads the receipt back, and replays the same idempotency key. It asserts the receipt carries the user and acting surface, carries no connection, and that the replay returns the original receipt rather than a unique violation — the exact failure the read-path changes prevent.

Full `platformmcp`, `mcp`, and `platformtools` suites pass; `mise lint:server` is clean.

## Not in this PR

- `platform_mcp_setup_handoffs.connection_id` is still `NOT NULL`, so setup handoff stays connection-only.
- `platform_mcp_distributions` needs the same treatment when distribution tools land.
- Contract migration dropping `platform_mcp_operation_receipts_connection_operation_key` once every writer populates `user_id`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes Platform MCP registrations and operation receipts to the acting surface and real user so the project assistant (no OAuth) can write and replay idempotently. Previously writes were connection-scoped and failed; now reads and writes use user_id and acting_surface, and live connection checks apply only if a connection is present.

- Queries: receipts and registrations match ownership by user_id with fallback to connection subject for legacy rows; LEFT JOINs replace inner joins; expiry deletion matches the lookup to avoid poisoned idempotency keys. Lifecycle checks the caller’s user and only enforces live generation when a connection exists.
- Principal and parsing: adds ActingSurface (`platform_mcp`, `project_assistant`, `dashboard`). `HasConnection` now treats either half as a claim; `parseConnection` stays strict and rejects half-populated pairs; `principalConnection` returns invalid NullUUIDs for connection-less surfaces. Callers that still require a connection (distribution, feedback, onboarding) use `parseConnection`.
- Writes: registrations and receipts populate user_id and acting_surface; receipt connection fields are uuid.NullUUID to distinguish “no connection” from a zero UUID. Adapters and dashboard setup set the correct surface; `platformtools` now sets `SurfaceProjectAssistant` and the real user.
- Tests: cover assistant writes without a connection (begin → converge → complete, replay succeeds) and rejection of half-populated connection identities.

**Rollout**
- Apply the migration that adds user_id and acting_surface to registrations and receipts before deploying this change.

<sup>Written for commit 945b401d56f6db69cabc96bf71ab14d7f902e358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

