### PR TITLE
fix(mcp): refuse a protocol revision the surface does not answer

### DIFF
--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -57,6 +57,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
@@ -995,6 +996,12 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			)
 		}
 		return oops.C(oops.CodeUnauthorized)
+	}
+
+	// Refuse a revision this surface does not answer before doing any work; see
+	// [Service.enforceServedProtocolVersion].
+	if rejected, gateErr := s.enforceServedProtocolVersion(ctx, w, r, &req, mcpversions.ServedHostedToolset); rejected || gateErr != nil {
+		return gateErr
 	}
 
 	body, err := s.handleRequest(ctx, mcpInputs, &req)

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -109,6 +109,40 @@ func Known(v string) bool {
 	return slices.Contains(all, v)
 }
 
+// Handshakeless reports whether v is a recognized revision that carries its
+// protocol version on every request instead of agreeing one at `initialize`.
+//
+// 2026-07-28 removed the handshake, which is what makes this distinction worth
+// drawing rather than simply comparing revisions. A client on a handshake-based
+// revision learns what a server speaks by being told at `initialize`, so a
+// surface answering an older revision than the client asked for is understood
+// and the client adapts. A client on a handshake-less revision is never told
+// anything: it declares a version per request and validates the reply against
+// it. Serving one of those a response shaped for an older revision cannot be
+// detected by the client, so the surface has to say so out loud — see
+// [Serves].
+func Handshakeless(v string) bool {
+	idx := slices.Index(all, v)
+	return idx >= 0 && idx >= slices.Index(all, Version20260728)
+}
+
+// Serves reports whether a surface answering the served revision can honour a
+// request declaring the requested one.
+//
+// An empty or unrecognized request version is served: those are clients that
+// either predate the header or are not speaking a revision this package knows,
+// and both are better handled by the surface's existing behaviour than by a
+// rejection. A handshake-less request for anything other than exactly the
+// served revision is not, because such a client has no other way to discover
+// the mismatch.
+func Serves(served, requested string) bool {
+	if requested == "" || !Known(requested) || requested == served {
+		return true
+	}
+
+	return !Handshakeless(requested)
+}
+
 // Clamp bounds a client-supplied version for use as a metric dimension: a
 // recognized revision passes through, an absent one becomes [None], and
 // anything else becomes [Other].

--- a/server/internal/mcp/mcpversions/serves_test.go
+++ b/server/internal/mcp/mcpversions/serves_test.go
@@ -1,0 +1,65 @@
+package mcpversions_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+)
+
+func TestHandshakeless(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range []string{
+		mcpversions.Version20241105,
+		mcpversions.Version20250326,
+		mcpversions.Version20250618,
+		mcpversions.Version20251125,
+	} {
+		require.False(t, mcpversions.Handshakeless(v), "%s agrees a version at initialize", v)
+	}
+
+	require.True(t, mcpversions.Handshakeless(mcpversions.Version20260728),
+		"2026-07-28 removed initialize and declares a version per request")
+	require.False(t, mcpversions.Handshakeless(""), "an absent version is not a revision")
+	require.False(t, mcpversions.Handshakeless("2099-01-01"), "an unrecognized version is not classifiable")
+}
+
+func TestServes(t *testing.T) {
+	t.Parallel()
+
+	served := mcpversions.Version20250326
+
+	t.Run("requests this surface can honour", func(t *testing.T) {
+		t.Parallel()
+
+		for name, requested := range map[string]string{
+			"the served revision itself":             mcpversions.Version20250326,
+			"no declared revision":                   "",
+			"an unrecognized revision":               "2099-01-01",
+			"a newer revision that still handshakes": mcpversions.Version20250618,
+			"the newest revision that handshakes":    mcpversions.Version20251125,
+		} {
+			require.True(t, mcpversions.Serves(served, requested), name)
+		}
+	})
+
+	// A handshake-less client is never told what the server speaks, so serving it
+	// a shape from another revision is undetectable on its side.
+	t.Run("requests this surface cannot honour", func(t *testing.T) {
+		t.Parallel()
+
+		require.False(t, mcpversions.Serves(served, mcpversions.Version20260728))
+	})
+
+	// A surface that moves to the handshake-less revision serves it, and stops
+	// serving the one it left behind only if that one is itself handshake-less.
+	t.Run("follows the served revision", func(t *testing.T) {
+		t.Parallel()
+
+		require.True(t, mcpversions.Serves(mcpversions.Version20260728, mcpversions.Version20260728))
+		require.True(t, mcpversions.Serves(mcpversions.Version20260728, mcpversions.Version20250326),
+			"a handshake-era client adapts to whatever initialize answers")
+	})
+}

