### PR TITLE
chore: add RFC workflow skills

### DIFF
--- a/.agents/skills/implement-rfc/SKILL.md
+++ b/.agents/skills/implement-rfc/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: implement-rfc
+description: Use when implementing, building, executing, or shipping an accepted Gram RFC or technical design in the repository, including code, schemas, migrations, tests, observability, documentation, and validation.
+---
+
+# Implement an RFC
+
+Treat the accepted RFC as a requirements contract while verifying its
+assumptions against the current repository. Do not silently redesign material
+decisions during implementation.
+
+## Establish the contract
+
+1. Read the complete RFC, applicable `AGENTS.md` files, and skills triggered by
+   every affected area.
+2. Extract goals, non-goals, stretch goals, key decisions, security controls,
+   rollout requirements, success criteria, and open questions.
+3. Inspect the current implementation and related tests before editing.
+4. Identify stale assumptions, contradictions, or missing decisions.
+
+A stretch goal is out of scope unless the user, implementation plan, or accepted
+RFC explicitly marks that specific goal for this implementation; its presence
+under `Stretch goals` alone is not authorization. If the RFC is still Draft,
+flag that fact. Ask before proceeding only when an unresolved decision
+materially changes public behavior, security, data compatibility, billing,
+migration safety, or implementation direction.
+
+Never copy customer-identifying information into code, fixtures, comments,
+filenames, branches, commits, logs, or other repository surfaces. Use approved
+placeholders.
+
+## Maintain traceability
+
+Create and maintain a working table:
+
+| RFC requirement | Planned change       | Verification       | Status  |
+| --------------- | -------------------- | ------------------ | ------- |
+| <Requirement>   | <Files or subsystem> | <Test or evidence> | Pending |
+
+Include negative requirements and rollout controls, not only feature behavior.
+Update the table as evidence is produced. Keep it in the working plan or final
+handoff unless the repository or user requires a persistent artifact.
+
+## Implement incrementally
+
+1. Plan small stages that remain buildable and testable.
+2. Find and update every call site when changing a public function, interface,
+   schema, command, or API contract.
+   If a caller cannot adopt the accepted contract without changing a material
+   accepted decision, do not alter the contract or caller semantics; record the
+   conflict and stop for direction.
+3. Reuse existing abstractions and follow repository generation and migration
+   workflows; never edit generated artifacts directly.
+4. Add or update tests alongside each behavior change.
+5. Add the RFC's authorization, threat controls, observability, compatibility,
+   rollout, and rollback mechanisms.
+6. Run focused checks after each stage and broader repository checks before
+   completion.
+7. Keep unrelated cleanup outside the RFC scope.
+
+Repository edits do not authorize deployment, external posting, feature-flag
+changes, data migration execution, or other production mutations.
+
+## Handle deviations
+
+When repository evidence requires a deviation, record:
+
+- Original RFC decision
+- Discovered constraint and evidence
+- Implemented or proposed deviation
+- Consequences for users, security, operations, and compatibility
+- Whether the RFC must be updated or re-approved
+
+Stop for direction when the deviation changes a material accepted decision.
+If the deviation itself is not authorized, include the proposal in the handoff
+and leave the affected requirement blocked. For an authorized deviation, record
+it before treating it as an implementation requirement:
+
+- When RFC or decision-record editing is authorized, persist it there.
+- When external editing is not authorized, put an interim amendment in the
+  visible working plan before editing code. Record its date and status,
+  authorizing owner or approval reference, original decision, invalidating
+  evidence, approved deviation, expected consequences, and publication status.
+  That record is sufficient to proceed unless the user explicitly makes
+  external publication a prerequisite.
+
+Preserve the accepted RFC as decision history. Do not rewrite its goals or
+proposal to imply that the shipped path was always the plan. In the final
+handoff, expand the interim record into a dated
+`Amendment — Shipped Implementation` containing:
+
+- the final implementation status, references, and verification evidence;
+- the evidence that invalidated or changed the accepted assumption;
+- a compact accepted-versus-shipped comparison;
+- capabilities removed, delayed, or narrowed;
+- changed security, compatibility, operational, and user consequences; and
+- follow-up work, external publication status, and explicitly superseded
+  decisions.
+
+An implementation link or ticket does not replace the amendment when the design
+changed materially.
+
+## Validate completion
+
+1. Map every committed goal and key decision to implemented behavior.
+2. Run the RFC's validation plan plus relevant tests, type checks, builds,
+   linters, generators, migration checks, and end-to-end checks.
+3. Exercise important failure scenarios and rollback controls where safe.
+4. Review the final diff for scope, confidentiality, compatibility, and missing
+   observability or documentation.
+5. Mark requirements complete only with evidence; report anything unverified.
+
+Return the implemented changes, requirement coverage, checks and results,
+deviations, RFC amendment or decision-record status, unverified areas, and
+remaining risks. Do not claim the RFC is fully implemented while required work
+remains.

