### PR TITLE
fix(admin): stop a project read hanging on a slug every organization uses

### DIFF
--- a/.changeset/admin-project-links-by-id.md
+++ b/.changeset/admin-project-links-by-id.md
@@ -13,3 +13,8 @@ child tables for every row it matches, and two of those counts have no index on
 `project_id` to use, so a common slug cost one full table scan per organization
 and the read never returned. It now resolves the slug to a single id first and
 counts once.
+
+`project.get` also takes the organization now. Inside an organization record the
+project is read scoped to it, so a slug names one project rather than an
+arbitrary one, and a project outside that organization is reported as not found
+whichever way it is addressed.

--- a/.changeset/admin-project-links-by-id.md
+++ b/.changeset/admin-project-links-by-id.md
@@ -1,0 +1,11 @@
+---
+"admin": patch
+---
+
+Every link into a project now addresses it by id rather than by slug, so a
+project named the same as one in another organization opens instead of hanging.
+
+Project slugs are unique only within an organization. `project.get` resolves a
+slug across all of them, so a common slug matches one project per organization
+and the read never returns. The projects table, the row click and the record
+nav's single-project shortcut all send the id.

--- a/.changeset/admin-project-links-by-id.md
+++ b/.changeset/admin-project-links-by-id.md
@@ -1,11 +1,15 @@
 ---
 "admin": patch
+"server": patch
 ---
 
-Every link into a project now addresses it by id rather than by slug, so a
-project named the same as one in another organization opens instead of hanging.
+Opening a project from an organization record could hang forever. Every link
+into a project now addresses it by id, and `project.get` resolves a slug to one
+project before it reads that project's detail.
 
-Project slugs are unique only within an organization. `project.get` resolves a
-slug across all of them, so a common slug matches one project per organization
-and the read never returns. The projects table, the row click and the record
-nav's single-project shortcut all send the id.
+Project slugs are unique only within an organization, so a slug the whole
+platform uses matches one project per organization. The detail read counts six
+child tables for every row it matches, and two of those counts have no index on
+`project_id` to use, so a common slug cost one full table scan per organization
+and the read never returned. It now resolves the slug to a single id first and
+counts once.

