### PR TITLE
feat(platform-mcp): add durable auth observability

### DIFF
--- a/.changeset/platform-mcp-durable-auth-observability.md
+++ b/.changeset/platform-mcp-durable-auth-observability.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add privacy-safe Platform MCP durable authorization telemetry and document the operational dashboard, monitor, and revocation-probe contract.

--- a/docs/runbooks/platform-mcp-durable-auth-monitors.md
+++ b/docs/runbooks/platform-mcp-durable-auth-monitors.md
@@ -16,16 +16,32 @@ These metrics are operational evidence only.
 
 ## Metric contracts
 
-| Metric                                        | Type                | Tags                                      | Meaning                                                                  |
-| --------------------------------------------- | ------------------- | ----------------------------------------- | ------------------------------------------------------------------------ |
-| `platform_mcp.oauth.events`                   | counter             | `operation`, `outcome`, optional `reason` | One bounded OAuth endpoint result for refresh and code exchange.         |
-| `platform_mcp.oauth.refresh_duration`         | histogram (seconds) | `operation:refresh`, `outcome:succeeded`  | Successful refresh latency only.                                         |
-| `platform_mcp.oauth.connection_age`           | histogram (seconds) | `operation:refresh`, `outcome:succeeded`  | Current authorization-generation age at a successful refresh.            |
-| `platform_mcp.oauth.reauthorization_required` | counter             | `reason`                                  | A committed terminal transition, after the durable transaction succeeds. |
+| Metric                                        | Type                | Tags                                      | Meaning                                                                                                                         |
+| --------------------------------------------- | ------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `platform_mcp.oauth.events`                   | counter             | `operation`, `outcome`, optional `reason` | One bounded OAuth endpoint result for refresh, code exchange, interactive authorization, revocation, or runtime authentication. |
+| `platform_mcp.oauth.refresh_duration`         | histogram (seconds) | `operation:refresh`, `outcome:succeeded`  | Successful refresh latency only.                                                                                                |
+| `platform_mcp.oauth.connection_age`           | histogram (seconds) | `operation:refresh`, `outcome:succeeded`  | Current authorization-generation age at a successful refresh.                                                                   |
+| `platform_mcp.oauth.reauthorization_required` | counter             | `reason`                                  | A committed terminal transition, after the durable transaction succeeds.                                                        |
 
 Terminal `reason` values are fixed: `refresh_idle_expired`,
 `authorization_expired`, `refresh_reuse`, `connection_revoked`,
 `client_revoked`, `authorization_lost`, and `security_reset`.
+
+Interactive-authorization events also use the fixed bounded reasons
+`authorization_denied`, `authorization_unavailable`, and `platform_disabled`
+when applicable.
+
+## Rollout prerequisites
+
+Before enabling the dogfood cohort, the Platform MCP on-call must create the
+Dashboard and monitors described below in the Datadog UI and link every monitor
+to this runbook. These operational assets are intentionally not repository IaC.
+
+Revocation-to-denial latency is measured by the external synthetic probe in this
+runbook, not by an application metric: each probe records its action timestamp
+and the next denied runtime request without sending an identifier into
+application telemetry. The probe's published contract bound and alert are a
+required rollout artifact.
 
 ## Dashboard
 
@@ -42,12 +58,14 @@ Create a **Platform MCP durable auth** dashboard scoped to
 7. Reauthorization-required transitions by reason.
 
 The active dogfood cohort belongs in the dashboard's saved scope/configuration;
-do not add organization or client identity as a metric tag.
+do not add organization or client identity as a metric tag. Creating this
+dashboard is a rollout prerequisite, not an application deployment side effect.
 
 ## Datadog monitors
 
 Thresholds are initial values. Tune after the dogfood baseline is established.
-All metric queries below are scoped to `service:gram-server`.
+All metric queries below are scoped to `service:gram-server`. Creating these
+monitors and linking their notifications to this runbook is a rollout prerequisite.
 
 ### Refresh availability
 

--- a/docs/runbooks/platform-mcp-durable-auth-monitors.md
+++ b/docs/runbooks/platform-mcp-durable-auth-monitors.md
@@ -1,0 +1,108 @@
+# Platform MCP durable authorization monitors
+
+This runbook covers the durable Platform MCP OAuth lifecycle added in AGE-3161.
+The application emits low-cardinality OpenTelemetry metrics from `gram-server`;
+Datadog monitors are managed in the Datadog UI, not as repository IaC.
+
+## Safety boundary
+
+The metrics use only the fixed `platform_mcp.operation`,
+`platform_mcp.outcome`, and `platform_mcp.reason` tags. They must never include
+an access token, refresh token, authorization code, token hash, JTI, user,
+organization, connection, client identifier, redirect URI, or free-form error.
+
+Durable authorization state and audited revocation actions remain authoritative.
+These metrics are operational evidence only.
+
+## Metric contracts
+
+| Metric                                        | Type                | Tags                                      | Meaning                                                                  |
+| --------------------------------------------- | ------------------- | ----------------------------------------- | ------------------------------------------------------------------------ |
+| `platform_mcp.oauth.events`                   | counter             | `operation`, `outcome`, optional `reason` | One bounded OAuth endpoint result for refresh and code exchange.         |
+| `platform_mcp.oauth.refresh_duration`         | histogram (seconds) | `operation:refresh`, `outcome:succeeded`  | Successful refresh latency only.                                         |
+| `platform_mcp.oauth.connection_age`           | histogram (seconds) | `operation:refresh`, `outcome:succeeded`  | Current authorization-generation age at a successful refresh.            |
+| `platform_mcp.oauth.reauthorization_required` | counter             | `reason`                                  | A committed terminal transition, after the durable transaction succeeds. |
+
+Terminal `reason` values are fixed: `refresh_idle_expired`,
+`authorization_expired`, `refresh_reuse`, `connection_revoked`,
+`client_revoked`, `authorization_lost`, and `security_reset`.
+
+## Dashboard
+
+Create a **Platform MCP durable auth** dashboard scoped to
+`service:gram-server` with these panels:
+
+1. Refresh success ratio: `succeeded / all refresh outcomes`.
+2. Refresh `temporarily_unavailable` ratio.
+3. Refresh `invalid_grant` outcomes, split by bounded reason; highlight
+   `refresh_reuse` terminal transitions.
+4. Interactive authorization and authorization-code exchange outcomes.
+5. p95 `platform_mcp.oauth.refresh_duration`.
+6. Authorization-generation age from `platform_mcp.oauth.connection_age`.
+7. Reauthorization-required transitions by reason.
+
+The active dogfood cohort belongs in the dashboard's saved scope/configuration;
+do not add organization or client identity as a metric tag.
+
+## Datadog monitors
+
+Thresholds are initial values. Tune after the dogfood baseline is established.
+All metric queries below are scoped to `service:gram-server`.
+
+### Refresh availability
+
+```
+Monitor type: Metric (ratio)
+Query: sum(last_15m):sum:platform_mcp.oauth.events{operation:refresh,outcome:succeeded}.as_count()
+       / sum:platform_mcp.oauth.events{operation:refresh}.as_count() * 100
+Warn:  < 98
+Alert: < 95
+```
+
+Also alert separately when `temporarily_unavailable` exceeds 2% of refresh
+outcomes in 15 minutes. Check dependency health before asking users to reconnect:
+this result is retryable and must not cause a durable reset.
+
+### Invalid grants and refresh reuse
+
+```
+Monitor type: Metric
+Query: sum(last_15m):sum:platform_mcp.oauth.events{operation:refresh,outcome:invalid_grant}.as_count()
+Warn:  > baseline + 10
+Alert: > baseline + 25
+```
+
+Add a second monitor for any sustained
+`platform_mcp.oauth.reauthorization_required{reason:refresh_reuse}` activity.
+Treat spikes as a security and client-retry investigation; do not infer token
+theft from a single event.
+
+### Interactive authorization rate
+
+Monitor a large rise in
+`platform_mcp.oauth.events{operation:interactive_authorization}` relative to
+the active internal rollout cohort. This is a leading signal for refresh or
+client-storage regressions. Investigate refresh outcomes and terminal reasons
+first.
+
+### Revocation propagation probe
+
+The counters do not claim a revocation propagation latency by themselves. Run a
+synthetic probe that performs each supported revocation action (connection,
+client, generation, JTI, organization gate, and org-admin loss), then makes the
+next runtime request with the formerly valid access token. Record action-to-denial
+latency in the probe system and alert if it exceeds the published contract bound.
+
+When this monitor fires, verify the affected durable state first, then inspect
+the runtime authorization query and dependency health. Do not use production
+user identifiers as monitor tags.
+
+## Ownership and response
+
+- **Owner:** Control Plane / Platform MCP on-call.
+- **Service:** `gram-server`.
+- **Runbook:** this document, linked from every monitor notification.
+
+For a terminal-reason spike, inspect bounded metrics and safe structured terminal
+logs only. Use audited management state to diagnose a specific report; never
+search for or copy bearer credentials into dashboards, logs, tickets, or comments.

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -103,17 +103,20 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		platformmcp.NewPostgresOrganizationSlugResolver(config.DB),
 	)
 	authorizer := platformmcp.NewLiveOrgAdminAuthorizer(config.DB, config.Authz)
