### PR TITLE
feat(dashboard): move project switcher into the page header

### DIFF
--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -155,7 +155,9 @@ const AppLayoutContent = ({
     <div className="flex h-screen w-full flex-col">
       {isImpersonating && <ImpersonationBanner />}
       <div className="flex w-full flex-1 overflow-hidden">
-        <AppSidebar variant="inset" />
+        {/* Default (non-inset) variant: flat panes divided by a hairline
+            instead of a floating bordered card. */}
+        <AppSidebar />
         <SidebarInset>
           <GlobalInsightsWrapper>
             <MembershipSyncGuard>
@@ -253,7 +255,7 @@ export const OrgLayout = (): JSX.Element => {
       <div className="flex h-screen w-full flex-col">
         {isImpersonating && <ImpersonationBanner />}
         <div className="flex w-full flex-1 overflow-hidden">
-          <OrgSidebar variant="inset" />
+          <OrgSidebar />
           <SidebarInset>
             <MembershipSyncGuard>
               <Outlet />

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -142,14 +142,20 @@ export function AppSidebar({
         <SidebarMenu className="gap-0.5 px-2 group-data-[collapsible=icon]:px-0">
           {/* Home — the org-scoped app (was the "Organization settings"
               footer action); the project's own landing page sits below it as
-              "Project Overview". */}
-          <SidebarMenuItem>
-            <NavButton
-              title="Home"
-              href={`/${orgSlug}`}
-              Icon={(p) => <Icon {...p} name="building" />}
-            />
-          </SidebarMenuItem>
+              "Project Overview". Scoped to match OrgSidebar's own Home item,
+              so it only shows to users who can open the page it links to. */}
+          <RequireScope
+            scope={["org:read", "project:read", "org:admin"]}
+            level="section"
+          >
+            <SidebarMenuItem>
+              <NavButton
+                title="Home"
+                href={`/${orgSlug}`}
+                Icon={(p) => <Icon {...p} name="building" />}
+              />
+            </SidebarMenuItem>
+          </RequireScope>
 
           {/* Project overview — top-level, no group */}
           <ScopeGatedTopLevelItem

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { AppRoute, useOrgRoutes, useRoutes } from "@/routes";
-import { MinusIcon, Settings, TestTube2Icon } from "lucide-react";
+import { MinusIcon, TestTube2Icon } from "lucide-react";
 import { NavButton, NavGroupProvider } from "@/components/nav-menu";
 import {
   Sidebar,
@@ -10,12 +10,13 @@ import {
   SidebarHeader,
   SidebarMenu,
   SidebarMenuItem,
+  SidebarTrigger,
 } from "@/components/ui/Sidebar";
 import { useMemo, useState } from "react";
 
 import { BuiltInMcpSidebarNav } from "./built-in-mcp-sidebar-nav";
 import { Button } from "./ui/Button";
-import { CommandPaletteTrigger } from "./command-palette/CommandPaletteTrigger";
+import { HatchRule } from "./hatch-rule";
 import { FeatureRequestModal } from "./FeatureRequestModal";
 import { GramLogo } from "./gram-logo";
 import { Icon } from "@/components/ui/Icon";
@@ -30,14 +31,12 @@ import type { ProjectNavRoute } from "@/hooks/useProjectNavRoutes";
 import { RequireScope } from "./require-scope";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { ScopeGatedNavGroup } from "@/components/scope-gated-nav-group";
-import { SidebarFooterAction } from "./sidebar-footer-action";
 import { SidebarNavSkeleton } from "./sidebar-nav-skeleton";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import { SkillDetailSidebarNav } from "./skill-detail-sidebar-nav";
 import { Stack } from "@/components/ui/Stack";
 import { Text } from "@/components/ui/Text";
 import { TrialStatusCard } from "./trial-status-card";
-import { WorkspaceSwitcher } from "./workspace-switcher";
 import { cn } from "@/lib/utils";
 import { useGetPeriodUsage } from "@gram/client/react-query/getPeriodUsage.js";
 import { useNavArea } from "@/hooks/useNavArea";
@@ -141,7 +140,18 @@ export function AppSidebar({
     sidebarContent = (
       <NavGroupProvider activeGroup={activeGroup} activeItem={activeItem}>
         <SidebarMenu className="gap-0.5 px-2 group-data-[collapsible=icon]:px-0">
-          {/* Home — top-level, no group */}
+          {/* Home — the org-scoped app (was the "Organization settings"
+              footer action); the project's own landing page sits below it as
+              "Project Overview". */}
+          <SidebarMenuItem>
+            <NavButton
+              title="Home"
+              href={`/${orgSlug}`}
+              Icon={(p) => <Icon {...p} name="building" />}
+            />
+          </SidebarMenuItem>
+
+          {/* Project overview — top-level, no group */}
           <ScopeGatedTopLevelItem
             item={routes.home}
             {...accessFor(routes.home)}
@@ -265,17 +275,23 @@ export function AppSidebar({
       }
       {...props}
     >
-      <SidebarHeader className="gap-3 pb-3">
-        <div className="flex items-center justify-between gap-2 group-data-[collapsible=icon]:justify-center">
+      {/* Logo row only — the project switcher now lives in the page header.
+          The row is exactly --header-height and closes with the same crosshatch
+          rule the page header uses, so the divider reads as one line running
+          across both panes. */}
+      <SidebarHeader className="gap-0 p-0">
+        <div className="flex h-(--header-height) items-center justify-between gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
           <Link
             to={`/${orgSlug}`}
-            className="flex h-(--header-height) items-center px-1 hover:no-underline group-data-[collapsible=icon]:hidden"
+            className="flex h-full items-center px-1 hover:no-underline group-data-[collapsible=icon]:hidden"
           >
             <GramLogo className="w-28" />
           </Link>
-          <CommandPaletteTrigger />
+          {/* Collapse control sits beside the logo (WorkOS placement); search
+              moved out to the page header. */}
+          <SidebarTrigger />
         </div>
-        <WorkspaceSwitcher />
+        <HatchRule />
       </SidebarHeader>
       <SidebarContent className="pt-2">{sidebarContent}</SidebarContent>
       <SidebarFooter className="border-t">
@@ -285,11 +301,6 @@ export function AppSidebar({
           <OnboardingResumeButton />
           <PlatformMcpSidebarCta />
           <InsightsDockResumeButton />
-          <SidebarFooterAction
-            to={`/${orgSlug}`}
-            icon={Settings}
-            label="Organization settings"
-          />
         </div>
         <SidebarUserMenu />
       </SidebarFooter>

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -125,7 +125,16 @@ export function AppSidebar({
 
   let sidebarContent: React.ReactNode;
   if (rbacLoading) {
-    sidebarContent = <SidebarNavSkeleton />;
+    // Shaped like the real list below — 3 top-level items, the divider, the
+    // 4 collapsed groups, then Settings — at the same spacing, so resolving
+    // the grants swaps the rows out without shifting the nav.
+    sidebarContent = (
+      <SidebarNavSkeleton
+        rows={8}
+        divideAfter={3}
+        className="gap-0.5 px-2 group-data-[collapsible=icon]:px-0"
+      />
+    );
   } else if (routes.mcp.details.active) {
     sidebarContent = <McpDetailSidebarNav />;
   } else if (routes.mcp.x.active) {

--- a/client/dashboard/src/components/hatch-rule.tsx
+++ b/client/dashboard/src/components/hatch-rule.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Marketing-site crosshatch rule: a hairline closed by small hollow squares
+ * sitting on the line at each end, the way the section grid on the marketing
+ * pages marks its intersections. Used to demarcate the app chrome (sidebar
+ * header, page header) instead of a heavier brand bar.
+ */
+export function HatchRule({ className }: { className?: string }): JSX.Element {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "border-border relative h-px w-full shrink-0 border-t",
+        className,
+      )}
+    >
+      <HatchNode className="-left-[3px]" />
+      <HatchNode className="-right-[3px]" />
+    </div>
+  );
+}
+
+function HatchNode({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "border-border bg-background absolute -top-[3px] size-[5px] border",
+        className,
+      )}
+    />
+  );
+}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -9,10 +9,11 @@ import {
   SidebarHeader,
   SidebarMenu,
   SidebarMenuItem,
+  SidebarTrigger,
 } from "@/components/ui/Sidebar";
 
-import { CommandPaletteTrigger } from "./command-palette/CommandPaletteTrigger";
 import { GramLogo } from "./gram-logo";
+import { HatchRule } from "./hatch-rule";
 import { Icon } from "@/components/ui/Icon";
 import { Link } from "react-router";
 import { OnboardingResumeButton } from "./onboarding-resume-button";
@@ -22,7 +23,6 @@ import { ScopeGatedNavGroup } from "@/components/scope-gated-nav-group";
 import { SidebarNavSkeleton } from "./sidebar-nav-skeleton";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import { TrialStatusCard } from "./trial-status-card";
-import { WorkspaceSwitcher } from "./workspace-switcher";
 import { useIsPlatformAdmin } from "@/contexts/Auth";
 import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
@@ -148,17 +148,19 @@ export function OrgSidebar({
 
   return (
     <Sidebar collapsible="icon" {...props}>
-      <SidebarHeader className="gap-3 pb-3">
-        <div className="flex items-center justify-between gap-2 group-data-[collapsible=icon]:justify-center">
+      {/* Matches AppSidebar: logo + collapse control on one --header-height row,
+          closed by the crosshatch rule so it lines up with the page header. */}
+      <SidebarHeader className="gap-0 p-0">
+        <div className="flex h-(--header-height) items-center justify-between gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
           <Link
             to={orgRoutes.home.href()}
-            className="flex h-(--header-height) items-center px-1 hover:no-underline group-data-[collapsible=icon]:hidden"
+            className="flex h-full items-center px-1 hover:no-underline group-data-[collapsible=icon]:hidden"
           >
             <GramLogo className="w-28" />
           </Link>
-          <CommandPaletteTrigger />
+          <SidebarTrigger />
         </div>
-        <WorkspaceSwitcher />
+        <HatchRule />
       </SidebarHeader>
       <SidebarContent className="pt-2">
         {rbacLoading ? (

--- a/client/dashboard/src/components/page-header.test.tsx
+++ b/client/dashboard/src/components/page-header.test.tsx
@@ -3,12 +3,6 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/components/ui/Sidebar", () => ({
-  SidebarTrigger: () => <button data-testid="sidebar-trigger" />,
-}));
-vi.mock("@/components/ui/Separator", () => ({
-  Separator: () => <hr data-testid="separator" />,
-}));
 vi.mock("./onboarding-banner.tsx", () => ({
   OnboardingBanner: () => null,
 }));
@@ -17,6 +11,12 @@ vi.mock("./onboarding-banner.tsx", () => ({
 // the thing that mounts them, so they reach every page that has a header.
 vi.mock("./billing/billing-banners.tsx", () => ({
   PaygCapReachedBanners: () => <div data-testid="cap-paused-banner" />,
+}));
+vi.mock("./workspace-switcher.tsx", () => ({
+  WorkspaceSwitcher: () => <div data-testid="workspace-switcher" />,
+}));
+vi.mock("./command-palette/CommandPaletteTrigger", () => ({
+  CommandPaletteTrigger: () => <button data-testid="command-palette" />,
 }));
 // Stub context/hook modules imported at the top of page-header.tsx (used only
 // in PageHeaderBreadcrumbs, not PageHeaderComponent, but they execute on import)

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -1,6 +1,5 @@
 // oxlint-disable react/only-export-components -- compound component (Object.assign) pattern
-import { Separator } from "@/components/ui/Separator";
-import { SidebarTrigger } from "@/components/ui/Sidebar";
+import { CommandPaletteTrigger } from "./command-palette/CommandPaletteTrigger";
 import { useOrganization, useProject } from "@/contexts/Auth.tsx";
 import { useSlugs } from "@/contexts/Sdk.tsx";
 import { useRBAC } from "@/hooks/useRBAC";
@@ -8,11 +7,12 @@ import { cn, titleCaseSlug } from "@/lib/utils.ts";
 import React from "react";
 import { Link, useLocation, useMatch, useParams } from "react-router";
 import { PaygCapReachedBanners } from "./billing/billing-banners.tsx";
-import { BrandGradientLine } from "./brand-gradient-line.tsx";
+import { HatchRule } from "./hatch-rule.tsx";
 import { InsightsDockShortcutHint } from "./insights-dock-shortcut-hint.tsx";
 import { OnboardingBanner } from "./onboarding-banner.tsx";
 import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge.tsx";
 import { Heading } from "@/components/ui/Heading";
+import { WorkspaceSwitcher } from "./workspace-switcher.tsx";
 
 function PageHeaderComponent({
   className,
@@ -35,18 +35,23 @@ function PageHeaderComponent({
           className,
         )}
       >
-        <div className="flex w-full items-center gap-3 px-3">
-          <SidebarTrigger className="mx-0 -ml-1 px-0" />
-          <Separator
-            orientation="vertical"
-            className="data-[orientation=vertical]:h-4"
-          />
+        {/* px-8 matches Page.Body's padding; the switcher pulls back by its own
+            inner padding so its tile lines up with the content edge. */}
+        <div className="flex w-full items-center gap-3 px-8">
+          {/* Project context lives here, in the slot the breadcrumbs used to
+              occupy, rather than in the sidebar. The collapse control moved to
+              the sidebar header alongside the logo. */}
+          <WorkspaceSwitcher className="-ml-1.5 w-auto border-0 px-1.5" />
           {children}
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            <InsightsDockShortcutHint />
+            <CommandPaletteTrigger />
+          </div>
         </div>
       </header>
-      {/* Brand gradient signature, relocated here from the old top bar — it now
-          divides the main panel's header from its content on the right side. */}
-      <BrandGradientLine />
+      {/* Crosshatch rule (marketing-site idiom) divides header from content and
+          continues the sidebar header's own rule across the pane boundary. */}
+      <HatchRule />
       <OnboardingBanner />
       {/* Inference stopping is felt on whichever page the user was working on,
           so the reason for it rides the header rather than waiting on the
@@ -145,19 +150,31 @@ function BreadcrumbCrumb({
   );
 }
 
-function PageHeaderBreadcrumbs({
-  fullWidth,
-  className,
-  substitutions = {}, // Any segment and how it should be displayed, for example toolset slug -> toolset name
-  skipSegments = [], // Segments to skip/hide from breadcrumbs
-  stage,
-}: {
+type PageHeaderBreadcrumbsProps = {
   fullWidth?: boolean;
   className?: string;
   substitutions?: Record<string, string | undefined>;
   skipSegments?: string[];
   stage?: ReleaseStage;
-}) {
+};
+
+// Breadcrumbs are hidden: the header now carries the project switcher instead.
+// The renderer below is kept intact (and every caller keeps mounting
+// <PageHeader.Breadcrumbs>) so flipping this back on is a one-line change.
+const SHOW_BREADCRUMBS: boolean = false;
+
+function PageHeaderBreadcrumbs(props: PageHeaderBreadcrumbsProps) {
+  if (!SHOW_BREADCRUMBS) return null;
+  return <PageHeaderBreadcrumbsTrail {...props} />;
+}
+
+function PageHeaderBreadcrumbsTrail({
+  fullWidth,
+  className,
+  substitutions = {}, // Any segment and how it should be displayed, for example toolset slug -> toolset name
+  skipSegments = [], // Segments to skip/hide from breadcrumbs
+  stage,
+}: PageHeaderBreadcrumbsProps) {
   const params = useParams();
   const { orgSlug, projectSlug } = useSlugs();
   const organization = useOrganization();
@@ -271,10 +288,6 @@ function PageHeaderBreadcrumbs({
   visibleElements.push(...pageElements);
 
   return (
-    // Breadcrumbs + hint share their own justify-between row so the hint
-    // always pins to the true right edge of the nav bar, independent of the
-    // SidebarTrigger/Separator siblings in the outer header row (their width
-    // otherwise threw off the old ml-auto-on-both-siblings layout).
     <div className="flex w-full items-center justify-between gap-2">
       <PageHeader.Title
         className={cn(fullWidth ? "max-w-full" : "", className)}
@@ -291,7 +304,6 @@ function PageHeaderBreadcrumbs({
           {stage && <ReleaseStageBadge stage={stage} />}
         </div>
       </PageHeader.Title>
-      <InsightsDockShortcutHint className="shrink-0" />
     </div>
   );
 }

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -161,7 +161,8 @@ type PageHeaderBreadcrumbsProps = {
 // Breadcrumbs are hidden: the header now carries the project switcher instead.
 // The renderer below is kept intact (and every caller keeps mounting
 // <PageHeader.Breadcrumbs>) so flipping this back on is a one-line change.
-const SHOW_BREADCRUMBS: boolean = false;
+// Widened to boolean so the renderer below doesn't type as unreachable.
+const SHOW_BREADCRUMBS = false as boolean;
 
 function PageHeaderBreadcrumbs(props: PageHeaderBreadcrumbsProps) {
   if (!SHOW_BREADCRUMBS) return null;

--- a/client/dashboard/src/components/sidebar-nav-skeleton.tsx
+++ b/client/dashboard/src/components/sidebar-nav-skeleton.tsx
@@ -1,6 +1,7 @@
 import { SidebarMenu, SidebarMenuItem } from "@/components/ui/Sidebar";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
+import { Fragment } from "react";
 
 // Deterministic label widths so the placeholder reads like a real nav list
 // without shifting between renders.
@@ -18,29 +19,47 @@ const LABEL_WIDTHS = [
  * Placeholder shown in the sidebar while RBAC grants are loading (e.g. right
  * after switching projects, when the query cache is cleared). Keeps the nav's
  * shape so it doesn't collapse/flash to empty before the gated items resolve.
+ *
+ * Row geometry mirrors NavButton/CollapsibleNavGroup exactly — h-8 (py-1.5
+ * around a text-sm line box) with a size-4 icon at px-2 — so swapping the
+ * skeleton for the real nav doesn't shift anything. Callers pass their own
+ * menu spacing and divider position to match the list they stand in for.
  */
 export function SidebarNavSkeleton({
   rows = 7,
+  divideAfter,
+  className,
 }: {
   rows?: number;
+  /** Render the nav's group divider after this many rows. */
+  divideAfter?: number;
+  /** Menu spacing, matched to the sidebar this stands in for. */
+  className?: string;
 }): JSX.Element {
   return (
     <SidebarMenu
       aria-hidden
-      className="gap-1 px-2 group-data-[collapsible=icon]:px-0"
+      className={cn("gap-1 px-2 group-data-[collapsible=icon]:px-0", className)}
     >
       {Array.from({ length: rows }).map((_, i) => (
-        <SidebarMenuItem key={i}>
-          <div className="flex items-center gap-2 px-2 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
-            <Skeleton className="size-4 shrink-0" />
-            <Skeleton
-              className={cn(
-                "h-3.5 group-data-[collapsible=icon]:hidden",
-                LABEL_WIDTHS[i % LABEL_WIDTHS.length],
-              )}
-            />
-          </div>
-        </SidebarMenuItem>
+        <Fragment key={i}>
+          <SidebarMenuItem>
+            <div className="flex h-8 items-center gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+              <Skeleton className="size-4 shrink-0" />
+              <Skeleton
+                className={cn(
+                  "h-3.5 group-data-[collapsible=icon]:hidden",
+                  LABEL_WIDTHS[i % LABEL_WIDTHS.length],
+                )}
+              />
+            </div>
+          </SidebarMenuItem>
+          {divideAfter === i + 1 && (
+            <li aria-hidden="true" className="my-2 px-1">
+              <div className="border-border border-t" />
+            </li>
+          )}
+        </Fragment>
       ))}
     </SidebarMenu>
   );

--- a/client/dashboard/src/components/workspace-switcher.test.tsx
+++ b/client/dashboard/src/components/workspace-switcher.test.tsx
@@ -35,7 +35,8 @@ afterEach(cleanup);
 describe("WorkspaceSwitcher", () => {
   it("shows the project name", () => {
     render(<WorkspaceSwitcher />);
-    // The trigger shows the project's display name (not the org/project slug).
-    expect(screen.getByText("Proj")).toBeTruthy();
+    // The trigger shows the project's display name (not the org/project slug),
+    // suffixed with "Project".
+    expect(screen.getByText("Proj Project")).toBeTruthy();
   });
 });

--- a/client/dashboard/src/components/workspace-switcher.tsx
+++ b/client/dashboard/src/components/workspace-switcher.tsx
@@ -22,7 +22,11 @@ import {
   PopoverTrigger,
 } from "@/components/ui/Popover";
 
-export function WorkspaceSwitcher(): JSX.Element {
+export function WorkspaceSwitcher({
+  className,
+}: {
+  className?: string;
+} = {}): JSX.Element {
   const organization = useOrganization();
   const project = useProject();
   const session = useSession();
@@ -59,8 +63,10 @@ export function WorkspaceSwitcher(): JSX.Element {
     const orgLabel = organization.name || organization.slug;
     const orgColors = getGradientColors(organization.id);
     const orgInitial = orgLabel.charAt(0).toUpperCase();
-    const rowClass =
-      "flex w-full items-center gap-2 border px-2 py-1.5 text-sm font-medium group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:border-0 group-data-[collapsible=icon]:p-0";
+    const rowClass = cn(
+      "flex w-full items-center gap-2 border px-2 py-1.5 text-sm font-medium group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:border-0 group-data-[collapsible=icon]:p-0",
+      className,
+    );
     const content = (
       <>
         <div
@@ -114,7 +120,10 @@ export function WorkspaceSwitcher(): JSX.Element {
         <PopoverTrigger asChild>
           <Button
             variant="tertiary"
-            className="h-auto w-full justify-start gap-2 border px-2 py-1.5 font-sans group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-1"
+            className={cn(
+              "hover:bg-accent h-auto w-full justify-start gap-2 border px-2 py-1.5 font-sans group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-1",
+              className,
+            )}
           >
             {/* rounded-none: keep the square tile idiom over ProjectAvatar's
                 rounded-full default. */}
@@ -122,14 +131,17 @@ export function WorkspaceSwitcher(): JSX.Element {
               project={project}
               className="h-5 w-5 shrink-0 rounded-none"
             />
+            {/* "Project" suffix names what the switcher switches. */}
             <span className="truncate text-sm font-medium group-data-[collapsible=icon]:hidden">
-              {project?.name || project?.slug || projectSlug}
+              {project?.name || project?.slug || projectSlug} Project
             </span>
             <ChevronsUpDown className="text-muted-foreground ml-auto h-4 w-4 shrink-0 group-data-[collapsible=icon]:hidden" />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[240px] p-0" align="start">
-          <Command className="border-none">
+          {/* CommandInput's wrapper is a fixed h-14 (command-palette sizing);
+              override it here so the popover's search row stays compact. */}
+          <Command className="border-none [&_[data-slot=command-input-wrapper]]:h-10">
             <CommandInput placeholder="Find Project..." className="h-10" />
             <CommandList className="max-h-[250px] !p-1">
               <CommandEmpty>No projects found.</CommandEmpty>
@@ -152,11 +164,14 @@ export function WorkspaceSwitcher(): JSX.Element {
                       <span className="flex-1 truncate">
                         {p.name || p.slug}
                       </span>
-                      {p.name && p.name !== p.slug && (
-                        <span className="text-muted-foreground max-w-[80px] truncate font-mono text-xs">
-                          {p.slug}
-                        </span>
-                      )}
+                      {/* Case-insensitive: "Default" / "default" is the same
+                          name, so the slug adds nothing. */}
+                      {p.name &&
+                        p.name.toLowerCase() !== p.slug.toLowerCase() && (
+                          <span className="text-muted-foreground max-w-[80px] truncate font-mono text-xs">
+                            {p.slug}
+                          </span>
+                        )}
                       {p.id === project.id && (
                         <CheckIcon className="h-4 w-4 shrink-0" />
                       )}

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { FullPageError } from "@/components/full-page-error";
 import { GramLogo } from "@/components/gram-logo";
-import { PageHeader } from "@/components/page-header";
+import { HatchRule } from "@/components/hatch-rule";
 import { SidebarNavSkeleton } from "@/components/sidebar-nav-skeleton";
 import {
   Sidebar,
@@ -339,16 +339,24 @@ const AppLoadingShell = () => (
   >
     <div className="flex h-screen w-full flex-col">
       <div className="flex w-full flex-1 overflow-hidden">
-        <Sidebar collapsible="icon" variant="inset">
-          <SidebarHeader className="gap-3 pb-3">
-            <div className="flex h-(--header-height) items-center px-1">
-              <GramLogo className="w-28" />
+        <Sidebar collapsible="icon">
+          {/* Logo row + crosshatch rule, exactly as AppSidebar renders it —
+              the switcher lives in the page header now, so no placeholder
+              for it here. */}
+          <SidebarHeader className="gap-0 p-0">
+            <div className="flex h-(--header-height) items-center px-2">
+              <div className="flex h-full items-center px-1">
+                <GramLogo className="w-28" />
+              </div>
             </div>
-            {/* Workspace switcher */}
-            <Skeleton className="h-8 w-full" />
+            <HatchRule />
           </SidebarHeader>
           <SidebarContent className="pt-2">
-            <SidebarNavSkeleton />
+            <SidebarNavSkeleton
+              rows={8}
+              divideAfter={3}
+              className="gap-0.5 px-2 group-data-[collapsible=icon]:px-0"
+            />
           </SidebarContent>
           <SidebarFooter className="border-t">
             <div className="flex items-center gap-2 py-2">
@@ -358,10 +366,14 @@ const AppLoadingShell = () => (
           </SidebarFooter>
         </Sidebar>
         <SidebarInset>
-          <PageHeader>
-            <PageHeader.Breadcrumbs />
+          {/* Mirrors PageHeader's own geometry (h-(--header-height), px-8,
+              hatch rule) without mounting it: the switcher inside needs the
+              auth context this shell is still waiting on. */}
+          <header className="flex h-(--header-height) shrink-0 items-center gap-3 px-8">
+            <Skeleton className="h-6 w-40" />
             <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
-          </PageHeader>
+          </header>
+          <HatchRule />
         </SidebarInset>
       </div>
     </div>

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -68,8 +68,10 @@ import { FALLBACK_TITLE } from "@/elements/components/activeChatTitle.helpers";
 import { useRoutes } from "@/routes";
 
 // Shared square icon button used by the page chrome (back affordances).
+// bg-card so the button stays a solid chip when it sits on the brand mesh;
+// hover darkens the border (and text) rather than filling the chip grey.
 const ICON_BUTTON_CLASS =
-  "border-border text-muted-foreground hover:text-foreground hover:bg-accent flex items-center gap-1 border px-2.5 py-1.5 transition-colors";
+  "border-border bg-card text-muted-foreground hover:border-foreground hover:text-foreground flex items-center gap-1 border px-2.5 py-1.5 transition-colors";
 
 /** Layout route for `/chat`; renders the index (home) or a conversation. */
 export function ChatRoot(): ReactElement {
@@ -92,7 +94,9 @@ export function ChatHome(): ReactElement {
     // the content.
     <div className={cn(BRAND_MESH_SURFACE_CLASS, "flex h-full flex-col")}>
       <BrandMeshLayers />
-      <div className="absolute top-4 left-4 z-10">
+      {/* Header row on the same --header-height grid as Page.Header, but with
+          no rule below it — the mesh surface should read unbroken here. */}
+      <header className="relative z-10 flex h-(--header-height) shrink-0 items-center px-8">
         <Link
           to={routes.home.href()}
           aria-label="Back to home"
@@ -101,7 +105,7 @@ export function ChatHome(): ReactElement {
           <ChevronLeft className="size-4" />
           <Home className="size-4" />
         </Link>
-      </div>
+      </header>
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto flex w-full max-w-3xl flex-col px-6 pt-[clamp(10rem,26vh,16rem)] pb-16">
           <ChatLanding autoFocusInput />
@@ -999,7 +1003,9 @@ export function ChatConversation(): ReactElement {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="border-border flex shrink-0 items-center gap-3 border-b px-4 py-3">
+      {/* h-(--header-height) + px-8: same row height and content inset as
+          Page.Header, so this header's rule lines up with the sidebar's. */}
+      <header className="border-border flex h-(--header-height) shrink-0 items-center gap-3 border-b px-8">
         <Link
           to={routes.chat.href()}
           aria-label="Back to chat"

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -229,7 +229,9 @@ const ROUTE_STRUCTURE = {
     unauthenticated: true,
   },
   home: {
-    title: "Home",
+    // "Home" now belongs to the org-level nav entry; the project's landing
+    // page is its overview.
+    title: "Project Overview",
     url: "",
     icon: "house",
     component: Home,


### PR DESCRIPTION
Reworks the app chrome so project context sits where the breadcrumbs used to, following the WorkOS dashboard layout.

## What changed

**Project switcher moves into the page header.** The breadcrumb trail was not carrying its weight, so its header slot now holds the switcher, labelled `<project> Project`. The sidebar sheds the switcher entirely.

**Breadcrumbs are hidden, not removed.** `PageHeader.Breadcrumbs` returns `null` behind a `SHOW_BREADCRUMBS` flag. Every caller still mounts it and the renderer is intact, so restoring the trail is a one-line change.

**Sidebar header is a logo + collapse row.** The collapse control moves next to the logo (it left the page header); search moves the other way, into the page header's right cluster alongside the insights hint.

**Crosshatch rule replaces the inset card + brand gradient bar.** The sidebar no longer uses the `inset` variant, so both panes are flat surfaces divided by a hairline. The new `HatchRule` — a hairline closed by small hollow squares, the marketing-site grid idiom — sits at the bottom of both headers on the same `--header-height` baseline, so the divider reads as one line across the pane boundary. Chat's own headers adopt the same height so their rules line up; the chat index keeps the row but drops the rule so the brand mesh reads unbroken.

**Nav renames.** The "Organization settings" footer action becomes a top-level **Home** item above the project nav, and the project landing page is retitled **Project Overview**.

**Switcher polish.** Compact search row in the popover, no redundant slug chip when it differs from the name only by case, back-affordance chips get a solid background and a border-darkening hover instead of a grey fill.

## Testing

- `aube run -F dashboard type-check`
- `aube run -F dashboard test` — 237 files, 2361 tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the project switcher from the sidebar into the page header and replaces the brand bar with a crosshatch rule. This aligns chrome with WorkOS, reduces layout shift, and standardizes `--header-height` across app and chat. Breadcrumbs are hidden behind a flag; old callers still mount them.

**Review notes**
- Page header: switcher replaces breadcrumbs; right side hosts the insights hint and command palette trigger; `HatchRule` divides header from content; content inset is px-8.
- Sidebar: header is logo + collapse control (`SidebarTrigger`) and closes with `HatchRule`; removes the switcher and the `inset` variant; adds a top-level org-scoped Home item; removes the footer “Organization settings” action.
- Loading shell: mirrors the new chrome (flat panes, logo + `HatchRule`, header at the same baseline); `SidebarNavSkeleton` matches real list geometry and divider (rows=8, `divideAfter=3`) to avoid layout shift.
- Navigation copy: the project landing page is retitled “Project Overview”.
- Workspace switcher: adds a “Project” suffix, compacts the popover search row, hides redundant slugs case-insensitively, supports `className`, and tweaks chip styling.
- Chat: headers use `--header-height`; the chat index keeps the header row but drops the rule so the brand mesh stays continuous.
- Breadcrumbs: `PageHeader.Breadcrumbs` still mounts but returns null (`SHOW_BREADCRUMBS=false`). To restore breadcrumbs, set the flag to true. No other migrations required.

<sup>Written for commit 83fa8c777732e0c28f7c5671709cc879385e8097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