--- a/client/admin/src/components/app-sidebar.test.tsx
+++ b/client/admin/src/components/app-sidebar.test.tsx
@@ -446,7 +446,7 @@ describe("AppSidebar", () => {
         within(sidebar())
           .getByRole("link", { name: "Projects" })
           .getAttribute("href"),
-      ).toBe(`/organizations/${ORG.slug}/projects/${PROJECT.slug}`);
+      ).toBe(`/organizations/${ORG.slug}/projects/${PROJECT.id}`);
     });
     expect(navState()).toEqual({
       "All organizations": { active: false, current: false },

--- a/client/admin/src/components/record-nav.test.tsx
+++ b/client/admin/src/components/record-nav.test.tsx
@@ -105,9 +105,11 @@ describe("RecordNav", () => {
     await mount([aProject()]);
 
     const item = navItem("Projects");
+    // The id, not the slug: project.get resolves a slug across every
+    // organization, and every organization has a project slugged "default".
     expect(
       screen.getByRole("link", { name: "Projects" }).getAttribute("href"),
-    ).toBe("/organizations/test-org/projects/first-project");
+    ).toBe("/organizations/test-org/projects/proj_1");
     expect(item.textContent).not.toMatch(/\d/);
     // The label does not become the project's name. Relabelling would make the
     // nav shift under the operator between records.

--- a/client/admin/src/components/record-nav.tsx
+++ b/client/admin/src/components/record-nav.tsx
@@ -170,11 +170,14 @@ export function RecordNav({
                 tooltip="Projects"
               >
                 {onlyProject ? (
+                  // Always the id. Project slugs are unique only within an
+                  // organization, so project.get resolves a slug across all of
+                  // them, and "default" matches one project in every one.
                   <Link
                     to="/organizations/$idOrSlug/projects/$projectIdOrSlug"
                     params={{
                       idOrSlug,
-                      projectIdOrSlug: onlyProject.slug || onlyProject.id,
+                      projectIdOrSlug: onlyProject.id,
                     }}
                     {...currentProps(onProjects)}
                   >

--- a/client/admin/src/components/site-header.test.tsx
+++ b/client/admin/src/components/site-header.test.tsx
@@ -65,10 +65,20 @@ beforeEach(() => {
       : Promise.reject(new Error(`no organization ${idOrSlug}`)),
   );
   mocks.getProject.mockReset();
-  mocks.getProject.mockImplementation((idOrSlug: string) =>
-    idOrSlug === PROJECT.id || idOrSlug === PROJECT.slug
-      ? Promise.resolve(PROJECT_DETAIL)
-      : Promise.reject(new Error(`no project ${idOrSlug}`)),
+  // Rejects a wrong organization for the same reason the organization mock
+  // rejects a wrong id: a mock that answers every scope alike lets a caller that
+  // sends the wrong one pass.
+  mocks.getProject.mockImplementation(
+    (idOrSlug: string, organizationIdOrSlug?: string) => {
+      const named = idOrSlug === PROJECT.id || idOrSlug === PROJECT.slug;
+      const scoped =
+        organizationIdOrSlug === undefined ||
+        organizationIdOrSlug === ORG.id ||
+        organizationIdOrSlug === ORG.slug;
+      return named && scoped
+        ? Promise.resolve(PROJECT_DETAIL)
+        : Promise.reject(new Error(`no project ${idOrSlug}`));
+    },
   );
   mocks.listOrganizationProjects.mockReset();
   mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
@@ -105,7 +115,14 @@ function seeded(): QueryClient {
     defaultOptions: { queries: { retry: false } },
   });
   qc.setQueryData(organizationQuery(ORG.slug).queryKey, ORG);
+  // Two entries, because the two routes to this page read under two keys: the
+  // record scopes the project by its organization and the standalone page
+  // cannot.
   qc.setQueryData(projectQuery(PROJECT.slug).queryKey, PROJECT_DETAIL);
+  qc.setQueryData(
+    projectQuery(PROJECT.slug, ORG.slug).queryKey,
+    PROJECT_DETAIL,
+  );
   return qc;
 }
 
@@ -164,6 +181,27 @@ describe("SiteHeader", () => {
     });
 
     expect(crumbs()).toEqual(["Organizations", ORG.name, PROJECT.name]);
+  });
+
+  it("fills the project crumb from the view's own read, nothing seeded", async () => {
+    // The one claim seeding cannot make. The bar watches the cache and never
+    // fetches, so its key must be the key the view writes under, and both tests
+    // above seed whatever key the crumb asks for. Here only the view reads, and
+    // it reads scoped by the organization the URL names.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    qc.setQueryData(organizationQuery(ORG.slug).queryKey, ORG);
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/projects/${PROJECT.slug}`,
+      queryClient: qc,
+    });
+
+    await waitFor(() =>
+      expect(crumbs()).toEqual(["Organizations", ORG.name, PROJECT.name]),
+    );
+    expect(mocks.getProject).toHaveBeenCalledWith(PROJECT.slug, ORG.slug);
   });
 
   it("names the standalone project page after its project", async () => {

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -6,10 +6,12 @@ import {
   organizationQuery,
   organizationsListQuery,
   organizationsStatsQuery,
+  projectQuery,
   writeOrganizationToCache,
 } from "@/lib/adminQueries";
 import type {
   AdminOrganization,
+  AdminProjectDetail,
   ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
 
@@ -297,6 +299,66 @@ describe("writeOrganizationToCache", () => {
 
     expect(qc.getQueryData(detail.queryKey)?.disabled_at).toBe(
       DISABLED.disabled_at,
+    );
+  });
+});
+
+// The same slug in two organizations is two projects, and the whole reason the
+// organization is a parameter. One cache entry for both would show whichever was
+// opened first under the other's URL.
+describe("projectQuery", () => {
+  // Both share the slug `default`, which is the collision the organization
+  // exists to settle.
+  function project(id: string, organizationID: string): AdminProjectDetail {
+    return {
+      id,
+      name: "Default",
+      slug: "default",
+      organization_id: organizationID,
+      toolset_count: 0,
+      deployment_count: 0,
+      http_tool_count: 0,
+      environment_count: 0,
+      api_key_count: 0,
+      assistant_count: 0,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+  }
+
+  it("keeps two organizations' project of the same name apart", () => {
+    const qc = new QueryClient();
+
+    qc.setQueryData(
+      projectQuery("default", "one").queryKey,
+      project("a", "one"),
+    );
+    qc.setQueryData(
+      projectQuery("default", "two").queryKey,
+      project("b", "two"),
+    );
+
+    expect(qc.getQueryData(projectQuery("default", "one").queryKey)?.id).toBe(
+      "a",
+    );
+    expect(qc.getQueryData(projectQuery("default", "two").queryKey)?.id).toBe(
+      "b",
+    );
+  });
+
+  // The global lookup page has no organization, so its entry has to be its own
+  // rather than borrowing a record's.
+  it("keeps the unscoped lookup apart from a record's read", () => {
+    const qc = new QueryClient();
+
+    qc.setQueryData(
+      projectQuery("default", "one").queryKey,
+      project("a", "one"),
+    );
+    qc.setQueryData(projectQuery("default").queryKey, project("b", "two"));
+
+    expect(qc.getQueryData(projectQuery("default", "one").queryKey)?.id).toBe(
+      "a",
     );
   });
 });

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -220,11 +220,24 @@ export function invalidateOrganizations(qc: QueryClient): Promise<void> {
   ).then(() => undefined);
 }
 
+// The organization is part of the key, not just the request: the same slug names
+// a different project in each one, so two organizations must not share a cache
+// entry. It is the route's own address for the organization, id or slug as
+// typed, because the breadcrumb builds this key from route params alone and can
+// never know the resolved id.
 export function projectQuery(
   idOrSlug: string,
-): AdminQuery<AdminProjectDetail, readonly ["gram-admin-project", string]> {
+  organizationIdOrSlug?: string,
+): AdminQuery<
+  AdminProjectDetail,
+  readonly ["gram-admin-project", string, string | null]
+> {
   return queryOptions({
-    queryKey: ["gram-admin-project", idOrSlug] as const,
-    queryFn: () => getProject(idOrSlug),
+    queryKey: [
+      "gram-admin-project",
+      idOrSlug,
+      organizationIdOrSlug ?? null,
+    ] as const,
+    queryFn: () => getProject(idOrSlug, organizationIdOrSlug),
   });
 }

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -6,6 +6,7 @@ import {
   enableOrganization,
   errorMessage,
   extendTrial,
+  getProject,
   listOrganizations,
   logout,
   MAX_TRIAL_EXTENSION_DAYS,
@@ -84,6 +85,47 @@ describe("listOrganizations", () => {
     await listOrganizations({ account_types: [], trial_states: [] });
 
     expect(fetch.mock.calls.at(-1)?.[0]).toBe("/admin/organizations.list");
+  });
+});
+
+// Every page that reads a project mocks this function, so the query string it
+// builds is asserted here or nowhere. The organization is what makes a slug
+// unambiguous, and a parameter that silently never leaves the browser looks
+// exactly like one that works.
+describe("getProject", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(): ReturnType<typeof vi.fn> {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    return fetch;
+  }
+
+  it("sends the organization alongside the project", async () => {
+    const fetch = stubFetch();
+
+    await getProject("default", "one");
+
+    expect(fetch.mock.calls.at(-1)?.[0]).toBe(
+      "/admin/project.get?id_or_slug=default&organization_id_or_slug=one",
+    );
+  });
+
+  it("omits the organization where there is none to send", async () => {
+    const fetch = stubFetch();
+
+    await getProject("default");
+
+    expect(fetch.mock.calls.at(-1)?.[0]).toBe(
+      "/admin/project.get?id_or_slug=default",
+    );
   });
 });
 

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -283,8 +283,14 @@ export type AdminProjectDetail = {
   updated_at: string;
 };
 
-export function getProject(idOrSlug: string): Promise<AdminProjectDetail> {
-  const qs = toSearchParams({ id_or_slug: idOrSlug });
+export function getProject(
+  idOrSlug: string,
+  organizationIdOrSlug?: string,
+): Promise<AdminProjectDetail> {
+  const qs = toSearchParams({
+    id_or_slug: idOrSlug,
+    organization_id_or_slug: organizationIdOrSlug,
+  });
   return gramAdminFetch<AdminProjectDetail>(`/admin/project.get?${qs}`);
 }
 

--- a/client/admin/src/pages/ProjectDetail.tsx
+++ b/client/admin/src/pages/ProjectDetail.tsx
@@ -38,9 +38,18 @@ function CountTile({ label, value }: { label: string; value: number }) {
 // The id arrives as a prop rather than out of `useParams`, because this page is
 // reached by two routes: the global project list and the organization record's
 // own project view. Each names the parameter differently.
-export function ProjectDetail({ idOrSlug }: { idOrSlug: string }): JSX.Element {
+// The organization is optional for the same reason: only one of those two routes
+// has one. Where it exists it scopes the read, so a project outside it is not
+// found rather than shown under the wrong record.
+export function ProjectDetail({
+  idOrSlug,
+  organizationIdOrSlug,
+}: {
+  idOrSlug: string;
+  organizationIdOrSlug?: string;
+}): JSX.Element {
   const { data, isLoading, isError, error } = useQuery({
-    ...projectQuery(idOrSlug),
+    ...projectQuery(idOrSlug, organizationIdOrSlug),
     enabled: !!idOrSlug,
   });
 

--- a/client/admin/src/pages/organization/Project.tsx
+++ b/client/admin/src/pages/organization/Project.tsx
@@ -4,11 +4,13 @@ import { useParams } from "@tanstack/react-router";
 import { ProjectDetail } from "@/pages/ProjectDetail";
 
 // The record's own project view. It draws the same page the global project
-// route draws; only the parameter it reads differs, because this URL names the
+// route draws, and it can scope the read, because this URL names the
 // organization as well.
 export function ProjectRoute(): JSX.Element {
-  const { projectIdOrSlug } = useParams({
+  const { projectIdOrSlug, idOrSlug } = useParams({
     from: "/organizations/$idOrSlug/projects/$projectIdOrSlug",
   });
-  return <ProjectDetail idOrSlug={projectIdOrSlug} />;
+  return (
+    <ProjectDetail idOrSlug={projectIdOrSlug} organizationIdOrSlug={idOrSlug} />
+  );
 }

--- a/client/admin/src/pages/organization/Projects.test.tsx
+++ b/client/admin/src/pages/organization/Projects.test.tsx
@@ -130,10 +130,12 @@ describe("Projects", () => {
     });
 
     const link = await screen.findByRole("link", { name: PROJECT.name });
-    // Not /projects/{slug}. That link leaves the record, and the record's own
-    // project view is what the nav and the breadcrumb both point at.
+    // Not /projects/{id}. That link leaves the record, and the record's own
+    // project view is what the nav and the breadcrumb both point at. The
+    // project segment is the id, because project.get resolves a slug across
+    // every organization.
     expect(link.getAttribute("href")).toBe(
-      `/organizations/${ORG.slug}/projects/${PROJECT.slug}`,
+      `/organizations/${ORG.slug}/projects/${PROJECT.id}`,
     );
   });
 
@@ -147,7 +149,7 @@ describe("Projects", () => {
     // second read of the record to fill it.
     const link = await screen.findByRole("link", { name: PROJECT.name });
     expect(link.getAttribute("href")).toBe(
-      `/organizations/${ORG.id}/projects/${PROJECT.slug}`,
+      `/organizations/${ORG.id}/projects/${PROJECT.id}`,
     );
   });
 
@@ -163,7 +165,7 @@ describe("Projects", () => {
 
     await waitFor(() => {
       expect(router.state.location.pathname).toBe(
-        `/organizations/${ORG.id}/projects/${PROJECT.slug}`,
+        `/organizations/${ORG.id}/projects/${PROJECT.id}`,
       );
     });
   });
@@ -214,7 +216,7 @@ describe("Projects", () => {
 
     const link = await screen.findByRole("link", { name: otherProject.name });
     expect(link.getAttribute("href")).toBe(
-      `/organizations/${other.slug}/projects/${otherProject.slug}`,
+      `/organizations/${other.slug}/projects/${otherProject.id}`,
     );
   });
 

--- a/client/admin/src/pages/organization/Projects.tsx
+++ b/client/admin/src/pages/organization/Projects.tsx
@@ -34,12 +34,16 @@ function projectColumns(idOrSlug: string) {
       header: "Name",
       // The link, not the row, carries the keyboard path and the accessible
       // name. It also lets the operator open the project in a new tab.
+      //
+      // Always the id. Project slugs are unique only within an organization, so
+      // project.get resolves a slug across all of them, and "default" matches
+      // one project in every organization.
       cell: ({ row }) => (
         <Link
           to="/organizations/$idOrSlug/projects/$projectIdOrSlug"
           params={{
             idOrSlug,
-            projectIdOrSlug: row.original.slug || row.original.id,
+            projectIdOrSlug: row.original.id,
           }}
           className="text-sm underline-offset-4 hover:underline focus-visible:underline"
         >
@@ -125,7 +129,7 @@ export function Projects({
                     to: "/organizations/$idOrSlug/projects/$projectIdOrSlug",
                     params: {
                       idOrSlug,
-                      projectIdOrSlug: project.slug || project.id,
+                      projectIdOrSlug: project.id,
                     },
                   });
                 }}

--- a/client/admin/src/routes/organizations.$idOrSlug.projects.$projectIdOrSlug.tsx
+++ b/client/admin/src/routes/organizations.$idOrSlug.projects.$projectIdOrSlug.tsx
@@ -8,7 +8,10 @@ export const Route = createFileRoute(
 )({
   component: ProjectRoute,
   staticData: {
-    crumb: ({ projectIdOrSlug }) =>
-      projectIdOrSlug ? projectQuery(projectIdOrSlug) : undefined,
+    // Both params, so this key matches the one the view under the bar fetches.
+    // The bar only watches the cache, so a key that differs by the organization
+    // would never fill.
+    crumb: ({ projectIdOrSlug, idOrSlug }) =>
+      projectIdOrSlug ? projectQuery(projectIdOrSlug, idOrSlug) : undefined,
   },
 });

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -254,6 +254,7 @@ var _ = Service("admin", func() {
 			Required("id_or_slug")
 
 			Attribute("id_or_slug", String, "Project ID or slug.")
+			Attribute("organization_id_or_slug", String, "Organization the project must belong to, by id or slug. A project outside it is reported as not found. Optional, because the global project lookup has no organization to scope by.")
 		})
 
 		Result(AdminProjectDetail)
@@ -262,6 +263,7 @@ var _ = Service("admin", func() {
 			GET("/admin/project.get")
 
 			Param("id_or_slug")
+			Param("organization_id_or_slug")
 			Response(StatusOK)
 		})
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -321,6 +321,10 @@ type GetProjectPayload struct {
 	AdminSessionToken *string
 	// Project ID or slug.
 	IDOrSlug string
+	// Organization the project must belong to, by id or slug. A project outside it
+	// is reported as not found. Optional, because the global project lookup has no
+	// organization to scope by.
+	OrganizationIDOrSlug *string
 }
 
 // ListOrganizationMembersPayload is the payload type of the admin service

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -97,10 +97,16 @@ func BuildLogoutPayload(adminLogoutSessionID string) (*admin.LogoutPayload, erro
 
 // BuildGetProjectPayload builds the payload for the admin getProject endpoint
 // from CLI flags.
-func BuildGetProjectPayload(adminGetProjectIDOrSlug string, adminGetProjectAdminSessionToken string) (*admin.GetProjectPayload, error) {
+func BuildGetProjectPayload(adminGetProjectIDOrSlug string, adminGetProjectOrganizationIDOrSlug string, adminGetProjectAdminSessionToken string) (*admin.GetProjectPayload, error) {
 	var idOrSlug string
 	{
 		idOrSlug = adminGetProjectIDOrSlug
+	}
+	var organizationIDOrSlug *string
+	{
+		if adminGetProjectOrganizationIDOrSlug != "" {
+			organizationIDOrSlug = &adminGetProjectOrganizationIDOrSlug
+		}
 	}
 	var adminSessionToken *string
 	{
@@ -110,6 +116,7 @@ func BuildGetProjectPayload(adminGetProjectIDOrSlug string, adminGetProjectAdmin
 	}
 	v := &admin.GetProjectPayload{}
 	v.IDOrSlug = idOrSlug
+	v.OrganizationIDOrSlug = organizationIDOrSlug
 	v.AdminSessionToken = adminSessionToken
 
 	return v, nil

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -780,6 +780,9 @@ func EncodeGetProjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*
 		}
 		values := req.URL.Query()
 		values.Add("id_or_slug", p.IDOrSlug)
+		if p.OrganizationIDOrSlug != nil {
+			values.Add("organization_id_or_slug", *p.OrganizationIDOrSlug)
+		}
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -649,13 +649,19 @@ func DecodeGetProjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goah
 	return func(r *http.Request) (*admin.GetProjectPayload, error) {
 		var payload *admin.GetProjectPayload
 		var (
-			idOrSlug          string
-			adminSessionToken *string
-			err               error
+			idOrSlug             string
+			organizationIDOrSlug *string
+			adminSessionToken    *string
+			err                  error
 		)
-		idOrSlug = r.URL.Query().Get("id_or_slug")
+		qp := r.URL.Query()
+		idOrSlug = qp.Get("id_or_slug")
 		if idOrSlug == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("id_or_slug", "query string"))
+		}
+		organizationIDOrSlugRaw := qp.Get("organization_id_or_slug")
+		if organizationIDOrSlugRaw != "" {
+			organizationIDOrSlug = &organizationIDOrSlugRaw
 		}
 		adminSessionTokenRaw := r.Header.Get("Authorization")
 		if adminSessionTokenRaw != "" {
@@ -664,7 +670,7 @@ func DecodeGetProjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goah
 		if err != nil {
 			return payload, err
 		}
-		payload = NewGetProjectPayload(idOrSlug, adminSessionToken)
+		payload = NewGetProjectPayload(idOrSlug, organizationIDOrSlug, adminSessionToken)
 		if payload.AdminSessionToken != nil {
 			if strings.Contains(*payload.AdminSessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -5986,9 +5986,10 @@ func NewLogoutPayload(sessionID *string) *admin.LogoutPayload {
 }
 
 // NewGetProjectPayload builds a admin service getProject endpoint payload.
-func NewGetProjectPayload(idOrSlug string, adminSessionToken *string) *admin.GetProjectPayload {
+func NewGetProjectPayload(idOrSlug string, organizationIDOrSlug *string, adminSessionToken *string) *admin.GetProjectPayload {
 	v := &admin.GetProjectPayload{}
 	v.IDOrSlug = idOrSlug
+	v.OrganizationIDOrSlug = organizationIDOrSlug
 	v.AdminSessionToken = adminSessionToken
 
 	return v

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -323,9 +323,10 @@ func ParseEndpoint(
 		adminLogoutFlags         = flag.NewFlagSet("logout", flag.ExitOnError)
 		adminLogoutSessionIDFlag = adminLogoutFlags.String("session-id", "", "")
 
-		adminGetProjectFlags                 = flag.NewFlagSet("get-project", flag.ExitOnError)
-		adminGetProjectIDOrSlugFlag          = adminGetProjectFlags.String("id-or-slug", "REQUIRED", "")
-		adminGetProjectAdminSessionTokenFlag = adminGetProjectFlags.String("admin-session-token", "", "")
+		adminGetProjectFlags                    = flag.NewFlagSet("get-project", flag.ExitOnError)
+		adminGetProjectIDOrSlugFlag             = adminGetProjectFlags.String("id-or-slug", "REQUIRED", "")
+		adminGetProjectOrganizationIDOrSlugFlag = adminGetProjectFlags.String("organization-id-or-slug", "", "")
+		adminGetProjectAdminSessionTokenFlag    = adminGetProjectFlags.String("admin-session-token", "", "")
 
 		adminUpdateOrganizationFlags                 = flag.NewFlagSet("update-organization", flag.ExitOnError)
 		adminUpdateOrganizationBodyFlag              = adminUpdateOrganizationFlags.String("body", "REQUIRED", "")
@@ -6420,7 +6421,7 @@ func ParseEndpoint(
 				data, err = adminc.BuildLogoutPayload(*adminLogoutSessionIDFlag)
 			case "get-project":
 				endpoint = c.GetProject()
-				data, err = adminc.BuildGetProjectPayload(*adminGetProjectIDOrSlugFlag, *adminGetProjectAdminSessionTokenFlag)
+				data, err = adminc.BuildGetProjectPayload(*adminGetProjectIDOrSlugFlag, *adminGetProjectOrganizationIDOrSlugFlag, *adminGetProjectAdminSessionTokenFlag)
 			case "update-organization":
 				endpoint = c.UpdateOrganization()
 				data, err = adminc.BuildUpdateOrganizationPayload(*adminUpdateOrganizationBodyFlag, *adminUpdateOrganizationAdminSessionTokenFlag)
@@ -8950,6 +8951,7 @@ func adminGetProjectUsage() {
 	// Header with flags
 	fmt.Fprintf(os.Stderr, "%s [flags] admin get-project", os.Args[0])
 	fmt.Fprint(os.Stderr, " -id-or-slug STRING")
+	fmt.Fprint(os.Stderr, " -organization-id-or-slug STRING")
 	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
 	fmt.Fprintln(os.Stderr)
 
@@ -8959,11 +8961,12 @@ func adminGetProjectUsage() {
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -id-or-slug STRING: `)
+	fmt.Fprintln(os.Stderr, `    -organization-id-or-slug STRING: `)
 	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin get-project --id-or-slug \"abc123\" --admin-session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin get-project --id-or-slug \"abc123\" --organization-id-or-slug \"abc123\" --admin-session-token \"abc123\"")
 }
 
 func adminUpdateOrganizationUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1144,6 +1144,13 @@ paths:
                   schema:
                     type: string
                     description: Project ID or slug.
+                - name: organization_id_or_slug
+                  in: query
+                  description: Organization the project must belong to, by id or slug. A project outside it is reported as not found. Optional, because the global project lookup has no organization to scope by.
+                  allowEmptyValue: true
+                  schema:
+                    type: string
+                    description: Organization the project must belong to, by id or slug. A project outside it is reported as not found. Optional, because the global project lookup has no organization to scope by.
             responses:
                 "200":
                     description: OK response.

--- a/server/internal/admin/getproject_test.go
+++ b/server/internal/admin/getproject_test.go
@@ -1,0 +1,131 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+)
+
+func seedProject(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, slug string) uuid.UUID {
+	t.Helper()
+
+	p, err := projectsRepo.New(conn).CreateProject(ctx, projectsRepo.CreateProjectParams{
+		Name:           slug,
+		Slug:           slug,
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	return p.ID
+}
+
+func TestGetProject_ByID(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	id := seedProject(t, ctx, conn, "org_one", "default")
+
+	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: id.String()})
+	require.NoError(t, err)
+
+	require.Equal(t, id.String(), got.ID)
+	require.Equal(t, "default", got.Slug)
+	require.Equal(t, "org_one", got.OrganizationID)
+	// A project with no children reports zero rather than omitting the counts.
+	require.Equal(t, 0, got.ToolsetCount)
+	require.Equal(t, 0, got.HTTPToolCount)
+}
+
+// The slug every organization uses. Both organizations own a project called
+// `default`, which is the shape that made this read never return: the lookup
+// used to price every match, and the detail query counts six child tables per
+// row.
+func TestGetProject_BySlugHeldByEveryOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_two", name: "Two", slug: "two"})
+	seedProject(t, ctx, conn, "org_one", "default")
+	seedProject(t, ctx, conn, "org_two", "default")
+
+	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: "default"})
+	require.NoError(t, err)
+	require.Equal(t, "default", got.Slug)
+
+	// Whichever of the two it named, naming it by id has to describe the same
+	// project in the same words: one query answers both addresses now.
+	byID, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: got.ID})
+	require.NoError(t, err)
+	require.Equal(t, got, byID)
+
+	// And the same call twice is the same answer, which is what the ORDER BY on
+	// the resolve is for.
+	again, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: "default"})
+	require.NoError(t, err)
+	require.Equal(t, got.ID, again.ID)
+}
+
+// A slug is only ever resolved against one organization's worth of projects
+// once the caller reaches this point, so the project it names must belong to
+// the organization the detail reports. Reading the organization off the wrong
+// row is what a lookup that matched many rows could do.
+func TestGetProject_BySlugReportsTheOwningOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedProject(t, ctx, conn, "org_one", "solo")
+
+	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: "solo"})
+	require.NoError(t, err)
+	require.Equal(t, "org_one", got.OrganizationID)
+}
+
+func TestGetProject_UnknownSlugIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedProject(t, ctx, conn, "org_one", "default")
+
+	_, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: "no-such-project"})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestGetProject_UnknownIDIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, _ := newTestAdminService(t)
+
+	_, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: uuid.New().String()})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// Soft deletion is filtered on the way in, not only on the detail read. A
+// resolve that ignored it would hand the detail query an id it then refuses,
+// which reads the same from outside but walks a deleted row first.
+func TestGetProject_DeletedProjectIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	id := seedProject(t, ctx, conn, "org_one", "default")
+
+	_, err := projectsRepo.New(conn).DeleteProject(ctx, id)
+	require.NoError(t, err)
+
+	_, err = svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: "default"})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	_, err = svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: id.String()})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}

