### PR TITLE
feat: fold the employee list through the identity map

### DIFF
--- a/.changeset/canonical-fold-searchusers.md
+++ b/.changeset/canonical-fold-searchusers.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fold the employee list (searchUsers raw-logs path) through the canonical identity map behind the same rollout flag, with a dedicated list-divergence shadow mode.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -481,6 +481,7 @@ const (
 	IdentityFoldCostDeltaKey       = attribute.Key("gram.identity_fold.cost_delta")
 	IdentityFoldLiteralGroupsKey   = attribute.Key("gram.identity_fold.literal_groups")
 	IdentityFoldNewKeysKey         = attribute.Key("gram.identity_fold.new_keys")
+	IdentityFoldTruncatedKey       = attribute.Key("gram.identity_fold.truncated")
 	IdentityFoldTokenDeltaKey      = attribute.Key("gram.identity_fold.token_delta")
 	IdentityMapEntryCountKey       = attribute.Key("gram.identity_map.entry_count")
 	LiteLLMInstanceIDKey           = attribute.Key("gram.litellm.instance_id")
@@ -836,6 +837,11 @@ func SlogIdentityFoldLiteralGroups(v int) slog.Attr {
 func IdentityFoldNewKeys(v int) attribute.KeyValue { return IdentityFoldNewKeysKey.Int(v) }
 func SlogIdentityFoldNewKeys(v int) slog.Attr {
 	return slog.Int(string(IdentityFoldNewKeysKey), v)
+}
+
+func IdentityFoldTruncated(v bool) attribute.KeyValue { return IdentityFoldTruncatedKey.Bool(v) }
+func SlogIdentityFoldTruncated(v bool) slog.Attr {
+	return slog.Bool(string(IdentityFoldTruncatedKey), v)
 }
 
 func IdentityFoldTokenDelta(v int64) attribute.KeyValue { return IdentityFoldTokenDeltaKey.Int64(v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -480,6 +480,8 @@ const (
 	IdentityFoldCanonicalGroupsKey = attribute.Key("gram.identity_fold.canonical_groups")
 	IdentityFoldCostDeltaKey       = attribute.Key("gram.identity_fold.cost_delta")
 	IdentityFoldLiteralGroupsKey   = attribute.Key("gram.identity_fold.literal_groups")
+	IdentityFoldNewKeysKey         = attribute.Key("gram.identity_fold.new_keys")
+	IdentityFoldTokenDeltaKey      = attribute.Key("gram.identity_fold.token_delta")
 	IdentityMapEntryCountKey       = attribute.Key("gram.identity_map.entry_count")
 	LiteLLMInstanceIDKey           = attribute.Key("gram.litellm.instance_id")
 	LiteLLMCallIDKey               = attribute.Key("gram.litellm.call_id")
@@ -829,6 +831,16 @@ func SlogIdentityFoldCostDelta(v float64) slog.Attr {
 func IdentityFoldLiteralGroups(v int) attribute.KeyValue { return IdentityFoldLiteralGroupsKey.Int(v) }
 func SlogIdentityFoldLiteralGroups(v int) slog.Attr {
 	return slog.Int(string(IdentityFoldLiteralGroupsKey), v)
+}
+
+func IdentityFoldNewKeys(v int) attribute.KeyValue { return IdentityFoldNewKeysKey.Int(v) }
+func SlogIdentityFoldNewKeys(v int) slog.Attr {
+	return slog.Int(string(IdentityFoldNewKeysKey), v)
+}
+
+func IdentityFoldTokenDelta(v int64) attribute.KeyValue { return IdentityFoldTokenDeltaKey.Int64(v) }
+func SlogIdentityFoldTokenDelta(v int64) slog.Attr {
+	return slog.Int64(string(IdentityFoldTokenDeltaKey), v)
 }
 
 func IdentityMapEntryCount(v int) attribute.KeyValue { return IdentityMapEntryCountKey.Int(v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -481,6 +481,7 @@ const (
 	IdentityFoldCostDeltaKey       = attribute.Key("gram.identity_fold.cost_delta")
 	IdentityFoldLiteralGroupsKey   = attribute.Key("gram.identity_fold.literal_groups")
 	IdentityFoldNewKeysKey         = attribute.Key("gram.identity_fold.new_keys")
+	IdentityFoldOrderChangedKey    = attribute.Key("gram.identity_fold.order_changed")
 	IdentityFoldTruncatedKey       = attribute.Key("gram.identity_fold.truncated")
 	IdentityFoldTokenDeltaKey      = attribute.Key("gram.identity_fold.token_delta")
 	IdentityMapEntryCountKey       = attribute.Key("gram.identity_map.entry_count")
@@ -837,6 +838,11 @@ func SlogIdentityFoldLiteralGroups(v int) slog.Attr {
 func IdentityFoldNewKeys(v int) attribute.KeyValue { return IdentityFoldNewKeysKey.Int(v) }
 func SlogIdentityFoldNewKeys(v int) slog.Attr {
 	return slog.Int(string(IdentityFoldNewKeysKey), v)
+}
+
+func IdentityFoldOrderChanged(v bool) attribute.KeyValue { return IdentityFoldOrderChangedKey.Bool(v) }
+func SlogIdentityFoldOrderChanged(v bool) slog.Attr {
+	return slog.Bool(string(IdentityFoldOrderChangedKey), v)
 }
 
 func IdentityFoldTruncated(v bool) attribute.KeyValue { return IdentityFoldTruncatedKey.Bool(v) }

--- a/server/internal/telemetry/canonical_fold.go
+++ b/server/internal/telemetry/canonical_fold.go
@@ -174,6 +174,11 @@ func (s *Service) shadowCompareSearchUsersFold(ctx context.Context, orgID string
 			attr.SlogIdentityFoldCanonicalGroups(len(folded)),
 			attr.SlogIdentityFoldNewKeys(newKeys),
 			attr.SlogIdentityFoldTokenDelta(foldedTokens-literalTokens),
+			// On a truncated page both lists are capped at limit+1 and the
+			// deltas are page-cap artifacts, not divergence — folding frees
+			// slots and pulls in groups past the literal horizon. Readers
+			// deciding a rollout must weigh only truncated=false lines.
+			attr.SlogIdentityFoldTruncated(len(literal) >= params.Limit),
 		)
 	}()
 }

--- a/server/internal/telemetry/canonical_fold.go
+++ b/server/internal/telemetry/canonical_fold.go
@@ -10,6 +10,7 @@ package telemetry
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"time"
 
@@ -128,11 +129,12 @@ func (s *Service) shadowCompareCanonicalFold(ctx context.Context, orgID string, 
 // shadowCompareSearchUsersFold re-runs the employee list query with folding
 // enabled and logs how the folded list diverges from the literal one already
 // served: row counts, keys that exist only folded (canonical emails replacing
-// literal variants), and the input+output token delta — folding merges rows,
-// so on an untruncated page the token sum must be preserved and the folded
-// list can only shrink. Emails are deliberately not logged; counts carry the
-// signal. Runs in the background off a detached context so it never delays or
-// fails the caller's request.
+// literal variants), whether the shared keys changed relative order, and the
+// input+output token delta — folding merges rows, so on an untruncated page
+// the token sum must be preserved and the folded list can only shrink. Emails
+// are deliberately not logged; counts carry the signal. Runs in the
+// background off a detached context so it never delays or fails the caller's
+// request.
 func (s *Service) shadowCompareSearchUsersFold(ctx context.Context, orgID string, params repo.SearchUsersParams, literal []repo.UserSummary) {
 	select {
 	case s.shadowFoldSem <- struct{}{}:
@@ -160,19 +162,41 @@ func (s *Service) shadowCompareSearchUsersFold(ctx context.Context, orgID string
 			literalKeys[u.UserID] = struct{}{}
 			literalTokens += u.TotalInputTokens + u.TotalOutputTokens
 		}
+		foldedKeys := make(map[string]struct{}, len(folded))
 		newKeys := 0
 		for _, u := range folded {
+			foldedKeys[u.UserID] = struct{}{}
 			foldedTokens += u.TotalInputTokens + u.TotalOutputTokens
 			if _, ok := literalKeys[u.UserID]; !ok {
 				newKeys++
 			}
 		}
 
+		// Ordering divergence is only well-defined on the keys both lists
+		// share — folded keys are canonicalized, so the key spaces differ by
+		// construction. If the shared keys appear in a different relative
+		// order, folding moved someone (a merged identity's last-seen is the
+		// max across its emails), which the ticket's list-divergence spec
+		// requires surfacing alongside membership and counts.
+		var commonLiteral, commonFolded []string
+		for _, u := range literal {
+			if _, ok := foldedKeys[u.UserID]; ok {
+				commonLiteral = append(commonLiteral, u.UserID)
+			}
+		}
+		for _, u := range folded {
+			if _, ok := literalKeys[u.UserID]; ok {
+				commonFolded = append(commonFolded, u.UserID)
+			}
+		}
+		orderChanged := !slices.Equal(commonLiteral, commonFolded)
+
 		s.logger.InfoContext(bgCtx, "identity fold shadow employee list comparison",
 			attr.SlogOrganizationID(orgID),
 			attr.SlogIdentityFoldLiteralGroups(len(literal)),
 			attr.SlogIdentityFoldCanonicalGroups(len(folded)),
 			attr.SlogIdentityFoldNewKeys(newKeys),
+			attr.SlogIdentityFoldOrderChanged(orderChanged),
 			attr.SlogIdentityFoldTokenDelta(foldedTokens-literalTokens),
 			// On a truncated page both lists are capped at limit+1 and the
 			// deltas are page-cap artifacts, not divergence — folding frees

--- a/server/internal/telemetry/canonical_fold.go
+++ b/server/internal/telemetry/canonical_fold.go
@@ -125,6 +125,59 @@ func (s *Service) shadowCompareCanonicalFold(ctx context.Context, orgID string, 
 	}()
 }
 
+// shadowCompareSearchUsersFold re-runs the employee list query with folding
+// enabled and logs how the folded list diverges from the literal one already
+// served: row counts, keys that exist only folded (canonical emails replacing
+// literal variants), and the input+output token delta — folding merges rows,
+// so on an untruncated page the token sum must be preserved and the folded
+// list can only shrink. Emails are deliberately not logged; counts carry the
+// signal. Runs in the background off a detached context so it never delays or
+// fails the caller's request.
+func (s *Service) shadowCompareSearchUsersFold(ctx context.Context, orgID string, params repo.SearchUsersParams, literal []repo.UserSummary) {
+	select {
+	case s.shadowFoldSem <- struct{}{}:
+	default:
+		s.logger.InfoContext(ctx, "identity fold shadow comparison skipped: concurrency cap reached", attr.SlogOrganizationID(orgID))
+		return
+	}
+
+	bgCtx := context.WithoutCancel(ctx)
+	go func() {
+		defer func() { <-s.shadowFoldSem }()
+		bgCtx, cancel := context.WithTimeout(bgCtx, shadowCompareTimeout)
+		defer cancel()
+
+		params.CanonicalIdentityOrg = orgID
+		folded, err := s.chRepo.SearchUsers(bgCtx, params)
+		if err != nil {
+			s.logger.WarnContext(bgCtx, "identity fold shadow employee list query failed", attr.SlogError(err), attr.SlogOrganizationID(orgID))
+			return
+		}
+
+		literalKeys := make(map[string]struct{}, len(literal))
+		var literalTokens, foldedTokens int64
+		for _, u := range literal {
+			literalKeys[u.UserID] = struct{}{}
+			literalTokens += u.TotalInputTokens + u.TotalOutputTokens
+		}
+		newKeys := 0
+		for _, u := range folded {
+			foldedTokens += u.TotalInputTokens + u.TotalOutputTokens
+			if _, ok := literalKeys[u.UserID]; !ok {
+				newKeys++
+			}
+		}
+
+		s.logger.InfoContext(bgCtx, "identity fold shadow employee list comparison",
+			attr.SlogOrganizationID(orgID),
+			attr.SlogIdentityFoldLiteralGroups(len(literal)),
+			attr.SlogIdentityFoldCanonicalGroups(len(folded)),
+			attr.SlogIdentityFoldNewKeys(newKeys),
+			attr.SlogIdentityFoldTokenDelta(foldedTokens-literalTokens),
+		)
+	}()
+}
+
 // canonicalOrgFor resolves the fold flag to the org id the repo params carry:
 // the org id when folding is enabled, "" when the org serves literal
 // identities. The single choke point for fold gating on org-scoped reads.

--- a/server/internal/telemetry/canonical_fold.go
+++ b/server/internal/telemetry/canonical_fold.go
@@ -162,34 +162,48 @@ func (s *Service) shadowCompareSearchUsersFold(ctx context.Context, orgID string
 			literalKeys[u.UserID] = struct{}{}
 			literalTokens += u.TotalInputTokens + u.TotalOutputTokens
 		}
-		foldedKeys := make(map[string]struct{}, len(folded))
 		newKeys := 0
 		for _, u := range folded {
-			foldedKeys[u.UserID] = struct{}{}
 			foldedTokens += u.TotalInputTokens + u.TotalOutputTokens
 			if _, ok := literalKeys[u.UserID]; !ok {
 				newKeys++
 			}
 		}
 
-		// Ordering divergence is only well-defined on the keys both lists
-		// share — folded keys are canonicalized, so the key spaces differ by
-		// construction. If the shared keys appear in a different relative
-		// order, folding moved someone (a merged identity's last-seen is the
-		// max across its emails), which the ticket's list-divergence spec
-		// requires surfacing alongside membership and counts.
-		var commonLiteral, commonFolded []string
+		// Ordering divergence is measured over the shared keys the fold did
+		// NOT touch — same last-seen and same token sums in both lists. A
+		// merged identity legitimately moves (its folded last-seen is the max
+		// across its emails), so including merge targets would make this
+		// signal permanently true for any org with real folds; untouched
+		// groups have identical sort keys in both queries, and any reorder
+		// among them is a genuine ordering bug, which is the divergence the
+		// spec needs surfaced alongside membership and counts.
+		type sortIdentity struct {
+			lastSeen int64
+			tokens   int64
+		}
+		literalSort := make(map[string]sortIdentity, len(literal))
 		for _, u := range literal {
-			if _, ok := foldedKeys[u.UserID]; ok {
-				commonLiteral = append(commonLiteral, u.UserID)
+			literalSort[u.UserID] = sortIdentity{lastSeen: u.LastSeenUnixNano, tokens: u.TotalInputTokens + u.TotalOutputTokens}
+		}
+		untouched := make(map[string]struct{}, len(folded))
+		for _, u := range folded {
+			if lit, ok := literalSort[u.UserID]; ok && lit == (sortIdentity{lastSeen: u.LastSeenUnixNano, tokens: u.TotalInputTokens + u.TotalOutputTokens}) {
+				untouched[u.UserID] = struct{}{}
+			}
+		}
+		var untouchedLiteral, untouchedFolded []string
+		for _, u := range literal {
+			if _, ok := untouched[u.UserID]; ok {
+				untouchedLiteral = append(untouchedLiteral, u.UserID)
 			}
 		}
 		for _, u := range folded {
-			if _, ok := literalKeys[u.UserID]; ok {
-				commonFolded = append(commonFolded, u.UserID)
+			if _, ok := untouched[u.UserID]; ok {
+				untouchedFolded = append(untouchedFolded, u.UserID)
 			}
 		}
-		orderChanged := !slices.Equal(commonLiteral, commonFolded)
+		orderChanged := !slices.Equal(untouchedLiteral, untouchedFolded)
 
 		s.logger.InfoContext(bgCtx, "identity fold shadow employee list comparison",
 			attr.SlogOrganizationID(orgID),

--- a/server/internal/telemetry/canonical_fold_test.go
+++ b/server/internal/telemetry/canonical_fold_test.go
@@ -703,8 +703,10 @@ func TestSearchUsers_CanonicalFold_CursorPagination(t *testing.T) {
 	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
 
 	// Staggered last-seen so page order is deterministic; the employee's most
-	// recent row is the personal one, making a merged canonical key the page-1
-	// cursor value — the case where cursor resolution must go through the fold.
+	// recent row is the personal one, so the merged identity leads the list
+	// and — at Limit 1 — becomes the page-1 cursor value, whose folded max
+	// last-seen (-5m) differs from its literal one (-30m): cursor resolution
+	// must go through the fold or page 2 comes back empty.
 	now := time.Now().UTC()
 	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-30*time.Minute), userID, workEmail, 100, 50, 1.0)
 	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), strings.ToUpper(personalEmail), 200, 100, 2.0)
@@ -714,11 +716,11 @@ func TestSearchUsers_CanonicalFold_CursorPagination(t *testing.T) {
 
 	from := now.Add(-time.Hour).Format(time.RFC3339)
 	to := now.Add(time.Hour).Format(time.RFC3339)
-	page := func(cursor *string) *gen.SearchUsersResult {
+	page := func(limit int, cursor *string) *gen.SearchUsersResult {
 		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
 			Filter:   &gen.SearchUsersFilter{From: from, To: to},
 			UserType: "internal",
-			Limit:    2,
+			Limit:    limit,
 			Sort:     "desc",
 			Cursor:   cursor,
 		})
@@ -726,18 +728,36 @@ func TestSearchUsers_CanonicalFold_CursorPagination(t *testing.T) {
 		return res
 	}
 
-	first := page(nil)
-	require.Len(t, first.Users, 2)
+	// Limit 1 walks the list one group at a time, so page 1's cursor IS the
+	// merged canonical key — the case a fold-unaware cursor subquery fails
+	// (its literal max last-seen would mismatch the folded HAVING tuple and
+	// page 2 would be empty).
+	first := page(1, nil)
+	require.Len(t, first.Users, 1)
 	require.Equal(t, workEmail, first.Users[0].UserID, "the merged identity sorts by its latest (personal) row")
-	require.Equal(t, strangerB, first.Users[1].UserID)
+	require.Equal(t, int64(300), first.Users[0].TotalInputTokens, "the merged summary carries both emails' tokens")
 	require.NotNil(t, first.NextCursor)
+	require.Equal(t, workEmail, *first.NextCursor, "the cursor handed out is the merged canonical key")
 
-	second := page(first.NextCursor)
-	require.Len(t, second.Users, 1, "no duplicate and no resurrected personal key on page 2")
-	require.Equal(t, strangerC, second.Users[0].UserID)
+	second := page(1, first.NextCursor)
+	require.Len(t, second.Users, 1, "a canonical cursor resolves through the fold")
+	require.Equal(t, strangerB, second.Users[0].UserID)
+	require.NotNil(t, second.NextCursor)
 
-	// The merged summary carries both emails' tokens wherever it appears.
-	require.Equal(t, int64(300), first.Users[0].TotalInputTokens)
+	third := page(1, second.NextCursor)
+	require.Len(t, third.Users, 1)
+	require.Equal(t, strangerC, third.Users[0].UserID)
+
+	// A wider page hands out an unmapped cursor instead; pagination must not
+	// duplicate or resurrect the personal key either way.
+	wideFirst := page(2, nil)
+	require.Len(t, wideFirst.Users, 2)
+	require.Equal(t, workEmail, wideFirst.Users[0].UserID)
+	require.Equal(t, strangerB, wideFirst.Users[1].UserID)
+
+	wideSecond := page(2, wideFirst.NextCursor)
+	require.Len(t, wideSecond.Users, 1, "no duplicate and no resurrected personal key on page 2")
+	require.Equal(t, strangerC, wideSecond.Users[0].UserID)
 }
 
 func TestSearchUsers_CanonicalFold_IDDrillReachesFoldedSummary(t *testing.T) {

--- a/server/internal/telemetry/canonical_fold_test.go
+++ b/server/internal/telemetry/canonical_fold_test.go
@@ -683,6 +683,116 @@ func TestHooksDrill_CanonicalFold_ExclusionAndTraceList(t *testing.T) {
 	require.Len(t, traces.Traces, 2)
 }
 
+func TestSearchUsers_CanonicalFold_OneRowPerEmployee(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	orgID := authCtx.ActiveOrganizationID
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.NewString()
+	suffix := uuid.NewString()[:8]
+	workEmail := "uwork-" + suffix + "@example.com"
+	personalEmail := "upersonal-" + suffix + "@example.com"
+	strangerEmail := "ustranger-" + suffix + "@example.com"
+	userID := "gram-user-" + uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	now := time.Now().UTC()
+	// One employee across three attribution shapes: id+work email, a
+	// case-variant personal-email row, and an id-only tool call (folds in via
+	// the known-emails join). Plus an unmapped stranger.
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, workEmail, 100, 50, 1.0)
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), strings.ToUpper(personalEmail), 200, 100, 2.0)
+	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), "tools:http:petstore:listPets", 200, 0.5, userID, "")
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-7*time.Minute), strangerEmail, 9, 9, 0.1)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter:   &gen.SearchUsersFilter{From: from, To: to},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 2)
+
+	byKey := map[string]*gen.UserSummary{}
+	for _, u := range res.Users {
+		byKey[u.UserID] = u
+	}
+	employee := byKey[workEmail]
+	require.NotNil(t, employee, "employee summary keyed by canonical email")
+	// Sum preservation across all three attribution shapes; the display email
+	// matches the canonical key rather than a literal variant.
+	require.Equal(t, workEmail, employee.UserEmail)
+	require.Equal(t, int64(300), employee.TotalInputTokens)
+	require.Equal(t, int64(150), employee.TotalOutputTokens)
+	require.Equal(t, int64(1), employee.TotalToolCalls)
+	require.Contains(t, byKey, strangerEmail)
+	require.NotContains(t, byKey, personalEmail)
+	require.NotContains(t, byKey, strings.ToUpper(personalEmail))
+
+	// Drilling by a linked personal email finds the one canonical summary:
+	// both sides of the key filter fold through the same map.
+	filtered, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter:   &gen.SearchUsersFilter{From: from, To: to, UserIds: []string{personalEmail}},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, filtered.Users, 1)
+	require.Equal(t, workEmail, filtered.Users[0].UserID)
+	require.Equal(t, int64(300), filtered.Users[0].TotalInputTokens)
+}
+
+func TestSearchUsers_CanonicalFold_ShadowServesLiteralList(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	orgID := authCtx.ActiveOrganizationID
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFoldShadow, orgID, true)
+
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.NewString()
+	suffix := uuid.NewString()[:8]
+	workEmail := "vwork-" + suffix + "@example.com"
+	personalEmail := "vpersonal-" + suffix + "@example.com"
+	userID := "gram-user-" + uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	now := time.Now().UTC()
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, workEmail, 100, 50, 1.0)
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), strings.ToUpper(personalEmail), 200, 100, 2.0)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// Shadow mode serves the literal list — the employee still splits across
+	// their two email keys — while the folded comparison runs detached.
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From: now.Add(-time.Hour).Format(time.RFC3339),
+			To:   now.Add(time.Hour).Format(time.RFC3339),
+		},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 2)
+	keys := []string{res.Users[0].UserID, res.Users[1].UserID}
+	require.Contains(t, keys, workEmail)
+	require.Contains(t, keys, strings.ToUpper(personalEmail))
+}
+
 func TestGetUnproxiedMcpServerUserUsage_CanonicalFold_OneRowPerEmployee(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/telemetry/canonical_fold_test.go
+++ b/server/internal/telemetry/canonical_fold_test.go
@@ -683,6 +683,145 @@ func TestHooksDrill_CanonicalFold_ExclusionAndTraceList(t *testing.T) {
 	require.Len(t, traces.Traces, 2)
 }
 
+func TestSearchUsers_CanonicalFold_CursorPagination(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	orgID := authCtx.ActiveOrganizationID
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.NewString()
+	suffix := uuid.NewString()[:8]
+	workEmail := "pwork-" + suffix + "@example.com"
+	personalEmail := "ppersonal-" + suffix + "@example.com"
+	strangerB := "pstrangerb-" + suffix + "@example.com"
+	strangerC := "pstrangerc-" + suffix + "@example.com"
+	userID := "gram-user-" + uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	// Staggered last-seen so page order is deterministic; the employee's most
+	// recent row is the personal one, making a merged canonical key the page-1
+	// cursor value — the case where cursor resolution must go through the fold.
+	now := time.Now().UTC()
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-30*time.Minute), userID, workEmail, 100, 50, 1.0)
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), strings.ToUpper(personalEmail), 200, 100, 2.0)
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), strangerB, 10, 10, 0.1)
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-20*time.Minute), strangerC, 20, 20, 0.2)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+	page := func(cursor *string) *gen.SearchUsersResult {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter:   &gen.SearchUsersFilter{From: from, To: to},
+			UserType: "internal",
+			Limit:    2,
+			Sort:     "desc",
+			Cursor:   cursor,
+		})
+		require.NoError(t, err)
+		return res
+	}
+
+	first := page(nil)
+	require.Len(t, first.Users, 2)
+	require.Equal(t, workEmail, first.Users[0].UserID, "the merged identity sorts by its latest (personal) row")
+	require.Equal(t, strangerB, first.Users[1].UserID)
+	require.NotNil(t, first.NextCursor)
+
+	second := page(first.NextCursor)
+	require.Len(t, second.Users, 1, "no duplicate and no resurrected personal key on page 2")
+	require.Equal(t, strangerC, second.Users[0].UserID)
+
+	// The merged summary carries both emails' tokens wherever it appears.
+	require.Equal(t, int64(300), first.Users[0].TotalInputTokens)
+}
+
+func TestSearchUsers_CanonicalFold_IDDrillReachesFoldedSummary(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	orgID := authCtx.ActiveOrganizationID
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.NewString()
+	suffix := uuid.NewString()[:8]
+	workEmail := "iwork-" + suffix + "@example.com"
+	personalEmail := "ipersonal-" + suffix + "@example.com"
+	userID := "gram-user-" + uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	now := time.Now().UTC()
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, workEmail, 100, 50, 1.0)
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), personalEmail, 200, 100, 2.0)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// An id-shaped key still reaches the summary that folded to an email:
+	// rows match by raw user_id and group under the canonical key.
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From:    now.Add(-time.Hour).Format(time.RFC3339),
+			To:      now.Add(time.Hour).Format(time.RFC3339),
+			UserIds: []string{userID},
+		},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 1)
+	require.Equal(t, workEmail, res.Users[0].UserID)
+	require.Equal(t, int64(100), res.Users[0].TotalInputTokens, "the id drill matches the id-bearing rows")
+}
+
+func TestSearchUsers_CanonicalFold_RoleRollupCountsEmployeeOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	orgID := authCtx.ActiveOrganizationID
+	ti.featureFlags.SetFlag(feature.FlagCanonicalIdentityFold, orgID, true)
+
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.NewString()
+	suffix := uuid.NewString()[:8]
+	workEmail := "rwork-" + suffix + "@example.com"
+	personalEmail := "rpersonal-" + suffix + "@example.com"
+	userID := "gram-user-" + uuid.NewString()
+	seedIdentityMapEntry(t, ctx, ti, orgID, workEmail, userID, workEmail)
+	seedIdentityMapEntry(t, ctx, ti, orgID, personalEmail, userID, workEmail)
+
+	now := time.Now().UTC()
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, workEmail, 100, 50, 1.0)
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), strings.ToUpper(personalEmail), 200, 100, 2.0)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// No role assignments seeded, so everything lands in Unassigned — which is
+	// exactly what pins the fold: one employee is one user in the rollup, not
+	// one per linked email, and the totals merge losslessly.
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From: now.Add(-time.Hour).Format(time.RFC3339),
+			To:   now.Add(time.Hour).Format(time.RFC3339),
+		},
+		UserType: "internal",
+		GroupBy:  "role",
+		Limit:    100,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Roles, 1)
+	require.Equal(t, "Unassigned", res.Roles[0].RoleName)
+	require.Equal(t, 1, res.Roles[0].UserCount, "one employee, not one per linked email")
+	require.Equal(t, int64(300), res.Roles[0].TotalInputTokens)
+}
+
 func TestSearchUsers_CanonicalFold_OneRowPerEmployee(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -440,24 +440,45 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 		groupBy = "external_user_id"
 	}
 