--- a/.agents/skills/implement-rfc/agents/openai.yaml
+++ b/.agents/skills/implement-rfc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Implement RFC"
+  short_description: "Turn an accepted RFC into verified code"
+  default_prompt: "Use $implement-rfc to implement this accepted RFC and verify every requirement."

--- a/.agents/skills/review-rfc/SKILL.md
+++ b/.agents/skills/review-rfc/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: review-rfc
+description: Use when reviewing, critiquing, stress-testing, approving, or identifying gaps in an existing Gram RFC, technical proposal, architecture decision, migration design, or feature design before implementation.
+---
+
+# Review an RFC
+
+Review the proposal as a decision artifact and technical argument, not as a
+template-completion or copy-editing exercise. Prioritize correctness,
+feasibility, customer impact, security, operability, and reversible delivery.
+
+## Boundaries
+
+- Do not change RFC status, publish an approval, comment externally, rewrite, or
+  implement unless the user requests that specific action. Still provide the
+  evaluative verdict required by this review.
+- A request to approve authorizes the external action, not a predetermined
+  verdict. Never publish an approval that contradicts the evidence-based
+  verdict. Verify the destination before any external comment; if it is
+  unknown, return the proposed comment and request the target.
+- Never repeat customer-identifying or secret information into repository
+  artifacts. Replace it with placeholders and flag the confidentiality issue.
+- Treat the RFC as evidence of the proposed intent, not independent proof of
+  current-system facts or predicted outcomes.
+
+## Gather evidence
+
+1. Read the complete RFC and applicable `AGENTS.md` files.
+2. Inspect evidence needed to test decisive claims and highest-consequence
+   failure modes. Consider referenced code, schemas, APIs, related RFCs,
+   feature gates, billing paths, and operations only when material; state the
+   resulting evidence boundary.
+3. Load any area-specific skill triggered by the proposal.
+4. Separate verified facts, author assumptions, and reviewer inferences.
+
+If the user intentionally supplies only an excerpt and no complete source is
+available, review that scope, state that whole-document completeness is
+unverified, and describe omitted material as absent from the excerpt rather
+than definitively absent from the RFC.
+
+Honor explicit evidence limits, including a prohibition on repository
+inspection, and state the verification those limits leave incomplete.
+
+Do not infer maturity from the RFC's workflow status. A Draft may already be a
+complete implementation blueprint, while an Approved RFC may still contain a
+stale placeholder. Review the actual argument and evidence.
+
+For approval-blocking evidence gaps, name the missing artifact, affected
+decision, owner when known, and closure condition. Report lesser uncertainty
+without manufacturing a finding. Require production-topology evidence when it
+affects capacity, availability, residency, security, rollout, or rollback.
+
+## Review the template contract
+
+Check every required section; apply context-dependent rows only when relevant.
+For an intentionally scoped excerpt, do not create findings merely because
+whole-RFC sections are not shown. Raise an omission only when a decision in the
+excerpt depends on that missing material:
+
+| Area                   | Review question                                                                                                                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Overview               | Does it connect current state, customer or business consequence, why the problem matters, and the proposed direction?                                                                           |
+| User stories           | For customer-affecting work, do representative stories connect an actor and need to the obstacle and intended outcome without inventing customer facts?                                         |
+| Goals                  | Are goals verifiable and compatible with non-goals?                                                                                                                                             |
+| Stretch goals          | Are optional outcomes kept out of committed scope?                                                                                                                                              |
+| Key decisions          | Do they accurately summarize the proposal and give the rationale or constraint behind each choice?                                                                                              |
+| Proposal               | Are producers, consumers, interfaces, data flows, state changes, ownership, authorization, and failure behavior concrete?                                                                       |
+| Data model             | Are important fields summarized with type and meaning, without an exhaustive schema dump?                                                                                                       |
+| Detail level           | Does it prefer conceptual tables and pseudocode, use focused syntax only when exact semantics are decision-critical, and avoid full DDL, YAML/API specs, generated schemas, or production code? |
+| User Experience        | Are dashboard, CLI/API, self-service, docs, and migration covered or explicitly unaffected?                                                                                                     |
+| Billing                | Are pricing, packaging, entitlements, metering, and billing traced?                                                                                                                             |
+| Threat Modeling        | Are trust boundaries, threats, controls, accepted risks, and InfoSec review credible?                                                                                                           |
+| Alternatives           | Are credible options compared using consistent criteria?                                                                                                                                        |
+| Rollout and Validation | Are tests, monitoring, success criteria, failure scenarios, rollback triggers, and mechanics concrete?                                                                                          |
+| Open Questions         | Are unresolved decisions visible and owned where possible?                                                                                                                                      |
+
+Also test compatibility, authorization, tenant isolation, privacy, concurrency,
+data lifecycle, migrations, capacity, degraded dependencies, observability,
+incident response, and blast radius where relevant.
+
+Check the decision history when present. Resolved Questions should retain the
+answer and evidence; verification updates should say exactly what was and was
+not proved; amendments should distinguish the accepted design from the shipped
+path without rewriting history. Flag stale statements that conflict with a
+later amendment or implementation result.
+
+## Report findings
+
+Open with a concise summary of the decision, decisive findings, and evidence
+coverage.
+
+Use only these severities:
+
+- **Blocking:** unsafe, incorrect, or unable to satisfy a stated goal.
+- **Major:** material design gap to resolve before implementation.
+- **Minor:** worthwhile improvement that does not invalidate the design.
+- **Question:** missing information that may change the verdict.
+
+Do not issue `Approve` when a plausible material risk to correctness, billing,
+security, tenant isolation, rollout, or operability remains unresolved and
+additional evidence could change the verdict. Unresolved material Questions
+require `Revise before approval`; non-material Questions may accompany
+`Approve with changes`.
+
+Do not label every omission `Blocking`. Use `Blocking` only when the current
+proposal is demonstrably unsafe, incorrect, or cannot satisfy a stated goal;
+use `Major` for a material design gap and `Question` when missing evidence may
+change the verdict. Style or template preferences are findings only when they
+hide a decision, evidence gap, or plausible consequence.
+
+Each finding must include the RFC section, concrete concern, plausible impact or
+failure scenario, supporting evidence, and smallest useful resolution. Avoid
+generic checklist findings without a demonstrated consequence.
+
+Finish with one verdict: `Approve`, `Approve with changes`, or `Revise before
+approval`. State which findings determine the verdict and which verification
+remains incomplete.

