### PR TITLE
feat: record last_used_at when sessions carry traffic

### DIFF
--- a/.changeset/session-last-used-stamp.md
+++ b/.changeset/session-last-used-stamp.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Record `last_used_at` on user sessions and remote sessions when they carry traffic, so a connection that has not been used is distinguishable from one whose token merely keeps refreshing. Writes are coalesced to a five-minute window on both token paths and are best-effort, so they never fail a request that holds a valid credential.

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -226,6 +227,35 @@ var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated 
 // authz.Engine.ShouldEnforce / PrepareContext treat the request as a real
 // authenticated session. AccountType is retained as session metadata but does
 // not control RBAC enforcement.
+// userSessionLastUsedCutoff coalesces the last_used_at stamp: a session records
+// at most one write per window regardless of request volume. Every other
+// request matches no rows and costs one index probe. The window is therefore
+// also the resolution of the liveness readout — "used 4m ago" is accurate to
+// within this much.
+const userSessionLastUsedCutoff = 5 * time.Minute
+
+// touchUserSessionLastUsed records that a validated session just carried a
+// request. Best-effort by design: this runs on the per-request MCP auth path,
+// where a bookkeeping write must never turn a good credential into a failed
+// call, so a failure is logged and swallowed.
+func (s *Service) touchUserSessionLastUsed(ctx context.Context, endpoint *ResolvedMcpEndpoint, jti string) {
+	if jti == "" {
+		return
+	}
+
+	now := time.Now()
+	err := usersessions_repo.New(s.db).TouchUserSessionLastUsed(ctx, usersessions_repo.TouchUserSessionLastUsedParams{
+		NowTs:               pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+		ProjectID:           endpoint.ProjectID,
+		UserSessionIssuerID: endpoint.UserSessionIssuerID,
+		Jti:                 jti,
+		UsedCutoff:          pgtype.Timestamptz{Time: now.Add(-userSessionLastUsedCutoff), Valid: true, InfinityModifier: pgtype.Finite},
+	})
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to stamp user session last_used_at", attr.SlogError(err))
+	}
+}
+
 func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, error) {
 	if token == "" {
 		return ctx, nil, nil
@@ -239,6 +269,11 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	if session.ClientID != "" {
 		ctx = contextvalues.SetOAuthClientID(ctx, session.ClientID)
 	}
+
+	// Stamped for every subject kind, anonymous included: liveness describes
+	// the connection, and an anonymous session is a real connection whose
+	// principal happens to be unknown.
+	s.touchUserSessionLastUsed(ctx, endpoint, session.JTI)
 
 	if subject.Kind == urn.SessionSubjectKindAnonymous {
 		return ctx, &subject, nil

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -202,31 +202,6 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // not a credential rejection.
 var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated endpoint")
 
-// validateUserSessionToken delegates the JWT verify + revocation check to
-// usersessions.Signer.ValidateBearer, then — for user / API-key subjects —
-// stamps a contextvalues.AuthContext scoped to the endpoint's org/project.
-// A nil subject means "not authenticated as a user session"; the returned
-// error carries the reason (bad signature, expired/notBefore, audience
-// mismatch, jti revoked, unparseable subject URN) when a token was presented
-// and rejected, and is nil when no token was presented at all — so the caller
-// can log a real rejection without logging the no-credentials handshake probe.
-// One non-rejection error shares this return: a token that validated fine but
-// whose org lookup failed wraps errIssuerGateOrgLookup, letting the caller
-// label it as an operational failure rather than a bad credential.
-//
-// Anonymous subjects deliberately leave the AuthContext unset (non-nil
-// subject, no AuthContext). The request belongs to no known principal, so
-// stamping the endpoint's org as ActiveOrganizationID would misrepresent
-// the caller as a member of that org. Downstream code on the public
-// path reads org/project off the resolved endpoint directly, the same
-// way it does for unauthenticated public-endpoint traffic. The OAuth client
-// id is still stamped for them — an anonymous session is anonymous in its
-// principal, not in the client that registered for it.
-//
-// SessionID is populated for non-anonymous subjects so
-// authz.Engine.ShouldEnforce / PrepareContext treat the request as a real
-// authenticated session. AccountType is retained as session metadata but does
-// not control RBAC enforcement.
 // userSessionLastUsedCutoff coalesces the last_used_at stamp: a session records
 // at most one write per window regardless of request volume. Every other
 // request matches no rows and costs one index probe. The window is therefore
@@ -256,6 +231,31 @@ func (s *Service) touchUserSessionLastUsed(ctx context.Context, endpoint *Resolv
 	}
 }
 
+// validateUserSessionToken delegates the JWT verify + revocation check to
+// usersessions.Signer.ValidateBearer, then — for user / API-key subjects —
+// stamps a contextvalues.AuthContext scoped to the endpoint's org/project.
+// A nil subject means "not authenticated as a user session"; the returned
+// error carries the reason (bad signature, expired/notBefore, audience
+// mismatch, jti revoked, unparseable subject URN) when a token was presented
+// and rejected, and is nil when no token was presented at all — so the caller
+// can log a real rejection without logging the no-credentials handshake probe.
+// One non-rejection error shares this return: a token that validated fine but
+// whose org lookup failed wraps errIssuerGateOrgLookup, letting the caller
+// label it as an operational failure rather than a bad credential.
+//
+// Anonymous subjects deliberately leave the AuthContext unset (non-nil
+// subject, no AuthContext). The request belongs to no known principal, so
+// stamping the endpoint's org as ActiveOrganizationID would misrepresent
+// the caller as a member of that org. Downstream code on the public
+// path reads org/project off the resolved endpoint directly, the same
+// way it does for unauthenticated public-endpoint traffic. The OAuth client
+// id is still stamped for them — an anonymous session is anonymous in its
+// principal, not in the client that registered for it.
+//
+// SessionID is populated for non-anonymous subjects so
+// authz.Engine.ShouldEnforce / PrepareContext treat the request as a real
+// authenticated session. AccountType is retained as session metadata but does
+// not control RBAC enforcement.
 func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, error) {
 	if token == "" {
 		return ctx, nil, nil

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -1993,3 +1993,19 @@ WHERE i.issuer = ANY(@issuers::text[])
   AND (sqlc.narg('cursor')::uuid IS NULL OR i.id < sqlc.narg('cursor')::uuid)
 ORDER BY i.id DESC
 LIMIT sqlc.arg('limit_value');
+
+-- name: TouchRemoteSessionLastUsed :exec
+-- Records that this upstream token was handed to a proxied call. Distinct from
+-- last_refresh_attempt_at, which records keepalive work rather than traffic.
+-- Coalesced by the cutoff for the same reason as the user_sessions stamp: this
+-- runs whenever a brokered call resolves a token, so most executions must match
+-- no rows.
+-- Scoped by the (subject_urn, remote_session_client_id) binding rather than a
+-- project_id, which this table does not carry; that pair is the table's
+-- uniqueness key and the client is itself tenant-owned.
+UPDATE remote_sessions
+SET last_used_at = @now_ts::timestamptz
+WHERE subject_urn = @subject_urn
+  AND remote_session_client_id = @remote_session_client_id
+  AND deleted IS FALSE
+  AND (last_used_at IS NULL OR last_used_at <= @used_cutoff::timestamptz);

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -4391,6 +4391,40 @@ func (q *Queries) SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer(ctx cont
 	return items, nil
 }
 
+const touchRemoteSessionLastUsed = `-- name: TouchRemoteSessionLastUsed :exec
+UPDATE remote_sessions
+SET last_used_at = $1::timestamptz
+WHERE subject_urn = $2
+  AND remote_session_client_id = $3
+  AND deleted IS FALSE
+  AND (last_used_at IS NULL OR last_used_at <= $4::timestamptz)
+`
+
+type TouchRemoteSessionLastUsedParams struct {
+	NowTs                 pgtype.Timestamptz
+	SubjectUrn            urn.SessionSubject
+	RemoteSessionClientID uuid.UUID
+	UsedCutoff            pgtype.Timestamptz
+}
+
+// Records that this upstream token was handed to a proxied call. Distinct from
+// last_refresh_attempt_at, which records keepalive work rather than traffic.
+// Coalesced by the cutoff for the same reason as the user_sessions stamp: this
+// runs whenever a brokered call resolves a token, so most executions must match
+// no rows.
+// Scoped by the (subject_urn, remote_session_client_id) binding rather than a
+// project_id, which this table does not carry; that pair is the table's
+// uniqueness key and the client is itself tenant-owned.
+func (q *Queries) TouchRemoteSessionLastUsed(ctx context.Context, arg TouchRemoteSessionLastUsedParams) error {
+	_, err := q.db.Exec(ctx, touchRemoteSessionLastUsed,
+		arg.NowTs,
+		arg.SubjectUrn,
+		arg.RemoteSessionClientID,
+		arg.UsedCutoff,
+	)
+	return err
+}
+
 const updateGlobalRemoteSessionClient = `-- name: UpdateGlobalRemoteSessionClient :one
 UPDATE remote_session_clients
 SET

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -109,6 +110,12 @@ type ResolvedAuthorization struct {
 	RemoteSessionIssuerID  uuid.UUID
 }
 
+// remoteSessionLastUsedCutoff coalesces the last_used_at stamp so a busy
+// binding writes at most one row per window. Matches the window used for
+// user_sessions, so both legs of a brokered connection report liveness at the
+// same resolution and a chain view can compare them directly.
+const remoteSessionLastUsedCutoff = 5 * time.Minute
+
 // ResolveAccessToken returns the upstream access token stored for the
 // (client, subject) pair, refreshing via the upstream /token endpoint
 // when the stored access_expires_at is in the past and a
@@ -172,6 +179,23 @@ func (m *ChallengeManager) ResolveAccessToken(
 		)
 		return "", nil
 	}
+
+	// Stamped only on the success path: a resolved token is one that is about
+	// to be spent on a proxied call, which is precisely what "used" means here.
+	// Best-effort — bookkeeping must not fail a call that has a valid token.
+	now := time.Now()
+	if err := remotesessions_repo.New(m.db).TouchRemoteSessionLastUsed(ctx, remotesessions_repo.TouchRemoteSessionLastUsedParams{
+		NowTs:                 pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+		SubjectUrn:            subject,
+		RemoteSessionClientID: clientID,
+		UsedCutoff:            pgtype.Timestamptz{Time: now.Add(-remoteSessionLastUsedCutoff), Valid: true, InfinityModifier: pgtype.Finite},
+	}); err != nil {
+		m.logger.WarnContext(ctx, "failed to stamp remote session last_used_at",
+			attr.SlogRemoteSessionClientID(clientID.String()),
+			attr.SlogError(err),
+		)
+	}
+
 	return tok, nil
 }
 

--- a/server/internal/remotesessions/touchremotesessionlastused_test.go
+++ b/server/internal/remotesessions/touchremotesessionlastused_test.go
@@ -1,0 +1,99 @@
+package remotesessions_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// The stamp runs whenever a brokered call resolves an upstream token, so the
+// properties that matter are that it records use at all, that it coalesces
+// within the cutoff window (otherwise every proxied call writes a row), and
+// that it cannot reach a session outside its own
+// (subject_urn, remote_session_client_id) binding — the pair standing in for
+// the project_id this table does not carry.
+func TestTouchRemoteSessionLastUsed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	enc := testenv.NewEncryptionClient(t)
+	q := repo.New(ti.conn)
+
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-touch-last-used")
+	clientID, _ := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, authCtx.ActiveOrganizationID, "rsi-touch-last-used")
+
+	subject := urn.NewUserSubject("touch-last-used-subject")
+	accessEnc, err := enc.Encrypt([]byte("upstream-access-token"))
+	require.NoError(t, err)
+	session, err := q.UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+		SubjectUrn:            subject,
+		UserSessionIssuerID:   userIssuerID,
+		RemoteSessionClientID: clientID,
+		AccessTokenEncrypted:  accessEnc,
+		AccessExpiresAt:       pgtype.Timestamptz{Time: time.Now().Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		Scopes:                []string{},
+	})
+	require.NoError(t, err)
+	require.False(t, session.LastUsedAt.Valid, "a freshly upserted session has never been used")
+
+	touch := func(now time.Time, subj urn.SessionSubject, client uuid.UUID) error {
+		return q.TouchRemoteSessionLastUsed(ctx, repo.TouchRemoteSessionLastUsedParams{
+			NowTs:                 pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+			SubjectUrn:            subj,
+			RemoteSessionClientID: client,
+			UsedCutoff:            pgtype.Timestamptz{Time: now.Add(-5 * time.Minute), Valid: true, InfinityModifier: pgtype.Finite},
+		})
+	}
+
+	reload := func() repo.RemoteSession {
+		t.Helper()
+		got, err := q.GetRemoteSessionByID(ctx, repo.GetRemoteSessionByIDParams{
+			ID:        session.ID,
+			ProjectID: *authCtx.ProjectID,
+		})
+		require.NoError(t, err)
+		return got
+	}
+
+	first := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, touch(first, subject, clientID))
+
+	stamped := reload()
+	require.True(t, stamped.LastUsedAt.Valid, "first use stamps the column")
+	require.WithinDuration(t, first, stamped.LastUsedAt.Time, time.Second)
+
+	// A second call inside the cutoff window must not write: this is what keeps
+	// a chatty proxied session down to one row per window.
+	require.NoError(t, touch(first.Add(30*time.Second), subject, clientID))
+	require.Equal(t, stamped.LastUsedAt.Time, reload().LastUsedAt.Time,
+		"a touch inside the cutoff window leaves the stamp untouched")
+
+	// Past the window, the next call advances it.
+	later := first.Add(6 * time.Minute)
+	require.NoError(t, touch(later, subject, clientID))
+	advanced := reload().LastUsedAt.Time
+	require.WithinDuration(t, later, advanced, time.Second,
+		"a touch past the cutoff window advances the stamp")
+
+	// Neither half of the binding on its own reaches the row: a different
+	// subject on the same client, or the same subject on another client, both
+	// match nothing even though the cutoff is long past.
+	beyond := later.Add(10 * time.Minute)
+	otherClientID, _ := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, createUserSessionIssuer(t, ctx, ti.conn, "usi-touch-last-used-other"), authCtx.ActiveOrganizationID, "rsi-touch-last-used-other")
+	require.NoError(t, touch(beyond, urn.NewUserSubject("touch-last-used-other-subject"), clientID))
+	require.NoError(t, touch(beyond, subject, otherClientID))
+	require.Equal(t, advanced, reload().LastUsedAt.Time,
+		"another binding must not stamp this session")
+}

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -618,3 +618,18 @@ WHERE iss.project_id = @project_id AND iss.deleted IS FALSE AND s.deleted IS FAL
   AND s.subject_urn::text LIKE 'user:%'
 GROUP BY s.subject_urn, u.display_name, u.email
 ORDER BY count DESC, display_name ASC;
+
+-- name: TouchUserSessionLastUsed :exec
+-- Records that this session's access token was presented on an MCP request.
+-- Runs on the per-request auth path, so it is deliberately coalesced: the
+-- cutoff means a session writes at most one row per cutoff window however many
+-- requests it makes, and every other request matches no rows and only probes
+-- user_sessions_user_session_issuer_id_jti_idx. Mirrors the claim-cutoff shape
+-- used by the remote_sessions keepalive sweep.
+UPDATE user_sessions
+SET last_used_at = @now_ts::timestamptz
+WHERE project_id = @project_id
+  AND user_session_issuer_id = @user_session_issuer_id
+  AND jti = @jti
+  AND deleted IS FALSE
+  AND (last_used_at IS NULL OR last_used_at <= @used_cutoff::timestamptz);

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -1665,6 +1665,41 @@ func (q *Queries) SoftDeleteUserSessionsByIssuerID(ctx context.Context, userSess
 	return items, nil
 }
 
+const touchUserSessionLastUsed = `-- name: TouchUserSessionLastUsed :exec
+UPDATE user_sessions
+SET last_used_at = $1::timestamptz
+WHERE project_id = $2
+  AND user_session_issuer_id = $3
+  AND jti = $4
+  AND deleted IS FALSE
+  AND (last_used_at IS NULL OR last_used_at <= $5::timestamptz)
+`
+
+type TouchUserSessionLastUsedParams struct {
+	NowTs               pgtype.Timestamptz
+	ProjectID           uuid.UUID
+	UserSessionIssuerID uuid.UUID
+	Jti                 string
+	UsedCutoff          pgtype.Timestamptz
+}
+
+// Records that this session's access token was presented on an MCP request.
+// Runs on the per-request auth path, so it is deliberately coalesced: the
+// cutoff means a session writes at most one row per cutoff window however many
+// requests it makes, and every other request matches no rows and only probes
+// user_sessions_user_session_issuer_id_jti_idx. Mirrors the claim-cutoff shape
+// used by the remote_sessions keepalive sweep.
+func (q *Queries) TouchUserSessionLastUsed(ctx context.Context, arg TouchUserSessionLastUsedParams) error {
+	_, err := q.db.Exec(ctx, touchUserSessionLastUsed,
+		arg.NowTs,
+		arg.ProjectID,
+		arg.UserSessionIssuerID,
+		arg.Jti,
+		arg.UsedCutoff,
+	)
+	return err
+}
+
 const updateUserSessionClientCIMDCache = `-- name: UpdateUserSessionClientCIMDCache :one
 UPDATE user_session_clients
 SET client_id_metadata_fetched_at = clock_timestamp(),

--- a/server/internal/usersessions/touchusersessionlastused_test.go
+++ b/server/internal/usersessions/touchusersessionlastused_test.go
@@ -1,0 +1,118 @@
+package usersessions_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	issuersgen "github.com/speakeasy-api/gram/server/gen/user_session_issuers"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// The stamp runs on the per-request MCP auth path, so the properties that
+// matter are that it records use at all, that it coalesces within the cutoff
+// window (otherwise every request writes a row), and that it cannot reach a
+// session in another project.
+func TestTouchUserSessionLastUsed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	q := repo.New(ti.conn)
+
+	issuer, err := ti.service.CreateUserSessionIssuer(ctx, &issuersgen.CreateUserSessionIssuerPayload{
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+		Slug:                 "touch-last-used-issuer",
+		AuthnChallengeMode:   "chain",
+		SessionDurationHours: 24,
+	})
+	require.NoError(t, err)
+
+	issuerID := uuid.MustParse(issuer.ID)
+	session, err := seedUserSession(t, ctx, ti.conn, issuerID, urn.NewUserSubject("touch-target"))
+	require.NoError(t, err)
+	require.False(t, session.LastUsedAt.Valid, "a freshly seeded session has never been used")
+
+	touch := func(now time.Time) error {
+		return q.TouchUserSessionLastUsed(ctx, repo.TouchUserSessionLastUsedParams{
+			NowTs:               pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+			ProjectID:           session.ProjectID,
+			UserSessionIssuerID: issuerID,
+			Jti:                 session.Jti,
+			UsedCutoff:          pgtype.Timestamptz{Time: now.Add(-5 * time.Minute), Valid: true, InfinityModifier: pgtype.Finite},
+		})
+	}
+
+	reload := func() repo.UserSession {
+		t.Helper()
+		got, err := q.GetUserSessionByID(ctx, repo.GetUserSessionByIDParams{
+			ID:        session.ID,
+			ProjectID: session.ProjectID,
+		})
+		require.NoError(t, err)
+		return got
+	}
+
+	first := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, touch(first))
+
+	stamped := reload()
+	require.True(t, stamped.LastUsedAt.Valid, "first use stamps the column")
+	require.WithinDuration(t, first, stamped.LastUsedAt.Time, time.Second)
+
+	// A second request inside the cutoff window must not write: this is what
+	// keeps a session doing hundreds of calls a minute to one row per window.
+	require.NoError(t, touch(first.Add(30*time.Second)))
+	require.Equal(t, stamped.LastUsedAt.Time, reload().LastUsedAt.Time,
+		"a touch inside the cutoff window leaves the stamp untouched")
+
+	// Past the window, the next request advances it.
+	later := first.Add(6 * time.Minute)
+	require.NoError(t, touch(later))
+	require.WithinDuration(t, later, reload().LastUsedAt.Time, time.Second,
+		"a touch past the cutoff window advances the stamp")
+}
+
+// The query is project-scoped, so a jti presented against one project can never
+// stamp a same-named session in another.
+func TestTouchUserSessionLastUsedIsProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	q := repo.New(ti.conn)
+
+	issuer, err := ti.service.CreateUserSessionIssuer(ctx, &issuersgen.CreateUserSessionIssuerPayload{
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+		Slug:                 "touch-scope-issuer",
+		AuthnChallengeMode:   "chain",
+		SessionDurationHours: 24,
+	})
+	require.NoError(t, err)
+
+	issuerID := uuid.MustParse(issuer.ID)
+	session, err := seedUserSession(t, ctx, ti.conn, issuerID, urn.NewUserSubject("touch-scope-target"))
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	require.NoError(t, q.TouchUserSessionLastUsed(ctx, repo.TouchUserSessionLastUsedParams{
+		NowTs:               pgtype.Timestamptz{Time: now, Valid: true, InfinityModifier: pgtype.Finite},
+		ProjectID:           uuid.New(),
+		UserSessionIssuerID: issuerID,
+		Jti:                 session.Jti,
+		UsedCutoff:          pgtype.Timestamptz{Time: now.Add(-5 * time.Minute), Valid: true, InfinityModifier: pgtype.Finite},
+	}))
+
+	got, err := q.GetUserSessionByID(ctx, repo.GetUserSessionByIDParams{
+		ID:        session.ID,
+		ProjectID: session.ProjectID,
+	})
+	require.NoError(t, err)
+	require.False(t, got.LastUsedAt.Valid, "another project's id must not stamp this session")
+}