--- a/server/internal/admin/getproject_test.go
+++ b/server/internal/admin/getproject_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 )
@@ -88,6 +89,143 @@ func TestGetProject_BySlugReportsTheOwningOrganization(t *testing.T) {
 	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{IDOrSlug: "solo"})
 	require.NoError(t, err)
 	require.Equal(t, "org_one", got.OrganizationID)
+}
+
+// The reason the organization is a parameter at all. Unscoped, `default` names
+// an arbitrary one of these two. Scoped, each call names the project the caller
+// asked about.
+func TestGetProject_ScopedSlugNamesTheAskedOrganizationsProject(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_two", name: "Two", slug: "two"})
+	one := seedProject(t, ctx, conn, "org_one", "default")
+	two := seedProject(t, ctx, conn, "org_two", "default")
+	require.NotEqual(t, one, two)
+
+	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             "default",
+		OrganizationIDOrSlug: conv.PtrEmpty("org_one"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, one.String(), got.ID)
+	require.Equal(t, "org_one", got.OrganizationID)
+
+	got, err = svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             "default",
+		OrganizationIDOrSlug: conv.PtrEmpty("org_two"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, two.String(), got.ID)
+	require.Equal(t, "org_two", got.OrganizationID)
+}
+
+// The organization arrives the way the URL writes it, which is a slug as often
+// as an id.
+func TestGetProject_OrganizationMayBeAddressedBySlug(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_two", name: "Two", slug: "two"})
+	seedProject(t, ctx, conn, "org_one", "default")
+	two := seedProject(t, ctx, conn, "org_two", "default")
+
+	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             "default",
+		OrganizationIDOrSlug: conv.PtrEmpty("two"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, two.String(), got.ID)
+}
+
+// A slug that exists, but not in the organization named, is not found. Falling
+// back to the unscoped resolve would answer with another organization's project
+// and look like a success.
+func TestGetProject_SlugOutsideTheNamedOrganizationIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_two", name: "Two", slug: "two"})
+	seedProject(t, ctx, conn, "org_two", "solo")
+
+	_, err := svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             "solo",
+		OrganizationIDOrSlug: conv.PtrEmpty("org_one"),
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// An id addresses a project on its own, so the organization is checked after the
+// detail read rather than inside it. Both directions: the right organization
+// still returns the project, the wrong one does not.
+func TestGetProject_ByIDIsCheckedAgainstTheNamedOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_two", name: "Two", slug: "two"})
+	id := seedProject(t, ctx, conn, "org_one", "default")
+
+	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             id.String(),
+		OrganizationIDOrSlug: conv.PtrEmpty("one"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id.String(), got.ID)
+
+	_, err = svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             id.String(),
+		OrganizationIDOrSlug: conv.PtrEmpty("org_two"),
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// An organization can hold a deleted project and a live one under one slug,
+// because the unique index on (organization_id, slug) is partial on
+// `deleted IS FALSE`. The resolve has to name the live one. A resolve that
+// stopped filtering would name either, and the detail read would then refuse a
+// project the operator can see in the list.
+func TestGetProject_ScopedSlugSkipsADeletedProjectOfTheSameName(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	gone := seedProject(t, ctx, conn, "org_one", "default")
+	_, err := projectsRepo.New(conn).DeleteProject(ctx, gone)
+	require.NoError(t, err)
+	live := seedProject(t, ctx, conn, "org_one", "default")
+
+	got, err := svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             "default",
+		OrganizationIDOrSlug: conv.PtrEmpty("org_one"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, live.String(), got.ID)
+}
+
+// An organization that does not exist cannot contain the project, whichever way
+// the project is addressed.
+func TestGetProject_UnknownOrganizationIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	id := seedProject(t, ctx, conn, "org_one", "default")
+
+	_, err := svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             "default",
+		OrganizationIDOrSlug: conv.PtrEmpty("org_missing"),
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	_, err = svc.GetProject(ctx, &gen.GetProjectPayload{
+		IDOrSlug:             id.String(),
+		OrganizationIDOrSlug: conv.PtrEmpty("org_missing"),
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
 }
 
 func TestGetProject_UnknownSlugIsNotFound(t *testing.T) {

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -292,49 +292,31 @@ func (s *Service) Logout(ctx context.Context, payload *gen.LogoutPayload) error 
 func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload) (*gen.AdminProjectDetail, error) {
 	queries := repo.New(s.db)
 
-	if id, err := uuid.Parse(payload.IDOrSlug); err == nil {
-		row, err := queries.AdminGetProjectDetailByID(ctx, id)
+	// A slug is resolved to one id before the detail is read, never counted
+	// against directly: slugs are unique only within an organization, and the
+	// detail query prices every row it matches. See AdminResolveProjectIDBySlug.
+	id, err := uuid.Parse(payload.IDOrSlug)
+	if err != nil {
+		id, err = queries.AdminResolveProjectIDBySlug(ctx, payload.IDOrSlug)
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil, oops.C(oops.CodeNotFound)
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by id").LogError(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "resolve project slug").LogError(ctx, s.logger)
 		}
-		return adminProjectDetailFromIDRow(row), nil
 	}
 
-	row, err := queries.AdminGetProjectDetailBySlug(ctx, payload.IDOrSlug)
+	row, err := queries.AdminGetProjectDetailByID(ctx, id)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by slug").LogError(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by id").LogError(ctx, s.logger)
 	}
