### PR TITLE
fix: seed the freeze chain from snapshots already stored

### DIFF
--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -403,6 +403,7 @@ WHERE organization_id = @organization_id
 SELECT
     generated.source_timestamp::date AS source_day
   , COALESCE(spend.spend_usd, 0::numeric) AS spend_usd
+  , frozen.source_snapshot_usd AS frozen_snapshot_usd
 FROM stripe_invoices invoice
 CROSS JOIN LATERAL generate_series(
   invoice.service_period_start,
@@ -413,6 +414,13 @@ LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = invoice.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = generated.source_timestamp::date
+-- Surface a snapshot an earlier pass already froze; the caller must not reseed
+-- that day from spend backfilled since.
+LEFT JOIN stripe_invoice_allocations frozen
+  ON frozen.organization_id = invoice.organization_id
+ AND frozen.source_kind = 'openrouter_daily_spend'
+ AND frozen.source_key = generated.source_timestamp::date::text || ':chat'
+ AND frozen.seq = 1
 WHERE invoice.organization_id = @organization_id
   AND invoice.stripe_invoice_id = @stripe_invoice_id
   AND invoice.service_period_end + interval '48 hours' <= @now
@@ -718,6 +726,13 @@ INSERT INTO stripe_invoice_allocations (
   , @idempotency_key
   , 'pending'
 );
+
+-- name: DeleteStripeInvoiceAllocationFixture :execrows
+DELETE FROM stripe_invoice_allocations
+WHERE organization_id = @organization_id
+  AND source_kind = @source_kind
+  AND source_key = @source_key
+  AND seq = @seq;
 
 -- name: ListStripeInvoiceAllocationsFixture :many
 SELECT

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -702,6 +702,34 @@ func (q *Queries) DeletePublishedOutboxRows(ctx context.Context, arg DeletePubli
 	return result.RowsAffected(), nil
 }
 
+const deleteStripeInvoiceAllocationFixture = `-- name: DeleteStripeInvoiceAllocationFixture :execrows
+DELETE FROM stripe_invoice_allocations
+WHERE organization_id = $1
+  AND source_kind = $2
+  AND source_key = $3
+  AND seq = $4
+`
+
+type DeleteStripeInvoiceAllocationFixtureParams struct {
+	OrganizationID pgtype.Text
+	SourceKind     string
+	SourceKey      string
+	Seq            int32
+}
+
+func (q *Queries) DeleteStripeInvoiceAllocationFixture(ctx context.Context, arg DeleteStripeInvoiceAllocationFixtureParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteStripeInvoiceAllocationFixture,
+		arg.OrganizationID,
+		arg.SourceKind,
+		arg.SourceKey,
+		arg.Seq,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const fetchOutboxRowsByIDs = `-- name: FetchOutboxRowsByIDs :many
 SELECT
     o.id,
@@ -1553,6 +1581,7 @@ const listOpenRouterInvoiceSourceDays = `-- name: ListOpenRouterInvoiceSourceDay
 SELECT
     generated.source_timestamp::date AS source_day
   , COALESCE(spend.spend_usd, 0::numeric) AS spend_usd
+  , frozen.source_snapshot_usd AS frozen_snapshot_usd
 FROM stripe_invoices invoice
 CROSS JOIN LATERAL generate_series(
   invoice.service_period_start,
@@ -1563,6 +1592,11 @@ LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = invoice.organization_id
  AND spend.key_type = 'chat'
  AND spend.day = generated.source_timestamp::date
+LEFT JOIN stripe_invoice_allocations frozen
+  ON frozen.organization_id = invoice.organization_id
+ AND frozen.source_kind = 'openrouter_daily_spend'
+ AND frozen.source_key = generated.source_timestamp::date::text || ':chat'
+ AND frozen.seq = 1
 WHERE invoice.organization_id = $1
   AND invoice.stripe_invoice_id = $2
   AND invoice.service_period_end + interval '48 hours' <= $3
@@ -1576,10 +1610,13 @@ type ListOpenRouterInvoiceSourceDaysParams struct {
 }
 
 type ListOpenRouterInvoiceSourceDaysRow struct {
-	SourceDay pgtype.Date
-	SpendUsd  pgtype.Numeric
+	SourceDay         pgtype.Date
+	SpendUsd          pgtype.Numeric
+	FrozenSnapshotUsd pgtype.Numeric
 }
 
+// Surface a snapshot an earlier pass already froze; the caller must not reseed
+// that day from spend backfilled since.
 func (q *Queries) ListOpenRouterInvoiceSourceDays(ctx context.Context, arg ListOpenRouterInvoiceSourceDaysParams) ([]ListOpenRouterInvoiceSourceDaysRow, error) {
 	rows, err := q.db.Query(ctx, listOpenRouterInvoiceSourceDays, arg.OrganizationID, arg.StripeInvoiceID, arg.Now)
 	if err != nil {
@@ -1589,7 +1626,7 @@ func (q *Queries) ListOpenRouterInvoiceSourceDays(ctx context.Context, arg ListO
 	var items []ListOpenRouterInvoiceSourceDaysRow
 	for rows.Next() {
 		var i ListOpenRouterInvoiceSourceDaysRow
-		if err := rows.Scan(&i.SourceDay, &i.SpendUsd); err != nil {
+		if err := rows.Scan(&i.SourceDay, &i.SpendUsd, &i.FrozenSnapshotUsd); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -177,8 +177,15 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 		frozenSnapshots := make([]pgtype.Numeric, 0, len(days))
 		previousCumulativeCents := int64(0)
 		for _, day := range days {
+			// A day frozen by an earlier pass is immovable, so the chain
+			// continues from the snapshot on record. Reseeding it from spend that
+			// backfilled since would shift every later day's cents away from the
+			// snapshots the carry pass reconciles against.
 			snapshot := day.SpendUsd
-			if missedFreeze {
+			switch {
+			case day.FrozenSnapshotUsd.Valid:
+				snapshot = day.FrozenSnapshotUsd
+			case missedFreeze:
 				snapshot = numericFromCents(0)
 			}
 			frozenSnapshots = append(frozenSnapshots, snapshot)

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -922,3 +922,45 @@ func TestM3FreezeObservationAndCarrySettlementLifecycle(t *testing.T) {
 	require.Empty(t, allocationStripe.creditInputs)
 	meterStripe.AssertExpectations(t)
 }
+
+// freezeInvoice writes each day on the pool with no enclosing transaction, so a
+// pass that dies partway leaves the days it already wrote. Those snapshots are
+// what the carry pass reconciles against, so a later pass has to continue the
+// cumulative chain from them rather than from spend backfilled since.
+func TestSettleStripeInvoiceAllocations_BackfilledSpendKeepsFrozenChain(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_backfill_chain")
+	start := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
+	secondDay := start.AddDate(0, 0, 1)
+	end := start.AddDate(0, 0, 2)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "0.004000")
+	putDailySpend(t, db, organizationID, secondDay, "0.004000")
+
+	now := end.Add(48 * time.Hour)
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
+
+	// Stand in for a pass that died after day one.
+	deleted, err := backgroundrepo.New(db).DeleteStripeInvoiceAllocationFixture(t.Context(),
+		backgroundrepo.DeleteStripeInvoiceAllocationFixtureParams{
+			OrganizationID: pgtype.Text{String: organizationID, Valid: true},
+			SourceKind:     "openrouter_daily_spend",
+			SourceKey:      secondDay.Format(time.DateOnly) + ":chat",
+			Seq:            1,
+		})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted, "the partial-freeze simulation must remove exactly one day")
+
+	// Day one's spend lands late, after its row was frozen.
+	putDailySpend(t, db, organizationID, start, "0.006000")
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
+
+	rows := listAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, "0.004000", numericString(t, rows[0].SourceSnapshotUsd),
+		"the frozen day keeps the snapshot it was written with, not the backfill")
+	require.Equal(t, "0", numericString(t, rows[0].AmountUsd))
+	require.Equal(t, "0.004000", numericString(t, rows[1].SourceSnapshotUsd))
+	require.Equal(t, "0.010000", numericString(t, rows[1].AmountUsd),
+		"day two carries the cent the frozen chain rounds up to")
+}


### PR DESCRIPTION
## Summary

The OpenRouter freeze chain reseeds itself from live spend on every pass, so a day whose spend backfills after it was frozen can leave a cent stranded on the customer's invoice.

`freezeInvoice` walks an invoice's days and writes cumulative-rounded amounts: `cents = roundCum(prefix) - previousCumulative`. It seeds that chain from `ListOpenRouterInvoiceSourceDays`, which returns **live** `openrouter_spend_daily` values. A day already frozen keeps the `source_snapshot_usd` it was written with, and `CreateOpenRouterInvoiceAllocation` is `ON CONFLICT ... DO NOTHING`, so the stored row never catches up. Once live spend and the stored snapshot disagree, every later day's cents are computed against a chain that does not match what is on record.

The carry pass cannot repair it: it diffs `FinalSpendUsd` against the **stored** `SourceSnapshotUsd`, assuming the frozen cents already reconcile with those stored snapshots. That assumption is exactly what drifts.

## Reachability

It needs a partially frozen invoice. `freezeInvoice` runs on the pool with no enclosing transaction, so a pass that dies partway leaves the days it already wrote — the days are written in `ORDER BY source_day`, so what remains is a prefix. If spend for one of those days backfills before the next pass, the next pass fills the tail off a chain that no longer matches the stored prefix.

Concretely, with two days at `0.004` each: day one freezes with snapshot `0.004` and 0 cents. Spend backfills to `0.006`. The next pass starts the chain at `round(0.6) = 1`, so day two gets `round(1.0) - 1 = 0` cents. Stored snapshots sum to a rounded cent; stored amounts sum to zero. One cent lost.

## Change

- `ListOpenRouterInvoiceSourceDays` LEFT JOINs `stripe_invoice_allocations` and returns the `seq = 1` snapshot for days already frozen. The join pins all four columns of `stripe_invoice_allocations_org_source_seq_key`, so it matches at most one row and cannot fan out.
- `freezeInvoice` prefers that stored snapshot when seeding the chain, falling back to live spend, so a replay reproduces the amounts already on record.

Nothing already delivered changes: the insert stays `ON CONFLICT DO NOTHING`, and no `UPDATE` in this package writes `amount_usd` or `source_snapshot_usd`. Only rows that do not exist yet get different cents, and the backfilled money is not dropped — it is picked up by the seq=2 carry, which is where it belongs.

## Tests

`TestSettleStripeInvoiceAllocations_BackfilledSpendKeepsFrozenChain` builds the partially frozen state and asserts the exact stored rows. It is a genuine regression test: with the seeding removed it fails, day two holding `0` where it should hold `0.010000`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seed the invoice freeze chain from stored snapshots for already-frozen days instead of live spend. This keeps rounding consistent with recorded allocations and prevents losing a cent when spend backfills after a partial freeze.

- `ListOpenRouterInvoiceSourceDays` now LEFT JOINs `stripe_invoice_allocations` and returns `frozen_snapshot_usd` for `seq=1` (join pins the org/source/seq key and cannot fan out).
- `freezeInvoice` prefers the stored snapshot to seed the chain, otherwise falls back to live spend (or zero when a day was missed entirely).
- No changes to existing rows: inserts remain `ON CONFLICT DO NOTHING`; only yet-unwritten days may compute different cents. Backfilled spend is picked up by the `seq=2` carry.
- Tests: added `TestSettleStripeInvoiceAllocations_BackfilledSpendKeepsFrozenChain` and a `DeleteStripeInvoiceAllocationFixture` helper for setup.

<sup>Written for commit 767aaef377a038f7bb316df668a16b92d4283651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

