### PR TITLE
fix: preserve unknown members through remote MCP proxy mutation setters

### DIFF
--- a/server/internal/remotemcp/proxy/jsonsplice.go
+++ b/server/internal/remotemcp/proxy/jsonsplice.go
@@ -63,3 +63,19 @@ func spliceTopLevelKey(object json.RawMessage, key string, value json.RawMessage
 	}
 	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
 }
+
+// marshalJSONNoHTMLEscape marshals v like json.Marshal but without HTML
+// escaping. Replacement values handed to spliceTopLevelKey must be encoded
+// this way: the splice and the SDK envelope encoder both leave literal <,
+// >, and & untouched in preserved members, so an HTML-escaped replacement
+// would relay <-escaped alongside neighbors that keep their literal
+// characters.
+func marshalJSONNoHTMLEscape(v any) (json.RawMessage, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, fmt.Errorf("encode replacement value: %w", err)
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
+}

--- a/server/internal/remotemcp/proxy/jsonsplice.go
+++ b/server/internal/remotemcp/proxy/jsonsplice.go
@@ -1,0 +1,65 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// spliceTopLevelKey returns object — a JSON object payload such as a
+// JSON-RPC result or params document — with its top-level key member
+// replaced by value, leaving every other member in place. Mutation setters
+// ([ToolsListResponse.SetTools], [ToolsCallRequest.SetArguments],
+// [ResourcesListResponse.SetResources], and any added later) MUST route
+// payload rewrites through this splice rather than re-marshaling a typed
+// SDK struct: a typed round-trip silently deletes every member the struct
+// does not model, stripping protocol fields the SDK has not caught up with
+// (under MCP 2026-07-28, the required resultType, ttlMs, and cacheScope
+// tools/list result members) from an otherwise byte-for-byte relay.
+//
+// Preserved members keep their original value bytes — numbers do not lose
+// precision and escape sequences are not rewritten — though insignificant
+// whitespace is compacted and top-level member order is not retained,
+// matching what the jsonrpc.EncodeMessage envelope re-encode already does
+// to every mutated message. Unknown members of the JSON-RPC envelope itself
+// live outside the result/params payload and are beyond this helper's
+// reach; that envelope encoder still drops them, which JSON-RPC 2.0's
+// closed envelope object makes acceptable.
+//
+// A zero-length value deletes the member, mirroring the omitempty encoding
+// of the typed fields this splice replaces. A literal null object is
+// treated as an empty object. Duplicate top-level keys in object collapse
+// to the last occurrence, exactly as encoding/json decodes them — a
+// property filter setters rely on, since preserving an earlier duplicate
+// would let upstream smuggle the unfiltered value past the mutation.
+//
+// The final marshal is what validates value: caller-supplied bytes that are
+// not well-formed JSON surface as an error here instead of reaching the
+// wire. Do not replace the map round-trip with raw byte assembly — that
+// validation would silently disappear.
+func spliceTopLevelKey(object json.RawMessage, key string, value json.RawMessage) (json.RawMessage, error) {
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(object, &members); err != nil {
+		return nil, fmt.Errorf("decode payload object: %w", err)
+	}
+	// A literal null decodes successfully into a nil map.
+	if members == nil {
+		members = make(map[string]json.RawMessage, 1)
+	}
+
+	if len(value) == 0 {
+		delete(members, key)
+	} else {
+		members[key] = value
+	}
+
+	// json.Encoder rather than json.Marshal so preserved and replacement
+	// bytes are not HTML-escaped, matching the SDK's envelope encoder.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(members); err != nil {
+		return nil, fmt.Errorf("encode payload object: %w", err)
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
+}