--- a/server/internal/mcp/protocolgate.go
+++ b/server/internal/mcp/protocolgate.go
@@ -1,0 +1,152 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// mcpCodeUnsupportedProtocolVersion is the JSON-RPC error code MCP allocates for
+// a request declaring a protocol revision the server does not implement. It sits
+// in the -32020..-32099 sub-range the specification reserves for itself, so it
+// carries this meaning and no other.
+//
+// See https://modelcontextprotocol.io/specification/2026-07-28/basic/index#error-codes.
+const mcpCodeUnsupportedProtocolVersion = -32022
+
+// metaProtocolVersionKey is where a request carries its protocol revision from
+// 2026-07-28 onward, mirrored into the MCP-Protocol-Version header by the
+// Streamable HTTP binding.
+const metaProtocolVersionKey = "io.modelcontextprotocol/protocolVersion"
+
+// unsupportedProtocolVersionError is the error response body. `supported` is the
+// field a client reads to pick a revision to retry with.
+type unsupportedProtocolVersionError struct {
+	JSONRPC string                            `json:"jsonrpc"`
+	ID      mcpjsonrpc.ID                     `json:"id"`
+	Error   unsupportedProtocolVersionPayload `json:"error"`
+}
+
+type unsupportedProtocolVersionPayload struct {
+	Code    int                            `json:"code"`
+	Message string                         `json:"message"`
+	Data    unsupportedProtocolVersionData `json:"data"`
+}
+
+type unsupportedProtocolVersionData struct {
+	Supported []string `json:"supported"`
+}
+
+// requestedProtocolVersion returns the protocol revision a request declares,
+// preferring the header the Streamable HTTP binding requires and falling back to
+// the `_meta` key it mirrors. Empty when the request declares none, which is
+// every client on a revision predating the header.
+//
+// The value is client-supplied and is bounded before use, since it reaches
+// telemetry and an error message.
+func requestedProtocolVersion(r *http.Request, req *rawRequest) string {
+	if v := mcpversions.Sanitize(r.Header.Get(mcpversions.HTTPHeader)); v != "" {
+		return v
+	}
+	if req == nil || len(req.Params) == 0 {
+		return ""
+	}
+
+	var params struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return ""
+	}
+	raw, ok := params.Meta[metaProtocolVersionKey]
+	if !ok {
+		return ""
+	}
+
+	var declared string
+	if err := json.Unmarshal(raw, &declared); err != nil {
+		return ""
+	}
+
+	return mcpversions.Sanitize(declared)
+}
+
+// rejectUnsupportedProtocolVersion writes the specified refusal for a request
+// declaring a revision this surface does not implement: HTTP 400 with a JSON-RPC
+// error naming the revisions it does.
+//
+// This is not merely a courtesy. A client on a handshake-less revision has no
+// `initialize` in which to be told what the server speaks, so the refusal is the
+// only signal it gets — and the specification's backward-compatibility flow is
+// built on receiving it: on a 400 the client either retries with an advertised
+// revision or falls back to `initialize`. Answering such a client with a result
+// shaped for an older revision leaves it validating that result against the only
+// revision it knows, which is how a missing `resultType` surfaces as a broken
+// server rather than as a version mismatch.
+func rejectUnsupportedProtocolVersion(
+	ctx context.Context,
+	logger *slog.Logger,
+	w http.ResponseWriter,
+	id mcpjsonrpc.ID,
+	served, requested string,
+) error {
+	logger.InfoContext(ctx, "rejecting request declaring an unsupported mcp protocol revision",
+		attr.SlogMCPRequestedProtocolVersion(requested),
+		attr.SlogMCPNegotiatedProtocolVersion(served))
+
+	payload := unsupportedProtocolVersionError{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: unsupportedProtocolVersionPayload{
+			Code:    mcpCodeUnsupportedProtocolVersion,
+			Message: "unsupported protocol version: " + requested,
+			Data:    unsupportedProtocolVersionData{Supported: []string{served}},
+		},
+	}
+
+	bs, err := json.Marshal(payload)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to serialize unsupported protocol version response").LogError(ctx, logger)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_, _ = w.Write(bs)
+
+	return nil
+}
+
+// enforceServedProtocolVersion refuses a request this surface cannot honour,
+// reporting whether it did so. See [mcpversions.Serves] for which requests those
+// are, and [rejectUnsupportedProtocolVersion] for why refusing beats serving a
+// mismatched shape.
+//
+// Only surfaces Gram answers from its own inventory call this. The remote and
+// tunneled backends relay to an upstream that answers for itself, and gating
+// those would have Gram refuse a revision the upstream may well implement.
+func (s *Service) enforceServedProtocolVersion(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	req *rawRequest,
+	served string,
+) (bool, error) {
+	requested := requestedProtocolVersion(r, req)
+	if mcpversions.Serves(served, requested) {
+		return false, nil
+	}
+
+	var id mcpjsonrpc.ID
+	if req != nil {
+		id = req.ID
+	}
+
+	return true, rejectUnsupportedProtocolVersion(ctx, s.logger, w, id, served, requested)
+}