+	oauthTelemetry := platformmcp.NewOAuthTelemetry(config.Logger, config.MeterProvider)
+	oauthStore := platformmcp.NewPostgresOAuthStore(config.DB).WithTelemetry(oauthTelemetry)
 	oauth, err := platformmcp.NewOAuthHTTP(platformmcp.OAuthHTTPConfig{
 		BaseURL:       config.ServerURL,
 		Environment:   config.Environment,
 		Cache:         cache.NewRedisCacheAdapter(config.Redis),
-		Store:         platformmcp.NewPostgresOAuthStore(config.DB),
+		Store:         oauthStore,
 		Identity:      config.Identity,
 		Gate:          gate,
 		Authorizer:    authorizer,
 		Organizations: platformmcp.NewLiveOrganizationSelector(config.DB, authorizer),
 		Signer:        sessiontokens.NewSigner(config.JWTSigningKey),
 		Encryption:    config.Encryption,
+		Telemetry:     oauthTelemetry,
 	})
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create local Platform MCP OAuth service: %w", err)
@@ -218,7 +221,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		platformmcp.NewOnboardingService(config.DB),
 		distributions,
 		fixtureConfig.CatalogDescriptor(),
-	)
+	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)
 	platformmcp.AttachManagement(config.Mux, platformmcp.NewManagementService(config.Logger, config.TracerProvider, config.DB, config.Sessions, config.Authz, gate, authorizer, config.ServerURL.JoinPath("platform-mcp").String(), registrations, readiness, distributions, config.JWTSigningKey, catalog))
@@ -269,17 +272,20 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		platformmcp.NewPostgresOrganizationSlugResolver(config.DB),
 	)
 	authorizer := platformmcp.NewLiveOrgAdminAuthorizer(config.DB, config.Authz)
+	oauthTelemetry := platformmcp.NewOAuthTelemetry(config.Logger, config.MeterProvider)
+	oauthStore := platformmcp.NewPostgresOAuthStore(config.DB).WithTelemetry(oauthTelemetry)
 	oauth, err := platformmcp.NewOAuthHTTP(platformmcp.OAuthHTTPConfig{
 		BaseURL:       config.ServerURL,
 		Environment:   config.Environment,
 		Cache:         cache.NewRedisCacheAdapter(config.Redis),
-		Store:         platformmcp.NewPostgresOAuthStore(config.DB),
+		Store:         oauthStore,
 		Identity:      config.Identity,
 		Gate:          gate,
 		Authorizer:    authorizer,
 		Organizations: platformmcp.NewLiveOrganizationSelector(config.DB, authorizer),
 		Signer:        sessiontokens.NewSigner(config.JWTSigningKey),
 		Encryption:    config.Encryption,
+		Telemetry:     oauthTelemetry,
 	})
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create platform mcp oauth service: %w", err)
@@ -369,7 +375,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		platformmcp.NewOnboardingService(config.DB),
 		distributions,
 		platformmcp.CatalogDescriptor{},
-	)
+	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)
 	platformmcp.AttachManagement(config.Mux, platformmcp.NewManagementService(config.Logger, config.TracerProvider, config.DB, config.Sessions, config.Authz, gate, authorizer, config.ServerURL.JoinPath("platform-mcp").String(), registrations, readiness, distributions, config.JWTSigningKey, catalog))

