### PR TITLE
feat(admin): count MCP servers per project on the organization projects list

### DIFF
--- a/.changeset/admin-project-mcp-server-count.md
+++ b/.changeset/admin-project-mcp-server-count.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+The admin projects list now reports how many MCP servers each project has, so an operator can read the number off the list instead of opening every project. The count covers both server models at once: every `mcp_servers` row in the project, plus every MCP-enabled toolset that no `mcp_servers` row already describes.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -56479,6 +56479,10 @@ components:
         id:
           type: string
           description: The ID of the project
+        mcp_server_count:
+          type: integer
+          description: Number of MCP servers in the project, counting both toolset-backed servers and mcp_servers rows.
+          format: int64
         name:
           type: string
           description: The name of the project
@@ -56494,6 +56498,7 @@ components:
         - id
         - name
         - slug
+        - mcp_server_count
         - created_at
         - updated_at
     AdminProjectDetail:

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -54,11 +54,12 @@ var AdminOrganization = Type("AdminOrganization", func() {
 
 var AdminProject = Type("AdminProject", func() {
 	Description("Project summary surfaced to admin operators.")
-	Required("id", "name", "slug", "created_at", "updated_at")
+	Required("id", "name", "slug", "mcp_server_count", "created_at", "updated_at")
 
 	Attribute("id", String, "The ID of the project")
 	Attribute("name", String, "The name of the project")
 	Attribute("slug", String, "The slug of the project")
+	Attribute("mcp_server_count", Int, "Number of MCP servers in the project, counting both toolset-backed servers and mcp_servers rows.")
 	Attribute("created_at", String, func() {
 		Description("The creation date of the project.")
 		Format(FormatDateTime)

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -198,6 +198,9 @@ type AdminProject struct {
 	Name string
 	// The slug of the project
 	Slug string
+	// Number of MCP servers in the project, counting both toolset-backed servers
+	// and mcp_servers rows.
+	McpServerCount int
 	// The creation date of the project.
 	CreatedAt string
 	// The last update date of the project.

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -3844,11 +3844,12 @@ func unmarshalAdminOrganizationMemberResponseBodyToAdminAdminOrganizationMember(
 // *admin.AdminProject from a value of type *AdminProjectResponseBody.
 func unmarshalAdminProjectResponseBodyToAdminAdminProject(v *AdminProjectResponseBody) *admin.AdminProject {
 	res := &admin.AdminProject{
-		ID:        *v.ID,
-		Name:      *v.Name,
-		Slug:      *v.Slug,
-		CreatedAt: *v.CreatedAt,
-		UpdatedAt: *v.UpdatedAt,
+		ID:             *v.ID,
+		Name:           *v.Name,
+		Slug:           *v.Slug,
+		McpServerCount: *v.McpServerCount,
+		CreatedAt:      *v.CreatedAt,
+		UpdatedAt:      *v.UpdatedAt,
 	}
 
 	return res

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -3351,6 +3351,9 @@ type AdminProjectResponseBody struct {
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// The slug of the project
 	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Number of MCP servers in the project, counting both toolset-backed servers
+	// and mcp_servers rows.
+	McpServerCount *int `form:"mcp_server_count,omitempty" json:"mcp_server_count,omitempty" xml:"mcp_server_count,omitempty"`
 	// The creation date of the project.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// The last update date of the project.
@@ -10527,6 +10530,9 @@ func ValidateAdminProjectResponseBody(body *AdminProjectResponseBody) (err error
 	}
 	if body.Slug == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.McpServerCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("mcp_server_count", "body"))
 	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -3413,11 +3413,12 @@ func marshalAdminAdminOrganizationMemberToAdminOrganizationMemberResponseBody(v 
 // *AdminProjectResponseBody from a value of type *admin.AdminProject.
 func marshalAdminAdminProjectToAdminProjectResponseBody(v *admin.AdminProject) *AdminProjectResponseBody {
 	res := &AdminProjectResponseBody{
-		ID:        v.ID,
-		Name:      v.Name,
-		Slug:      v.Slug,
-		CreatedAt: v.CreatedAt,
-		UpdatedAt: v.UpdatedAt,
+		ID:             v.ID,
+		Name:           v.Name,
+		Slug:           v.Slug,
+		McpServerCount: v.McpServerCount,
+		CreatedAt:      v.CreatedAt,
+		UpdatedAt:      v.UpdatedAt,
 	}
 
 	return res

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -3353,6 +3353,9 @@ type AdminProjectResponseBody struct {
 	Name string `form:"name" json:"name" xml:"name"`
 	// The slug of the project
 	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Number of MCP servers in the project, counting both toolset-backed servers
+	// and mcp_servers rows.
+	McpServerCount int `form:"mcp_server_count" json:"mcp_server_count" xml:"mcp_server_count"`
 	// The creation date of the project.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// The last update date of the project.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -57278,6 +57278,10 @@ components:
                 id:
                     type: string
                     description: The ID of the project
+                mcp_server_count:
+                    type: integer
+                    description: Number of MCP servers in the project, counting both toolset-backed servers and mcp_servers rows.
+                    format: int64
                 name:
                     type: string
                     description: The name of the project
@@ -57293,6 +57297,7 @@ components:
                 - id
                 - name
                 - slug
+                - mcp_server_count
                 - created_at
                 - updated_at
         AdminProjectDetail:

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -596,11 +596,12 @@ func (s *Service) ListOrganizationProjects(ctx context.Context, payload *gen.Lis
 	projects := make([]*gen.AdminProject, len(rows))
 	for i, row := range rows {
 		projects[i] = &gen.AdminProject{
-			ID:        row.ID.String(),
-			Name:      row.Name,
-			Slug:      row.Slug,
-			CreatedAt: row.CreatedAt.Time.Format(time.RFC3339),
-			UpdatedAt: row.UpdatedAt.Time.Format(time.RFC3339),
+			ID:             row.ID.String(),
+			Name:           row.Name,
+			Slug:           row.Slug,
+			McpServerCount: int(row.McpServerCount),
+			CreatedAt:      row.CreatedAt.Time.Format(time.RFC3339),
+			UpdatedAt:      row.UpdatedAt.Time.Format(time.RFC3339),
 		}
 	}
 

--- a/server/internal/admin/listorganizationprojects_test.go
+++ b/server/internal/admin/listorganizationprojects_test.go
@@ -1,0 +1,251 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	mcpserversRepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+func seedToolset(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, projectID uuid.UUID, slug string, mcpEnabled bool) uuid.UUID {
+	t.Helper()
+
+	ts, err := toolsetsRepo.New(conn).CreateToolset(ctx, toolsetsRepo.CreateToolsetParams{
+		OrganizationID: orgID,
+		ProjectID:      projectID,
+		Name:           slug,
+		Slug:           slug,
+		McpSlug:        pgtype.Text{String: slug, Valid: true},
+		McpEnabled:     mcpEnabled,
+	})
+	require.NoError(t, err)
+
+	return ts.ID
+}
+
+// Every mcp_servers row needs exactly one backend, and a toolset-backed one is
+// the only backend that needs no other row seeded alongside it.
+func seedMCPServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, toolsetID uuid.UUID, slug string) uuid.UUID {
+	t.Helper()
+
+	id := uuid.New()
+	srv, err := mcpserversRepo.New(conn).CreateMCPServer(ctx, mcpserversRepo.CreateMCPServerParams{
+		ID:         id,
+		ProjectID:  projectID,
+		Name:       pgtype.Text{String: slug, Valid: true},
+		Slug:       pgtype.Text{String: slug, Valid: true},
+		ToolsetID:  uuid.NullUUID{UUID: toolsetID, Valid: true},
+		Visibility: "disabled",
+	})
+	require.NoError(t, err)
+
+	return srv.ID
+}
+
+func deleteToolset(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, slug string) {
+	t.Helper()
+
+	_, err := toolsetsRepo.New(conn).DeleteToolset(ctx, toolsetsRepo.DeleteToolsetParams{
+		Slug:      slug,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+}
+
+func deleteMCPServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, id uuid.UUID) {
+	t.Helper()
+
+	_, err := mcpserversRepo.New(conn).DeleteMCPServer(ctx, mcpserversRepo.DeleteMCPServerParams{
+		ID:        id,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+}
+
+func listProjects(t *testing.T, ctx context.Context, svc *Service, orgID string) map[string]int {
+	t.Helper()
+
+	res, err := svc.ListOrganizationProjects(ctx, &gen.ListOrganizationProjectsPayload{OrganizationID: orgID})
+	require.NoError(t, err)
+
+	counts := make(map[string]int, len(res.Projects))
+	for _, p := range res.Projects {
+		counts[p.Slug] = p.McpServerCount
+	}
+
+	return counts
+}
+
+func TestListOrganizationProjects_CountIsZeroWithoutServers(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedProject(t, ctx, conn, "org_one", "empty")
+
+	require.Equal(t, map[string]int{"empty": 0}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// A toolset is only an MCP server when mcp_enabled says so.
+func TestListOrganizationProjects_CountsOnlyMCPEnabledToolsets(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "mixed")
+	seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	seedToolset(t, ctx, conn, "org_one", projectID, "plain", false)
+
+	require.Equal(t, map[string]int{"mixed": 1}, listProjects(t, ctx, svc, "org_one"))
+}
+
+func TestListOrganizationProjects_CountsMCPServerRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "new-model")
+	backing := seedToolset(t, ctx, conn, "org_one", projectID, "backing", false)
+	seedMCPServer(t, ctx, conn, projectID, backing, "one")
+	seedMCPServer(t, ctx, conn, projectID, backing, "two")
+
+	require.Equal(t, map[string]int{"new-model": 2}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// The shape AGE-1880's data copy produces: one server described twice, by an
+// mcp_enabled toolset and by the mcp_servers row that points at it. A plain sum
+// of the two halves would report 2.
+func TestListOrganizationProjects_DoesNotDoubleCountAMigratedServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "migrated")
+	toolsetID := seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	seedMCPServer(t, ctx, conn, projectID, toolsetID, "served")
+
+	require.Equal(t, map[string]int{"migrated": 1}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// And the dedupe is per toolset, not a blanket "this project has both models".
+func TestListOrganizationProjects_DedupesPerToolsetNotPerProject(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "half-migrated")
+	migrated := seedToolset(t, ctx, conn, "org_one", projectID, "migrated", true)
+	seedToolset(t, ctx, conn, "org_one", projectID, "legacy", true)
+	seedMCPServer(t, ctx, conn, projectID, migrated, "migrated")
+
+	require.Equal(t, map[string]int{"half-migrated": 2}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// A deleted mcp_servers row stops hiding the toolset it pointed at, so the
+// count has to stay 1 rather than fall to 0.
+func TestListOrganizationProjects_IgnoresDeletedMCPServerRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "deleted-server")
+	toolsetID := seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	serverID := seedMCPServer(t, ctx, conn, projectID, toolsetID, "served")
+	deleteMCPServer(t, ctx, conn, projectID, serverID)
+
+	require.Equal(t, map[string]int{"deleted-server": 1}, listProjects(t, ctx, svc, "org_one"))
+}
+
+func TestListOrganizationProjects_IgnoresDeletedToolsets(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "deleted-toolset")
+	seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	deleteToolset(t, ctx, conn, projectID, "served")
+
+	require.Equal(t, map[string]int{"deleted-toolset": 0}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// A deleted mcp_servers row is not counted on its own half either.
+func TestListOrganizationProjects_IgnoresDeletedServersWithoutAnMCPEnabledToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "deleted-only")
+	backing := seedToolset(t, ctx, conn, "org_one", projectID, "backing", false)
+	serverID := seedMCPServer(t, ctx, conn, projectID, backing, "gone")
+	deleteMCPServer(t, ctx, conn, projectID, serverID)
+
+	require.Equal(t, map[string]int{"deleted-only": 0}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// Each row carries its own count. Transposing the two would still add up.
+func TestListOrganizationProjects_CountsAreNotTransposedAcrossRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+
+	one := seedProject(t, ctx, conn, "org_one", "alpha")
+	seedToolset(t, ctx, conn, "org_one", one, "a1", true)
+
+	three := seedProject(t, ctx, conn, "org_one", "beta")
+	seedToolset(t, ctx, conn, "org_one", three, "b1", true)
+	seedToolset(t, ctx, conn, "org_one", three, "b2", true)
+	seedToolset(t, ctx, conn, "org_one", three, "b3", true)
+
+	require.Equal(t, map[string]int{"alpha": 1, "beta": 3}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// The count is per project, so a sibling project's servers must not leak in
+// even though they share an organization.
+func TestListOrganizationProjects_CountIsScopedToTheProject(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_two", name: "Two", slug: "two"})
+
+	// Both halves of the count are scoped, so both halves are seeded in every
+	// project here: a bare mcp_servers row as well as an mcp_enabled toolset.
+	mine := seedProject(t, ctx, conn, "org_one", "mine")
+	seedMCPServer(t, ctx, conn, mine, seedToolset(t, ctx, conn, "org_one", mine, "m1", false), "m1")
+
+	sibling := seedProject(t, ctx, conn, "org_one", "sibling")
+	seedToolset(t, ctx, conn, "org_one", sibling, "s1", true)
+	seedMCPServer(t, ctx, conn, sibling, seedToolset(t, ctx, conn, "org_one", sibling, "s2", false), "s2")
+
+	theirs := seedProject(t, ctx, conn, "org_two", "theirs")
+	seedMCPServer(t, ctx, conn, theirs, seedToolset(t, ctx, conn, "org_two", theirs, "t1", false), "t1")
+
+	require.Equal(t, map[string]int{"mine": 1, "sibling": 2}, listProjects(t, ctx, svc, "org_one"))
+	require.Equal(t, map[string]int{"theirs": 1}, listProjects(t, ctx, svc, "org_two"))
+}
+
+// A soft-deleted project drops out of the list entirely, count or no count.
+func TestListOrganizationProjects_SkipsDeletedProjects(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	live := seedProject(t, ctx, conn, "org_one", "live")
+	seedToolset(t, ctx, conn, "org_one", live, "l1", true)
+
+	gone := seedProject(t, ctx, conn, "org_one", "gone")
+	seedToolset(t, ctx, conn, "org_one", gone, "g1", true)
+	_, err := projectsRepo.New(conn).DeleteProject(ctx, gone)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]int{"live": 1}, listProjects(t, ctx, svc, "org_one"))
+}

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -298,11 +298,26 @@ SET disabled_at = NULL,
 WHERE id = @id;
 
 -- name: AdminListProjectsForOrganization :many
-SELECT id, slug, name, created_at, updated_at
-FROM projects
-WHERE organization_id = @organization_id
-  AND deleted IS FALSE
-ORDER BY created_at DESC
+-- Not a plain sum: once AGE-1880 copies legacy servers into mcp_servers, a
+-- toolset and its mcp_servers row would each be counted. The anti join on the
+-- legacy half gives the same answer before and after that copy, and it is the
+-- direction that plans as an index anti join rather than a seq scan of toolsets.
+SELECT
+    p.id,
+    p.slug,
+    p.name,
+    p.created_at,
+    p.updated_at,
+    ((SELECT count(*) FROM toolsets t
+        WHERE t.project_id = p.id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+          AND NOT EXISTS (SELECT 1 FROM mcp_servers m2
+                           WHERE m2.toolset_id = t.id AND m2.deleted IS FALSE))
+     + (SELECT count(*) FROM mcp_servers m
+          WHERE m.project_id = p.id AND m.deleted IS FALSE))::bigint AS mcp_server_count
+FROM projects p
+WHERE p.organization_id = @organization_id
+  AND p.deleted IS FALSE
+ORDER BY p.created_at DESC
 LIMIT 200;
 
 -- name: AdminListOrganizationMembers :many

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -591,22 +591,38 @@ func (q *Queries) AdminListOrganizations(ctx context.Context, arg AdminListOrgan
 }
 
 const adminListProjectsForOrganization = `-- name: AdminListProjectsForOrganization :many
-SELECT id, slug, name, created_at, updated_at
-FROM projects
-WHERE organization_id = $1
-  AND deleted IS FALSE
-ORDER BY created_at DESC
+SELECT
+    p.id,
+    p.slug,
+    p.name,
+    p.created_at,
+    p.updated_at,
+    ((SELECT count(*) FROM toolsets t
+        WHERE t.project_id = p.id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+          AND NOT EXISTS (SELECT 1 FROM mcp_servers m2
+                           WHERE m2.toolset_id = t.id AND m2.deleted IS FALSE))
+     + (SELECT count(*) FROM mcp_servers m
+          WHERE m.project_id = p.id AND m.deleted IS FALSE))::bigint AS mcp_server_count
+FROM projects p
+WHERE p.organization_id = $1
+  AND p.deleted IS FALSE
+ORDER BY p.created_at DESC
 LIMIT 200
 `
 
 type AdminListProjectsForOrganizationRow struct {
-	ID        uuid.UUID
-	Slug      string
-	Name      string
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
+	ID             uuid.UUID
+	Slug           string
+	Name           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	McpServerCount int64
 }
 
+// Not a plain sum: once AGE-1880 copies legacy servers into mcp_servers, a
+// toolset and its mcp_servers row would each be counted. The anti join on the
+// legacy half gives the same answer before and after that copy, and it is the
+// direction that plans as an index anti join rather than a seq scan of toolsets.
 func (q *Queries) AdminListProjectsForOrganization(ctx context.Context, organizationID string) ([]AdminListProjectsForOrganizationRow, error) {
 	rows, err := q.db.Query(ctx, adminListProjectsForOrganization, organizationID)
 	if err != nil {
@@ -622,6 +638,7 @@ func (q *Queries) AdminListProjectsForOrganization(ctx context.Context, organiza
 			&i.Name,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.McpServerCount,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
An operator reading an organization's Projects list in the admin console cannot tell which projects actually serve MCP without opening each one. `AdminProject` now carries a required `mcp_server_count`, so the number is on the list.

Server side only. AGE-3277 draws the column and owns everything under `client/`.

Linear: [AGE-3276](https://linear.app/speakeasy/issue/AGE-3276)

## Why the count is not a plain sum

Gram has two MCP server models: an `mcp_enabled` toolset, and a row in `mcp_servers`. The count is every `mcp_servers` row in the project, plus every `mcp_enabled` toolset that no `mcp_servers` row points at.

```sql
(SELECT count(*) FROM toolsets t
   WHERE t.project_id = p.id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
     AND NOT EXISTS (SELECT 1 FROM mcp_servers m2
                      WHERE m2.toolset_id = t.id AND m2.deleted IS FALSE))
+ (SELECT count(*) FROM mcp_servers m
     WHERE m.project_id = p.id AND m.deleted IS FALSE)
```

The two models do not overlap today, so a plain sum would give the same answer right now. They will overlap: AGE-1880's data copy gives each legacy server a matching `mcp_servers` row, and on the day it runs a plain sum starts double counting every migrated server. The anti join answers the same before and after, so nothing has to be revisited then.

The dedupe sits on the legacy half deliberately. That direction plans as a nested loop anti join through `mcp_servers_toolset_id_idx`. The mirror image, anti joining from `mcp_servers` back to `toolsets`, plans as a hash anti join over a **sequential scan of `toolsets`, once per project row** — the shape that caused the outage this epic already fixed once. Plans for both are below.

## This will disagree with the billed count

`GetEnabledServerCount` in `server/internal/usage/queries.sql` counts only `toolsets WHERE mcp_enabled`, so for any organization on the new model this number and the billed one differ. That is accepted, not an oversight. Whether the platform count should change is AGE-3272 and is not this PR's business.

## Verification

- `mise run gen:server` then `git status` clean.
- `mise run lint:server`: 0 findings.
- `go test ./internal/admin/...`: 263 tests, 0 failures, 23.8s.

Mutation sweep against the 23 tests matching `TestListOrganizationProjects|TestGetProject`. Baseline 0 failures; canary (count replaced by a literal `0`) killed 8, so the harness reports.

| Mutation | Result | Tests died |
| --- | --- | --- |
| Canary: count replaced by literal `0` | killed | 8 |
| Drop `mcp_enabled IS TRUE` | killed | 2 |
| Drop the `NOT EXISTS` anti join | killed | 2 |
| Drop `t.deleted IS FALSE` | killed | 1 |
| Drop `m.deleted IS FALSE` | killed | 2 |
| Drop `m2.deleted IS FALSE` inside the anti join | killed | 1 |
| Drop `m.project_id = p.id` | killed | 1 |
| Drop `t.project_id = p.id` | killed | 3 |
| Drop `p.deleted IS FALSE` | killed | 1 |
| Mapper reads the wrong value | killed | 7 |
| Swap the two halves (order only) | **survived** | 0 |
| Move the anti join to the `mcp_servers` half | **survived** | 0 |

Both survivors are numerically equivalent, so no test can kill them and none claims to. They are settled by the plans instead. The `mcp_servers`-side anti join was caught by EXPLAIN, not by a test.

Dropping `m.project_id = p.id` survived the first sweep — the scope test only exercised toolsets. The test now seeds a bare `mcp_servers` row in every project it compares.

<details>
<summary>EXPLAIN, shipped form: no sequential scan</summary>

```
 Limit  (cost=8.15..32.63 rows=1 width=104)
   ->  Result  (cost=8.15..32.63 rows=1 width=104)
         ->  Sort  (cost=8.15..8.16 rows=1 width=96)
               Sort Key: p.created_at DESC
               ->  Index Scan using projects_organization_id_slug_key on projects p  (cost=0.12..8.14 rows=1 width=96)
                     Index Cond: (organization_id = '<org-id>'::text)
         SubPlan 1
           ->  Aggregate  (cost=16.30..16.31 rows=1 width=8)
                 ->  Nested Loop Anti Join  (cost=0.25..16.30 rows=1 width=0)
                       ->  Index Scan using toolsets_project_id_slug_key on toolsets t  (cost=0.12..8.14 rows=1 width=16)
                             Index Cond: (project_id = p.id)
                             Filter: (mcp_enabled IS TRUE)
                       ->  Index Scan using mcp_servers_toolset_id_idx on mcp_servers m2  (cost=0.12..8.14 rows=1 width=16)
                             Index Cond: (toolset_id = t.id)
                             Filter: (deleted IS FALSE)
         SubPlan 2
           ->  Aggregate  (cost=8.14..8.15 rows=1 width=8)
                 ->  Index Only Scan using mcp_servers_project_id_slug_key on mcp_servers m  (cost=0.12..8.14 rows=1 width=0)
                       Index Cond: (project_id = p.id)
```

</details>

<details>
<summary>EXPLAIN, mirror-image form: sequential scan of toolsets, per project row</summary>

```
         SubPlan 2
           ->  Aggregate  (cost=20.37..20.38 rows=1 width=8)
                 ->  Hash Right Anti Join  (cost=8.17..20.37 rows=1 width=0)
                       Hash Cond: (t2.id = m.toolset_id)
                       ->  Seq Scan on toolsets t2  (cost=0.00..12.00 rows=50 width=16)
                             Filter: ((deleted IS FALSE) AND (mcp_enabled IS TRUE))
                       ->  Hash  (cost=8.16..8.16 rows=1 width=16)
                             ->  Index Scan using mcp_servers_project_id_slug_key on mcp_servers m  (cost=0.14..8.16 rows=1 width=16)
                                   Index Cond: (project_id = p.id)
```

</details>

No screenshot: nothing on screen changes here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts MCP servers per project on the admin organization Projects list so operators can see which projects serve MCP without opening each one. Previously the list had no server info; now `AdminProject` includes a required `mcp_server_count`.

- Adds required `mcp_server_count` to `AdminProject` (OpenAPI and admin HTTP client/server types updated). Admin clients must regenerate from the updated spec. No DB migrations.
- Counts non-deleted `mcp_servers` in the project plus `mcp_enabled` toolsets with no matching non-deleted `mcp_servers` row. Anti-join on toolsets avoids double counting during AGE-1880 and keeps index-only plans.
- May differ from billing’s `GetEnabledServerCount` (toolsets-only). Divergence is intentional (AGE-3272).
- Regenerates the internal SDK spec in `.speakeasy/out.openapi.yaml`; admin paths are stripped, so the TypeScript SDK does not change.
- Linear: AGE-3276. UI column is tracked in AGE-3277 and is not part of this PR.

<sup>Written for commit 2b465e850d288d93a5e90b12c89b0a9940947708. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

