### PR TITLE
feat(admin): group the organization record's Overview facts

### DIFF
--- a/.changeset/admin-organization-record-facts.md
+++ b/.changeset/admin-organization-record-facts.md
@@ -1,0 +1,19 @@
+---
+"admin": patch
+---
+
+An organization record's Overview now reads as three named groups rather than
+one flat list of facts. Identity carries the name, slug, organization id, WorkOS
+id and the created and updated dates. Plan carries the account type and the
+trial. Access carries Whitelisted and Disabled at.
+
+Whitelisted keeps its name and sits on its own, because it gates the
+organization's access to the platform rather than expressing a preference.
+
+The slug, the organization id and the WorkOS id can each be copied with one
+click, the same control the organizations list already uses when you peek at a
+record. An organization with no WorkOS id gets no copy button rather than a
+button that copies a dash.
+
+The Members row is gone from the Overview. The record's own nav already counts
+members, so the row said the same thing twice.

--- a/client/admin/src/components/CopyValue.tsx
+++ b/client/admin/src/components/CopyValue.tsx
@@ -1,0 +1,59 @@
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useEffect, useRef, useState, type JSX } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const COPY_CONFIRM_MS = 1500;
+
+function noop(): void {}
+
+// An identifier the operator can take away with one click. `label` names the
+// value for the control's accessible name, so two controls in one panel are
+// told apart by what they copy.
+export function CopyValue({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value: string;
+  className?: string;
+}): JSX.Element {
+  // The value copied, not a flag. Peek swaps the record under a mounted panel,
+  // and a flag would stand as a confirmation against an id never copied,
+  // including where the write resolves after the swap.
+  const [copiedValue, setCopiedValue] = useState<string>();
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const copied = copiedValue === value;
+
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  return (
+    <span className="flex items-center gap-1">
+      <span className={cn("truncate font-mono text-xs", className)}>
+        {value}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        aria-label={copied ? `${label} copied` : `Copy ${label}`}
+        onClick={() => {
+          // Undefined outside a secure context, where the call would throw.
+          if (!navigator.clipboard?.writeText) return;
+          // A check over a failed write sends the operator off with the wrong id.
+          void navigator.clipboard.writeText(value).then(() => {
+            setCopiedValue(value);
+            clearTimeout(timer.current);
+            timer.current = setTimeout(
+              () => setCopiedValue(undefined),
+              COPY_CONFIRM_MS,
+            );
+          }, noop);
+        }}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </Button>
+    </span>
+  );
+}

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -81,7 +81,17 @@ function labelsIn(group: string): string[] {
   );
 }
 