-	return adminProjectDetailFromSlugRow(row), nil
+	return adminProjectDetailFromIDRow(row), nil
 }
 
 func adminProjectDetailFromIDRow(row repo.AdminGetProjectDetailByIDRow) *gen.AdminProjectDetail {
-	logo := uuidPtr(row.LogoAssetID)
-	runner := conv.FromPGText[string](row.FunctionsRunnerVersion)
-	return &gen.AdminProjectDetail{
-		ID:                     row.ID.String(),
-		Name:                   row.Name,
-		Slug:                   row.Slug,
-		OrganizationID:         row.OrganizationID,
-		LogoAssetID:            logo,
-		FunctionsRunnerVersion: runner,
-		ToolsetCount:           int(row.ToolsetCount),
-		DeploymentCount:        int(row.DeploymentCount),
-		HTTPToolCount:          int(row.HttpToolCount),
-		EnvironmentCount:       int(row.EnvironmentCount),
-		APIKeyCount:            int(row.ApiKeyCount),
-		AssistantCount:         int(row.AssistantCount),
-		CreatedAt:              row.CreatedAt.Time.Format(time.RFC3339),
-		UpdatedAt:              row.UpdatedAt.Time.Format(time.RFC3339),
-	}
-}
-
-func adminProjectDetailFromSlugRow(row repo.AdminGetProjectDetailBySlugRow) *gen.AdminProjectDetail {
 	logo := uuidPtr(row.LogoAssetID)
 	runner := conv.FromPGText[string](row.FunctionsRunnerVersion)
 	return &gen.AdminProjectDetail{

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -292,12 +292,34 @@ func (s *Service) Logout(ctx context.Context, payload *gen.LogoutPayload) error 
 func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload) (*gen.AdminProjectDetail, error) {
 	queries := repo.New(s.db)
 
+	// The organization is resolved to its id first so that both project
+	// addresses below are checked against the same value: the caller names it
+	// the way the URL does, by id or slug, and a project row carries only the id.
+	var orgID string
+	if payload.OrganizationIDOrSlug != nil {
+		var err error
+		orgID, err = queries.AdminResolveOrganizationID(ctx, *payload.OrganizationIDOrSlug)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			return nil, oops.C(oops.CodeNotFound)
+		case err != nil:
+			return nil, oops.E(oops.CodeUnexpected, err, "resolve organization").LogError(ctx, s.logger)
+		}
+	}
+
 	// A slug is resolved to one id before the detail is read, never counted
 	// against directly: slugs are unique only within an organization, and the
 	// detail query prices every row it matches. See AdminResolveProjectIDBySlug.
 	id, err := uuid.Parse(payload.IDOrSlug)
 	if err != nil {
-		id, err = queries.AdminResolveProjectIDBySlug(ctx, payload.IDOrSlug)
+		if orgID != "" {
+			id, err = queries.AdminResolveProjectIDBySlugInOrganization(ctx, repo.AdminResolveProjectIDBySlugInOrganizationParams{
+				OrganizationID: orgID,
+				Slug:           payload.IDOrSlug,
+			})
+		} else {
+			id, err = queries.AdminResolveProjectIDBySlug(ctx, payload.IDOrSlug)
+		}
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil, oops.C(oops.CodeNotFound)
@@ -313,6 +335,14 @@ func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by id").LogError(ctx, s.logger)
 	}
+
+	// An id addresses a project on its own, so the organization is checked after
+	// the read rather than inside it. Duplicating the six-subquery detail read
+	// for one comparison would cost more than the comparison saves.
+	if orgID != "" && row.OrganizationID != orgID {
+		return nil, oops.C(oops.CodeNotFound)
+	}
+
 	return adminProjectDetailFromIDRow(row), nil
 }
 

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -47,6 +47,31 @@ WHERE slug = @slug
 ORDER BY id
 LIMIT 1;
 