### PR DESCRIPTION
**Stacked on #5386** — review that one first; this PR targets it, not `main`.

Writes the `last_used_at` columns #5386 added. Nothing reads them yet; the UI lands in the next PR of the stack.

## Why

A connection whose token keeps refreshing looks identical to one in daily use. `updated_at` moves on refresh-grant writes, and `remote_sessions.last_refresh_attempt_at` records keepalive work, so neither answers "is anyone actually using this?" — the question the connection UI in AIS-399 has to answer.

## Where it stamps

Both legs of a brokered connection, at the moment the credential is spent:

- **Inbound** — `validateUserSessionToken` (`internal/mcp/authnchallenge.go`), once a presented bearer validates. Stamped for every subject kind including anonymous: liveness describes the connection, and an anonymous session is a real connection whose principal is unknown.
- **Outbound** — `ResolveAccessToken` (`internal/remotesessions/tokenservice.go`), on the success path only. A resolved token is one about to be spent on a proxied call.

## Cost

The inbound path previously did no database work at all — JWT verify plus an in-memory revocation check — so this is the one change worth scrutinising.

Both writes are coalesced by a 5-minute cutoff, the same shape the `remote_sessions` keepalive sweep already uses (`WHERE ... last_refresh_attempt_at IS NULL OR <= @attempt_cutoff`). A session writes at most one row per 5 minutes however many requests it makes; every other request matches no rows and costs one probe of `user_sessions_user_session_issuer_id_jti_idx`. A session making 600 calls in a window writes once and probes 599 times.

