### PR TITLE
chore: bump pitchfork to 2.22.0

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -849,28 +849,28 @@ version = "0.1.17"
 backend = "npm:@playwright/cli"
 
 [[tools.pitchfork]]
-version = "2.20.0"
+version = "2.22.0"
 backend = "aqua:jdx/pitchfork"
 
 [tools.pitchfork."platforms.linux-arm64"]
-checksum = "sha256:cfa5db42b8a3c068c88f78b60f47e64f8bf7c2841c26b80628770f9844e3f7d5"
-url = "https://github.com/jdx/pitchfork/releases/download/v2.20.0/pitchfork-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/499131744"
+checksum = "sha256:7f9af294f0867e6b39f51d0ebeb9b30c900dedd2fa1faee56f23aedb5e9b8f75"
+url = "https://github.com/jdx/pitchfork/releases/download/v2.22.0/pitchfork-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/519295415"
 
 [tools.pitchfork."platforms.linux-x64"]
-checksum = "sha256:ad9011369dd5ab3b77af2d70e9930d6058c3f58c1e3867dc902960ee089519a2"
-url = "https://github.com/jdx/pitchfork/releases/download/v2.20.0/pitchfork-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/499131174"
+checksum = "sha256:fd682a6efccd6d39a532157c26c306585cde07370fd96ddc2bfa6904248a977f"
+url = "https://github.com/jdx/pitchfork/releases/download/v2.22.0/pitchfork-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/519295975"
 
 [tools.pitchfork."platforms.macos-arm64"]
-checksum = "sha256:07d27b5dc3dc998de9e68a2a213fd7b186b3f7031c5dd12bb95a2a0903d374fe"
-url = "https://github.com/jdx/pitchfork/releases/download/v2.20.0/pitchfork-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/499133563"
+checksum = "sha256:80ff94a8ad589da4f52988acc63ef11ade513a6acebf39d4d11bc63eefb90d69"
+url = "https://github.com/jdx/pitchfork/releases/download/v2.22.0/pitchfork-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/519300593"
 
 [tools.pitchfork."platforms.windows-x64"]
-checksum = "sha256:234b17756a2c39dccaa2cfcef9998702a8c2cc176bfa6cf63f7cce7d874fb763"
-url = "https://github.com/jdx/pitchfork/releases/download/v2.20.0/pitchfork-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/499137411"
+checksum = "sha256:b501664e6961b4944f0163dff6d44a80d217331e02690e967e303e2e92e06237"
+url = "https://github.com/jdx/pitchfork/releases/download/v2.22.0/pitchfork-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/pitchfork/releases/assets/519302598"
 
 [[tools.pkl]]
 version = "0.32.1"

--- a/mise.toml
+++ b/mise.toml
@@ -57,7 +57,7 @@ pkl = "0.32.1"
 buf = "1.72.0"
 ruff = "0.16.1"
 "github:ast-grep/ast-grep" = "0.45.0"
-pitchfork = "2.20.0"
+pitchfork = "2.22.0"
 "npm:@playwright/cli" = "0.1.17"
 
 # ℹ️ The settings below are sensible defaults for local development. When


### PR DESCRIPTION
Bumps pitchfork from 2.20.0 to 2.22.0 (`mise.toml` pin + `mise.lock` checksums/URLs).

Notable changes since 2.20.0:

- Namespace scoping for `pitchfork tui` and `pitchfork list` (`--namespace`, `--project`)
- Auto-discovery of daemons defined in git worktrees / jj workspaces
- Fix for a proxy self-deadlock that could wedge every pitchfork command on the machine
- Interactive multi-select picker for bare `start`/`stop`/`restart`, throttled process-table refreshes

Release notes: [v2.21.0](https://github.com/jdx/pitchfork/releases/tag/v2.21.0), [v2.22.0](https://github.com/jdx/pitchfork/releases/tag/v2.22.0)

Verified locally with `mise install pitchfork` → `pitchfork 2.22.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `pitchfork` from 2.20.0 to 2.22.0 to pick up a proxy deadlock fix and CLI improvements. Updates the `mise.toml` pin and `mise.lock` URLs/checksums; no source code changes.

**Rollout and review notes**
- Run `mise install pitchfork` locally to sync to 2.22.0; CI uses `mise.lock`.
- Bare `pitchfork start|stop|restart` now opens an interactive multi-select picker; scripts must pass explicit daemon names to avoid blocking.
- CLI additions: `pitchfork tui`/`pitchfork list` support `--namespace`/`--project`; daemon auto-discovery now includes git worktrees and JJ workspaces.

<sup>Written for commit 66168c08e81795df6a5fd1830e5855a4a9a1bfc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