+-- name: AdminResolveProjectIDBySlugInOrganization :one
+-- Scoped by the organization a slug names exactly one project, because the
+-- unique index on (organization_id, slug) says so. That is what the resolve
+-- above cannot promise.
+SELECT id
+FROM projects
+WHERE organization_id = @organization_id
+  AND slug = @slug
+  AND deleted IS FALSE;
+
+-- name: AdminResolveOrganizationID :one
+-- A caller names an organization the way the URL does, by id or slug, and a
+-- project row carries only the id. Resolving to the id first is what lets both
+-- project addresses be checked against the same value.
+--
+-- Both columns are bare TEXT, so one organization's slug can equal another's id
+-- and two rows can match. The ORDER BY settles that collision the way
+-- AdminGetOrganization already does, with the exact id match first.
+SELECT id
+FROM organization_metadata
+WHERE id = sqlc.arg('id_or_slug')::text
+   OR slug = sqlc.arg('id_or_slug')::text
+ORDER BY (id = sqlc.arg('id_or_slug')::text) DESC
+LIMIT 1;
+
 -- name: AdminListOrganizations :many
 -- Two paging modes share this query. A caller that supplies no sort key gets the
 -- cursor walk it always had: the sort ladder collapses to all-NULL and the

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -30,25 +30,22 @@ FROM projects p
 WHERE p.id = @id
   AND p.deleted IS FALSE;
 