--- a/server/internal/platformmcp/adapters.go
+++ b/server/internal/platformmcp/adapters.go
@@ -66,10 +66,7 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (Prin
 		Jti:            claims.ID,
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return Principal{}, ErrUnauthorized
-		}
-		return Principal{}, fmt.Errorf("lookup active platform mcp session: %w", err)
+		return Principal{}, jwtAuthenticationStoreError(err)
 	}
 	if session.SubjectUrn != subject.String() || session.ClientID != claims.ClientID || session.ConnectionGeneration != session.ActiveGeneration {
 		return Principal{}, ErrUnauthorized
@@ -88,6 +85,13 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (Prin
 type LiveOrgAdminAuthorizer struct {
 	db     *pgxpool.Pool
 	engine *authz.Engine
+}
+
+func jwtAuthenticationStoreError(err error) error {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrUnauthorized
+	}
+	return fmt.Errorf("%w: lookup active platform mcp session: %w", ErrUnavailable, err)
 }
 
 func NewLiveOrgAdminAuthorizer(db *pgxpool.Pool, engine *authz.Engine) *LiveOrgAdminAuthorizer {

--- a/server/internal/platformmcp/oauth/state.go
+++ b/server/internal/platformmcp/oauth/state.go
@@ -434,7 +434,15 @@ func (s *InMemoryStore) DetectRefreshReuse(_ context.Context, organizationID, re
 	if session.RevokedAt == nil {
 		return false, nil
 	}
-	s.revokeGeneration(session.Connection.ID, session.Connection.Generation, now)
+	connection, ok := s.connections[session.Connection.ID]
+	if !ok || connection.OrganizationID != organizationID {
+		return false, ErrNotFound
+	}
+	if connection.Generation == session.Connection.Generation && connection.ReauthorizationRequiredAt == nil {
+		s.markGenerationTerminal(connection, ReauthorizationReasonRefreshReuse, now)
+	} else {
+		s.revokeGeneration(session.Connection.ID, session.Connection.Generation, now)
+	}
 	return true, nil
 }
 

--- a/server/internal/platformmcp/oauth/state_test.go
+++ b/server/internal/platformmcp/oauth/state_test.go
@@ -156,6 +156,52 @@ func TestInMemoryStore_RefreshReuseRevokesGeneration(t *testing.T) {
 	require.ErrorIs(t, err, platformoauth.ErrRevoked)
 }
 
+func TestInMemoryStore_DetectRefreshReuseTerminalizesConnectionOnce(t *testing.T) {
+	t.Parallel()
+
+	store, grant := consumedGrant(t)
+	session := sessionFor(grant.Connection, grant.ClientID, "refresh-old")
+	now := time.Now().UTC()
+	session.RevokedAt = &now
+	require.NoError(t, store.CreateSession(t.Context(), session))
+
+	reused, err := store.DetectRefreshReuse(t.Context(), grant.Connection.OrganizationID, session.RefreshHash, now)
+	require.NoError(t, err)
+	require.True(t, reused)
+
+	_, err = store.PrepareRefresh(t.Context(), platformoauth.PrepareRefreshInput{
+		OrganizationID: grant.Connection.OrganizationID,
+		RefreshHash:    session.RefreshHash,
+		ClientID:       grant.ClientID,
+		Now:            now.Add(time.Minute),
+	})
+	require.ErrorIs(t, err, platformoauth.ErrRevoked)
+	require.ErrorIs(t, store.CreateSession(t.Context(), sessionFor(grant.Connection, grant.ClientID, "refresh-blocked")), platformoauth.ErrRevoked)
+
+	reused, err = store.DetectRefreshReuse(t.Context(), grant.Connection.OrganizationID, session.RefreshHash, now.Add(2*time.Minute))
+	require.NoError(t, err)
+	require.True(t, reused)
+	require.ErrorIs(t, store.CreateSession(t.Context(), sessionFor(grant.Connection, grant.ClientID, "refresh-still-blocked")), platformoauth.ErrRevoked)
+}
+
+func TestInMemoryStore_DetectRefreshReuseDoesNotTerminalizeNewGeneration(t *testing.T) {
+	t.Parallel()
+
+	store, grant := consumedGrant(t)
+	session := sessionFor(grant.Connection, grant.ClientID, "refresh-old")
+	now := time.Now().UTC()
+	session.RevokedAt = &now
+	require.NoError(t, store.CreateSession(t.Context(), session))
+
+	updated, err := store.RotateConnectionGeneration(t.Context(), grant.Connection.OrganizationID, grant.Connection.ID, "generation-next", now.Add(time.Minute))
+	require.NoError(t, err)
+
+	reused, err := store.DetectRefreshReuse(t.Context(), grant.Connection.OrganizationID, session.RefreshHash, now.Add(2*time.Minute))
+	require.NoError(t, err)
+	require.True(t, reused)
+	require.NoError(t, store.CreateSession(t.Context(), sessionFor(updated, grant.ClientID, "refresh-new-generation")))
+}
+
 func TestInMemoryStore_RefreshRaceHasOneWinner(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/oauth_telemetry.go
+++ b/server/internal/platformmcp/oauth_telemetry.go
@@ -125,7 +125,7 @@ func validOAuthReason(reason string) bool {
 		return true
 	}
 	switch reason {
-	case "not_found", "already_used", "expired", "revoked", "client_mismatch", "generation_invalid", "redirect_uri_invalid", "pkce_invalid", "authorization_denied", "platform_disabled":
+	case "not_found", "already_used", "expired", "revoked", "client_mismatch", "generation_invalid", "redirect_uri_invalid", "pkce_invalid", "authorization_denied", "authorization_unavailable", "platform_disabled":
 		return true
 	default:
 		return false

--- a/server/internal/platformmcp/oauth_telemetry.go
+++ b/server/internal/platformmcp/oauth_telemetry.go
@@ -1,0 +1,167 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	platformoauth "github.com/speakeasy-api/gram/server/internal/platformmcp/oauth"
+)
+
+const (
+	platformMCPOAuthEventMetric                   = "platform_mcp.oauth.events"
+	platformMCPOAuthRefreshDurationMetric         = "platform_mcp.oauth.refresh_duration"
+	platformMCPOAuthConnectionAgeMetric           = "platform_mcp.oauth.connection_age"
+	platformMCPOAuthReauthorizationRequiredMetric = "platform_mcp.oauth.reauthorization_required"
+)
+
+type OAuthEvent struct {
+	Operation string
+	Outcome   string
+	Reason    string
+}
+
+type OAuthTelemetry interface {
+	Record(context.Context, OAuthEvent)
+	RecordRefreshSuccess(context.Context, time.Duration, time.Duration)
+	RecordTerminalTransition(context.Context, platformoauth.ReauthorizationReason)
+}
+
+type noopOAuthTelemetry struct{}
+
+func (noopOAuthTelemetry) Record(context.Context, OAuthEvent)                                 {}
+func (noopOAuthTelemetry) RecordRefreshSuccess(context.Context, time.Duration, time.Duration) {}
+func (noopOAuthTelemetry) RecordTerminalTransition(context.Context, platformoauth.ReauthorizationReason) {
+}
+
+type oauthTelemetry struct {
+	logger                  *slog.Logger
+	events                  metric.Int64Counter
+	refreshDuration         metric.Float64Histogram
+	connectionAge           metric.Float64Histogram
+	reauthorizationRequired metric.Int64Counter
+}
+
+func NewOAuthTelemetry(logger *slog.Logger, meterProvider metric.MeterProvider) OAuthTelemetry {
+	if logger == nil || meterProvider == nil {
+		return noopOAuthTelemetry{}
+	}
+
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/platformmcp")
+	events, err := meter.Int64Counter(platformMCPOAuthEventMetric, metric.WithDescription("Bounded Platform MCP OAuth outcomes"), metric.WithUnit("{event}"))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create Platform MCP OAuth metric", attr.SlogMetricName(platformMCPOAuthEventMetric), attr.SlogError(err))
+	}
+	refreshDuration, err := meter.Float64Histogram(platformMCPOAuthRefreshDurationMetric, metric.WithDescription("Successful Platform MCP refresh duration"), metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create Platform MCP OAuth metric", attr.SlogMetricName(platformMCPOAuthRefreshDurationMetric), attr.SlogError(err))
+	}
+	connectionAge, err := meter.Float64Histogram(platformMCPOAuthConnectionAgeMetric, metric.WithDescription("Age of a Platform MCP authorization generation at successful refresh"), metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(60, 300, 900, 3600, 21600, 86400, 604800, 2592000, 7776000))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create Platform MCP OAuth metric", attr.SlogMetricName(platformMCPOAuthConnectionAgeMetric), attr.SlogError(err))
+	}
+	reauthorizationRequired, err := meter.Int64Counter(platformMCPOAuthReauthorizationRequiredMetric, metric.WithDescription("Committed Platform MCP reauthorization-required transitions"), metric.WithUnit("{transition}"))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create Platform MCP OAuth metric", attr.SlogMetricName(platformMCPOAuthReauthorizationRequiredMetric), attr.SlogError(err))
+	}
+
+	return &oauthTelemetry{logger: logger, events: events, refreshDuration: refreshDuration, connectionAge: connectionAge, reauthorizationRequired: reauthorizationRequired}
+}
+
+func (t *oauthTelemetry) Record(ctx context.Context, event OAuthEvent) {
+	if t == nil || t.events == nil || !validOAuthEvent(event) {
+		return
+	}
+	attributes := []attribute.KeyValue{
+		attribute.String("platform_mcp.operation", event.Operation),
+		attribute.String("platform_mcp.outcome", event.Outcome),
+	}
+	if event.Reason != "" {
+		attributes = append(attributes, attribute.String("platform_mcp.reason", event.Reason))
+	}
+	t.events.Add(ctx, 1, metric.WithAttributes(attributes...))
+}
+
+func (t *oauthTelemetry) RecordRefreshSuccess(ctx context.Context, duration, connectionAge time.Duration) {
+	if t == nil {
+		return
+	}
+	attributes := metric.WithAttributes(attribute.String("platform_mcp.operation", "refresh"), attribute.String("platform_mcp.outcome", "succeeded"))
+	if t.refreshDuration != nil {
+		t.refreshDuration.Record(ctx, duration.Seconds(), attributes)
+	}
+	if t.connectionAge != nil && connectionAge >= 0 {
+		t.connectionAge.Record(ctx, connectionAge.Seconds(), attributes)
+	}
+}
+
+func (t *oauthTelemetry) RecordTerminalTransition(ctx context.Context, reason platformoauth.ReauthorizationReason) {
+	if t == nil || t.reauthorizationRequired == nil || !validReauthorizationReason(reason) {
+		return
+	}
+	t.reauthorizationRequired.Add(ctx, 1, metric.WithAttributes(attribute.String("platform_mcp.reason", string(reason))))
+	t.logger.WarnContext(ctx, "platform mcp authorization requires reauthorization", attr.SlogEvent("platform_mcp.oauth.terminal_transition"), attr.SlogReason(string(reason)))
+}
+
+func validOAuthEvent(event OAuthEvent) bool {
+	if event.Operation != "refresh" && event.Operation != "code_exchange" && event.Operation != "interactive_authorization" && event.Operation != "revocation" && event.Operation != "runtime_auth" {
+		return false
+	}
+	switch event.Outcome {
+	case "succeeded", "invalid_grant", "access_denied", "temporarily_unavailable", "invalid_client", "invalid_request", "server_error", "unsupported_grant_type", "unauthorized":
+	default:
+		return false
+	}
+	return event.Reason == "" || validOAuthReason(event.Reason)
+}
+
+func validOAuthReason(reason string) bool {
+	if validReauthorizationReason(platformoauth.ReauthorizationReason(reason)) {
+		return true
+	}
+	switch reason {
+	case "not_found", "already_used", "expired", "revoked", "client_mismatch", "generation_invalid", "redirect_uri_invalid", "pkce_invalid", "authorization_denied", "platform_disabled":
+		return true
+	default:
+		return false
+	}
+}
+
+func validReauthorizationReason(reason platformoauth.ReauthorizationReason) bool {
+	switch reason {
+	case platformoauth.ReauthorizationReasonRefreshIdleExpired, platformoauth.ReauthorizationReasonAuthorizationExpired, platformoauth.ReauthorizationReasonRefreshReuse, platformoauth.ReauthorizationReasonConnectionRevoked, platformoauth.ReauthorizationReasonClientRevoked, platformoauth.ReauthorizationReasonAuthorizationLost, platformoauth.ReauthorizationReasonSecurityReset:
+		return true
+	default:
+		return false
+	}
+}
+
+func oauthStateFailureReason(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, platformoauth.ErrNotFound):
+		return "not_found"
+	case errors.Is(err, platformoauth.ErrAlreadyUsed):
+		return "already_used"
+	case errors.Is(err, platformoauth.ErrExpired):
+		return "expired"
+	case errors.Is(err, platformoauth.ErrRevoked):
+		return "revoked"
+	case errors.Is(err, platformoauth.ErrClientMismatch):
+		return "client_mismatch"
+	case errors.Is(err, platformoauth.ErrGeneration):
+		return "generation_invalid"
+	case errors.Is(err, platformoauth.ErrRedirectURI):
+		return "redirect_uri_invalid"
+	case errors.Is(err, platformoauth.ErrPKCE):
+		return "pkce_invalid"
+	default:
+		return ""
+	}
+}

--- a/server/internal/platformmcp/oauth_telemetry_test.go
+++ b/server/internal/platformmcp/oauth_telemetry_test.go
@@ -70,20 +70,34 @@ func TestOAuthResponseRecorderDoesNotRetainResponseBody(t *testing.T) {
 	require.NotContains(t, strings.Join([]string{recorder.oauthOutcome, recorder.reason}, " "), "token")
 }
 
-func TestOAuthResponseRecorderClassifiesSuccessfulRedirectExplicitly(t *testing.T) {
+func TestOAuthResponseRecorderPrefersExplicitRedirectOutcome(t *testing.T) {
 	t.Parallel()
 
-	recorder := &oauthResponseRecorder{ResponseWriter: testResponseWriter{}}
-	recorder.setOAuthOutcome("succeeded")
-	recorder.WriteHeader(http.StatusSeeOther)
+	for _, tc := range []struct {
+		name    string
+		outcome string
+	}{
+		{name: "success", outcome: "succeeded"},
+		{name: "denied", outcome: "access_denied"},
+		{name: "unavailable", outcome: "temporarily_unavailable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Equal(t, "succeeded", recorder.outcome())
+			recorder := &oauthResponseRecorder{ResponseWriter: testResponseWriter{}}
+			recorder.setOAuthOutcome(tc.outcome)
+			recorder.WriteHeader(http.StatusSeeOther)
+
+			require.Equal(t, tc.outcome, recorder.outcome())
+		})
+	}
 }
 
 func TestOAuthTelemetryAcceptsOnlyBoundedDimensions(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, validOAuthEvent(OAuthEvent{Operation: "runtime_auth", Outcome: "access_denied", Reason: "authorization_denied"}))
