### PR TITLE
feat: emit resultType and serverInfo on every MCP result

### DIFF
--- a/.changeset/mcp-result-type-server-info.md
+++ b/.changeset/mcp-result-type-server-info.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Every result the hosted and platform MCP surfaces return now carries the `resultType` field that MCP 2026-07-28 requires on every result, and identifies the responding server under the `io.modelcontextprotocol/serverInfo` key in the result's `_meta`. Both fields are filled only when missing, so a result relayed from an upstream MCP server keeps whatever the upstream already supplied.

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -256,6 +256,7 @@ func handleSearchToolsCall(
 			StructuredContent: json.RawMessage(payload),
 			IsError:           false,
 		},
+		serverIdentity: serverInfoHostedToolset,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize find_tools response").LogError(ctx, logger)
@@ -371,6 +372,7 @@ func handleDescribeToolsCall(
 			StructuredContent: json.RawMessage(payload),
 			IsError:           false,
 		},
+		serverIdentity: serverInfoHostedToolset,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize describe_tools response").LogError(ctx, logger)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1249,7 +1249,7 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 
 	switch req.Method {
 	case "ping":
-		return handlePing(ctx, s.logger, req.ID)
+		return handlePing(ctx, s.logger, req.ID, serverInfoHostedToolset)
 	case "initialize":
 		return handleInitialize(ctx, s.logger, s.metrics, req, payload, s.posthog, s.toolsetsRepo, s.mcpMetadataRepo, s.sessionClientInfo)
 	case "notifications/initialized", "notifications/cancelled":

--- a/server/internal/mcp/rpc.go
+++ b/server/internal/mcp/rpc.go
@@ -108,9 +108,13 @@ func spliceResultProtocolFields(resultBytes []byte, identity serverInfo) (json.R
 	meta := map[string]json.RawMessage{}
 	injectMeta := true
 	if rawMeta, ok := fields["_meta"]; ok {
-		// A non-object _meta is left untouched; resultType is still injected.
-		if err := json.Unmarshal(rawMeta, &meta); err != nil || meta == nil {
+		// A _meta holding anything other than an object or null is left
+		// untouched; resultType is still injected. A null _meta is
+		// equivalent to an absent one, so it is replaced the same way.
+		if err := json.Unmarshal(rawMeta, &meta); err != nil {
 			injectMeta = false
+		} else if meta == nil {
+			meta = map[string]json.RawMessage{}
 		}
 	}
 	if injectMeta {

--- a/server/internal/mcp/rpc.go
+++ b/server/internal/mcp/rpc.go
@@ -13,6 +13,24 @@ import (
 const (
 	MetaGramKind     = "gram.ai/kind"
 	MetaGramMimeType = "getgram.ai/mime-type"
+
+	// metaKeyServerInfo is the _meta key reserved by MCP 2026-07-28 for the
+	// server to identify itself on every result under a stateless protocol.
+	metaKeyServerInfo = "io.modelcontextprotocol/serverInfo"
+
+	// resultTypeComplete is the resultType MCP 2026-07-28 requires on every
+	// ordinary result. Gram implements no multi round-trip requests, so it is
+	// the only value Gram produces.
+	resultTypeComplete = "complete"
+)
+
+// Server identities injected into every result's _meta and answered from the
+// two initialize handlers. serverInfo is display/debug only per the MCP spec,
+// so the static version carries no compatibility meaning; keeping it constant
+// also keeps the initialize response and per-result _meta in agreement.
+var (
+	serverInfoHostedToolset   = serverInfo{Name: "Gram", Version: "0.0.0"}
+	serverInfoPlatformToolset = serverInfo{Name: "Gram Platform Toolset", Version: "0.0.0"}
 )
 
 var (
@@ -28,19 +46,94 @@ type resultEnvelope[T any] struct {
 type result[T any] struct {
 	ID     mcpjsonrpc.ID `json:"id"`
 	Result T             `json:"result"`
+
+	// serverIdentity is injected into the result's _meta as the server's
+	// identity. A zero value falls back to the hosted-toolset identity at
+	// marshal time.
+	serverIdentity serverInfo
 }
 
 func (m result[T]) MarshalJSON() ([]byte, error) {
-	bs, err := json.Marshal(resultEnvelope[T]{
-		JSONRPC: "2.0",
-		ID:      m.ID,
-		Result:  m.Result,
-	})
+	resultBytes, err := json.Marshal(m.Result)
 	if err != nil {
 		return nil, fmt.Errorf("marshal result: %w", err)
 	}
 
+	identity := m.serverIdentity
+	if identity.Name == "" {
+		identity = serverInfoHostedToolset
+	}
+
+	spliced, err := spliceResultProtocolFields(resultBytes, identity)
+	if err != nil {
+		return nil, fmt.Errorf("splice result protocol fields: %w", err)
+	}
+
+	bs, err := json.Marshal(resultEnvelope[json.RawMessage]{
+		JSONRPC: "2.0",
+		ID:      m.ID,
+		Result:  spliced,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal result envelope: %w", err)
+	}
+
 	return bs, nil
+}
+
+// spliceResultProtocolFields injects the fields MCP 2026-07-28 defines on
+// every result: a top-level resultType and the server identity under _meta.
+// Every earlier revision permits extra result fields, so both are emitted
+// unconditionally. Both are fill-if-missing so a result relayed from an
+// upstream MCP server keeps whatever the upstream already supplied.
+//
+// A result that is not a JSON object — possible only when an MCP-passthrough
+// tool returns spec-violating output — is returned unchanged: the malformed
+// shape stays the upstream's problem rather than becoming a Gram
+// serialization failure. On the spliced path values are preserved
+// semantically rather than byte-for-byte: top-level (and _meta) keys are
+// re-marshaled in sorted order, and insignificant whitespace and HTML
+// escaping inside values may change, exactly as the pre-splice envelope
+// already did to passthrough bodies.
+func spliceResultProtocolFields(resultBytes []byte, identity serverInfo) (json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(resultBytes, &fields); err != nil || fields == nil {
+		return resultBytes, nil
+	}
+
+	if _, ok := fields["resultType"]; !ok {
+		fields["resultType"] = json.RawMessage(strconv.Quote(resultTypeComplete))
+	}
+
+	meta := map[string]json.RawMessage{}
+	injectMeta := true
+	if rawMeta, ok := fields["_meta"]; ok {
+		// A non-object _meta is left untouched; resultType is still injected.
+		if err := json.Unmarshal(rawMeta, &meta); err != nil || meta == nil {
+			injectMeta = false
+		}
+	}
+	if injectMeta {
+		if _, ok := meta[metaKeyServerInfo]; !ok {
+			identityBytes, err := json.Marshal(identity)
+			if err != nil {
+				return nil, fmt.Errorf("marshal server info: %w", err)
+			}
+			meta[metaKeyServerInfo] = identityBytes
+		}
+		metaBytes, err := json.Marshal(meta)
+		if err != nil {
+			return nil, fmt.Errorf("marshal result _meta: %w", err)
+		}
+		fields["_meta"] = metaBytes
+	}
+
+	out, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("marshal result fields: %w", err)
+	}
+
+	return out, nil
 }
 
 func (m *result[T]) UnmarshalJSON(data []byte) error {
@@ -53,10 +146,9 @@ func (m *result[T]) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("%w: %s", errInvalidJSONRPCVersion, envelope.JSONRPC)
 	}
 
-	*m = result[T]{
-		ID:     envelope.ID,
-		Result: envelope.Result,
-	}
+	m.ID = envelope.ID
+	m.Result = envelope.Result
+	m.serverIdentity = serverInfo{Name: "", Version: ""}
 
 	return nil
 }

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -97,7 +97,8 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, telemetry *metri
 	instructions := fetchInstructions(ctx, logger, toolsetsRepoParam, metadataRepoParam, payload.toolset, payload.projectID)
 
 	result := &result[initializeResult]{
-		ID: req.ID,
+		ID:             req.ID,
+		serverIdentity: serverInfoHostedToolset,
 		Result: initializeResult{
 			ProtocolVersion: mcpversions.ServedHostedToolset,
 			Capabilities: map[string]json.RawMessage{
@@ -105,10 +106,7 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, telemetry *metri
 				"prompts":   json.RawMessage("{}"),
 				"resources": json.RawMessage("{}"),
 			},
-			ServerInfo: serverInfo{
-				Name:    "Gram",
-				Version: "0.0.0",
-			},
+			ServerInfo:   serverInfoHostedToolset,
 			Instructions: instructions,
 		},
 	}

--- a/server/internal/mcp/rpc_internal_test.go
+++ b/server/internal/mcp/rpc_internal_test.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+)
+
+func TestSpliceResultProtocolFields_ObjectGainsBothFields(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceResultProtocolFields([]byte(`{}`), serverInfoHostedToolset)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"resultType": "complete",
+		"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "Gram", "version": "0.0.0"}}
+	}`, string(out))
+}
+
+func TestSpliceResultProtocolFields_PreservesExistingResultType(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceResultProtocolFields([]byte(`{"resultType":"input_required"}`), serverInfoHostedToolset)
+	require.NoError(t, err)
+
+	// The upstream resultType survives while serverInfo is still injected;
+	// the two fields are filled independently.
+	require.JSONEq(t, `{
+		"resultType": "input_required",
+		"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "Gram", "version": "0.0.0"}}
+	}`, string(out))
+}
+
+func TestSpliceResultProtocolFields_NullMetaLeftAlone(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceResultProtocolFields([]byte(`{"_meta":null}`), serverInfoHostedToolset)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"resultType":"complete","_meta":null}`, string(out))
+}
+
+func TestSpliceResultProtocolFields_PreservesUpstreamServerInfo(t *testing.T) {
+	t.Parallel()
+
+	in := `{"_meta":{"io.modelcontextprotocol/serverInfo":{"name":"Upstream","version":"1.2.3"}}}`
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"resultType": "complete",
+		"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "Upstream", "version": "1.2.3"}}
+	}`, string(out))
+}
+
+func TestSpliceResultProtocolFields_MergesIntoExistingMeta(t *testing.T) {
+	t.Parallel()
+
+	in := `{"_meta":{"com.example/key":"kept"},"content":[]}`
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"resultType": "complete",
+		"content": [],
+		"_meta": {
+			"com.example/key": "kept",
+			"io.modelcontextprotocol/serverInfo": {"name": "Gram", "version": "0.0.0"}
+		}
+	}`, string(out))
+}
+
+func TestSpliceResultProtocolFields_NonObjectMetaLeftAlone(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceResultProtocolFields([]byte(`{"_meta":"not-an-object"}`), serverInfoHostedToolset)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"resultType":"complete","_meta":"not-an-object"}`, string(out))
+}
+
+func TestSpliceResultProtocolFields_NonObjectResultUnchanged(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{`"a string"`, `[1,2,3]`, `null`, `42`} {
+		out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+		require.NoError(t, err)
+		require.Equal(t, in, string(out))
+	}
+}
+
+func TestSpliceResultProtocolFields_PreservesValueContent(t *testing.T) {
+	t.Parallel()
+
+	// Values are re-emitted as raw bytes, so content that float64 decoding
+	// would corrupt — like big numbers — survives the splice intact.
+	in := `{"content":[{"text":"a","n":123456789012345678901234567890}]}`
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+	require.NoError(t, err)
+	require.Contains(t, string(out), `123456789012345678901234567890`)
+	require.Contains(t, string(out), `[{"text":"a","n":123456789012345678901234567890}]`)
+}
+
+func TestResultMarshal_DefaultsToHostedIdentity(t *testing.T) {
+	t.Parallel()
+
+	bs, err := json.Marshal(result[struct{}]{
+		ID:     mcpjsonrpc.NumberID(7),
+		Result: struct{}{},
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"jsonrpc": "2.0",
+		"id": 7,
+		"result": {
+			"resultType": "complete",
+			"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "Gram", "version": "0.0.0"}}
+		}
+	}`, string(bs))
+}
+
+func TestResultMarshal_PlatformIdentity(t *testing.T) {
+	t.Parallel()
+
+	bs, err := json.Marshal(result[struct{}]{
+		ID:             mcpjsonrpc.NumberID(7),
+		Result:         struct{}{},
+		serverIdentity: serverInfoPlatformToolset,
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"jsonrpc": "2.0",
+		"id": 7,
+		"result": {
+			"resultType": "complete",
+			"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "Gram Platform Toolset", "version": "0.0.0"}}
+		}
+	}`, string(bs))
+}
+
+func TestResultMarshal_RoundTripDropsInjectedFields(t *testing.T) {
+	t.Parallel()
+
+	// The envelope's UnmarshalJSON decodes only the typed result, so
+	// marshal -> unmarshal -> marshal is stable rather than lossless: the
+	// injected fields are dropped on decode and re-injected on encode.
+	type payload struct {
+		Key string `json:"key"`
+	}
+	original := result[payload]{
+		ID:     mcpjsonrpc.NumberID(1),
+		Result: payload{Key: "value"},
+	}
+	bs, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded result[payload]
+	require.NoError(t, json.Unmarshal(bs, &decoded))
+	require.Equal(t, original.Result, decoded.Result)
+
+	again, err := json.Marshal(decoded)
+	require.NoError(t, err)
+	require.JSONEq(t, string(bs), string(again))
+}

--- a/server/internal/mcp/rpc_internal_test.go
+++ b/server/internal/mcp/rpc_internal_test.go
@@ -34,12 +34,15 @@ func TestSpliceResultProtocolFields_PreservesExistingResultType(t *testing.T) {
 	}`, string(out))
 }
 
