### PR TITLE
fix: accept WorkOS impersonation callbacks

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -113,17 +113,18 @@ const (
 	TemporalWorkflowIDKey    = attribute.Key("temporal.workflow.id")
 	TemporalRunIDKey         = attribute.Key("temporal.run.id")
 
-	AuthAccountTypeKey      = attribute.Key("gram.auth.account_type")
-	AuthAPIKeyIDKey         = attribute.Key("gram.auth.api_key.id")
-	AuthOrganizationIDKey   = attribute.Key("gram.auth.organization_id")
-	AuthOrganizationSlugKey = attribute.Key("gram.auth.organization_slug")
-	AuthProjectIDKey        = attribute.Key("gram.auth.project_id")
-	AuthProjectSlugKey      = attribute.Key("gram.auth.project_slug")
-	AuthSchemeKey           = attribute.Key("gram.auth.scheme")
-	AuthSessionIDKey        = attribute.Key("gram.auth.session_id")
-	AuthUserEmailKey        = attribute.Key("gram.auth.user_email")
-	AuthUserIDKey           = attribute.Key("gram.auth.user_id")
-	AuthUserExternalIDKey   = attribute.Key("gram.auth.external_user_id")
+	AuthAccountTypeKey       = attribute.Key("gram.auth.account_type")
+	AuthAPIKeyIDKey          = attribute.Key("gram.auth.api_key.id")
+	AuthOrganizationIDKey    = attribute.Key("gram.auth.organization_id")
+	AuthOrganizationSlugKey  = attribute.Key("gram.auth.organization_slug")
+	AuthProjectIDKey         = attribute.Key("gram.auth.project_id")
+	AuthProjectSlugKey       = attribute.Key("gram.auth.project_slug")
+	AuthSchemeKey            = attribute.Key("gram.auth.scheme")
+	AuthSessionIDKey         = attribute.Key("gram.auth.session_id")
+	AuthUserEmailKey         = attribute.Key("gram.auth.user_email")
+	AuthUserIDKey            = attribute.Key("gram.auth.user_id")
+	AuthUserExternalIDKey    = attribute.Key("gram.auth.external_user_id")
+	AuthImpersonatorEmailKey = attribute.Key("gram.auth.impersonator_email")
 
 	TopicProtoNameKey        = attribute.Key("gram.topic.proto_name")
 	SubscriptionProtoNameKey = attribute.Key("gram.subscription.proto_name")
@@ -1004,6 +1005,11 @@ func SlogAuthSessionID(v string) slog.Attr      { return slog.String(string(Auth
 
 func AuthUserEmail(v string) attribute.KeyValue { return AuthUserEmailKey.String(v) }
 func SlogAuthUserEmail(v string) slog.Attr      { return slog.String(string(AuthUserEmailKey), v) }
+
+func AuthImpersonatorEmail(v string) attribute.KeyValue { return AuthImpersonatorEmailKey.String(v) }
+func SlogAuthImpersonatorEmail(v string) slog.Attr {
+	return slog.String(string(AuthImpersonatorEmailKey), v)
+}
 
 func AuthUserID(v string) attribute.KeyValue { return AuthUserIDKey.String(v) }
 func SlogAuthUserID(v string) slog.Attr      { return slog.String(string(AuthUserIDKey), v) }

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -635,6 +635,16 @@ func TestService_CallbackAllowsWorkOSImpersonationWithoutState(t *testing.T) {
 	require.Equal(t, userInfo.Organizations[0].ID, authCtx.ActiveOrganizationID)
 }
 
+func TestIdentityResolverCapturesWorkOSImpersonatorEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, instance := newTestAuthService(t, defaultMockUserInfo())
+
+	idpUser, err := instance.identityResolver.ExchangeCodeForTokens(ctx, "impersonation_code")
+	require.NoError(t, err)
+	require.Equal(t, "support@example.com", idpUser.ImpersonatorEmail())
+}
+
 // extractStateFromURL extracts the state query parameter from a URL string.
 func extractStateFromURL(t *testing.T, urlStr string) string {
 	t.Helper()

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -608,6 +608,33 @@ func TestService_Callback(t *testing.T) {
 	})
 }
 
+func TestService_CallbackAllowsWorkOSImpersonationWithoutState(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	ctx, instance := newTestAuthService(t, userInfo)
+
+	require.NoError(t, instance.createTestUser(ctx, userInfo))
+	for _, org := range userInfo.Organizations {
+		require.NoError(t, instance.createTestOrganization(ctx, org, userInfo.UserID))
+	}
+
+	result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
+		Code: "impersonation_code",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, instance.authConfigs.SignInRedirectURL, result.Location)
+	require.NotEmpty(t, result.SessionToken)
+	require.Equal(t, result.SessionToken, result.SessionCookie)
+
+	ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err, "load impersonation session after callback")
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok, "auth context should be set after callback")
+	require.Equal(t, userInfo.Organizations[0].ID, authCtx.ActiveOrganizationID)
+}
+
 // extractStateFromURL extracts the state query parameter from a URL string.
 func extractStateFromURL(t *testing.T, urlStr string) string {
 	t.Helper()

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -62,6 +62,7 @@ type AuthenticateResult struct {
 	AccessToken    string
 	OrganizationID string // WorkOS org ID the user selected during auth (may be empty)
 	User           AuthenticatedUser
+	impersonated   bool
 }
 
 type MagicAuthChallenge struct {
@@ -103,6 +104,13 @@ type IDPUserInfo struct {
 	ExternalID      string  `json:"-"`
 	WorkOSSessionID string  `json:"-"`
 	OrganizationID  string  `json:"-"` // WorkOS org ID selected during auth
+	impersonated    bool
+}
+
+// IsImpersonated reports whether WorkOS authenticated the user through a
+// Dashboard-initiated impersonation session.
+func (u *IDPUserInfo) IsImpersonated() bool {
+	return u != nil && u.impersonated
 }
 
 // Resolver handles identity concerns: IDP code exchange, user upsert, org
@@ -221,6 +229,7 @@ func idpUserInfoFromAuthenticateResult(resp *AuthenticateResult) *IDPUserInfo {
 		ExternalID:      resp.User.ExternalID,
 		WorkOSSessionID: extractSessionIDFromJWT(resp.AccessToken),
 		OrganizationID:  resp.OrganizationID,
+		impersonated:    resp.impersonated,
 	}
 }
 

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -59,10 +59,10 @@ type AuthorizationURLParams struct {
 
 // AuthenticateResult holds the fields Gram uses from the IDP code exchange.
 type AuthenticateResult struct {
-	AccessToken    string
-	OrganizationID string // WorkOS org ID the user selected during auth (may be empty)
-	User           AuthenticatedUser
-	impersonated   bool
+	AccessToken       string
+	OrganizationID    string // WorkOS org ID the user selected during auth (may be empty)
+	User              AuthenticatedUser
+	impersonatorEmail string
 }
 
 type MagicAuthChallenge struct {
@@ -97,20 +97,23 @@ type WorkOSClient interface {
 
 // IDPUserInfo represents the user identity returned by the IDP after code exchange.
 type IDPUserInfo struct {
-	Sub             string  `json:"sub"`
-	Email           string  `json:"email"`
-	Name            string  `json:"name"`
-	Picture         *string `json:"picture,omitempty"`
-	ExternalID      string  `json:"-"`
-	WorkOSSessionID string  `json:"-"`
-	OrganizationID  string  `json:"-"` // WorkOS org ID selected during auth
-	impersonated    bool
+	Sub               string  `json:"sub"`
+	Email             string  `json:"email"`
+	Name              string  `json:"name"`
+	Picture           *string `json:"picture,omitempty"`
+	ExternalID        string  `json:"-"`
+	WorkOSSessionID   string  `json:"-"`
+	OrganizationID    string  `json:"-"` // WorkOS org ID selected during auth
+	impersonatorEmail string
 }
 
-// IsImpersonated reports whether WorkOS authenticated the user through a
-// Dashboard-initiated impersonation session.
-func (u *IDPUserInfo) IsImpersonated() bool {
-	return u != nil && u.impersonated
+// ImpersonatorEmail returns the WorkOS Dashboard operator who initiated an
+// impersonation session. It is empty for ordinary authentication.
+func (u *IDPUserInfo) ImpersonatorEmail() string {
+	if u == nil {
+		return ""
+	}
+	return u.impersonatorEmail
 }
 
 // Resolver handles identity concerns: IDP code exchange, user upsert, org
@@ -222,14 +225,14 @@ func idpUserInfoFromAuthenticateResult(resp *AuthenticateResult) *IDPUserInfo {
 	}
 
 	return &IDPUserInfo{
-		Sub:             resp.User.ID,
-		Email:           resp.User.Email,
-		Name:            name,
-		Picture:         picture,
-		ExternalID:      resp.User.ExternalID,
-		WorkOSSessionID: extractSessionIDFromJWT(resp.AccessToken),
-		OrganizationID:  resp.OrganizationID,
-		impersonated:    resp.impersonated,
+		Sub:               resp.User.ID,
+		Email:             resp.User.Email,
+		Name:              name,
+		Picture:           picture,
+		ExternalID:        resp.User.ExternalID,
+		WorkOSSessionID:   extractSessionIDFromJWT(resp.AccessToken),
+		OrganizationID:    resp.OrganizationID,
+		impersonatorEmail: resp.impersonatorEmail,
 	}
 }
 

--- a/server/internal/auth/identity/workos_adapter.go
+++ b/server/internal/auth/identity/workos_adapter.go
@@ -47,6 +47,7 @@ func (a *WorkOSAdapter) AuthenticateWithCode(ctx context.Context, clientID, code
 			ProfilePictureURL: resp.User.ProfilePictureURL,
 			ExternalID:        resp.User.ExternalID,
 		},
+		impersonated: resp.Impersonator != nil,
 	}, nil
 }
 
@@ -90,6 +91,7 @@ func (a *WorkOSAdapter) AuthenticateWithMagicAuth(ctx context.Context, clientID,
 			ProfilePictureURL: resp.User.ProfilePictureURL,
 			ExternalID:        resp.User.ExternalID,
 		},
+		impersonated: false,
 	}, nil
 }
 

