### PR TITLE
feat: indicate active WorkOS impersonation

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -65479,6 +65479,9 @@ components:
         has_active_subscription:
           type: boolean
           description: Whether the organization has an active billing subscription
+        impersonator_email:
+          type: string
+          description: The WorkOS Dashboard operator who initiated this impersonation session. Empty for ordinary authentication.
         is_admin:
           type: boolean
         organizations:

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -142,8 +142,7 @@ const ImpersonationBanner = () => {
         "flex h-9 items-center justify-center gap-3 border-b px-4",
         toneClasses,
       )}
-      role="status"
-      aria-live="polite"
+      role="alert"
     >
       <ShieldAlert className={cn("h-3.5 w-3.5 shrink-0", labelTone)} />
       {/* Plain concatenation: tailwind-merge would treat text-eyebrow and the

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -75,12 +75,17 @@ function getAdminOverrideCookie(): string | null {
 // the admin override cookie or session-side via auth.enterDemo (any user),
 // so demo detection keys off the active org slug, not the cookie.
 
-/** Banner shows for admin cookie-impersonation or any session in the demo org. */
+/** Banner shows for WorkOS impersonation, admin override, or the demo org. */
 const useShowsImpersonationBanner = (): boolean => {
   const isAdmin = useIsPlatformAdmin();
   const organization = useOrganization();
+  const session = useSession();
   const overrideSlug = useMemo(() => getAdminOverrideCookie(), []);
-  return (isAdmin && !!overrideSlug) || organization.slug === DEMO_ORG_SLUG;
+  return (
+    organization.slug === DEMO_ORG_SLUG ||
+    !!session.impersonatorEmail ||
+    (isAdmin && !!overrideSlug)
+  );
 };
 
 const ImpersonationBanner = () => {
@@ -88,6 +93,17 @@ const ImpersonationBanner = () => {
   const session = useSession();
   const client = useSdkClient();
   const isDemo = organization.slug === DEMO_ORG_SLUG;
+  const isWorkOSImpersonation = !!session.impersonatorEmail;
+  const organizationLabel = organization.name || organization.slug;
+
+  let label = `Impersonating ${organization.slug}`;
+  let actionLabel = "Stop impersonating";
+  if (isDemo) {
+    label = "Demo org — sample data";
+    actionLabel = "Exit demo";
+  } else if (isWorkOSImpersonation) {
+    label = `WorkOS impersonation active — signed in as ${session.user.email} in ${organizationLabel}`;
+  }
 
   const exit = () => {
     void (async () => {
@@ -126,21 +142,21 @@ const ImpersonationBanner = () => {
         "flex h-9 items-center justify-center gap-3 border-b px-4",
         toneClasses,
       )}
+      role="status"
+      aria-live="polite"
     >
       <ShieldAlert className={cn("h-3.5 w-3.5 shrink-0", labelTone)} />
       {/* Plain concatenation: tailwind-merge would treat text-eyebrow and the
           text-default-* tone as conflicting text-* utilities and drop one. */}
-      <span className={`text-eyebrow ${labelTone}`}>
-        {isDemo
-          ? "Demo org — sample data"
-          : `Impersonating ${organization.slug}`}
+      <span className={`text-eyebrow min-w-0 truncate ${labelTone}`}>
+        {label}
       </span>
       <button
         type="button"
         onClick={exit}
-        className="border-neutral-softest text-default-fixed-light ml-2 border px-2 py-0.5 font-mono text-[11px] tracking-[0.08em] uppercase hover:bg-white/10"
+        className="border-neutral-softest text-default-fixed-light ml-2 shrink-0 border px-2 py-0.5 font-mono text-[11px] tracking-[0.08em] uppercase hover:bg-white/10"
       >
-        {isDemo ? "Exit demo" : "Stop impersonating"}
+        {actionLabel}
       </button>
     </div>
   );

--- a/client/dashboard/src/sdk/src/models/components/inforesponsebody.ts
+++ b/client/dashboard/src/sdk/src/models/components/inforesponsebody.ts
@@ -24,6 +24,10 @@ export type InfoResponseBody = {
    * Whether the organization has an active billing subscription
    */
   hasActiveSubscription: boolean;
+  /**
+   * The WorkOS Dashboard operator who initiated this impersonation session. Empty for ordinary authentication.
+   */
+  impersonatorEmail?: string | undefined;
   isAdmin: boolean;
   organizations: Array<OrganizationEntry>;
   trial: Trial | null;
@@ -77,6 +81,7 @@ export const InfoResponseBody$inboundSchema: z.ZodMiniType<
     active_organization_id: z.string(),
     gram_account_type: z.string(),
     has_active_subscription: z.boolean(),
+    impersonator_email: z.optional(z.string()),
     is_admin: z.boolean(),
     organizations: z.array(OrganizationEntry$inboundSchema),
     trial: z.nullable(z.lazy(() => Trial$inboundSchema)),
@@ -92,6 +97,7 @@ export const InfoResponseBody$inboundSchema: z.ZodMiniType<
       "active_organization_id": "activeOrganizationId",
       "gram_account_type": "gramAccountType",
       "has_active_subscription": "hasActiveSubscription",
+      "impersonator_email": "impersonatorEmail",
       "is_admin": "isAdmin",
       "user_display_name": "userDisplayName",
       "user_email": "userEmail",

--- a/server/design/auth/design.go
+++ b/server/design/auth/design.go
@@ -212,6 +212,7 @@ var _ = Service("auth", func() {
 			Attribute("user_display_name", String)
 			Attribute("user_photo_url", String)
 			Attribute("is_admin", Boolean)
+			Attribute("impersonator_email", String, "The WorkOS Dashboard operator who initiated this impersonation session. Empty for ordinary authentication.")
 			Attribute("active_organization_id", String)
 			Attribute("gram_account_type", String)
 			Attribute("has_active_subscription", Boolean, "Whether the organization has an active billing subscription")

--- a/server/gen/auth/service.go
+++ b/server/gen/auth/service.go
@@ -93,12 +93,15 @@ type InfoPayload struct {
 
 // InfoResult is the result type of the auth service info method.
 type InfoResult struct {
-	UserID               string
-	UserEmail            string
-	UserSignature        *string
-	UserDisplayName      *string
-	UserPhotoURL         *string
-	IsAdmin              bool
+	UserID          string
+	UserEmail       string
+	UserSignature   *string
+	UserDisplayName *string
+	UserPhotoURL    *string
+	IsAdmin         bool
+	// The WorkOS Dashboard operator who initiated this impersonation session.
+	// Empty for ordinary authentication.
+	ImpersonatorEmail    *string
 	ActiveOrganizationID string
 	GramAccountType      string
 	// Whether the organization has an active billing subscription

--- a/server/gen/http/auth/client/types.go
+++ b/server/gen/http/auth/client/types.go
@@ -24,12 +24,15 @@ type RegisterRequestBody struct {
 // InfoResponseBody is the type of the "auth" service "info" endpoint HTTP
 // response body.
 type InfoResponseBody struct {
-	UserID               *string `form:"user_id,omitempty" json:"user_id,omitempty" xml:"user_id,omitempty"`
-	UserEmail            *string `form:"user_email,omitempty" json:"user_email,omitempty" xml:"user_email,omitempty"`
-	UserSignature        *string `form:"user_signature,omitempty" json:"user_signature,omitempty" xml:"user_signature,omitempty"`
-	UserDisplayName      *string `form:"user_display_name,omitempty" json:"user_display_name,omitempty" xml:"user_display_name,omitempty"`
-	UserPhotoURL         *string `form:"user_photo_url,omitempty" json:"user_photo_url,omitempty" xml:"user_photo_url,omitempty"`
-	IsAdmin              *bool   `form:"is_admin,omitempty" json:"is_admin,omitempty" xml:"is_admin,omitempty"`
+	UserID          *string `form:"user_id,omitempty" json:"user_id,omitempty" xml:"user_id,omitempty"`
+	UserEmail       *string `form:"user_email,omitempty" json:"user_email,omitempty" xml:"user_email,omitempty"`
+	UserSignature   *string `form:"user_signature,omitempty" json:"user_signature,omitempty" xml:"user_signature,omitempty"`
+	UserDisplayName *string `form:"user_display_name,omitempty" json:"user_display_name,omitempty" xml:"user_display_name,omitempty"`
+	UserPhotoURL    *string `form:"user_photo_url,omitempty" json:"user_photo_url,omitempty" xml:"user_photo_url,omitempty"`
+	IsAdmin         *bool   `form:"is_admin,omitempty" json:"is_admin,omitempty" xml:"is_admin,omitempty"`
+	// The WorkOS Dashboard operator who initiated this impersonation session.
+	// Empty for ordinary authentication.
+	ImpersonatorEmail    *string `form:"impersonator_email,omitempty" json:"impersonator_email,omitempty" xml:"impersonator_email,omitempty"`
 	ActiveOrganizationID *string `form:"active_organization_id,omitempty" json:"active_organization_id,omitempty" xml:"active_organization_id,omitempty"`
 	GramAccountType      *string `form:"gram_account_type,omitempty" json:"gram_account_type,omitempty" xml:"gram_account_type,omitempty"`
 	// Whether the organization has an active billing subscription
@@ -2277,6 +2280,7 @@ func NewInfoResultOK(body *InfoResponseBody, sessionToken string, sessionCookie 
 		UserDisplayName:       body.UserDisplayName,
 		UserPhotoURL:          body.UserPhotoURL,
 		IsAdmin:               *body.IsAdmin,
+		ImpersonatorEmail:     body.ImpersonatorEmail,
 		ActiveOrganizationID:  *body.ActiveOrganizationID,
 		GramAccountType:       *body.GramAccountType,
 		HasActiveSubscription: *body.HasActiveSubscription,

--- a/server/gen/http/auth/server/types.go
+++ b/server/gen/http/auth/server/types.go
@@ -22,12 +22,15 @@ type RegisterRequestBody struct {
 // InfoResponseBody is the type of the "auth" service "info" endpoint HTTP
 // response body.
 type InfoResponseBody struct {
-	UserID               string  `form:"user_id" json:"user_id" xml:"user_id"`
-	UserEmail            string  `form:"user_email" json:"user_email" xml:"user_email"`
-	UserSignature        *string `form:"user_signature,omitempty" json:"user_signature,omitempty" xml:"user_signature,omitempty"`
-	UserDisplayName      *string `form:"user_display_name,omitempty" json:"user_display_name,omitempty" xml:"user_display_name,omitempty"`
-	UserPhotoURL         *string `form:"user_photo_url,omitempty" json:"user_photo_url,omitempty" xml:"user_photo_url,omitempty"`
-	IsAdmin              bool    `form:"is_admin" json:"is_admin" xml:"is_admin"`
+	UserID          string  `form:"user_id" json:"user_id" xml:"user_id"`
+	UserEmail       string  `form:"user_email" json:"user_email" xml:"user_email"`
+	UserSignature   *string `form:"user_signature,omitempty" json:"user_signature,omitempty" xml:"user_signature,omitempty"`
+	UserDisplayName *string `form:"user_display_name,omitempty" json:"user_display_name,omitempty" xml:"user_display_name,omitempty"`
+	UserPhotoURL    *string `form:"user_photo_url,omitempty" json:"user_photo_url,omitempty" xml:"user_photo_url,omitempty"`
+	IsAdmin         bool    `form:"is_admin" json:"is_admin" xml:"is_admin"`
+	// The WorkOS Dashboard operator who initiated this impersonation session.
+	// Empty for ordinary authentication.
+	ImpersonatorEmail    *string `form:"impersonator_email,omitempty" json:"impersonator_email,omitempty" xml:"impersonator_email,omitempty"`
 	ActiveOrganizationID string  `form:"active_organization_id" json:"active_organization_id" xml:"active_organization_id"`
 	GramAccountType      string  `form:"gram_account_type" json:"gram_account_type" xml:"gram_account_type"`
 	// Whether the organization has an active billing subscription
@@ -1340,6 +1343,7 @@ func NewInfoResponseBody(res *auth.InfoResult) *InfoResponseBody {
 		UserDisplayName:       res.UserDisplayName,
 		UserPhotoURL:          res.UserPhotoURL,
 		IsAdmin:               res.IsAdmin,
+		ImpersonatorEmail:     res.ImpersonatorEmail,
 		ActiveOrganizationID:  res.ActiveOrganizationID,
 		GramAccountType:       res.GramAccountType,
 		HasActiveSubscription: res.HasActiveSubscription,

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -66262,6 +66262,9 @@ components:
                 has_active_subscription:
                     type: boolean
                     description: Whether the organization has an active billing subscription
+                impersonator_email:
+                    type: string
+                    description: The WorkOS Dashboard operator who initiated this impersonation session. Empty for ordinary authentication.
                 is_admin:
                     type: boolean
                 organizations:

--- a/server/internal/auth/authenticate_test.go
+++ b/server/internal/auth/authenticate_test.go
@@ -36,6 +36,7 @@ func TestAuthenticate_AdminCanAccessNonMemberOrg(t *testing.T) {
 		UserID:               userInfo.UserID,
 		ActiveOrganizationID: customerOrg.ID,
 		WorkOSSessionID:      "workos-sid-admin",
+		ImpersonatorEmail:    "",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -72,6 +73,7 @@ func TestAuthenticate_NonAdminCannotAccessNonMemberOrg(t *testing.T) {
 		SessionID:            "nonadmin-foreign-auth",
 		UserID:               userInfo.UserID,
 		ActiveOrganizationID: foreignOrg.ID,
+		ImpersonatorEmail:    "",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 

--- a/server/internal/auth/authorize_test.go
+++ b/server/internal/auth/authorize_test.go
@@ -104,6 +104,7 @@ func TestAuthorizeSessionCanSelectGrantedOrganizationProjects(t *testing.T) {
 		ActiveOrganizationID: userInfo.Organizations[0].ID,
 		UserID:               userInfo.UserID,
 		WorkOSSessionID:      "workos-project-access-session",
+		ImpersonatorEmail:    "",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -136,6 +137,7 @@ func TestAuthorizeSessionRejectsUngrantedOrganizationProject(t *testing.T) {
 		ActiveOrganizationID: userInfo.Organizations[0].ID,
 		UserID:               userInfo.UserID,
 		WorkOSSessionID:      "workos-project-access-session-ungranted",
+		ImpersonatorEmail:    "",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -633,6 +633,15 @@ func TestService_CallbackAllowsWorkOSImpersonationWithoutState(t *testing.T) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok, "auth context should be set after callback")
 	require.Equal(t, userInfo.Organizations[0].ID, authCtx.ActiveOrganizationID)
+
+	storedSession, err := instance.sessionManager.GetSession(ctx, result.SessionToken)
+	require.NoError(t, err)
+	require.Equal(t, "support@example.com", storedSession.ImpersonatorEmail)
+
+	info, err := instance.service.Info(ctx, &gen.InfoPayload{})
+	require.NoError(t, err)
+	require.NotNil(t, info.ImpersonatorEmail)
+	require.Equal(t, "support@example.com", *info.ImpersonatorEmail)
 }
 
 func TestIdentityResolverCapturesWorkOSImpersonatorEmail(t *testing.T) {

--- a/server/internal/auth/enterdemo_test.go
+++ b/server/internal/auth/enterdemo_test.go
@@ -36,6 +36,7 @@ func TestService_EnterDemo(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -76,6 +77,7 @@ func TestService_EnterDemo(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -351,6 +351,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		UserID:               userID,
 		ActiveOrganizationID: "",
 		WorkOSSessionID:      idpUser.WorkOSSessionID,
+		ImpersonatorEmail:    idpUser.ImpersonatorEmail(),
 	}
 
 	if len(userInfo.Organizations) == 0 {
@@ -783,6 +784,7 @@ func (s *Service) Logout(ctx context.Context, payload *gen.LogoutPayload) (res *
 		ActiveOrganizationID: authCtx.ActiveOrganizationID,
 		UserID:               authCtx.UserID,
 		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "",
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error clearing session").LogError(ctx, s.logger)
 	}
@@ -805,6 +807,11 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").LogError(ctx, s.logger)
+	}
+
+	session, err := s.sessions.GetSession(ctx, *authCtx.SessionID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting auth session").LogError(ctx, s.logger)
 	}
 
 	// Sessions in the shared demo org: append the demo org alongside real
@@ -923,6 +930,7 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 		UserDisplayName:       userInfo.DisplayName,
 		UserPhotoURL:          userInfo.PhotoURL,
 		IsAdmin:               userInfo.Admin,
+		ImpersonatorEmail:     conv.PtrEmpty(session.ImpersonatorEmail),
 		Organizations:         organizations,
 	}, nil
 }

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -32,6 +32,7 @@ func TestInfoTransport_TrialNull(t *testing.T) {
 		UserDisplayName:       nil,
 		UserPhotoURL:          nil,
 		IsAdmin:               false,
+		ImpersonatorEmail:     nil,
 		ActiveOrganizationID:  "organization-id",
 		GramAccountType:       "test",
 		HasActiveSubscription: false,
@@ -52,6 +53,7 @@ func TestInfoTransport_TrialNull(t *testing.T) {
 
 	result := authclient.NewInfoResultOK(&body, "session-token", "session-cookie")
 	require.Nil(t, result.Trial)
+	require.Nil(t, result.ImpersonatorEmail)
 }
 
 func TestService_Info(t *testing.T) {
@@ -70,6 +72,7 @@ func TestService_Info(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -209,6 +212,7 @@ func TestService_Info(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -282,6 +286,7 @@ func TestService_Info(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID, // First org is active
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -345,6 +350,7 @@ func TestService_Info(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "customer-org-for-info",
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -404,6 +410,7 @@ func TestService_Info(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "target-org-info",
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -462,6 +469,7 @@ func TestService_Info(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "org-b-info",
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -556,6 +564,7 @@ func TestService_Info(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -607,6 +616,7 @@ func TestService_Info_OrganizationlessSessionContinuesLogin(t *testing.T) {
 		UserID:               userInfo.UserID,
 		ActiveOrganizationID: "",
 		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -643,6 +653,7 @@ func TestService_Info_ProjectFiltering(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -782,6 +793,7 @@ func TestService_Info_AdminVisitingCustomerOrgDoesNotUpsertRelationship(t *testi
 		UserID:               userInfo.UserID,
 		ActiveOrganizationID: customerOrgID,
 		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "",
 	}
 	err = instance.sessionManager.StoreSession(ctx, session)
 	require.NoError(t, err)

--- a/server/internal/auth/logout_test.go
+++ b/server/internal/auth/logout_test.go
@@ -26,6 +26,7 @@ func TestService_Logout(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)

--- a/server/internal/auth/register_test.go
+++ b/server/internal/auth/register_test.go
@@ -36,6 +36,7 @@ func TestService_Register(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "", // No active organization
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -80,6 +81,7 @@ func TestService_Register(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID, // Has active organization
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -125,6 +127,7 @@ func TestService_Register(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "", // No active organization
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -170,6 +173,7 @@ func TestService_Register(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "", // No active organization
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -231,6 +235,7 @@ func TestService_Register(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "", // No active organization
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -315,6 +320,7 @@ func TestService_Register(t *testing.T) {
 					UserID:               userInfo.UserID,
 					ActiveOrganizationID: "",
 					WorkOSSessionID:      "",
+					ImpersonatorEmail:    "",
 				}
 				err := instance.sessionManager.StoreSession(ctx, session)
 				require.NoError(t, err)
@@ -389,7 +395,7 @@ func TestService_Register(t *testing.T) {
 		require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 	})
 
-	t.Run("register preserves WorkOSSessionID", func(t *testing.T) {
+	t.Run("register preserves WorkOS session metadata", func(t *testing.T) {
 		t.Parallel()
 
 		userInfo := defaultMockUserInfo()
@@ -401,6 +407,7 @@ func TestService_Register(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "",
 			WorkOSSessionID:      "workos-sid-register-456",
+			ImpersonatorEmail:    "support@example.com",
 		}
 		require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -421,6 +428,7 @@ func TestService_Register(t *testing.T) {
 		stored, err := instance.sessionManager.GetSession(ctx, session.SessionID)
 		require.NoError(t, err)
 		require.Equal(t, "workos-sid-register-456", stored.WorkOSSessionID, "WorkOSSessionID must survive Register")
+		require.Equal(t, "support@example.com", stored.ImpersonatorEmail, "ImpersonatorEmail must survive Register")
 		require.NotEmpty(t, stored.ActiveOrganizationID, "should have an active org after Register")
 	})
 
@@ -435,6 +443,7 @@ func TestService_Register(t *testing.T) {
 			SessionID:            "slug-no-collision",
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "",
+			ImpersonatorEmail:    "",
 		}
 		require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -477,6 +486,7 @@ func TestService_Register(t *testing.T) {
 			SessionID:            "slug-collision",
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "",
+			ImpersonatorEmail:    "",
 		}
 		require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -519,6 +529,7 @@ func TestRegister_CreatesOrganizationForNameWithNoDerivableSlug(t *testing.T) {
 		SessionID:            "slug-non-latin",
 		UserID:               userInfo.UserID,
 		ActiveOrganizationID: "",
+		ImpersonatorEmail:    "",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -558,6 +569,7 @@ func TestRegisterHTTP_OrganizationlessSessionProvisionsOrg(t *testing.T) {
 		UserID:               userInfo.UserID,
 		ActiveOrganizationID: "",
 		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 

--- a/server/internal/auth/sessions/types.go
+++ b/server/internal/auth/sessions/types.go
@@ -18,6 +18,7 @@ type Session struct {
 	ActiveOrganizationID string
 	UserID               string
 	WorkOSSessionID      string
+	ImpersonatorEmail    string
 }
 
 func SessionCacheKey(sessionID string) string {

--- a/server/internal/auth/switchscopes_test.go
+++ b/server/internal/auth/switchscopes_test.go
@@ -34,6 +34,7 @@ func TestService_SwitchScopes(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -89,6 +90,7 @@ func TestService_SwitchScopes(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err := instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -164,6 +166,7 @@ func TestService_SwitchScopes(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
+			ImpersonatorEmail:    "",
 		}
 		err = instance.sessionManager.StoreSession(ctx, session)
 		require.NoError(t, err)
@@ -203,7 +206,7 @@ func TestService_SwitchScopes(t *testing.T) {
 		require.Equal(t, userInfo.Organizations[0].ID, authCtx.ActiveOrganizationID, "incorrect active organization id after switch")
 	})
 
-	t.Run("switch preserves WorkOSSessionID", func(t *testing.T) {
+	t.Run("switch preserves WorkOS session metadata", func(t *testing.T) {
 		t.Parallel()
 
 		userInfo := speakeasyMockUserInfo()
@@ -219,6 +222,7 @@ func TestService_SwitchScopes(t *testing.T) {
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "workos-sid-abc123",
+			ImpersonatorEmail:    "support@example.com",
 		}
 		require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
@@ -238,10 +242,10 @@ func TestService_SwitchScopes(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		// Verify the WorkOSSessionID survived the switch
 		stored, err := instance.sessionManager.GetSession(ctx, session.SessionID)
 		require.NoError(t, err)
 		require.Equal(t, "workos-sid-abc123", stored.WorkOSSessionID, "WorkOSSessionID must survive SwitchScopes")
+		require.Equal(t, "support@example.com", stored.ImpersonatorEmail, "ImpersonatorEmail must survive SwitchScopes")
 		require.Equal(t, newOrgID, stored.ActiveOrganizationID)
 	})
 }

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -1532,6 +1532,7 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		UserID:               gramUserID,
 		ActiveOrganizationID: invite.OrganizationID,
 		WorkOSSessionID:      idpUser.WorkOSSessionID,
+		ImpersonatorEmail:    "",
 	}
 	if err := s.sessions.StoreSession(ctx, session); err != nil {
 		s.logger.ErrorContext(ctx, "invite callback: failed to store session", attr.SlogError(err))

--- a/server/internal/testenv/auth.go
+++ b/server/internal/testenv/auth.go
@@ -121,6 +121,7 @@ func InitAuthContext(t *testing.T, ctx context.Context, conn *pgxpool.Pool, sess
 		UserID:               userID,
 		ActiveOrganizationID: mockidp.MockOrgID,
 		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "",
 	}
 	err = sessionManager.StoreSession(ctx, session)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- retain WorkOS impersonation metadata in Gram sessions and expose it through `auth.info`
- show a persistent dashboard warning with the impersonated user, organization, and exit action
- preserve impersonation metadata across registration and organization switching

## Verification

- `mise run test:server ./internal/auth -run 'TestService_(CallbackAllowsWorkOSImpersonationWithoutState|Register/register_preserves_WorkOS_session_metadata|SwitchScopes/switch_preserves_WorkOS_session_metadata)$' -count=1`
- `mise run lint:server`
- `aube run -F dashboard type-check`
- `aube run -F dashboard lint`
- browser smoke test with an impersonated `auth.info` response

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indicates active WorkOS impersonation across sessions and the dashboard. Previously, the banner showed only for admin override or the demo org; now it also shows during WorkOS impersonation and displays “WorkOS impersonation active — signed in as <user email> in <org>” with an exit action.

- Server: captures the WorkOS operator’s email during callback, stores it in the session, and exposes it via `auth.info` as optional `impersonator_email`; logout clears it. OpenAPI and generated types updated.
- Client (dashboard): shows the banner for WorkOS impersonation, demo, or admin override by reading `session.impersonatorEmail`. Adds role=alert and truncation for long labels; keeps “Exit demo” vs “Stop impersonating” actions.
- Session lifecycle: preserves WorkOS session metadata (session ID and impersonator email) across registration and organization switching.
- Compatibility: response-only addition; no required migrations. Clients using `auth.info` may regenerate from the updated schema if they rely on generated types.

<sup>Written for commit fd552694ea86f061812c02b481e76771ad1ee38e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

