### PR TITLE
fix: tolerate a lost allocation insert race in settle

### DIFF
--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -28,6 +28,11 @@ const (
 
 	stripeAllocationSourceOpenRouter = "openrouter_daily_spend"
 	stripeAllocationSourceTUM        = "tum_cycle"
+
+	// The unique indexes on stripe_invoice_allocations that a concurrent settle
+	// can trip while storing an allocation this run also wanted.
+	stripeAllocationIdempotencyKeyIndex = "stripe_invoice_allocations_idempotency_key_key"
+	stripeAllocationOrgSourceSeqIndex   = "stripe_invoice_allocations_org_source_seq_key"
 )
 
 // SettleStripeInvoiceAllocationsArgs fixes the observation time for one daily
@@ -306,9 +311,22 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 // that reaches the idempotency-key index first still raises a unique violation.
 // Either conflict means the row this run wanted is already stored, and these
 // rows are immutable once written, so the loser has nothing left to do.
+//
+// Only those two indexes qualify. A violation from any other constraint —
+// including one added later — is a fault this activity has never reasoned
+// about, so it still has to surface.
 func allocationAlreadyClaimed(err error) bool {
 	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation
+	if !errors.As(err, &pgErr) || pgErr.Code != pgerrcode.UniqueViolation {
+		return false
+	}
+
+	switch pgErr.ConstraintName {
+	case stripeAllocationIdempotencyKeyIndex, stripeAllocationOrgSourceSeqIndex:
+		return true
+	default:
+		return false
+	}
 }
 
 func openRouterAllocationParams(

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -8,7 +8,9 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -198,7 +200,7 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 				invoice.StripeInvoiceID,
 				destination,
 				now,
-			)); err != nil {
+			)); err != nil && !allocationAlreadyClaimed(err) {
 				return fmt.Errorf("freeze baseline for %s: %w", day.SourceDay.Time.Format(time.DateOnly), err)
 			}
 		}
@@ -286,12 +288,27 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 			invoice.StripeInvoiceID,
 			destination,
 			now,
-		)); err != nil {
+		)); err != nil && !allocationAlreadyClaimed(err) {
 			return fmt.Errorf("freeze carry for %s: %w", baseline.SourceKey, err)
 		}
 	}
 
 	return nil