--- a/server/internal/auth/identity/workos_adapter.go
+++ b/server/internal/auth/identity/workos_adapter.go
@@ -35,6 +35,11 @@ func (a *WorkOSAdapter) AuthenticateWithCode(ctx context.Context, clientID, code
 		return nil, fmt.Errorf("workos authenticate: %w", err)
 	}
 
+	impersonatorEmail := ""
+	if resp.Impersonator != nil {
+		impersonatorEmail = resp.Impersonator.Email
+	}
+
 	return &AuthenticateResult{
 		AccessToken:    resp.AccessToken,
 		OrganizationID: resp.OrganizationID,
@@ -47,7 +52,7 @@ func (a *WorkOSAdapter) AuthenticateWithCode(ctx context.Context, clientID, code
 			ProfilePictureURL: resp.User.ProfilePictureURL,
 			ExternalID:        resp.User.ExternalID,
 		},
-		impersonated: resp.Impersonator != nil,
+		impersonatorEmail: impersonatorEmail,
 	}, nil
 }
 
@@ -91,7 +96,7 @@ func (a *WorkOSAdapter) AuthenticateWithMagicAuth(ctx context.Context, clientID,
 			ProfilePictureURL: resp.User.ProfilePictureURL,
 			ExternalID:        resp.User.ExternalID,
 		},