--- a/server/internal/mcp/protocolgate_test.go
+++ b/server/internal/mcp/protocolgate_test.go
@@ -1,0 +1,156 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+const toolsListRPC = `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`
+
+// newPublicToolsetForProtocolTest creates a public toolset-backed MCP server, the
+// surface Gram answers from its own inventory.
+func newPublicToolsetForProtocolTest(t *testing.T, ctx context.Context, ti *testInstance, slug string) string {
+	t.Helper()
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   slug,
+		Slug:                   slug,
+		Description:            conv.ToPGText("protocol gate"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText(slug),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	_, err = toolsetsRepo.UpdateToolset(ctx, toolsets_repo.UpdateToolsetParams{
+		Name:                   toolset.Name,
+		Description:            toolset.Description,
+		DefaultEnvironmentSlug: toolset.DefaultEnvironmentSlug,
+		McpSlug:                toolset.McpSlug,
+		McpIsPublic:            true,
+		McpEnabled:             toolset.McpEnabled,
+		Slug:                   toolset.Slug,
+		ProjectID:              toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	return toolset.McpSlug.String
+}
+
+// TestServePublic_RejectsHandshakelessProtocolVersion is the regression test for a
+// client on 2026-07-28 receiving a result shaped for the revision this surface
+// actually answers. There is no `initialize` on that revision in which to tell it
+// otherwise, so the refusal is the only signal it gets — and the spec's fallback
+// flow is built on receiving it.
+func TestServePublic_RejectsHandshakelessProtocolVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	slug := newPublicToolsetForProtocolTest(t, ctx, ti, "gate-header")
+
+	w, err := servePublicHTTP(t, ctx, ti, slug, []byte(toolsListRPC), "",
+		map[string]string{mcpversions.HTTPHeader: mcpversions.Version20260728})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+
+	var envelope struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      any    `json:"id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    struct {
+				Supported []string `json:"supported"`
+			} `json:"data"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope), "body: %s", w.Body.String())
+	require.Equal(t, "2.0", envelope.JSONRPC)
+	require.Equal(t, -32022, envelope.Error.Code, "the code MCP allocates for an unsupported revision")
+	require.Equal(t, []string{mcpversions.ServedHostedToolset}, envelope.Error.Data.Supported,
+		"the client needs a revision to retry with")
+	require.InDelta(t, 1, envelope.ID, 0, "the refusal must correlate to the request")
+}
+
+// TestServePublic_RejectsHandshakelessProtocolVersionFromMeta covers the same
+// declaration made only in `_meta`, which is where 2026-07-28 puts it; the header
+// merely mirrors it.
+func TestServePublic_RejectsHandshakelessProtocolVersionFromMeta(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	slug := newPublicToolsetForProtocolTest(t, ctx, ti, "gate-meta")
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`
+	w, err := servePublicHTTP(t, ctx, ti, slug, []byte(body), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	require.Contains(t, w.Body.String(), "-32022")
+}
+
+// TestServePublic_ServesHandshakeEraProtocolVersions pins the blast radius. Every
+// revision that agrees a version at `initialize` keeps working exactly as before,
+// including ones newer than the surface answers: such a client is told what the
+// server speaks and adapts.
+func TestServePublic_ServesHandshakeEraProtocolVersions(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	slug := newPublicToolsetForProtocolTest(t, ctx, ti, "gate-legacy")
+
+	for name, header := range map[string]string{
+		"the served revision":       mcpversions.Version20250326,
+		"a newer handshake version": mcpversions.Version20250618,
+		"the newest handshake one":  mcpversions.Version20251125,
+		"an unrecognized version":   "2099-01-01",
+		"no version at all":         "",
+	} {
+		headers := map[string]string{}
+		if header != "" {
+			headers[mcpversions.HTTPHeader] = header
+		}
+
+		w, err := servePublicHTTP(t, ctx, ti, slug, []byte(toolsListRPC), "", headers)
+		require.NoError(t, err, name)
+		require.Equal(t, http.StatusOK, w.Code, "%s must keep working: %s", name, w.Body.String())
+	}
+}
+
+// TestServePublic_ToolsListEmptyArrayNotNull covers the shape violation the gate
+// work surfaced: a toolset resolving to no tools answered `"tools":null`, and MCP
+// list results carry an array.
+func TestServePublic_ToolsListEmptyArrayNotNull(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	slug := newPublicToolsetForProtocolTest(t, ctx, ti, "gate-empty")
+
+	w, err := servePublicHTTP(t, ctx, ti, slug, []byte(toolsListRPC), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var envelope struct {
+		Result struct {
+			Tools json.RawMessage `json:"tools"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope), "body: %s", w.Body.String())
+	require.JSONEq(t, `[]`, string(envelope.Result.Tools), "an empty tool list is an empty array, not null")
+}

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -148,6 +148,12 @@ func handleToolsList(
 		}
 	}
 