+}
+
+// allocationAlreadyClaimed reports whether a failed allocation insert lost a
+// race to a concurrent settle rather than hitting a real fault.
+//
+// stripe_invoice_allocations carries two unique indexes that both derive from
+// the same (organization, source day, seq) tuple: the idempotency key and
+// (organization_id, source_kind, source_key, seq). ON CONFLICT DO NOTHING only
+// swallows conflicts on the index it names as the arbiter, so a racing insert
+// that reaches the idempotency-key index first still raises a unique violation.
+// Either conflict means the row this run wanted is already stored, and these
+// rows are immutable once written, so the loser has nothing left to do.
+func allocationAlreadyClaimed(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation
 }
 
 func openRouterAllocationParams(

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -29,10 +29,7 @@ const (
 	stripeAllocationSourceOpenRouter = "openrouter_daily_spend"
 	stripeAllocationSourceTUM        = "tum_cycle"
 
-	// The unique indexes on stripe_invoice_allocations that a concurrent settle
-	// can trip while storing an allocation this run also wanted.
 	stripeAllocationIdempotencyKeyIndex = "stripe_invoice_allocations_idempotency_key_key"
-	stripeAllocationOrgSourceSeqIndex   = "stripe_invoice_allocations_org_source_seq_key"
 )
 
 // SettleStripeInvoiceAllocationsArgs fixes the observation time for one daily
@@ -304,29 +301,22 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 // allocationAlreadyClaimed reports whether a failed allocation insert lost a
 // race to a concurrent settle rather than hitting a real fault.
 //
-// stripe_invoice_allocations carries two unique indexes that both derive from
-// the same (organization, source day, seq) tuple: the idempotency key and
-// (organization_id, source_kind, source_key, seq). ON CONFLICT DO NOTHING only
-// swallows conflicts on the index it names as the arbiter, so a racing insert
-// that reaches the idempotency-key index first still raises a unique violation.
-// Either conflict means the row this run wanted is already stored, and these
-// rows are immutable once written, so the loser has nothing left to do.
+// The insert arbitrates ON CONFLICT on (organization_id, source_kind,
+// source_key, seq), and Postgres resolves a concurrent conflict on the arbiter
+// through the speculative-insert wait without raising. It does not extend that
+// to the table's other unique index, idempotency_key, so a racing insert that
+// reaches that one still raises. Both keys derive from the same (organization,
+// source day, seq) tuple, so the violation means the row this run wanted is
+// already stored, and no UPDATE in this package rewrites a stored allocation's
+// amount_usd or source_snapshot_usd. The loser has nothing left to do.
 //
-// Only those two indexes qualify. A violation from any other constraint —
-// including one added later — is a fault this activity has never reasoned
-// about, so it still has to surface.
+// Any other violation, the arbiter's included, is a fault this activity has
+// never reasoned about and still has to surface.
 func allocationAlreadyClaimed(err error) bool {
 	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) || pgErr.Code != pgerrcode.UniqueViolation {
-		return false
-	}
-
-	switch pgErr.ConstraintName {
-	case stripeAllocationIdempotencyKeyIndex, stripeAllocationOrgSourceSeqIndex:
-		return true
-	default:
-		return false
-	}
+	return errors.As(err, &pgErr) &&
+		pgErr.Code == pgerrcode.UniqueViolation &&
+		pgErr.ConstraintName == stripeAllocationIdempotencyKeyIndex
 }
 
 func openRouterAllocationParams(

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
@@ -3,6 +3,8 @@ package activities
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgerrcode"
@@ -10,80 +12,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A settle run that loses the insert race has to carry on: the allocation it
-// wanted is already stored and immutable. Only a unique violation means that,
-// so every other failure still has to surface.
 func TestAllocationAlreadyClaimed(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
+	cases := []struct {
 		err  error
 		want bool
 	}{
-		{
-			name: "idempotency key index, the non-arbiter one ON CONFLICT cannot swallow",
-			err: &pgconn.PgError{
-				Code:           pgerrcode.UniqueViolation,
-				ConstraintName: "stripe_invoice_allocations_idempotency_key_key",
-			},
-			want: true,
-		},
-		{
-			name: "arbiter index, when the conflict surfaces as an error rather than DO NOTHING",
-			err: &pgconn.PgError{
-				Code:           pgerrcode.UniqueViolation,
-				ConstraintName: "stripe_invoice_allocations_org_source_seq_key",
-			},
-			want: true,
-		},
-		{
-			name: "wrapped by the caller's context",
-			err:  fmt.Errorf("freeze baseline for 2026-07-01: %w", &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "stripe_invoice_allocations_idempotency_key_key"}),
-			want: true,
-		},
-		{
-			name: "a unique violation from the primary key is a real fault",
-			err: &pgconn.PgError{
-				Code:           pgerrcode.UniqueViolation,
-				ConstraintName: "stripe_invoice_allocations_pkey",
-			},
-			want: false,
-		},
-		{
-			name: "a unique violation from an index this activity has never reasoned about is a real fault",
-			err: &pgconn.PgError{
-				Code:           pgerrcode.UniqueViolation,
-				ConstraintName: "stripe_invoice_allocations_some_future_key",
-			},
-			want: false,
-		},
-		{
-			name: "a foreign key violation is a real fault",
-			err:  &pgconn.PgError{Code: pgerrcode.ForeignKeyViolation},
-			want: false,
-		},
-		{
-			name: "a check constraint violation is a real fault",
-			err:  &pgconn.PgError{Code: pgerrcode.CheckViolation},
-			want: false,
-		},
-		{
-			name: "a non-database failure is a real fault",
-			err:  errors.New("connection reset"),
-			want: false,
-		},
-		{
-			name: "no error",
-			err:  nil,
-			want: false,
-		},
+		{err: &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: stripeAllocationIdempotencyKeyIndex}, want: true},
+		{err: fmt.Errorf("freeze baseline for 2026-07-01: %w", &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: stripeAllocationIdempotencyKeyIndex}), want: true},
+		// The arbiter resolves without raising, so a violation naming it is a
+		// state this insert cannot reach and must not be swallowed.
+		{err: &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "stripe_invoice_allocations_org_source_seq_key"}, want: false},
+		{err: &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "stripe_invoice_allocations_pkey"}, want: false},
+		{err: &pgconn.PgError{Code: pgerrcode.ForeignKeyViolation}, want: false},
+		{err: errors.New("connection reset"), want: false},
+		{err: nil, want: false},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.want, allocationAlreadyClaimed(tt.err))
-		})
+	for _, tc := range cases {
+		require.Equal(t, tc.want, allocationAlreadyClaimed(tc.err), "err=%v", tc.err)
 	}