--- name: AdminGetProjectDetailBySlug :one
-SELECT
-    p.id,
-    p.name,
-    p.slug,
-    p.organization_id,
-    p.logo_asset_id,
-    p.functions_runner_version,
-    p.created_at,
-    p.updated_at,
-    (SELECT count(*) FROM toolsets t WHERE t.project_id = p.id AND t.deleted IS FALSE)::bigint AS toolset_count,
-    (SELECT count(*) FROM deployments d WHERE d.project_id = p.id)::bigint AS deployment_count,
-    (SELECT count(*) FROM http_tool_definitions h WHERE h.project_id = p.id AND h.deleted IS FALSE)::bigint AS http_tool_count,
-    (SELECT count(*) FROM environments e WHERE e.project_id = p.id AND e.deleted IS FALSE)::bigint AS environment_count,
-    (SELECT count(*) FROM api_keys k WHERE k.project_id = p.id AND k.deleted IS FALSE)::bigint AS api_key_count,
-    (SELECT count(*) FROM assistants a WHERE a.project_id = p.id AND a.deleted IS FALSE)::bigint AS assistant_count
-FROM projects p
-WHERE p.slug = @slug
-  AND p.deleted IS FALSE;
+-- name: AdminResolveProjectIDBySlug :one
+-- The detail query above counts six child tables for every row it matches, and
+-- two of those counts have no index on project_id to use. A project slug is
+-- unique only within an organization, so a slug the whole platform uses matches
+-- one project per organization, and that cost multiplies by the match count.
+-- Resolving the slug to a single id first is what holds it to one project's
+-- worth of counting.
+--
+-- Which project a duplicated slug names is arbitrary either way. The ORDER BY
+-- only makes the same call answer the same way twice.
+SELECT id
+FROM projects
+WHERE slug = @slug
+  AND deleted IS FALSE
+ORDER BY id
+LIMIT 1;
 
 -- name: AdminListOrganizations :many
 -- Two paging modes share this query. A caller that supplies no sort key gets the

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -363,66 +363,6 @@ func (q *Queries) AdminGetProjectDetailByID(ctx context.Context, id uuid.UUID) (
 	return i, err
 }
 