+	if tools == nil {
+		// MCP list results carry an array, never null — a toolset that resolves
+		// to no tools still answers with an empty one.
+		tools = []*toolListEntry{}
+	}
+
 	result := &toolsListResult{
 		ID: req.ID,
 		Result: toolsListResultTools{

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -102,6 +102,12 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").LogError(ctx, s.logger)
 	}
 
+	// Refuse a revision this surface does not answer before doing any work; see
+	// [Service.enforceServedProtocolVersion].
+	if rejected, err := s.enforceServedProtocolVersion(ctx, w, r, &req, mcpversions.ServedPlatformToolset); rejected || err != nil {
+		return err
+	}
+
 	body, err := s.handlePlatformToolsetRequest(ctx, authCtx, toolset, &req, r.Header.Get("Gram-Chat-ID"))
 	switch {
 	case body == nil && err == nil:


### PR DESCRIPTION
## Summary

Gram's hosted toolset surfaces answer `2025-03-26` and dispatch every method with no regard for what the client asked for. A client on MCP 2026-07-28 therefore gets a 200 with a result shaped for a revision it has never heard of — no `resultType`, none of the caching members — and rejects it:

```
Invalid result for tools/list: missing required resultType — servers implementing
protocol revision 2026-07-28 MUST include it
```

Reproduced against production. A `tools/list` declaring 2026-07-28, one declaring 2025-03-26, and one declaring nothing all came back byte-identical:

```
2026-07-28   members=['tools']  resultType=null  tools=44
2025-03-26   members=['tools']  resultType=null  tools=44
none         members=['tools']  resultType=null  tools=44
```

## Why serving an older shape isn't good enough

For the handshake-based revisions it *is* good enough, which is why nearly everything works today: the client sends `initialize`, is told `2025-03-26`, and adapts. The absent-`resultType` bridge is explicitly available to it — "clients **MUST** treat an absent `resultType` as `complete`" — because it knows it is talking to an earlier-revision server.

2026-07-28 removed `initialize`. Such a client never handshakes; it declares its version per request and validates the reply against it. There is no exchange in which Gram can say it speaks something older, so the client cannot apply the bridge and has no way to discover the mismatch.

The refusal is the mechanism the spec provides for exactly this:

> If the server does not implement the requested protocol version […] it **MUST** respond with `400 Bad Request` and an `UnsupportedProtocolVersionError` listing its supported versions.

and the fallback is built on receiving it:

> On `400 Bad Request`, the client **SHOULD** inspect the response body before falling back […] If the body is empty or is not a recognized modern JSON-RPC error, fall back to `initialize` and continue with the legacy version.

Answering 200 with a mismatched shape is the one behaviour that strands the client. Simply emitting `resultType` would silence the symptom while Gram still doesn't implement MRT, header validation or the caching contract — asserting a revision it doesn't serve, and hiding the next gap.

## Change

Gram-originated surfaces refuse a request declaring a handshake-less revision they do not answer: HTTP 400, JSON-RPC `-32022` (`UnsupportedProtocolVersion`), `data.supported` naming what the surface does serve.

Deliberately narrow, because this is a live behaviour change:

- **Only revisions from 2026-07-28 onward are refused.** Every handshake-based revision keeps working exactly as before, *including ones newer than the surface answers* — such a client is told what the server speaks and adapts, so refusing it would break working traffic to no purpose.
- **A request declaring nothing, or an unrecognized revision, is served as before.**
- **Only surfaces Gram answers from its own inventory are gated.** The remote and tunneled backends relay to an upstream that answers for itself; gating those would have Gram refuse a revision the upstream may well implement. (That relay path is #5381's territory.)

The version is read from the `MCP-Protocol-Version` header, falling back to the `io.modelcontextprotocol/protocolVersion` `_meta` key the header mirrors, so a client sending only the body form is caught too.

Also fixes a shape violation this surfaced: a toolset resolving to no tools answered `"tools":null`, and MCP list results carry an array.

## Testing

Through the real hosted handler: a 2026-07-28 declaration is refused with 400/`-32022`/`supported`, correlated to the request id; the same declaration made only in `_meta` is refused identically; every handshake-era revision, an unrecognized one, and no declaration at all still return 200; an empty tool list is `[]`. Plus unit coverage of the `Handshakeless`/`Serves` predicates, including a surface that later moves to the newer revision.

`mise lint:server` and the full `./server/internal/mcp/...` suite pass.

## Rollout note

This is a live behaviour change for every hosted MCP server: a client currently declaring 2026-07-28 and tolerating the old shape starts receiving a 400 and must fall back. That is the spec's intent and the fallback is the point — but it is why this ships separately from #5381 rather than riding along with it.

## Relationship to #5381

Same client-visible symptom, two unrelated causes, in two different packages:

- **#5381** (`internal/remotemcp/proxy`) — Gram *relays* an upstream's result and was destroying members in transit, including `resultType`. Validated against a real Linear upstream.
- **This PR** (`internal/mcp`) — Gram *originates* the result and never produces a `resultType` at all, so there is nothing to preserve; the fix is to stop claiming to serve a revision it doesn't.

Neither subsumes the other; #5381 touches no file under `server/internal/mcp/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsupported handshakeless MCP revisions on Gram‑originated surfaces and returns 400 with JSON‑RPC `UnsupportedProtocolVersion` (-32022) listing the supported revision, instead of replying 200 with a mismatched result. This lets 2026‑07‑28 clients detect a version mismatch and follow the spec’s fallback.

- Applies to hosted and platform toolset surfaces in `server/internal/mcp`; remote/tunneled proxies are unaffected.
- Only handshakeless requests are refused: 2026‑07‑28 must match exactly; handshake‑era requests (incl. newer than served) keep working as before.
- Absent or unrecognized request versions are served as before.
- Reads the version from `MCP-Protocol-Version` or `_meta['io.modelcontextprotocol/protocolVersion']`.
- Also fixes `tools/list` to return an empty array instead of `null` when there are no tools.

**Rollout**
- Clients declaring 2026‑07‑28 must retry with the revision in `error.data.supported` or fall back to `initialize`.

<sup>Written for commit 0eed855f073f39dd8c2c02152e2a77dace239f40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

