### PR TITLE
feat: send PAYG activation confirmation

### DIFF
--- a/.changeset/confirm-payg-activation.md
+++ b/.changeset/confirm-payg-activation.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Send a confirmation email when an organization activates pay as you go. It goes to the billing email, or to every organization admin when none is set, and states the metered rate, which inference is billed at provider cost, and which is funded by Speakeasy.

--- a/server/internal/background/access_paused_email.go
+++ b/server/internal/background/access_paused_email.go
@@ -2,34 +2,16 @@ package background
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
-	"go.temporal.io/api/enums/v1"
-	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 )
 
 const accessPausedEmailWorkflowIDPrefix = "v1:access-paused-email"
 
 func (s *TemporalBillingEmailScheduler) ScheduleAccessPaused(ctx context.Context, input billingnotifications.SendAccessPausedInput) error {
-	if s == nil || s.TemporalEnv == nil {
-		return fmt.Errorf("temporal environment is not configured")
-	}
-	_, err := s.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                                       fmt.Sprintf("%s:%s", accessPausedEmailWorkflowIDPrefix, input.EventID),
-		TaskQueue:                                string(s.TemporalEnv.Queue()),
-		WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-		WorkflowExecutionErrorWhenAlreadyStarted: true,
-		WorkflowRunTimeout:                       billingEmailWorkflowRunTimeout,
-	}, AccessPausedEmailWorkflow, input)
-	if err != nil {
-		var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
-		if errors.As(err, &alreadyStarted) {
-			return nil
-		}
+	if err := s.enqueue(ctx, accessPausedEmailWorkflowIDPrefix, input.EventID, AccessPausedEmailWorkflow, input); err != nil {
 		return fmt.Errorf("enqueue access paused email workflow: %w", err)
 	}
 	return nil

--- a/server/internal/background/access_paused_email_test.go
+++ b/server/internal/background/access_paused_email_test.go
@@ -34,5 +34,5 @@ func TestAccessPausedEmailWorkflowStopsAfterBoundedRetries(t *testing.T) {
 	})
 
 	require.ErrorContains(t, env.GetWorkflowError(), "send access paused email")
-	require.Equal(t, accessPausedEmailRetryMaximumAttempts, attempts.Load())
+	require.Equal(t, billingEmailRetryMaximumAttempts, attempts.Load())
 }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -469,6 +469,16 @@ func (a *Activities) SendAccessPausedEmail(ctx context.Context, input billingnot
 	return nil
 }
 
+func (a *Activities) SendPaygActivatedEmail(ctx context.Context, input billingnotifications.SendPaygActivatedInput) error {
+	if a.billingNotifications == nil {
+		return fmt.Errorf("billing notification service is not configured")
+	}
+	if err := a.billingNotifications.SendPaygActivated(ctx, input); err != nil {
+		return fmt.Errorf("send PAYG activated notification: %w", err)
+	}
+	return nil
+}
+
 func (a *Activities) ProcessWorkOSOrganizationEvents(ctx context.Context, params activities.ProcessWorkOSOrganizationEventsParams) (*activities.ProcessWorkOSOrganizationEventsResult, error) {
 	return a.processWorkOSOrganizationEvents.Do(ctx, params)
 }

--- a/server/internal/background/billing_email.go
+++ b/server/internal/background/billing_email.go
@@ -1,0 +1,32 @@
+package background
+
+import (
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
+	tenvironment "github.com/speakeasy-api/gram/server/internal/temporal"
+	"go.temporal.io/sdk/temporal"
+)
+
+const (
+	billingEmailWorkflowRunTimeout            = 7 * 24 * time.Hour
+	billingEmailRetryInitialInterval          = 5 * time.Second
+	billingEmailRetryMaximumInterval          = time.Minute
+	billingEmailRetryBackoffCoefficient       = 2
+	billingEmailRetryMaximumAttempts    int32 = 12
+)
+
+func billingEmailRetryPolicy() *temporal.RetryPolicy {
+	return &temporal.RetryPolicy{
+		InitialInterval:    billingEmailRetryInitialInterval,
+		MaximumInterval:    billingEmailRetryMaximumInterval,
+		BackoffCoefficient: billingEmailRetryBackoffCoefficient,
+		MaximumAttempts:    billingEmailRetryMaximumAttempts,
+	}
+}
+
+type TemporalBillingEmailScheduler struct {
+	TemporalEnv *tenvironment.Environment
+}
+
+var _ billingnotifications.BillingEmailScheduler = (*TemporalBillingEmailScheduler)(nil)

--- a/server/internal/background/billing_email.go
+++ b/server/internal/background/billing_email.go
@@ -1,10 +1,16 @@
 package background
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	tenvironment "github.com/speakeasy-api/gram/server/internal/temporal"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 )
 
@@ -30,3 +36,26 @@ type TemporalBillingEmailScheduler struct {
 }
 
 var _ billingnotifications.BillingEmailScheduler = (*TemporalBillingEmailScheduler)(nil)