-const adminGetProjectDetailBySlug = `-- name: AdminGetProjectDetailBySlug :one
-SELECT
-    p.id,
-    p.name,
-    p.slug,
-    p.organization_id,
-    p.logo_asset_id,
-    p.functions_runner_version,
-    p.created_at,
-    p.updated_at,
-    (SELECT count(*) FROM toolsets t WHERE t.project_id = p.id AND t.deleted IS FALSE)::bigint AS toolset_count,
-    (SELECT count(*) FROM deployments d WHERE d.project_id = p.id)::bigint AS deployment_count,
-    (SELECT count(*) FROM http_tool_definitions h WHERE h.project_id = p.id AND h.deleted IS FALSE)::bigint AS http_tool_count,
-    (SELECT count(*) FROM environments e WHERE e.project_id = p.id AND e.deleted IS FALSE)::bigint AS environment_count,
-    (SELECT count(*) FROM api_keys k WHERE k.project_id = p.id AND k.deleted IS FALSE)::bigint AS api_key_count,
-    (SELECT count(*) FROM assistants a WHERE a.project_id = p.id AND a.deleted IS FALSE)::bigint AS assistant_count
-FROM projects p
-WHERE p.slug = $1
-  AND p.deleted IS FALSE
-`
-
-type AdminGetProjectDetailBySlugRow struct {
-	ID                     uuid.UUID
-	Name                   string
-	Slug                   string
-	OrganizationID         string
-	LogoAssetID            uuid.NullUUID
-	FunctionsRunnerVersion pgtype.Text
-	CreatedAt              pgtype.Timestamptz
-	UpdatedAt              pgtype.Timestamptz
-	ToolsetCount           int64
-	DeploymentCount        int64
-	HttpToolCount          int64
-	EnvironmentCount       int64
-	ApiKeyCount            int64
-	AssistantCount         int64
-}
-
-func (q *Queries) AdminGetProjectDetailBySlug(ctx context.Context, slug string) (AdminGetProjectDetailBySlugRow, error) {
-	row := q.db.QueryRow(ctx, adminGetProjectDetailBySlug, slug)
-	var i AdminGetProjectDetailBySlugRow
-	err := row.Scan(
-		&i.ID,
-		&i.Name,
-		&i.Slug,
-		&i.OrganizationID,
-		&i.LogoAssetID,
-		&i.FunctionsRunnerVersion,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.ToolsetCount,
-		&i.DeploymentCount,
-		&i.HttpToolCount,
-		&i.EnvironmentCount,
-		&i.ApiKeyCount,
-		&i.AssistantCount,
-	)
-	return i, err
-}
-
 const adminListOrganizationMembers = `-- name: AdminListOrganizationMembers :many
 SELECT
     u.id,
@@ -691,6 +631,31 @@ func (q *Queries) AdminListProjectsForOrganization(ctx context.Context, organiza
 		return nil, err
 	}
 	return items, nil
+}
+
+const adminResolveProjectIDBySlug = `-- name: AdminResolveProjectIDBySlug :one
+SELECT id
+FROM projects
+WHERE slug = $1
+  AND deleted IS FALSE
+ORDER BY id
+LIMIT 1
+`
+
+// The detail query above counts six child tables for every row it matches, and
+// two of those counts have no index on project_id to use. A project slug is
+// unique only within an organization, so a slug the whole platform uses matches
+// one project per organization, and that cost multiplies by the match count.
+// Resolving the slug to a single id first is what holds it to one project's
+// worth of counting.
+//
+// Which project a duplicated slug names is arbitrary either way. The ORDER BY
+// only makes the same call answer the same way twice.
+func (q *Queries) AdminResolveProjectIDBySlug(ctx context.Context, slug string) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, adminResolveProjectIDBySlug, slug)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const adminUpdateOrganization = `-- name: AdminUpdateOrganization :exec

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -633,6 +633,29 @@ func (q *Queries) AdminListProjectsForOrganization(ctx context.Context, organiza
 	return items, nil
 }
 