-	items, err := s.chRepo.SearchUsers(ctx, repo.SearchUsersParams{
-		GramProjectID:    params.projectID,
-		TimeStart:        params.timeStart,
-		TimeEnd:          params.timeEnd,
-		GramDeploymentID: deploymentID,
-		EventSource:      conv.PtrValOr(filter.EventSource, ""),
-		HookSource:       conv.PtrValOr(filter.HookSource, ""),
-		AccountType:      conv.PtrValOr(filter.AccountType, ""),
-		ExternalOrgID:    conv.PtrValOr(filter.ExternalOrgID, ""),
-		GroupBy:          groupBy,
-		UserIDs:          filter.UserIds,
-		SortOrder:        params.sortOrder,
-		Cursor:           params.cursor,
-		Limit:            params.limit + 1,
-		MetricsDetail:    metricsDetailFromPayload(payload.Metrics),
-	})
+	// Internal grouping folds one employee's linked emails into one summary
+	// when the org is on the canonical fold; external ids never fold.
+	fold, shadow := false, false
+	if groupBy != "external_user_id" {
+		fold, shadow = s.canonicalIdentityMode(ctx, params.organizationID)
+	}
+	canonicalOrg := ""
+	if fold {
+		canonicalOrg = params.organizationID
+	}
+
+	searchParams := repo.SearchUsersParams{
+		GramProjectID:        params.projectID,
+		TimeStart:            params.timeStart,
+		TimeEnd:              params.timeEnd,
+		GramDeploymentID:     deploymentID,
+		EventSource:          conv.PtrValOr(filter.EventSource, ""),
+		HookSource:           conv.PtrValOr(filter.HookSource, ""),
+		AccountType:          conv.PtrValOr(filter.AccountType, ""),
+		ExternalOrgID:        conv.PtrValOr(filter.ExternalOrgID, ""),
+		GroupBy:              groupBy,
+		UserIDs:              filter.UserIds,
+		SortOrder:            params.sortOrder,
+		Cursor:               params.cursor,
+		Limit:                params.limit + 1,
+		MetricsDetail:        metricsDetailFromPayload(payload.Metrics),
+		CanonicalIdentityOrg: canonicalOrg,
+	}
+	items, err := s.chRepo.SearchUsers(ctx, searchParams)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error searching users")
+	}
+
+	// List divergence is customer-visible in a way aggregate drift is not, so
+	// the employee list gets its own shadow: first pages only — under a cursor
+	// the literal and folded orderings paginate differently and a membership
+	// diff would be noise.
+	if shadow && params.cursor == "" {
+		s.shadowCompareSearchUsersFold(ctx, params.organizationID, searchParams, items)
 	}
 
 	var nextCursor *string