+	require.True(t, validOAuthEvent(OAuthEvent{Operation: "interactive_authorization", Outcome: "temporarily_unavailable", Reason: "authorization_unavailable"}))
 	require.False(t, validOAuthEvent(OAuthEvent{Operation: "https://untrusted.example", Outcome: "succeeded"}))
 	require.False(t, validOAuthEvent(OAuthEvent{Operation: "refresh", Outcome: "succeeded", Reason: "access-token"}))
 }

--- a/server/internal/platformmcp/oauth_telemetry_test.go
+++ b/server/internal/platformmcp/oauth_telemetry_test.go
@@ -1,0 +1,137 @@
+package platformmcp
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	platformoauth "github.com/speakeasy-api/gram/server/internal/platformmcp/oauth"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestOAuthTelemetryUsesOnlyBoundedAttributes(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+	telemetry := NewOAuthTelemetry(testenv.NewLogger(t), provider)
+
+	telemetry.Record(t.Context(), OAuthEvent{Operation: "refresh", Outcome: "invalid_grant", Reason: "refresh_reuse"})
+	telemetry.Record(t.Context(), OAuthEvent{Operation: "refresh", Outcome: "invalid_grant", Reason: "https://untrusted.example/token"})
+	telemetry.RecordRefreshSuccess(t.Context(), 250*time.Millisecond, 7*24*time.Hour)
+	telemetry.RecordTerminalTransition(t.Context(), platformoauth.ReauthorizationReasonRefreshReuse)
+	telemetry.RecordTerminalTransition(t.Context(), platformoauth.ReauthorizationReason("token-secret"))
+
+	var metrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &metrics))
+
+	events := oauthCounterPoints(t, metrics, platformMCPOAuthEventMetric)
+	require.Len(t, events, 1)
+	require.Equal(t, int64(1), events[0].Value)
+	requireMetricAttribute(t, events[0].Attributes, "platform_mcp.operation", "refresh")
+	requireMetricAttribute(t, events[0].Attributes, "platform_mcp.outcome", "invalid_grant")
+	requireMetricAttribute(t, events[0].Attributes, "platform_mcp.reason", "refresh_reuse")
+	for _, kv := range events[0].Attributes.ToSlice() {
+		require.NotContains(t, kv.Value.AsString(), "token-secret")
+		require.NotContains(t, kv.Value.AsString(), "untrusted.example")
+	}
+
+	refreshDuration := oauthHistogramPoints(t, metrics, platformMCPOAuthRefreshDurationMetric)
+	require.Len(t, refreshDuration, 1)
+	require.Equal(t, uint64(1), refreshDuration[0].Count)
+	requireMetricAttribute(t, refreshDuration[0].Attributes, "platform_mcp.operation", "refresh")
+	requireMetricAttribute(t, refreshDuration[0].Attributes, "platform_mcp.outcome", "succeeded")
+
+	connectionAge := oauthHistogramPoints(t, metrics, platformMCPOAuthConnectionAgeMetric)
+	require.Len(t, connectionAge, 1)
+	require.Equal(t, uint64(1), connectionAge[0].Count)
+
+	transitions := oauthCounterPoints(t, metrics, platformMCPOAuthReauthorizationRequiredMetric)
+	require.Len(t, transitions, 1)
+	require.Equal(t, int64(1), transitions[0].Value)
+	requireMetricAttribute(t, transitions[0].Attributes, "platform_mcp.reason", "refresh_reuse")
+}
+
+func TestOAuthResponseRecorderDoesNotRetainResponseBody(t *testing.T) {
+	t.Parallel()
+
+	recorder := &oauthResponseRecorder{ResponseWriter: testResponseWriter{}}
+	_, err := recorder.Write([]byte("access-token refresh-token authorization-code"))
+
+	require.NoError(t, err)
+	require.Equal(t, "succeeded", recorder.outcome())
+	require.NotContains(t, strings.Join([]string{recorder.oauthOutcome, recorder.reason}, " "), "token")
+}
+
+func TestOAuthResponseRecorderClassifiesSuccessfulRedirectExplicitly(t *testing.T) {
+	t.Parallel()
+
+	recorder := &oauthResponseRecorder{ResponseWriter: testResponseWriter{}}
+	recorder.setOAuthOutcome("succeeded")
+	recorder.WriteHeader(http.StatusSeeOther)
+
+	require.Equal(t, "succeeded", recorder.outcome())
+}
+
+func TestOAuthTelemetryAcceptsOnlyBoundedDimensions(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, validOAuthEvent(OAuthEvent{Operation: "runtime_auth", Outcome: "access_denied", Reason: "authorization_denied"}))
+	require.False(t, validOAuthEvent(OAuthEvent{Operation: "https://untrusted.example", Outcome: "succeeded"}))
+	require.False(t, validOAuthEvent(OAuthEvent{Operation: "refresh", Outcome: "succeeded", Reason: "access-token"}))
+}
+
+func oauthCounterPoints(t *testing.T, resourceMetrics metricdata.ResourceMetrics, name string) []metricdata.DataPoint[int64] {
+	t.Helper()
+
+	for _, scope := range resourceMetrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %q is not a counter", name)
+			return sum.DataPoints
+		}
+	}
+	t.Fatalf("missing metric %q", name)
+	return nil
+}
+
+func oauthHistogramPoints(t *testing.T, resourceMetrics metricdata.ResourceMetrics, name string) []metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+
+	for _, scope := range resourceMetrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "metric %q is not a histogram", name)
+			return histogram.DataPoints
+		}
+	}
+	t.Fatalf("missing metric %q", name)
+	return nil
+}
+
+func requireMetricAttribute(t *testing.T, attributes attribute.Set, key, want string) {
+	t.Helper()
+
+	value, ok := attributes.Value(attribute.Key(key))
+	require.True(t, ok, "missing attribute %q", key)
+	require.Equal(t, want, value.AsString())
+}
+
+type testResponseWriter struct{}
+
+func (testResponseWriter) Header() http.Header            { return http.Header{} }
+func (testResponseWriter) Write(body []byte) (int, error) { return len(body), nil }
+func (testResponseWriter) WriteHeader(int)                {}