+}
+
+// The predicate keys off an index name, so a migration that renames the index
+// turns a swallowed race back into a hard failure. Catch that here rather than
+// in a settle run.
+func TestAllocationIndexNameMatchesSchema(t *testing.T) {
+	t.Parallel()
+
+	schema, err := os.ReadFile("../../../database/schema.sql")
+	require.NoError(t, err)
+	require.Contains(t, string(schema), stripeAllocationIdempotencyKeyIndex,
+		"index renamed in schema.sql without updating stripeAllocationIdempotencyKeyIndex")
+	require.True(t, strings.Contains(string(schema), "CREATE UNIQUE INDEX IF NOT EXISTS "+stripeAllocationIdempotencyKeyIndex),
+		"index is no longer unique, so it can no longer signal a lost race")
 }

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
@@ -39,8 +39,24 @@ func TestAllocationAlreadyClaimed(t *testing.T) {
 		},
 		{
 			name: "wrapped by the caller's context",
-			err:  fmt.Errorf("freeze baseline for 2026-07-01: %w", &pgconn.PgError{Code: pgerrcode.UniqueViolation}),
+			err:  fmt.Errorf("freeze baseline for 2026-07-01: %w", &pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "stripe_invoice_allocations_idempotency_key_key"}),
 			want: true,
+		},
+		{
+			name: "a unique violation from the primary key is a real fault",
+			err: &pgconn.PgError{
+				Code:           pgerrcode.UniqueViolation,
+				ConstraintName: "stripe_invoice_allocations_pkey",
+			},
+			want: false,
+		},
+		{
+			name: "a unique violation from an index this activity has never reasoned about is a real fault",
+			err: &pgconn.PgError{
+				Code:           pgerrcode.UniqueViolation,
+				ConstraintName: "stripe_invoice_allocations_some_future_key",
+			},
+			want: false,
 		},
 		{
 			name: "a foreign key violation is a real fault",

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
@@ -1,0 +1,73 @@
+package activities
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+// A settle run that loses the insert race has to carry on: the allocation it
+// wanted is already stored and immutable. Only a unique violation means that,
+// so every other failure still has to surface.
+func TestAllocationAlreadyClaimed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "idempotency key index, the non-arbiter one ON CONFLICT cannot swallow",
+			err: &pgconn.PgError{
+				Code:           pgerrcode.UniqueViolation,
+				ConstraintName: "stripe_invoice_allocations_idempotency_key_key",
+			},
+			want: true,
+		},
+		{
+			name: "arbiter index, when the conflict surfaces as an error rather than DO NOTHING",
+			err: &pgconn.PgError{
+				Code:           pgerrcode.UniqueViolation,
+				ConstraintName: "stripe_invoice_allocations_org_source_seq_key",
+			},
+			want: true,
+		},
+		{
+			name: "wrapped by the caller's context",
+			err:  fmt.Errorf("freeze baseline for 2026-07-01: %w", &pgconn.PgError{Code: pgerrcode.UniqueViolation}),
+			want: true,
+		},
+		{
+			name: "a foreign key violation is a real fault",
+			err:  &pgconn.PgError{Code: pgerrcode.ForeignKeyViolation},
+			want: false,
+		},
+		{
+			name: "a check constraint violation is a real fault",
+			err:  &pgconn.PgError{Code: pgerrcode.CheckViolation},
+			want: false,
+		},
+		{
+			name: "a non-database failure is a real fault",
+			err:  errors.New("connection reset"),
+			want: false,
+		},
+		{
+			name: "no error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, allocationAlreadyClaimed(tt.err))
+		})
+	}
+}

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/jackc/pgerrcode"
@@ -45,6 +44,6 @@ func TestAllocationIndexNameMatchesSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(schema), stripeAllocationIdempotencyKeyIndex,
 		"index renamed in schema.sql without updating stripeAllocationIdempotencyKeyIndex")