+const writeText = vi.fn<(text: string) => Promise<void>>(() =>
+  Promise.resolve(),
+);
+
 beforeEach(() => {
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
   mocks.getSession.mockReset();
   mocks.getSession.mockResolvedValue({
     email: "ops@example.test",
@@ -461,6 +471,54 @@ describe("Overview", () => {
         whitelisted: false,
       });
     });
+  });
+
+  it("copies each identifier off its own row", async () => {
+    const identified = {
+      ...ORG,
+      workos_id: "org_workos_placeholder_identifier",
+    };
+    mocks.getOrganization.mockResolvedValue(identified);
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${identified.slug}`,
+    });
+
+    // Row by row, each against its own value. Three controls stand side by
+    // side, and one wired to a neighbour hands the operator an identifier that
+    // belongs to a different field of the same record, which reads as right.
+    const rows: [string, string][] = [
+      ["Copy Slug", identified.slug],
+      ["Copy Organization id", identified.id],
+      ["Copy WorkOS id", identified.workos_id],
+    ];
+    for (const [name, value] of rows) {
+      const control = await screen.findByRole("button", { name });
+      fireEvent.click(control);
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(value);
+      });
+      expect(
+        await screen.findByRole("button", {
+          name: `${name.replace("Copy ", "")} copied`,
+        }),
+      ).toBeTruthy();
+    }
+    expect(writeText).toHaveBeenCalledTimes(rows.length);
+    // The three values are told apart, so a control pointed at a neighbour
+    // cannot pass by writing the same string twice.
+    expect(new Set(rows.map(([, value]) => value)).size).toBe(rows.length);
+  });
+
+  it("offers no copy control over an absent WorkOS id", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await screen.findByText("WorkOS id");
+    expect(ORG.workos_id).toBeUndefined();
+    // A button that copies "-" is worse than no button.
+    expect(valueBeside("WorkOS id").textContent).toBe("-");
+    expect(screen.queryByRole("button", { name: "Copy WorkOS id" })).toBeNull();
   });
 
   it("renders a dash for a record that was never disabled", async () => {

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -423,6 +423,22 @@ describe("Overview", () => {
     expect(labelsIn("Access")).toEqual(["Whitelisted", "Disabled at"]);
   });
 
+  it("nests the group headings under the record's own heading", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    // The record names itself at level 4, which is the level the whole admin
+    // app titles a page at. A group drawn above that level is read as a
+    // sibling of the record rather than a part of it.
+    expect(
+      await screen.findByRole("heading", { level: 4, name: ORG.name }),
+    ).toBeTruthy();
+    for (const group of ["Identity", "Plan", "Access"]) {
+      expect(screen.getByRole("heading", { name: group }).tagName).toBe("H5");
+    }
+  });
+
   it("no longer counts the members the record nav already counts", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -68,6 +68,19 @@ function valueBeside(label: string): HTMLElement {
   return value;
 }
 
+// The labels of one group's rows, in the order they are drawn. Read off the
+// group's heading, so a row that moves out of a group fails the group it left
+// as well as the one it joined.
+function labelsIn(group: string): string[] {
+  const section = screen
+    .getByRole("heading", { name: group })
+    .closest("section");
+  if (!section) throw new Error(`the ${group} heading is not in a group`);
+  return [...section.querySelectorAll('[data-slot="field-label"]')].map(
+    (n) => n.textContent ?? "",
+  );
+}
+
 beforeEach(() => {
   mocks.getSession.mockReset();
   mocks.getSession.mockResolvedValue({
@@ -377,6 +390,77 @@ describe("Overview", () => {
     // The edit belonged to the record that was open when it was made. Carrying
     // it over offers to save one organization's change against another.
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+  });
+
+  it("draws the facts in three named groups", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await screen.findByRole("heading", { name: "Identity" });
+    // Written out rather than counted: the label an operator reads is the
+    // whole contract of a fact row, and "Whitelisted" in particular must not
+    // drift to a name that reads like a preference. See S2-FACTS-AUDIT.md.
+    expect(labelsIn("Identity")).toEqual([
+      "Name",
+      "Slug",
+      "Organization id",
+      "WorkOS id",
+      "Created",
+      "Updated",
+    ]);
+    expect(labelsIn("Plan")).toEqual(["Account type", "Trial"]);
+    expect(labelsIn("Access")).toEqual(["Whitelisted", "Disabled at"]);
+  });
+
+  it("no longer counts the members the record nav already counts", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await screen.findByRole("heading", { name: "Identity" });
+    // By label, not by text: the record nav says "Members" too, and that one
+    // is the count this row was dropped in favour of.
+    const labels = [
+      ...document.querySelectorAll('[data-slot="field-label"]'),
+    ].map((n) => n.textContent);
+    expect(labels).not.toContain("Members");
+  });
+
+  it("keeps the save bar under the whole record, not inside a group", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("switch"));
+    // A save bar drawn inside Access would read as saving Access alone, while
+    // it writes the account type in Plan too.
+    expect(
+      screen.getByRole("button", { name: "Save" }).closest("section"),
+    ).toBeNull();
+  });
+
+  it("saves the whitelisted switch as whitelisted", async () => {
+    mocks.updateOrganization.mockResolvedValue({ ...ORG, whitelisted: false });
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("switch"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    // The field by name, not merely that a write happened: the two editors
+    // write one record between them, and a switch that lands on the account
+    // type changes the plan of an organization nobody meant to touch.
+    await waitFor(() => {
+      expect(mocks.updateOrganization).toHaveBeenCalledWith({
+        id: ORG.id,
+        account_type: undefined,
+        whitelisted: false,
+      });
+    });
   });
 
   it("renders a dash for a record that was never disabled", async () => {

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 
 import { useConfirmDialog } from "@/components/ConfirmDialog";
+import { CopyValue } from "@/components/CopyValue";
 import { Trial } from "@/components/Trial";
 import { Button } from "@/components/ui/button";
 import {
@@ -147,17 +148,27 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
           <span className="text-sm">{org.name}</span>
         </Row>
         <Row label="Slug">
-          <span className="text-sm">{org.slug}</span>
+          <CopyValue label="Slug" value={org.slug} className="text-sm" />
         </Row>
         <Row label="Organization id">
-          <span className="text-sm">{org.id}</span>
+          <CopyValue
+            label="Organization id"
+            value={org.id}
+            className="text-sm"
+          />
         </Row>
         <Row label="WorkOS id">
-          <span
-            className={cn("text-sm", !org.workos_id && "text-muted-foreground")}
-          >
-            {org.workos_id ?? "-"}
-          </span>
+          {/* No control over an absent value: a button that copies "-" is
+              worse than no button. */}
+          {org.workos_id ? (
+            <CopyValue
+              label="WorkOS id"
+              value={org.workos_id}
+              className="text-sm"
+            />
+          ) : (
+            <span className="text-muted-foreground text-sm">-</span>
+          )}
         </Row>
         <Row label="Created">
           <span className="text-sm">{fmtDateShort(org.created_at)}</span>

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -36,9 +36,28 @@ function Row({
 }) {
   return (
     <div className="grid grid-cols-[12rem_1fr] items-baseline gap-3 py-1">
-      <span className="text-muted-foreground text-sm">{label}</span>
+      <span data-slot="field-label" className="text-muted-foreground text-sm">
+        {label}
+      </span>
       <div>{children}</div>
     </div>
+  );
+}
+
+function Group({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-5 first:mt-0">
+      <h3 className="text-muted-foreground mb-1 text-xs font-medium">
+        {title}
+      </h3>
+      {children}
+    </section>
   );
 }
 
@@ -123,71 +142,81 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
 
   return (
     <div className="border-border bg-muted/10 rounded-md border p-4">
-      <Row label="ID">
-        <span className="text-sm">{org.id}</span>
-      </Row>
-      <Row label="Name">
-        <span className="text-sm">{org.name}</span>
-      </Row>
-      <Row label="Slug">
-        <span className="text-sm">{org.slug}</span>
-      </Row>
-      <Row label="Account type">
-        <Select
-          value={accountType}
-          disabled={mut.isPending}
-          onValueChange={(v) => setDraft((d) => ({ ...d, account_type: v }))}
-        >
-          <SelectTrigger className="h-auto w-auto px-2 py-1.5">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {ACCOUNT_TYPE_OPTIONS.map((t) => (
-              <SelectItem key={t} value={t}>
-                {t}
-              </SelectItem>
-            ))}
-            {!isAccountType(org.account_type) && (
-              <SelectItem value={org.account_type}>
-                {org.account_type}
-              </SelectItem>
+      <Group title="Identity">
+        <Row label="Name">
+          <span className="text-sm">{org.name}</span>
+        </Row>
+        <Row label="Slug">
+          <span className="text-sm">{org.slug}</span>
+        </Row>
+        <Row label="Organization id">
+          <span className="text-sm">{org.id}</span>
+        </Row>
+        <Row label="WorkOS id">
+          <span
+            className={cn("text-sm", !org.workos_id && "text-muted-foreground")}
+          >
+            {org.workos_id ?? "-"}
+          </span>
+        </Row>
+        <Row label="Created">
+          <span className="text-sm">{fmtDateShort(org.created_at)}</span>
+        </Row>
+        <Row label="Updated">
+          <span className="text-sm">{fmtDateShort(org.updated_at)}</span>
+        </Row>
+      </Group>
+
+      <Group title="Plan">
+        <Row label="Account type">
+          <Select
+            value={accountType}
+            disabled={mut.isPending}
+            onValueChange={(v) => setDraft((d) => ({ ...d, account_type: v }))}
+          >
+            <SelectTrigger className="h-auto w-auto px-2 py-1.5">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ACCOUNT_TYPE_OPTIONS.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+              {!isAccountType(org.account_type) && (
+                <SelectItem value={org.account_type}>
+                  {org.account_type}
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+        </Row>
+        <Row label="Trial">
+          <Trial org={org} />
+        </Row>
+      </Group>
+
+      {/* Access, not a setting. `whitelisted` gates the platform, so it keeps
+          its own group away from anything that reads as a preference. */}
+      <Group title="Access">
+        <Row label="Whitelisted">
+          <Switch
+            checked={whitelisted}
+            disabled={mut.isPending}
+            onCheckedChange={(v) => setDraft((d) => ({ ...d, whitelisted: v }))}
+          />
+        </Row>
+        <Row label="Disabled at">
+          <span
+            className={cn(
+              "text-sm",
+              !org.disabled_at && "text-muted-foreground",
             )}
-          </SelectContent>
-        </Select>
-      </Row>
-      <Row label="Members">
-        <span className="text-sm">{org.member_count}</span>
-      </Row>
-      <Row label="Whitelisted">
-        <Switch
-          checked={whitelisted}
-          disabled={mut.isPending}
-          onCheckedChange={(v) => setDraft((d) => ({ ...d, whitelisted: v }))}
-        />
-      </Row>
-      <Row label="WorkOS ID">
-        <span
-          className={cn("text-sm", !org.workos_id && "text-muted-foreground")}
-        >
-          {org.workos_id ?? "-"}
-        </span>
-      </Row>
-      <Row label="Disabled at">
-        <span
-          className={cn("text-sm", !org.disabled_at && "text-muted-foreground")}
-        >
-          {fmtDateShort(org.disabled_at)}
-        </span>
-      </Row>
-      <Row label="Trial">
-        <Trial org={org} />
-      </Row>
-      <Row label="Created">
-        <span className="text-sm">{fmtDateShort(org.created_at)}</span>
-      </Row>
-      <Row label="Updated">
-        <span className="text-sm">{fmtDateShort(org.updated_at)}</span>
-      </Row>
+          >
+            {fmtDateShort(org.disabled_at)}
+          </span>
+        </Row>
+      </Group>
 
       {dirty && (
         <div className="border-border mt-4 flex items-center gap-2 border-t pt-3">

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -54,9 +54,11 @@ function Group({
 }) {
   return (
     <section className="mt-5 first:mt-0">
-      <h3 className="text-muted-foreground mb-1 text-xs font-medium">
+      {/* h5 under the record name's h4 in RecordHeader. A group is part of the
+          record, not a sibling of it. */}
+      <h5 className="text-muted-foreground mb-1 text-xs font-medium">
         {title}
-      </h3>
+      </h5>
       {children}
     </section>
   );

--- a/client/admin/src/pages/organizations/PeekPanel.tsx
+++ b/client/admin/src/pages/organizations/PeekPanel.tsx
@@ -1,13 +1,13 @@
-import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
+import { XIcon } from "lucide-react";
 import {
   useEffect,
   useRef,
-  useState,
   type JSX,
   type ReactNode,
   type RefObject,
 } from "react";
 
+import { CopyValue } from "@/components/CopyValue";
 import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -18,13 +18,9 @@ import { cn, fmtDateShort } from "@/lib/utils";
 
 import { OrganizationActions } from "./OrganizationActions";
 
-const COPY_CONFIRM_MS = 1500;
-
 // One panel is on the page at a time, so a constant is enough and the row's
 // trigger can point `aria-controls` at it without threading an id through.
 export const PEEK_PANEL_ID = "organization-peek-panel";
-
-function noop(): void {}
 
 function Field({
   label,
@@ -38,49 +34,6 @@ function Field({
       <dt className="text-muted-foreground text-sm">{label}</dt>
       <dd className="min-w-0 text-sm">{children}</dd>
     </>
-  );
-}
-
-function CopyValue({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}): JSX.Element {
-  // The value copied, not a flag. Peek swaps the record under a mounted panel,
-  // and a flag would stand as a confirmation against an id never copied,
-  // including where the write resolves after the swap.
-  const [copiedValue, setCopiedValue] = useState<string>();
-  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const copied = copiedValue === value;
-
-  useEffect(() => () => clearTimeout(timer.current), []);
-
-  return (
-    <span className="flex items-center gap-1">
-      <span className="truncate font-mono text-xs">{value}</span>
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        aria-label={copied ? `${label} copied` : `Copy ${label}`}
-        onClick={() => {
-          // Undefined outside a secure context, where the call would throw.
-          if (!navigator.clipboard?.writeText) return;
-          // A check over a failed write sends the operator off with the wrong id.
-          void navigator.clipboard.writeText(value).then(() => {
-            setCopiedValue(value);
-            clearTimeout(timer.current);
-            timer.current = setTimeout(
-              () => setCopiedValue(undefined),
-              COPY_CONFIRM_MS,
-            );
-          }, noop);
-        }}
-      >
-        {copied ? <CheckIcon /> : <CopyIcon />}
-      </Button>
-    </span>
   );
 }
 


### PR DESCRIPTION
An organization record's Overview reads as three named groups instead of one
flat list of eleven facts, and its three identifiers can be copied with one
click.

**#5360 has merged**, so this now targets `main` and the branch was rebased onto
it. The four commits are unchanged: every patch id matches what they were on the
stacked base. The full check set runs here, unlike while it was stacked.

## What an operator gets

- **Identity**: name, slug, organization id, WorkOS id, created, updated.
- **Plan**: account type and the trial.
- **Access**: Whitelisted and Disabled at.
- **A copy button on the slug, the organization id and the WorkOS id.** It is
  the control the organizations list already uses in its peek panel, promoted to
  a shared component rather than written a second time. An organization with no
  WorkOS id gets no button, because a button that copies `-` is worse than none.
- **The Members row is gone.** The record nav counts members already, so the row
  said the same thing twice.

Everything editable stays editable. The account type select, the whitelisted
switch, the dirty check, the confirm dialog and the save bar all behave exactly
as before, and the save bar sits below all three groups because it writes the
record rather than a group.

The capture of the grouped panel is at
`<scratchpad>/overview-groups.png` on the build machine and is not published
here: gist upload was refused by a permission gate this run. It shows the three
groups in the order above against an invented organization.

## Why Whitelisted is its own group and keeps its name

The design draws a **Settings** group whose first row is "Include in reporting".
`whitelisted` is the only boolean on the record that could plausibly back it, and
it must not. Both designs describe it as access control:
`server/design/auth/design.go:218` says "whitelisted to access the platform" and
`server/design/admin/design.go:23` says "whitelisted for full access".

So filing it under a heading that reads as a preference would mean an operator
switching off what looks like a reporting opt-out silently cuts that
organization off the platform. It keeps its honest label and a group named
Access. The test that pins the group's row labels says this in a comment, so a
later rename fails a test rather than a customer.

## What is deliberately not built

Five of the design's twelve Overview facts have no field on the admin API:
**Billing period**, **Payment method**, **Include in reporting**, **Event limit**
and **Support tier**. Identity is 5 of 5, Plan is 2 of 4, Settings is 0 of 3.

They are backlogged as **AGE-3245** rather than drawn as empty rows. Billing
period and payment method in particular are unlikely to live in the Gram
database at all, so that ticket starts by finding out where they come from.

Two facts the design omits are kept on purpose:

- **Disabled at**, until the disabled-organization treatment is designed. It is
  the only surface that shows a disabled organization is disabled.
- **Updated**, as a sixth Identity row. The design also omits Whitelisted and
  Disabled at, which are kept for good reasons, so its omission reads as an
  oversight. It is the only signal of when the record last changed. Cheap to
  drop if you disagree.

## How this was verified

Two build tasks and one review pass, rather than the eleven tasks and four-lens
review round #5360 ran. That was a deliberate reduction: the per-task
verification loop on #5360 cost more than the work justified.

**Gates**, all five, re-run independently at the tip rather than taken on report:

| Gate | Result |
| --- | --- |
| `type-check` | 0 |
| `lint:oxlint` | 0 |
| `oxfmt --check` | clean, 115 files |
| `test` | 560 passed in 24 files |
| `build` | 0 |

`aube run -F admin lint:format` is a false pass on this package: `oxfmt` lives in
the root `node_modules/.bin`, so the script exits 0 having checked nothing. Every
format check here is `aube exec oxfmt -- --check client/admin`.

**Mutation testing, aimed rather than swept.** Three mutations, at the three
places where a mistake here is silent rather than visible, canary first:

| Mutation | Result |
| --- | --- |
| Whitelisted row relabelled | killed |
| the whitelisted switch writes `account_type` | killed |
| the Slug row's copy control points at the organization id | killed |

Two more were run independently against the same tests, using pairs the first
sweep had not: the WorkOS id control pointed at the slug, and the Whitelisted row
moved out of Access into Identity. Both died. The group test reads a group's rows
through its heading, so a row that moves fails the group it left as well as the
one it joined.

## One review finding, fixed

The group headings first landed as `<h3>` inside a record whose name is an
`<h4>`, so a screen reader user heard the organization at level 4 and its own
sub-sections at level 3, reading as siblings of the record rather than parts of
it. Fixed in `a9529fc5b` by nesting them at `<h5>`, with a test that pins both
levels.

**The underlying convention is worse and is not fixed here.** The whole admin app
titles pages with `<h4>` and an explicit font size, on this record and three
places in `ProjectDetail.tsx`, so it skips `h1` through `h3` entirely and no page
has a top-level heading. That is a real defect, it predates this branch, and
changing it touches pages this slice has no business in.

## Scope

Client only, five files. `Overview.tsx` and its test, the new shared
`CopyValue.tsx`, `PeekPanel.tsx` losing the copy control it used to keep private,
and a changeset. No `server/` file, no migration, no lockfile change, and nothing
under `components/ui/` is edited.

`PeekPanel.test.tsx` is untouched and still passes, which is the evidence that
promoting the component preserved its behaviour, including the two cases it
already covered: an insecure context with no `navigator.clipboard`, and a write
that fails rather than resolving.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups the organization Overview into Identity, Plan, and Access, and adds one‑click copy for slug, organization id, and WorkOS id. This replaces the previous 11‑row flat list; the Members row is removed, and an absent WorkOS id shows a dash with no copy button.

- Facts by group: Identity (Name, Slug, Organization id, WorkOS id, Created, Updated), Plan (Account type, Trial), Access (Whitelisted, Disabled at). “Whitelisted” keeps its label and sits under Access.
- Editing is unchanged; the save bar stays below all groups because it writes the whole record.
- Group headings are h5 nested under the record’s h4 for correct reading order.
- Shared `CopyValue` powers the copy buttons here and in the organizations list peek panel; it handles insecure contexts and failed writes.
- Client-only change; no API or DB changes.

<sup>Written for commit bdd71df1874d61d5a2098a93ab4264df3438e251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