@@ -1027,24 +1048,29 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 	var items []repo.UserSummary
 	var assignments []orgsRepo.ListActiveRoleAssignmentsByOrganizationRow
 
+	// Canonical keys also serve the role rollup: one employee aggregates once
+	// per role instead of splitting across their linked emails.
+	canonicalOrg := s.canonicalOrgFor(ctx, params.organizationID)
+
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		var fetchErr error
 		items, fetchErr = s.chRepo.SearchUsers(egCtx, repo.SearchUsersParams{
-			GramProjectID:    params.projectID,
-			TimeStart:        params.timeStart,
-			TimeEnd:          params.timeEnd,
-			GramDeploymentID: deploymentID,
-			EventSource:      conv.PtrValOr(filter.EventSource, ""),
-			HookSource:       conv.PtrValOr(filter.HookSource, ""),
-			AccountType:      conv.PtrValOr(filter.AccountType, ""),
-			ExternalOrgID:    conv.PtrValOr(filter.ExternalOrgID, ""),
-			GroupBy:          "user_id",
-			UserIDs:          filter.UserIds,
-			SortOrder:        "desc",
-			Cursor:           "",
-			Limit:            10001,                  // Upper bound; orgs rarely have >10k users
-			MetricsDetail:    repo.MetricsDetailFull, // role aggregation sums cost/tokens across the full metric set
+			GramProjectID:        params.projectID,
+			TimeStart:            params.timeStart,
+			TimeEnd:              params.timeEnd,
+			GramDeploymentID:     deploymentID,
+			EventSource:          conv.PtrValOr(filter.EventSource, ""),
+			HookSource:           conv.PtrValOr(filter.HookSource, ""),
+			AccountType:          conv.PtrValOr(filter.AccountType, ""),
+			ExternalOrgID:        conv.PtrValOr(filter.ExternalOrgID, ""),
+			GroupBy:              "user_id",
+			UserIDs:              filter.UserIds,
+			SortOrder:            "desc",
+			Cursor:               "",
+			Limit:                10001,                  // Upper bound; orgs rarely have >10k users
+			MetricsDetail:        repo.MetricsDetailFull, // role aggregation sums cost/tokens across the full metric set
+			CanonicalIdentityOrg: canonicalOrg,
 		})
 		if fetchErr != nil {
 			return oops.E(oops.CodeUnexpected, fetchErr, "error searching users for role aggregation")

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -441,7 +441,10 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	}
 
 	// Internal grouping folds one employee's linked emails into one summary