-func TestSpliceResultProtocolFields_NullMetaLeftAlone(t *testing.T) {
+func TestSpliceResultProtocolFields_NullMetaTreatedAsAbsent(t *testing.T) {
 	t.Parallel()
 
 	out, err := spliceResultProtocolFields([]byte(`{"_meta":null}`), serverInfoHostedToolset)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"resultType":"complete","_meta":null}`, string(out))
+	require.JSONEq(t, `{
+		"resultType": "complete",
+		"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "Gram", "version": "0.0.0"}}
+	}`, string(out))
 }
 
 func TestSpliceResultProtocolFields_PreservesUpstreamServerInfo(t *testing.T) {

--- a/server/internal/mcp/rpc_ping.go
+++ b/server/internal/mcp/rpc_ping.go
@@ -9,10 +9,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-func handlePing(ctx context.Context, logger *slog.Logger, id mcpjsonrpc.ID) (json.RawMessage, error) {
+func handlePing(ctx context.Context, logger *slog.Logger, id mcpjsonrpc.ID, identity serverInfo) (json.RawMessage, error) {
 	bs, err := json.Marshal(&result[struct{}]{
-		ID:     id,
-		Result: struct{}{},
+		ID:             id,
+		Result:         struct{}{},
+		serverIdentity: identity,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize ping response").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_ping_test.go
+++ b/server/internal/mcp/rpc_ping_test.go
@@ -17,7 +17,7 @@ func TestHandlePing_IncludesEmptyResultObject(t *testing.T) {
 	ctx := context.Background()
 	logger := testenv.NewLogger(t)
 
-	bs, err := handlePing(ctx, logger, mcpjsonrpc.NumberID(42))
+	bs, err := handlePing(ctx, logger, mcpjsonrpc.NumberID(42), serverInfoHostedToolset)
 	require.NoError(t, err)
 
 	// MCP/JSON-RPC require the result field be present even when empty.
@@ -25,7 +25,21 @@ func TestHandlePing_IncludesEmptyResultObject(t *testing.T) {
 	var decoded map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(bs, &decoded))
 	require.Contains(t, decoded, "result")
-	require.JSONEq(t, `{}`, string(decoded["result"]))
+	require.JSONEq(t, `{"resultType":"complete","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"Gram","version":"0.0.0"}}}`, string(decoded["result"]))
 	require.JSONEq(t, `42`, string(decoded["id"]))
 	require.JSONEq(t, `"2.0"`, string(decoded["jsonrpc"]))
+}
+
+func TestHandlePing_PlatformIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := testenv.NewLogger(t)
+
+	bs, err := handlePing(ctx, logger, mcpjsonrpc.NumberID(42), serverInfoPlatformToolset)
+	require.NoError(t, err)
+
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(bs, &decoded))
+	require.JSONEq(t, `{"resultType":"complete","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"Gram Platform Toolset","version":"0.0.0"}}}`, string(decoded["result"]))
 }

