### PR TITLE
feat(admin): rework the organization record's projects and members views

### DIFF
--- a/.changeset/admin-project-mcp-server-count.md
+++ b/.changeset/admin-project-mcp-server-count.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+The admin projects list now reports how many MCP servers each project has, so an operator can read the number off the list instead of opening every project. The count covers both server models at once: every `mcp_servers` row in the project, plus every MCP-enabled toolset that no `mcp_servers` row already describes.

--- a/.changeset/admin-record-projects-members-views.md
+++ b/.changeset/admin-record-projects-members-views.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Work the admin organization record's Projects and Members as proper views. Projects gains an MCP Servers count and drops the raw id column; Members gains a monogram, reads "Never" for a member who has never signed in, and drops the id column. Both draw oldest first, count their rows above the table, and keep their empty state. The Projects nav item keeps its count for every organization except the one-project case it already shortcuts.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -56479,6 +56479,10 @@ components:
         id:
           type: string
           description: The ID of the project
+        mcp_server_count:
+          type: integer
+          description: Number of MCP servers in the project, counting both toolset-backed servers and mcp_servers rows.
+          format: int64
         name:
           type: string
           description: The name of the project
@@ -56494,6 +56498,7 @@ components:
         - id
         - name
         - slug
+        - mcp_server_count
         - created_at
         - updated_at
     AdminProjectDetail:

--- a/client/admin/src/components/record-nav.test.tsx
+++ b/client/admin/src/components/record-nav.test.tsx
@@ -125,14 +125,18 @@ describe("RecordNav", () => {
     expect(navItem("Projects").textContent).toContain("2");
   });
 