--- a/server/internal/remotemcp/proxy/jsonsplice_internal_test.go
+++ b/server/internal/remotemcp/proxy/jsonsplice_internal_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpliceTopLevelKey_ReplacesKeyPreservingOtherMembers(t *testing.T) {
+	t.Parallel()
+
+	original := json.RawMessage(`{
+		"_meta": {"upstream/trace": 9007199254740993},
+		"resultType": "tools/list",
+		"ttlMs": 60000,
+		"cacheScope": "server",
+		"tools": [{"name": "tool_a"}]
+	}`)
+
+	out, err := spliceTopLevelKey(original, "tools", json.RawMessage(`[{"name":"kept"}]`))
+	require.NoError(t, err)
+
+	require.Contains(t, string(out), `"tools":[{"name":"kept"}]`, "target member must carry the replacement value")
+	require.Contains(t, string(out), `"resultType":"tools/list"`, "unmodeled member must survive the splice")
+	require.Contains(t, string(out), `"ttlMs":60000`, "unmodeled member must survive the splice")
+	require.Contains(t, string(out), `"cacheScope":"server"`, "unmodeled member must survive the splice")
+	require.Contains(t, string(out), `"_meta":{"upstream/trace":9007199254740993}`,
+		"_meta must relay with its original bytes — no float64 precision loss from a typed round-trip")
+	require.NotContains(t, string(out), "tool_a", "replaced member must not retain its original value")
+}
+
+func TestSpliceTopLevelKey_AppendsMissingKey(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceTopLevelKey(json.RawMessage(`{"resultType":"tools/list"}`), "tools", json.RawMessage(`[]`))
+	require.NoError(t, err)
+	require.Contains(t, string(out), `"tools":[]`, "absent target member must be appended")
+	require.Contains(t, string(out), `"resultType":"tools/list"`)
+}
+
+func TestSpliceTopLevelKey_EmptyValueDeletesKey(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceTopLevelKey(json.RawMessage(`{"name":"w","arguments":{"a":1}}`), "arguments", nil)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), `"arguments"`, "nil value must delete the member")
+	require.Contains(t, string(out), `"name":"w"`)
+
+	// A non-nil but zero-length RawMessage deletes too — len, not nilness,
+	// mirrors the omitempty encoding this splice replaces.
+	out, err = spliceTopLevelKey(json.RawMessage(`{"name":"w","arguments":{"a":1}}`), "arguments", json.RawMessage{})
+	require.NoError(t, err)
+	require.NotContains(t, string(out), `"arguments"`, "empty value must delete the member")
+}
+
+func TestSpliceTopLevelKey_NullObjectTreatedAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceTopLevelKey(json.RawMessage(`null`), "tools", json.RawMessage(`[]`))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"tools":[]}`, string(out), "a literal null payload must splice into a fresh object, not panic")
+}
+
+func TestSpliceTopLevelKey_DuplicateKeysCollapseLastWins(t *testing.T) {
+	t.Parallel()
+
+	// A duplicated non-target member collapses to its last occurrence, the
+	// same way encoding/json decodes it — a filter setter must never leave
+	// an earlier duplicate behind for last-key-wins clients to read.
+	original := json.RawMessage(`{"ttlMs":1,"ttlMs":2,"tools":[{"name":"secret"}],"tools":[{"name":"visible"}]}`)
+	out, err := spliceTopLevelKey(original, "tools", json.RawMessage(`[]`))
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(out), `"tools"`), "duplicate target keys must collapse to one member")
+	require.Contains(t, string(out), `"ttlMs":2`, "duplicate preserved keys must collapse last-wins")
+	require.NotContains(t, string(out), "secret", "no duplicate may retain a pre-mutation value")
+	require.NotContains(t, string(out), "visible", "no duplicate may retain a pre-mutation value")
+}
+
+func TestSpliceTopLevelKey_NonObjectPayloadErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := spliceTopLevelKey(json.RawMessage(`[1,2]`), "tools", json.RawMessage(`[]`))
+	require.Error(t, err, "a JSON array payload is not a splice target")
+
+	_, err = spliceTopLevelKey(json.RawMessage(`"str"`), "tools", json.RawMessage(`[]`))
+	require.Error(t, err, "a JSON string payload is not a splice target")
+}
+
+func TestSpliceTopLevelKey_InvalidValueErrors(t *testing.T) {
+	t.Parallel()
+
+	// The final marshal validates the caller-supplied value; malformed
+	// bytes must error out rather than reach the wire.
+	_, err := spliceTopLevelKey(json.RawMessage(`{"name":"w"}`), "arguments", json.RawMessage{0xff})
+	require.Error(t, err)
+}
+
+func TestSpliceTopLevelKey_DoesNotHTMLEscape(t *testing.T) {
+	t.Parallel()
+
+	// The SDK's envelope encoder writes with HTML escaping off; the splice
+	// must match so preserved and replacement bytes relay unrewritten.
+	out, err := spliceTopLevelKey(
+		json.RawMessage(`{"kept":"a<b&c"}`),
+		"arguments",
+		json.RawMessage(`{"q":"<&>"}`),
+	)
+	require.NoError(t, err)
+	require.Contains(t, string(out), `"kept":"a<b&c"`, "preserved member must not be HTML-escaped")
+	require.Contains(t, string(out), `"q":"<&>"`, "replacement value must not be HTML-escaped")
+}

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -1464,7 +1464,11 @@ func TestProxy_Post_InitializeRequestInterceptor_RunsAfterGeneric(t *testing.T) 
 	require.Equal(t, []string{"generic-req", "typed-req"}, order, "generic interceptors must run before typed interceptors")
 }
 
-const toolsCallRequest = `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"location":"sf"}}}`
+// toolsCallRequest carries, alongside name and arguments, params members the
+// SDK's CallToolParamsRaw does not model — an invented future member and an
+// _meta value whose integer exceeds float64 precision. Mutation tests assert
+// both forward intact through SetArguments.
+const toolsCallRequest = `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"location":"sf"},"_meta":{"trace":9007199254740993},"futureUnknownField":{"mode":"strict"}}}`
 
 func TestProxy_Post_ToolsCallRequestInterceptor_RunsForToolsCall(t *testing.T) {
 	t.Parallel()
@@ -1597,15 +1601,58 @@ func TestProxy_Post_ToolsCallRequest_SetArguments_RewritesForwardedBody(t *testi
 	require.NotContains(t, gotBody, `"sf"`, "original arguments must not leak upstream")
 	require.Contains(t, gotBody, `"tools/call"`, "method must survive re-encoding")
 	require.Contains(t, gotBody, `"id":1`, "request id must survive re-encoding")
+
+	// Params members the SDK types don't model must survive the mutation:
+	// SetArguments splices only the arguments member into the original
+	// payload instead of round-tripping through CallToolParamsRaw.
+	require.Contains(t, gotBody, `"futureUnknownField":{"mode":"strict"}`, "unmodeled params member must survive SetArguments")
+	require.Contains(t, gotBody, `"_meta":{"trace":9007199254740993}`,
+		"_meta must forward with its original bytes — no float64 precision loss")
+}
+
+func TestProxy_Post_ToolsCallRequest_SetArguments_EmptyRemovesArgumentsMember(t *testing.T) {
+	t.Parallel()
+
+	// A nil replacement removes the arguments member from the forwarded
+	// params, mirroring the omitempty encoding the typed field had. No
+	// production interceptor commits an empty replacement today, so this
+	// path is only exercised here.
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.ToolsCallRequestInterceptors = []proxy.ToolsCallRequestInterceptor{
+		&mutatingToolsCallRequestInterceptor{
+			name: "drop-arguments",
+			argsFn: func(_ json.RawMessage) json.RawMessage {
+				return nil
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(toolsCallRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.NotContains(t, gotBody, `"arguments"`, "empty replacement must delete the arguments member, not send null")
+	require.Contains(t, gotBody, `"name":"get_weather"`, "modeled params members must survive the delete")
+	require.Contains(t, gotBody, `"futureUnknownField":{"mode":"strict"}`, "unmodeled params members must survive the delete")
 }
 
 func TestProxy_Post_ToolsCallRequest_SetArguments_MarshalFailureSurfacesAs5xx(t *testing.T) {
 	t.Parallel()
 
-	// Force a marshal failure inside SetArguments by handing it a
-	// json.RawMessage holding invalid JSON bytes. json.Marshal of the
-	// enclosing CallToolParamsRaw delegates to RawMessage.MarshalJSON
-	// and then validates the returned bytes; an invalid byte (0xff)
+	// Force a mutation failure inside SetArguments by handing it a
+	// json.RawMessage holding invalid JSON bytes. Re-encoding the spliced
+	// params members validates each raw value; an invalid byte (0xff)
 	// trips the validator. SetArguments must reject with a
 	// *MutationError before mutating any state, and the proxy must
 	// surface that as a 5xx rather than a JSON-RPC rejection.
@@ -2269,10 +2316,20 @@ func TestProxy_Post_ToolsListResponseInterceptor_RejectionWritesJSONRPCError(t *
 	require.Contains(t, rr.Body.String(), "listing blocked", "RejectError message must propagate")
 }
 
+// toolsListResponseThreeTools carries, alongside the tools array, result
+// members the SDK's ListToolsResult does not model — the MCP 2026-07-28
+// required resultType/ttlMs/cacheScope trio and an invented future member —
+// plus an _meta value whose integer exceeds float64 precision. Mutation
+// tests assert all of them relay intact through SetTools.
 const toolsListResponseThreeTools = `{
   "jsonrpc": "2.0",
   "id": 2,
   "result": {
+    "_meta": {"upstream/trace": 9007199254740993},
+    "resultType": "tools/list",
+    "ttlMs": 60000,
+    "cacheScope": "server",
+    "futureUnknownField": {"nested": ["ok"]},
     "tools": [
       {"name": "tool_a", "description": "first", "inputSchema": {"type": "object"}},
       {"name": "tool_b", "description": "second", "inputSchema": {"type": "object"}},
@@ -2511,6 +2568,16 @@ func TestProxy_Post_ToolsListResponse_SetTools_RewritesRelayedBody_JSONPath(t *t
 	require.NotContains(t, rr.Body.String(), `"tool_a"`, "filtered tool must not reach client")
 	require.NotContains(t, rr.Body.String(), `"tool_c"`, "filtered tool must not reach client")
 	require.Contains(t, rr.Body.String(), `"id":2`, "response id must survive re-encoding")
+
+	// Result members the SDK types don't model must survive the mutation:
+	// SetTools splices only the tools member into the original payload
+	// instead of round-tripping through ListToolsResult.
+	require.Contains(t, rr.Body.String(), `"resultType":"tools/list"`, "unmodeled required member must survive SetTools")
+	require.Contains(t, rr.Body.String(), `"ttlMs":60000`, "unmodeled required member must survive SetTools")
+	require.Contains(t, rr.Body.String(), `"cacheScope":"server"`, "unmodeled required member must survive SetTools")
+	require.Contains(t, rr.Body.String(), `"futureUnknownField":{"nested":["ok"]}`, "unknown future member must survive SetTools")
+	require.Contains(t, rr.Body.String(), `"_meta":{"upstream/trace":9007199254740993}`,
+		"_meta must relay with its original bytes — no float64 precision loss")
 }
 
 func TestProxy_Post_SSEResponse_TerminalEventDispatchesTypedToolsListInterceptor(t *testing.T) {
@@ -2627,6 +2694,12 @@ func TestProxy_Post_ToolsListResponse_SetTools_RewritesRelayedEvent_SSEPath(t *t
 	require.Contains(t, out, `"tool_a"`, "client must see kept tool on terminal SSE event")
 	require.NotContains(t, out, `"tool_b"`, "filtered tool must not reach client")
 	require.NotContains(t, out, `"tool_c"`, "filtered tool must not reach client")
+
+	// Unmodeled result members must survive the SSE-path mutation the same
+	// way they do on the buffered JSON path.
+	require.Contains(t, out, `"resultType":"tools/list"`, "unmodeled required member must survive SetTools on SSE path")
+	require.Contains(t, out, `"_meta":{"upstream/trace":9007199254740993}`,
+		"_meta must relay with its original bytes on SSE path")
 
 	// Non-data SSE fields must survive the rebuild so the client's MCP
 	// runtime sees the same event type and id as the upstream sent.

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -2332,7 +2332,7 @@ const toolsListResponseThreeTools = `{
     "futureUnknownField": {"nested": ["ok"]},
     "tools": [
       {"name": "tool_a", "description": "first", "inputSchema": {"type": "object"}},
-      {"name": "tool_b", "description": "second", "inputSchema": {"type": "object"}},
+      {"name": "tool_b", "description": "second <b&c>", "inputSchema": {"type": "object"}},
       {"name": "tool_c", "description": "third", "inputSchema": {"type": "object"}}
     ]
   }
@@ -2578,6 +2578,8 @@ func TestProxy_Post_ToolsListResponse_SetTools_RewritesRelayedBody_JSONPath(t *t
 	require.Contains(t, rr.Body.String(), `"futureUnknownField":{"nested":["ok"]}`, "unknown future member must survive SetTools")
 	require.Contains(t, rr.Body.String(), `"_meta":{"upstream/trace":9007199254740993}`,
 		"_meta must relay with its original bytes — no float64 precision loss")
+	require.Contains(t, rr.Body.String(), `"description":"second <b&c>"`,
+		"kept tool bytes must not be HTML-escaped, matching the non-escaping relay of preserved members")
 }
 
 func TestProxy_Post_SSEResponse_TerminalEventDispatchesTypedToolsListInterceptor(t *testing.T) {

--- a/server/internal/remotemcp/proxy/resources_list_response.go
+++ b/server/internal/remotemcp/proxy/resources_list_response.go
@@ -98,9 +98,9 @@ func resourcesListResponseFromRemoteMessage(request *ResourcesListRequest, msg *
 // inner payload swap up front so the dirty signal alone is sufficient to
 // trigger that re-encode. Only the result's resources member is rewritten:
 // the replacement array is spliced into the original wire payload, so
-// _meta, nextCursor, and members [mcp.ListResourcesResult] does not model
+// _meta, nextCursor, and members not modeled by [mcp.ListResourcesResult]
 // (under MCP 2026-07-28, the required resultType, ttlMs, and cacheScope)
-// relay with their original values instead of being dropped by a typed
+// retain their original values instead of being dropped by a typed
 // re-marshal. Marshal and splice both happen before any typed-view or
 // underlying-message state is touched so a failure leaves everything at
 // its pre-call values — the typed view and the wire remain in sync
@@ -131,7 +131,7 @@ func (r *ResourcesListResponse) SetResources(resources []*mcp.Resource) error {
 	// from the underlying wire bytes. Only commit (assign to
 	// Result.Resources, rpcResp.Result, dirty) once both steps have
 	// succeeded.
-	payload, err := json.Marshal(resources)
+	payload, err := marshalJSONNoHTMLEscape(resources)
 	if err != nil {
 		return &MutationError{Op: "set resources", Cause: fmt.Errorf("marshal replacement resources array: %w", err)}
 	}

--- a/server/internal/remotemcp/proxy/resources_list_response.go
+++ b/server/internal/remotemcp/proxy/resources_list_response.go
@@ -96,18 +96,23 @@ func resourcesListResponseFromRemoteMessage(request *ResourcesListRequest, msg *
 // required. The outer jsonrpc.Message is re-encoded once after the chain
 // completes (see [RemoteMessage.materializedBytes]); this method does the
 // inner payload swap up front so the dirty signal alone is sufficient to
-// trigger that re-encode. Marshal happens before any typed-view or
-// underlying-message state is touched so a marshal failure leaves
-// everything at its pre-call values — the typed view and the wire
-// remain in sync regardless of the failure mode.
+// trigger that re-encode. Only the result's resources member is rewritten:
+// the replacement array is spliced into the original wire payload, so
+// _meta, nextCursor, and members [mcp.ListResourcesResult] does not model
+// (under MCP 2026-07-28, the required resultType, ttlMs, and cacheScope)
+// relay with their original values instead of being dropped by a typed
+// re-marshal. Marshal and splice both happen before any typed-view or
+// underlying-message state is touched so a failure leaves everything at
+// its pre-call values — the typed view and the wire remain in sync
+// regardless of the failure mode.
 //
 // Returns a [*MutationError] when the response carries a JSON-RPC Error
 // rather than a Result (mutually exclusive per the typed-view contract),
-// when marshaling the mutated ListResourcesResult fails, or when the
-// underlying jsonrpc.Message is not a *jsonrpc.Response. The proxy detects
-// [*MutationError] at the interceptor return path and surfaces it as an
-// HTTP 5xx via [oops.E] with [oops.CodeUnexpected] rather than as a
-// user-facing JSON-RPC rejection.
+// when marshaling the replacement resources array or splicing it into the
+// original result fails, or when the underlying jsonrpc.Message is not a
+// *jsonrpc.Response. The proxy detects [*MutationError] at the interceptor
+// return path and surfaces it as an HTTP 5xx via [oops.E] with
+// [oops.CodeUnexpected] rather than as a user-facing JSON-RPC rejection.
 func (r *ResourcesListResponse) SetResources(resources []*mcp.Resource) error {
 	if r.Result == nil {
 		return &MutationError{Op: "set resources", Cause: errors.New("response carries an error, not a result")}
@@ -121,19 +126,22 @@ func (r *ResourcesListResponse) SetResources(resources []*mcp.Resource) error {
 		resources = []*mcp.Resource{}
 	}
 
-	// Stage the mutation against a temporary copy of Result so a marshal
-	// failure can't leave the typed view's Resources desynced from the
-	// underlying wire bytes. Only commit (assign to Result.Resources,
-	// rpcResp.Result, dirty) once marshaling has succeeded.
-	staged := *r.Result
-	staged.Resources = resources
-	payload, err := json.Marshal(&staged)
+	// Marshal the replacement array and splice it into the original wire
+	// payload so a failure can't leave the typed view's Resources desynced
+	// from the underlying wire bytes. Only commit (assign to
+	// Result.Resources, rpcResp.Result, dirty) once both steps have
+	// succeeded.
+	payload, err := json.Marshal(resources)
 	if err != nil {
-		return &MutationError{Op: "set resources", Cause: fmt.Errorf("marshal mutated ListResourcesResult: %w", err)}
+		return &MutationError{Op: "set resources", Cause: fmt.Errorf("marshal replacement resources array: %w", err)}
+	}
+	result, err := spliceTopLevelKey(rpcResp.Result, "resources", payload)
+	if err != nil {
+		return &MutationError{Op: "set resources", Cause: fmt.Errorf("splice replacement resources array: %w", err)}
 	}
 
 	r.Result.Resources = resources
-	rpcResp.Result = payload
+	rpcResp.Result = result
 	r.RemoteMessage.dirty = true
 	return nil
 }

--- a/server/internal/remotemcp/proxy/resources_test.go
+++ b/server/internal/remotemcp/proxy/resources_test.go
@@ -14,13 +14,18 @@ import (
 )
 
 const (
-	resourcesReadRequest    = `{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"file:///etc/hosts"}}`
-	resourcesReadResponse   = `{"jsonrpc":"2.0","id":3,"result":{"contents":[{"uri":"file:///etc/hosts","text":"127.0.0.1 localhost"}]}}`
-	resourcesListRequest    = `{"jsonrpc":"2.0","id":4,"method":"resources/list","params":{}}`
+	resourcesReadRequest  = `{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"file:///etc/hosts"}}`
+	resourcesReadResponse = `{"jsonrpc":"2.0","id":3,"result":{"contents":[{"uri":"file:///etc/hosts","text":"127.0.0.1 localhost"}]}}`
+	resourcesListRequest  = `{"jsonrpc":"2.0","id":4,"method":"resources/list","params":{}}`
+	// resourcesListThreeItems carries, alongside the resources array, result
+	// members the SDK's ListResourcesResult does not model. Mutation tests
+	// assert they relay intact through SetResources.
 	resourcesListThreeItems = `{
         "jsonrpc":"2.0",
         "id":4,
         "result":{
+            "resultType":"resources/list",
+            "futureUnknownField":{"nested":["ok"]},
             "resources":[
                 {"name":"a","uri":"file:///a"},
                 {"name":"b","uri":"file:///b"},
@@ -212,6 +217,12 @@ func TestProxy_Post_ResourcesListResponse_SetResources_RewritesRelayedBody(t *te
 	require.NotContains(t, out, `"file:///b"`, "filtered resource must not reach the client")
 	require.NotContains(t, out, `"file:///c"`, "filtered resource must not reach the client")
 	require.Contains(t, out, `"id":4`, "response id must survive re-encoding")
+
+	// Result members the SDK types don't model must survive the mutation:
+	// SetResources splices only the resources member into the original
+	// payload instead of round-tripping through ListResourcesResult.
+	require.Contains(t, out, `"resultType":"resources/list"`, "unmodeled member must survive SetResources")
+	require.Contains(t, out, `"futureUnknownField":{"nested":["ok"]}`, "unknown future member must survive SetResources")
 }
 
 func TestProxy_Post_ResourcesListResponse_SetResources_EmptyArrayWhenAllFiltered(t *testing.T) {

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -78,7 +78,7 @@ func toolsCallRequestFromUserRequest(req *UserRequest) (*ToolsCallRequest, bool)
 // front so the dirty signal alone is sufficient to trigger that
 // re-encode. Only the params' arguments member is rewritten: the
 // replacement is spliced into the original wire payload, so _meta, name,
-// and members [mcp.CallToolParamsRaw] does not model relay with their
+// and members not modeled by [mcp.CallToolParamsRaw] retain their
 // original values instead of being dropped by a typed re-marshal. The
 // splice happens before any typed-view or underlying-message state is
 // touched so a failure leaves everything at its pre-call values — the

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -68,37 +68,41 @@ func toolsCallRequestFromUserRequest(req *UserRequest) (*ToolsCallRequest, bool)
 // argument shapes, or rewriting wholesale.
 //
 // arguments must be a JSON object payload that the upstream tool can
-// unmarshal against its declared input schema. The replacement is
-// observed by every subsequent interceptor in the same chain through the
-// shared *Params pointer — no re-read of wire bytes is required. The
-// outer jsonrpc.Message is re-encoded once after the chain completes (see
+// unmarshal against its declared input schema; a nil or empty arguments
+// removes the member from the forwarded params, mirroring the omitempty
+// encoding of the field. The replacement is observed by every subsequent
+// interceptor in the same chain through the shared *Params pointer — no
+// re-read of wire bytes is required. The outer jsonrpc.Message is
+// re-encoded once after the chain completes (see
 // [UserRequest.refreshBody]); this method does the inner payload swap up
 // front so the dirty signal alone is sufficient to trigger that
-// re-encode. Marshal happens before any typed-view or underlying-message
-// state is touched so a marshal failure leaves everything at its
-// pre-call values — the typed view and the wire remain in sync
-// regardless of the failure mode.
+// re-encode. Only the params' arguments member is rewritten: the
+// replacement is spliced into the original wire payload, so _meta, name,
+// and members [mcp.CallToolParamsRaw] does not model relay with their
+// original values instead of being dropped by a typed re-marshal. The
+// splice happens before any typed-view or underlying-message state is
+// touched so a failure leaves everything at its pre-call values — the
+// typed view and the wire remain in sync regardless of the failure mode.
 //
 // Returns a [*MutationError] when the underlying jsonrpc.Message is not
-// a *jsonrpc.Request or when marshaling the mutated CallToolParamsRaw
-// fails. The proxy detects [*MutationError] at the interceptor return
-// path and surfaces it as an HTTP 5xx via [oops.E] with
-// [oops.CodeUnexpected] rather than as a user-facing JSON-RPC rejection.
+// a *jsonrpc.Request or when splicing the replacement arguments — which
+// also validates that arguments is well-formed JSON — fails. The proxy
+// detects [*MutationError] at the interceptor return path and surfaces
+// it as an HTTP 5xx via [oops.E] with [oops.CodeUnexpected] rather than
+// as a user-facing JSON-RPC rejection.
 func (r *ToolsCallRequest) SetArguments(arguments json.RawMessage) error {
 	rpcReq, ok := r.UserRequest.JSONRPCMessages[0].(*jsonrpc.Request)
 	if !ok {
 		return &MutationError{Op: "set arguments", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Request", r.UserRequest.JSONRPCMessages[0])}
 	}
 
-	// Stage the mutation against a temporary copy of Params so a marshal
-	// failure can't leave the typed view's Arguments desynced from the
-	// underlying wire bytes. Only commit (assign to Params.Arguments,
-	// rpcReq.Params, dirty) once marshaling has succeeded.
-	staged := *r.Params
-	staged.Arguments = arguments
-	payload, err := json.Marshal(&staged)
+	// Splice the replacement into the original wire payload so a failure
+	// can't leave the typed view's Arguments desynced from the underlying
+	// wire bytes. Only commit (assign to Params.Arguments, rpcReq.Params,
+	// dirty) once splicing has succeeded.
+	payload, err := spliceTopLevelKey(rpcReq.Params, "arguments", arguments)
 	if err != nil {
-		return &MutationError{Op: "set arguments", Cause: fmt.Errorf("marshal mutated CallToolParamsRaw: %w", err)}
+		return &MutationError{Op: "set arguments", Cause: fmt.Errorf("splice replacement arguments: %w", err)}
 	}
 
 	r.Params.Arguments = arguments

--- a/server/internal/remotemcp/proxy/tools_list_response.go
+++ b/server/internal/remotemcp/proxy/tools_list_response.go
@@ -98,9 +98,9 @@ func toolsListResponseFromRemoteMessage(request *ToolsListRequest, msg *RemoteMe
 // inner payload swap up front so the dirty signal alone is sufficient to
 // trigger that re-encode. Only the result's tools member is rewritten:
 // the replacement array is spliced into the original wire payload, so
-// _meta, nextCursor, and members [mcp.ListToolsResult] does not model
+// _meta, nextCursor, and members not modeled by [mcp.ListToolsResult]
 // (under MCP 2026-07-28, the required resultType, ttlMs, and cacheScope)
-// relay with their original values instead of being dropped by a typed
+// retain their original values instead of being dropped by a typed
 // re-marshal. Marshal and splice both happen before any typed-view or
 // underlying-message state is touched so a failure leaves everything at
 // its pre-call values — the typed view and the wire remain in sync
@@ -131,7 +131,7 @@ func (r *ToolsListResponse) SetTools(tools []*mcp.Tool) error {
 	// payload so a failure can't leave the typed view's Tools desynced from
 	// the underlying wire bytes. Only commit (assign to Result.Tools,
 	// rpcResp.Result, dirty) once both steps have succeeded.
-	payload, err := json.Marshal(tools)
+	payload, err := marshalJSONNoHTMLEscape(tools)
 	if err != nil {
 		return &MutationError{Op: "set tools", Cause: fmt.Errorf("marshal replacement tools array: %w", err)}
 	}

--- a/server/internal/remotemcp/proxy/tools_list_response.go
+++ b/server/internal/remotemcp/proxy/tools_list_response.go
@@ -96,18 +96,24 @@ func toolsListResponseFromRemoteMessage(request *ToolsListRequest, msg *RemoteMe
 // required. The outer jsonrpc.Message is re-encoded once after the chain
 // completes (see [RemoteMessage.materializedBytes]); this method does the
 // inner payload swap up front so the dirty signal alone is sufficient to
-// trigger that re-encode. Marshal happens before any typed-view or
-// underlying-message state is touched so a marshal failure leaves
-// everything at its pre-call values — the typed view and the wire
-// remain in sync regardless of the failure mode.
+// trigger that re-encode. Only the result's tools member is rewritten:
+// the replacement array is spliced into the original wire payload, so
+// _meta, nextCursor, and members [mcp.ListToolsResult] does not model
+// (under MCP 2026-07-28, the required resultType, ttlMs, and cacheScope)
+// relay with their original values instead of being dropped by a typed
+// re-marshal. Marshal and splice both happen before any typed-view or
+// underlying-message state is touched so a failure leaves everything at
+// its pre-call values — the typed view and the wire remain in sync
+// regardless of the failure mode.
 //
 // Returns a [*MutationError] when the response carries a JSON-RPC Error
 // rather than a Result (mutually exclusive per the typed-view
-// contract), when marshaling the mutated ListToolsResult fails, or when
-// the underlying jsonrpc.Message is not a *jsonrpc.Response. The proxy
-// detects [*MutationError] at the interceptor return path and surfaces
-// it as an HTTP 5xx via [oops.E] with [oops.CodeUnexpected] rather than
-// as a user-facing JSON-RPC rejection.
+// contract), when marshaling the replacement tools array or splicing it
+// into the original result fails, or when the underlying
+// jsonrpc.Message is not a *jsonrpc.Response. The proxy detects
+// [*MutationError] at the interceptor return path and surfaces it as an
+// HTTP 5xx via [oops.E] with [oops.CodeUnexpected] rather than as a
+// user-facing JSON-RPC rejection.
 func (r *ToolsListResponse) SetTools(tools []*mcp.Tool) error {
 	if r.Result == nil {
 		return &MutationError{Op: "set tools", Cause: errors.New("response carries an error, not a result")}
@@ -121,19 +127,21 @@ func (r *ToolsListResponse) SetTools(tools []*mcp.Tool) error {
 		tools = []*mcp.Tool{}
 	}
 
-	// Stage the mutation against a temporary copy of Result so a marshal
-	// failure can't leave the typed view's Tools desynced from the
-	// underlying wire bytes. Only commit (assign to Result.Tools,
-	// rpcResp.Result, dirty) once marshaling has succeeded.
-	staged := *r.Result
-	staged.Tools = tools
-	payload, err := json.Marshal(&staged)
+	// Marshal the replacement array and splice it into the original wire
+	// payload so a failure can't leave the typed view's Tools desynced from
+	// the underlying wire bytes. Only commit (assign to Result.Tools,
+	// rpcResp.Result, dirty) once both steps have succeeded.
+	payload, err := json.Marshal(tools)
 	if err != nil {
-		return &MutationError{Op: "set tools", Cause: fmt.Errorf("marshal mutated ListToolsResult: %w", err)}
+		return &MutationError{Op: "set tools", Cause: fmt.Errorf("marshal replacement tools array: %w", err)}
+	}
+	result, err := spliceTopLevelKey(rpcResp.Result, "tools", payload)
+	if err != nil {
+		return &MutationError{Op: "set tools", Cause: fmt.Errorf("splice replacement tools array: %w", err)}
 	}
 
 	r.Result.Tools = tools
-	rpcResp.Result = payload
+	rpcResp.Result = result
 	r.RemoteMessage.dirty = true
 	return nil
 }

--- a/server/internal/remotemcp/tools_call_strip_toolset_id_interceptor.go
+++ b/server/internal/remotemcp/tools_call_strip_toolset_id_interceptor.go
@@ -109,8 +109,8 @@ func (i *ToolsCallStripToolsetIDInterceptor) InterceptToolsCallRequest(ctx conte
 	// reaches this point with nothing actually removed. Committing an
 	// unchanged payload is not free: SetArguments flips the request's dirty
 	// flag, which re-encodes the whole JSON-RPC message before forwarding
-	// (dropping any params member CallToolParamsRaw doesn't model) and logs
-	// "forwarding mutated request body upstream". Only commit a real change.
+	// and logs "forwarding mutated request body upstream". Only commit a
+	// real change.
 	if bytes.Equal(stripped, call.Params.Arguments) {
 		return nil
 	}

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
@@ -27,6 +27,15 @@ import (
 // the filter matches disposition-scoped grants the same way the paired
 // tools/call enforcement does. A tool with no recorded metadata resolves to
 // the empty disposition, leaving a pure tool-name match.
+//
+// A catalog where every tool is authorized is not rewritten at all and
+// relays byte-for-byte. When filtering does remove tools, the rewrite
+// touches only the result's tools member; every other member of the
+// upstream result relays untouched, including members future protocol
+// revisions add. Should such a member ever carry tool identities the way
+// tools does, this filter will not scrub it. The kept tool objects,
+// however, are re-marshaled from [mcp.Tool], so per-tool members the SDK
+// does not model are dropped from a filtered catalog.
 type ToolsListMCPConnectFilterInterceptor struct {
 	authz       *authz.Engine
 	resolver    ToolDispositionResolver
@@ -105,6 +114,15 @@ func (i *ToolsListMCPConnectFilterInterceptor) InterceptToolsListResponse(ctx co
 		if matched[idx] {
 			allowed = append(allowed, t)
 		}
+	}
+
+	// Committing an unchanged catalog is not free: SetTools flips the
+	// message's dirty flag, which re-encodes the whole JSON-RPC message
+	// (re-marshaling each kept tool through mcp.Tool) before relaying.
+	// When every tool matched, skip the commit so the response relays
+	// byte-for-byte.
+	if len(allowed) == len(tools) {
+		return nil
 	}
 
 	if err := list.SetTools(allowed); err != nil {

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
@@ -1,6 +1,7 @@
 package remotemcp_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -19,7 +20,9 @@ import (
 // newToolsListResponse constructs a typed view with the given tools and
 // a fresh RemoteMessage backing the SetTools setter. The RemoteMessage
 // carries a *jsonrpc.Response whose Result is set to a marshaled
-// ListToolsResult so SetTools can re-marshal cleanly.
+// ListToolsResult so SetTools can splice its mutation into a real wire
+// payload, matching the production invariant that the typed view only
+// exists when those bytes decoded successfully.
 func newToolsListResponse(t *testing.T, tools []*mcp.Tool) *proxy.ToolsListResponse {
 	t.Helper()
 
@@ -28,9 +31,11 @@ func newToolsListResponse(t *testing.T, tools []*mcp.Tool) *proxy.ToolsListRespo
 		NextCursor: "",
 		Tools:      tools,
 	}
+	payload, err := json.Marshal(result)
+	require.NoError(t, err)
 	rpcResp := &jsonrpc.Response{
 		ID:     jsonrpc.ID{},
-		Result: nil,
+		Result: payload,
 		Error:  nil,
 	}
 	return &proxy.ToolsListResponse{
@@ -91,6 +96,44 @@ func TestToolsListMCPConnectFilterInterceptor_KeepsOnlyGrantedTools(t *testing.T
 
 	require.Len(t, resp.Result.Tools, 1)
 	require.Equal(t, "search_tickets", resp.Result.Tools[0].Name)
+}
+
+func TestToolsListMCPConnectFilterInterceptor_AllGrantedRelaysUnchangedBytes(t *testing.T) {
+	t.Parallel()
+
+	// When every tool is authorized there is nothing to filter, and the
+	// interceptor must not commit: SetTools would re-marshal each kept
+	// tool through mcp.Tool, dropping per-tool members the SDK does not
+	// model. The wire payload must relay byte-for-byte.
+	engine := newAuthzEngineForTest(t)
+	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
+	ctx = authztest.WithExactGrants(t, ctx,
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"tool":          "tool_a",
+		}),
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"tool":          "tool_b",
+		}),
+	)
+
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
+
+	resp := newToolsListResponse(t, []*mcp.Tool{
+		{Name: "tool_a", InputSchema: map[string]any{}},
+		{Name: "tool_b", InputSchema: map[string]any{}},
+	})
+	rpcResp, ok := resp.RemoteMessage.Message.(*jsonrpc.Response)
+	require.True(t, ok)
+	original := string(rpcResp.Result)
+
+	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
+
+	require.Len(t, resp.Result.Tools, 2, "no tool may be filtered when all are granted")
+	require.Equal(t, original, string(rpcResp.Result), "a fully authorized catalog must relay byte-for-byte, not be re-marshaled")
 }
 
 func TestToolsListMCPConnectFilterInterceptor_EmptyArrayWhenNoGrantsMatch(t *testing.T) {


### PR DESCRIPTION
Fixes the remote MCP proxy's only sanctioned mutation paths silently corrupting relayed traffic. The typed mutation setters (`ToolsListResponse.SetTools`, `ToolsCallRequest.SetArguments`, `ResourcesListResponse.SetResources`) decoded the wire payload into a go-sdk struct and re-marshaled it wholesale, deleting every top-level result/params member the struct does not model. Under MCP 2026-07-28 that strips the required `resultType`, `ttlMs`, and `cacheScope` members from a conformant upstream's `tools/list` response behind a private-visibility server, which strict modern clients then reject (the INC-440 signature).

Linear: AIS-575

## Changes

- New `spliceTopLevelKey` helper in `server/internal/remotemcp/proxy/jsonsplice.go`: rewrites exactly one top-level member of a JSON object payload via a `map[string]json.RawMessage` round-trip, so every other member (known and unknown, current and future protocol revisions) relays with its original value bytes. `_meta` integers above 2^53 no longer lose precision through `map[string]any`.
- All three setters now marshal the replacement value, splice it into the original wire payload, and only then commit, preserving the existing stage-then-commit failure contract (a failed setter leaves the typed view and wire bytes at pre-call values, surfaced as `MutationError` and an HTTP 5xx).
- Deliberate helper semantics, each pinned by a unit test: a zero-length replacement deletes the member (mirroring the `omitempty` encoding `SetArguments` had), a literal `null` payload splices into a fresh object, duplicate top-level keys collapse last-wins (so an unfiltered duplicate `tools` key cannot survive the visibility filter), and encoding matches the SDK envelope encoder's non-HTML-escaping output. The final marshal doubles as validation of caller-supplied bytes.
- The `mcp:connect` visibility filter now skips the commit entirely when every tool is authorized, so a fully granted catalog relays byte-for-byte (asserted down to the wire bytes in a new test).
- Response and request fixtures grew unmodeled members (`resultType`, `ttlMs`, `cacheScope`, an invented future member) plus an `_meta` integer exceeding float64 precision, with survival asserted on the buffered JSON path, the SSE-terminal path, and the forwarded request path; each assertion fails if a typed round-trip is reintroduced. The filter test helper now marshals a real `rpcResp.Result`, matching the production invariant that a typed view only exists once those bytes decoded.
- Doc updates at the setters, the strip-toolset-id interceptor (its comment documented the now-removed member-dropping behavior), and the visibility filter (disclosing that kept tool objects in a filtered catalog still re-marshal through `mcp.Tool`, a pre-existing per-tool residual to be handled in a follow-up issue).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves unknown JSON members when the remote MCP proxy mutates relayed payloads, preventing strict clients from rejecting conformant responses. Previously the setters re-marshaled SDK structs and dropped unmodeled top‑level members (e.g., required `resultType`, `ttlMs`, `cacheScope`); now each setter splices only the target member into the original payload.

- Adds `spliceTopLevelKey` to replace exactly one top-level key while keeping every other member’s original bytes; validates replacements, treats `null` as empty object, deletes on zero-length input, collapses duplicate keys last-wins, and performs no HTML escaping.
- Routes `ToolsListResponse.SetTools`, `ToolsCallRequest.SetArguments`, and `ResourcesListResponse.SetResources` through the splice; empty arguments now remove the `arguments` member. Failures surface as `MutationError` and HTTP 5xx without partial state.
- Skips commit in the `mcp:connect` tools/list filter when all tools are authorized so fully granted catalogs relay byte-for-byte; otherwise only the `tools` member is rewritten (kept tool objects still re-marshal via `mcp.Tool`).
- Expands tests and fixtures to assert survival of `resultType`, `ttlMs`, `cacheScope`, future unknown members, and large `_meta` integers on JSON and SSE paths, and pins non-HTML-escaped bytes (e.g., `<` and `&`) in kept tool descriptions.

Linear: AIS-575

<sup>Written for commit 39ca5e4164dae3d77f40f8eda821187c1e2df324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

