### PR TITLE
mig: index HTTP tool definitions by project

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1300,6 +1300,7 @@ CREATE TABLE IF NOT EXISTS http_tool_definitions (
 CREATE INDEX IF NOT EXISTS http_tool_definitions_name_idx ON http_tool_definitions (name);
 CREATE INDEX IF NOT EXISTS http_tool_definitions_deployment_deleted_id_idx ON http_tool_definitions(deployment_id, deleted, id DESC) WHERE deleted IS FALSE;
 CREATE INDEX IF NOT EXISTS http_tool_definitions_deployment_tool_urn_idx ON http_tool_definitions (deployment_id, tool_urn) WHERE deleted IS FALSE;
+CREATE INDEX IF NOT EXISTS http_tool_definitions_project_id_deleted_idx ON http_tool_definitions (project_id, deleted);
 
 CREATE TABLE IF NOT EXISTS deployments_functions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/20260818183520_http-tool-definitions-project-id-index.sql
+++ b/server/migrations/20260818183520_http-tool-definitions-project-id-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "http_tool_definitions_project_id_deleted_idx" to table: "http_tool_definitions"
+CREATE INDEX CONCURRENTLY "http_tool_definitions_project_id_deleted_idx" ON "http_tool_definitions" ("project_id", "deleted");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:VElYTLYkSuIo5ZDAi9FuSSxo1o4KfgL/xNohfgeSgzM=
+h1:8qJhyw6+QDSFt4xyrBpqSlcV8cpdPEd9WB3J98f3wq0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -352,3 +352,4 @@ h1:VElYTLYkSuIo5ZDAi9FuSSxo1o4KfgL/xNohfgeSgzM=
 20260818084059_audit-logs-add-acting-surface.sql h1:oAWlHYz8B3yYoaS8x5IYSvT7Y/MPBnNS50ACQoaEZ5c=
 20260818093227_platform-mcp-connectionless-surfaces.sql h1:dPsVJ4U8Ck18wb+vlUnHguxBW/cbDmzAejccBs9x/2w=
 20260818121359_platform-mcp-connectionless-onboarding-evidence.sql h1:TQQ0kyMRLQ7G78JCsZ1vRhbU39erV7r1a7QAxjiohi4=
+20260818183520_http-tool-definitions-project-id-index.sql h1:X4dI05qrxUpgNaQquYPJWUbWxHmCNXNWKXLuuc2lO8k=


### PR DESCRIPTION
## Summary

- add a non-partial `(project_id, deleted)` index for HTTP tool definitions
- generate the index concurrently so deployments remain writable during the build
- keep the migration isolated from the related application query change

## Why

Project-scoped tool counts and cleanup paths currently have no index leading on `project_id`, forcing full-table scans. Including `deleted` preserves index-only scans for active-tool counts while keeping the index usable by cleanup queries that do not filter on deletion state.

Refs AGE-3275.

## Validation

- `mise run lint:migrations` transaction-mode and ordering checks
- Atlas migration lint against a clean PostgreSQL 17 dev database
- `git diff --check`

## Rollout

Confirm production table size and write rates before deployment. Monitor the concurrent build and verify the index is valid afterward.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes HTTP tool definitions by project and deletion state to eliminate full-table scans on project-scoped counts and cleanup. Previously there was no index on project_id; now a non-partial (project_id, deleted) index is built concurrently, enabling index-only counts for active tools and speeding delete paths.

- Rollout: CREATE INDEX CONCURRENTLY keeps writes flowing; monitor the build and confirm the index is VALID after migration; estimate the build window from table size and write rates.
- Scope: No application query changes in this PR; the `api_keys` count rewrite from AGE-3275 ships separately.

<sup>Written for commit 69ee53e58c646dad1e2973ad1cc0390ca1679cbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

