### PR TITLE
feat: resolve directory audiences for plugin delivery

### DIFF
--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -156,6 +156,13 @@ func TestGetPlugins_DeliversDirectoryAttributeAssignments(t *testing.T) {
 	const email = "directory-attributes@example.com"
 	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-1", email, []byte(`{"department":"Engineering"}`))
 	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-2", email, []byte(`{"manager.email":"lead@example.com"}`))
+	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-3", email, []byte(`{"department":"Engineering"}`))
+	audiences, err := plugins.ResolveDirectoryAudiencePrincipalsByEmails(ctx, ti.conn, ti.orgID, []string{email})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		plugins.DirectoryAttributePrincipal("department", "Engineering"),
+		plugins.DirectoryAttributePrincipal("manager.email", "lead@example.com"),
+	}, audiences[email])
 	departmentPlugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "department-tool")
 	assignPlugin(t, ctx, ti.conn, departmentPlugin, ti.orgID, plugins.DirectoryAttributePrincipal("department", "Engineering"))
 	managerPlugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "manager-tool")

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -2,15 +2,19 @@ package agent_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	mockidp "github.com/speakeasy-api/gram/dev-idp/pkg/testidp"
 	gen "github.com/speakeasy-api/gram/server/gen/agent"
 	agentrepo "github.com/speakeasy-api/gram/server/internal/agent/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
 	"github.com/speakeasy-api/gram/server/internal/plugins/naming"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
 )
 
 // ptr takes the address of a literal. conv.PtrEmpty collapses the zero value
@@ -126,6 +130,115 @@ func TestGetPlugins_DeliversUserAndRoleAssignments(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{wantObservability}, pluginSlugs(nonMember),
 		"user:/role: assignments are withheld from non-members")