--- a/.agents/skills/review-rfc/agents/openai.yaml
+++ b/.agents/skills/review-rfc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review RFC"
+  short_description: "Stress-test an RFC before approval"
+  default_prompt: "Use $review-rfc to review this RFC and return prioritized findings."

--- a/.agents/skills/write-rfc/SKILL.md
+++ b/.agents/skills/write-rfc/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: write-rfc
+description: Use when drafting, creating, scoping, or substantially revising a Gram software-engineering RFC, technical proposal, architecture decision, migration design, or feature design before implementation.
+---
+
+# Write an RFC
+
+Produce a decision-ready technical argument grounded in the current system.
+Follow `assets/rfc-template.md`, preserve every top-level section, state "No
+impact" when appropriate, and add useful domain-specific subsections.
+
+## Boundaries
+
+- Treat drafting, publishing, approving, and implementing as separate actions.
+  Do not post the RFC or change code unless the user explicitly requests it.
+- Draft and publish in one request only after checks pass and destination,
+  audience, and confidentiality boundary are unambiguous.
+- Never put customer names, identifiers, emails, URLs with identifying slugs,
+  or commercial figures in repository artifacts. Use `<CUSTOMER>`,
+  `<PROJECT_ID>`, or "the customer" and keep real values in internal systems.
+- Use customer identity internally only when explicitly authorized and allowed
+  by destination policy; otherwise redact it.
+- Mark unknown metadata with angle-bracket placeholders. Do not invent authors,
+  reviewers, channels, projects, design partners, or customers.
+
+## Establish the decision
+
+Identify the problem, affected users, customer or business impact, desired
+outcome, constraints, decision deadline, and success criteria. Build the
+Overview as: current state, concrete consequence, why it matters, and proposed
+direction. For customer-affecting work, include representative user stories
+that connect an actor and need to the current obstacle and intended outcome;
+use `As a …` syntax only when it reads naturally. Never invent customer facts.
+
+## Ground the proposal
+
+1. Read the applicable `AGENTS.md` files and any skills triggered by the area.
+2. Search for related RFCs, plans, docs, implementations, APIs, schemas, feature
+   gates, billing paths, and operational conventions.
+3. Trace the current behavior before proposing a replacement.
+4. Cite repository evidence and internal sources without copying confidential
+   identifiers; separate verified behavior, assumptions, and recommendations.
+
+Do not present an invented interface, type, table, or service as current state.
+
+## Design the proposal
+
+- Make goals verifiable without forcing artificial metrics; keep non-goals
+  explicit; label optional work as stretch goals.
+- Trace important interfaces and data flows end to end: producers, consumers,
+  synchronous or asynchronous boundaries, identity and authorization, state
+  changes, failure behavior, and operational ownership.
+- For data-model changes, use a compact table for decision-relevant fields with
+  name, type, and meaning; add constraints or defaults only when material. Do
+  not enumerate every field or reproduce the complete schema.
+- When changing a CLI or API contract, characterize existing flags, request and
+  response shapes, stdout/stderr behavior, exit semantics, and compatibility
+  expectations with repository evidence or golden tests.
+- Cover every User Experience surface named by the template. State why an
+  unaffected surface is unaffected.
+- Trace pricing, packaging, entitlements, metering, and billing. State "No
+  billing impact" only with evidence; otherwise write `Billing impact:
+Unverified`, name the missing evidence and owner, and keep it unresolved.
+- Identify trust boundaries, sensitive data, authorization decisions, abuse
+  paths, and failure modes. Pair each concrete threat with a control; record
+  accepted risks and the required Information Security reviewer.
+- Compare credible alternatives using consistent criteria. Do not manufacture
+  weak alternatives to make the proposal appear stronger.
+- Define incremental rollout, observability, success thresholds, important
+  failure scenarios, rollback triggers, and rollback mechanics.
+
+Use diagrams, tables, and pseudocode only when they clarify a material
+relationship or decision. Keep code illustrative: do not paste full table DDL,
+YAML or API specifications, generated schemas, or production-ready samples.
+Reference exact existing contracts instead of copying them into the RFC.
+
+## Write in Gram's RFC voice
+
+- Write the Overview, rationale, and trade-offs as connected prose. Reserve
+  bullets for parallel facts, requirements, or decisions.
+- Say what happens today, what breaks, and what this RFC proposes. Label
+  uncertainty `verified`, `partially verified`, or `unverified`.
+- Write each TLDR item as a decision plus its rationale or governing
+  constraint, for example: `**Dynamic sync, not package baking.** This keeps
+targeting and revocation independent of plugin releases.`
+- Keep simple conclusions proportionate. Once billing or another required
+  no-impact claim has been traced, state it directly instead of inventing
+  speculative detail.
+- Organize around real decision domains, adding Architecture, Day 2 Operations,
+  Resolved Questions, Verification Updates, or Appendices as useful. Keep large
+  parent RFCs on shared architecture and rollout; move subsystems to child RFCs.
+
+## Preserve the decision record
+
+Treat an RFC as a living record, not a disposable draft. Move answered Open
+Questions into `Resolved Questions` with the answer and supporting evidence.
+Add dated verification updates when experiments narrow or invalidate a claim.
+After review or acceptance, do not silently rewrite a material decision;
+record the correction, supersession, or amendment explicitly while preserving
+the earlier context.
+
+## Finish the RFC
+
+Write `TLDR / Key Decisions` after completing the proposal. Remove unused
+template helper text, but retain explicit placeholders for genuinely unknown
+metadata or decisions. Then verify:
+
+1. Every goal maps to proposal behavior and validation evidence.
+2. Non-goals and stretch goals have not entered the committed scope.
+3. Claims about current behavior are supported by sources.
+4. User experience, billing, threat modeling, alternatives, rollout,
+   validation, rollback, and open questions are complete.
+5. Open questions name the missing decision and, when known, its owner.
+6. The document contains no customer-identifying or secret information.
+7. Every key decision states why it was chosen or which constraint it resolves.
+8. Resolved questions, verification updates, and amendments preserve material
+   decision history where applicable.
+9. Customer stories, interfaces, data flows, and important data-model fields
+   make the proposal concrete without turning it into an implementation spec.
+
+Return the RFC and unresolved assumptions. If published, report destination,
+status, and redactions; do not infer authorization to implement.

--- a/.agents/skills/write-rfc/agents/openai.yaml
+++ b/.agents/skills/write-rfc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write RFC"
+  short_description: "Research and draft a grounded engineering RFC"
+  default_prompt: "Use $write-rfc to research and draft an RFC for this proposal."

--- a/.agents/skills/write-rfc/assets/rfc-template.md
+++ b/.agents/skills/write-rfc/assets/rfc-template.md
@@ -1,0 +1,111 @@
+# RFC: <YOUR TITLE HERE>
+
+Status: Draft  
+Author: <NAME>  
+Reviewers: <NAMES>  
+Team channel: <CHANNEL>  
+Linear project: <LINK>  
+Design partners: <NAMES>  
+Interested customers/prospects: <NAMES>
+
+## Overview
+
+Describe the problem, its impact on customers or the business, and the proposed
+solution at a high level. Establish why this work matters and build the case for
+addressing it.
+
+For customer-affecting work, include representative user stories that connect
+the affected user, their need, the current obstacle, and the intended outcome.
+
+## Goals
+
+- <Goal>
+- <Goal>
+- <Goal>
+
+### Non-goals
+
+- <Non-goal>
+- <Non-goal>
+
+### Stretch goals
+
+- <Stretch goal>
+- <Stretch goal>
+
+## TLDR / Key Decisions
+
+> Complete this section after writing the proposal.
+
+- <Key decision>
+- <Key decision>
+- <Key decision>
+
+## Proposal
+
+Explain how the problem will be solved. Include enough detail for reviewers to
+understand the design, important trade-offs, and expected outcomes.
+
+Describe the important interfaces and how data moves between them, including
+ownership, trust boundaries, state changes, and failure behavior.
+
+For data-model changes, summarize only decision-relevant fields in a table with
+their names, types, and descriptions. Include constraints or defaults when they
+affect the design; do not reproduce the complete schema.
+
+Use diagrams, tables, examples, or pseudocode where they aid understanding.
+Avoid full DDL, YAML or API specifications, generated schemas, and detailed
+production code; link to those artifacts when reviewers need exact syntax.
+
+### User Experience
+
+Describe how customers will discover and use the feature.
+
+Cover the relevant:
+
+- Dashboard experience
+- CLI or API experience
+- Self-service workflow
+- Documentation changes
+- Migration experience
+
+### Billing
+
+Explain whether the feature affects pricing, packaging, entitlements, usage
+measurement, or billing.
+
+If there is no impact, state that explicitly.
+
+### Threat Modeling
+
+Describe the trust boundaries and data flows introduced or changed by this
+proposal.
+
+| Threat   | Control      |
+| -------- | ------------ |
+| <Threat> | <Mitigation> |
+| <Threat> | <Mitigation> |
+
+Record any accepted risks and identify the Information Security reviewer.
+
+## Alternatives Considered
+
+### <Alternative>
+
+Explain the alternative, its advantages, and why it was not selected.
+
+### <Alternative>
+
+Explain the alternative, its advantages, and why it was not selected.
+
+## Rollout and Validation
+
+Describe how the feature will be tested, released, monitored, and—if
+necessary—rolled back.
+
+Include concrete success criteria and important failure scenarios.
+
+## Open Questions
+
+- <Open question>
+- <Open question>

--- a/.claude/skills/implement-rfc
+++ b/.claude/skills/implement-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/implement-rfc

--- a/.claude/skills/review-rfc
+++ b/.claude/skills/review-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/review-rfc

--- a/.claude/skills/write-rfc
+++ b/.claude/skills/write-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/write-rfc

--- a/.codex/skills/implement-rfc
+++ b/.codex/skills/implement-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/implement-rfc

--- a/.codex/skills/review-rfc
+++ b/.codex/skills/review-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/review-rfc

--- a/.codex/skills/write-rfc
+++ b/.codex/skills/write-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/write-rfc

--- a/.cursor/skills/implement-rfc
+++ b/.cursor/skills/implement-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/implement-rfc

--- a/.cursor/skills/review-rfc
+++ b/.cursor/skills/review-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/review-rfc

--- a/.cursor/skills/write-rfc
+++ b/.cursor/skills/write-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/write-rfc

--- a/.opencode/skills/implement-rfc
+++ b/.opencode/skills/implement-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/implement-rfc

--- a/.opencode/skills/review-rfc
+++ b/.opencode/skills/review-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/review-rfc

--- a/.opencode/skills/write-rfc
+++ b/.opencode/skills/write-rfc
@@ -1,0 +1,1 @@
+../../.agents/skills/write-rfc


### PR DESCRIPTION
## Why?

Codify the RFC workflow so agents consistently produce decision-ready proposals that emphasize customer impact, user stories, interfaces and data flow, concise data-model summaries, and actionable review and implementation handoffs.

## What?

- Add `write-rfc`, `review-rfc`, and `implement-rfc` skills with a shared RFC template.
- Sync the skills across Claude, Codex, OpenCode, and Cursor.
- Prefer readable prose, diagrams, compact typed field tables, pseudocode, and preserved decision history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the RFC workflow by adding `write-rfc`, `review-rfc`, and `implement-rfc` agent skills and a shared template, replacing ad‑hoc prompts/templates with documented boundaries, evidence requirements, and default prompts. This improves consistency and traceability without changing product behavior.

- Confirm SKILL guides cover scope, traceability tables, deviation recording, security/PII rules, rollout/rollback, and verification steps.
- Validate `assets/rfc-template.md` for completeness and that it prefers prose, diagrams, and compact field tables over full schemas or code.
- Check `openai.yaml` for each skill: `display_name`, `short_description`, and `default_prompt` reference `$write-rfc`, `$review-rfc`, and `$implement-rfc` exactly.
- Verify `.claude`, `.codex`, `.cursor`, and `.opencode` pointers target `../../.agents/skills/*` correctly.
- Rollout: no runtime changes or migrations. RFC authors, reviewers, and implementers should use the new skills and template; update internal docs and reload tooling to pick up the skills.

<sup>Written for commit f25899732bda5cb3142389a618d406845bc892ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