--- a/server/internal/mcp/rpc_prompt_get.go
+++ b/server/internal/mcp/rpc_prompt_get.go
@@ -72,6 +72,7 @@ func handlePromptsGet(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool
 			Description: description,
 			Messages:    []promptMessage{{Role: "user", Content: content}},
 		},
+		serverIdentity: serverInfoHostedToolset,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize prompts/get result").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_prompts_list.go
+++ b/server/internal/mcp/rpc_prompts_list.go
@@ -99,6 +99,7 @@ func handlePromptsList(ctx context.Context, logger *slog.Logger, db *pgxpool.Poo
 		Result: promptsListResult{
 			Prompts: prompts,
 		},
+		serverIdentity: serverInfoHostedToolset,
 	}
 
 	bs, err := json.Marshal(result)

--- a/server/internal/mcp/rpc_resources_list.go
+++ b/server/internal/mcp/rpc_resources_list.go
@@ -54,6 +54,7 @@ func handleResourcesList(ctx context.Context, logger *slog.Logger, db *pgxpool.P
 		Result: resourcesListResult{
 			Resources: resources,
 		},
+		serverIdentity: serverInfoHostedToolset,
 	}
 
 	bs, err := json.Marshal(result)

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -233,8 +233,9 @@ func handleResourcesRead(
 	if isMCPPassthrough(resourceDef.Meta) {
 		// For MCP passthrough tools, return the raw result we get from the underlying mcp server
 		bs, err := json.Marshal(result[json.RawMessage]{
-			ID:     req.ID,
-			Result: json.RawMessage(rw.body.Bytes()),
+			ID:             req.ID,
+			Result:         json.RawMessage(rw.body.Bytes()),
+			serverIdentity: serverInfoHostedToolset,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP passthrough result").LogError(ctx, logger)
@@ -270,6 +271,7 @@ func handleResourcesRead(
 		Result: resourceReadResult{
 			Contents: []resourceContent{content},
 		},
+		serverIdentity: serverInfoHostedToolset,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize resources/read result").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -437,8 +437,9 @@ func handleToolsCall(
 	// External MCP tools and MCP passthrough tools already return properly formatted responses
 	if plan.Kind == gateway.ToolKindExternalMCP || isMCPPassthrough(meta) {
 		bs, err := json.Marshal(result[json.RawMessage]{
-			ID:     req.ID,
-			Result: json.RawMessage(rw.body.Bytes()),
+			ID:             req.ID,
+			Result:         json.RawMessage(rw.body.Bytes()),
+			serverIdentity: serverInfoHostedToolset,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP result").LogError(ctx, logger)
@@ -459,6 +460,7 @@ func handleToolsCall(
 			StructuredContent: structured,
 			IsError:           rw.statusCode < 200 || rw.statusCode >= 300,
 		},
+		serverIdentity: serverInfoHostedToolset,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -153,6 +153,7 @@ func handleToolsList(
 		Result: toolsListResultTools{
 			Tools: tools,
 		},
+		serverIdentity: serverInfoHostedToolset,
 	}
 
 	bs, err := json.Marshal(result)

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -208,7 +208,7 @@ func (s *Service) handlePlatformToolsetRequest(
 
 	switch req.Method {
 	case "ping":
-		return handlePing(ctx, s.logger, req.ID)
+		return handlePing(ctx, s.logger, req.ID, serverInfoPlatformToolset)
 	case "initialize":
 		return handlePlatformInitialize(ctx, s.logger, s.metrics, req)
 	case "notifications/initialized", "notifications/cancelled":
@@ -245,12 +245,10 @@ func handlePlatformInitialize(ctx context.Context, logger *slog.Logger, telemetr
 			Capabilities: map[string]json.RawMessage{
 				"tools": json.RawMessage("{}"),
 			},
-			ServerInfo: serverInfo{
-				Name:    "Gram Platform Toolset",
-				Version: "0.0.0",
-			},
+			ServerInfo:   serverInfoPlatformToolset,
 			Instructions: "",
 		},
+		serverIdentity: serverInfoPlatformToolset,
 	}
 	bs, err := json.Marshal(result)
 	if err != nil {
@@ -288,8 +286,9 @@ func (s *Service) listPlatformToolsetTools(
 	}
 
 	bs, err := json.Marshal(&result[toolsListResultTools]{
-		ID:     req.ID,
-		Result: toolsListResultTools{Tools: tools},
+		ID:             req.ID,
+		Result:         toolsListResultTools{Tools: tools},
+		serverIdentity: serverInfoPlatformToolset,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/list response").LogError(ctx, s.logger)
@@ -482,6 +481,7 @@ func (s *Service) callPlatformToolsetTool(
 			StructuredContent: structured,
 			IsError:           rw.statusCode < 200 || rw.statusCode >= 300,
 		},
+		serverIdentity: serverInfoPlatformToolset,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").LogError(ctx, logger, attr.SlogToolName(params.Name))


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-569/feat-emit-resulttype-and-serverinfo-on-every-mcp-result

MCP 2026-07-28 requires every result to carry a `resultType` field (`"complete"` for every result Gram can produce, since Gram implements no multi round-trip requests) and recommends identifying the server via the `io.modelcontextprotocol/serverInfo` key in every result's `_meta`. Both fields are now spliced into every hosted and platform surface result inside the shared envelope's `MarshalJSON`, so all construction sites gain them through one code path and no version branch exists. Emission is unconditional: every protocol revision permits extra result fields, and clients on earlier revisions must treat the fields as unknown extras.

Both fields are filled only when missing, so a result relayed from an upstream MCP server (functions MCP passthrough) keeps whatever the upstream already supplied. A result that is not a JSON object, which only customer-authored passthrough output can produce, passes through unchanged rather than becoming a Gram serialization failure.

`serverInfo` keeps the static version `0.0.0` that the initialize handlers already report. The initialize handlers and the splice now share the same identity constants, so the handshake and per-result `_meta` agree by construction, including the platform surface's distinct identity, which now also flows through `ping`.

The envelope's identity is declared explicitly at every construction site because `exhaustruct` does not honor the field-level optional directive on generic structs. That churn buys a guarantee: the linter now forces every future construction site to declare which surface identity it emits.

The remote and tunneled proxy surface is intentionally untouched. It relays upstream responses verbatim, so conformance there belongs to the upstream server rather than to Gram.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits `resultType: "complete"` and `_meta.io.modelcontextprotocol/serverInfo` on every MCP result from hosted and platform surfaces so results are identifiable and conform to MCP 2026-07-28. Previously results omitted `resultType` and only `initialize` carried `serverInfo`; now results include both, added only if missing.

- Injects fields in `result[T].MarshalJSON` (`server/internal/mcp/rpc.go`) via `spliceResultProtocolFields`; emission is unconditional across protocol revisions.
- Preserves upstream `resultType` and merges `serverInfo` into existing `_meta`; treats a `null` `_meta` as absent so `serverInfo` is injected; leaves non-object `_meta` and non-object results unchanged.
- Adds identities `serverInfoHostedToolset` and `serverInfoPlatformToolset`; defaults to hosted when unset. Construction sites now pass `serverIdentity`; `ping` emits per-surface identity.
- Remote/tunneled proxy remains verbatim; upstream servers are responsible for conformance.
- Tests cover splicing and identity selection (`server/internal/mcp/rpc_internal_test.go`, `server/internal/mcp/rpc_ping_test.go`).

**Rollout**
- No config or migration required; satisfies Linear AIS-569 for Stateless MCP 2026-07-28. Risk: strict client SDKs validating concrete result types may reject unknown `resultType`; monitor tool-call failures isolated to specific clients.

<sup>Written for commit c5f22507edbb4389ff00b4958013a54b94041a5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