The cutoff is therefore also the resolution of the liveness readout, which is deliberate — "used 4m ago" is the intended precision, not a limitation to work around.

Both writes are best-effort: a failure is logged and swallowed, because bookkeeping must never turn a valid credential into a failed call.

## Scoping

`TouchUserSessionLastUsed` is project-scoped per the sqlc convention. `TouchRemoteSessionLastUsed` cannot be — `remote_sessions` carries no `project_id` — so it is scoped by `(subject_urn, remote_session_client_id)`, that table's uniqueness key, where the client is itself tenant-owned. Called out in a comment on the query.

## Verification

- New tests cover the three properties that matter: a first use stamps, a second use inside the window does not move the stamp, and a use past the window advances it. A separate test asserts another project's id cannot stamp the session.
- `go test ./internal/usersessions/... ./internal/remotesessions/...` — 733 pass.
- `go test ./internal/mcp/...` — 474 pass.
- `mise lint:server` — clean.

AIS-399

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record last_used_at for user and remote sessions when tokens carry traffic, coalesced to 5 minutes, so AIS-399 can show real liveness rather than refresh activity. Previously inbound auth did no DB writes and updated_at/last_refresh_attempt_at reflected refreshes, not use.

- Inbound: `validateUserSessionToken` stamps after bearer validation for all subject kinds, including anonymous.
- Outbound: `ResolveAccessToken` stamps only on the success path when handing an upstream token to a proxied call.
- Coalescing and cost: one index probe per request; at most one write per session per 5 minutes. Best-effort; failures log and do not fail valid requests.
- Scoping: user-session stamp is project-scoped; remote-session stamp is scoped by (subject_urn, remote_session_client_id).
- Tests: cover first-use stamp, within-window no-op, post-window advance, and isolation across projects/bindings.

<sup>Written for commit c1e548eb04fd7250d4e2f7bc1f0e8f41ff3f5e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

