### PR TITLE
fix: stop recording the MCP session id as the MCP URL in resources/read telemetry

### DIFF
--- a/.changeset/resources-read-mcp-url.md
+++ b/.changeset/resources-read-mcp-url.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+MCP `resources/read` requests now record the actual MCP server URL in billing telemetry and logs instead of the MCP session id, so resource reads are attributable to the server that served them and the MCP URL filter is no longer polluted with random UUIDs.

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
@@ -133,7 +134,11 @@ func handleResourcesRead(
 	var functionMem *float64
 	var functionsExecutionTime *float64
 
-	mcpURL := payload.sessionID
+	var mcpURL string
+	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
+		mcpURL = requestContext.Host + requestContext.ReqURL
+	}
+
 	err = checkToolUsageLimits(ctx, logger, toolset.OrganizationID, toolset.AccountType, billingRepository)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-443/fix-resourcesread-records-the-mcp-session-id-as-the-mcp-url-in-billing

`resources/read` assigned the MCP session id to the variable feeding the billing event's `MCPURL` field and the `gram.mcp.url` ClickHouse log attribute. Since `parseMcpSessionID` mints a fresh UUID when the client sends no `Mcp-Session-Id` header, most resource reads recorded a random UUID as the MCP URL, polluting the dashboard's MCP URL filter options and making resource reads unattributable to the server that served them in PostHog, Polar billing metadata, and ClickHouse.

This change derives the value from the request context (`Host + ReqURL`) exactly as `tools/call` does. The session id remains separately recorded via `MCPSessionID` on the same event. `RecordMCPToolCall` is intentionally not added here; that instrument is tool-call-scoped.

After deploy, `resources/read` `mcp_url` values collapse from unique random UUIDs into real server URLs, so per-URL breakdowns will show a step change. Pre-fix rows are left in place: PostHog events are immutable and ClickHouse `telemetry_logs` rows age out via the 90-day TTL. Consolidating the ten copy-pasted derivation sites into a shared helper is tracked in AIS-577.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `resources/read` telemetry to record the actual MCP server URL instead of the MCP session id (often a minted UUID), making resource reads attributable and cleaning up MCP URL filters in PostHog, Polar billing, and ClickHouse. Addresses AIS-443.

- Derives the URL from the request context (Host + ReqURL) to match `tools/call`; continues recording the session id via `MCPSessionID`; no changes to `RecordMCPToolCall`.
- `mcp_url` and `gram.mcp.url` collapse from UUIDs to real URLs; historical rows remain, so expect a step change in per-URL breakdowns; ClickHouse rows age out after 90 days.
- No migration required; update any saved dashboards or filters that reference UUID-like MCP URL values.

<sup>Written for commit a698f8a3672c2597aff401677268e1f199254f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

