### PR TITLE
fix: return 404 instead of 502 when a tunneled MCP server has no live tunnel route

### DIFF
--- a/server/internal/mcp/servepublic_tunneled_test.go
+++ b/server/internal/mcp/servepublic_tunneled_test.go
@@ -281,6 +281,28 @@ func TestServePublic_Tunneled_UnknownOrMalformedSessionIs404(t *testing.T) {
 	require.Zero(t, gateway.forwardCount(), "unknown sessions must not reach the tunnel")
 }
 
+// An offline tunnel (no live route) means the user's tunnel client is not
+// running — that is not a platform fault, so it must surface as 404 rather
+// than polluting the platform 5xx error budget with 502s. The public message
+// must stay generic: tunnel internals are not exposed to callers.
+func TestServePublic_Tunneled_OfflineTunnelIs404(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
+
+	require.NoError(t, ti.tunnelRoutes.Delete(ctx, fixture.tunnelID.String()))
+
+	_, err := serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeInitializeBody(), "")
+	require.Error(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+	require.Equal(t, "not found", oopsErr.Error(), "public message must not expose tunnel internals")
+	require.Zero(t, gateway.forwardCount(), "an offline tunnel has nothing to forward to")
+}
+
 // A dead pinned agent session must surface as 404 and drop the mapping so
 // the client re-initializes rather than seeing 502s forever.
 func TestServePublic_Tunneled_DeadAgentSessionTranslatesTo404(t *testing.T) {

--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp/tunnelrouting"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
@@ -62,7 +63,14 @@ func (m *tunnelManager) buildProxy(
 	}
 	addr, ok := tunnelrouting.SelectRoute(clientAffinityKey, candidates, nil)
 	if !ok {
-		return nil, oops.E(oops.CodeGatewayError, nil, "tunnel has no live route").LogWarn(ctx, logger)
+		// Nowhere to route the request. Tunnel outages are likely customer-side
+		// rather than something the platform administrators can control. While
+		// tunnel route selection may be a platform issue, this is not a great
+		// place to signal that class of issue, especially to a MCP Client user.
+		// If necessary, use another observability solution if this requires
+		// explicit monitoring, ideally alerting the customer instead of using
+		// the platform 5xx error budget which alerts platform administrators.
+		return nil, oops.E(oops.CodeNotFound, nil, "not found").LogWarn(ctx, logger.With(attr.SlogErrorMessage("tunnel has no live route")))
 	}
 
 	gatewayURL, err := tunnelrouting.GatewayURL(addr)


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-578/tunneled-mcp-server-with-no-live-tunnel-route-returns-502-instead-of

When the tunnel client backing a tunneled MCP server is offline, the "no live route" branch in `tunnelManager.buildProxy` returned `oops.CodeGatewayError` (HTTP 502). The platform is healthy in that situation (the request fails locally after auth and server resolution succeed, with no upstream call at all), so an offline development tunnel polluted the production ingress 5xx error rate and surfaced in health digests as platform failure.

The branch now returns `oops.CodeNotFound` (HTTP 404, JSON-RPC `-32002`) with a generic "not found" message. The "tunnel has no live route" detail moves into the warning log via `attr.SlogErrorMessage`, keeping the existing logger attributes, so the condition remains observable in Datadog. The sibling failure modes in the same function (route store unavailable, route listing error, invalid route) are real platform faults and keep returning 502.

Each tunnel-death event can still emit one residual 502 during the stale-route window: while a dead route is still published, the retryer relays the gateway's 502 before unpublishing it, and only subsequent requests reach the empty-candidates branch. Per the MCP spec, clients receiving a 404 on a session-bearing request re-initialize, matching the existing "session not found" 404 behavior for dead agent sessions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 404 instead of 502 when a tunneled MCP server has no live tunnel route. Previously this path in `tunnelManager.buildProxy` returned `oops.CodeGatewayError` (502); it now returns `oops.CodeNotFound` (404, JSON-RPC -32002) with a generic "not found" message to avoid polluting ingress 5xx and to trigger client re-initialization per MCP spec. Addresses AIS-578.

**Review notes**
- Scope: `server/internal/mcp/tunnel_manager.go` only. Replace 502 with 404 in the “no live route” branch; keep other failure modes (route store/listing/invalid route) as 502.
- Observability: keep warn log and existing attributes; move “tunnel has no live route” into `attr.SlogErrorMessage` while returning a generic message to callers.
- Tests: add `TestServePublic_Tunneled_OfflineTunnelIs404` to assert 404, generic body, and no forwarding attempts.
- Side effect: one residual 502 may occur while a stale route is still published; subsequent requests hit the 404 branch.

<sup>Written for commit 746b1a64c65e8ee37c9e07bf6e556c2486e25d45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