+}
+
+func TestGetPlugins_DeliversDirectoryGroupAssignmentsToUnlinkedUsers(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
+	group := seedDirectoryGroup(t, ctx, ti.conn, ti.orgID, "group-directory-audience")
+	user := seedDirectoryUser(t, ctx, ti.conn, ti.orgID, "user-directory-audience", "Unlinked@Example.com")
+	seedDirectoryGroupMembership(t, ctx, ti.conn, user, group, "user-directory-audience", "group-directory-audience")
+	plugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "directory-group-tool")
+	assignPlugin(t, ctx, ti.conn, plugin, ti.orgID, plugins.DirectoryGroupPrincipal(group))
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "unlinked@example.com"})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{wantObservability, "directory-group-tool"}, pluginSlugs(res))
+}
+
+func TestGetPlugins_DeliversDirectoryAttributeAssignments(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
+
+	const email = "directory-attributes@example.com"
+	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-1", email, []byte(`{"department":"Engineering"}`))
+	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-2", email, []byte(`{"manager.email":"lead@example.com"}`))
+	departmentPlugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "department-tool")
+	assignPlugin(t, ctx, ti.conn, departmentPlugin, ti.orgID, plugins.DirectoryAttributePrincipal("department", "Engineering"))
+	managerPlugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "manager-tool")
+	assignPlugin(t, ctx, ti.conn, managerPlugin, ti.orgID, plugins.DirectoryAttributePrincipal("manager.email", "lead@example.com"))
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{wantObservability, "department-tool", "manager-tool"}, pluginSlugs(res))
+}
+
+func TestGetPlugins_RefreshesDirectoryGroupMembership(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
+
+	const email = "directory-user@example.com"
+	alpha := seedDirectoryGroup(t, ctx, ti.conn, ti.orgID, "group-alpha")
+	beta := seedDirectoryGroup(t, ctx, ti.conn, ti.orgID, "group-beta")
+	gamma := seedDirectoryGroup(t, ctx, ti.conn, ti.orgID, "group-gamma")
+	alphaUser := seedDirectoryUser(t, ctx, ti.conn, ti.orgID, "user-alpha", email)
+	betaUser := seedDirectoryUser(t, ctx, ti.conn, ti.orgID, "user-beta", email)
+	gammaUser := seedDirectoryUser(t, ctx, ti.conn, ti.orgID, "user-gamma", email)
+	seedDirectoryGroupMembership(t, ctx, ti.conn, alphaUser, alpha, "user-alpha", "group-alpha")
+	seedDirectoryGroupMembership(t, ctx, ti.conn, betaUser, beta, "user-beta", "group-beta")
+	seedDirectoryGroupMembership(t, ctx, ti.conn, gammaUser, gamma, "user-gamma", "group-gamma")
+
+	for _, assignment := range []struct {
+		group uuid.UUID
+		slug  string
+	}{{alpha, "alpha-tool"}, {beta, "beta-tool"}, {gamma, "gamma-tool"}} {
+		plugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, assignment.slug)
+		assignPlugin(t, ctx, ti.conn, plugin, ti.orgID, plugins.DirectoryGroupPrincipal(assignment.group))
+	}
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{wantObservability, "alpha-tool", "beta-tool", "gamma-tool"}, pluginSlugs(res))
+
+	_, err = workosrepo.New(ti.conn).CloseDirectoryUserGroupMembership(ctx, workosrepo.CloseDirectoryUserGroupMembershipParams{
+		DirectoryUserID:  alphaUser,
+		DirectoryGroupID: alpha,
+	})
+	require.NoError(t, err)
+	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{wantObservability, "beta-tool", "gamma-tool"}, pluginSlugs(res))
+
+	_, err = workosrepo.New(ti.conn).DeleteDirectoryGroupByWorkOSID(ctx, workosrepo.DeleteDirectoryGroupByWorkOSIDParams{
+		WorkosDirectoryGroupID: "group-beta",
+		WorkosDeletedAt:        conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:      conv.ToPGText("event-group-beta-deleted"),
+	})
+	require.NoError(t, err)
+	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{wantObservability, "gamma-tool"}, pluginSlugs(res))
+
+	_, err = workosrepo.New(ti.conn).DeleteDirectoryUserByWorkOSID(ctx, workosrepo.DeleteDirectoryUserByWorkOSIDParams{
+		WorkosDirectoryUserID: "user-gamma",
+		WorkosDeletedAt:       conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:     conv.ToPGText("event-user-gamma-deleted"),
+	})
+	require.NoError(t, err)
+	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	require.NoError(t, err)
+	require.Equal(t, []string{wantObservability}, pluginSlugs(res))
+}
+
+func TestGetPlugins_DirectoryGroupsAreOrganizationScoped(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
+	seedSecondOrg(t, ctx, ti.conn)
+
+	group := seedDirectoryGroup(t, ctx, ti.conn, "other-org-id", "group-other-org")
+	user := seedDirectoryUser(t, ctx, ti.conn, "other-org-id", "user-other-org", "directory-user@example.com")
+	seedDirectoryGroupMembership(t, ctx, ti.conn, user, group, "user-other-org", "group-other-org")
+	plugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "other-org-group-tool")
+	assignPlugin(t, ctx, ti.conn, plugin, ti.orgID, plugins.DirectoryGroupPrincipal(group))
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "directory-user@example.com"})
+	require.NoError(t, err)
+	require.Equal(t, []string{wantObservability}, pluginSlugs(res))
 }
 
 func TestGetPlugins_UnpublishedProjectExcluded(t *testing.T) {

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -33,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
@@ -109,10 +110,11 @@ func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.A
 
 // GetPlugins returns every plugin assigned to the device user's resolved
 // principal set within the caller's org, marketplace-first. From the polling
-// user's email it resolves email → user_id, then RBAC role membership, to
-// produce the user:<id>, user:all, and role:<...> principals; the email
-// principal and the org wildcard are always included so email- and
-// everyone-scoped assignments still deliver.
+// user's email it resolves directory audiences, email → user_id, then RBAC
+// role membership, to produce directory_group:<id>, directory_attribute:<...>,
+// user:<id>, user:all, and role:<...> principals; the email principal and the
+// org wildcard are always included so email- and everyone-scoped assignments
+// still deliver.
 //
 // The polling identity is resolved by credential type (DNO-383), because who
 // the key belongs to differs:
@@ -245,6 +247,11 @@ func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload
 	// Assignments can target the email or the org wildcard directly; those always
 	// apply regardless of whether the email maps to an org member.
 	principals := []string{emailPrincipal.String(), urn.PrincipalWildcard}
+	directoryAudiences, err := plugins.ResolveDirectoryAudiencePrincipalsByEmails(ctx, s.db, authCtx.ActiveOrganizationID, []string{email})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error resolving agent directory audiences").LogError(ctx, s.logger)
+	}
+	principals = append(principals, directoryAudiences[email]...)
 
 	// Resolve the reported email to an org member so user:<id>, user:all, and
 	// role:<kind>:<uuid> assignments deliver too. A non-member (or unknown email) is not

--- a/server/internal/agent/setup_test.go
+++ b/server/internal/agent/setup_test.go
@@ -29,6 +29,7 @@ import (
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
 )
 
 const testServerURL = "https://app.getgram.ai"