+const adminResolveOrganizationID = `-- name: AdminResolveOrganizationID :one
+SELECT id
+FROM organization_metadata
+WHERE id = $1::text
+   OR slug = $1::text
+ORDER BY (id = $1::text) DESC
+LIMIT 1
+`
+
+// A caller names an organization the way the URL does, by id or slug, and a
+// project row carries only the id. Resolving to the id first is what lets both
+// project addresses be checked against the same value.
+//
+// Both columns are bare TEXT, so one organization's slug can equal another's id
+// and two rows can match. The ORDER BY settles that collision the way
+// AdminGetOrganization already does, with the exact id match first.
+func (q *Queries) AdminResolveOrganizationID(ctx context.Context, idOrSlug string) (string, error) {
+	row := q.db.QueryRow(ctx, adminResolveOrganizationID, idOrSlug)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const adminResolveProjectIDBySlug = `-- name: AdminResolveProjectIDBySlug :one
 SELECT id
 FROM projects
@@ -653,6 +676,29 @@ LIMIT 1
 // only makes the same call answer the same way twice.
 func (q *Queries) AdminResolveProjectIDBySlug(ctx context.Context, slug string) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, adminResolveProjectIDBySlug, slug)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const adminResolveProjectIDBySlugInOrganization = `-- name: AdminResolveProjectIDBySlugInOrganization :one
+SELECT id
+FROM projects
+WHERE organization_id = $1
+  AND slug = $2
+  AND deleted IS FALSE
+`
+
+type AdminResolveProjectIDBySlugInOrganizationParams struct {
+	OrganizationID string
+	Slug           string
+}
+
+// Scoped by the organization a slug names exactly one project, because the
+// unique index on (organization_id, slug) says so. That is what the resolve
+// above cannot promise.
+func (q *Queries) AdminResolveProjectIDBySlugInOrganization(ctx context.Context, arg AdminResolveProjectIDBySlugInOrganizationParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, adminResolveProjectIDBySlugInOrganization, arg.OrganizationID, arg.Slug)
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err


### PR DESCRIPTION
Opening a project from an organization record could hang forever. This fixes it
from both ends: the client stops addressing projects by slug, and the server
stops pricing every project that shares one. It also scopes the read to the
organization, so a project outside the record is not found rather than shown
under it.

## What was happening

`GET /admin/project.get?id_or_slug=<slug>` never returned. Reported from the
admin app, where the page sat on that one request while `session.get`,
`organization.get` and `organization.projects` all answered in under 65 ms and
the project list contained the project being asked for.

Two things compound in the old `AdminGetProjectDetailBySlug`:

- **The slug lookup had no organization scope.** Project slugs are unique only
  within an organization, so a slug the whole platform uses matches one project
  per organization.
- **Two of its six count subqueries have no index to use.**
  `http_tool_definitions` is indexed on `name`, `deployment_id` and
  `(deployment_id, tool_urn)`, with nothing on `project_id`. `api_keys` has only
  `(organization_id, project_id, id)`, wrong leading column. Confirmed against
  the dev database:

  ```
  Index Scan using projects_organization_id_slug_key on projects p
    Index Cond: (slug = 'default')
    SubPlan 1
      ->  Seq Scan on http_tool_definitions h
            Filter: ((deleted IS FALSE) AND (project_id = p.id))
    SubPlan 2
      ->  Seq Scan on api_keys k
  ```

So each matching project cost a full sequential scan of the largest table in the
database, once per organization. Dev has a single row per slug, which is why
this never showed up locally.

## What changes

**Client.** All three sites that built the project segment as `slug || id` now
send the id: the projects table cell, the row click, and the record nav's
single-project shortcut. The route still accepts either, so an existing slug URL
is not broken, it is just no longer generated.

**Server.** `project.get` resolves a slug to a single project id and then reads
the detail by id. One query answers both addresses now, so
`AdminGetProjectDetailBySlug` and its duplicate mapper are deleted. The cost
drops from one full scan of `http_tool_definitions` per match to one, for every
caller, including the global project lookup page, which has no organization to
scope by.

**Scoped by the organization.** `project.get` takes an
`organization_id_or_slug`, and inside an organization record the client sends
it. That is what makes the answer unambiguous rather than merely repeatable: a
slug resolves within the organization, and an id is compared against it after
the detail read, so a project outside the organization named is not found
whichever way it is addressed. It closes the wrong-organization check AGE-3261
asks for on the server, not just in the client.

The parameter takes an id or a slug because the URL does. The admin breadcrumb
watches the query cache with `enabled: false` and builds its key from route
params alone, so it can only ever know the organization's route address, never a
resolved id. Sending a resolved id would give the crumb a key that never fills
and drop the project's name out of the bar. The id-versus-slug collision is
settled the way `AdminGetOrganization` already settles it, with the exact id
match sorted first.

The parameter is optional, because `/projects/{idOrSlug}`, the global lookup
page, has no organization to send. That caller keeps the unscoped resolve, which
is arbitrary but now bounded and fast.

## What this does not do

**The missing indexes are still missing.** `http_tool_definitions (project_id)`
and `api_keys (project_id)` are a `mig:` change. Until then the by-id read still
pays one full scan of `http_tool_definitions`, which returns, slowly. That is
the only remaining part of this and it is the one that makes the call actually
cheap.

## Verification

| Gate | Result |
| --- | --- |
| `aube run -F admin type-check` | 0 |
| `aube run -F admin lint:oxlint` | 0 |
| `aube exec oxfmt -- --check client/admin` | clean, 117 files |
| `aube run -F admin test` | 657 tests in 25 files |
| `aube run -F admin build` | built |
| `mise run lint:server` | 0 |
| `go test ./internal/admin/...` | ok, 21.6s |

**Client mutations.** Each of the three link sites was reverted to `slug || id`
in turn. The record nav site kills 2 tests, the projects table cell kills 3, the
row click kills 1, and reverting all three fails 6. One assertion a plain grep
missed, in `app-sidebar.test.tsx`, was found by the suite rather than by reading.

**Server mutations.** `getproject_test.go` is new: the package had no coverage
of this handler. Canary first, then four of my own.

| Mutation | Result |
| --- | --- |
| canary: detail read always returns `pgx.ErrNoRows` | killed, 3 tests |
| resolve failure reported as `CodeUnexpected` | killed, 2 tests |
| a uuid is treated as a slug | killed, 2 tests |
| resolve stops filtering soft-deleted rows | **survived, equivalent** |
| resolve drops its `ORDER BY` | **survived, not reachable** |

Both survivors are judged, not waved through. The soft-delete filter on the
resolve is genuinely equivalent from outside: the detail read filters `deleted
IS FALSE` as well, so removing it from the resolve still ends in the same
NotFound. It stays because resolving to a row the next query will refuse is
worse than not resolving it.

The `ORDER BY` is not reachable from a test. With two rows the planner returns
them in insertion order either way, and ids are uuidv7, so id order and
insertion order agree. Forcing a different plan from a test would be testing the
planner. It stays because `LIMIT 1` without an `ORDER BY` is nondeterministic by
definition, not because a test proves it.

One more gap worth naming: the count fields are all zero in these tests, so a
mapper that swapped two of them would survive. That mapper is unchanged by this
PR and was untested before it.

**Organization scoping, mutated separately.** Six on the server, canary first,
all six killed.

| Mutation | Result |
| --- | --- |
| canary: the organization check always refuses | killed, 3 |
| the by-id path is no longer checked against the organization | killed, 1 |
| the slug path ignores the organization and resolves unscoped | killed, 2 |
| an unknown organization falls through as unscoped | killed, 1 |
| the organization resolve accepts only an id | killed, 2 |
| the organization resolve accepts only a slug | killed, 1 |
| the scoped resolve stops filtering soft-deleted rows | killed, 1 |

The last one **survived at first**, and unlike the unscoped resolve's version of
the same mutation it was not equivalent. The unique index on
`(organization_id, slug)` is partial on `deleted IS FALSE`, so an organization
can hold a deleted `default` and a live `default` at once. Without the filter
the resolve names either, and the detail read then refuses a project the
operator can see in their list. `TestGetProject_ScopedSlugSkipsADeletedProjectOfTheSameName`
closes it and dies under that mutation and nothing else.

Four on the client, canary first, all four killed.

| Mutation | Result |
| --- | --- |
| canary: the crumb's key drops the organization | killed, 1 |
| the view stops scoping its read | killed, 1 |
| the organization leaves the cache key but stays in the request | killed, 2 |
| the organization never reaches the query string | killed, 1 |

The last two also **survived at first**, and both were real. The key mutation
makes two organizations' `default` share one cache entry, so opening one then
the other shows the first. The query-string mutation was invisible because every
page that reads a project mocks `getProject`, so the URL it builds was asserted
nowhere. Both now have tests, in `adminQueries.test.ts` and
`gramAdminApi.test.ts`.

The breadcrumb test is the one worth reading. Both existing crumb tests seed
whatever key the crumb asks for, so neither can catch the crumb and the view
disagreeing. The new one seeds nothing and lets the view's own read fill the
bar, which is the only arrangement where a key mismatch shows up.

No screenshot: nothing on screen changes. The visible difference is a page that
loads instead of hanging, and reproducing that needs a database with more than
one organization holding the same project slug.
