### PR TITLE
feat(admin): edit a record's fact in place, one write at a time

### DIFF
--- a/.changeset/admin-organization-record-inline-edit.md
+++ b/.changeset/admin-organization-record-inline-edit.md
@@ -1,0 +1,18 @@
+---
+"admin": patch
+---
+
+An organization record's editable facts are now committed one at a time. The
+save bar that sat under the whole record is gone, along with the draft it wrote
+into, so the record no longer holds an unsaved change.
+
+Changing the account type, or the Whitelisted switch, raises a confirmation
+naming that one change and nothing else: "Account type: pro → enterprise." The
+write that follows carries only the field that was changed. A change that is
+not confirmed is never written, and the control goes back to reading the record
+on its own.
+
+Both controls are held while a write is in flight, so one record cannot take
+two writes at once. Every write now reports through the record's own reporter:
+spoken on success, and both spoken and shown on failure, in place of the error
+line the save bar used to carry.

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -266,6 +266,52 @@ describe("Overview", () => {
     );
   });
 
+  it("names the whitelisted change as yes and no, in that order", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("switch"));
+    const dialog = await screen.findByRole("dialog");
+
+    // The record under test is whitelisted, so the change reads yes → no. Both
+    // halves are asserted: a description that renders the boolean backwards, or
+    // one that names the two states the wrong way round, still reads like a
+    // sentence and asks the operator to approve the opposite of the write.
+    expect(ORG.whitelisted).toBe(true);
+    expect(dialog.textContent).toContain("Whitelisted: yes → no");
+    expect(dialog.textContent).not.toContain("Whitelisted: no → yes");
+  });
+
+  it("does not run a new write under the last one's failure", async () => {
+    mocks.updateOrganization.mockRejectedValueOnce(new Error("update failed"));
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("switch"));
+    await confirmDialog();
+    await waitFor(() => {
+      expect(document.querySelector(".text-destructive")?.textContent).toMatch(
+        /update failed/,
+      );
+    });
+
+    mocks.updateOrganization.mockResolvedValue({
+      ...ORG,
+      account_type: "enterprise",
+    });
+    await pickAccountType("enterprise");
+    await confirmDialog();
+
+    // A failure left standing over a write that landed tells the operator the
+    // change they just watched succeed did not happen.
+    await waitFor(() => {
+      expect(screen.getByRole("combobox").textContent).toBe("enterprise");
+    });
+    expect(document.querySelector(".text-destructive")).toBeNull();
+  });
+
   it("writes the account type on its own, with no whitelisted field", async () => {
     mocks.updateOrganization.mockResolvedValue({
       ...ORG,

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -792,6 +792,36 @@ describe("Overview", () => {
     await landsFocusBackAfter(() => failTheWrite());
   });
 
+  it("puts the keyboard back on the control on a second write", async () => {
+    // Fast enough that neither write commits a pending render, which is the
+    // case where one settled write looks exactly like the last one.
+    mocks.updateOrganization.mockImplementation((body: { id: string }) =>
+      Promise.resolve({ ...ORG, ...body }),
+    );
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    const toggle = await screen.findByRole("switch");
+    fireEvent.click(toggle);
+    await confirmDialog();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole("switch"));
+    });
+
+    // The second write is the one at issue: the first moves the write off
+    // `idle`, and after that a repeat has nothing new to say about itself.
+    (document.activeElement as HTMLElement | null)?.blur();
+    fireEvent.click(screen.getByRole("switch"));
+    await confirmDialog();
+    await waitFor(() => {
+      expect(mocks.updateOrganization).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole("switch"));
+    });
+  });
+
   it("disables both controls while a write is in flight", async () => {
     let landTheWrite = () => {};
     mocks.updateOrganization.mockImplementation(

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -312,6 +312,36 @@ describe("Overview", () => {
     expect(document.querySelector(".text-destructive")).toBeNull();
   });
 
+  it("keeps a failure showing when the next change is cancelled", async () => {
+    mocks.updateOrganization.mockRejectedValue(new Error("update failed"));
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("switch"));
+    await confirmDialog();
+    await waitFor(() => {
+      expect(document.querySelector(".text-destructive")?.textContent).toMatch(
+        /update failed/,
+      );
+    });
+
+    await pickAccountType("enterprise");
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    // Only a write clears the failure, and a cancelled change is not a write.
+    // Clearing it here would take away the only account of a failure the
+    // operator may not have read yet, in exchange for nothing happening.
+    expect(document.querySelector(".text-destructive")?.textContent).toMatch(
+      /update failed/,
+    );
+    expect(mocks.updateOrganization).toHaveBeenCalledTimes(1);
+  });
+
   it("writes the account type on its own, with no whitelisted field", async () => {
     mocks.updateOrganization.mockResolvedValue({
       ...ORG,

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -717,9 +717,11 @@ describe("Overview", () => {
       initialPath: `/organizations/${ORG.slug}`,
     });
 
-    // Cancelled first, then confirmed. Radix restores focus to a
-    // `DialogTrigger`, and this dialog has none, so both exits drop the
-    // keyboard on `document.body` unless the control is focused back.
+    // Radix restores focus to a `DialogTrigger`, and this dialog has none, so
+    // both exits drop the keyboard on `document.body` unless the control is
+    // focused back. The confirmed half of this test proves only that the
+    // control ends up focused; it cannot see the browser's blur-on-disable, so
+    // the real cover for that path is the two tests below.
     const select = await pickAccountType("enterprise");
     const dialog = await screen.findByRole("dialog");
     fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
@@ -733,6 +735,61 @@ describe("Overview", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(toggle);
     });
+  });
+
+  // The control is disabled while its write is in flight, and a browser drops
+  // focus to the body when the focused element becomes disabled. jsdom does not:
+  // it leaves focus where it was, so a restore that runs before the disable
+  // passes here and fails in front of an operator. Both tests below blur the
+  // control by hand to stand in for the browser, then require the write to put
+  // the keyboard back.
+  async function landsFocusBackAfter(settle: () => void): Promise<void> {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    const toggle = await screen.findByRole("switch");
+    fireEvent.click(toggle);
+    await confirmDialog();
+    await waitFor(() => {
+      expect(isDisabled(screen.getByRole("switch"))).toBe(true);
+    });
+
+    // What the browser does when a focused control becomes disabled.
+    (document.activeElement as HTMLElement | null)?.blur();
+    expect(document.activeElement).not.toBe(toggle);
+
+    settle();
+    await waitFor(() => {
+      expect(isDisabled(screen.getByRole("switch"))).toBe(false);
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole("switch"));
+    });
+  }
+
+  it("puts the keyboard back on the control after a write lands", async () => {
+    let landTheWrite = () => {};
+    mocks.updateOrganization.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          landTheWrite = () => resolve({ ...ORG, whitelisted: false });
+        }),
+    );
+
+    await landsFocusBackAfter(() => landTheWrite());
+  });
+
+  it("puts the keyboard back on the control after a write fails", async () => {
+    let failTheWrite = () => {};
+    mocks.updateOrganization.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          failTheWrite = () => reject(new Error("update failed"));
+        }),
+    );
+
+    await landsFocusBackAfter(() => failTheWrite());
   });
 
   it("disables both controls while a write is in flight", async () => {

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -81,6 +81,47 @@ function labelsIn(group: string): string[] {
   );
 }
 
+// Opens the account type select and picks an option, and hands back the
+// trigger so a test can read what the control says afterwards.
+async function pickAccountType(option: string): Promise<HTMLElement> {
+  const select = await screen.findByRole("combobox");
+  fireEvent.keyDown(select, { key: "ArrowDown" });
+  fireEvent.click(await screen.findByRole("option", { name: option }));
+  return select;
+}
+
+async function confirmDialog(): Promise<void> {
+  const dialog = await screen.findByRole("dialog");
+  fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+}
+
+// The body of the one write under test. Read off the mock rather than asserted
+// through `toHaveBeenCalledWith`, so a test can name the keys it must not have.
+function payloadOf(mock: { mock: { calls: unknown[][] } }): object {
+  const [first] = mock.mock.calls;
+  if (!first) throw new Error("no write was made");
+  return first[0] as object;
+}
+
+// Both controls are buttons under the hood, so the attribute is the answer.
+// This suite has no jest-dom matchers.
+function isDisabled(control: HTMLElement): boolean {
+  return control.hasAttribute("disabled");
+}
+
+// `RecordLayout`'s live region, the one place a write reported from inside a
+// dialog reaches a screen reader.
+function liveRegion(): HTMLElement {
+  const region = document.querySelector('[aria-live="polite"]');
+  if (!(region instanceof HTMLElement)) {
+    throw new Error("the record has no live region");
+  }
+  return region;
+}
+
 const writeText = vi.fn<(text: string) => Promise<void>>(() =>
   Promise.resolve(),
 );
@@ -188,21 +229,124 @@ describe("Overview", () => {
     expect(valueBeside("Disabled at").textContent).toBe(shortDate(disabled));
   });
 
-  it("shows the account type the operator picked, not the saved one", async () => {
+  it("leaves the control reading the record while the dialog asks", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,
     });
 
-    const select = await screen.findByRole("combobox");
-    fireEvent.keyDown(select, { key: "ArrowDown" });
-    fireEvent.click(await screen.findByRole("option", { name: "enterprise" }));
+    const select = await pickAccountType("enterprise");
+    await screen.findByRole("dialog");
 
-    // A control that keeps reading the record shows the old value while Save
-    // offers to write the new one, so the operator saves a change the page
-    // never showed them.
-    expect(select.textContent).toBe("enterprise");
+    // Honest: the record has not changed yet, and the dialog carries the words
+    // for what is about to change. A control that ran ahead of the write would
+    // read as saved to an operator who then cancels.
+    expect(select.textContent).toBe(ORG.account_type);
     expect(ORG.account_type).not.toBe("enterprise");
-    expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+  });
+
+  it("names the change from the old value to the new one", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await pickAccountType("enterprise");
+    const dialog = await screen.findByRole("dialog");
+
+    expect(within(dialog).getByRole("heading").textContent).toBe(
+      `Update ${ORG.name}?`,
+    );
+    // Written out with both values in order. A description built backwards
+    // still names the right two words and asks the operator to approve the
+    // opposite of what will be written.
+    expect(dialog.textContent).toContain(
+      `Account type: ${ORG.account_type} → enterprise`,
+    );
+    expect(dialog.textContent).not.toContain(
+      `Account type: enterprise → ${ORG.account_type}`,
+    );
+  });
+
+  it("writes the account type on its own, with no whitelisted field", async () => {
+    mocks.updateOrganization.mockResolvedValue({
+      ...ORG,
+      account_type: "enterprise",
+    });
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await pickAccountType("enterprise");
+    await confirmDialog();
+
+    await waitFor(() => {
+      expect(mocks.updateOrganization).toHaveBeenCalledTimes(1);
+    });
+    // The keys, not just the values. `toHaveBeenCalledWith` treats an absent
+    // key and a key set to `undefined` as the same object, so a write that
+    // sends `whitelisted: undefined` alongside passes a loose assertion while
+    // the endpoint reads it as a field the operator never touched.
+    expect(payloadOf(mocks.updateOrganization)).toStrictEqual({
+      id: ORG.id,
+      account_type: "enterprise",
+    });
+    expect(Object.keys(payloadOf(mocks.updateOrganization)).sort()).toEqual([
+      "account_type",
+      "id",
+    ]);
+  });
+
+  it("writes whitelisted on its own, with no account type field", async () => {
+    mocks.updateOrganization.mockResolvedValue({ ...ORG, whitelisted: false });
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("switch"));
+    await confirmDialog();
+
+    // The field by name, not merely that a write happened: the two editors
+    // write one record between them, and a switch that lands on the account
+    // type changes the plan of an organization nobody meant to touch.
+    await waitFor(() => {
+      expect(mocks.updateOrganization).toHaveBeenCalledTimes(1);
+    });
+    expect(payloadOf(mocks.updateOrganization)).toStrictEqual({
+      id: ORG.id,
+      whitelisted: false,
+    });
+    expect(Object.keys(payloadOf(mocks.updateOrganization)).sort()).toEqual([
+      "id",
+      "whitelisted",
+    ]);
+  });
+
+  it("writes nothing when the operator cancels, and the control snaps back", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    const select = await pickAccountType("enterprise");
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(mocks.updateOrganization).not.toHaveBeenCalled();
+    // No revert code wrote this back. The control reads `org`, so a change
+    // nobody confirmed was never anywhere but the dialog's words.
+    expect(select.textContent).toBe(ORG.account_type);
+
+    fireEvent.click(screen.getByRole("switch"));
+    const second = await screen.findByRole("dialog");
+    fireEvent.click(within(second).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(mocks.updateOrganization).not.toHaveBeenCalled();
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      String(ORG.whitelisted),
+    );
   });
 
   it("shows a saved change on a record the operator reached by id", async () => {
@@ -216,24 +360,36 @@ describe("Overview", () => {
       initialPath: `/organizations/${ORG.id}`,
     });
 
-    const select = await screen.findByRole("combobox");
-    fireEvent.keyDown(select, { key: "ArrowDown" });
-    fireEvent.click(await screen.findByRole("option", { name: "enterprise" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await pickAccountType("enterprise");
+    await confirmDialog();
 
-    const dialog = await screen.findByRole("dialog");
-    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
-
-    // Waited out rather than asserted straight away: while the write is in
-    // flight the draft is still what the control reads, so it says "enterprise"
-    // either way. Save leaving is the record answering for itself again.
-    await waitFor(() => {
-      expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
-    });
     // An operator who watched the save land and then reads the old value back
     // has no way to tell a stale page from a write that did not happen.
-    expect(screen.getByRole("combobox").textContent).toBe("enterprise");
+    await waitFor(() => {
+      expect(screen.getByRole("combobox").textContent).toBe("enterprise");
+    });
     expect(ORG.account_type).not.toBe("enterprise");
+  });
+
+  it("announces a write that lands", async () => {
+    mocks.updateOrganization.mockResolvedValue({
+      ...ORG,
+      account_type: "enterprise",
+    });
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    await pickAccountType("enterprise");
+    await confirmDialog();
+
+    // Spoken, because the record repaints in place and a screen reader is told
+    // nothing by a select whose text changed.
+    await waitFor(() => {
+      expect(liveRegion().textContent).toContain(
+        `${ORG.name} updated. Account type: ${ORG.account_type} → enterprise.`,
+      );
+    });
   });
 
   it("keeps a saved change through a list read that was already in flight", async () => {
@@ -274,16 +430,10 @@ describe("Overview", () => {
       expect(mocks.listOrganizations).toHaveBeenCalled();
     });
 
-    const select = await screen.findByRole("combobox");
-    fireEvent.keyDown(select, { key: "ArrowDown" });
-    fireEvent.click(await screen.findByRole("option", { name: "enterprise" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    const dialog = await screen.findByRole("dialog");
-    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
-
+    await pickAccountType("enterprise");
+    await confirmDialog();
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+      expect(mocks.updateOrganization).toHaveBeenCalled();
     });
 
     // Now, after the write. React Query commits whatever a request answers
@@ -343,15 +493,17 @@ describe("Overview", () => {
       expect(mocks.getOrganizationStats).toHaveBeenCalled();
     });
 
-    const select = await screen.findByRole("combobox");
-    fireEvent.keyDown(select, { key: "ArrowDown" });
-    fireEvent.click(await screen.findByRole("option", { name: "enterprise" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await pickAccountType("enterprise");
+    await confirmDialog();
 
-    const dialog = await screen.findByRole("dialog");
-    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
-
-    await screen.findByText(/update failed/);
+    // Shown as well as spoken. The save bar carried this line and went with the
+    // draft, so without the reporter a failed write is silent on the page.
+    await waitFor(() => {
+      expect(document.querySelector(".text-destructive")?.textContent).toMatch(
+        /Could not update .*update failed/,
+      );
+    });
+    expect(liveRegion().textContent).toContain("update failed");
     answerStatsRead();
 
     // Cancelled and replaced by nothing: a failed write repaints no record, so
@@ -364,7 +516,7 @@ describe("Overview", () => {
     });
   });
 
-  it("does not carry an unsaved draft to the next record", async () => {
+  it("does not carry an open dialog to the next record", async () => {
     const other = anOrganization({
       id: "org_2",
       name: "Second Org",
@@ -373,7 +525,7 @@ describe("Overview", () => {
     // Both records are already in the cache, which is the state the list
     // navigates from: `useOpenOrganization` writes the record before it moves.
     // Without the seed the second record arrives pending, the layout paints its
-    // loading state, and the unmount that follows clears the draft for reasons
+    // loading state, and the unmount that follows closes the dialog for reasons
     // that have nothing to do with the record it belonged to.
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -387,7 +539,7 @@ describe("Overview", () => {
     });
 
     fireEvent.click(await screen.findByRole("switch"));
-    expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+    expect((await screen.findByRole("dialog")).textContent).toContain(ORG.name);
 
     await router.navigate({
       to: "/organizations/$idOrSlug",
@@ -397,9 +549,12 @@ describe("Overview", () => {
     expect(
       await screen.findByRole("heading", { name: other.name }),
     ).toBeTruthy();
-    // The edit belonged to the record that was open when it was made. Carrying
-    // it over offers to save one organization's change against another.
-    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    // The question belonged to the record it was asked about. Carried over, it
+    // offers to write one organization's change against another.
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(mocks.updateOrganization).not.toHaveBeenCalled();
   });
 
   it("draws the facts in three named groups", async () => {
@@ -453,40 +608,84 @@ describe("Overview", () => {
     expect(labels).not.toContain("Members");
   });
 
-  it("keeps the save bar under the whole record, not inside a group", async () => {
-    await renderRouteTree(routeTree, {
-      initialPath: `/organizations/${ORG.slug}`,
-    });
-
-    fireEvent.click(await screen.findByRole("switch"));
-    // A save bar drawn inside Access would read as saving Access alone, while
-    // it writes the account type in Plan too.
-    expect(
-      screen.getByRole("button", { name: "Save" }).closest("section"),
-    ).toBeNull();
-  });
-
-  it("saves the whitelisted switch as whitelisted", async () => {
+  it("raises no save bar over the record when a fact changes", async () => {
     mocks.updateOrganization.mockResolvedValue({ ...ORG, whitelisted: false });
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,
     });
 
     fireEvent.click(await screen.findByRole("switch"));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    const dialog = await screen.findByRole("dialog");
-    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
-
-    // The field by name, not merely that a write happened: the two editors
-    // write one record between them, and a switch that lands on the account
-    // type changes the plan of an organization nobody meant to touch.
+    await confirmDialog();
     await waitFor(() => {
-      expect(mocks.updateOrganization).toHaveBeenCalledWith({
-        id: ORG.id,
-        account_type: undefined,
-        whitelisted: false,
-      });
+      expect(mocks.updateOrganization).toHaveBeenCalled();
     });
+
+    // The record commits one fact at a time now. A bar left over the whole
+    // record offers to write facts the operator never touched, and the dialog
+    // it would raise could not name what it was about to save.
+    const overview = screen
+      .getByText("Whitelisted")
+      .closest("section")?.parentElement;
+    expect(overview).toBeTruthy();
+    expect(
+      within(overview!).queryByRole("button", { name: "Save" }),
+    ).toBeNull();
+    expect(
+      within(overview!).queryByRole("button", { name: "Cancel" }),
+    ).toBeNull();
+  });
+
+  it("returns focus to the control the dialog was opened from", async () => {
+    mocks.updateOrganization.mockResolvedValue({ ...ORG, whitelisted: false });
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    // Cancelled first, then confirmed. Radix restores focus to a
+    // `DialogTrigger`, and this dialog has none, so both exits drop the
+    // keyboard on `document.body` unless the control is focused back.
+    const select = await pickAccountType("enterprise");
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(document.activeElement).toBe(select);
+    });
+
+    const toggle = screen.getByRole("switch");
+    fireEvent.click(toggle);
+    await confirmDialog();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(toggle);
+    });
+  });
+
+  it("disables both controls while a write is in flight", async () => {
+    let landTheWrite = () => {};
+    mocks.updateOrganization.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          landTheWrite = () => resolve({ ...ORG, whitelisted: false });
+        }),
+    );
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("switch"));
+    await confirmDialog();
+
+    // Two writes in flight against one record race each other into the cache,
+    // and the loser's answer is the one that stays.
+    await waitFor(() => {
+      expect(isDisabled(screen.getByRole("switch"))).toBe(true);
+    });
+    expect(isDisabled(screen.getByRole("combobox"))).toBe(true);
+
+    landTheWrite();
+    await waitFor(() => {
+      expect(isDisabled(screen.getByRole("switch"))).toBe(false);
+    });
+    expect(isDisabled(screen.getByRole("combobox"))).toBe(false);
   });
 
   it("copies each identifier off its own row", async () => {

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -116,14 +116,16 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
   // Re-enabling does not bring it back, so the restore waits for the write to
   // settle and runs from here, after React has taken `disabled` off again.
   // Asked for at `mutate` rather than read off a pending render, because a write
-  // that settles fast never commits one.
+  // that settles fast never commits one. `variables` is a dep for the same
+  // reason: without it a fast write after another goes `success` to `success`
+  // and nothing here changes.
   const restoreWanted = useRef(false);
   useEffect(() => {
     if (mut.isPending || !restoreWanted.current) return;
     restoreWanted.current = false;
     // A control that has left the page is not somewhere to put the keyboard.
     if (openedFrom.current?.isConnected) openedFrom.current.focus();
-  }, [mut.status, mut.isPending]);
+  }, [mut.status, mut.isPending, mut.variables]);
 
   const commit = async (
     change: FactChange,

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -76,7 +76,9 @@ export function OverviewRoute(): JSX.Element | null {
   const { data } = useQuery(organizationQuery(idOrSlug));
   if (!data) return null;
   // Keyed, so a write in flight and the dialog asking about it belong to the
-  // record they were started on.
+  // record they were started on. `RecordLayout` keys this whole subtree the
+  // same way, which is what actually enforces it today; this one holds if the
+  // view is ever mounted somewhere that does not.
   return <Overview key={data.id} org={data} />;
 }
 

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -1,4 +1,4 @@
-import { useRef, type JSX } from "react";
+import { useEffect, useRef, type JSX } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 
@@ -95,6 +95,7 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
   // `DialogTrigger`, so Radix's own restore drops focus on `document.body`.
   const accountTypeControl = useRef<HTMLButtonElement>(null);
   const whitelistedControl = useRef<HTMLButtonElement>(null);
+  const openedFrom = useRef<HTMLButtonElement | null>(null);
 
   const mut = useMutation({
     mutationFn: (change: FactChange) =>
@@ -110,6 +111,20 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
     onError: () => invalidateOrganizationStats(qc),
   });
 
+  // The confirmed path cannot restore focus itself: it disables the control it
+  // would focus, and a browser drops focus to the body when that happens.
+  // Re-enabling does not bring it back, so the restore waits for the write to
+  // settle and runs from here, after React has taken `disabled` off again.
+  // Asked for at `mutate` rather than read off a pending render, because a write
+  // that settles fast never commits one.
+  const restoreWanted = useRef(false);
+  useEffect(() => {
+    if (mut.isPending || !restoreWanted.current) return;
+    restoreWanted.current = false;
+    // A control that has left the page is not somewhere to put the keyboard.
+    if (openedFrom.current?.isConnected) openedFrom.current.focus();
+  }, [mut.status, mut.isPending]);
+
   const commit = async (
     change: FactChange,
     // Old → new, in the operator's words. The dialog asks it and the
@@ -117,16 +132,21 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
     describe: string,
     control: React.RefObject<HTMLButtonElement | null>,
   ): Promise<void> => {
+    openedFrom.current = control.current;
     const confirmed = await confirm({
       title: `Update ${org.name}?`,
       description: `${describe}.`,
       confirmLabel: "Save",
     });
-    control.current?.focus();
-    if (!confirmed) return;
+    if (!confirmed) {
+      // Nothing disables the control on this exit, so it takes the keyboard now.
+      control.current?.focus();
+      return;
+    }
 
     // A new write does not run under the last one's failure.
     showFailure(null);
+    restoreWanted.current = true;
     mut.mutate(change, {
       onSuccess: () => announce(`${org.name} updated. ${describe}.`),
       onError: (error) => {

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -1,11 +1,10 @@
-import { useState, type JSX } from "react";
+import { useRef, type JSX } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 
 import { useConfirmDialog } from "@/components/ConfirmDialog";
 import { CopyValue } from "@/components/CopyValue";
 import { Trial } from "@/components/Trial";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -27,6 +26,7 @@ import {
   type AdminOrganization,
 } from "@/lib/gramAdminApi";
 import { cn, fmtDateShort } from "@/lib/utils";
+import { useWriteReport } from "@/pages/organizations/writeReport";
 
 function Row({
   label,
@@ -75,72 +75,64 @@ export function OverviewRoute(): JSX.Element | null {
   const { idOrSlug } = useParams({ from: "/organizations/$idOrSlug" });
   const { data } = useQuery(organizationQuery(idOrSlug));
   if (!data) return null;
-  // Keyed, so an unsaved draft cannot follow the operator to another record.
+  // Keyed, so a write in flight and the dialog asking about it belong to the
+  // record they were started on.
   return <Overview key={data.id} org={data} />;
 }
+
+// One field per write. The endpoint takes both as optional, and a type that
+// allows both would let a write carry a field the operator never touched.
+type FactChange = { account_type: string } | { whitelisted: boolean };
 
 export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
   const qc = useQueryClient();
   const [confirm, confirmDialog] = useConfirmDialog();
+  const { announce, showFailure } = useWriteReport();
 
-  // Only the fields the operator touched live here. The rest read straight
-  // from the server record, so a refetch cannot discard an unsaved edit and
-  // cannot leave an untouched field showing a stale value.
-  const [draft, setDraft] = useState<{
-    account_type?: string;
-    whitelisted?: boolean;
-  }>({});
-  const accountType = draft.account_type ?? org.account_type;
-  const whitelisted = draft.whitelisted ?? org.whitelisted;
+  // Where the keyboard goes when the dialog closes. `useConfirmDialog` has no
+  // `DialogTrigger`, so Radix's own restore drops focus on `document.body`.
+  const accountTypeControl = useRef<HTMLButtonElement>(null);
+  const whitelistedControl = useRef<HTMLButtonElement>(null);
 
   const mut = useMutation({
-    mutationFn: () =>
-      updateOrganization({
-        id: org.id,
-        account_type:
-          accountType !== org.account_type ? accountType : undefined,
-        whitelisted: whitelisted !== org.whitelisted ? whitelisted : undefined,
-      }),
+    mutationFn: (change: FactChange) =>
+      updateOrganization({ id: org.id, ...change }),
     // Through `adminQueries`, like every other admin write. A copy of the cache
     // path spelled out here is how one of its caches gets left out: this one
     // cancelled nothing, so a list read already in flight put the pre-write row
     // back, and the stats kept their old totals.
     onMutate: () => cancelOrganizationFetches(qc),
-    onSuccess: (updated) => {
-      setDraft({});
-      writeOrganizationToCache(qc, updated);
-    },
+    onSuccess: (updated) => writeOrganizationToCache(qc, updated),
     // A failed write replaces nothing it cancelled, so the totals have to be
     // asked for again. The record needs nothing: it was never repainted.
     onError: () => invalidateOrganizationStats(qc),
   });
 
-  const dirty =
-    accountType !== org.account_type || whitelisted !== org.whitelisted;
-
-  const handleCancel = () => {
-    setDraft({});
-  };
-
-  const handleSave = async () => {
-    const changes: string[] = [];
-    if (accountType !== org.account_type) {
-      changes.push(`Account type: ${org.account_type} → ${accountType}`);
-    }
-    if (whitelisted !== org.whitelisted) {
-      changes.push(
-        `Whitelisted: ${yesNo(org.whitelisted)} → ${yesNo(whitelisted)}`,
-      );
-    }
-
+  const commit = async (
+    change: FactChange,
+    // Old → new, in the operator's words. The dialog asks it and the
+    // announcement reports it, so the two cannot name different changes.
+    describe: string,
+    control: React.RefObject<HTMLButtonElement | null>,
+  ): Promise<void> => {
     const confirmed = await confirm({
       title: `Update ${org.name}?`,
-      description: changes.join(". ") + ".",
+      description: `${describe}.`,
       confirmLabel: "Save",
     });
-    if (confirmed) {
-      mut.mutate();
-    }
+    control.current?.focus();
+    if (!confirmed) return;
+
+    // A new write does not run under the last one's failure.
+    showFailure(null);
+    mut.mutate(change, {
+      onSuccess: () => announce(`${org.name} updated. ${describe}.`),
+      onError: (error) => {
+        const text = `Could not update ${org.name}: ${errorMessage(error)}`;
+        announce(text);
+        showFailure(text);
+      },
+    });
   };
 
   return (
@@ -183,11 +175,20 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
       <Group title="Plan">
         <Row label="Account type">
           <Select
-            value={accountType}
+            value={org.account_type}
             disabled={mut.isPending}
-            onValueChange={(v) => setDraft((d) => ({ ...d, account_type: v }))}
+            onValueChange={(v) => {
+              void commit(
+                { account_type: v },
+                `Account type: ${org.account_type} → ${v}`,
+                accountTypeControl,
+              );
+            }}
           >
-            <SelectTrigger className="h-auto w-auto px-2 py-1.5">
+            <SelectTrigger
+              ref={accountTypeControl}
+              className="h-auto w-auto px-2 py-1.5"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -214,9 +215,16 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
       <Group title="Access">
         <Row label="Whitelisted">
           <Switch
-            checked={whitelisted}
+            ref={whitelistedControl}
+            checked={org.whitelisted}
             disabled={mut.isPending}
-            onCheckedChange={(v) => setDraft((d) => ({ ...d, whitelisted: v }))}
+            onCheckedChange={(v) => {
+              void commit(
+                { whitelisted: v },
+                `Whitelisted: ${yesNo(org.whitelisted)} → ${yesNo(v)}`,
+                whitelistedControl,
+              );
+            }}
           />
         </Row>
         <Row label="Disabled at">
@@ -230,34 +238,6 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
           </span>
         </Row>
       </Group>
-
-      {dirty && (
-        <div className="border-border mt-4 flex items-center gap-2 border-t pt-3">
-          <Button
-            variant="default"
-            size="xs"
-            disabled={mut.isPending}
-            onClick={() => {
-              void handleSave();
-            }}
-          >
-            {mut.isPending ? "Saving..." : "Save"}
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            disabled={mut.isPending}
-            onClick={handleCancel}
-          >
-            Cancel
-          </Button>
-          {mut.isError && (
-            <span className="text-muted-foreground text-sm">
-              Error: {errorMessage(mut.error)}
-            </span>
-          )}
-        </div>
-      )}
 
       {confirmDialog}
     </div>

--- a/client/admin/src/pages/organizations/OrganizationActions.tsx
+++ b/client/admin/src/pages/organizations/OrganizationActions.tsx
@@ -1,6 +1,5 @@
 import { CalendarIcon, MoreHorizontalIcon } from "lucide-react";
 import {
-  createContext,
   useContext,
   useId,
   useRef,
@@ -47,6 +46,9 @@ import {
   useEnableOrganization,
   useExtendTrial,
 } from "./rowActions";
+import { WriteReportContext, type WriteReporter } from "./writeReport";
+
+export type { WriteReporter } from "./writeReport";
 
 // The trial length the rest of the system assumes, so the operator extending a
 // trial by the usual amount picks nothing.
@@ -67,32 +69,6 @@ function extensionRange(
     latest: anchor + MAX_TRIAL_EXTENSION_DAYS,
   };
 }
-
-/**
- * How these controls report a write.
- *
- * The list owns both surfaces a write can report on, the live region and the
- * failure banner, and these controls are drawn inside table cells the list
- * cannot pass props to, so they reach them through context the way the peek
- * controls do.
- *
- * The default is a no-op rather than a throw: the peek panel renders these
- * actions too and it is mounted on its own in tests.
- */
-export type WriteReporter = {
-  // Speaks. Every write ends in one of these, whether it succeeded or not.
-  announce: (text: string) => void;
-  // Shows, and only for a failure with no dialog of its own to report in.
-  // `null` clears whatever is showing.
-  showFailure: (text: string | null) => void;
-};
-
-const NO_REPORTER: WriteReporter = {
-  announce: () => {},
-  showFailure: () => {},
-};
-
-const WriteReportContext = createContext<WriteReporter>(NO_REPORTER);
 
 export function WriteReportProvider({
   value,

--- a/client/admin/src/pages/organizations/writeReport.ts
+++ b/client/admin/src/pages/organizations/writeReport.ts
@@ -1,0 +1,34 @@
+import { createContext, useContext } from "react";
+
+/**
+ * How a write on an organization reports itself.
+ *
+ * The list owns both surfaces a write can report on, the live region and the
+ * failure banner, and the row controls are drawn inside table cells the list
+ * cannot pass props to, so they reach them through context the way the peek
+ * controls do. The record reports the same way: its layout provides the
+ * reporter, and `Overview` renders through an `<Outlet/>` that takes no prop.
+ *
+ * Its own module rather than beside `WriteReportProvider`, because a file that
+ * exports a component may export nothing else without losing fast refresh.
+ */
+export type WriteReporter = {
+  // Speaks. Every write ends in one of these, whether it succeeded or not.
+  announce: (text: string) => void;
+  // Shows, and only for a failure with no dialog of its own to report in.
+  // `null` clears whatever is showing.
+  showFailure: (text: string | null) => void;
+};
+
+// A no-op rather than a throw: the peek panel renders these actions too and it
+// is mounted on its own in tests.
+const NO_REPORTER: WriteReporter = {
+  announce: () => {},
+  showFailure: () => {},
+};
+
+export const WriteReportContext = createContext<WriteReporter>(NO_REPORTER);
+
+export function useWriteReport(): WriteReporter {
+  return useContext(WriteReportContext);
+}


### PR DESCRIPTION
An operator changes one fact on an organization record and commits that fact on
its own. The save bar that sat under the whole record is gone, and so is the
draft it wrote into.

Slice S3 of AGE-3262. AGE-3265, and its design is a
[Linear document](https://linear.app/speakeasy/document/inline-edit-on-a-records-facts-design-8efc4ebe1e3b).
S2, #5397, has merged, so this targets `main`.

## Demo

![Editing one fact on an organization record](https://gist.githubusercontent.com/walker-tx/f82bcf6f59734698bdac75a98cda2b45/raw/demo.gif)

1. Changing the account type raises a dialog naming that one change and nothing
   else.
2. Cancelling leaves the control showing its old value, and writes nothing.
3. Confirming a Whitelisted change writes only that field, and the record says
   what changed.

## What an operator gets

Changing the account type, or the Whitelisted switch, raises a confirmation
naming that one change and nothing else: `Account type: pro → enterprise.` The
write that follows carries only the field that changed. A change that is not
confirmed is never written.

Both controls are held while a write is in flight, so one record cannot take two
writes at once. Every write reports through the record's own reporter, spoken on
success and both spoken and shown on failure, in place of the error line the
save bar used to carry.

## Two things worth a reviewer's attention

**There is no draft anywhere.** Both controls read `org` on every render. That is
what makes the cancel path free: they are Radix and controlled, so a change that
is not confirmed snaps back with no revert code to write and no revert path to
get wrong. While the dialog is open the control still shows the old value, which
is honest, because the record has not changed yet and the dialog carries the
words for what is about to change.

**One file the brief put out of scope changed anyway.** `WriteReportContext`
lived unexported inside `OrganizationActions.tsx`. Overview renders through an
`<Outlet/>` and cannot take the reporter as a prop, so it has to read the
context, and oxlint's `react/only-export-components` will not let a file that
exports a component also export a context. The type, the context and a
`useWriteReport` hook moved to `writeReport.ts`, which has no component in it.
`WriteReportProvider` stays where it was and `WriteReporter` is re-exported from
there, so every existing importer is untouched and the list page does not change.

## Verification

Five gates, each canaried, because a gate that prints nothing on success looks
the same as a gate that never ran.

| Gate | Result |
| --- | --- |
| `type-check` | 0 |
| `lint:oxlint` | 0 |
| `aube exec oxfmt -- --check client/admin` | clean, 116 files |
| `test` | 582 tests in 24 files |
| `build` | built |

`aube run -F admin lint:format` is a false pass: `oxfmt` lives in the root
`node_modules/.bin`, so the script exits 0 having checked nothing. Every format
check here is `aube exec oxfmt -- --check client/admin`.

**Mutations.** 21 from the builder plus a deliberate known survivor to prove the
harness, then 7 more of mine, canary first, none of them the builder's. Four
survivors were closed: three were real gaps in the wording and the cleared
failure, and one was mine, that a cancelled dialog also clears a failure left by
an earlier write. Each closed with a test that dies with the mutation applied
and passes without it.

One survivor was **equivalent and is a correction to the design**, not a defect.
The design said to keep `OverviewRoute`'s `key={data.id}` because it resets a
write in flight. It does not do that on its own: `RecordLayout` already renders
`<Record key={data.id}>` and Overview sits in that subtree, so removing both
keys fails the tests and removing only this one passes. The key is kept, because
it holds if the view is ever mounted somewhere that does not key it, and the
comment now says that instead of claiming an effect the key does not have.

**Two review rounds, both about the keyboard, both real.** The first: the
confirmed path focused the control and then started the write that disables it,
and a browser drops focus to the body when the focused element becomes disabled.
The restore now runs from an effect once the write settles, and covers a failed
write as well as a landed one. The second: that effect watched only `status` and
`isPending`, so a fast write after another went `success` to `success` with
nothing changed and never reran. It now watches `variables` too.

Both were validated by probe before either was fixed, because **jsdom does not
blur an element when it becomes disabled** and the committed focus test was
passing for a reason that does not hold in Chrome. The three tests added since
blur the control by hand to stand in for the browser, and one of them writes
twice, which nothing in the suite did before. 13 further mutations were run
across the two fixes, canary first; 11 died. The two survivors are equivalent:
`submittedAt` in place of `variables` only differs for two writes inside one
millisecond, which two dialog confirmations cannot produce, and dropping the
`isConnected` guard only differs for a control that has left the page, where
`focus()` is already a no-op.

## Not in this slice

Editing name or slug, which `updateOrganization` does not accept. Disable,
enable and the trial actions, which are header chrome. The Projects and Members
views, which are AGE-3266.
