### PR TITLE
fix: refresh MCP readiness auth step after identity provider changes

### DIFF
--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
@@ -20,6 +20,9 @@ import { cn } from "@/lib/utils";
 import type { UserSessionIssuer } from "@gram/client/models/components/usersessionissuer.js";
 import { UpdateUserSessionIssuerFormClientIdMetadataAdmissionMode as WritableMode } from "@gram/client/models/components/updateusersessionissuerform.js";
 import { useCimdClientPresets } from "@gram/client/react-query/cimdClientPresets.js";
+import { invalidateAllGetMcpServer } from "@gram/client/react-query/getMcpServer.js";
+import { invalidateAllMcpServers } from "@gram/client/react-query/mcpServers.js";
+import { invalidateAllRemoteSessionClients } from "@gram/client/react-query/remoteSessionClients.js";
 import { useUpdateUserSessionIssuerMutation } from "@gram/client/react-query/updateUserSessionIssuer.js";
 import { invalidateAllUserSessionIssuer } from "@gram/client/react-query/userSessionIssuer.js";
 import { invalidateAllUserSessionIssuers } from "@gram/client/react-query/userSessionIssuers.js";
@@ -98,6 +101,11 @@ export function CimdAdmissionModeField({
       await Promise.all([
         invalidateAllUserSessionIssuers(queryClient, { refetchType: "all" }),
         invalidateAllUserSessionIssuer(queryClient, { refetchType: "all" }),
+        // Also invalidate MCP server and remote session client queries so the
+        // sidebar readiness bar refreshes (AGE-3279).
+        invalidateAllGetMcpServer(queryClient, { refetchType: "all" }),
+        invalidateAllMcpServers(queryClient, { refetchType: "all" }),
+        invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
       ]);
       toast.success("Client admission policy updated");
     },

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/DeleteRemoteIdentityProviderDialog.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/DeleteRemoteIdentityProviderDialog.tsx
@@ -2,6 +2,8 @@ import { Input } from "@/components/ui/Input";
 import { Text } from "@/components/ui/Text";
 import { useSdkClient } from "@/contexts/Sdk";
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
+import { invalidateAllGetMcpServer } from "@gram/client/react-query/getMcpServer.js";
+import { invalidateAllMcpServers } from "@gram/client/react-query/mcpServers.js";
 import { invalidateAllRemoteSessionClients } from "@gram/client/react-query/remoteSessionClients.js";
 import { invalidateAllRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
 import { Alert } from "@/components/ui/Alert";
@@ -100,6 +102,10 @@ function DeleteRemoteIdentityProviderDialogBody({
       await Promise.all([
         invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
         invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
+        // Also invalidate MCP server queries so the sidebar readiness bar
+        // refreshes (AGE-3279).
+        invalidateAllGetMcpServer(queryClient, { refetchType: "all" }),
+        invalidateAllMcpServers(queryClient, { refetchType: "all" }),
       ]);
       toast.success("Identity provider removed from this server");
       onClose();

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/ModifyRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/ModifyRemoteIdentityProviderSheet.tsx
@@ -14,7 +14,11 @@ import type { RemoteSessionClient } from "@gram/client/models/components/remotes
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
 import type { UserSessionIssuer } from "@gram/client/models/components/usersessionissuer.js";
 import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/client/models/components/createremotesessionclientform.js";
-import { useMcpServers } from "@gram/client/react-query/mcpServers.js";
+import { invalidateAllGetMcpServer } from "@gram/client/react-query/getMcpServer.js";
+import {
+  invalidateAllMcpServers,
+  useMcpServers,
+} from "@gram/client/react-query/mcpServers.js";
 import { invalidateAllRemoteSessionClients } from "@gram/client/react-query/remoteSessionClients.js";
 import { invalidateAllRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
 import { Alert } from "@/components/ui/Alert";
@@ -281,6 +285,10 @@ function ModifyRemoteIdentityProviderSheetBody({
       await Promise.all([
         invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
         invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
+        // Also invalidate MCP server queries so the sidebar readiness bar
+        // refreshes (AGE-3279).
+        invalidateAllGetMcpServer(queryClient, { refetchType: "all" }),
+        invalidateAllMcpServers(queryClient, { refetchType: "all" }),
       ]);
       toast.success("Identity provider updated");
       onClose();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the bug where the MCP Readiness authentication step doesn't automatically refresh after configuring a CIMD client admission policy and adding a remote identity provider.

## Changes

Added comprehensive cache invalidations to authentication-related mutation handlers:

### `CimdAdmissionModeField`
- Added `invalidateAllGetMcpServer`, `invalidateAllMcpServers`, and `invalidateAllRemoteSessionClients` to the `onSuccess` callback after updating the CIMD admission policy

### `DeleteRemoteIdentityProviderDialog`
- Added `invalidateAllGetMcpServer` and `invalidateAllMcpServers` to the success handler after removing an identity provider

### `ModifyRemoteIdentityProviderSheet`
- Added `invalidateAllGetMcpServer` and `invalidateAllMcpServers` to the `onSuccess` callback after modifying an identity provider

Note: `AttachRemoteIdentityProviderSheet` already had comprehensive invalidations via `target.invalidate(queryClient)`, which calls the appropriate MCP server invalidations for MCP server targets.

## How it works

The MCP sidebar readiness bar's Authentication step depends on:
- `hasRemoteIdentityProvider` - computed from the `remoteSessionClients` query
- `userSessionIssuerId` - from the MCP server data

By invalidating both the MCP server queries and remote session client queries when authentication settings change, the sidebar component will refetch the data and update the readiness state accordingly.

## Testing

- Type check passes
- Lint passes
- Local dev environment setup and service startup verified

Fixes: AGE-3279
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3279](https://linear.app/speakeasy/issue/AGE-3279/bug-mcp-readiness-authentication-step-does-not-refresh)

<div><a href="https://cursor.com/agents/bc-159a14ca-1c04-4777-9190-a6f7ba0b032f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159a14ca-1c04-4777-9190-a6f7ba0b032f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the MCP sidebar readiness Authentication step refreshes immediately after changing the CIMD client admission policy or remote identity providers. Previously it required a manual reload; now it refetches relevant data by invalidating MCP server and remote session client queries, with no API or UI changes. Addresses AGE-3279.

**Changes**
- In `CimdAdmissionModeField`, on success also invalidate `invalidateAllGetMcpServer`, `invalidateAllMcpServers`, and `invalidateAllRemoteSessionClients` to refresh MCP server and remote client data.
- In `DeleteRemoteIdentityProviderDialog`, on success also invalidate MCP server queries via `invalidateAllGetMcpServer` and `invalidateAllMcpServers`.
- In `ModifyRemoteIdentityProviderSheet`, on success also invalidate MCP server queries via `invalidateAllGetMcpServer` and `invalidateAllMcpServers`.

<sup>Written for commit a981bd4c31e8fd7f7d97ad0afefd238b586e3f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