--- a/server/internal/platformmcp/oauthhttp.go
+++ b/server/internal/platformmcp/oauthhttp.go
@@ -495,7 +495,11 @@ func (s *OAuthHTTP) connectPost(w http.ResponseWriter, r *http.Request) {
 	recorded := &oauthResponseRecorder{ResponseWriter: w}
 	w = recorded
 	defer func() {
-		s.oauthTelemetry().Record(r.Context(), OAuthEvent{Operation: "interactive_authorization", Outcome: recorded.outcome()})
+		s.oauthTelemetry().Record(r.Context(), OAuthEvent{
+			Operation: "interactive_authorization",
+			Outcome:   recorded.outcome(),
+			Reason:    recorded.reason,
+		})
 	}()
 
 	r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
@@ -513,6 +517,7 @@ func (s *OAuthHTTP) connectPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.PostForm.Get("action") != "approve" {
+		setOAuthTelemetryReason(w, "authorization_denied")
 		redirectOAuthError(w, r, challenge.RedirectURI, challenge.State, &oauthwire.Error{Code: "access_denied", Description: "user denied authorization"})
 		return
 	}
@@ -796,6 +801,7 @@ func (s *OAuthHTTP) gateAndAuthorize(ctx context.Context, principal Principal) e
 }
 
 func writeAuthorizationGateError(w http.ResponseWriter, r *http.Request, challenge oauthChallenge, err error) {
+	setOAuthTelemetryReason(w, oauthGateReason(err))
 	if errors.Is(err, ErrUnavailable) {
 		redirectOAuthError(w, r, challenge.RedirectURI, challenge.State, &oauthwire.Error{Code: "temporarily_unavailable", Description: "organization access could not be verified"})
 		return
@@ -850,11 +856,11 @@ func (w *oauthResponseRecorder) Write(body []byte) (int, error) {
 }
 
 func (w *oauthResponseRecorder) outcome() string {
-	if w.status >= http.StatusOK && w.status < http.StatusMultipleChoices {
-		return "succeeded"
-	}
 	if validOAuthOutcome(w.oauthOutcome) {
 		return w.oauthOutcome
+	}
+	if w.status >= http.StatusOK && w.status < http.StatusMultipleChoices {
+		return "succeeded"
 	}
 	return "server_error"
 }
@@ -898,6 +904,9 @@ func oauthGateReason(err error) string {
 	}
 	if errors.Is(err, ErrForbidden) {
 		return "authorization_denied"
+	}
+	if errors.Is(err, ErrUnavailable) {
+		return "authorization_unavailable"
 	}
 	return ""
 }

--- a/server/internal/platformmcp/oauthhttp.go
+++ b/server/internal/platformmcp/oauthhttp.go
@@ -108,6 +108,7 @@ type OAuthHTTP struct {
 	credentials   *CredentialCodec
 	issuer        string
 	audience      string
+	telemetry     OAuthTelemetry
 	now           func() time.Time
 }
 
@@ -122,6 +123,7 @@ type OAuthHTTPConfig struct {
 	Organizations OrganizationSelector
 	Signer        *sessiontokens.Signer
 	Encryption    *encryption.Client
+	Telemetry     OAuthTelemetry
 }
 
 func NewOAuthHTTP(config OAuthHTTPConfig) (*OAuthHTTP, error) {
@@ -150,8 +152,16 @@ func NewOAuthHTTP(config OAuthHTTPConfig) (*OAuthHTTP, error) {
 		credentials:   credentials,
 		issuer:        issuer,
 		audience:      issuer,
+		telemetry:     config.Telemetry,
 		now:           time.Now,
 	}, nil
+}
+
+func (s *OAuthHTTP) oauthTelemetry() OAuthTelemetry {
+	if s.telemetry == nil {
+		return noopOAuthTelemetry{}
+	}
+	return s.telemetry
 }
 
 func (s *OAuthHTTP) Attach(mux interface {
@@ -482,6 +492,12 @@ func (s *OAuthHTTP) connectGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *OAuthHTTP) connectPost(w http.ResponseWriter, r *http.Request) {
+	recorded := &oauthResponseRecorder{ResponseWriter: w}
+	w = recorded
+	defer func() {
+		s.oauthTelemetry().Record(r.Context(), OAuthEvent{Operation: "interactive_authorization", Outcome: recorded.outcome()})
+	}()
+
 	r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
 	if err := r.ParseForm(); err != nil {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not parse authorization")
@@ -540,15 +556,24 @@ func (s *OAuthHTTP) connectPost(w http.ResponseWriter, r *http.Request) {
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "could not complete authorization")
 		return
 	}
+	recorded.setOAuthOutcome("succeeded")
 	http.Redirect(w, r, redirectURL(challenge.RedirectURI, code, challenge.State, "", ""), http.StatusSeeOther)
 }
 
 func (s *OAuthHTTP) TokenHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded := &oauthResponseRecorder{ResponseWriter: w}
+		w = recorded
 		r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
 		if err := r.ParseForm(); err != nil {
 			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not parse token request")
 			return
+		}
+		operation, ok := tokenOperation(r.PostForm.Get("grant_type"))
+		if ok {
+			defer func() {
+				s.oauthTelemetry().Record(r.Context(), OAuthEvent{Operation: operation, Outcome: recorded.outcome(), Reason: recorded.reason})
+			}()
 		}
 		now := s.now()
 		clientID, clientSecret := clientCredentials(r)
@@ -718,6 +743,8 @@ func (s *OAuthHTTP) mintReplacementAndRespond(w http.ResponseWriter, r *http.Req
 		writeTokenStateError(w, err, "refresh token")
 		return
 	}
+	generationAuthorizedAt := old.Connection.AuthorizationExpiresAt.Add(-platformoauth.AuthorizationLifetime)
+	s.oauthTelemetry().RecordRefreshSuccess(r.Context(), s.now().Sub(now), now.Sub(generationAuthorizedAt))
 	writeJSON(w, http.StatusOK, map[string]any{"access_token": accessToken, "token_type": "Bearer", "expires_in": int64(accessExpiresAt.Sub(now).Seconds()), "refresh_token": refreshToken})
 }
 
@@ -777,6 +804,7 @@ func writeAuthorizationGateError(w http.ResponseWriter, r *http.Request, challen
 }
 
 func writeTokenStateError(w http.ResponseWriter, err error, credential string) {
+	setOAuthTelemetryReason(w, oauthStateFailureReason(err))
 	switch {
 	case errors.Is(err, platformoauth.ErrNotFound), errors.Is(err, platformoauth.ErrRevoked), errors.Is(err, platformoauth.ErrExpired), errors.Is(err, platformoauth.ErrAlreadyUsed), errors.Is(err, platformoauth.ErrClientMismatch), errors.Is(err, platformoauth.ErrGeneration), errors.Is(err, platformoauth.ErrRedirectURI), errors.Is(err, platformoauth.ErrPKCE):
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", credential+" is invalid")
@@ -785,7 +813,97 @@ func writeTokenStateError(w http.ResponseWriter, err error, credential string) {
 	}
 }
 
+func tokenOperation(grantType string) (string, bool) {
+	switch grantType {
+	case "authorization_code":
+		return "code_exchange", true
+	case "refresh_token":
+		return "refresh", true
+	default:
+		return "", false
+	}
+}
+
+type oauthResponseRecorder struct {
+	http.ResponseWriter
+	status       int
+	oauthOutcome string
+	reason       string
+}
+
+func (w *oauthResponseRecorder) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *oauthResponseRecorder) Write(body []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	written, err := w.ResponseWriter.Write(body)
+	if err != nil {
+		return written, fmt.Errorf("write OAuth response: %w", err)
+	}
+	return written, nil
+}
+
+func (w *oauthResponseRecorder) outcome() string {
+	if w.status >= http.StatusOK && w.status < http.StatusMultipleChoices {
+		return "succeeded"
+	}
+	if validOAuthOutcome(w.oauthOutcome) {
+		return w.oauthOutcome
+	}
+	return "server_error"
+}
+
+func (w *oauthResponseRecorder) setOAuthOutcome(outcome string) {
+	if validOAuthOutcome(outcome) {
+		w.oauthOutcome = outcome
+	}
+}
+
+func (w *oauthResponseRecorder) setOAuthReason(reason string) {
+	if validOAuthReason(reason) {
+		w.reason = reason
+	}
+}
+
+func setOAuthTelemetryOutcome(w http.ResponseWriter, outcome string) {
+	if recorder, ok := w.(*oauthResponseRecorder); ok {
+		recorder.setOAuthOutcome(outcome)
+	}
+}
+
+func setOAuthTelemetryReason(w http.ResponseWriter, reason string) {
+	if recorder, ok := w.(*oauthResponseRecorder); ok {
+		recorder.setOAuthReason(reason)
+	}
+}
+
+func validOAuthOutcome(outcome string) bool {
+	switch outcome {
+	case "succeeded", "invalid_grant", "access_denied", "temporarily_unavailable", "invalid_client", "invalid_request", "server_error", "unsupported_grant_type":
+		return true
+	default:
+		return false
+	}
+}
+
+func oauthGateReason(err error) string {
+	if errors.Is(err, errPlatformMCPDisabled) {
+		return "platform_disabled"
+	}
+	if errors.Is(err, ErrForbidden) {
+		return "authorization_denied"
+	}
+	return ""
+}
+
 func writeTokenGateError(w http.ResponseWriter, err error) {
+	setOAuthTelemetryReason(w, oauthGateReason(err))
 	if errors.Is(err, ErrUnavailable) {
 		writeOAuthError(w, http.StatusServiceUnavailable, "temporarily_unavailable", "organization access could not be verified")
 		return
@@ -878,6 +996,7 @@ func oauthPageContentSecurityPolicy(redirectURI, scriptNonce string) string {
 }
 
 func writeOAuthError(w http.ResponseWriter, status int, code, description string) {
+	setOAuthTelemetryOutcome(w, code)
 	writeJSON(w, status, map[string]string{"error": code, "error_description": description})
 }
 
@@ -895,6 +1014,7 @@ func redirectOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, sta
 	if !errors.As(err, &oauthError) {
 		oauthError = &oauthwire.Error{Code: "invalid_request", Description: "invalid request"}
 	}
+	setOAuthTelemetryOutcome(w, oauthError.Code)
 	http.Redirect(w, r, redirectURL(redirectURI, "", state, oauthError.Code, oauthError.Description), http.StatusFound)
 }
 

--- a/server/internal/platformmcp/oauthstore.go
+++ b/server/internal/platformmcp/oauthstore.go
@@ -279,7 +279,9 @@ func (s *PostgresOAuthStore) RevokeConnection(ctx context.Context, organizationI
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit revoke platform mcp connection: %w", err)
 	}
-	s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonConnectionRevoked)
+	if !connection.ReauthorizationRequiredAt.Valid {
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonConnectionRevoked)
+	}
 	return nil
 }
 
@@ -454,13 +456,20 @@ func (s *PostgresOAuthStore) DetectRefreshReuse(ctx context.Context, organizatio
 		}
 		return false, nil
 	}
-	if err := q.RevokePlatformMCPSessionFamily(ctx, platformrepo.RevokePlatformMCPSessionFamilyParams{OrganizationID: organizationID, ConnectionID: row.ConnectionID, ConnectionGeneration: row.ConnectionGeneration, RevokedAt: timestamp(now)}); err != nil {
-		return false, fmt.Errorf("revoke reused platform mcp session family: %w", err)
+	terminalized := false
+	if !row.ReauthorizationRequiredAt.Valid {
+		err := markConnectionTerminal(ctx, q, row.OrganizationID, row.ConnectionID, row.ConnectionGeneration, platformoauth.ReauthorizationReasonRefreshReuse, now)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return false, err
+		}
+		terminalized = err == nil
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return false, fmt.Errorf("commit reused platform mcp session family: %w", err)
 	}
-	s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
+	if terminalized {
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
+	}
 	return true, nil
 }
 