-	// when the org is on the canonical fold; external ids never fold.
+	// when the org is on the canonical fold; external ids never fold. A
+	// canonical cursor minted under the fold stops resolving if the flag
+	// flips off mid-pagination (short page, no error) — transient, inherent
+	// to per-request flag evaluation.
 	fold, shadow := false, false
 	if groupBy != "external_user_id" {
 		fold, shadow = s.canonicalIdentityMode(ctx, params.organizationID)

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -933,6 +933,12 @@ func dedupeNonEmpty(values []string) []string {
 // pairing one person's email with another person's user id hand the second
 // person's accounts to the first summary (DNO-509). Best-effort: a lookup
 // failure leaves accounts empty rather than failing the listing.
+//
+// Canonical-fold edge, accepted: if the fold's canonical key fails directory
+// resolution (owner deleted after the last identity-map sync), the email
+// fallback targets the folded-away personal-email summary and the chip
+// attaches nowhere for that page load. Transient — the next map sync drops
+// the deleted owner's entries and the rows return to literal keys.
 func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []*telem_gen.UserSummary, rawUserIDsByKey map[string][]string) {
 	if len(users) == 0 {
 		return

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -131,14 +131,56 @@ func withAccountTypeFilter(sb squirrel.SelectBuilder, accountType string) squirr
 // known_emails join (see SearchUsers) so a person's email-less rows (e.g. tool
 // calls attributed by id only) merge into their email-keyed summary instead of
 // splitting into a second, token-less one.
-func searchUsersGroupExpr(groupBy string) string {
+// In canonical mode (canonicalOrgLit != "", internal grouping only) both email
+// arms fold through the identity_map, so one employee's work, personal, and
+// case-variant emails key a single summary; rows whose user_id never co-occurs
+// with an email keep their literal id key — the map is email-keyed and cannot
+// resolve a bare id.
+func searchUsersGroupExpr(groupBy, canonicalOrgLit string) string {
 	if groupBy == "external_user_id" {
 		return userIdentifierExpr("external_user_id")
+	}
+	if canonicalOrgLit != "" {
+		return "multiIf(" +
+			"telemetry_logs.user_email != '', " + canonicalEmailExpr(canonicalOrgLit, "telemetry_logs.user_email") + ", " +
+			"known_emails.known_email != '', " + canonicalEmailExpr(canonicalOrgLit, "known_emails.known_email") + ", " +
+			"telemetry_logs.user_id)"
 	}
 	return "multiIf(" +
 		"telemetry_logs.user_email != '', telemetry_logs.user_email, " +
 		"known_emails.known_email != '', known_emails.known_email, " +
 		"telemetry_logs.user_id)"
+}
+
+// searchUsersCanonicalKeyFilter matches requested summary keys in canonical
+// mode: email-shaped keys fold through the identity_map on both sides — a
+// drill by any of an employee's linked emails finds their one canonical
+// summary — while id-shaped keys keep the literal exact-match arms (the group
+// key and the raw id column; ids never fold, the map is email-keyed).
+func searchUsersCanonicalKeyFilter(orgLit, groupExpr, groupCol string, keys []string) squirrel.Sqlizer {
+	emailKeys := make([]string, 0, len(keys))
+	idKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if strings.Contains(key, "@") {
+			emailKeys = append(emailKeys, key)
+		} else {
+			idKeys = append(idKeys, key)
+		}
+	}
+	var or squirrel.Or
+	if len(emailKeys) > 0 {
+		fragments, args, _ := canonicalEmailValueList(orgLit, emailKeys)
+		if len(fragments) > 0 {
+			or = append(or, squirrel.Expr(groupExpr+" IN ("+strings.Join(fragments, ", ")+")", args...))
+		}
+	}
+	if len(idKeys) > 0 {
+		or = append(or, squirrel.Eq{groupExpr: idKeys}, squirrel.Eq{userIdentifierExpr(groupCol): idKeys})
+	}
+	if len(or) == 0 {
+		return squirrel.Expr("0")
+	}
+	return or
 }
 
 // searchUsersKnownEmailsJoin maps each user_id to an email observed alongside it
@@ -3058,6 +3100,10 @@ type SearchUsersParams struct {
 	// employee enrollment list uses MetricsDetailBasic because it renders only the
 	// lean fields.
 	MetricsDetail string
+	// CanonicalIdentityOrg, when set (internal grouping only), folds the email
+	// group-key arms and requested email keys through the identity_map so one
+	// employee is one summary keyed by their canonical email.
+	CanonicalIdentityOrg string
 }
 
 // MetricsDetail levels for SearchUsersParams.MetricsDetail. The string values
@@ -3081,14 +3127,26 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 	if arg.GroupBy == "external_user_id" {
 		groupCol = "external_user_id"
 	}
-	groupExpr := searchUsersGroupExpr(arg.GroupBy)
+	orgLit := ""
+	if arg.GroupBy != "external_user_id" {
+		orgLit = canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg)
+	}
+	groupExpr := searchUsersGroupExpr(arg.GroupBy, orgLit)
+
+	// The displayed email folds with the group key: an arbitrary literal variant
+	// (e.g. the personal address) labeling a canonical bucket would contradict
+	// the key it merged into.
+	emailDisplay := "anyIf(user_email, user_email != '')"
+	if orgLit != "" {
+		emailDisplay = "anyIf(" + canonicalEmailExpr(orgLit, "telemetry_logs.user_email") + ", user_email != '')"
+	}
 
 	// Lean columns rendered by every caller (identity, activity window, tokens) and
 	// the raw ids the account-enrichment join needs. The employee enrollment list
 	// consumes only these, so "basic" stops here — see MetricsDetail.
 	columns := []string{
 		groupExpr + " AS user_id",
-		"anyIf(user_email, user_email != '') AS user_email",
+		emailDisplay + " AS user_email",
 
 		// Activity timestamps
 		"min(time_unix_nano) AS first_seen_unix_nano",
@@ -3175,9 +3233,12 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 		sb = sb.Where("external_org_id = ?", arg.ExternalOrgID)
 	}
 	if len(arg.UserIDs) > 0 {
-		if arg.GroupBy == "external_user_id" {
+		switch {
+		case arg.GroupBy == "external_user_id":
 			sb = sb.Where(squirrel.Eq{groupExpr: arg.UserIDs})
-		} else {
+		case orgLit != "":
+			sb = sb.Where(searchUsersCanonicalKeyFilter(orgLit, groupExpr, groupCol, arg.UserIDs))
+		default:
 			sb = sb.Where(squirrel.Or{
 				squirrel.Eq{groupExpr: arg.UserIDs},
 				squirrel.Eq{userIdentifierExpr(groupCol): arg.UserIDs},
@@ -3195,6 +3256,7 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 
 	sb = sb.Limit(uint64(arg.Limit)) //nolint:gosec // Limit is always positive
 
+	sb = withCanonicalFoldSettings(sb, orgLit)
 	query, args, err := sb.ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("building search users query: %w", err)


### PR DESCRIPTION
Part of DNO-879 (Canonical Identity Map for Cost Analytics), slice B — the last group-by-email surface. Stacked on #5353.

## What

Behind the same `canonical-identity-fold` flag, the employee list (the `searchUsers` raw-logs path) folds one employee's linked emails into one summary:

- **Group key folds on both email arms**: `searchUsersGroupExpr` folds `user_email` and the `known_emails` join fallback through the identity map, so work, personal, and case-variant emails key a single summary under the canonical email. Rows whose user_id never co-occurs with an email keep their literal id key — the map is email-keyed and cannot resolve a bare id.
- **Key filters fold on both sides**: drilling by any linked email (`filter.user_ids`) finds the one canonical summary; id-shaped keys keep their literal exact-match arms.
- **The display email folds with the key**, so a canonical bucket is never labeled with an arbitrary literal variant.
- **The role rollup reuses the canonical keys**: one employee aggregates once per role, and canonical keys resolve cleanly through the owner directory (they are directory emails by construction).
- External-id grouping never folds; flag off is byte-identical literal behavior.

## List-divergence shadow

List membership changing is customer-visible in a way aggregate drift is not, so this surface gets its own shadow comparison instead of reusing the aggregate one: on first pages under the shadow flag, the folded list is re-queried in the background (detached context, shared concurrency cap) and the log line `identity fold shadow employee list comparison` records literal vs folded row counts, keys that exist only folded, and the input+output token delta. On an untruncated page the fold can only shrink the list and must preserve the token sum. Emails are never logged.

## Verification

- 372 telemetry tests. New integration coverage: fold-on one-row-per-employee across all three attribution shapes (email row, case-variant personal row, id-only tool call folding in via the known-emails join) with sum preservation and a stranger staying separate; a drill by the personal email returning the canonical summary; shadow mode serving the literal split list.
- The 20+ pre-existing searchUsers tests pass untouched as the flag-off guard.
- `mise lint:server` green; folded query carries `SETTINGS use_query_condition_cache = 0` like every fold surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds the employee list in `searchUsers` through the canonical identity map so one employee appears once under their canonical email. Previously employees split across literal email variants; now linked emails fold to the canonical email while id-only rows keep their literal id, and external-id grouping stays literal.

- Grouping and filters: both email arms of the group key and requested email keys fold via the map; id-shaped keys keep literal exact-match arms; the displayed email folds with the key.
- Pagination and drills: canonical cursors resolve through the fold; id-shaped drills reach the folded summary; role rollup counts one employee once per role. If the flag flips off mid-pagination, a canonical cursor may yield a short page without error.
- Service/SQL: passes `CanonicalIdentityOrg`; folds the email group-key arms and key filters; canonicalizes the displayed email; applies canonical-fold query settings. Known edge: if the canonical key fails directory resolution, the accounts chip may be empty until the next map sync.
- Telemetry and shadow: adds `gram.identity_fold.new_keys`, `gram.identity_fold.order_changed`, `gram.identity_fold.truncated`, `gram.identity_fold.token_delta`. Shadow mode re-runs the first page only and logs literal vs folded counts, fold-only keys, order changes among untouched shared keys, the token delta, and a truncation marker; responses stay literal under shadow and no emails are logged.

**Rollout**
- Flag-gated per org (Linear DNO-879). Shadow comparison runs on first pages only.
- Expect folded groups ≤ literal and zero token delta on untruncated pages. No client changes required.

<sup>Written for commit 1c25a1ee86e3af84f3f2d81d8f254aa99d43d8fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