-		impersonated: false,
+		impersonatorEmail: "",
 	}, nil
 }
 

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -270,8 +270,10 @@ func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.A
 }
 
 func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (res *gen.CallbackResult, err error) {
+	logger := s.logger
+
 	redirectWithError := func(code authErr, err error) (*gen.CallbackResult, error) {
-		s.logger.ErrorContext(ctx, "signin error", attr.SlogError(err), attr.SlogReason(string(code)))
+		logger.ErrorContext(ctx, "signin error", attr.SlogError(err), attr.SlogReason(string(code)))
 		return &gen.CallbackResult{
 			Location:      fmt.Sprintf("%s?signin_error=%s", s.cfg.SignInRedirectURL, err.Error()),
 			SessionToken:  "",
@@ -306,7 +308,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 			// Swallow so a cache blip cannot fail an otherwise valid login, but
 			// say so: without this line a signup silently degrades into landing
 			// on the register page with nothing explaining why.
-			s.logger.WarnContext(ctx, "failed to read signup intent", attr.SlogError(err))
+			logger.WarnContext(ctx, "failed to read signup intent", attr.SlogError(err))
 		}
 	}
 
@@ -314,8 +316,14 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 	if err != nil {
 		return redirectWithError(authErrCodeLookup, err)
 	}
-	if !stateProvided && !idpUser.IsImpersonated() {
+	if !stateProvided && idpUser.ImpersonatorEmail() == "" {
 		return redirectWithError(authErrCodeLookup, errors.New("missing or invalid state parameter"))
+	}
+
+	if ie := idpUser.ImpersonatorEmail(); ie != "" {
+		logger = logger.With(attr.SlogAuthImpersonatorEmail(ie))
+		logger.InfoContext(ctx, "impersonating user")
+		trace.SpanFromContext(ctx).SetAttributes(attr.AuthImpersonatorEmail(ie))
 	}
 
 	userID, err := s.identity.UpsertUserFromIDP(ctx, idpUser)
@@ -366,7 +374,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 			}
 
 			if err := s.trialNotifier.TrialStarted(ctx, org.ID); err != nil {
-				s.logger.ErrorContext(ctx, "failed to notify trial started", attr.SlogError(err), attr.SlogOrganizationID(org.ID), attr.SlogUserID(userID))
+				logger.ErrorContext(ctx, "failed to notify trial started", attr.SlogError(err), attr.SlogOrganizationID(org.ID), attr.SlogUserID(userID))
 			}
 
 			s.captureSignupTelemetry(ctx, userInfo.Email, intent.OrgName, org)
@@ -456,7 +464,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 	}
 	if inviteeEmail := conv.NormalizeEmail(userInfo.Email); inviteeEmail != "" {
 		if err := s.acceptPendingInvitationForMember(ctx, activeOrgID, inviteeEmail, userID, idpUser.Sub); err != nil {
-			s.logger.WarnContext(ctx, "failed to accept pending invite after login",
+			logger.WarnContext(ctx, "failed to accept pending invite after login",
 				attr.SlogError(err),
 				attr.SlogOrganizationID(activeOrgID),
 				attr.SlogAuthUserEmail(inviteeEmail),

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -283,8 +283,11 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		return redirectWithError(authErrCodeLookup, errors.New("code is required"))
 	}
 
-	if err := s.validateAuthNonce(ctx, payload); err != nil {
-		return redirectWithError(authErrCodeLookup, err)
+	stateProvided := conv.PtrValOr(payload.State, "") != ""
+	if stateProvided {
+		if err := s.validateAuthNonce(ctx, payload); err != nil {
+			return redirectWithError(authErrCodeLookup, err)
+		}
 	}
 
 	// Consume the signup intent on every path, not only the zero-org one, so a
@@ -310,6 +313,9 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 	idpUser, err := s.identity.ExchangeCodeForTokens(ctx, payload.Code)
 	if err != nil {
 		return redirectWithError(authErrCodeLookup, err)
+	}
+	if !stateProvided && !idpUser.IsImpersonated() {
+		return redirectWithError(authErrCodeLookup, errors.New("missing or invalid state parameter"))
 	}
 
 	userID, err := s.identity.UpsertUserFromIDP(ctx, idpUser)

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -123,6 +123,14 @@ func createMockWorkOSServer(userInfo *MockUserInfo) *httptest.Server {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("POST /user_management/authenticate", func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Code string `json:"code"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		resp := map[string]any{
 			"access_token":    fmt.Sprintf("mock_access_token_%p", userInfo),
@@ -136,6 +144,13 @@ func createMockWorkOSServer(userInfo *MockUserInfo) *httptest.Server {
 				"profile_picture_url": "",
 				"external_id":         userInfo.ExternalID,
 			},
+		}
+		if request.Code == "impersonation_code" {
+			resp["authentication_method"] = "Impersonation"
+			resp["impersonator"] = map[string]string{
+				"email":  "support@example.com",
+				"reason": "Investigating a reported issue",
+			}
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	})


### PR DESCRIPTION
## Summary

- accept state-less WorkOS Dashboard impersonation callbacks only after the code exchange returns impersonator metadata
- preserve nonce and browser-binding validation for regular authentication callbacks
- cover successful impersonation and rejection of ordinary callbacks without state

## Verification

- `mise exec -- go test ./server/internal/auth -run 'TestService_CallbackAllowsWorkOSImpersonationWithoutState|TestService_Callback/missing_nonce_returns_error' -count=1`
- `mise lint:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts WorkOS Dashboard–initiated impersonation callbacks that omit state after verifying the code exchange includes impersonator metadata, and records the impersonator email for observability. Previously all stateless callbacks were rejected; now only non‑impersonation callbacks without state are rejected, and standard auth still requires nonce/state.

- Skip nonce/state validation only when WorkOS returns an impersonator; otherwise a missing state triggers an error.
- Capture impersonator email from WorkOS; expose it via `ImpersonatorEmail()` on IDP user info and emit `gram.auth.impersonator_email` to logs and traces.
- Add tests for successful impersonation session creation, capturing impersonator email, and rejecting ordinary stateless callbacks.
- No client or config changes required; Dashboard impersonation works out of the box.

<sup>Written for commit a73f3a036b80dc013e29776fd6c9b2a870164a33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