-  it("points Projects at the list when the organization has no projects", async () => {
+  it("points Projects at the list, still counted, when the organization has none", async () => {
     await mount([]);
 
     const item = navItem("Projects");
     expect(
       screen.getByRole("link", { name: "Projects" }).getAttribute("href"),
     ).toBe("/organizations/test-org/projects");
-    expect(item.textContent).not.toMatch(/\d/);
+    // The badge is dropped for one project and for nothing else. An answered
+    // zero is a fact about the record, and hiding it makes an empty
+    // organization look like the one-project case, which behaves differently.
+    // AGE-3278.
+    expect(item.textContent).toContain("0");
   });
 
   it("points Projects at the list when the organization has two projects", async () => {

--- a/client/admin/src/components/record-nav.tsx
+++ b/client/admin/src/components/record-nav.tsx
@@ -195,7 +195,11 @@ export function RecordNav({
                   </Link>
                 )}
               </SidebarMenuButton>
-              {projectCount !== undefined && projectCount > 1 && (
+              {/* Dropped at exactly one, and only there. That is the case the
+                  item's target already answers, so a "1" beside a link that
+                  opens the project itself counts a list the operator will never
+                  see. Zero is a fact about the record and keeps its badge. */}
+              {projectCount !== undefined && projectCount !== 1 && (
                 <SidebarMenuBadge>{projectCount}</SidebarMenuBadge>
               )}
             </SidebarMenuItem>

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -439,6 +439,10 @@ export type AdminProject = {
   id: string;
   name: string;
   slug: string;
+  // Both server models: every mcp_servers row, plus every mcp_enabled toolset
+  // no such row points at. Required on the wire, so 0 is an answer rather than
+  // an omission. AGE-3276.
+  mcp_server_count: number;
   created_at: string;
   updated_at: string;
 };

--- a/client/admin/src/lib/utils.test.ts
+++ b/client/admin/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fmtDateShort } from "./utils";
+import { byOldestFirst, fmtDateShort } from "./utils";
 
 // Node re-reads the TZ variable when it next builds a Date, so the reader's
 // zone can be moved for the length of a call. Written out rather than left to
@@ -74,5 +74,53 @@ describe("fmtDateShort", () => {
 
     expect(rendered).toBe(fmtDateShort("2026-05-06T00:00:00Z"));
     expect(rendered).not.toContain(":");
+  });
+});
+
+describe("byOldestFirst", () => {
+  const row = (id: string, created_at: string) => ({ id, created_at });
+
+  it("puts the older record first", () => {
+    expect(
+      byOldestFirst(
+        row("b", "2026-02-01T00:00:00Z"),
+        row("a", "2026-01-01T00:00:00Z"),
+      ),
+    ).toBeGreaterThan(0);
+    expect(
+      byOldestFirst(
+        row("a", "2026-01-01T00:00:00Z"),
+        row("b", "2026-02-01T00:00:00Z"),
+      ),
+    ).toBeLessThan(0);
+  });
+
+  it("reads the instant, not the string", () => {
+    // The same moment, written two ways. A comparator that compares the text
+    // orders these by their offset instead of by when they happened.
+    expect(
+      byOldestFirst(
+        row("a", "2026-01-01T00:00:00Z"),
+        row("b", "2025-12-31T16:00:00-08:00"),
+      ),
+    ).toBe("a".localeCompare("b"));
+  });
+
+  it("breaks a tie on the id, so equal rows keep one order", () => {
+    const same = "2026-01-01T00:00:00Z";
+    expect(byOldestFirst(row("a", same), row("b", same))).toBeLessThan(0);
+    expect(byOldestFirst(row("b", same), row("a", same))).toBeGreaterThan(0);
+    expect(byOldestFirst(row("a", same), row("a", same))).toBe(0);
+  });
+
+  it("falls back to the id rather than shuffling around an unparseable date", () => {
+    // NaN compares false against everything, so an arithmetic comparator
+    // returns NaN here and the sort order becomes whatever the engine did last.
+    expect(
+      byOldestFirst(row("a", "not a date"), row("b", "2026-01-01T00:00:00Z")),
+    ).toBeLessThan(0);
+    expect(
+      byOldestFirst(row("b", "not a date"), row("a", "not a date")),
+    ).toBeGreaterThan(0);
   });
 });

--- a/client/admin/src/lib/utils.ts
+++ b/client/admin/src/lib/utils.ts
@@ -28,3 +28,17 @@ export function fmtDateShort(iso?: string): string {
   if (Number.isNaN(d.getTime())) return "-";
   return d.toLocaleDateString(undefined, { timeZone: "UTC" });
 }
+
+// Oldest first, which is the order the record's views draw: the project a
+// customer started with and the member who opened the account explain the
+// account, so they lead. The id breaks a tie, because two rows created in the
+// same second would otherwise swap places between renders.
+export function byOldestFirst<T extends { id: string; created_at: string }>(
+  a: T,
+  b: T,
+): number {
+  const at = Date.parse(a.created_at);
+  const bt = Date.parse(b.created_at);
+  if (at !== bt && !Number.isNaN(at) && !Number.isNaN(bt)) return at - bt;
+  return a.id.localeCompare(b.id);
+}

--- a/client/admin/src/pages/organization/Members.test.tsx
+++ b/client/admin/src/pages/organization/Members.test.tsx
@@ -83,17 +83,129 @@ describe("Members", () => {
     const emailCell = await screen.findByRole("cell", { name: MEMBER.email });
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Email", "Name", "ID", "Last login", "Joined"]);
+    ).toEqual(["Member", "Email", "Last active", "Joined"]);
 
     const row = emailCell.closest("tr");
     if (!row) throw new Error("the email cell is not inside a row");
+    // The member cell carries the monogram and then the name it was taken
+    // from. The monogram is `aria-hidden`, so the cell's accessible name is the
+    // name alone, but its text is both.
     expect(cellsOf(row)).toEqual([
+      `PM${MEMBER.display_name}`,
       MEMBER.email,
-      MEMBER.display_name,
-      MEMBER.id,
       shortDate(lastLogin),
       shortDate(MEMBER.created_at),
     ]);
+    expect(
+      screen.getByRole("cell", { name: MEMBER.display_name }),
+    ).toBeTruthy();
+  });
+
+  it("falls back to the email when a member record carries no name", async () => {
+    mocks.listOrganizationMembers.mockImplementation(() =>
+      Promise.resolve({
+        members: [aMember({ display_name: "   " })],
+      }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/members`,
+    });
+
+    // A member with no name is still a member, and an empty first cell reads
+    // as a broken row rather than as a record with a field unset.
+    await screen.findByText("1 member");
+    const row = screen.getAllByRole("row")[1];
+    if (!row) throw new Error("the table drew no member row");
+    expect(cellsOf(row)[0]).toBe(`ME${MEMBER.email}`);
+  });
+
+  it("takes a one-word name's monogram from that word", async () => {
+    mocks.listOrganizationMembers.mockImplementation(() =>
+      Promise.resolve({ members: [aMember({ display_name: "Ada" })] }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/members`,
+    });
+
+    await screen.findByRole("cell", { name: "Ada" });
+    const row = screen.getAllByRole("row")[1];
+    if (!row) throw new Error("the table drew no member row");
+    // Two letters from the one word, not one letter and not the whole name.
+    expect(cellsOf(row)[0]).toBe("ADAda");
+  });
+
+  it("draws the members oldest first, whatever order the endpoint sent", async () => {
+    // Shuffled on the wire. `organization.members` promises no order, so a view
+    // that renders what it was handed shows one organization two ways on two
+    // reads.
+    const middle = aMember({
+      id: "user_2",
+      email: "middle@example.test",
+      display_name: "Middle Member",
+      created_at: "2026-01-08T00:00:00Z",
+    });
+    const newest = aMember({
+      id: "user_3",
+      email: "newest@example.test",
+      display_name: "Newest Member",
+      created_at: "2026-02-01T00:00:00Z",
+    });
+    mocks.listOrganizationMembers.mockImplementation(() =>
+      Promise.resolve({ members: [newest, MEMBER, middle] }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/members`,
+    });
+    await screen.findByRole("cell", { name: MEMBER.email });
+
+    expect(
+      screen
+        .getAllByRole("row")
+        .slice(1)
+        .map((row) => cellsOf(row)[1]),
+    ).toEqual([MEMBER.email, middle.email, newest.email]);
+  });
+
+  it("counts the members above the table", async () => {
+    const second = aMember({ id: "user_2", email: "second@example.test" });
+    mocks.listOrganizationMembers.mockImplementation(() =>
+      Promise.resolve({ members: [MEMBER, second] }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/members`,
+    });
+
+    expect(await screen.findByText("2 members")).toBeTruthy();
+  });
+
+  it("says one member in the singular", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/members`,
+    });
+
+    expect(await screen.findByText("1 member")).toBeTruthy();
+    expect(screen.queryByText("1 members")).toBeNull();
+  });
+
+  it("says the organization has no members rather than showing an empty table", async () => {
+    mocks.listOrganizationMembers.mockImplementation(() =>
+      Promise.resolve({ members: [] }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/members`,
+    });
+
+    expect(
+      await screen.findByText("No members in this organization"),
+    ).toBeTruthy();
+    // No "0 members" line above it. The sentence in the table already says
+    // that, and a count of nothing beside it says it twice.
+    expect(screen.queryByText("0 members")).toBeNull();
   });
 
   it("draws no checkbox on a table that did not ask for one", async () => {
@@ -109,7 +221,7 @@ describe("Members", () => {
     expect(screen.queryAllByRole("checkbox")).toEqual([]);
   });
 
-  it("reads a dash for a member who has never logged in", async () => {
+  it("reads Never for a member who has never logged in", async () => {
     mocks.listOrganizationMembers.mockImplementation(() =>
       Promise.resolve({ members: [aMember({ last_login: undefined })] }),
     );
@@ -121,7 +233,11 @@ describe("Members", () => {
     const emailCell = await screen.findByRole("cell", { name: MEMBER.email });
     const row = emailCell.closest("tr");
     if (!row) throw new Error("the email cell is not inside a row");
-    expect(cellsOf(row)[3]).toBe("-");
+    // Not the dash every other absent date draws. A member who has never
+    // signed in is a fact about the account, and the dash that means "nothing
+    // recorded" hides it among the fields that merely have no value.
+    expect(cellsOf(row)[2]).toBe("Never");
+    expect(cellsOf(row)[2]).not.toBe("-");
   });
 
   it("says it is loading rather than that there are none while the read is paused", async () => {

--- a/client/admin/src/pages/organization/Members.test.tsx
+++ b/client/admin/src/pages/organization/Members.test.tsx
@@ -136,6 +136,25 @@ describe("Members", () => {
     expect(cellsOf(row)[0]).toBe("ADAda");
   });
 
+  it("takes a three-word name's monogram from its first and last word", async () => {
+    mocks.listOrganizationMembers.mockImplementation(() =>
+      Promise.resolve({
+        members: [aMember({ display_name: "Ada Byron Lovelace" })],
+      }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/members`,
+    });
+
+    await screen.findByRole("cell", { name: "Ada Byron Lovelace" });
+    const row = screen.getAllByRole("row")[1];
+    if (!row) throw new Error("the table drew no member row");
+    // The surname, not the middle name. Reading the second word gives "AB",
+    // which is the initials of a different person and nothing else notices.
+    expect(cellsOf(row)[0]).toBe("ALAda Byron Lovelace");
+  });
+
   it("draws the members oldest first, whatever order the endpoint sent", async () => {
     // Shuffled on the wire. `organization.members` promises no order, so a view
     // that renders what it was handed shows one organization two ways on two

--- a/client/admin/src/pages/organization/Members.tsx
+++ b/client/admin/src/pages/organization/Members.tsx
@@ -141,7 +141,9 @@ export function Members({ org }: { org: AdminOrganization }): JSX.Element {
           {rows.length === 1 ? "1 member" : `${rows.length} members`}
         </p>
       )}
-      <div className="overflow-hidden rounded-lg border">
+      {/* `overflow-clip`, not `overflow-hidden`: hidden makes this a scroll
+          container and the `sticky top-0` header would pin to it, not the page. */}
+      <div className="overflow-clip rounded-lg border">
         <Table cellPadding="condensed">
           <Table.Header table={table} />
           <Table.Body>

--- a/client/admin/src/pages/organization/Members.tsx
+++ b/client/admin/src/pages/organization/Members.tsx
@@ -45,8 +45,13 @@ const memberColumn = createColumnHelper<
 const MEMBER_COLUMNS = memberColumn.columns([
   memberColumn.accessor("display_name", {
     header: "Member",
+    // Wrapping, against the table's own `whitespace-nowrap`. A name and an
+    // email have no length the column can be sized for, and the border around
+    // the table clips rather than scrolls, so a squeezed column has to fold the
+    // text instead of pushing it out of reach.
+    meta: { cellClassName: "whitespace-normal" },
     cell: ({ row }) => (
-      <span className="flex items-center gap-2 text-sm whitespace-nowrap">
+      <span className="flex items-center gap-2 text-sm">
         <span
           aria-hidden="true"
           className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full text-[10px] font-medium"
@@ -59,6 +64,9 @@ const MEMBER_COLUMNS = memberColumn.columns([
   }),
   memberColumn.accessor("email", {
     header: "Email",
+    // `break-all` rather than `break-words`: an email is one word, so a rule
+    // that only breaks between words never fires on it.
+    meta: { cellClassName: "whitespace-normal break-all" },
     cell: ({ row }) => (
       <span className="text-muted-foreground text-sm">
         {row.original.email}

--- a/client/admin/src/pages/organization/Members.tsx
+++ b/client/admin/src/pages/organization/Members.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import { useMemo, type JSX } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { createColumnHelper, useTable } from "@tanstack/react-table";
@@ -16,7 +16,26 @@ import type {
   AdminOrganization,
   AdminOrganizationMember,
 } from "@/lib/gramAdminApi";
-import { cn, fmtDateShort } from "@/lib/utils";
+import { byOldestFirst, fmtDateShort } from "@/lib/utils";
+
+// Two letters where the name gives two words, one where it does not, and the
+// email when the record carries no name at all. It is decoration beside the
+// name it was taken from, so it is hidden from a screen reader rather than read
+// out twice, once as initials and once as words.
+function monogram(member: AdminOrganizationMember): string {
+  const words = member.display_name.trim().split(/\s+/).filter(Boolean);
+  const letters =
+    words.length > 1
+      ? `${words[0]?.[0] ?? ""}${words[words.length - 1]?.[0] ?? ""}`
+      : (words[0]?.slice(0, 2) ?? member.email.slice(0, 2));
+  return letters.toUpperCase();
+}
+
+// A member with no name is still a member. The email is what the operator has
+// to go on, and an empty cell reads as a broken row.
+function memberName(member: AdminOrganizationMember): string {
+  return member.display_name.trim() || member.email;
+}
 
 const memberColumn = createColumnHelper<
   DataTableFeatures,
@@ -24,34 +43,39 @@ const memberColumn = createColumnHelper<
 >();
 
 const MEMBER_COLUMNS = memberColumn.columns([
-  memberColumn.accessor("email", {
-    header: "Email",
-    cell: ({ row }) => <span className="text-sm">{row.original.email}</span>,
-  }),
   memberColumn.accessor("display_name", {
-    header: "Name",
+    header: "Member",
     cell: ({ row }) => (
-      <span className="text-sm">{row.original.display_name}</span>
+      <span className="flex items-center gap-2 text-sm whitespace-nowrap">
+        <span
+          aria-hidden="true"
+          className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full text-[10px] font-medium"
+        >
+          {monogram(row.original)}
+        </span>
+        {memberName(row.original)}
+      </span>
     ),
   }),
-  memberColumn.accessor("id", {
-    header: "ID",
+  memberColumn.accessor("email", {
+    header: "Email",
     cell: ({ row }) => (
-      <span className="text-muted-foreground text-sm">{row.original.id}</span>
+      <span className="text-muted-foreground text-sm">
+        {row.original.email}
+      </span>
     ),
   }),
   memberColumn.accessor("last_login", {
-    header: "Last login",
-    cell: ({ row }) => (
-      <span
-        className={cn(
-          "text-sm",
-          !row.original.last_login && "text-muted-foreground",
-        )}
-      >
-        {fmtDateShort(row.original.last_login)}
-      </span>
-    ),
+    header: "Last active",
+    // "Never", not the dash every other absent date draws. A member who has
+    // never signed in is a fact about the account, and the dash that means
+    // "nothing recorded" hides it among the fields that merely have no value.
+    cell: ({ row }) =>
+      row.original.last_login ? (
+        <span className="text-sm">{fmtDateShort(row.original.last_login)}</span>
+      ) : (
+        <span className="text-muted-foreground text-sm">Never</span>
+      ),
   }),
   memberColumn.accessor("created_at", {
     header: "Joined",
@@ -60,9 +84,6 @@ const MEMBER_COLUMNS = memberColumn.columns([
     ),
   }),
 ]);
-
-// A fresh fallback array each render would rebuild the row model every time.
-const NO_MEMBERS: AdminOrganizationMember[] = [];
 
 // `isPending`, not `isLoading`: React Query makes the second of those
 // `isPending && isFetching`, so a paused read is neither loading nor errored and
@@ -86,31 +107,48 @@ export function Members({ org }: { org: AdminOrganization }): JSX.Element {
     enabled: !!org.id,
   });
 
+  // Sorted here rather than trusted from the endpoint, which promises no order,
+  // and a fresh array each render would rebuild the row model every time.
+  const members = useMemo(
+    () => [...(data?.members ?? [])].sort(byOldestFirst),
+    [data],
+  );
+
   const table = useTable({
     features: dataTableFeatures,
     columns: MEMBER_COLUMNS,
-    data: data?.members ?? NO_MEMBERS,
+    data: members,
     getRowId: (member) => member.id,
   });
 
   const rows = table.getRowModel().rows;
 
   return (
-    <div className="max-h-96 overflow-auto rounded-lg border">
-      <Table cellPadding="condensed">
-        <Table.Header table={table} />
-        <Table.Body>
-          {isPending || rows.length === 0 ? (
-            <Table.NoResultsMessage>
-              <span className="text-muted-foreground text-sm">
-                {membersMessage(isPending, isError)}
-              </span>
-            </Table.NoResultsMessage>
-          ) : (
-            rows.map((row) => <Table.Row key={row.id} row={row} />)
-          )}
-        </Table.Body>
-      </Table>
+    <div className="flex flex-col gap-3">
+      {/* Only once the read has answered with rows. A count over a pending read
+          is a number nobody has established, and "0 members" beside the
+          sentence that says there are none says it twice. */}
+      {rows.length > 0 && (
+        <p className="text-sm font-medium">
+          {rows.length === 1 ? "1 member" : `${rows.length} members`}
+        </p>
+      )}
+      <div className="overflow-hidden rounded-lg border">
+        <Table cellPadding="condensed">
+          <Table.Header table={table} />
+          <Table.Body>
+            {isPending || rows.length === 0 ? (
+              <Table.NoResultsMessage>
+                <span className="text-muted-foreground text-sm">
+                  {membersMessage(isPending, isError)}
+                </span>
+              </Table.NoResultsMessage>
+            ) : (
+              rows.map((row) => <Table.Row key={row.id} row={row} />)
+            )}
+          </Table.Body>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/client/admin/src/pages/organization/Projects.test.tsx
+++ b/client/admin/src/pages/organization/Projects.test.tsx
@@ -32,7 +32,12 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
 });
 
 const ORG = anOrganization();
-const PROJECT = aProject({ created_at: "2026-01-03T00:00:00Z" });
+const PROJECT = aProject({
+  created_at: "2026-01-03T00:00:00Z",
+  // Not 0 and not 1: a cell that read the wrong field, or counted the rows,
+  // would land on one of those.
+  mcp_server_count: 7,
+});
 
 function shortDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
@@ -102,13 +107,88 @@ describe("Projects", () => {
 
     expect(
       screen.getAllByRole("columnheader").map((header) => header.textContent),
-    ).toEqual(["Name", "Slug", "ID", "Created"]);
+    ).toEqual(["Name", "Slug", "MCP Servers", "Created"]);
     expect(cellsOf(rowFor(link))).toEqual([
       PROJECT.name,
       PROJECT.slug,
-      PROJECT.id,
+      String(PROJECT.mcp_server_count),
       shortDate(PROJECT.created_at),
     ]);
+  });
+
+  it("counts a project with no MCP servers rather than leaving the cell blank", async () => {
+    mocks.listOrganizationProjects.mockImplementation(() =>
+      Promise.resolve({ projects: [aProject({ mcp_server_count: 0 })] }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/projects`,
+    });
+
+    const link = await screen.findByRole("link", { name: PROJECT.name });
+    // A blank cell reads as a project nobody has measured. None is an answer
+    // about a project that has been, and it is the answer an operator looking
+    // for unused projects is scanning for.
+    expect(cellsOf(rowFor(link))[2]).toBe("0");
+  });
+
+  it("draws the projects oldest first, whatever order the endpoint sent", async () => {
+    // Shuffled on the wire. `organization.projects` promises no order, so a
+    // view that renders what it was handed shows one organization two ways on
+    // two reads.
+    const middle = aProject({
+      id: "proj_2",
+      name: "Middle Project",
+      slug: "middle-project",
+      created_at: "2026-01-05T00:00:00Z",
+    });
+    const newest = aProject({
+      id: "proj_3",
+      name: "Newest Project",
+      slug: "newest-project",
+      created_at: "2026-02-01T00:00:00Z",
+    });
+    mocks.listOrganizationProjects.mockImplementation(() =>
+      Promise.resolve({ projects: [newest, PROJECT, middle] }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/projects`,
+    });
+    await screen.findByRole("link", { name: PROJECT.name });
+
+    expect(
+      screen
+        .getAllByRole("row")
+        .slice(1)
+        .map((row) => cellsOf(row)[0]),
+    ).toEqual([PROJECT.name, middle.name, newest.name]);
+  });
+
+  it("counts the projects above the table, and says nothing while there is nothing to count", async () => {
+    const second = aProject({
+      id: "proj_2",
+      name: "Second Project",
+      slug: "second-project",
+    });
+    mocks.listOrganizationProjects.mockImplementation(() =>
+      Promise.resolve({ projects: [PROJECT, second] }),
+    );
+
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/projects`,
+    });
+
+    expect(await screen.findByText("2 projects")).toBeTruthy();
+  });
+
+  it("says one project in the singular", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}/projects`,
+    });
+
+    expect(await screen.findByText("1 project")).toBeTruthy();
+    expect(screen.queryByText("1 projects")).toBeNull();
   });
 
   it("draws no checkbox on a table that did not ask for one", async () => {
@@ -245,6 +325,9 @@ describe("Projects", () => {
     expect(
       await screen.findByText("No projects in this organization"),
     ).toBeTruthy();
+    // No "0 projects" line above it. The sentence in the table already says
+    // that, and a count of nothing beside it says it twice.
+    expect(screen.queryByText("0 projects")).toBeNull();
   });
 
   it("says it is loading rather than that there are none while the read is paused", async () => {

--- a/client/admin/src/pages/organization/Projects.tsx
+++ b/client/admin/src/pages/organization/Projects.tsx
@@ -13,7 +13,7 @@ import {
   organizationQuery,
 } from "@/lib/adminQueries";
 import type { AdminOrganization, AdminProject } from "@/lib/gramAdminApi";
-import { fmtDateShort } from "@/lib/utils";
+import { byOldestFirst, fmtDateShort } from "@/lib/utils";
 
 // `isPending`, not `isLoading`: React Query makes the second of those
 // `isPending && isFetching`, so a paused read is neither loading nor errored and
@@ -55,10 +55,16 @@ function projectColumns(idOrSlug: string) {
       header: "Slug",
       cell: ({ row }) => <span className="text-sm">{row.original.slug}</span>,
     }),
-    projectColumn.accessor("id", {
-      header: "ID",
+    projectColumn.accessor("mcp_server_count", {
+      // "MCP Servers", not "Toolsets": the count is both server models, the
+      // toolset-backed legacy one and the `mcp_servers` row. AGE-3276.
+      header: "MCP Servers",
+      // Printed even when it is zero. A blank cell reads as a project nobody
+      // has measured, and none is a real answer about a project that has been.
       cell: ({ row }) => (
-        <span className="text-muted-foreground text-sm">{row.original.id}</span>
+        <span className="text-sm tabular-nums">
+          {row.original.mcp_server_count}
+        </span>
       ),
     }),
     projectColumn.accessor("created_at", {
@@ -69,9 +75,6 @@ function projectColumns(idOrSlug: string) {
     }),
   ]);
 }
-
-// A fresh fallback array each render would rebuild the row model every time.
-const NO_PROJECTS: AdminProject[] = [];
 
 export function ProjectsRoute(): JSX.Element | null {
   const { idOrSlug } = useParams({ from: "/organizations/$idOrSlug" });
@@ -95,6 +98,13 @@ export function Projects({
     enabled: !!org.id,
   });
 
+  // Sorted here rather than trusted from the endpoint, which promises no order,
+  // and a fresh array each render would rebuild the row model every time.
+  const projects = useMemo(
+    () => [...(data?.projects ?? [])].sort(byOldestFirst),
+    [data],
+  );
+
   // Rebuilt only when the record changes. A fresh column set each render
   // rebuilds the row model with it.
   const columns = useMemo(() => projectColumns(idOrSlug), [idOrSlug]);
@@ -102,42 +112,52 @@ export function Projects({
   const table = useTable({
     features: dataTableFeatures,
     columns,
-    data: data?.projects ?? NO_PROJECTS,
+    data: projects,
     getRowId: (project) => project.id,
   });
 
   const rows = table.getRowModel().rows;
 
   return (
-    <div className="max-h-96 overflow-auto rounded-lg border">
-      <Table cellPadding="condensed">
-        <Table.Header table={table} />
-        <Table.Body>
-          {isPending || rows.length === 0 ? (
-            <Table.NoResultsMessage>
-              <span className="text-muted-foreground text-sm">
-                {projectsMessage(isPending, isError)}
-              </span>
-            </Table.NoResultsMessage>
-          ) : (
-            rows.map((row) => (
-              <Table.Row
-                key={row.id}
-                row={row}
-                onClick={(project) => {
-                  void navigate({
-                    to: "/organizations/$idOrSlug/projects/$projectIdOrSlug",
-                    params: {
-                      idOrSlug,
-                      projectIdOrSlug: project.id,
-                    },
-                  });
-                }}
-              />
-            ))
-          )}
-        </Table.Body>
-      </Table>
+    <div className="flex flex-col gap-3">
+      {/* Only once the read has answered with rows. A count over a pending read
+          is a number nobody has established, and "0 projects" beside the
+          sentence that says there are none says it twice. */}
+      {rows.length > 0 && (
+        <p className="text-sm font-medium">
+          {rows.length === 1 ? "1 project" : `${rows.length} projects`}
+        </p>
+      )}
+      <div className="overflow-hidden rounded-lg border">
+        <Table cellPadding="condensed">
+          <Table.Header table={table} />
+          <Table.Body>
+            {isPending || rows.length === 0 ? (
+              <Table.NoResultsMessage>
+                <span className="text-muted-foreground text-sm">
+                  {projectsMessage(isPending, isError)}
+                </span>
+              </Table.NoResultsMessage>
+            ) : (
+              rows.map((row) => (
+                <Table.Row
+                  key={row.id}
+                  row={row}
+                  onClick={(project) => {
+                    void navigate({
+                      to: "/organizations/$idOrSlug/projects/$projectIdOrSlug",
+                      params: {
+                        idOrSlug,
+                        projectIdOrSlug: project.id,
+                      },
+                    });
+                  }}
+                />
+              ))
+            )}
+          </Table.Body>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/client/admin/src/pages/organization/Projects.tsx
+++ b/client/admin/src/pages/organization/Projects.tsx
@@ -134,7 +134,9 @@ export function Projects({
           {rows.length === 1 ? "1 project" : `${rows.length} projects`}
         </p>
       )}
-      <div className="overflow-hidden rounded-lg border">
+      {/* `overflow-clip`, not `overflow-hidden`: hidden makes this a scroll
+          container and the `sticky top-0` header would pin to it, not the page. */}
+      <div className="overflow-clip rounded-lg border">
         <Table cellPadding="condensed">
           <Table.Header table={table} />
           <Table.Body>

--- a/client/admin/src/pages/organization/Projects.tsx
+++ b/client/admin/src/pages/organization/Projects.tsx
@@ -32,6 +32,10 @@ function projectColumns(idOrSlug: string) {
   return projectColumn.columns([
     projectColumn.accessor("name", {
       header: "Name",
+      // Wrapping, against the table's own `whitespace-nowrap`, for the reason
+      // the Members view gives: the border clips rather than scrolls, so a
+      // squeezed column folds its text instead of hiding it.
+      meta: { cellClassName: "whitespace-normal" },
       // The link, not the row, carries the keyboard path and the accessible
       // name. It also lets the operator open the project in a new tab.
       //
@@ -53,6 +57,8 @@ function projectColumns(idOrSlug: string) {
     }),
     projectColumn.accessor("slug", {
       header: "Slug",
+      // `break-all`, because a slug is one word to a word-breaking rule.
+      meta: { cellClassName: "whitespace-normal break-all" },
       cell: ({ row }) => <span className="text-sm">{row.original.slug}</span>,
     }),
     projectColumn.accessor("mcp_server_count", {

--- a/client/admin/src/test/fixtures.ts
+++ b/client/admin/src/test/fixtures.ts
@@ -31,6 +31,7 @@ export function aProject(overrides: Partial<AdminProject> = {}): AdminProject {
     id: "proj_1",
     name: "First Project",
     slug: "first-project",
+    mcp_server_count: 0,
     created_at: "2026-01-15T00:00:00Z",
     updated_at: "2026-01-15T00:00:00Z",
     ...overrides,

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -54,11 +54,12 @@ var AdminOrganization = Type("AdminOrganization", func() {
 
 var AdminProject = Type("AdminProject", func() {
 	Description("Project summary surfaced to admin operators.")
-	Required("id", "name", "slug", "created_at", "updated_at")
+	Required("id", "name", "slug", "mcp_server_count", "created_at", "updated_at")
 
 	Attribute("id", String, "The ID of the project")
 	Attribute("name", String, "The name of the project")
 	Attribute("slug", String, "The slug of the project")
+	Attribute("mcp_server_count", Int, "Number of MCP servers in the project, counting both toolset-backed servers and mcp_servers rows.")
 	Attribute("created_at", String, func() {
 		Description("The creation date of the project.")
 		Format(FormatDateTime)

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -198,6 +198,9 @@ type AdminProject struct {
 	Name string
 	// The slug of the project
 	Slug string
+	// Number of MCP servers in the project, counting both toolset-backed servers
+	// and mcp_servers rows.
+	McpServerCount int
 	// The creation date of the project.
 	CreatedAt string
 	// The last update date of the project.

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -3844,11 +3844,12 @@ func unmarshalAdminOrganizationMemberResponseBodyToAdminAdminOrganizationMember(
 // *admin.AdminProject from a value of type *AdminProjectResponseBody.
 func unmarshalAdminProjectResponseBodyToAdminAdminProject(v *AdminProjectResponseBody) *admin.AdminProject {
 	res := &admin.AdminProject{
-		ID:        *v.ID,
-		Name:      *v.Name,
-		Slug:      *v.Slug,
-		CreatedAt: *v.CreatedAt,
-		UpdatedAt: *v.UpdatedAt,
+		ID:             *v.ID,
+		Name:           *v.Name,
+		Slug:           *v.Slug,
+		McpServerCount: *v.McpServerCount,
+		CreatedAt:      *v.CreatedAt,
+		UpdatedAt:      *v.UpdatedAt,
 	}
 
 	return res

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -3351,6 +3351,9 @@ type AdminProjectResponseBody struct {
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// The slug of the project
 	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Number of MCP servers in the project, counting both toolset-backed servers
+	// and mcp_servers rows.
+	McpServerCount *int `form:"mcp_server_count,omitempty" json:"mcp_server_count,omitempty" xml:"mcp_server_count,omitempty"`
 	// The creation date of the project.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// The last update date of the project.
@@ -10527,6 +10530,9 @@ func ValidateAdminProjectResponseBody(body *AdminProjectResponseBody) (err error
 	}
 	if body.Slug == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.McpServerCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("mcp_server_count", "body"))
 	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -3413,11 +3413,12 @@ func marshalAdminAdminOrganizationMemberToAdminOrganizationMemberResponseBody(v 
 // *AdminProjectResponseBody from a value of type *admin.AdminProject.
 func marshalAdminAdminProjectToAdminProjectResponseBody(v *admin.AdminProject) *AdminProjectResponseBody {
 	res := &AdminProjectResponseBody{
-		ID:        v.ID,
-		Name:      v.Name,
-		Slug:      v.Slug,
-		CreatedAt: v.CreatedAt,
-		UpdatedAt: v.UpdatedAt,
+		ID:             v.ID,
+		Name:           v.Name,
+		Slug:           v.Slug,
+		McpServerCount: v.McpServerCount,
+		CreatedAt:      v.CreatedAt,
+		UpdatedAt:      v.UpdatedAt,
 	}
 
 	return res

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -3353,6 +3353,9 @@ type AdminProjectResponseBody struct {
 	Name string `form:"name" json:"name" xml:"name"`
 	// The slug of the project
 	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Number of MCP servers in the project, counting both toolset-backed servers
+	// and mcp_servers rows.
+	McpServerCount int `form:"mcp_server_count" json:"mcp_server_count" xml:"mcp_server_count"`
 	// The creation date of the project.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// The last update date of the project.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -57278,6 +57278,10 @@ components:
                 id:
                     type: string
                     description: The ID of the project
+                mcp_server_count:
+                    type: integer
+                    description: Number of MCP servers in the project, counting both toolset-backed servers and mcp_servers rows.
+                    format: int64
                 name:
                     type: string
                     description: The name of the project
@@ -57293,6 +57297,7 @@ components:
                 - id
                 - name
                 - slug
+                - mcp_server_count
                 - created_at
                 - updated_at
         AdminProjectDetail:

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -596,11 +596,12 @@ func (s *Service) ListOrganizationProjects(ctx context.Context, payload *gen.Lis
 	projects := make([]*gen.AdminProject, len(rows))
 	for i, row := range rows {
 		projects[i] = &gen.AdminProject{
-			ID:        row.ID.String(),
-			Name:      row.Name,
-			Slug:      row.Slug,
-			CreatedAt: row.CreatedAt.Time.Format(time.RFC3339),
-			UpdatedAt: row.UpdatedAt.Time.Format(time.RFC3339),
+			ID:             row.ID.String(),
+			Name:           row.Name,
+			Slug:           row.Slug,
+			McpServerCount: int(row.McpServerCount),
+			CreatedAt:      row.CreatedAt.Time.Format(time.RFC3339),
+			UpdatedAt:      row.UpdatedAt.Time.Format(time.RFC3339),
 		}
 	}
 

--- a/server/internal/admin/listorganizationprojects_test.go
+++ b/server/internal/admin/listorganizationprojects_test.go
@@ -1,0 +1,251 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	mcpserversRepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+func seedToolset(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, projectID uuid.UUID, slug string, mcpEnabled bool) uuid.UUID {
+	t.Helper()
+
+	ts, err := toolsetsRepo.New(conn).CreateToolset(ctx, toolsetsRepo.CreateToolsetParams{
+		OrganizationID: orgID,
+		ProjectID:      projectID,
+		Name:           slug,
+		Slug:           slug,
+		McpSlug:        pgtype.Text{String: slug, Valid: true},
+		McpEnabled:     mcpEnabled,
+	})
+	require.NoError(t, err)
+
+	return ts.ID
+}
+
+// Every mcp_servers row needs exactly one backend, and a toolset-backed one is
+// the only backend that needs no other row seeded alongside it.
+func seedMCPServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, toolsetID uuid.UUID, slug string) uuid.UUID {
+	t.Helper()
+
+	id := uuid.New()
+	srv, err := mcpserversRepo.New(conn).CreateMCPServer(ctx, mcpserversRepo.CreateMCPServerParams{
+		ID:         id,
+		ProjectID:  projectID,
+		Name:       pgtype.Text{String: slug, Valid: true},
+		Slug:       pgtype.Text{String: slug, Valid: true},
+		ToolsetID:  uuid.NullUUID{UUID: toolsetID, Valid: true},
+		Visibility: "disabled",
+	})
+	require.NoError(t, err)
+
+	return srv.ID
+}
+
+func deleteToolset(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, slug string) {
+	t.Helper()
+
+	_, err := toolsetsRepo.New(conn).DeleteToolset(ctx, toolsetsRepo.DeleteToolsetParams{
+		Slug:      slug,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+}
+
+func deleteMCPServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, id uuid.UUID) {
+	t.Helper()
+
+	_, err := mcpserversRepo.New(conn).DeleteMCPServer(ctx, mcpserversRepo.DeleteMCPServerParams{
+		ID:        id,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+}
+
+func listProjects(t *testing.T, ctx context.Context, svc *Service, orgID string) map[string]int {
+	t.Helper()
+
+	res, err := svc.ListOrganizationProjects(ctx, &gen.ListOrganizationProjectsPayload{OrganizationID: orgID})
+	require.NoError(t, err)
+
+	counts := make(map[string]int, len(res.Projects))
+	for _, p := range res.Projects {
+		counts[p.Slug] = p.McpServerCount
+	}
+
+	return counts
+}
+
+func TestListOrganizationProjects_CountIsZeroWithoutServers(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedProject(t, ctx, conn, "org_one", "empty")
+
+	require.Equal(t, map[string]int{"empty": 0}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// A toolset is only an MCP server when mcp_enabled says so.
+func TestListOrganizationProjects_CountsOnlyMCPEnabledToolsets(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "mixed")
+	seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	seedToolset(t, ctx, conn, "org_one", projectID, "plain", false)
+
+	require.Equal(t, map[string]int{"mixed": 1}, listProjects(t, ctx, svc, "org_one"))
+}
+
+func TestListOrganizationProjects_CountsMCPServerRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "new-model")
+	backing := seedToolset(t, ctx, conn, "org_one", projectID, "backing", false)
+	seedMCPServer(t, ctx, conn, projectID, backing, "one")
+	seedMCPServer(t, ctx, conn, projectID, backing, "two")
+
+	require.Equal(t, map[string]int{"new-model": 2}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// The shape AGE-1880's data copy produces: one server described twice, by an
+// mcp_enabled toolset and by the mcp_servers row that points at it. A plain sum
+// of the two halves would report 2.
+func TestListOrganizationProjects_DoesNotDoubleCountAMigratedServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "migrated")
+	toolsetID := seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	seedMCPServer(t, ctx, conn, projectID, toolsetID, "served")
+
+	require.Equal(t, map[string]int{"migrated": 1}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// And the dedupe is per toolset, not a blanket "this project has both models".
+func TestListOrganizationProjects_DedupesPerToolsetNotPerProject(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "half-migrated")
+	migrated := seedToolset(t, ctx, conn, "org_one", projectID, "migrated", true)
+	seedToolset(t, ctx, conn, "org_one", projectID, "legacy", true)
+	seedMCPServer(t, ctx, conn, projectID, migrated, "migrated")
+
+	require.Equal(t, map[string]int{"half-migrated": 2}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// A deleted mcp_servers row stops hiding the toolset it pointed at, so the
+// count has to stay 1 rather than fall to 0.
+func TestListOrganizationProjects_IgnoresDeletedMCPServerRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "deleted-server")
+	toolsetID := seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	serverID := seedMCPServer(t, ctx, conn, projectID, toolsetID, "served")
+	deleteMCPServer(t, ctx, conn, projectID, serverID)
+
+	require.Equal(t, map[string]int{"deleted-server": 1}, listProjects(t, ctx, svc, "org_one"))
+}
+
+func TestListOrganizationProjects_IgnoresDeletedToolsets(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "deleted-toolset")
+	seedToolset(t, ctx, conn, "org_one", projectID, "served", true)
+	deleteToolset(t, ctx, conn, projectID, "served")
+
+	require.Equal(t, map[string]int{"deleted-toolset": 0}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// A deleted mcp_servers row is not counted on its own half either.
+func TestListOrganizationProjects_IgnoresDeletedServersWithoutAnMCPEnabledToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	projectID := seedProject(t, ctx, conn, "org_one", "deleted-only")
+	backing := seedToolset(t, ctx, conn, "org_one", projectID, "backing", false)
+	serverID := seedMCPServer(t, ctx, conn, projectID, backing, "gone")
+	deleteMCPServer(t, ctx, conn, projectID, serverID)
+
+	require.Equal(t, map[string]int{"deleted-only": 0}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// Each row carries its own count. Transposing the two would still add up.
+func TestListOrganizationProjects_CountsAreNotTransposedAcrossRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+
+	one := seedProject(t, ctx, conn, "org_one", "alpha")
+	seedToolset(t, ctx, conn, "org_one", one, "a1", true)
+
+	three := seedProject(t, ctx, conn, "org_one", "beta")
+	seedToolset(t, ctx, conn, "org_one", three, "b1", true)
+	seedToolset(t, ctx, conn, "org_one", three, "b2", true)
+	seedToolset(t, ctx, conn, "org_one", three, "b3", true)
+
+	require.Equal(t, map[string]int{"alpha": 1, "beta": 3}, listProjects(t, ctx, svc, "org_one"))
+}
+
+// The count is per project, so a sibling project's servers must not leak in
+// even though they share an organization.
+func TestListOrganizationProjects_CountIsScopedToTheProject(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_two", name: "Two", slug: "two"})
+
+	// Both halves of the count are scoped, so both halves are seeded in every
+	// project here: a bare mcp_servers row as well as an mcp_enabled toolset.
+	mine := seedProject(t, ctx, conn, "org_one", "mine")
+	seedMCPServer(t, ctx, conn, mine, seedToolset(t, ctx, conn, "org_one", mine, "m1", false), "m1")
+
+	sibling := seedProject(t, ctx, conn, "org_one", "sibling")
+	seedToolset(t, ctx, conn, "org_one", sibling, "s1", true)
+	seedMCPServer(t, ctx, conn, sibling, seedToolset(t, ctx, conn, "org_one", sibling, "s2", false), "s2")
+
+	theirs := seedProject(t, ctx, conn, "org_two", "theirs")
+	seedMCPServer(t, ctx, conn, theirs, seedToolset(t, ctx, conn, "org_two", theirs, "t1", false), "t1")
+
+	require.Equal(t, map[string]int{"mine": 1, "sibling": 2}, listProjects(t, ctx, svc, "org_one"))
+	require.Equal(t, map[string]int{"theirs": 1}, listProjects(t, ctx, svc, "org_two"))
+}
+
+// A soft-deleted project drops out of the list entirely, count or no count.
+func TestListOrganizationProjects_SkipsDeletedProjects(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
+	live := seedProject(t, ctx, conn, "org_one", "live")
+	seedToolset(t, ctx, conn, "org_one", live, "l1", true)
+
+	gone := seedProject(t, ctx, conn, "org_one", "gone")
+	seedToolset(t, ctx, conn, "org_one", gone, "g1", true)
+	_, err := projectsRepo.New(conn).DeleteProject(ctx, gone)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]int{"live": 1}, listProjects(t, ctx, svc, "org_one"))
+}

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -298,11 +298,26 @@ SET disabled_at = NULL,
 WHERE id = @id;
 
 -- name: AdminListProjectsForOrganization :many
-SELECT id, slug, name, created_at, updated_at
-FROM projects
-WHERE organization_id = @organization_id
-  AND deleted IS FALSE
-ORDER BY created_at DESC
+-- Not a plain sum: once AGE-1880 copies legacy servers into mcp_servers, a
+-- toolset and its mcp_servers row would each be counted. The anti join on the
+-- legacy half gives the same answer before and after that copy, and it is the
+-- direction that plans as an index anti join rather than a seq scan of toolsets.
+SELECT
+    p.id,
+    p.slug,
+    p.name,
+    p.created_at,
+    p.updated_at,
+    ((SELECT count(*) FROM toolsets t
+        WHERE t.project_id = p.id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+          AND NOT EXISTS (SELECT 1 FROM mcp_servers m2
+                           WHERE m2.toolset_id = t.id AND m2.deleted IS FALSE))
+     + (SELECT count(*) FROM mcp_servers m
+          WHERE m.project_id = p.id AND m.deleted IS FALSE))::bigint AS mcp_server_count
+FROM projects p
+WHERE p.organization_id = @organization_id
+  AND p.deleted IS FALSE
+ORDER BY p.created_at DESC
 LIMIT 200;
 
 -- name: AdminListOrganizationMembers :many

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -591,22 +591,38 @@ func (q *Queries) AdminListOrganizations(ctx context.Context, arg AdminListOrgan
 }
 
 const adminListProjectsForOrganization = `-- name: AdminListProjectsForOrganization :many
-SELECT id, slug, name, created_at, updated_at
-FROM projects
-WHERE organization_id = $1
-  AND deleted IS FALSE
-ORDER BY created_at DESC
+SELECT
+    p.id,
+    p.slug,
+    p.name,
+    p.created_at,
+    p.updated_at,
+    ((SELECT count(*) FROM toolsets t
+        WHERE t.project_id = p.id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+          AND NOT EXISTS (SELECT 1 FROM mcp_servers m2
+                           WHERE m2.toolset_id = t.id AND m2.deleted IS FALSE))
+     + (SELECT count(*) FROM mcp_servers m
+          WHERE m.project_id = p.id AND m.deleted IS FALSE))::bigint AS mcp_server_count
+FROM projects p
+WHERE p.organization_id = $1
+  AND p.deleted IS FALSE
+ORDER BY p.created_at DESC
 LIMIT 200
 `
 
 type AdminListProjectsForOrganizationRow struct {
-	ID        uuid.UUID
-	Slug      string
-	Name      string
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
+	ID             uuid.UUID
+	Slug           string
+	Name           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	McpServerCount int64
 }
 
+// Not a plain sum: once AGE-1880 copies legacy servers into mcp_servers, a
+// toolset and its mcp_servers row would each be counted. The anti join on the
+// legacy half gives the same answer before and after that copy, and it is the
+// direction that plans as an index anti join rather than a seq scan of toolsets.
 func (q *Queries) AdminListProjectsForOrganization(ctx context.Context, organizationID string) ([]AdminListProjectsForOrganizationRow, error) {
 	rows, err := q.db.Query(ctx, adminListProjectsForOrganization, organizationID)
 	if err != nil {
@@ -622,6 +638,7 @@ func (q *Queries) AdminListProjectsForOrganization(ctx context.Context, organiza
 			&i.Name,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.McpServerCount,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The admin organization record's Projects and Members views were the raw endpoint payload in a table. They now carry the columns an operator actually reads.

**Projects** gains an MCP Servers count (the field added by the parent PR) and drops the raw id column. **Members** gains a monogram beside the name, reads "Never" for a member who has never signed in, and drops its id column too. Both views sort oldest first rather than trusting the endpoint's order, count their rows above the table once the read has answered, and keep their empty state.

The Projects nav item keeps its badge for every organization except the single-project case, which the item's own target already answers.

AGE-3277.

## Decisions worth a look

- **"Never", not a dash, for an absent last login.** A member who has never signed in is a fact about the account. The dash that means "nothing recorded" would hide it among the fields that merely have no value.
- **The MCP Servers cell prints a zero.** A blank cell reads as a project nobody has measured; none is a real answer about a project that has been.
- **Sorted in the component, not trusted from the endpoint,** which promises no order. Ties break on id so two rows created in the same second do not swap places between renders.
- **The count line renders only for a resolved, non-empty list.** A count over a pending read is a number nobody has established, and "0 projects" beside "No projects in this organization" says it twice.
- **The nav badge is dropped at exactly one project and nowhere else.** Zero is a fact about the record and keeps its badge. The spec's table and the chunk brief disagree here; the brief won, and the disagreement is filed as AGE-3278.
- **Cut from the drawing:** the Role column (no role exists in Postgres), "Events, 30d" (no endpoint), and the "Invite member" button (no endpoint, and admin surfaces do not author customer records).

## Verification

| Gate | Result |
| --- | --- |
| `aube run -F admin type-check` | exit 0 |
| `aube run -F admin lint:oxlint` | exit 0 |
| `aube exec oxfmt -- --check client/admin` | all 117 files correctly formatted |
| `aube run -F admin test` | 672 passed, 25 files |
| `aube run -F admin build` | built in 284ms |

Type-check and oxlint both print nothing on success, so each was canaried with a deliberate error (a type mismatch and an unused binding) to prove the gate reports failures, then restored and re-verified with `diff -q`.

Mutation testing: **18 mutations, 17 killed, 1 survived**. The harness was canaried first (deleting the Members rows killed 6 tests). The survivor drops `tabular-nums` from the MCP Servers cell: a cosmetic Tailwind class with no behavioural claim, which jsdom cannot observe. Equivalent for test purposes.

The views were also exercised end to end against a locally-run admin stack with invented seed data. The MCP Servers column read 7 / 2 / 0 against a seed built to produce exactly those counts, across both server models.

## Stacked PR

Stacked on #5426. I expected `hygiene.yaml` to be skipped here because it filters on base
`main`, and said so in the first draft of this description. That was wrong: **Lint PR Title
and Changesets ran and passed**, as did Check formatting with hk and Detect UI
anti-patterns. The migration jobs are skipped by their path filter, not by the base branch,
and this PR touches no migration files.

## One red check, explained

`preview-image-tags (gram, server)` fails, and will keep failing until #5426 merges. It is
not caused by anything in this PR, which touches no server file.

The job exists to give an *unchanged* component its preview tag by aliasing an image already
built on main. It walks the last 50 first-parent main commits looking for one whose
server-watched paths are identical to this head, then reuses that commit's image
(`.github/workflows/composite/tag-preview-images/action.yaml:91`). This head carries the
parent PR's server changes, which are not on main yet, so no main commit can match and there
is nothing to alias.

It is **not** in `CI Gate`'s `needs` list, and CI Gate passes. Its only consumer is a preview
environment, and this PR has no `preview` label. Three reruns failed identically, which is
consistent with the cause above rather than with a flake. Forcing it green would mean adding
`ci:full` to build server images for a PR that needs none, so I left it red rather than spend
that build.

## Screenshots

Captured but not attached: `gh gist create` is refused in this environment, so the files are on disk in the worktree at `.playwright-cli/pr-demos/`.

- `projects.png` — the Projects view, three projects with counts 7 / 2 / 0, oldest first, "3 projects" above the table.
- `members.png` — the Members view, four members with monograms, one reading "Never", "4 members" above the table.
- `demo.gif` (19s) — the single-project rule: an organization with three projects shows a badge and opens the list; an organization with one project shows no badge and the nav item opens that project directly.
