### PR TITLE
chore: status dots, agent naming, and /mcp-sessions route

### DIFF
--- a/.changeset/mcp-sessions-status-dots.md
+++ b/.changeset/mcp-sessions-status-dots.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The MCP connection listings now carry a status dot — green live, amber expiring, red needs re-auth, grey idle or revoked — so a roster is scanned by colour rather than read row by row; healthy rows state Live or Idle where the status column used to be blank. The OAuth client on the other side of a connection is called an agent throughout, matching the rest of the product, and the organization page moves from `/user-sessions` to `/mcp-sessions` with the nav entry and title to match.

--- a/client/dashboard/src/components/connections/ConnectionsList.tsx
+++ b/client/dashboard/src/components/connections/ConnectionsList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import {
+  CONNECTION_GROUPING_LABELS,
   connectionGroupSummary,
   groupAttentionState,
   groupConnections,
@@ -22,6 +23,7 @@ import {
   connectionActivityLabel,
   connectionDeadlineLabel,
   connectionState,
+  type ConnectionState,
 } from "@/lib/connection-state";
 import { getInitials } from "@/lib/initials";
 import { providerLabel } from "@/lib/provider-label";
@@ -78,18 +80,28 @@ function useNow(): number {
   return now;
 }
 
-const GROUPING_HEADERS: Record<ConnectionGrouping, string> = {
-  subject: "Person",
-  provider: "Provider",
-  client: "Client",
-};
-
 /** What a sub-row stands for, given what its parent row stands for. */
-const CHILD_OF: Record<ConnectionGrouping, "client" | "person"> = {
-  subject: "client",
+const CHILD_OF: Record<ConnectionGrouping, "agent" | "person"> = {
+  subject: "agent",
   provider: "person",
   client: "person",
 };
+
+/**
+ * The state read at a glance, before the word beside it is read at all. A
+ * roster is scanned for the one row that is wrong, and a colour carries that
+ * faster than text — green live, red spent, amber about to be, grey dormant.
+ */
+function StatusDot({ state }: { state: ConnectionState }): JSX.Element {
+  return (
+    <span
+      className={cn(
+        "size-1.5 shrink-0 rounded-full",
+        CONNECTION_STATE_PRESENTATION[state].dotClass,
+      )}
+    />
+  );
+}
 
 /**
  * The providers this group's subject holds tokens for, named.
@@ -199,12 +211,12 @@ function ConnectionSubRow({
   now: number;
   actions?: React.ReactNode;
 }): JSX.Element {
-  const presentation =
-    CONNECTION_STATE_PRESENTATION[connectionState(session, now)];
+  const state = connectionState(session, now);
+  const presentation = CONNECTION_STATE_PRESENTATION[state];
   const childIsPerson = CHILD_OF[grouping] === "person";
   const label = childIsPerson
     ? subjectLabel(session)
-    : (session.clientName ?? "Unknown client");
+    : (session.clientName ?? "Unknown agent");
 
   // A person's providers are a property of the person, not of each client they
   // connect through, so they belong on the parent row under person grouping and
@@ -252,10 +264,11 @@ function ConnectionSubRow({
 
         <span
           className={cn(
-            "hidden truncate text-xs sm:block",
+            "hidden items-center gap-2 truncate text-xs sm:flex",
             presentation.toneClass,
           )}
         >
+          <StatusDot state={state} />
           {presentation.label}
         </span>
       </div>
@@ -328,9 +341,15 @@ function ConnectionGroupRow({
     group.sessions.every(
       (session) => connectionState(session, now) === attention,
     );
-  const attentionTone = unanimous
-    ? CONNECTION_STATE_PRESENTATION[attention]
-    : null;
+
+  // The dot still shows on a mixed group, where the word does not: a colour
+  // beside a row that also carries an accent reads as "something in here",
+  // which is true, while the word would read as a claim about all of it. With
+  // nothing wrong, the group states the plain fact — carrying traffic or not.
+  const groupState: ConnectionState =
+    attention ?? (group.liveCount > 0 ? "live" : "idle");
+  const groupPresentation = CONNECTION_STATE_PRESENTATION[groupState];
+  const showStateLabel = attention === null || unanimous;
 
   return (
     <div
@@ -398,11 +417,12 @@ function ConnectionGroupRow({
 
           <span
             className={cn(
-              "hidden truncate text-xs sm:block",
-              attentionTone?.toneClass,
+              "hidden items-center gap-2 truncate text-xs sm:flex",
+              groupPresentation.toneClass,
             )}
           >
-            {attentionTone?.label ?? ""}
+            <StatusDot state={groupState} />
+            {showStateLabel ? groupPresentation.label : ""}
           </span>
         </button>
 
@@ -532,7 +552,7 @@ export function ConnectionsList({
                 name. */}
             <span />
             <span />
-            <span>{GROUPING_HEADERS[grouping]}</span>
+            <span>{CONNECTION_GROUPING_LABELS[grouping]}</span>
             <span className="hidden sm:block">Last used</span>
             <span className="hidden sm:block">Connections</span>
             <span className="hidden sm:block">Status</span>

--- a/client/dashboard/src/components/connections/groupConnections.ts
+++ b/client/dashboard/src/components/connections/groupConnections.ts
@@ -18,10 +18,13 @@ import type { UserSessionUpstream } from "@gram/client/models/components/userses
  */
 export type ConnectionGrouping = "subject" | "provider" | "client";
 
+// "Agent" rather than "client": the OAuth client on the other side of a
+// connection is an agent, and that is what it is called everywhere else in the
+// product. `client` stays as the key, which names the protocol record.
 export const CONNECTION_GROUPING_LABELS: Record<ConnectionGrouping, string> = {
   subject: "Person",
   provider: "Provider",
-  client: "Client",
+  client: "Agent",
 };
 
 export type ConnectionGroup = {

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -92,7 +92,7 @@ export function OrgSidebar({
   ].some((r) => r.active);
 
   const identityActive = [
-    orgRoutes.userSessions,
+    orgRoutes.mcpSessions,
     orgRoutes.identity,
     orgRoutes.remoteIdentityProviders,
   ].some((r) => r.active);
@@ -133,7 +133,7 @@ export function OrgSidebar({
     orgRoutes.auditLogs,
     orgRoutes.deviceAgent,
     orgRoutes.access,
-    orgRoutes.userSessions,
+    orgRoutes.mcpSessions,
     orgRoutes.identity,
     orgRoutes.remoteIdentityProviders,
     orgRoutes.platformAdminOverview,
@@ -245,7 +245,7 @@ export function OrgSidebar({
                 Icon={(p) => <Icon {...p} name="fingerprint" />}
                 items={[
                   ...(isUserSessionsEnabled
-                    ? [{ item: orgRoutes.userSessions, scope: orgReadOrAdmin }]
+                    ? [{ item: orgRoutes.mcpSessions, scope: orgReadOrAdmin }]
                     : []),
                   { item: orgRoutes.identity, scope: orgReadOrAdmin },
                   {

--- a/client/dashboard/src/components/sessions/ClientsAndSessionsTab.test.tsx
+++ b/client/dashboard/src/components/sessions/ClientsAndSessionsTab.test.tsx
@@ -342,7 +342,7 @@ describe("ClientsAndSessionsTab", () => {
 
     renderTab(<ClientsAndSessionsTab issuerId="issuer-1" />);
 
-    fireEvent.click(screen.getByText("Client"));
+    fireEvent.click(screen.getByText("Agent"));
 
     expect(screen.getByText("Never Used Client")).toBeDefined();
 
@@ -363,7 +363,7 @@ describe("ClientsAndSessionsTab", () => {
 
     renderTab(<ClientsAndSessionsTab issuerId="issuer-1" />);
 
-    fireEvent.click(screen.getByText("Client"));
+    fireEvent.click(screen.getByText("Agent"));
 
     expect(screen.getByText("Revoke registration")).toBeDefined();
     expect(screen.getByText("Revoke all connections")).toBeDefined();

--- a/client/dashboard/src/components/sessions/ClientsAndSessionsTab.tsx
+++ b/client/dashboard/src/components/sessions/ClientsAndSessionsTab.tsx
@@ -114,7 +114,7 @@ export function ClientsAndSessionsTab({
       <InlineEmptyState
         icon="unplug"
         heading="No connections can be made yet"
-        description="This server has no session issuer, so no client can register against it and no session can be established. Turn on authentication to start accepting OAuth connections."
+        description="This server has no session issuer, so no agent can register against it and no session can be established. Turn on authentication to start accepting OAuth connections."
         action={
           // The last path segment is swapped rather than using a `../` link:
           // these tabs are a switch on a route param, not nested routes, so
@@ -146,7 +146,7 @@ export function ClientsAndSessionsTab({
           subtext="Currently authenticated MCP sessions"
         />
         <StatTile
-          title="Clients"
+          title="Agents"
           value={clients.length}
           tone="information"
           icon="app-window"
@@ -158,7 +158,7 @@ export function ClientsAndSessionsTab({
           cap cut short has to say so rather than read as the whole picture. */}
       {isTruncated && (
         <Text small muted>
-          Showing {sessions.length} sessions and {clients.length} clients. Later
+          Showing {sessions.length} sessions and {clients.length} agents. Later
           pages were not loaded, so the counts, search, and filters on this tab
           cover only these.
         </Text>

--- a/client/dashboard/src/components/sessions/RevokeClientDialog.tsx
+++ b/client/dashboard/src/components/sessions/RevokeClientDialog.tsx
@@ -28,7 +28,7 @@ export function RevokeClientDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <Dialog.Content>
         <Dialog.Header>
-          <Dialog.Title>Revoke client?</Dialog.Title>
+          <Dialog.Title>Revoke agent?</Dialog.Title>
           <Dialog.Description>
             This revokes {client.clientName}
             {origin ? ` (${origin})` : ""} and ends every session it established
@@ -43,13 +43,13 @@ export function RevokeClientDialog({
           // row. Revoking clears today's access; it does not block the client.
           // Durable blocking is admission control's job.
           <Alert variant="warning">
-            <AlertTitle>Revoking will not block this client</AlertTitle>
+            <AlertTitle>Revoking will not block this agent</AlertTitle>
             <AlertDescription>
-              This client is identified by its metadata document
+              This agent is identified by its metadata document
               {origin ? ` at ${origin}` : ""}, not by a registration Gram
               issued. It can register again the next time it authorizes.
-              Revoking ends its current sessions, but it does not lock the
-              client out.
+              Revoking ends its current sessions, but it does not lock the agent
+              out.
             </AlertDescription>
           </Alert>
         )}

--- a/client/dashboard/src/components/sessions/ViewOrgSessionsButton.test.tsx
+++ b/client/dashboard/src/components/sessions/ViewOrgSessionsButton.test.tsx
@@ -21,9 +21,9 @@ vi.mock("@/hooks/useRBAC", () => ({
 // Link; stubbing it keeps this test off the router.
 vi.mock("@/routes", () => ({
   useOrgRoutes: () => ({
-    userSessions: {
+    mcpSessions: {
       Link: ({ children }: { children: React.ReactNode }) => (
-        <a href="/org-slug/user-sessions">{children}</a>
+        <a href="/org-slug/mcp-sessions">{children}</a>
       ),
     },
   }),
@@ -46,10 +46,10 @@ describe("ViewOrgSessionsButton", () => {
     vi.clearAllMocks();
   });
 
-  it("links to the org MCP Connections page when the flag and scopes allow it", () => {
+  it("links to the org MCP Sessions page when the flag and scopes allow it", () => {
     render(<ViewOrgSessionsButton />);
 
-    expect(link()?.getAttribute("href")).toBe("/org-slug/user-sessions");
+    expect(link()?.getAttribute("href")).toBe("/org-slug/mcp-sessions");
     expect(hasAnyScope).toHaveBeenCalledWith(["org:read", "org:admin"]);
   });
 

--- a/client/dashboard/src/components/sessions/ViewOrgSessionsButton.tsx
+++ b/client/dashboard/src/components/sessions/ViewOrgSessionsButton.tsx
@@ -7,7 +7,7 @@ import { useOrgRoutes } from "@/routes";
 
 /**
  * Deep link from a project-scoped sessions listing to the org-level MCP
- * Connections page, where sessions are governed across every project.
+ * Sessions page, where sessions are governed across every project.
  *
  * Hidden rather than disabled when the viewer can't reach that page. The
  * destination guards itself twice — it redirects to org home when the
@@ -28,13 +28,13 @@ export function ViewOrgSessionsButton(): JSX.Element | null {
   if (!hasAnyScope(["org:read", "org:admin"])) return null;
 
   return (
-    <orgRoutes.userSessions.Link className="hover:no-underline">
+    <orgRoutes.mcpSessions.Link className="hover:no-underline">
       <Button variant="secondary" size="sm">
         <Button.Text>View all organization sessions</Button.Text>
         <Button.RightIcon>
           <Icon name="arrow-right" size="small" />
         </Button.RightIcon>
       </Button>
-    </orgRoutes.userSessions.Link>
+    </orgRoutes.mcpSessions.Link>
   );
 }

--- a/client/dashboard/src/lib/assistantEntityLinkResolve.ts
+++ b/client/dashboard/src/lib/assistantEntityLinkResolve.ts
@@ -69,7 +69,7 @@ export function resolveEntityLink(
         : UNRESOLVABLE;
     case "user_session":
       // No per-session detail route — link to the connections list.
-      return newTab(`${org}/user-sessions`);
+      return newTab(`${org}/mcp-sessions`);
   }
 
   // --- Project-scoped ---

--- a/client/dashboard/src/lib/connection-state.ts
+++ b/client/dashboard/src/lib/connection-state.ts
@@ -50,32 +50,37 @@ const DORMANT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 export const CONNECTION_STATE_PRESENTATION: Record<
   ConnectionState,
-  { label: string; tone: ConnectionTone; toneClass: string }
+  { label: string; tone: ConnectionTone; toneClass: string; dotClass: string }
 > = {
   live: {
     label: "Live",
     tone: "success",
     toneClass: "text-default-success",
+    dotClass: "bg-[var(--text-default-success)]",
   },
   idle: {
     label: "Idle",
     tone: "neutral",
     toneClass: "text-muted-foreground",
+    dotClass: "bg-muted-foreground/50",
   },
   expiring: {
     label: "Expiring",
     tone: "warning",
     toneClass: "text-default-warning",
+    dotClass: "bg-[var(--text-default-warning)]",
   },
   needs_reauth: {
     label: "Needs re-auth",
     tone: "destructive",
     toneClass: "text-default-destructive",
+    dotClass: "bg-[var(--text-default-destructive)]",
   },
   revoked: {
     label: "Revoked",
     tone: "neutral",
     toneClass: "text-muted-foreground",
+    dotClass: "bg-muted-foreground/50",
   },
 };
 

--- a/client/dashboard/src/pages/org/UserSessions.tsx
+++ b/client/dashboard/src/pages/org/UserSessions.tsx
@@ -259,7 +259,7 @@ function UserSessionsInner(): JSX.Element {
   return (
     <ResourceListPage
       scope="org:read"
-      title="MCP Connections"
+      title="MCP Sessions"
       description="Every connection Gram brokers: what an agent connects through, the MCP server it reaches, and the upstream provider Gram holds credentials for on that person's behalf. Revoke a connection to immediately cut off access."
     >
       <div className="space-y-8">

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -1100,9 +1100,9 @@ const ORG_ROUTE_STRUCTURE = {
     icon: "history",
     component: OrgAuditLogs,
   },
-  userSessions: {
-    title: "MCP Connections",
-    url: "user-sessions",
+  mcpSessions: {
+    title: "MCP Sessions",
+    url: "mcp-sessions",
     icon: "users",
     component: UserSessions,
   },


### PR DESCRIPTION
Three polish passes over the MCP connection surfaces (org page, MCP server detail tab, employee page — all render the same shared list).

## Status dots

The status column now leads with a coloured dot: green live, amber expiring, red needs re-auth, grey idle or revoked. The colour lives on `CONNECTION_STATE_PRESENTATION` next to the label and text tone, so the left accent bar, the word, and the dot can never disagree.

Healthy group rows also state `Live` / `Idle`, where the column used to render empty unless something was wrong. A group whose connections disagree gets the dot but still no word — "Needs re-auth" as a row label would assert it of every connection underneath, which was already the reason the word was withheld.

## Client → agent

The OAuth client on the other side of a connection is called an _agent_, matching the language used everywhere else. This is copy only: the grouping key, the types, and the protocol fields (`Client ID`, the CIMD metadata sheet) keep their names, because those name the OAuth record rather than the thing a person connected with.

## `/user-sessions` → `/mcp-sessions`

Route, sidebar entry, and page title. The PostHog flag key (`user-sessions-dashboard`) is deliberately untouched — renaming it would break the live flag.

## Verification

Type-check and the sessions/connections suites pass. Every state was also checked in the running dashboard against temporary local rows covering live, expiring, idle, and needs-re-auth, in both the person and agent groupings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds colored status dots to MCP session listings and renames “Client” to “Agent” in UI copy. Moves the org route from /user-sessions to /mcp-sessions and retitles the page to MCP Sessions.

- Status column now shows a dot and label for healthy rows: Live or Idle; mixed groups show a dot but no word. Dot/label/accent colors come from CONNECTION_STATE_PRESENTATION to keep them consistent.
- All UI copy uses “Agent” (grouping tab, stats tile, revoke dialog, empty state). The grouping key remains client and protocol fields (e.g., Client ID) are unchanged.

**Review notes**
- Verify state rendering across live, idle, expiring, needs re-auth, and revoked, including mixed groups and both person and agent groupings.
- Check nav and deep links use /mcp-sessions (sidebar, routes, entity link resolver, button). PostHog flag key remains user-sessions-dashboard.

**Rollout**
- Update any external links or docs from /user-sessions to /mcp-sessions.

<sup>Written for commit 69bd354fbe4255ab460f1830fcb9358f1fab3e7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

