### PR TITLE
fix(dashboard): default an unset device agent platform gate to User

### DIFF
--- a/.changeset/device-agent-platform-default-layer.md
+++ b/.changeset/device-agent-platform-default-layer.md
@@ -1,0 +1,14 @@
+---
+"dashboard": patch
+---
+
+Fleet configuration now reports a managed tool that is absent from the
+`platforms` map as `User` rather than `Off`. The device agent's `platforms`
+map is opt-out — a tool with no entry is managed at the user layer, and only
+an explicit `false` disables it — but this page defaulted three of the four
+tools to `Off`, so an organization whose configuration predated a tool being
+added here saw it reported as unmanaged while every enrolled device was
+enforcing it. Saving the page then wrote that incorrect reading back, turning
+the tool off for the fleet as a side effect of editing an unrelated field.
+The per-tool default is now a single constant that mirrors the agent's own
+resolution, so a tool added to this list later cannot reintroduce the skew.

--- a/client/dashboard/src/pages/device-agent/device-agent-configuration.test.ts
+++ b/client/dashboard/src/pages/device-agent/device-agent-configuration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { enforcementLayer } from "./device-agent-configuration";
+
+// Mirrors config.PlatformMode.Layer() in the device-agent repo: the
+// `platforms` map is opt-out, so anything but an explicit false is managed.
+describe("enforcementLayer", () => {
+  it("treats an absent key as managed at the user layer", () => {
+    expect(enforcementLayer({ codex: "managed" }, "opencode")).toBe("user");
+    expect(enforcementLayer(undefined, "opencode")).toBe("user");
+    expect(enforcementLayer({}, "claude_code")).toBe("user");
+  });
+
+  it("reads explicit values back", () => {
+    expect(enforcementLayer({ opencode: false }, "opencode")).toBe("off");
+    expect(enforcementLayer({ opencode: "user" }, "opencode")).toBe("user");
+    expect(enforcementLayer({ opencode: "managed" }, "opencode")).toBe(
+      "managed",
+    );
+  });
+
+  it("degrades a non-object platforms value to the default", () => {
+    expect(enforcementLayer("nonsense", "opencode")).toBe("user");
+  });
+});