--- a/server/internal/platformmcp/oauthstore.go
+++ b/server/internal/platformmcp/oauthstore.go
@@ -24,13 +24,27 @@ import (
 // codes and refresh tokens hashed, and uses transactions for every transition
 // that locks or invalidates a grant/session family.
 type PostgresOAuthStore struct {
-	db *pgxpool.Pool
+	db        *pgxpool.Pool
+	telemetry OAuthTelemetry
 }
 
 var _ platformoauth.Store = (*PostgresOAuthStore)(nil)
 
 func NewPostgresOAuthStore(db *pgxpool.Pool) *PostgresOAuthStore {
-	return &PostgresOAuthStore{db: db}
+	return &PostgresOAuthStore{db: db, telemetry: noopOAuthTelemetry{}}
+}
+
+func (s *PostgresOAuthStore) WithTelemetry(telemetry OAuthTelemetry) *PostgresOAuthStore {
+	if telemetry != nil {
+		s.telemetry = telemetry
+	}
+	return s
+}
+
+func (s *PostgresOAuthStore) recordTerminalTransition(ctx context.Context, reason platformoauth.ReauthorizationReason) {
+	if s != nil && s.telemetry != nil {
+		s.telemetry.RecordTerminalTransition(ctx, reason)
+	}
 }
 
 func (s *PostgresOAuthStore) RegisterClient(ctx context.Context, client platformoauth.Client) error {
@@ -91,6 +105,9 @@ func (s *PostgresOAuthStore) RevokeClient(ctx context.Context, clientID string, 
 
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit revoke platform mcp client: %w", err)
+	}
+	for range connections {
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonClientRevoked)
 	}
 	return nil
 }
@@ -262,6 +279,7 @@ func (s *PostgresOAuthStore) RevokeConnection(ctx context.Context, organizationI
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit revoke platform mcp connection: %w", err)
 	}
+	s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonConnectionRevoked)
 	return nil
 }
 
@@ -442,6 +460,7 @@ func (s *PostgresOAuthStore) DetectRefreshReuse(ctx context.Context, organizatio
 	if err := tx.Commit(ctx); err != nil {
 		return false, fmt.Errorf("commit reused platform mcp session family: %w", err)
 	}
+	s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
 	return true, nil
 }
 
@@ -472,6 +491,7 @@ func (s *PostgresOAuthStore) PrepareRefresh(ctx context.Context, input platformo
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit reused platform mcp refresh: %w", err)
 		}
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
 		return platformoauth.Session{}, platformoauth.ErrAlreadyUsed
 	}
 	if row.ConnectionRevokedAt.Valid || row.ClientRevokedAt.Valid || row.ReauthorizationRequiredAt.Valid {
@@ -487,6 +507,7 @@ func (s *PostgresOAuthStore) PrepareRefresh(ctx context.Context, input platformo
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit expired platform mcp authorization: %w", err)
 		}
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonAuthorizationExpired)
 		return platformoauth.Session{}, platformoauth.ErrExpired
 	}
 	if !row.RefreshExpiresAt.Valid || !input.Now.Before(row.RefreshExpiresAt.Time) {
@@ -496,6 +517,7 @@ func (s *PostgresOAuthStore) PrepareRefresh(ctx context.Context, input platformo
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit expired platform mcp refresh: %w", err)
 		}
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshIdleExpired)
 		return platformoauth.Session{}, platformoauth.ErrExpired
 	}
 	session := sessionFromRefreshRow(row)
@@ -532,6 +554,7 @@ func (s *PostgresOAuthStore) RotateSession(ctx context.Context, input platformoa
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit reused platform mcp session family: %w", err)
 		}
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
 		return platformoauth.Session{}, platformoauth.ErrAlreadyUsed
 	}
 	if row.OrganizationID != input.OrganizationID || row.ClientID != input.ClientID || row.ConnectionGeneration.String() != input.Generation || row.ActiveGeneration != row.ConnectionGeneration || input.Replacement.Connection.ID != row.ConnectionID.String() || input.Replacement.Connection.Generation != row.ConnectionGeneration.String() {
@@ -547,6 +570,7 @@ func (s *PostgresOAuthStore) RotateSession(ctx context.Context, input platformoa
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit expired platform mcp authorization: %w", err)
 		}
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonAuthorizationExpired)
 		return platformoauth.Session{}, platformoauth.ErrExpired
 	}
 	if !row.RefreshExpiresAt.Valid || !input.Now.Before(row.RefreshExpiresAt.Time) {
@@ -556,6 +580,7 @@ func (s *PostgresOAuthStore) RotateSession(ctx context.Context, input platformoa
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit expired platform mcp session: %w", err)
 		}
+		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshIdleExpired)
 		return platformoauth.Session{}, platformoauth.ErrExpired
 	}
 	if input.Replacement.ExpiresAt.After(row.EffectiveAuthorizationExpiresAt.Time) || input.Replacement.RefreshExpiresAt.After(row.EffectiveAuthorizationExpiresAt.Time) {
@@ -603,6 +628,7 @@ func (s *PostgresOAuthStore) MarkAuthorizationLost(ctx context.Context, organiza
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit mark platform mcp authorization lost: %w", err)
 	}
+	s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonAuthorizationLost)
 	return nil
 }
 
@@ -632,6 +658,7 @@ func (s *PostgresOAuthStore) RevokeSession(ctx context.Context, organizationID, 
 	if err := tx.Commit(ctx); err != nil {
 		return platformoauth.Session{}, fmt.Errorf("commit revoke platform mcp session: %w", err)
 	}
+	s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonConnectionRevoked)
 	return platformoauth.Session{ID: row.ID.String(), ClientID: row.ClientID, JTI: row.Jti, RefreshHash: row.RefreshTokenHash, ExpiresAt: row.ExpiresAt.Time, RefreshExpiresAt: row.RefreshExpiresAt.Time, RevokedAt: &now, Connection: platformoauth.Connection{ID: row.ConnectionID.String(), ClientID: row.ClientID, Subject: row.SubjectUrn, OrganizationID: row.OrganizationID, Generation: row.ConnectionGeneration.String()}}, nil
 }
 

--- a/server/internal/platformmcp/oauthstore.go
+++ b/server/internal/platformmcp/oauthstore.go
@@ -456,13 +456,9 @@ func (s *PostgresOAuthStore) DetectRefreshReuse(ctx context.Context, organizatio
 		}
 		return false, nil
 	}
