### PR TITLE
fix: improve org home banner copy

### DIFF
--- a/.changeset/org-home-banner-copy.md
+++ b/.changeset/org-home-banner-copy.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Improve org home banner copy after enterprise setup has been started.

--- a/client/dashboard/src/hooks/useOrgSetupStarted.ts
+++ b/client/dashboard/src/hooks/useOrgSetupStarted.ts
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+
+import { createDismissedCtaStore } from "@/hooks/useDismissedCtaStore";
+
+const store = createDismissedCtaStore("gram-org-welcome-rollout-started");
+
+export function useOrgSetupStarted(orgSlug: string | undefined): {
+  setupStarted: boolean;
+  markSetupStarted: () => void;
+} {
+  const setupStarted = store.useDismissed(orgSlug);
+  const markSetupStarted = useCallback(() => {
+    if (orgSlug) store.write(orgSlug, true);
+  }, [orgSlug]);
+
+  return { setupStarted, markSetupStarted };
+}

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const projects = vi.hoisted(() => ({
@@ -8,6 +8,9 @@ const setupEligible = vi.hoisted(() => ({ current: true }));
 
 vi.mock("@/contexts/Auth", () => ({
   useOrganization: () => ({ projects: projects.current }),
+}));
+vi.mock("@/contexts/Sdk", () => ({
+  useSlugs: () => ({ orgSlug: "acme" }),
 }));
 vi.mock("@/hooks/useOnboardingCta", () => ({
   useOnboardingCta: () => ({ eligible: setupEligible.current }),
@@ -27,8 +30,18 @@ vi.mock("@/routes", () => ({
   }),
 }));
 vi.mock("react-router", () => ({
-  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
-    <a href={to}>{children}</a>
+  Link: ({
+    to,
+    children,
+    onClick,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <a href={to} onClick={onClick}>
+      {children}
+    </a>
   ),
 }));
 
@@ -51,6 +64,24 @@ describe("OrgWelcomeBanner", () => {
     expect(hrefFor("Enter demo org")).toBe("/explore-demo");
     expect(hrefFor("Start using Speakeasy")).toBe("/acme/projects/alpha");
     expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+  });
+
+  it("records rollout intent when the setup card is clicked", () => {
+    render(<OrgWelcomeBanner />);
+
+    fireEvent.click(screen.getByText("Begin rollout"));
+
+    expect(localStorage.getItem("gram-org-welcome-rollout-started:acme")).toBe(
+      "true",
+    );
+  });
+
+  it("shows resume copy after rollout intent is recorded", () => {
+    localStorage.setItem("gram-org-welcome-rollout-started:acme", "true");
+    render(<OrgWelcomeBanner />);
+
+    expect(screen.getByText("Continue enterprise rollout")).toBeTruthy();
+    expect(hrefFor("Resume rollout")).toBe("/acme/setup");
   });
 
   it("drops the setup card when the org cannot run the wizard", () => {

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -3,7 +3,9 @@ import {
   BrandMeshLayers,
 } from "@/components/brand-mesh";
 import { useOrganization } from "@/contexts/Auth";
+import { useSlugs } from "@/contexts/Sdk";
 import { useOnboardingCta } from "@/hooks/useOnboardingCta";
+import { useOrgSetupStarted } from "@/hooks/useOrgSetupStarted";
 import { useOrgWelcomeBanner } from "@/hooks/useOrgWelcomeBanner";
 import { getPreferredProject } from "@/lib/preferredProject";
 import { cn } from "@/lib/utils";
@@ -21,6 +23,7 @@ type RouteCard = {
   meta: string;
   to: string;
   recommended?: boolean;
+  onClick?: () => void;
 };
 
 /**
@@ -29,8 +32,10 @@ type RouteCard = {
  */
 export function OrgWelcomeBanner(): JSX.Element | null {
   const organization = useOrganization();
+  const { orgSlug } = useSlugs();
   const orgRoutes = useOrgRoutes();
   const { visible } = useOrgWelcomeBanner();
+  const { setupStarted, markSetupStarted } = useOrgSetupStarted(orgSlug);
   // Same gate as the header's "Finish setup" banner: the wizard is an
   // enterprise org-admin surface.
   const { eligible: canSetUpOrg } = useOnboardingCta();
@@ -68,11 +73,14 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   if (canSetUpOrg) {
     cards.push({
       index: "03",
-      title: "Start enterprise rollout",
+      title: setupStarted
+        ? "Continue enterprise rollout"
+        : "Start enterprise rollout",
       body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
-      cta: "Begin rollout",
+      cta: setupStarted ? "Resume rollout" : "Begin rollout",
       meta: "5 steps · resumable",
       to: orgRoutes.setup.href(),
+      onClick: markSetupStarted,
     });
   }
 
@@ -125,6 +133,7 @@ function RouteCardLink({ card }: { card: RouteCard }): JSX.Element {
   return (
     <Link
       to={card.to}
+      onClick={card.onClick}
       className="group bg-card border-border hover:border-foreground relative flex min-h-[250px] flex-col gap-3 border px-6.5 pt-7.5 pb-6.5 no-underline transition-colors hover:no-underline"
     >
       {card.recommended && (

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ orgSlug: "acme" }),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+vi.mock("@gram/client/react-query/onboardingStatus", () => ({
+  useOnboardingStatus: () => ({
+    data: { ssoConfigured: false, dsyncConfigured: false },
+    isLoading: false,
+  }),
+}));
+vi.mock("@gram/client/react-query/publishStatus", () => ({
+  usePublishStatus: () => ({ data: { connected: false }, isLoading: false }),
+}));
+vi.mock("@/hooks/usePlatformMcpDashboardVisibility", () => ({
+  usePlatformMcpDashboardVisibility: () => ({
+    enabled: false,
+    isLoading: false,
+  }),
+}));
+vi.mock("@/components/ui/Skeleton", () => ({
+  Skeleton: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("./onboarding-header", () => ({
+  OnboardingHeader: () => null,
+}));
+vi.mock("./onboarding-footer", () => ({
+  OnboardingFooter: () => null,
+}));
+vi.mock("./onboarding-stepper", () => ({
+  OnboardingStepper: () => null,
+}));
+vi.mock("./steps", () => ({
+  ConnectIdpStep: () => null,
+  DirectorySyncStep: () => null,
+  CreateMarketplaceStep: () => null,
+  DistributeServersStep: () => null,
+  InstrumentAgentsStep: () => null,
+  AdditionalAgentConfigStep: () => null,
+  ConfirmTrafficStep: () => null,
+  ConfigurePoliciesStep: () => null,
+  PlatformMCPSetupStep: () => null,
+}));
+
+import { SetupWizard } from "./onboarding-wizard";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("SetupWizard", () => {
+  it("records that the setup view was opened for the org", () => {
+    render(<SetupWizard />);
+
+    expect(localStorage.getItem("gram-org-welcome-rollout-started:acme")).toBe(
+      "true",
+    );
+  });
+});

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router";
 import { useOnboardingStatus } from "@gram/client/react-query/onboardingStatus";
 import { usePublishStatus } from "@gram/client/react-query/publishStatus";
 import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
+import { useOrgSetupStarted } from "@/hooks/useOrgSetupStarted";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { OnboardingHeader } from "./onboarding-header";
 import { OnboardingFooter } from "./onboarding-footer";
@@ -74,6 +75,11 @@ export function SetupWizard(): JSX.Element {
   const navigate = useNavigate();
   const { orgSlug } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { markSetupStarted } = useOrgSetupStarted(orgSlug);
+
+  useEffect(() => {
+    markSetupStarted();
+  }, [markSetupStarted]);
 
   const {
     enabled: platformMcpDashboardEnabled,


### PR DESCRIPTION
## Summary

- Track org-scoped setup intent in browser storage when the setup card is clicked or `/setup` is opened.
- Show resume copy only on the enterprise rollout card; keep the project card copy unchanged.
- Add coverage for the card click and setup-page mount signals.

## Test plan

- `aube run -F dashboard test`
- `aube run -F dashboard type-check`
- `aube run -F dashboard lint:format`
- `git diff --check`

Linear: AGE-3271

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show “resume” copy for the enterprise rollout card on the org home banner and persist org-scoped setup intent. Previously the banner always showed “Start enterprise rollout”; now clicking the rollout card or visiting `/setup` records intent and the banner switches to “Continue enterprise rollout” with a “Resume rollout” CTA.

- Persist intent per org in `localStorage` under `gram-org-welcome-rollout-started:${orgSlug}`; no server changes.
- Add `useOrgSetupStarted`; call it from the banner card `onClick` and on Setup Wizard mount; leave the project card copy unchanged (addresses Linear AGE-3271).
- Add tests for banner click tracking, resume copy, and wizard mount behavior; add a `dashboard` patch changeset.

<sup>Written for commit c83dbfa433e68baea23f88cb6f60b6439903e618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

