### PR TITLE
fix: shorten Platform MCP page copy

### DIFF
--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -88,6 +88,7 @@ function PageHeaderTitle({
 //     kept in the URL for backwards compatibility but was renamed.
 const breadcrumbSubstitutions = {
   mcp: "MCP",
+  "platform-mcp": "Platform MCP",
   "shadow-mcp": "Shadow MCP",
   sdks: "SDKs",
   elements: "Chat Elements",

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -532,14 +532,9 @@ export function PlatformMCPOnboardingContent({
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
       <Page.Section>
-        <Page.Section.Title stage="preview">
-          Speakeasy AICP Platform MCP
-        </Page.Section.Title>
+        <Page.Section.Title stage="preview">Platform MCP</Page.Section.Title>
         <Page.Section.Description className="max-w-3xl">
-          Use an AI agent to add a reviewed MCP server to a project: connect the
-          agent, choose a reviewed MCP server from the MCP Catalogue, complete
-          any required setup, then make the server available through that
-          project&apos;s existing Default plugin.
+          Manage MCPs, Risk Policies and explore logs in your favorite agent.
         </Page.Section.Description>
         {showManagement ? (
           <Page.Section.Body>
@@ -571,9 +566,7 @@ export function PlatformMCPOnboardingContent({
         <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <Text variant="subheading" id="platform-mcp-setup">
-              {showManagement
-                ? "Set up another agent"
-                : "Set up Speakeasy AICP Platform MCP"}
+              {showManagement ? "Set up another agent" : "Set up Platform MCP"}
             </Text>
             <Text muted small className="mt-2 max-w-2xl">
               {showManagement
@@ -1406,7 +1399,7 @@ function PlatformMCPSetupSheet({
         className="flex w-full flex-col overflow-hidden sm:max-w-[662px]"
       >
         <SheetHeader className="sr-only">
-          <SheetTitle>Set up Speakeasy AICP Platform MCP</SheetTitle>
+          <SheetTitle>Set up Platform MCP</SheetTitle>
           <SheetDescription>
             Complete Platform MCP setup one lifecycle step at a time.
           </SheetDescription>

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -719,7 +719,7 @@ function PlatformMCPPluginCard(): JSX.Element {
           variant="subheading"
           as="div"
           className="text-md truncate"
-          title="Speakeasy AICP Platform MCP"
+          title="Platform MCP"
         >
           Platform MCP
         </Text>
@@ -729,9 +729,7 @@ function PlatformMCPPluginCard(): JSX.Element {
       </div>
 
       <Text small muted className="mb-3 line-clamp-3">
-        Connects your selected coding agent to Speakeasy through OAuth and
-        includes a reviewed workflow for adding an MCP Catalogue server to an
-        explicit project.
+        Manage MCPs, Risk Policies and explore logs in your favorite agent.
       </Text>
 
       <div className="mt-auto flex items-center justify-between gap-2 pt-2">

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -386,9 +386,8 @@ export function DistributeServersStep({
                 Set up with Platform MCP
               </p>
               <p className="text-muted-foreground mt-1 max-w-2xl text-sm leading-relaxed">
-                Connect your AI agent to Speakeasy AICP Platform MCP to explore
-                reviewed MCP servers before setting them up for distribution in
-                the browser.
+                Connect your AI agent to Platform MCP to explore reviewed MCP
+                servers before setting them up for distribution in the browser.
               </p>
             </div>
             <Button

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -408,7 +408,7 @@ const (
 	platformMCPPluginName         = "speakeasy-aicp-platform-mcp"
 	platformMCPServerName         = "platform-mcp"
 	platformMCPPluginRoot         = "platform-mcp"
-	platformMCPDescription        = "Manage reviewed MCP Catalogue servers through the Speakeasy AICP Platform MCP."
+	platformMCPDescription        = "Manage MCPs, Risk Policies and explore logs in your favorite agent."
 	platformMCPCursorPluginRoot   = cursorPluginRoot + "/platform-mcp-cursor"
 	platformMCPCodexPluginRoot    = "platform-mcp-codex"
 	platformMCPOpenCodePluginRoot = opencodePluginRoot + "/platform-mcp"


### PR DESCRIPTION
## Summary
- Rename the Platform MCP page from Speakeasy AICP Platform MCP to Platform MCP (title, setup heading, breadcrumbs, and related copy).
- Update the page and plugins card subtext to "Manage MCPs, Risk Policies and explore logs in your favorite agent."
- Use the same description on the generated Platform MCP plugin package.

## Test plan
- [ ] Open the org Platform MCP page and confirm the title, breadcrumb, and subtext
- [ ] Confirm the plugins marketplace card uses the same subtext
- [ ] Confirm setup still starts from "Set up Platform MCP"

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes and shortens Platform MCP copy across the dashboard and generated plugin. Previously used “Speakeasy AICP Platform MCP” with a long description; now uses “Platform MCP” and “Manage MCPs, Risk Policies and explore logs in your favorite agent.” for clearer, consistent labeling. Breadcrumbs now map the `platform-mcp` slug to “Platform MCP.” URLs and identifiers remain unchanged.

- Confirm the org Platform MCP page shows “Platform MCP” in the title, breadcrumb, and setup headers (including the sheet’s SR-only title) with the new description.
- Check the Plugins marketplace card uses the new title and description.
- Verify the Distribute Servers step copy drops “Speakeasy AICP” and references “Platform MCP.”
- Ensure the generated plugin description reflects the new text; plugin name `speakeasy-aicp-platform-mcp` and server name `platform-mcp` are unchanged.

<sup>Written for commit 5b7598f1f6e03448cd8811627b0097f158b2600e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