-	require.True(t, strings.Contains(string(schema), "CREATE UNIQUE INDEX IF NOT EXISTS "+stripeAllocationIdempotencyKeyIndex),
+	require.Contains(t, string(schema), "CREATE UNIQUE INDEX IF NOT EXISTS "+stripeAllocationIdempotencyKeyIndex,
 		"index is no longer unique, so it can no longer signal a lost race")
 }


### PR DESCRIPTION
## Summary

`SettleStripeInvoiceAllocations` fails when two runs race to store the same allocation, instead of letting the loser carry on.

`stripe_invoice_allocations` carries two unique indexes that both derive from the same `(organization, source day, seq)` tuple:

- `stripe_invoice_allocations_idempotency_key_key` on `idempotency_key`
- `stripe_invoice_allocations_org_source_seq_key` on `(organization_id, source_kind, source_key, seq)`

`CreateOpenRouterInvoiceAllocation` already ends in `ON CONFLICT (organization_id, source_kind, source_key, seq) DO NOTHING`, but Postgres only swallows conflicts on the index named as the arbiter. A concurrent insert that reaches the idempotency-key index first still raises `23505`, which the caller wraps and returns, failing the whole activity.

Both keys identify the same row, and no UPDATE in this package rewrites a stored allocation's `amount_usd` or `source_snapshot_usd`, so the violation means the row this run wanted is already stored and the loser has nothing left to do. (Other columns — `delivery_state`, `destination_invoice_id`, even `idempotency_key` — do get rewritten; only the money is stable, which is what the argument needs.)

## Change

- Add `allocationAlreadyClaimed`, following the existing `errors.As` + `pgerrcode.UniqueViolation` idiom used elsewhere in the server.
- Apply it at both insert sites (baseline freeze and carry), so a lost race is a no-op rather than an activity failure.
- Match on the idempotency-key index by name. The arbiter index cannot raise here — Postgres resolves arbiter conflicts through the speculative-insert wait — so a violation naming it, the primary key, or any future index still surfaces.

The losing racer deliberately keeps looping rather than returning early: `ListStripeInvoicesForOpenRouterBilling` re-lists an invoice while any day still lacks a row, so bailing on the first conflict would stall a partially frozen invoice at day one.

Exactly-once delivery to Stripe is unaffected: that guarantee comes from the separate claim query (`claim.ID` / `UnassignPositiveStripeInvoiceAllocation`), not from this insert.

## Observed

`TestSettleStripeInvoiceAllocations_ConcurrentClaimsWriteOnce` failed in the merge queue for #5371, which does not touch this code:

```
settle organization org-730a2d27: freeze baseline for 2026-07-01:
ERROR: duplicate key value violates unique constraint
"stripe_invoice_allocations_idempotency_key_key" (SQLSTATE 23505)
```

https://github.com/speakeasy-api/gram/actions/runs/32130633816

The interleaving is timing dependent and needs CI-level contention: the test passes 10/10 locally both with and without this change, so the fix is not backed by a local reproduction. It removes the failure mode regardless of which index the race trips.

Covered instead by `TestAllocationAlreadyClaimed`, which pins that only an idempotency-key violation (wrapped or bare) counts as already-claimed while arbiter, primary-key, foreign-key, and non-database failures still propagate, and by `TestAllocationIndexNameMatchesSchema`, which fails if a migration renames the index out from under the predicate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates a lost allocation-insert race in `SettleStripeInvoiceAllocations` so concurrent runs don’t fail. Previously a `23505` on `stripe_invoice_allocations_idempotency_key_key` aborted the activity; now it is treated as “already claimed” and processing continues. Exactly-once delivery remains unchanged.

- Adds `allocationAlreadyClaimed` that matches only `pgerrcode.UniqueViolation` on `stripe_invoice_allocations_idempotency_key_key`; violations on `stripe_invoice_allocations_org_source_seq_key` and all other constraints still surface.
- Applies the check at both insert sites (baseline freeze and carry).
- Adds `TestAllocationAlreadyClaimed` and `TestAllocationIndexNameMatchesSchema` (asserts index name and uniqueness); no schema or migration changes.

<sup>Written for commit 04156d461da5f869623c8d135d7c6bc3d45b1bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