+
+// enqueue starts one billing email workflow per durable event. The workflow id
+// carries the event id, so a redelivered event never sends a second email.
+func (s *TemporalBillingEmailScheduler) enqueue(ctx context.Context, workflowIDPrefix, eventID string, workflowFunc any, input any) error {
+	if s == nil || s.TemporalEnv == nil {
+		return fmt.Errorf("temporal environment is not configured")
+	}
+	_, err := s.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                                       fmt.Sprintf("%s:%s", workflowIDPrefix, eventID),
+		TaskQueue:                                string(s.TemporalEnv.Queue()),
+		WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+		WorkflowExecutionErrorWhenAlreadyStarted: true,
+		WorkflowRunTimeout:                       billingEmailWorkflowRunTimeout,
+	}, workflowFunc, input)
+	if err != nil {
+		var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+		if errors.As(err, &alreadyStarted) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/server/internal/background/payg_activated_email.go
+++ b/server/internal/background/payg_activated_email.go
@@ -12,38 +12,38 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-const accessPausedEmailWorkflowIDPrefix = "v1:access-paused-email"
+const paygActivatedEmailWorkflowIDPrefix = "v1:payg-activated-email"
 
-func (s *TemporalBillingEmailScheduler) ScheduleAccessPaused(ctx context.Context, input billingnotifications.SendAccessPausedInput) error {
+func (s *TemporalBillingEmailScheduler) SchedulePaygActivated(ctx context.Context, input billingnotifications.SendPaygActivatedInput) error {
 	if s == nil || s.TemporalEnv == nil {
 		return fmt.Errorf("temporal environment is not configured")
 	}
 	_, err := s.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                                       fmt.Sprintf("%s:%s", accessPausedEmailWorkflowIDPrefix, input.EventID),
+		ID:                                       fmt.Sprintf("%s:%s", paygActivatedEmailWorkflowIDPrefix, input.EventID),
 		TaskQueue:                                string(s.TemporalEnv.Queue()),
 		WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
 		WorkflowExecutionErrorWhenAlreadyStarted: true,
 		WorkflowRunTimeout:                       billingEmailWorkflowRunTimeout,
-	}, AccessPausedEmailWorkflow, input)
+	}, PaygActivatedEmailWorkflow, input)
 	if err != nil {
 		var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
 		if errors.As(err, &alreadyStarted) {
 			return nil
 		}
-		return fmt.Errorf("enqueue access paused email workflow: %w", err)
+		return fmt.Errorf("enqueue PAYG activated email workflow: %w", err)
 	}
 	return nil
 }
 
-func AccessPausedEmailWorkflow(ctx workflow.Context, input billingnotifications.SendAccessPausedInput) error {
+func PaygActivatedEmailWorkflow(ctx workflow.Context, input billingnotifications.SendPaygActivatedInput) error {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: trialLifecycleEmailActivityTimeout,
 		RetryPolicy:         billingEmailRetryPolicy(),
 	})
 	var a *Activities
-	if err := workflow.ExecuteActivity(ctx, a.SendAccessPausedEmail, input).Get(ctx, nil); err != nil {
-		workflow.GetLogger(ctx).Error("access paused email delivery failed", "organization_id", input.OrganizationID, "event_id", input.EventID, "error", err)
-		return fmt.Errorf("send access paused email: %w", err)
+	if err := workflow.ExecuteActivity(ctx, a.SendPaygActivatedEmail, input).Get(ctx, nil); err != nil {
+		workflow.GetLogger(ctx).Error("PAYG activated email delivery failed", "organization_id", input.OrganizationID, "event_id", input.EventID, "error", err)
+		return fmt.Errorf("send PAYG activated email: %w", err)
 	}
 	return nil
 }

--- a/server/internal/background/payg_activated_email.go
+++ b/server/internal/background/payg_activated_email.go
@@ -2,34 +2,16 @@ package background
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
-	"go.temporal.io/api/enums/v1"
-	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 )
 
 const paygActivatedEmailWorkflowIDPrefix = "v1:payg-activated-email"
 
 func (s *TemporalBillingEmailScheduler) SchedulePaygActivated(ctx context.Context, input billingnotifications.SendPaygActivatedInput) error {
-	if s == nil || s.TemporalEnv == nil {
-		return fmt.Errorf("temporal environment is not configured")
-	}
-	_, err := s.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                                       fmt.Sprintf("%s:%s", paygActivatedEmailWorkflowIDPrefix, input.EventID),
-		TaskQueue:                                string(s.TemporalEnv.Queue()),
-		WorkflowIDReusePolicy:                    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-		WorkflowExecutionErrorWhenAlreadyStarted: true,
-		WorkflowRunTimeout:                       billingEmailWorkflowRunTimeout,
-	}, PaygActivatedEmailWorkflow, input)
-	if err != nil {
-		var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
-		if errors.As(err, &alreadyStarted) {
-			return nil
-		}
+	if err := s.enqueue(ctx, paygActivatedEmailWorkflowIDPrefix, input.EventID, PaygActivatedEmailWorkflow, input); err != nil {
 		return fmt.Errorf("enqueue PAYG activated email workflow: %w", err)
 	}
 	return nil

--- a/server/internal/background/payg_activated_email_test.go
+++ b/server/internal/background/payg_activated_email_test.go
@@ -1,0 +1,37 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
+)
+
+func TestPaygActivatedEmailWorkflowStopsAfterBoundedRetries(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	var attempts atomic.Int32
+	env.RegisterActivityWithOptions(
+		func(context.Context, billingnotifications.SendPaygActivatedInput) error {
+			attempts.Add(1)
+			return errors.New("email service unavailable")
+		},
+		activity.RegisterOptions{Name: "SendPaygActivatedEmail"},
+	)
+
+	env.ExecuteWorkflow(PaygActivatedEmailWorkflow, billingnotifications.SendPaygActivatedInput{
+		EventID:        "<EVENT_ID>",
+		OrganizationID: "<ORGANIZATION_ID>",
+	})
+
+	require.ErrorContains(t, env.GetWorkflowError(), "send PAYG activated email")
+	require.Equal(t, billingEmailRetryMaximumAttempts, attempts.Load())
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -485,6 +485,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.ResolveTrialEndingReminder)
 	temporalWorker.RegisterActivity(activities.SendTrialEndingSoonEmail)
 	temporalWorker.RegisterActivity(activities.SendAccessPausedEmail)