-	terminalized := false
-	if !row.ReauthorizationRequiredAt.Valid {
-		err := markConnectionTerminal(ctx, q, row.OrganizationID, row.ConnectionID, row.ConnectionGeneration, platformoauth.ReauthorizationReasonRefreshReuse, now)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return false, err
-		}
-		terminalized = err == nil
+	terminalized, err := terminalizeRefreshReuse(ctx, q, row, now)
+	if err != nil {
+		return false, err
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return false, fmt.Errorf("commit reused platform mcp session family: %w", err)
@@ -494,13 +490,16 @@ func (s *PostgresOAuthStore) PrepareRefresh(ctx context.Context, input platformo
 		if !row.RotatedAt.Valid {
 			return platformoauth.Session{}, platformoauth.ErrRevoked
 		}
-		if err := markConnectionTerminal(ctx, q, row.OrganizationID, row.ConnectionID, row.ConnectionGeneration, platformoauth.ReauthorizationReasonRefreshReuse, input.Now); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		terminalized, err := terminalizeRefreshReuse(ctx, q, row, input.Now)
+		if err != nil {
 			return platformoauth.Session{}, err
 		}
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit reused platform mcp refresh: %w", err)
 		}
-		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
+		if terminalized {
+			s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
+		}
 		return platformoauth.Session{}, platformoauth.ErrAlreadyUsed
 	}
 	if row.ConnectionRevokedAt.Valid || row.ClientRevokedAt.Valid || row.ReauthorizationRequiredAt.Valid {
@@ -557,13 +556,16 @@ func (s *PostgresOAuthStore) RotateSession(ctx context.Context, input platformoa
 		if !row.RotatedAt.Valid {
 			return platformoauth.Session{}, platformoauth.ErrRevoked
 		}
-		if err := markConnectionTerminal(ctx, q, row.OrganizationID, row.ConnectionID, row.ConnectionGeneration, platformoauth.ReauthorizationReasonRefreshReuse, input.Now); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		terminalized, err := terminalizeRefreshReuse(ctx, q, row, input.Now)
+		if err != nil {
 			return platformoauth.Session{}, err
 		}
 		if err := tx.Commit(ctx); err != nil {
 			return platformoauth.Session{}, fmt.Errorf("commit reused platform mcp session family: %w", err)
 		}
-		s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
+		if terminalized {
+			s.recordTerminalTransition(ctx, platformoauth.ReauthorizationReasonRefreshReuse)
+		}
 		return platformoauth.Session{}, platformoauth.ErrAlreadyUsed
 	}
 	if row.OrganizationID != input.OrganizationID || row.ClientID != input.ClientID || row.ConnectionGeneration.String() != input.Generation || row.ActiveGeneration != row.ConnectionGeneration || input.Replacement.Connection.ID != row.ConnectionID.String() || input.Replacement.Connection.Generation != row.ConnectionGeneration.String() {
@@ -743,6 +745,20 @@ func (s *PostgresOAuthStore) createSessionWithQueries(ctx context.Context, q *pl
 	}
 	_, err = q.CreatePlatformMCPSession(ctx, platformrepo.CreatePlatformMCPSessionParams{ID: id, OrganizationID: session.Connection.OrganizationID, ConnectionID: connectionID, OauthClientID: connection.OauthClientID, ConnectionGeneration: generation, Jti: session.JTI, RefreshTokenHash: session.RefreshHash, ExpiresAt: timestamp(session.ExpiresAt), RefreshExpiresAt: timestamp(session.RefreshExpiresAt)})
 	return mapOAuthWriteError(err)
+}
+
+func terminalizeRefreshReuse(ctx context.Context, q *platformrepo.Queries, row platformrepo.GetPlatformMCPSessionForRefreshForUpdateRow, now time.Time) (bool, error) {
+	if row.ReauthorizationRequiredAt.Valid {
+		return false, nil
+	}
+	err := markConnectionTerminal(ctx, q, row.OrganizationID, row.ConnectionID, row.ConnectionGeneration, platformoauth.ReauthorizationReasonRefreshReuse, now)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func validateSessionConnection(ctx context.Context, q *platformrepo.Queries, session platformoauth.Session) error {

--- a/server/internal/platformmcp/oauthstore_test.go
+++ b/server/internal/platformmcp/oauthstore_test.go
@@ -3,11 +3,13 @@ package platformmcp
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
@@ -32,6 +34,16 @@ func TestConnectionFromRowDerivesLegacyAuthorizationDeadline(t *testing.T) {
 
 	connection := connectionFromRow(row, "client-1")
 	require.Equal(t, reauthorizedAt.Add(platformoauth.AuthorizationLifetime), connection.AuthorizationExpiresAt)
+}
+
+func TestJWTAuthenticationStoreErrorClassifiesAvailability(t *testing.T) {
+	t.Parallel()
+
+	storeErr := errors.New("database unavailable")
+
+	require.ErrorIs(t, jwtAuthenticationStoreError(pgx.ErrNoRows), ErrUnauthorized)
+	require.ErrorIs(t, jwtAuthenticationStoreError(storeErr), ErrUnavailable)
+	require.ErrorIs(t, jwtAuthenticationStoreError(storeErr), storeErr)
 }
 
 func TestVerifyPKCE(t *testing.T) {

--- a/server/internal/platformmcp/registration_integration_test.go
+++ b/server/internal/platformmcp/registration_integration_test.go
@@ -50,6 +50,46 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestPostgresOAuthStoreRefreshReplayRecordsTerminalTransitionOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_refresh_replay_terminal_metric")
+	require.NoError(t, err)
+
+	organizationID := "org_" + uuid.NewString()
+	_, err = organizationsrepo.New(conn).UpsertOrganizationMetadata(ctx, organizationsrepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Platform MCP OAuth test organization",
+		Slug:        "org-" + uuid.NewString()[:8],
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	telemetry := &testOAuthTelemetry{}
+	store := NewPostgresOAuthStore(conn).WithTelemetry(telemetry)
+	client := platformoauth.Client{ID: "client-" + uuid.NewString(), Name: "Platform MCP OAuth test client", RedirectURIs: []string{"https://client.example.test/callback"}}
+	require.NoError(t, store.RegisterClient(ctx, client))
+	connection := platformoauth.Connection{ID: uuid.NewString(), ClientID: client.ID, Subject: userSubjectURN("user_" + uuid.NewString()), OrganizationID: organizationID, Generation: uuid.NewString(), AuthorizationExpiresAt: now.Add(platformoauth.AuthorizationLifetime)}
+	require.NoError(t, store.RegisterConnection(ctx, connection))
+	parent := platformoauth.Session{ID: uuid.NewString(), ClientID: client.ID, Connection: connection, JTI: "jti-" + uuid.NewString(), RefreshHash: "refresh-" + uuid.NewString(), ExpiresAt: now.Add(time.Hour), RefreshExpiresAt: now.Add(30 * 24 * time.Hour)}
+	require.NoError(t, store.CreateSession(ctx, parent))
+	replacement := parent
+	replacement.ID = uuid.NewString()
+	replacement.JTI = "jti-" + uuid.NewString()
+	replacement.RefreshHash = "refresh-" + uuid.NewString()
+	_, err = store.RotateSession(ctx, platformoauth.RotateSessionInput{OrganizationID: organizationID, RefreshHash: parent.RefreshHash, ClientID: client.ID, Generation: connection.Generation, Now: now.Add(time.Minute), Replacement: replacement})
+	require.NoError(t, err)
+
+	_, err = store.PrepareRefresh(ctx, platformoauth.PrepareRefreshInput{OrganizationID: organizationID, RefreshHash: parent.RefreshHash, ClientID: client.ID, Now: now.Add(2 * time.Minute)})
+	require.ErrorIs(t, err, platformoauth.ErrAlreadyUsed)
+	_, err = store.RotateSession(ctx, platformoauth.RotateSessionInput{OrganizationID: organizationID, RefreshHash: parent.RefreshHash, ClientID: client.ID, Generation: connection.Generation, Now: now.Add(3 * time.Minute), Replacement: platformoauth.Session{ID: uuid.NewString(), ClientID: client.ID, Connection: connection, JTI: "jti-" + uuid.NewString(), RefreshHash: "refresh-" + uuid.NewString(), ExpiresAt: now.Add(time.Hour), RefreshExpiresAt: now.Add(30 * 24 * time.Hour)}})
+	require.ErrorIs(t, err, platformoauth.ErrAlreadyUsed)
+	require.Equal(t, []platformoauth.ReauthorizationReason{platformoauth.ReauthorizationReasonRefreshReuse}, telemetry.terminalTransitionReasons)
+}
+
 func TestPostgresOAuthStoreRefreshReplayAfterConnectionRevocationIsTerminal(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -188,6 +188,11 @@ func (r *Runtime) Handler() http.Handler {
 
 		principal, err := r.authenticate(req)
 		if err != nil {
+			if errors.Is(err, ErrUnavailable) {
+				r.recordAuthOutcome(req.Context(), "temporarily_unavailable", "")
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+				return
+			}
 			r.recordAuthOutcome(req.Context(), "unauthorized", "")
 			if r.protectedResourceURL != "" {
 				w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+r.protectedResourceURL+`"`)
@@ -207,8 +212,13 @@ func (r *Runtime) Handler() http.Handler {
 			return
 		}
 		if err := r.authorizer.RequireLiveOrgAdmin(req.Context(), principal); err != nil {
-			r.recordAuthOutcome(req.Context(), "access_denied", "authorization_denied")
-			http.Error(w, "forbidden", http.StatusForbidden)
+			if isAuthorizationDenied(err) {
+				r.recordAuthOutcome(req.Context(), "access_denied", "authorization_denied")
+				http.Error(w, "forbidden", http.StatusForbidden)
+			} else {
+				r.recordAuthOutcome(req.Context(), "temporarily_unavailable", "")
+				http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			}
 			return
 		}
 

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -109,6 +109,7 @@ type Runtime struct {
 	authorizer           Authorizer
 	protectedResourceURL string
 	readiness            ReadinessRecorder
+	telemetry            OAuthTelemetry
 	server               *mcp.Server
 }
 
@@ -132,6 +133,7 @@ func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, g
 		authorizer:           authorizer,
 		protectedResourceURL: protectedResourceURL,
 		readiness:            readiness,
+		telemetry:            noopOAuthTelemetry{},
 		server:               server,
 		registrar:            registrar,
 	}
@@ -155,6 +157,19 @@ func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, g
 	return runtime
 }
 
+func (r *Runtime) WithOAuthTelemetry(telemetry OAuthTelemetry) *Runtime {
+	if telemetry != nil {
+		r.telemetry = telemetry
+	}
+	return r
+}
+
+func (r *Runtime) recordAuthOutcome(ctx context.Context, outcome, reason string) {
+	if r.telemetry != nil {
+		r.telemetry.Record(ctx, OAuthEvent{Operation: "runtime_auth", Outcome: outcome, Reason: reason})
+	}
+}
+
 func (r *Runtime) Handler() http.Handler {
 	handler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		return r.server
@@ -173,6 +188,7 @@ func (r *Runtime) Handler() http.Handler {
 
 		principal, err := r.authenticate(req)
 		if err != nil {
+			r.recordAuthOutcome(req.Context(), "unauthorized", "")
 			if r.protectedResourceURL != "" {
 				w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+r.protectedResourceURL+`"`)
 			}
@@ -181,18 +197,22 @@ func (r *Runtime) Handler() http.Handler {
 		}
 		enabled, err := r.gate.Enabled(req.Context(), principal.OrganizationID)
 		if err != nil {
+			r.recordAuthOutcome(req.Context(), "temporarily_unavailable", "")
 			http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			return
 		}
 		if !enabled {
+			r.recordAuthOutcome(req.Context(), "access_denied", "platform_disabled")
 			http.Error(w, "unavailable", http.StatusForbidden)
 			return
 		}
 		if err := r.authorizer.RequireLiveOrgAdmin(req.Context(), principal); err != nil {
+			r.recordAuthOutcome(req.Context(), "access_denied", "authorization_denied")
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
 
+		r.recordAuthOutcome(req.Context(), "succeeded", "")
 		req = req.WithContext(contextWithPrincipal(req.Context(), principal))
 		req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
 		w.Header().Set("Cache-Control", "no-store")

--- a/server/internal/platformmcp/runtime_test.go
+++ b/server/internal/platformmcp/runtime_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	platformoauth "github.com/speakeasy-api/gram/server/internal/platformmcp/oauth"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -57,29 +58,63 @@ func TestRuntimeHandlerFailsClosedWhenGateIsDisabledOrErrors(t *testing.T) {
 	}
 }
 
-func TestRuntimeHandlerRequiresLiveOrganizationAdmin(t *testing.T) {
+func TestRuntimeHandlerClassifiesAuthenticationFailures(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name string
-		err  error
+		name      string
+		authErr   error
+		status    int
+		telemetry OAuthEvent
 	}{
-		{name: "denied", err: ErrForbidden},
-		{name: "unexpected error", err: errors.New("authorization store unavailable")},
+		{name: "unavailable", authErr: ErrUnavailable, status: http.StatusServiceUnavailable, telemetry: OAuthEvent{Operation: "runtime_auth", Outcome: "temporarily_unavailable"}},
+		{name: "unauthorized", authErr: ErrUnauthorized, status: http.StatusUnauthorized, telemetry: OAuthEvent{Operation: "runtime_auth", Outcome: "unauthorized"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			authorizer := &testAuthorizer{err: tc.err}
-			handler := NewRuntime(testenv.NewLogger(t), &testAuthenticator{principal: testPrincipal()}, testGate{enabled: true}, authorizer, "", "test-cursor-key", nil, nil, nil, nil, nil).Handler()
+			telemetry := &testOAuthTelemetry{}
+			handler := NewRuntime(testenv.NewLogger(t), &testAuthenticator{err: tc.authErr}, testGate{enabled: true}, &testAuthorizer{}, "", "test-cursor-key", nil, nil, nil, nil, nil).WithOAuthTelemetry(telemetry).Handler()
 			req := httptest.NewRequest(http.MethodPost, Path, nil)
 			req.Header.Set("Authorization", "Bearer access-token")
 			res := httptest.NewRecorder()
 
 			handler.ServeHTTP(res, req)
 
-			require.Equal(t, http.StatusForbidden, res.Code)
+			require.Equal(t, tc.status, res.Code)
+			require.Equal(t, []OAuthEvent{tc.telemetry}, telemetry.events)
+		})
+	}
+}
+
+func TestRuntimeHandlerRequiresLiveOrganizationAdmin(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		err       error
+		status    int
+		telemetry OAuthEvent
+	}{
+		{name: "denied", err: ErrForbidden, status: http.StatusForbidden, telemetry: OAuthEvent{Operation: "runtime_auth", Outcome: "access_denied", Reason: "authorization_denied"}},
+		{name: "unavailable", err: ErrUnavailable, status: http.StatusServiceUnavailable, telemetry: OAuthEvent{Operation: "runtime_auth", Outcome: "temporarily_unavailable"}},
+		{name: "unexpected error", err: errors.New("authorization store unavailable"), status: http.StatusServiceUnavailable, telemetry: OAuthEvent{Operation: "runtime_auth", Outcome: "temporarily_unavailable"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			authorizer := &testAuthorizer{err: tc.err}
+			telemetry := &testOAuthTelemetry{}
+			handler := NewRuntime(testenv.NewLogger(t), &testAuthenticator{principal: testPrincipal()}, testGate{enabled: true}, authorizer, "", "test-cursor-key", nil, nil, nil, nil, nil).WithOAuthTelemetry(telemetry).Handler()
+			req := httptest.NewRequest(http.MethodPost, Path, nil)
+			req.Header.Set("Authorization", "Bearer access-token")
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			require.Equal(t, tc.status, res.Code)
 			require.Equal(t, 1, authorizer.calls)
+			require.Equal(t, []OAuthEvent{tc.telemetry}, telemetry.events)
 		})
 	}
 }
@@ -150,6 +185,19 @@ func (r *testReadinessRecorder) RecordReady(_ context.Context, principal Princip
 	r.calls++
 	r.principal = principal
 	return nil
+}
+
+type testOAuthTelemetry struct {
+	events []OAuthEvent
+}
+
+func (t *testOAuthTelemetry) Record(_ context.Context, event OAuthEvent) {
+	t.events = append(t.events, event)
+}
+
+func (*testOAuthTelemetry) RecordRefreshSuccess(context.Context, time.Duration, time.Duration) {}
+
+func (*testOAuthTelemetry) RecordTerminalTransition(context.Context, platformoauth.ReauthorizationReason) {
 }
 
 type testAuthenticator struct {

--- a/server/internal/platformmcp/runtime_test.go
+++ b/server/internal/platformmcp/runtime_test.go
@@ -188,7 +188,8 @@ func (r *testReadinessRecorder) RecordReady(_ context.Context, principal Princip
 }
 
 type testOAuthTelemetry struct {
-	events []OAuthEvent
+	events                    []OAuthEvent
+	terminalTransitionReasons []platformoauth.ReauthorizationReason
 }
 
 func (t *testOAuthTelemetry) Record(_ context.Context, event OAuthEvent) {
@@ -197,7 +198,8 @@ func (t *testOAuthTelemetry) Record(_ context.Context, event OAuthEvent) {
 
 func (*testOAuthTelemetry) RecordRefreshSuccess(context.Context, time.Duration, time.Duration) {}
 
-func (*testOAuthTelemetry) RecordTerminalTransition(context.Context, platformoauth.ReauthorizationReason) {
+func (t *testOAuthTelemetry) RecordTerminalTransition(_ context.Context, reason platformoauth.ReauthorizationReason) {
+	t.terminalTransitionReasons = append(t.terminalTransitionReasons, reason)
 }
 
 type testAuthenticator struct {


### PR DESCRIPTION
## Why

AGE-3248 follows durable Platform MCP refresh work with the operational signals needed to detect refresh failures, unexpected reauthorization, and revocation behavior without exposing OAuth credentials or customer identifiers.

## What changed

- Added bounded OpenTelemetry counters and histograms for OAuth exchanges, successful refresh latency, authorization-generation age, runtime authorization outcomes, and committed terminal reauthorization transitions.
- Wired the telemetry into browser and local-fixture Platform MCP composition, durable OAuth-store transitions, and the runtime authorization gate.
- Added a Datadog runbook with dashboard panels, starting monitor thresholds, and the synthetic revocation-to-denial probe contract.
- Added regression tests that reject unbounded dimensions, avoid retaining bearer-token response bodies, and classify successful browser authorization redirects correctly.

## Review notes

- `server/internal/platformmcp/oauth_telemetry.go` defines the complete allowed metric vocabulary; it is deliberately separate from the existing registration/readiness lifecycle metric.
- OAuth response instrumentation stores only bounded outcome/reason labels. It does not read or retain response bodies, so minted access and refresh tokens cannot enter telemetry.
- Terminal transition signals are emitted only after their durable database transaction commits. Durable state remains the lifecycle authority; telemetry is operational evidence.

## Testing

- `mise exec -- go test ./server/internal/platformmcp`
- `mise exec -- go test ./server/cmd/gram -run '^$'`
- `hk fix` on changed Go files
- `git diff --check`

## Rollout / deployment notes

- Stack on #5380; base branch: `tristan/age-3163-platform-mcp-dashboard-ctas`.
- No migration or feature-flag change.
- Create the documented monitors in Datadog before expanding the internal dogfood cohort.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds privacy-safe OpenTelemetry for Platform MCP durable OAuth and runtime auth, and clarifies dashboard/monitor rollout. Previously only readiness was observable; now we emit bounded outcome/latency metrics and committed reauthorization transitions to detect refresh failures, reauthorization, and revocation without leaking credentials.

- Metrics: `platform_mcp.oauth.events`, `platform_mcp.oauth.refresh_duration`, `platform_mcp.oauth.connection_age`, `platform_mcp.oauth.reauthorization_required` tagged by `platform_mcp.operation`, `platform_mcp.outcome`, optional `platform_mcp.reason` (fixed vocabulary only; never tokens, JTIs, org/client IDs, or free‑form errors).
- `OAuthHTTP`: instruments `interactive_authorization`, `code_exchange`, and `refresh` via a response recorder that sets explicit outcomes and bounded reasons from gate/state errors; records refresh latency and generation age on successful refresh only.
- `PostgresOAuthStore.WithTelemetry`: emits `reauthorization_required` after commit for `refresh_reuse`, `authorization_expired`, `refresh_idle_expired`, `connection_revoked`, `client_revoked`, `authorization_lost`, `security_reset`; `refresh_reuse` is recorded once per connection generation. In‑memory store mirrors single terminalization.
- Runtime auth: records `runtime_auth` outcomes `unauthorized`, `temporarily_unavailable`, and `access_denied` (reasons `platform_disabled`, `authorization_denied`); JWT auth store errors are classified as `temporarily_unavailable`.
- Wiring: `server/cmd/gram` now provides telemetry to `OAuthHTTP`, `PostgresOAuthStore.WithTelemetry`, and `Runtime.WithOAuthTelemetry`.
- Tests: enforce bounded dimensions, no response‑body retention, redirect-success classification, outage classification, and single terminalization on refresh replay.

**Rollout**
- No migrations or feature‑flag changes.
- Create the Datadog dashboard and monitors per the runbook in the Datadog UI and link them to the runbook before widening rollout; revocation‑to‑denial latency is measured by an external synthetic probe per the documented contract.
- Satisfies Linear AGE-3248 production observability requirements.

<sup>Written for commit 560905a76a71f8ea65ae0221002ca1ca2b48aea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