@@ -205,6 +206,57 @@ func assignPlugin(t *testing.T, ctx context.Context, conn *pgxpool.Pool, pluginI
 		PluginID:       pluginID,
 		OrganizationID: orgID,
 		PrincipalUrn:   principalURN,
+	})
+	require.NoError(t, err)
+}
+
+func seedDirectoryGroup(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, workosID string) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	id, err := workosrepo.New(conn).UpsertDirectoryGroup(ctx, workosrepo.UpsertDirectoryGroupParams{
+		OrganizationID:         orgID,
+		WorkosDirectoryGroupID: workosID,
+		Name:                   workosID,
+		Attributes:             []byte(`{}`),
+		WorkosCreatedAt:        conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:        conv.ToPGTimestamptz(now),
+		WorkosLastEventID:      conv.ToPGText("event_" + workosID),
+	})
+	require.NoError(t, err)
+	return id
+}
+
+func seedDirectoryUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, workosID, email string) uuid.UUID {
+	t.Helper()
+	return seedDirectoryUserWithAttributes(t, ctx, conn, orgID, workosID, email, []byte(`{}`))
+}
+
+func seedDirectoryUserWithAttributes(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, workosID, email string, attributes []byte) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	id, err := workosrepo.New(conn).UpsertDirectoryUser(ctx, workosrepo.UpsertDirectoryUserParams{
+		OrganizationID:        orgID,
+		UserID:                conv.ToPGTextEmpty(""),
+		WorkosDirectoryUserID: workosID,
+		Email:                 conv.ToPGText(email),
+		Attributes:            attributes,
+		RestoreDeleted:        true,
+		WorkosCreatedAt:       conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:       conv.ToPGTimestamptz(now),
+		WorkosLastEventID:     conv.ToPGText("event_" + workosID),
+	})
+	require.NoError(t, err)
+	return id
+}
+
+func seedDirectoryGroupMembership(t *testing.T, ctx context.Context, conn *pgxpool.Pool, directoryUserID, directoryGroupID uuid.UUID, workosUserID, workosGroupID string) {
+	t.Helper()
+	_, err := workosrepo.New(conn).OpenDirectoryUserGroupMembership(ctx, workosrepo.OpenDirectoryUserGroupMembershipParams{
+		DirectoryUserID:        directoryUserID,
+		DirectoryGroupID:       directoryGroupID,
+		WorkosDirectoryUserID:  workosUserID,
+		WorkosDirectoryGroupID: workosGroupID,
+		WorkosCreatedAt:        conv.ToPGTimestamptz(time.Now().UTC()),
 	})
 	require.NoError(t, err)
 }