--- a/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
@@ -28,18 +28,14 @@ import {
 import { useUpdateDeviceAgentConfigurationMutation } from "@gram/client/react-query/updateDeviceAgentConfiguration.js";
 import { Button } from "@/components/ui/Button";
 import { Stack } from "@/components/ui/Stack";
+import {
+  enforcementLayer,
+  recordValue,
+  type EnforcementLayer,
+} from "./platform-layers";
 import { useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { toast } from "sonner";
-
-type EnforcementLayer = "off" | "user" | "managed";
-
-// The `platforms` map is opt-out on the device agent: a tool absent from it is
-// managed at the user layer (config.PlatformMode.Layer in the device-agent
-// repo). Only an explicit `false` disables one. This UI must resolve an absent
-// key the same way, or it reports a tool as Off while the fleet is enforcing
-// it — and then writes that false reading back on the next save.
-const DEFAULT_LAYER: EnforcementLayer = "user";
 
 const PLATFORMS = [
   {
@@ -94,23 +90,6 @@ const AUTO_UPDATE_POLICIES = [
     description: "Install updates as they release",
   },
 ] as const;
-
-function recordValue(value: unknown): Record<string, unknown> {
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  return {};
-}
-
-export function enforcementLayer(
-  platforms: unknown,
-  platformKey: string,
-): EnforcementLayer {
-  const value = recordValue(platforms)[platformKey];
-  if (value === "user" || value === "managed") return value;
-  if (value === false) return "off";
-  return DEFAULT_LAYER;
-}
 
 function stringSetting(
   config: DeviceAgentConfiguration,

--- a/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
@@ -34,36 +34,38 @@ import { toast } from "sonner";
 
 type EnforcementLayer = "off" | "user" | "managed";
 
+// The `platforms` map is opt-out on the device agent: a tool absent from it is
+// managed at the user layer (config.PlatformMode.Layer in the device-agent
+// repo). Only an explicit `false` disables one. This UI must resolve an absent
+// key the same way, or it reports a tool as Off while the fleet is enforcing
+// it — and then writes that false reading back on the next save.
+const DEFAULT_LAYER: EnforcementLayer = "user";
+
 const PLATFORMS = [
   {
     key: "claude_code",
     label: "Claude Code",
     description: "Configure Claude Code plugins and MCP settings.",
-    defaultLayer: "user",
   },
   {
     key: "codex",
     label: "Codex",
     description: "Configure Codex plugins and MCP settings.",
-    defaultLayer: "off",
   },
   {
     key: "cursor",
     label: "Cursor",
     description: "Configure Cursor plugins and MCP settings.",
-    defaultLayer: "off",
   },
   {
     key: "opencode",
     label: "OpenCode",
     description: "Configure OpenCode plugins and MCP settings.",
-    defaultLayer: "off",
   },
 ] as const satisfies ReadonlyArray<{
   key: string;
   label: string;
   description: string;
-  defaultLayer: EnforcementLayer;
 }>;
 
 const MIN_SYNC_INTERVAL_SECONDS = 60;
@@ -100,14 +102,14 @@ function recordValue(value: unknown): Record<string, unknown> {
   return {};
 }
 
-function enforcementLayer(
-  config: DeviceAgentConfiguration,
-  platform: (typeof PLATFORMS)[number],
+export function enforcementLayer(
+  platforms: unknown,
+  platformKey: string,
 ): EnforcementLayer {
-  const value = recordValue(config.config.platforms)[platform.key];
+  const value = recordValue(platforms)[platformKey];
   if (value === "user" || value === "managed") return value;
   if (value === false) return "off";
-  return platform.defaultLayer;
+  return DEFAULT_LAYER;
 }
 
 function stringSetting(
@@ -222,7 +224,7 @@ function DeviceAgentConfigurationForm({
     Object.fromEntries(
       PLATFORMS.map((platform) => [
         platform.key,
-        enforcementLayer(configuration, platform),
+        enforcementLayer(configuration.config.platforms, platform.key),
       ]),
     ),
   );
@@ -264,7 +266,7 @@ function DeviceAgentConfigurationForm({
   const currentPlatformLayers = Object.fromEntries(
     PLATFORMS.map((platform) => [
       platform.key,
-      enforcementLayer(configuration, platform),
+      enforcementLayer(configuration.config.platforms, platform.key),
     ]),
   );
   const isDirty =

--- a/client/dashboard/src/pages/device-agent/platform-layers.test.ts
+++ b/client/dashboard/src/pages/device-agent/platform-layers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { enforcementLayer } from "./device-agent-configuration";
+import { enforcementLayer } from "./platform-layers";
 
 // Mirrors config.PlatformMode.Layer() in the device-agent repo: the
 // `platforms` map is opt-out, so anything but an explicit false is managed.

--- a/client/dashboard/src/pages/device-agent/platform-layers.ts
+++ b/client/dashboard/src/pages/device-agent/platform-layers.ts
@@ -1,0 +1,25 @@
+export type EnforcementLayer = "off" | "user" | "managed";
+
+// The `platforms` map is opt-out on the device agent: a tool absent from it is
+// managed at the user layer (config.PlatformMode.Layer in the device-agent
+// repo). Only an explicit `false` disables one. This UI must resolve an absent
+// key the same way, or it reports a tool as Off while the fleet is enforcing
+// it — and then writes that false reading back on the next save.
+const DEFAULT_LAYER: EnforcementLayer = "user";
+
+export function recordValue(value: unknown): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function enforcementLayer(
+  platforms: unknown,
+  platformKey: string,
+): EnforcementLayer {
+  const value = recordValue(platforms)[platformKey];
+  if (value === "user" || value === "managed") return value;
+  if (value === false) return "off";
+  return DEFAULT_LAYER;
+}


### PR DESCRIPTION
## What

Fleet configuration reported a managed tool with no entry in the `platforms`
map as **Off**, while every enrolled device was enforcing it.

The device agent's `platforms` map is **opt-out**: a tool absent from the map
resolves to `PlatformUser` (`PlatformMode.Layer()` in the device-agent repo),
and only an explicit `false` disables it. This page carried a per-tool
`defaultLayer` that said `"off"` for Codex, Cursor, and OpenCode, and
`"user"` only for Claude Code — so an absent key rendered as Off.

That default is replaced with a single `DEFAULT_LAYER = "user"` constant that
mirrors the agent's own resolution. `enforcementLayer` now takes the platforms
value and a key so it can be unit-tested.

## Why it matters

Reported via support: an organization whose stored configuration predates
OpenCode being added to this list has no `opencode` key, so the page said Off
while the agent was materializing OpenCode's config and MCP entries on every
sync tick. The reporter reasonably read that as the agent scanning other
tools' configuration files.

Worse than the display: `handleSave` writes **every** platform key from local
state, so an admin editing only the sync interval would have saved
`{codex: false, cursor: false, opencode: false}` — silently opting the fleet
out of three tools from a screen that never showed them as on.

Dropping the per-tool field rather than flipping three strings is deliberate:
it was wrong for three of the four entries and would have been wrong again for
the next tool added.

## Behavior change to expect

For an organization with no `opencode` key, the row flips from Off to User
with no action on their part. That is the truth of what their devices were
already doing, but it will read as a change. Turning it Off now writes
`opencode: false`, which the agent resolves to `PlatformOff` and tears down
via `Unmanage` on the next sync tick (remote is the highest-precedence layer,
so it overrides local and MDM).

## Testing

- New unit test: absent key → `user`, explicit `false` → `off`, `"managed"`
  round-trips, non-object `platforms` → `user`.
- `aube run -F dashboard test src/pages/device-agent` and `type-check` pass.

## Not in scope

- `copilot` is a real tool id that the agent manages by default and is still
  absent from this list — invisible on the page and impossible to turn off.
- `handleSave` still writes every platform key rather than only changed ones.
  Harmless now that the defaults agree, worth tightening separately.