+	temporalWorker.RegisterActivity(activities.SendPaygActivatedEmail)
 	// Skill efficacy activities — the database steps run on the main queue and
 	// only the judged publication goes to the dedicated worker.
 	temporalWorker.RegisterActivity(activities.skillEfficacyScorer.EnqueueSkillEfficacyPage)
@@ -602,6 +603,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(DemoteExpiredTrialsWorkflow)
 	temporalWorker.RegisterWorkflow(TrialLifecycleEmailWorkflow)
 	temporalWorker.RegisterWorkflow(AccessPausedEmailWorkflow)
+	temporalWorker.RegisterWorkflow(PaygActivatedEmailWorkflow)
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
 			logger.ErrorContext(context.Background(), "failed to add platform usage metrics schedule", attr.SlogError(err))

--- a/server/internal/billingnotifications/handler.go
+++ b/server/internal/billingnotifications/handler.go
@@ -13,16 +13,17 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 )
 
-type AccessPausedScheduler interface {
+type BillingEmailScheduler interface {
 	ScheduleAccessPaused(context.Context, SendAccessPausedInput) error
+	SchedulePaygActivated(context.Context, SendPaygActivatedInput) error
 }
 
 type EventHandler struct {
 	logger    *slog.Logger
-	scheduler AccessPausedScheduler
+	scheduler BillingEmailScheduler
 }
 
-func NewEventHandler(logger *slog.Logger, scheduler AccessPausedScheduler) *EventHandler {
+func NewEventHandler(logger *slog.Logger, scheduler BillingEmailScheduler) *EventHandler {
 	return &EventHandler{
 		logger:    logger.With(attr.SlogComponent("billing-notification-events")),
 		scheduler: scheduler,
@@ -45,13 +46,12 @@ func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gc
 		return nil
 	}
 
-	var kind AccessPausedKind
-	switch event.GetEventType() {
-	case string(events.OrganizationBillingV1.EventType()):
-		kind = AccessPausedSubscriptionLoss
-	case string(events.OrganizationEnterpriseTrialV1.EventType()):
-		kind = AccessPausedTrialDemotion
-	default:
+	// Every webhook event on the topic reaches this handler, so anything that is
+	// not an audited billing transition must leave before the payload is read.
+	billingEvent := string(events.OrganizationBillingV1.EventType())
+	trialEvent := string(events.OrganizationEnterpriseTrialV1.EventType())
+	eventType := event.GetEventType()
+	if eventType != billingEvent && eventType != trialEvent {
 		return nil
 	}
 
@@ -60,22 +60,52 @@ func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gc
 		h.logger.ErrorContext(ctx, "dropping unreadable billing notification event", attr.SlogOutboxPublicID(eventID), attr.SlogError(err))
 		return nil
 	}
-	expectedAction := audit.ActionOrganizationPaygDeactivated
-	if kind == AccessPausedTrialDemotion {
-		expectedAction = audit.ActionOrganizationEnterpriseTrialDemoted
-	}
-	if audit.Action(payload.Action) != expectedAction || payload.OrganizationID != organizationID || payload.SubjectID != organizationID || payload.SubjectType != "organization" {
-		if audit.Action(payload.Action) == expectedAction {
-			h.logger.ErrorContext(ctx, "dropping mismatched billing notification event",
-				attr.SlogOrganizationID(organizationID),
-				attr.SlogOutboxPublicID(eventID),
-			)
+
+	// Activation and subscription loss share the billing event type, so the
+	// audited action is what separates them.
+	action := audit.Action(payload.Action)
+	var schedule func(context.Context) error
+	switch {
+	case eventType == billingEvent && action == audit.ActionOrganizationPaygActivated:
+		schedule = func(ctx context.Context) error {
+			return h.schedulePaygActivated(ctx, eventID, organizationID)
 		}
+	case eventType == billingEvent && action == audit.ActionOrganizationPaygDeactivated:
+		schedule = func(ctx context.Context) error {
+			return h.scheduleAccessPaused(ctx, eventID, organizationID, AccessPausedSubscriptionLoss)
+		}
+	case eventType == trialEvent && action == audit.ActionOrganizationEnterpriseTrialDemoted:
+		schedule = func(ctx context.Context) error {
+			return h.scheduleAccessPaused(ctx, eventID, organizationID, AccessPausedTrialDemotion)
+		}
+	default:
+		return nil
+	}
+
+	if payload.OrganizationID != organizationID || payload.SubjectID != organizationID || payload.SubjectType != "organization" {
+		h.logger.ErrorContext(ctx, "dropping mismatched billing notification event",
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogOutboxPublicID(eventID),
+		)
 		return nil
 	}
 	if h.scheduler == nil {
-		return fmt.Errorf("access paused scheduler is unavailable")
+		return fmt.Errorf("billing email scheduler is unavailable")
 	}
+	return schedule(ctx)
+}
+
+func (h *EventHandler) schedulePaygActivated(ctx context.Context, eventID, organizationID string) error {
+	if err := h.scheduler.SchedulePaygActivated(ctx, SendPaygActivatedInput{
+		EventID:        eventID,
+		OrganizationID: organizationID,
+	}); err != nil {
+		return fmt.Errorf("schedule PAYG activation email: %w", err)
+	}
+	return nil
+}
+
+func (h *EventHandler) scheduleAccessPaused(ctx context.Context, eventID, organizationID string, kind AccessPausedKind) error {
 	if err := h.scheduler.ScheduleAccessPaused(ctx, SendAccessPausedInput{
 		EventID:        eventID,
 		OrganizationID: organizationID,

--- a/server/internal/billingnotifications/handler_test.go
+++ b/server/internal/billingnotifications/handler_test.go
@@ -14,12 +14,18 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-type captureAccessPausedScheduler struct {
-	inputs []SendAccessPausedInput
+type captureBillingEmailScheduler struct {
+	inputs    []SendAccessPausedInput
+	activated []SendPaygActivatedInput
 }
 
-func (s *captureAccessPausedScheduler) ScheduleAccessPaused(_ context.Context, input SendAccessPausedInput) error {
+func (s *captureBillingEmailScheduler) ScheduleAccessPaused(_ context.Context, input SendAccessPausedInput) error {
 	s.inputs = append(s.inputs, input)
+	return nil
+}
+
+func (s *captureBillingEmailScheduler) SchedulePaygActivated(_ context.Context, input SendPaygActivatedInput) error {
+	s.activated = append(s.activated, input)
 	return nil
 }
 
@@ -44,9 +50,9 @@ func billingNotificationEvent(t *testing.T, eventType string, action audit.Actio
 	}.Build()
 }
 
-func TestEventHandlerSchedulesOnlyAccessPausedTransitions(t *testing.T) {
+func TestEventHandlerRoutesBillingTransitionsByAuditedAction(t *testing.T) {
 	t.Parallel()
-	scheduler := &captureAccessPausedScheduler{}
+	scheduler := &captureBillingEmailScheduler{}
 	handler := NewEventHandler(testenv.NewLogger(t), scheduler)
 	metadata := gcp.MessageMetadata{ID: "<MESSAGE_ID>", Attributes: nil, DeliveryAttempt: nil}
 
@@ -58,11 +64,18 @@ func TestEventHandlerSchedulesOnlyAccessPausedTransitions(t *testing.T) {
 
 	require.NoError(t, handler.Handle(t.Context(), billingNotificationEvent(t, string(events.OrganizationBillingV1.EventType()), audit.ActionOrganizationPaygActivated), metadata))
 	require.Len(t, scheduler.inputs, 2)
+	require.Len(t, scheduler.activated, 1)
+	require.Equal(t, "<EVENT_ID>", scheduler.activated[0].EventID)
+	require.Equal(t, "<ORGANIZATION_ID>", scheduler.activated[0].OrganizationID)
+
+	require.NoError(t, handler.Handle(t.Context(), billingNotificationEvent(t, string(events.OrganizationBillingV1.EventType()), audit.ActionOrganizationWebhooksEnabled), metadata))
+	require.Len(t, scheduler.inputs, 2)
+	require.Len(t, scheduler.activated, 1)
 }
 
 func TestEventHandlerDropsMismatchedEnvelope(t *testing.T) {
 	t.Parallel()
-	scheduler := &captureAccessPausedScheduler{}
+	scheduler := &captureBillingEmailScheduler{}
 	handler := NewEventHandler(testenv.NewLogger(t), scheduler)
 	event := billingNotificationEvent(t, string(events.OrganizationBillingV1.EventType()), audit.ActionOrganizationPaygDeactivated)
 	payload, err := json.Marshal(map[string]string{
@@ -76,4 +89,5 @@ func TestEventHandlerDropsMismatchedEnvelope(t *testing.T) {
 
 	require.NoError(t, handler.Handle(t.Context(), event, gcp.MessageMetadata{ID: "<MESSAGE_ID>", Attributes: nil, DeliveryAttempt: nil}))
 	require.Empty(t, scheduler.inputs)
+	require.Empty(t, scheduler.activated)
 }

--- a/server/internal/billingnotifications/service.go
+++ b/server/internal/billingnotifications/service.go
@@ -113,18 +113,8 @@ func (s *Service) SendTrialEndingSoon(ctx context.Context, input SendTrialEnding
 		TrialEndDate:     state.TrialEndsAt.UTC().Format("January 2, 2006"),
 		ActionURL:        s.siteURL.JoinPath(organization.Slug, "billing").String(),
 	}
-	sendErrors := make([]error, 0, len(recipients)+1)
-	if resolutionErr != nil {
-		sendErrors = append(sendErrors, resolutionErr)
-	}
-	for _, recipient := range recipients {
-		key := RecipientIdempotencyKey(recipient, "trial-ending-soon", input.OrganizationID, state.TrialCreatedAt.UTC().Format(time.RFC3339Nano), state.TrialEndsAt.UTC().Format(time.RFC3339Nano))
-		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
-			s.logger.ErrorContext(ctx, "send trial ending soon email", attr.SlogOrganizationID(input.OrganizationID), attr.SlogError(err))
-			sendErrors = append(sendErrors, err)
-		}
-	}
-	return SendTrialEndingSoonResult{}, errors.Join(sendErrors...)
+	return SendTrialEndingSoonResult{}, s.deliver(ctx, input.OrganizationID, "", recipients, resolutionErr, template,
+		"trial-ending-soon", input.OrganizationID, state.TrialCreatedAt.UTC().Format(time.RFC3339Nano), state.TrialEndsAt.UTC().Format(time.RFC3339Nano))
 }
 
 type AccessPausedKind string
@@ -197,18 +187,7 @@ func (s *Service) SendAccessPaused(ctx context.Context, input SendAccessPausedIn
 		OrganizationName: organization.Name,
 		ActionURL:        s.siteURL.JoinPath(organization.Slug).String(),
 	}
-	sendErrors := make([]error, 0, len(recipients)+1)
-	if resolutionErr != nil {
-		sendErrors = append(sendErrors, resolutionErr)
-	}
-	for _, recipient := range recipients {
-		key := RecipientIdempotencyKey(recipient, "access-paused", input.EventID)
-		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
-			s.logger.ErrorContext(ctx, "send access paused email", attr.SlogOrganizationID(input.OrganizationID), attr.SlogOutboxPublicID(input.EventID), attr.SlogError(err))
-			sendErrors = append(sendErrors, err)
-		}
-	}
-	return errors.Join(sendErrors...)
+	return s.deliver(ctx, input.OrganizationID, input.EventID, recipients, resolutionErr, template, "access-paused", input.EventID)
 }
 
 type SendPaygActivatedInput struct {
@@ -250,14 +229,29 @@ func (s *Service) SendPaygActivated(ctx context.Context, input SendPaygActivated
 		TumPricePerMillionUsd: billing.TUMPricePerMillionUSD,
 		ActionURL:             s.siteURL.JoinPath(organization.Slug, "billing").String(),
 	}
+	return s.deliver(ctx, input.OrganizationID, input.EventID, recipients, resolutionErr, template, "payg-activated", input.EventID)
+}
+
+// deliver sends one template to every resolved recipient. A recipient
+// resolution failure never skips the addresses that did resolve: the send
+// happens first and the failure joins the per-recipient errors.
+func (s *Service) deliver(ctx context.Context, organizationID, eventID string, recipients []string, resolutionErr error, template email.Template, keyParts ...string) error {
 	sendErrors := make([]error, 0, len(recipients)+1)
 	if resolutionErr != nil {
 		sendErrors = append(sendErrors, resolutionErr)
 	}
 	for _, recipient := range recipients {
-		key := RecipientIdempotencyKey(recipient, "payg-activated", input.EventID)
+		key := RecipientIdempotencyKey(recipient, keyParts...)
 		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
-			s.logger.ErrorContext(ctx, "send PAYG activation email", attr.SlogOrganizationID(input.OrganizationID), attr.SlogOutboxPublicID(input.EventID), attr.SlogError(err))
+			logAttrs := []any{
+				attr.SlogOrganizationID(organizationID),
+				attr.SlogEvent(string(template.Key())),
+				attr.SlogError(err),
+			}
+			if eventID != "" {
+				logAttrs = append(logAttrs, attr.SlogOutboxPublicID(eventID))
+			}
+			s.logger.ErrorContext(ctx, "send billing notification email", logAttrs...)
 			sendErrors = append(sendErrors, err)
 		}
 	}

--- a/server/internal/billingnotifications/service.go
+++ b/server/internal/billingnotifications/service.go
@@ -13,6 +13,7 @@ import (
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/email"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -105,7 +106,7 @@ func (s *Service) SendTrialEndingSoon(ctx context.Context, input SendTrialEnding
 	if err != nil {
 		return SendTrialEndingSoonResult{}, err
 	}
-	recipients, resolutionErr := s.resolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
+	recipients, resolutionErr := s.resolveRecipients(ctx, s.db, input.OrganizationID, string(billing.TierPayg), configuredEmail)
 
 	template := email.TrialEndingSoon{
 		OrganizationName: organization.Name,
@@ -155,15 +156,15 @@ func (s *Service) SendAccessPaused(ctx context.Context, input SendAccessPausedIn
 	if err != nil {
 		return fmt.Errorf("get organization: %w", err)
 	}
-	if organization.GramAccountType != "free" || organization.Whitelisted {
+	if billing.Tier(organization.GramAccountType) != billing.TierBase || organization.Whitelisted {
 		return nil
 	}
 
-	metadata, err := usagerepo.New(s.db).GetBillingMetadata(ctx, input.OrganizationID)
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return fmt.Errorf("get billing metadata: %w", err)
+	metadata, metadataErr := usagerepo.New(s.db).GetBillingMetadata(ctx, input.OrganizationID)
+	if metadataErr != nil && !errors.Is(metadataErr, pgx.ErrNoRows) {
+		return fmt.Errorf("get billing metadata: %w", metadataErr)
 	}
-	if err == nil && metadata.StripeSubscriptionID.Valid {
+	if metadataErr == nil && metadata.StripeSubscriptionID.Valid {
 		return nil
 	}
 
@@ -187,11 +188,11 @@ func (s *Service) SendAccessPaused(ctx context.Context, input SendAccessPausedIn
 		}
 	}
 
-	configuredEmail, err := s.configuredEmail(ctx, input.OrganizationID)
-	if err != nil {
-		return err
+	var configuredEmail *string
+	if metadataErr == nil && metadata.AlertEmail.Valid {
+		configuredEmail = &metadata.AlertEmail.String
 	}
-	recipients, resolutionErr := s.resolveRecipients(ctx, s.db, input.OrganizationID, "payg", configuredEmail)
+	recipients, resolutionErr := s.resolveRecipients(ctx, s.db, input.OrganizationID, string(billing.TierPayg), configuredEmail)
 	template := email.AccessPaused{
 		OrganizationName: organization.Name,
 		ActionURL:        s.siteURL.JoinPath(organization.Slug).String(),
@@ -204,6 +205,59 @@ func (s *Service) SendAccessPaused(ctx context.Context, input SendAccessPausedIn
 		key := RecipientIdempotencyKey(recipient, "access-paused", input.EventID)
 		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
 			s.logger.ErrorContext(ctx, "send access paused email", attr.SlogOrganizationID(input.OrganizationID), attr.SlogOutboxPublicID(input.EventID), attr.SlogError(err))
+			sendErrors = append(sendErrors, err)
+		}
+	}
+	return errors.Join(sendErrors...)
+}
+
+type SendPaygActivatedInput struct {
+	EventID        string
+	OrganizationID string
+}
+
+func (s *Service) SendPaygActivated(ctx context.Context, input SendPaygActivatedInput) error {
+	organization, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, input.OrganizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get organization: %w", err)
+	}
+	if billing.Tier(organization.GramAccountType) != billing.TierPayg {
+		return nil
+	}
+
+	metadata, err := usagerepo.New(s.db).GetBillingMetadata(ctx, input.OrganizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get billing metadata: %w", err)
+	}
+	if !metadata.StripeSubscriptionID.Valid {
+		return nil
+	}
+
+	var configuredEmail *string
+	if metadata.AlertEmail.Valid {
+		configuredEmail = &metadata.AlertEmail.String
+	}
+	recipients, resolutionErr := s.resolveRecipients(ctx, s.db, input.OrganizationID, string(billing.TierPayg), configuredEmail)
+
+	template := email.PaygActivated{
+		OrganizationName:      organization.Name,
+		TumPricePerMillionUsd: billing.TUMPricePerMillionUSD,
+		ActionURL:             s.siteURL.JoinPath(organization.Slug, "billing").String(),
+	}
+	sendErrors := make([]error, 0, len(recipients)+1)
+	if resolutionErr != nil {
+		sendErrors = append(sendErrors, resolutionErr)
+	}
+	for _, recipient := range recipients {
+		key := RecipientIdempotencyKey(recipient, "payg-activated", input.EventID)
+		if err := s.sender.SendIdempotent(ctx, recipient, key, template); err != nil {
+			s.logger.ErrorContext(ctx, "send PAYG activation email", attr.SlogOrganizationID(input.OrganizationID), attr.SlogOutboxPublicID(input.EventID), attr.SlogError(err))
 			sendErrors = append(sendErrors, err)
 		}
 	}

--- a/server/internal/billingnotifications/service_test.go
+++ b/server/internal/billingnotifications/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/email"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -193,4 +194,109 @@ func TestSendAccessPausedDeliversResolvedRecipientsBeforeReturningResolutionErro
 	require.ErrorIs(t, err, resolutionErr)
 	require.Len(t, sender.sends, 1)
 	require.Equal(t, "resolved@example.test", sender.sends[0].recipient)
+}
+
+func seedPaygStripeSubscription(t *testing.T, service *Service, organizationID string) {
+	t.Helper()
+	queries := usagerepo.New(service.db)
+	customerID := pgtype.Text{String: "<STRIPE_CUSTOMER_ID>", Valid: true}
+	require.NoError(t, queries.CreateStripeBillingMetadataFixture(t.Context(), usagerepo.CreateStripeBillingMetadataFixtureParams{
+		OrganizationID:   organizationID,
+		StripeCustomerID: customerID,
+	}))
+	activatePaygStripeSubscription(t, service, organizationID)
+}
+
+func activatePaygStripeSubscription(t *testing.T, service *Service, organizationID string) {
+	t.Helper()
+	anchor := time.Now().UTC().Truncate(24 * time.Hour)
+	_, err := usagerepo.New(service.db).ActivatePaygBillingMetadata(t.Context(), usagerepo.ActivatePaygBillingMetadataParams{
+		StripeSubscriptionID:     pgtype.Text{String: "<STRIPE_SUBSCRIPTION_ID>", Valid: true},
+		StripeBillingCycleAnchor: pgtype.Timestamptz{Time: anchor, InfinityModifier: pgtype.Finite, Valid: true},
+		BillingCycleAnchorDay:    int32(anchor.Day()),
+		OrganizationID:           organizationID,
+		StripeCustomerID:         pgtype.Text{String: "<STRIPE_CUSTOMER_ID>", Valid: true},
+	})
+	require.NoError(t, err)
+}
+
+func TestSendPaygActivatedRequiresActivePaygSubscription(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "payg", true)
+	input := SendPaygActivatedInput{EventID: "event-placeholder", OrganizationID: organizationID}
+
+	require.NoError(t, service.SendPaygActivated(t.Context(), input))
+	require.Empty(t, sender.sends)
+
+	require.NoError(t, usagerepo.New(service.db).CreateStripeBillingMetadataFixture(t.Context(), usagerepo.CreateStripeBillingMetadataFixtureParams{
+		OrganizationID:   organizationID,
+		StripeCustomerID: pgtype.Text{String: "<STRIPE_CUSTOMER_ID>", Valid: true},
+	}))
+	_, err := usagerepo.New(service.db).UpsertBillingEmail(t.Context(), usagerepo.UpsertBillingEmailParams{
+		OrganizationID: organizationID,
+		AlertEmail:     pgtype.Text{String: "billing@example.test", Valid: true},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, service.SendPaygActivated(t.Context(), input))
+	require.Empty(t, sender.sends)
+
+	activatePaygStripeSubscription(t, service, organizationID)
+
+	require.NoError(t, service.SendPaygActivated(t.Context(), input))
+	require.Len(t, sender.sends, 1)
+	require.Equal(t, "billing@example.test", sender.sends[0].recipient)
+	template, ok := sender.sends[0].template.(email.PaygActivated)
+	require.True(t, ok)
+	require.Equal(t, "Example Organization", template.OrganizationName)
+	require.Equal(t, billing.TUMPricePerMillionUSD, template.TumPricePerMillionUsd)
+	require.Equal(t, "https://app.example.test/example-org/billing", template.ActionURL)
+
+	// Each activation carries its own durable event, so a later return to PAYG
+	// derives a distinct provider key and sends again.
+	require.NoError(t, service.SendPaygActivated(t.Context(), SendPaygActivatedInput{EventID: "later-event-placeholder", OrganizationID: organizationID}))
+	require.Len(t, sender.sends, 2)
+	require.NotEqual(t, sender.sends[0].key, sender.sends[1].key)
+}
+
+func TestSendPaygActivatedSkipsOrganizationsOffPayg(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "free", false)
+	seedPaygStripeSubscription(t, service, organizationID)
+
+	require.NoError(t, service.SendPaygActivated(t.Context(), SendPaygActivatedInput{EventID: "event-placeholder", OrganizationID: organizationID}))
+	require.Empty(t, sender.sends)
+}
+
+func TestSendPaygActivatedFallsBackToOrganizationAdministrators(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "payg", true)
+	seedPaygStripeSubscription(t, service, organizationID)
+	var requestedTier string
+	var requestedEmail *string
+	service.resolveRecipients = func(_ context.Context, _ accessrepo.DBTX, _ string, accountType string, configuredEmail *string) ([]string, error) {
+		requestedTier = accountType
+		requestedEmail = configuredEmail
+		return []string{"admin@example.test"}, nil
+	}
+
+	require.NoError(t, service.SendPaygActivated(t.Context(), SendPaygActivatedInput{EventID: "event-placeholder", OrganizationID: organizationID}))
+	require.Equal(t, string(billing.TierPayg), requestedTier)
+	require.Nil(t, requestedEmail)
+	require.Len(t, sender.sends, 1)
+	require.Equal(t, "admin@example.test", sender.sends[0].recipient)
+}
+
+func TestSendPaygActivatedDeliversResolvedRecipientsBeforeReturningResolutionError(t *testing.T) {
+	t.Parallel()
+	service, sender, organizationID := newNotificationTestService(t, "payg", true)
+	seedPaygStripeSubscription(t, service, organizationID)
+	resolutionErr := errors.New("resolve recipients")
+	service.resolveRecipients = func(context.Context, accessrepo.DBTX, string, string, *string) ([]string, error) {
+		return []string{"admin@example.test"}, resolutionErr
+	}
+
+	err := service.SendPaygActivated(t.Context(), SendPaygActivatedInput{EventID: "event-placeholder", OrganizationID: organizationID})
+	require.ErrorIs(t, err, resolutionErr)
+	require.Len(t, sender.sends, 1)
 }

--- a/server/internal/email/loops/manifest.json
+++ b/server/internal/email/loops/manifest.json
@@ -48,6 +48,17 @@
       "source": "openrouter_internal_credits_threshold.lmx",
       "variables": ["organization_name", "threshold_percent", "exhausted"]
     },
+    "payg_activated": {
+      "managed_name": "gram.transactional.v2.payg_activated",
+      "subject": "Pay as you go is active for {data.organization_name}",
+      "preview_text": "Review your rates and manage billing.",
+      "source": "payg_activated.lmx",
+      "variables": [
+        "organization_name",
+        "tum_price_per_million_usd",
+        "action_url"
+      ]
+    },
     "team_invite": {
       "managed_name": "gram.transactional.v2.team_invite",
       "subject": "Join {data.organization_name} on Gram",

--- a/server/internal/email/loops/payg_activated.lmx
+++ b/server/internal/email/loops/payg_activated.lmx
@@ -1,0 +1,27 @@
+<Style backgroundColor="#FAFAFA" backgroundXPadding="0" backgroundYPadding="32" bodyColor="#FFFFFF" bodyXPadding="0" bodyYPadding="0" bodyFontFamily="Inter" bodyFontCategory="ui-sans-serif" borderColor="" borderWidth="0" borderRadius="0" buttonBodyColor="#121212" buttonBodyXPadding="22" buttonBodyYPadding="14" buttonBorderColor="" buttonBorderWidth="0" buttonBorderRadius="0" buttonTextColor="#FFFFFF" buttonTextFormat="0" buttonTextFontSize="13" dividerColor="#BABABA" dividerBorderWidth="1" textBaseColor="#545454" textBaseFontSize="16" textBaseLineHeight="165" textBaseLetterSpacing="0" textLinkColor="#121212" heading1Color="#121212" heading1FontSize="44" heading1LineHeight="112" heading1LetterSpacing="-1.5" heading2Color="" heading2FontSize="24" heading2LineHeight="125" heading2LetterSpacing="0" heading3Color="" heading3FontSize="20" heading3LineHeight="125" heading3LetterSpacing="0" />
+<Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzwke702cu0j3bz2gats4u.png" width="600" />
+<Columns gap="12" widths="10,45,45" stackOnMobile="false" paddingTop="26" paddingRight="40" paddingBottom="24" paddingLeft="40">
+  <ColumnItem verticalAlignment="middle">
+    <Image src="https://images.vialoops.com/clydgspni01t0bsa10jmd46rt/cmsrzv81y00z60i1dmtf9twha.png" width="28" />
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="21" lineHeight="100">speakeasy</Paragraph>
+  </ColumnItem>
+  <ColumnItem verticalAlignment="middle">
+    <Paragraph fontSize="12" lineHeight="140" align="right"><Text textColor="#757575">AI CONTROL PLANE</Text></Paragraph>
+  </ColumnItem>
+</Columns>
+<Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">BILLING · PAY AS YOU GO ACTIVE</Strong></Paragraph>
+<H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Pay as you go is active.</H1>
+<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is on pay as you go with the full feature set. Tokens under management are metered and billed each cycle. Other inference is billed at provider cost, and security inference is funded by Speakeasy.</Paragraph>
+<Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
+  <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">METERED RATE</Strong></Paragraph>
+  <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">${data.tum_price_per_million_usd} per million tokens under management</Text></Paragraph>
+</Section>
+<Paragraph paddingTop="28" paddingRight="40" paddingBottom="28" paddingLeft="40">Cycle usage, the current invoice estimate, inference caps, and your payment method are all managed from the billing page.</Paragraph>
+<Button href="{data.action_url}" paddingRight="40" paddingBottom="48" paddingLeft="40">View billing →</Button>
+<Divider />
+<Section blockColor="#FAFAFA" paddingTop="24" paddingRight="40" paddingBottom="30" paddingLeft="40">
+  <Paragraph fontSize="12" lineHeight="160"><Strong textColor="#757575">SPEAKEASY · AI CONTROL PLANE</Strong></Paragraph>
+  <Paragraph fontSize="12" lineHeight="160" paddingTop="8">You’re receiving this operational email because this address receives billing notifications for {data.organization_name}.</Paragraph>
+</Section>

--- a/server/internal/email/template_payg_activated.go
+++ b/server/internal/email/template_payg_activated.go
@@ -1,0 +1,21 @@
+package email
+
+type PaygActivated struct {
+	OrganizationName      string
+	TumPricePerMillionUsd string
+	ActionURL             string
+}
+
+func (PaygActivated) Key() TemplateKey {
+	return TemplateKeyPaygActivated
+}
+
+func (PaygActivated) AddToAudience() bool { return false }
+
+func (t PaygActivated) Variables() map[string]string {
+	return map[string]string{
+		"organization_name":         t.OrganizationName,
+		"tum_price_per_million_usd": t.TumPricePerMillionUsd,
+		"action_url":                t.ActionURL,
+	}
+}

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -38,6 +38,7 @@ const (
 	TemplateKeyAccessRequest             TemplateKey = "access_request"
 	TemplateKeyTrialEndingSoon           TemplateKey = "trial_ending_soon"
 	TemplateKeyAccessPaused              TemplateKey = "access_paused"
+	TemplateKeyPaygActivated             TemplateKey = "payg_activated"
 )
 
 var (
@@ -124,4 +125,5 @@ var RegisteredTemplates = []Template{
 	AccessRequest{RequesterName: "", OrganizationName: "", ManageAccessLink: ""},
 	TrialEndingSoon{OrganizationName: "", TrialEndDate: "", ActionURL: ""},
 	AccessPaused{OrganizationName: "", ActionURL: ""},
+	PaygActivated{OrganizationName: "", TumPricePerMillionUsd: "", ActionURL: ""},
 }

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -34,7 +34,8 @@ func TestParseTemplateIDs_ValidatesCompleteRegistry(t *testing.T) {
 		"weekly_usage_summary":"id-8",
 		"access_request":"id-9",
 		"trial_ending_soon":"id-10",
-		"access_paused":"id-11"
+		"access_paused":"id-11",
+		"payg_activated":"id-12"
 	}`)
 	require.NoError(t, err)
 	require.NoError(t, ids.ValidateRegistered())


### PR DESCRIPTION
## Summary

- Send a confirmation email when an organization activates pay as you go: it names the metered rate, says Other inference is billed at provider cost, and says Security inference is funded by Speakeasy. No provider key identifiers appear in the copy.
- Route billing notification events on the audited action. Activation and subscription loss share the organization billing event type, so the previous event-type routing dropped every activation silently.
- Deliver through the existing rails: recipients are the customer-set billing email, falling back to every organization admin, and the Temporal workflow id is the durable activation event id, so redelivery of the same event cannot send twice.
- A later return to pay as you go after a lockout is a distinct durable event and sends again, per the decision recorded on the issue.
- The rate comes from the server billing authority rather than a literal in the template.

Closes [DNO-884](https://linear.app/speakeasy/issue/DNO-884/feat-send-payg-activation-confirmation)

The RFC's email matrix has no activation row; that gap is noted on the RFC document for a follow-up edit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends a confirmation email when an organization activates pay as you go so customers know activation succeeded and their rates. Previously, activations were dropped because routing used the shared billing event type; now routing uses the audited action and activations deliver reliably. Fulfills DNO-884.

- Adds `payg_activated` Loops template and `email.PaygActivated`; the metered rate comes from the server billing authority.
- Routes `OrganizationBillingV1` by audited action: `payg_activated` → activation email; `payg_deactivated` → access-paused. `OrganizationEnterpriseTrialV1` demotion remains access-paused; all other actions are ignored.
- Introduces shared `billingnotifications.BillingEmailScheduler` with `TemporalBillingEmailScheduler.enqueue` and a common retry policy; registers `PaygActivatedEmailWorkflow`. Access-paused emails now use the same enqueue/retry path. Each workflow ID includes the durable event ID to dedupe redeliveries.
- Shares one delivery loop for billing emails across templates; delivery continues even if recipient resolution partially fails and logs by template key. Idempotency keys for billing-event emails include the durable event ID.
- Sends only when the org is on PAYG with an active Stripe subscription; recipients resolve to the configured billing email, falling back to org admins.

<sup>Written for commit ad6d7bc1a68431e291616f3f91fcb34eca3494a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