--- a/server/internal/plugins/audience.go
+++ b/server/internal/plugins/audience.go
@@ -1,0 +1,74 @@
+package plugins
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
+)
+
+const (
+	directoryAttributePrincipalPrefix = "directory_attribute:"
+	directoryGroupPrincipalPrefix     = "directory_group:"
+)
+
+// DirectoryGroupPrincipal returns the plugin-only principal that represents a
+// locally stored directory group. It deliberately is not an urn.Principal:
+// directory groups are delivery audiences, not RBAC principals.
+func DirectoryGroupPrincipal(id uuid.UUID) string {
+	return directoryGroupPrincipalPrefix + id.String()
+}
+
+// DirectoryAttributePrincipal returns the plugin-only principal for an exact
+// directory-user attribute match. Each component is encoded independently so
+// arbitrary WorkOS attribute keys and values remain unambiguous.
+func DirectoryAttributePrincipal(key, value string) string {
+	return directoryAttributePrincipalPrefix + base64.RawURLEncoding.EncodeToString([]byte(key)) + ":" + base64.RawURLEncoding.EncodeToString([]byte(value))
+}
+
+// ResolveDirectoryAudiencePrincipalsByEmails resolves each normalized email to
+// its active directory-group and directory-attribute delivery audiences in an
+// organization. Multiple active directory-user records for the same email
+// contribute their combined memberships and attributes.
+func ResolveDirectoryAudiencePrincipalsByEmails(ctx context.Context, db workosrepo.DBTX, organizationID string, emails []string) (map[string][]string, error) {
+	normalized := make([]string, 0, len(emails))
+	for _, email := range emails {
+		email = conv.NormalizeEmail(email)
+		if email == "" || slices.Contains(normalized, email) {
+			continue
+		}
+		normalized = append(normalized, email)
+	}
+	if len(normalized) == 0 {
+		return map[string][]string{}, nil
+	}
+
+	rows, err := workosrepo.New(db).ListActiveDirectoryGroupIDsByEmails(ctx, workosrepo.ListActiveDirectoryGroupIDsByEmailsParams{
+		OrganizationID: organizationID,
+		Emails:         normalized,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list active directory groups: %w", err)
+	}
+	attributes, err := workosrepo.New(db).ListActiveDirectoryUserAttributesByEmails(ctx, workosrepo.ListActiveDirectoryUserAttributesByEmailsParams{
+		OrganizationID: organizationID,
+		Emails:         normalized,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list active directory user attributes: %w", err)
+	}
+
+	principals := make(map[string][]string, len(normalized))
+	for _, row := range rows {
+		principals[row.Email] = append(principals[row.Email], DirectoryGroupPrincipal(row.DirectoryGroupID))
+	}
+	for _, attribute := range attributes {
+		principals[attribute.Email] = append(principals[attribute.Email], DirectoryAttributePrincipal(attribute.AttributeKey, attribute.AttributeValue))
+	}
+	return principals, nil
+}

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -252,3 +252,37 @@ WHERE du.user_id = @user_id
   AND dg.organization_id = @organization_id
   AND du.deleted_at IS NULL
 ORDER BY dg.workos_directory_group_id;
+
+-- name: ListActiveDirectoryGroupIDsByEmails :many
+SELECT DISTINCT
+  LOWER(du.email) AS email,
+  dg.id AS directory_group_id
+FROM directory_users AS du
+JOIN directory_user_group_memberships AS m
+  ON m.directory_user_id = du.id
+  AND m.deleted IS FALSE
+JOIN directory_groups AS dg
+  ON dg.id = m.directory_group_id
+  AND dg.organization_id = du.organization_id
+  AND dg.deleted IS FALSE
+  AND dg.workos_deleted IS FALSE
+WHERE du.organization_id = @organization_id
+  AND du.deleted IS FALSE
+  AND du.workos_deleted IS FALSE
+  AND du.email IS NOT NULL
+  AND LOWER(du.email) = ANY(@emails::text[])
+ORDER BY email, directory_group_id;
+
+-- name: ListActiveDirectoryUserAttributesByEmails :many
+SELECT
+  LOWER(du.email) AS email,
+  attribute.key::text AS attribute_key,
+  attribute.value::text AS attribute_value
+FROM directory_users AS du
+CROSS JOIN LATERAL jsonb_each_text(du.attributes) AS attribute(key, value)
+WHERE du.organization_id = @organization_id
+  AND du.deleted IS FALSE
+  AND du.workos_deleted IS FALSE
+  AND du.email IS NOT NULL
+  AND LOWER(du.email) = ANY(@emails::text[])
+ORDER BY email, attribute.key, attribute.value;

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -274,7 +274,7 @@ WHERE du.organization_id = @organization_id
 ORDER BY email, directory_group_id;
 
 -- name: ListActiveDirectoryUserAttributesByEmails :many
-SELECT
+SELECT DISTINCT
   LOWER(du.email) AS email,
   attribute.key::text AS attribute_key,
   attribute.value::text AS attribute_value

--- a/server/internal/thirdparty/workos/repo/queries.sql.go
+++ b/server/internal/thirdparty/workos/repo/queries.sql.go
@@ -430,7 +430,7 @@ func (q *Queries) ListActiveDirectoryGroupIDsByEmails(ctx context.Context, arg L
 }
 
 const listActiveDirectoryUserAttributesByEmails = `-- name: ListActiveDirectoryUserAttributesByEmails :many
-SELECT
+SELECT DISTINCT
   LOWER(du.email) AS email,
   attribute.key::text AS attribute_key,
   attribute.value::text AS attribute_value

--- a/server/internal/thirdparty/workos/repo/queries.sql.go
+++ b/server/internal/thirdparty/workos/repo/queries.sql.go
@@ -378,6 +378,103 @@ func (q *Queries) LinkDirectoryUsersToUserByEmail(ctx context.Context, arg LinkD
 	return result.RowsAffected(), nil
 }
 
+const listActiveDirectoryGroupIDsByEmails = `-- name: ListActiveDirectoryGroupIDsByEmails :many
+SELECT DISTINCT
+  LOWER(du.email) AS email,
+  dg.id AS directory_group_id
+FROM directory_users AS du
+JOIN directory_user_group_memberships AS m
+  ON m.directory_user_id = du.id
+  AND m.deleted IS FALSE
+JOIN directory_groups AS dg
+  ON dg.id = m.directory_group_id
+  AND dg.organization_id = du.organization_id
+  AND dg.deleted IS FALSE
+  AND dg.workos_deleted IS FALSE
+WHERE du.organization_id = $1
+  AND du.deleted IS FALSE
+  AND du.workos_deleted IS FALSE
+  AND du.email IS NOT NULL
+  AND LOWER(du.email) = ANY($2::text[])
+ORDER BY email, directory_group_id
+`
+
+type ListActiveDirectoryGroupIDsByEmailsParams struct {
+	OrganizationID string
+	Emails         []string
+}
+
+type ListActiveDirectoryGroupIDsByEmailsRow struct {
+	Email            string
+	DirectoryGroupID uuid.UUID
+}
+
+func (q *Queries) ListActiveDirectoryGroupIDsByEmails(ctx context.Context, arg ListActiveDirectoryGroupIDsByEmailsParams) ([]ListActiveDirectoryGroupIDsByEmailsRow, error) {
+	rows, err := q.db.Query(ctx, listActiveDirectoryGroupIDsByEmails, arg.OrganizationID, arg.Emails)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveDirectoryGroupIDsByEmailsRow
+	for rows.Next() {
+		var i ListActiveDirectoryGroupIDsByEmailsRow
+		if err := rows.Scan(&i.Email, &i.DirectoryGroupID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listActiveDirectoryUserAttributesByEmails = `-- name: ListActiveDirectoryUserAttributesByEmails :many
+SELECT
+  LOWER(du.email) AS email,
+  attribute.key::text AS attribute_key,
+  attribute.value::text AS attribute_value
+FROM directory_users AS du
+CROSS JOIN LATERAL jsonb_each_text(du.attributes) AS attribute(key, value)
+WHERE du.organization_id = $1
+  AND du.deleted IS FALSE
+  AND du.workos_deleted IS FALSE
+  AND du.email IS NOT NULL
+  AND LOWER(du.email) = ANY($2::text[])
+ORDER BY email, attribute.key, attribute.value
+`
+
+type ListActiveDirectoryUserAttributesByEmailsParams struct {
+	OrganizationID string
+	Emails         []string
+}
+
+type ListActiveDirectoryUserAttributesByEmailsRow struct {
+	Email          string
+	AttributeKey   string
+	AttributeValue string
+}
+
+func (q *Queries) ListActiveDirectoryUserAttributesByEmails(ctx context.Context, arg ListActiveDirectoryUserAttributesByEmailsParams) ([]ListActiveDirectoryUserAttributesByEmailsRow, error) {
+	rows, err := q.db.Query(ctx, listActiveDirectoryUserAttributesByEmails, arg.OrganizationID, arg.Emails)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveDirectoryUserAttributesByEmailsRow
+	for rows.Next() {
+		var i ListActiveDirectoryUserAttributesByEmailsRow
+		if err := rows.Scan(&i.Email, &i.AttributeKey, &i.AttributeValue); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCurrentDirectoryGroupsByUserID = `-- name: ListCurrentDirectoryGroupsByUserID :many
 SELECT DISTINCT ON (dg.workos_directory_group_id)
   dg.workos_directory_group_id,


### PR DESCRIPTION
## Why?

Plugin delivery currently cannot target directory-sync audiences. This lays the runtime foundation for [AGE-3249](https://linear.app/speakeasy/issue/AGE-3249/add-directory-group-plugin-delivery-foundation).

## What?

Resolve active directory-group memberships and exact directory-user attributes for the polling email, then include those plugin-only audiences when selecting plugins. The resolver is organization-scoped, uses the existing active-directory indexes, and keeps directory audiences outside RBAC.

## Notes

Management API and dashboard assignment workflows remain follow-up work. The local commit hook could not run its `gofix` task because this isolated worktree lacks the `zx` dependency; formatting, agent tests, server build, and server lint all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers plugins to directory audiences (directory groups and exact directory-user attributes) resolved from the polling email. Previously these were ignored; now `GetPlugins` includes `directory_group` and `directory_attribute` principals ahead of user/role resolution and fails on audience resolution errors. Supports Linear AGE-3249.

- Introduces plugin-only principals `directory_group:<uuid>` and `directory_attribute:<b64Key>:<b64Value>` kept outside RBAC.
- Resolves audiences via `plugins.ResolveDirectoryAudiencePrincipalsByEmails` before user/role resolution; email and org wildcard behavior is unchanged.
- Adds repo queries `ListActiveDirectoryGroupIDsByEmails` and `ListActiveDirectoryUserAttributesByEmails`; they normalize emails, scope to the organization, exclude deleted users/groups/memberships, and deduplicate attribute audiences.
- Tests cover unlinked users, exact attribute delivery, deduping across duplicate directory-user records, membership removal, group/user deletion, and tenant isolation.

<sup>Written for commit c8813664810702f7e7fd08c6ae434c2bc8eb7687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

