### PR TITLE
feat: negotiate the MCP protocol version at initialize

### DIFF
--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -265,11 +265,14 @@ type mcpInputs struct {
 	// tools/call expose only tools whose variation row carries one of these
 	// tags. Empty means no filtering.
 	tags []string
-	// protocolVersionHeader is the sanitized MCP-Protocol-Version header value
-	// the request arrived with, or empty when absent (every `initialize`, and
-	// every request from a pre-2025-06-18 client). Threaded here because the
-	// dispatch and handlers run without access to the *http.Request.
-	protocolVersionHeader string
+	// protocolVersion is the protocol revision resolved for this request:
+	// what the request declared (header, falling back to per-request `_meta`)
+	// for telemetry, and the supported-set member in effect for behavior.
+	// Threaded here because the dispatch and handlers run without access to
+	// the *http.Request. Resolved once where this struct is built; the
+	// initialize handler overwrites InEffect with the negotiated answer, which
+	// is the one sanctioned mutation.
+	protocolVersion mcpversions.Resolution
 	// toolSelection is the consent-screen tool policy loaded from the
 	// session row by the issuer gate. Nil means all tools; non-nil is always
 	// restrictive and intersects with the live toolset, ?tags=, and RBAC.
@@ -1003,7 +1006,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		toolVariationsGroupID: toolVariationsGroupID,
 		mcpServerID:           mcpServerID,
 		tags:                  tags,
-		protocolVersionHeader: mcpversions.Sanitize(r.Header.Get(mcpversions.HTTPHeader)),
+		protocolVersion:       mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset()),
 		toolSelection:         callerToolSelection,
 	}
 
@@ -1299,12 +1302,13 @@ func parseMcpEnvVariables(r *http.Request, headerDisplayNames map[string]string)
 }
 
 func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *rawRequest) (json.RawMessage, error) {
-	// The census version resolves lazily: the header answers for every
-	// conforming client since 2025-06-18, and only a header-less request pays
-	// the `_meta` scan. Handlers that consume the rest of the per-request
-	// metadata decode it themselves (tools/call in the same pass as its
-	// params, tools/list scoped to its analytics event).
-	s.metrics.RecordMCPRequest(ctx, mcprequests.DeclaredProtocolVersion(payload.protocolVersionHeader, req.Params), req.Method, mcpmetrics.SurfaceHosting)
+	// The census dimension is what the request declared, not the in-effect
+	// revision: clamping keeps absent and unknown declarations countable,
+	// and the resolved value would fabricate a revision for clients that
+	// named none. Handlers that consume the rest of the per-request metadata
+	// decode it themselves (tools/call in the same pass as its params,
+	// tools/list scoped to its analytics event).
+	s.metrics.RecordMCPRequest(ctx, payload.protocolVersion.Declared, req.Method, mcpmetrics.SurfaceHosting)
 
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
 		start := time.Now()

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -10,10 +10,10 @@ import (
 // Published MCP protocol revisions, oldest first. Sourced from the
 // specification's revision list (https://modelcontextprotocol.io/specification/versioning).
 //
-// These are NOT a statement of what Gram implements or accepts; the Served*
-// constants below carry the revision each Gram surface answers with. They exist
-// so telemetry can distinguish "a revision we know about" from "something else
-// entirely".
+// These are NOT a statement of what Gram implements or accepts; the Supported*
+// functions below carry the revisions each Gram surface actually negotiates
+// and serves. They exist so telemetry can distinguish "a revision we know
+// about" from "something else entirely".
 const (
 	Version20241105 = "2024-11-05"
 	Version20250326 = "2025-03-26"
@@ -22,34 +22,125 @@ const (
 	Version20260728 = "2026-07-28"
 )
 
-// The protocol revision each Gram surface that terminates an MCP session
-// answers with. Both are answered unconditionally, without regard to what the
-// client requested — which is precisely why requested and negotiated are
-// tracked as separate telemetry attributes rather than collapsed into one.
+// DefaultInEffect is the revision put in effect when no usable version can be
+// taken from the request: a request that names no version at all, and a
+// per-request declaration outside the surface's supported set. The 2026-07-28
+// specification sanctions exactly this value for the first case — a server
+// supporting pre-2025-06-18 clients MAY treat a request that omits the
+// version header as 2025-03-26 — and the second case deliberately reuses it:
+// defaulting downward over-serves rather than wrongly rejecting, which is the
+// safe direction for both cohorts.
+const DefaultInEffect = Version20250326
+
+// The protocol revisions each Gram surface that terminates an MCP session
+// supports, oldest first. A revision in a surface's set is echoed at
+// `initialize` and governs per-request behavior when declared; anything
+// outside the set is answered with the newest member, per the spec's rule that
+// a server must respond with a version it supports and should pick its latest.
 //
-// They are split per surface deliberately, despite currently holding the same
-// value. The surfaces face different client populations, so raising one is not
-// the same decision as raising the other, and a supported-version ceiling is
-// expected to move them on different schedules.
+// The sets are split per surface deliberately, despite currently holding the
+// same values. The surfaces face different client populations, so raising one
+// is not the same decision as raising the other, and the ceilings are expected
+// to move on different schedules. The current ceiling is Version20251125;
+// advertising Version20260728 is its own project with its own preconditions.
+// The Version20241105 floor is evidence-based — clients on that revision still
+// make tool calls — and claims support on the Streamable HTTP transport only,
+// not the HTTP+SSE transport that revision also defined.
 //
 // The remote MCP proxy has no entry here by design: it never answers a
 // version, it relays whatever the client and the upstream negotiate between
 // themselves. Gram's outbound remote-URL verification probe is also absent —
 // that is Gram acting as a client, so the version it sends is a requested one
 // rather than a served one, and it lives with the probe.
-const (
-	// ServedHostedToolset is answered on /mcp/{slug} and on the
-	// toolset-backed /x/mcp/{slug}, which share a handler. This surface faces
-	// arbitrary third-party MCP clients, so changing it is a compatibility
-	// event with external blast radius.
-	ServedHostedToolset = Version20250326
-
-	// ServedPlatformToolset is answered on /platform/mcp/{slug}, which accepts
-	// only the assistant token — user OAuth, API keys, and chat sessions are
-	// deliberately not honored there. That closed, first-party client set
-	// means this can move without third-party exposure.
-	ServedPlatformToolset = Version20250326
+var (
+	supportedHostedToolset   = []string{Version20241105, Version20250326, Version20250618, Version20251125}
+	supportedPlatformToolset = []string{Version20241105, Version20250326, Version20250618, Version20251125}
 )
+
+// SupportedHostedToolset returns the revisions supported on /mcp/{slug} and on
+// the toolset-backed /x/mcp/{slug}, which share a handler, oldest first. This
+// surface faces arbitrary third-party MCP clients, so changing the set is a
+// compatibility event with external blast radius.
+func SupportedHostedToolset() []string {
+	return slices.Clone(supportedHostedToolset)
+}
+
+// SupportedPlatformToolset returns the revisions supported on
+// /platform/mcp/{toolsetSlug}, oldest first. That surface accepts only the
+// assistant token — user OAuth, API keys, and chat sessions are deliberately
+// not honored there — so its closed, first-party client set can move without
+// third-party exposure.
+func SupportedPlatformToolset() []string {
+	return slices.Clone(supportedPlatformToolset)
+}
+
+// Negotiate applies the MCP version-negotiation rule to an `initialize`
+// request: a supported requested revision is echoed, an absent one resolves to
+// [DefaultInEffect], and anything else — unknown, unrecognized, or known
+// but unsupported — is answered with the newest supported revision. The
+// absent case deliberately does not fall through to the ceiling: a client
+// that omitted the field entirely is the cohort likeliest to break on a new
+// revision, and the spec's omitted-version rule points at 2025-03-26.
+//
+// requested may be raw client input; it is bounded by [Sanitize] first.
+// supported must be non-empty and ordered oldest first, as the Supported*
+// functions return.
+func Negotiate(requested string, supported []string) string {
+	requested = Sanitize(requested)
+	switch {
+	case requested == "":
+		return DefaultInEffect
+	case slices.Contains(supported, requested):
+		return requested
+	default:
+		return supported[len(supported)-1]
+	}
+}
+
+// Resolution is the protocol revision resolved for one MCP request. It keeps
+// the two version semantics a request carries distinguishable: what the client
+// said, for telemetry, and what governs the request, for behavior. Confusing
+// the two silently corrupts one or the other — feeding InEffect to a census
+// metric fabricates data points for clients that declared nothing, and
+// branching behavior on Declared trusts a value outside the supported set.
+type Resolution struct {
+	// Declared is the sanitized revision the request declared — the
+	// MCP-Protocol-Version header, falling back to the 2026-07-28 per-request
+	// `_meta` key. It may be empty (every legacy `initialize`, and every
+	// request from a pre-2025-06-18 client) or a revision outside the
+	// supported set. Telemetry consumers own this half: metric dimensions
+	// clamp it themselves so absent and unknown declarations stay countable.
+	Declared string
+
+	// InEffect is the revision governing the request: Declared when the
+	// surface supports it, otherwise [DefaultInEffect]. Never empty.
+	// Version-conditional behavior branches on this value and nothing else.
+	//
+	// For an `initialize` request the entry-time value is provisional — a
+	// conforming handshake declares no version, so it starts at the default —
+	// and the initialize handler overwrites it with the negotiated answer
+	// once computed, superseding whatever a nonconforming header may have
+	// resolved to. That write-back is the one sanctioned mutation after
+	// [Resolve].
+	InEffect string
+}
+
+// Resolve computes the [Resolution] for a request that declared declared (raw
+// client input; bounded by [Sanitize] here) against a surface's supported
+// set. A declared revision outside the set resolves to [DefaultInEffect],
+// deliberately over-serving downward instead of rejecting; replacing that arm
+// with the spec's UnsupportedProtocolVersionError (-32022) is separate,
+// planned work, so callers must not treat the fallback as a permanent
+// contract.
+func Resolve(declared string, supported []string) Resolution {
+	declared = Sanitize(declared)
+	inEffect := DefaultInEffect
+	if slices.Contains(supported, declared) {
+		inEffect = declared
+	}
+
+	return Resolution{Declared: declared, InEffect: inEffect}
+}
 
 // HTTPHeader is the header MCP clients stamp on every request once the
 // protocol version is established. Under the handshake-based revisions it

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -34,13 +34,121 @@ func TestAllReturnsACopy(t *testing.T) {
 	require.Equal(t, mcpversions.Version20241105, mcpversions.All()[0], "All must not hand out a mutable view of package state")
 }
 
-// TestServedVersionsAreKnown guards every surface's served revision against
-// drifting out of the registry. Add a case here when a surface is added.
-func TestServedVersionsAreKnown(t *testing.T) {
+// TestSupportedSetsAreKnownAndOrdered guards every surface's supported set
+// against drifting out of the registry or out of the oldest-first ordering
+// Negotiate's highest-supported fallback depends on. Add a case here when a
+// surface is added.
+func TestSupportedSetsAreKnownAndOrdered(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, mcpversions.Known(mcpversions.ServedHostedToolset))
-	require.True(t, mcpversions.Known(mcpversions.ServedPlatformToolset))
+	for _, supported := range [][]string{
+		mcpversions.SupportedHostedToolset(),
+		mcpversions.SupportedPlatformToolset(),
+	} {
+		require.NotEmpty(t, supported)
+		require.True(t, slices.IsSorted(supported), "revision identifiers are YYYY-MM-DD, so chronological order is lexical order")
+		require.Contains(t, supported, mcpversions.DefaultInEffect, "the unversioned default must itself be servable")
+		for _, v := range supported {
+			require.True(t, mcpversions.Known(v), "expected %q to be recognized", v)
+		}
+	}
+}
+
+func TestSupportedSetsReturnCopies(t *testing.T) {
+	t.Parallel()
+
+	mcpversions.SupportedHostedToolset()[0] = "mutated"
+	mcpversions.SupportedPlatformToolset()[0] = "mutated"
+
+	require.Equal(t, mcpversions.Version20241105, mcpversions.SupportedHostedToolset()[0], "SupportedHostedToolset must not hand out a mutable view of package state")
+	require.Equal(t, mcpversions.Version20241105, mcpversions.SupportedPlatformToolset()[0], "SupportedPlatformToolset must not hand out a mutable view of package state")
+}
+
+// TestSupportedSetsExclude20260728 pins the current ceiling: advertising
+// 2026-07-28 is its own project, and adding it to a set is the entire
+// behavioral switch for that work — it must not happen by accident.
+func TestSupportedSetsExclude20260728(t *testing.T) {
+	t.Parallel()
+
+	require.NotContains(t, mcpversions.SupportedHostedToolset(), mcpversions.Version20260728)
+	require.NotContains(t, mcpversions.SupportedPlatformToolset(), mcpversions.Version20260728)
+}
+
+func TestNegotiateEchoesEverySupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	supported := mcpversions.SupportedHostedToolset()
+	for _, v := range supported {
+		require.Equal(t, v, mcpversions.Negotiate(v, supported))
+	}
+}
+
+// TestNegotiateAnswersAbsentWithTheDefault pins that the no-version cohort is
+// not handed the ceiling: a client that omitted the field entirely is the
+// likeliest to break on a newer revision, and the spec's omitted-version rule
+// points at 2025-03-26.
+func TestNegotiateAnswersAbsentWithTheDefault(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, mcpversions.DefaultInEffect, mcpversions.Negotiate("", mcpversions.SupportedHostedToolset()))
+}
+
+func TestNegotiateAnswersUnsupportedWithTheNewestSupported(t *testing.T) {
+	t.Parallel()
+
+	supported := mcpversions.SupportedHostedToolset()
+	newest := supported[len(supported)-1]
+
+	require.Equal(t, newest, mcpversions.Negotiate(mcpversions.Version20260728, supported), "known but unsupported")
+	require.Equal(t, newest, mcpversions.Negotiate("1999-12-31", supported), "well-formed but unrecognized")
+	require.Equal(t, newest, mcpversions.Negotiate("garbage", supported), "not a version at all")
+}
+
+func TestNegotiateSanitizesRawClientInput(t *testing.T) {
+	t.Parallel()
+
+	supported := mcpversions.SupportedHostedToolset()
+
+	require.Equal(t, mcpversions.Version20250618, mcpversions.Negotiate("  2025-06-18\t", supported), "surrounding whitespace trims to a supported version")
+	require.Equal(t, mcpversions.DefaultInEffect, mcpversions.Negotiate("2025-06-18\x00", supported), "non-printable input sanitizes to absent, not to the ceiling")
+}
+
+func TestResolveKeepsEverySupportedDeclarationInEffect(t *testing.T) {
+	t.Parallel()
+
+	supported := mcpversions.SupportedHostedToolset()
+	for _, v := range supported {
+		got := mcpversions.Resolve(v, supported)
+		require.Equal(t, v, got.Declared)
+		require.Equal(t, v, got.InEffect)
+	}
+}
+
+func TestResolveDefaultsAnAbsentDeclaration(t *testing.T) {
+	t.Parallel()
+
+	got := mcpversions.Resolve("", mcpversions.SupportedHostedToolset())
+	require.Empty(t, got.Declared, "telemetry must still see that nothing was declared")
+	require.Equal(t, mcpversions.DefaultInEffect, got.InEffect)
+}
+
+// TestResolveDefaultsAnUnsupportedDeclaration pins the over-serve-downward
+// arm: a declaration outside the supported set keeps its raw value for
+// telemetry while behavior falls back to the default rather than trusting it.
+func TestResolveDefaultsAnUnsupportedDeclaration(t *testing.T) {
+	t.Parallel()
+
+	got := mcpversions.Resolve(mcpversions.Version20260728, mcpversions.SupportedHostedToolset())
+	require.Equal(t, mcpversions.Version20260728, got.Declared)
+	require.Equal(t, mcpversions.DefaultInEffect, got.InEffect)
+}
+
+func TestResolveSanitizesRawClientInput(t *testing.T) {
+	t.Parallel()
+
+	got := mcpversions.Resolve("  2025-06-18\t", mcpversions.SupportedHostedToolset())
+	require.Equal(t, mcpversions.Version20250618, got.Declared)
+	require.Equal(t, mcpversions.Version20250618, got.InEffect)
 }
 
 func TestKnownAcceptsEveryPublishedRevision(t *testing.T) {

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -97,11 +97,13 @@ func TestNegotiateAnswersUnsupportedWithTheNewestSupported(t *testing.T) {
 	t.Parallel()
 
 	supported := mcpversions.SupportedHostedToolset()
-	newest := supported[len(supported)-1]
 
-	require.Equal(t, newest, mcpversions.Negotiate(mcpversions.Version20260728, supported), "known but unsupported")
-	require.Equal(t, newest, mcpversions.Negotiate("1999-12-31", supported), "well-formed but unrecognized")
-	require.Equal(t, newest, mcpversions.Negotiate("garbage", supported), "not a version at all")
+	// The expected value is pinned rather than derived from the set, so
+	// raising the ceiling breaks this test and forces choosing new out-of-set
+	// inputs that keep the fallback arm exercised.
+	require.Equal(t, mcpversions.Version20251125, mcpversions.Negotiate(mcpversions.Version20260728, supported), "known but unsupported")
+	require.Equal(t, mcpversions.Version20251125, mcpversions.Negotiate("1999-12-31", supported), "well-formed but unrecognized")
+	require.Equal(t, mcpversions.Version20251125, mcpversions.Negotiate("garbage", supported), "not a version at all")
 }
 
 func TestNegotiateSanitizesRawClientInput(t *testing.T) {

--- a/server/internal/mcp/protocolversion.go
+++ b/server/internal/mcp/protocolversion.go
@@ -12,8 +12,8 @@ import (
 
 // recordMCPProtocolVersionSpan annotates the active span with the MCP protocol
 // revision a client asked for and the one actually in effect, so a trace can
-// be attributed to a protocol version and a pinned or downgraded negotiation
-// is visible rather than implied.
+// be attributed to a protocol version and a downgraded negotiation is visible
+// rather than implied.
 //
 // Either value may be empty — a client can omit protocolVersion from its
 // initialize params — in which case that attribute is omitted rather than

--- a/server/internal/mcp/protocolversion_internal_test.go
+++ b/server/internal/mcp/protocolversion_internal_test.go
@@ -37,24 +37,24 @@ func recordedProtocolVersionAttrs(t *testing.T, requested, negotiated string) ma
 	return got
 }
 
-// TestRecordMCPProtocolVersionSpan_RecordsGramsPinAsADiscrepancy is the case that
-// motivates tracking the two versions separately: the hosted path answers
-// ServedHostedToolset no matter what the client asked for, and collapsing them
-// into one attribute would hide that.
-func TestRecordMCPProtocolVersionSpan_RecordsGramsPinAsADiscrepancy(t *testing.T) {
+// TestRecordMCPProtocolVersionSpan_RecordsDowngradeAsADiscrepancy is the case
+// that motivates tracking the two versions separately: a client requesting a
+// revision outside the supported set is negotiated down to a different one,
+// and collapsing the two into one attribute would hide that.
+func TestRecordMCPProtocolVersionSpan_RecordsDowngradeAsADiscrepancy(t *testing.T) {
 	t.Parallel()
 
-	got := recordedProtocolVersionAttrs(t, mcpversions.Version20260728, mcpversions.ServedHostedToolset)
+	got := recordedProtocolVersionAttrs(t, mcpversions.Version20260728, mcpversions.Version20251125)
 	require.Equal(t, mcpversions.Version20260728, got[string(attr.McpRequestedProtocolVersionKey)])
-	require.Equal(t, mcpversions.ServedHostedToolset, got[string(attr.McpNegotiatedProtocolVersionKey)])
+	require.Equal(t, mcpversions.Version20251125, got[string(attr.McpNegotiatedProtocolVersionKey)])
 }
 
 func TestRecordMCPProtocolVersionSpan_OmitsAbsentRequestedVersion(t *testing.T) {
 	t.Parallel()
 
-	got := recordedProtocolVersionAttrs(t, "", mcpversions.ServedHostedToolset)
+	got := recordedProtocolVersionAttrs(t, "", mcpversions.Version20250326)
 	require.NotContains(t, got, string(attr.McpRequestedProtocolVersionKey))
-	require.Equal(t, mcpversions.ServedHostedToolset, got[string(attr.McpNegotiatedProtocolVersionKey)])
+	require.Equal(t, mcpversions.Version20250326, got[string(attr.McpNegotiatedProtocolVersionKey)])
 }
 
 // TestRecordMCPProtocolVersionSpan_OmitsAbsentNegotiatedVersion covers the
@@ -82,7 +82,7 @@ func TestRecordMCPProtocolVersionSpan_RecordsNothingWhenBothAbsent(t *testing.T)
 func TestRecordMCPProtocolVersionSpan_KeepsUnrecognizedVersions(t *testing.T) {
 	t.Parallel()
 
-	got := recordedProtocolVersionAttrs(t, "1999-12-31", mcpversions.ServedHostedToolset)
+	got := recordedProtocolVersionAttrs(t, "1999-12-31", mcpversions.Version20250326)
 	require.Equal(t, "1999-12-31", got[string(attr.McpRequestedProtocolVersionKey)])
 }
 
@@ -100,6 +100,6 @@ func TestRecordMCPProtocolVersionSpan_ToleratesNonRecordingSpan(t *testing.T) {
 	// Sampled-out requests reach handlers with a non-recording span; recording
 	// must be a no-op rather than a panic.
 	require.NotPanics(t, func() {
-		recordMCPProtocolVersionSpan(t.Context(), mcpversions.Version20250618, mcpversions.ServedHostedToolset)
+		recordMCPProtocolVersionSpan(t.Context(), mcpversions.Version20250618, mcpversions.Version20250326)
 	})
 }

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -69,12 +69,22 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, telemetry *mcpme
 		logger.WarnContext(ctx, "failed to parse mcp initialize params", attr.SlogError(err))
 	}
 
-	// The requested version is what the client asked for; the negotiated one is
-	// what this handler answers below, which is ServedHostedToolset
-	// unconditionally. Recording both makes that pin visible rather than
-	// collapsing it — on this path they differ for most clients.
-	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, mcpversions.ServedHostedToolset)
-	telemetry.RecordMCPInitialize(ctx, params.ProtocolVersion, mcpversions.ServedHostedToolset)
+	// Genuine version negotiation: echo the requested revision when this
+	// surface supports it, otherwise answer the newest supported one. The
+	// answer is written back into the request's resolution because initialize
+	// is the one request whose in-effect revision is established mid-handling
+	// — the entry-time value is provisional — and anything downstream of
+	// dispatch must see the negotiated value. The body's requested version
+	// wins over any MCP-Protocol-Version header a nonconforming client sent
+	// on initialize: the body is the negotiation.
+	negotiated := mcpversions.Negotiate(params.ProtocolVersion, mcpversions.SupportedHostedToolset())
+	payload.protocolVersion.InEffect = negotiated
+
+	// Recording requested and negotiated separately keeps a downgrade — a
+	// client asking for a revision outside the supported set — visible rather
+	// than collapsed.
+	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, negotiated)
+	telemetry.RecordMCPInitialize(ctx, params.ProtocolVersion, negotiated)
 
 	storeSessionClientInfo(ctx, logger, clientInfoStore, payload, params.ClientInfo.Name, params.ClientInfo.Version, params.ProtocolVersion)
 
@@ -101,7 +111,7 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, telemetry *mcpme
 		ID:             req.ID,
 		serverIdentity: serverInfoHostedToolset,
 		Result: initializeResult{
-			ProtocolVersion: mcpversions.ServedHostedToolset,
+			ProtocolVersion: negotiated,
 			Capabilities: map[string]json.RawMessage{
 				"tools":     json.RawMessage("{}"),
 				"prompts":   json.RawMessage("{}"),

--- a/server/internal/mcp/rpc_initialize_test.go
+++ b/server/internal/mcp/rpc_initialize_test.go
@@ -1,11 +1,21 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
 func TestParseInitializeParams(t *testing.T) {
@@ -99,4 +109,70 @@ func TestParseInitializeParams_DeepClientNameNotTruncatedAtParse(t *testing.T) {
 	params, _, err := parseInitializeParams(json.RawMessage(raw))
 	require.NoError(t, err)
 	require.Len(t, params.ClientInfo.Name, 250)
+}
+
+// failingDBTX satisfies the sqlc DBTX interfaces with a stub that fails every
+// operation, for exercising handlers whose database reads are best-effort.
+type failingDBTX struct{}
+
+var errNoDatabaseInTest = errors.New("no database in this test")
+
+func (failingDBTX) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, errNoDatabaseInTest
+}
+
+func (failingDBTX) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, errNoDatabaseInTest
+}
+
+func (failingDBTX) QueryRow(context.Context, string, ...any) pgx.Row {
+	return failingRow{}
+}
+
+func (failingDBTX) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	return 0, errNoDatabaseInTest
+}
+
+type failingRow struct{}
+
+func (failingRow) Scan(...any) error { return errNoDatabaseInTest }
+
+// TestHandleInitialize_WritesNegotiatedVersionBackIntoPayload pins the hosted
+// write-back: after negotiation the payload's resolution must carry the
+// negotiated revision rather than the provisional entry-time default, because
+// consumers downstream of dispatch read the in-effect revision from there.
+// The failing repositories exercise the documented tolerance of the
+// instructions lookup, which must not affect the handshake.
+func TestHandleInitialize_WritesNegotiatedVersionBackIntoPayload(t *testing.T) {
+	t.Parallel()
+
+	store, payload := newClientIdentityFixture(t)
+	require.Equal(t, mcpversions.DefaultInEffect, payload.protocolVersion.InEffect)
+
+	rawParams, err := json.Marshal(map[string]any{
+		"protocolVersion": mcpversions.Version20251125,
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "test-client", "version": "1.0.0"},
+	})
+	require.NoError(t, err)
+
+	req := &rawRequest{
+		JSONRPC: "2.0",
+		ID:      mcpjsonrpc.NumberID(1),
+		Method:  "initialize",
+		Params:  rawParams,
+	}
+
+	body, err := handleInitialize(t.Context(), testenv.NewLogger(t), nil, req, payload, nil, toolsets_repo.New(failingDBTX{}), metadata_repo.New(failingDBTX{}), store)
+	require.NoError(t, err)
+
+	require.Equal(t, mcpversions.Version20251125, payload.protocolVersion.InEffect)
+
+	var response struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(body, &response), "response body: %s", body)
+	require.Equal(t, mcpversions.Version20251125, response.Result.ProtocolVersion)
 }

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -99,7 +99,7 @@ func handleToolsList(
 		// the event: tools/list params are tiny, so the scan is negligible.
 		reqMeta := mcprequests.ParseMeta(req.Params)
 		identity, storedProtocolVersion := resolveClientIdentity(ctx, logger, clientInfoStore, payload, reqMeta.ClientInfo)
-		protocolVersion := reqMeta.DeclaredProtocolVersion(payload.protocolVersionHeader)
+		protocolVersion := payload.protocolVersion.Declared
 		if protocolVersion == "" {
 			protocolVersion = storedProtocolVersion
 		}

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -104,7 +104,11 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").LogError(ctx, s.logger)
 	}
 
-	body, err := s.handlePlatformToolsetRequest(ctx, authCtx, toolset, &req, r.Header.Get("Gram-Chat-ID"), mcpversions.Sanitize(r.Header.Get(mcpversions.HTTPHeader)))
+	// Resolved once per request; the initialize handler overwrites InEffect
+	// with the negotiated answer, which is the one sanctioned mutation.
+	protocolVersion := mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedPlatformToolset())
+
+	body, err := s.handlePlatformToolsetRequest(ctx, authCtx, toolset, &req, r.Header.Get("Gram-Chat-ID"), &protocolVersion)
 	switch {
 	case body == nil && err == nil:
 		return respondWithNoContent(true, w)
@@ -209,10 +213,13 @@ func (s *Service) handlePlatformToolsetRequest(
 	toolset platformtools.Toolset,
 	req *rawRequest,
 	chatIDHeader string,
-	protocolVersionHeader string,
+	protocolVersion *mcpversions.Resolution,
 ) (json.RawMessage, error) {
-	// Census parity with the hosted dispatch.
-	s.metrics.RecordMCPRequest(ctx, mcprequests.DeclaredProtocolVersion(protocolVersionHeader, req.Params), req.Method, mcpmetrics.SurfacePlatform)
+	// Count this request on the same census as the hosted dispatch. The
+	// version dimension must be Declared, not InEffect: the census exists to
+	// show what clients actually send, and RecordMCPRequest buckets an empty
+	// or unrecognized declaration into its "none"/"other" series.
+	s.metrics.RecordMCPRequest(ctx, protocolVersion.Declared, req.Method, mcpmetrics.SurfacePlatform)
 
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
 		start := time.Now()
@@ -225,7 +232,7 @@ func (s *Service) handlePlatformToolsetRequest(
 	case "ping":
 		return handlePing(ctx, s.logger, req.ID, serverInfoPlatformToolset)
 	case "initialize":
-		return handlePlatformInitialize(ctx, s.logger, s.metrics, req)
+		return handlePlatformInitialize(ctx, s.logger, s.metrics, req, protocolVersion)
 	case "notifications/initialized", "notifications/cancelled":
 		return nil, nil
 	case "tools/list":
@@ -237,26 +244,31 @@ func (s *Service) handlePlatformToolsetRequest(
 	}
 }
 
-func handlePlatformInitialize(ctx context.Context, logger *slog.Logger, telemetry *mcpmetrics.Metrics, req *rawRequest) (json.RawMessage, error) {
-	// This path answers ServedPlatformToolset unconditionally and does not
-	// otherwise read the request params. Parsing them purely for telemetry is
-	// the point: without it the platform surface is the one inbound path where
-	// the client's requested revision is invisible, which reads as a hole in
-	// the data rather than as "platform clients don't negotiate". Malformed
-	// params must not fail the handshake, so a parse error is logged and the
-	// requested version is simply left unrecorded.
+func handlePlatformInitialize(ctx context.Context, logger *slog.Logger, telemetry *mcpmetrics.Metrics, req *rawRequest, protocolVersion *mcpversions.Resolution) (json.RawMessage, error) {
+	// Malformed params must not fail the handshake, so a parse error is
+	// logged, the requested version is left unrecorded, and negotiation
+	// proceeds from an absent request — answering the unversioned default.
 	params, _, err := parseInitializeParams(req.Params)
 	if err != nil {
 		logger.WarnContext(ctx, "failed to parse platform mcp initialize params", attr.SlogError(err))
 	}
 
-	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, mcpversions.ServedPlatformToolset)
-	telemetry.RecordMCPInitialize(ctx, params.ProtocolVersion, mcpversions.ServedPlatformToolset)
+	// Genuine version negotiation, mirroring the hosted surface: echo the
+	// requested revision when this surface supports it, otherwise answer the
+	// newest supported one. The answer is written back into the request's
+	// resolution because entry-time resolution saw a handshake with no
+	// declared version; anything downstream of dispatch must see the
+	// negotiated value.
+	negotiated := mcpversions.Negotiate(params.ProtocolVersion, mcpversions.SupportedPlatformToolset())
+	protocolVersion.InEffect = negotiated
+
+	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, negotiated)
+	telemetry.RecordMCPInitialize(ctx, params.ProtocolVersion, negotiated)
 
 	result := &result[initializeResult]{
 		ID: req.ID,
 		Result: initializeResult{
-			ProtocolVersion: mcpversions.ServedPlatformToolset,
+			ProtocolVersion: negotiated,
 			Capabilities: map[string]json.RawMessage{
 				"tools": json.RawMessage("{}"),
 			},

--- a/server/internal/mcp/serve_platform_internal_test.go
+++ b/server/internal/mcp/serve_platform_internal_test.go
@@ -1,0 +1,112 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// runPlatformInitialize runs handlePlatformInitialize for a handshake requesting
+// the given version (empty omits the field) and returns the answered
+// protocolVersion plus the resolution after the handler's write-back.
+func runPlatformInitialize(t *testing.T, requested string) (string, mcpversions.Resolution) {
+	t.Helper()
+
+	params := map[string]any{
+		"capabilities": map[string]any{},
+		"clientInfo":   map[string]any{"name": "test-client", "version": "1.0.0"},
+	}
+	if requested != "" {
+		params["protocolVersion"] = requested
+	}
+	rawParams, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	req := &rawRequest{
+		JSONRPC: "2.0",
+		ID:      mcpjsonrpc.NumberID(1),
+		Method:  "initialize",
+		Params:  rawParams,
+	}
+
+	// A conforming handshake request declares no version, so entry-time
+	// resolution hands the handler the default.
+	resolution := mcpversions.Resolve("", mcpversions.SupportedPlatformToolset())
+
+	body, err := handlePlatformInitialize(t.Context(), testenv.NewLogger(t), nil, req, &resolution)
+	require.NoError(t, err)
+
+	var response struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(body, &response), "response body: %s", body)
+
+	return response.Result.ProtocolVersion, resolution
+}
+
+func TestHandlePlatformInitialize_EchoesEverySupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range mcpversions.SupportedPlatformToolset() {
+		answered, resolution := runPlatformInitialize(t, v)
+		require.Equal(t, v, answered, "a supported requested version must be echoed")
+		require.Equal(t, v, resolution.InEffect, "the negotiated answer must be written back into the resolution")
+	}
+}
+
+func TestHandlePlatformInitialize_AnswersUnsupportedVersionWithNewestSupported(t *testing.T) {
+	t.Parallel()
+
+	supported := mcpversions.SupportedPlatformToolset()
+	newest := supported[len(supported)-1]
+
+	answered, resolution := runPlatformInitialize(t, mcpversions.Version20260728)
+	require.Equal(t, newest, answered)
+	require.Equal(t, newest, resolution.InEffect)
+}
+
+// TestHandlePlatformInitialize_AnswersAbsentVersionWithDefault pins that the
+// no-version cohort is not handed the ceiling: a handshake naming no revision
+// is answered the spec's unversioned default.
+func TestHandlePlatformInitialize_AnswersAbsentVersionWithDefault(t *testing.T) {
+	t.Parallel()
+
+	answered, resolution := runPlatformInitialize(t, "")
+	require.Equal(t, mcpversions.DefaultInEffect, answered)
+	require.Equal(t, mcpversions.DefaultInEffect, resolution.InEffect)
+}
+
+// TestHandlePlatformInitialize_MalformedParamsNegotiateTheDefault mirrors the
+// malformed-params guarantee on the hosted surface: a params shape that fails
+// to decode must not fail the handshake, and negotiation proceeds as if the
+// client requested nothing.
+func TestHandlePlatformInitialize_MalformedParamsNegotiateTheDefault(t *testing.T) {
+	t.Parallel()
+
+	req := &rawRequest{
+		JSONRPC: "2.0",
+		ID:      mcpjsonrpc.NumberID(1),
+		Method:  "initialize",
+		Params:  json.RawMessage(`["unexpected"]`),
+	}
+	resolution := mcpversions.Resolve("", mcpversions.SupportedPlatformToolset())
+
+	body, err := handlePlatformInitialize(t.Context(), testenv.NewLogger(t), nil, req, &resolution)
+	require.NoError(t, err)
+
+	var response struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(body, &response), "response body: %s", body)
+	require.Equal(t, mcpversions.DefaultInEffect, response.Result.ProtocolVersion)
+	require.Equal(t, mcpversions.DefaultInEffect, resolution.InEffect)
+}

--- a/server/internal/mcp/serve_platform_internal_test.go
+++ b/server/internal/mcp/serve_platform_internal_test.go
@@ -64,12 +64,12 @@ func TestHandlePlatformInitialize_EchoesEverySupportedVersion(t *testing.T) {
 func TestHandlePlatformInitialize_AnswersUnsupportedVersionWithNewestSupported(t *testing.T) {
 	t.Parallel()
 
-	supported := mcpversions.SupportedPlatformToolset()
-	newest := supported[len(supported)-1]
-
+	// The expected value is pinned rather than derived from the supported
+	// set, so raising the ceiling breaks this test and forces choosing a new
+	// out-of-set requested version that keeps the fallback arm exercised.
 	answered, resolution := runPlatformInitialize(t, mcpversions.Version20260728)
-	require.Equal(t, newest, answered)
-	require.Equal(t, newest, resolution.InEffect)
+	require.Equal(t, mcpversions.Version20251125, answered)
+	require.Equal(t, mcpversions.Version20251125, resolution.InEffect)
 }
 
 // TestHandlePlatformInitialize_AnswersAbsentVersionWithDefault pins that the

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -773,18 +773,18 @@ func TestServePublic_InitializeAnswersUnsupportedVersionWithNewestSupported(t *t
 
 	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "negotiate-down-mcp")
 
-	supported := mcpversions.SupportedHostedToolset()
-	newest := supported[len(supported)-1]
-
+	// The expected value is pinned rather than derived from the supported
+	// set, so raising the ceiling breaks this test and forces choosing new
+	// out-of-set requested versions that keep the fallback arm exercised.
 	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion(mcpversions.Version20260728), "", nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, newest, answeredProtocolVersion(t, w), "an unsupported requested version is answered with the newest supported one")
+	require.Equal(t, mcpversions.Version20251125, answeredProtocolVersion(t, w), "an unsupported requested version is answered with the newest supported one")
 
 	w, err = servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion("1999-12-31"), "", nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, newest, answeredProtocolVersion(t, w), "an unrecognized requested version is answered with the newest supported one")
+	require.Equal(t, mcpversions.Version20251125, answeredProtocolVersion(t, w), "an unrecognized requested version is answered with the newest supported one")
 }
 
 // TestServePublic_InitializeAnswersAbsentVersionWithDefault pins that the

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	variations_repo "github.com/speakeasy-api/gram/server/internal/variations/repo"
@@ -704,4 +705,126 @@ func TestServePublic_ToolsCall_FilteredOutTool_NotFound(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "body: %s", w.Body.String())
 	require.NotNil(t, resp.Error, "expected a JSON-RPC error, body: %s", w.Body.String())
 	require.Contains(t, resp.Error.Message, "not found")
+}
+
+// makeInitializeBodyWithVersion mirrors makeInitializeBody with a
+// caller-chosen protocolVersion; an empty version omits the field entirely,
+// which is how the no-version cohort handshakes.
+func makeInitializeBodyWithVersion(version string) []byte {
+	params := map[string]any{
+		"capabilities": map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "test-client",
+			"version": "1.0.0",
+		},
+	}
+	if version != "" {
+		params["protocolVersion"] = version
+	}
+	bs, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params":  params,
+	})
+	return bs
+}
+
+// answeredProtocolVersion extracts result.protocolVersion from a successful
+// initialize response.
+func answeredProtocolVersion(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response), "response body: %s", w.Body.String())
+	require.Nil(t, response["error"], "response body: %s", w.Body.String())
+	result, ok := response["result"].(map[string]any)
+	require.True(t, ok, "result should be a map: %v", response)
+	version, ok := result["protocolVersion"].(string)
+	require.True(t, ok, "protocolVersion should be a string: %v", result)
+	return version
+}
+
+func TestServePublic_InitializeEchoesEverySupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "negotiate-echo-mcp")
+
+	for _, v := range mcpversions.SupportedHostedToolset() {
+		w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion(v), "", nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, w.Code, "requested %s, body: %s", v, w.Body.String())
+		require.Equal(t, v, answeredProtocolVersion(t, w), "a supported requested version must be echoed")
+	}
+}
+
+func TestServePublic_InitializeAnswersUnsupportedVersionWithNewestSupported(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "negotiate-down-mcp")
+
+	supported := mcpversions.SupportedHostedToolset()
+	newest := supported[len(supported)-1]
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion(mcpversions.Version20260728), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, newest, answeredProtocolVersion(t, w), "an unsupported requested version is answered with the newest supported one")
+
+	w, err = servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion("1999-12-31"), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, newest, answeredProtocolVersion(t, w), "an unrecognized requested version is answered with the newest supported one")
+}
+
+// TestServePublic_InitializeAnswersAbsentVersionWithDefault pins that the
+// no-version cohort is not handed the ceiling: a handshake naming no revision
+// is answered the spec's unversioned default.
+func TestServePublic_InitializeAnswersAbsentVersionWithDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "negotiate-absent-mcp")
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion(""), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, mcpversions.DefaultInEffect, answeredProtocolVersion(t, w))
+}
+
+// TestServePublic_InitializeBodyWinsOverNonconformingHeader pins which source
+// negotiation reads when a nonconforming client stamps MCP-Protocol-Version on
+// the initialize request itself, where the header is not defined: the body's
+// requested version is the negotiation, so the header must not influence the
+// answer.
+func TestServePublic_InitializeBodyWinsOverNonconformingHeader(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "negotiate-header-mcp")
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion(mcpversions.Version20251125), "", map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20250618,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, mcpversions.Version20251125, answeredProtocolVersion(t, w))
 }

--- a/server/internal/mcp/sessionclientinfo.go
+++ b/server/internal/mcp/sessionclientinfo.go
@@ -111,14 +111,15 @@ func resolveClientIdentity(ctx context.Context, logger *slog.Logger, store sessi
 	// predating that header, which is why it is best-effort by design.
 	//
 	// The stored value is what the client asked for at initialize. The
-	// negotiated half is deterministic rather than stored: this store is only
-	// written by the hosted toolset handler, which answers
-	// ServedHostedToolset unconditionally. Recording it here is what gives
-	// pre-header clients a negotiated attribute at all, since the middleware
-	// has no header to read for them. A session that handshaked before a
-	// change to that constant would be attributed the current value, which is
-	// the one inaccuracy the determinism costs.
-	recordMCPProtocolVersionSpan(ctx, info.ProtocolVersion, mcpversions.ServedHostedToolset)
+	// negotiated half is derived rather than stored: this store is only
+	// written by the hosted toolset handler, whose negotiation is a pure
+	// function of the requested version and the surface's supported set, so
+	// re-running it here reproduces the handshake's answer. Recording it is
+	// what gives pre-header clients a negotiated attribute at all, since the
+	// middleware has no header to read for them. A session that handshaked
+	// before a change to the supported set would be attributed the answer the
+	// current set produces, which is the one inaccuracy the derivation costs.
+	recordMCPProtocolVersionSpan(ctx, info.ProtocolVersion, mcpversions.Negotiate(info.ProtocolVersion, mcpversions.SupportedHostedToolset()))
 
 	return identity, info.ProtocolVersion
 }

--- a/server/internal/mcp/sessionclientinfo_internal_test.go
+++ b/server/internal/mcp/sessionclientinfo_internal_test.go
@@ -319,7 +319,9 @@ func TestResolveClientIdentity_DerivesDowngradedNegotiatedVersion(t *testing.T) 
 		got[string(kv.Key)] = kv.Value.AsString()
 	}
 
-	supported := mcpversions.SupportedHostedToolset()
+	// The expected value is pinned rather than derived from the supported
+	// set, so raising the ceiling breaks this test and forces choosing a new
+	// out-of-set stored version that keeps the downgrade arm exercised.
 	require.Equal(t, mcpversions.Version20260728, got[string(attr.McpRequestedProtocolVersionKey)])
-	require.Equal(t, supported[len(supported)-1], got[string(attr.McpNegotiatedProtocolVersionKey)])
+	require.Equal(t, mcpversions.Version20251125, got[string(attr.McpNegotiatedProtocolVersionKey)])
 }

--- a/server/internal/mcp/sessionclientinfo_internal_test.go
+++ b/server/internal/mcp/sessionclientinfo_internal_test.go
@@ -65,7 +65,7 @@ func newClientIdentityFixture(t *testing.T) (*fakeClientInfoStore, *mcpInputs) {
 		toolVariationsGroupID: nil,
 		mcpServerID:           nil,
 		tags:                  nil,
-		protocolVersionHeader: "",
+		protocolVersion:       mcpversions.Resolve("", mcpversions.SupportedHostedToolset()),
 	}
 }
 
@@ -285,6 +285,41 @@ func TestResolveClientIdentity_StampsBothProtocolVersions(t *testing.T) {
 	}
 
 	require.Equal(t, mcpversions.Version20241105, got[string(attr.McpRequestedProtocolVersionKey)])
-	require.Equal(t, mcpversions.ServedHostedToolset, got[string(attr.McpNegotiatedProtocolVersionKey)],
-		"this surface answers its served constant, so the negotiated half is deterministic here")
+	require.Equal(t, mcpversions.Version20241105, got[string(attr.McpNegotiatedProtocolVersionKey)],
+		"negotiation echoes a supported requested version, so the derived negotiated half matches the handshake's answer")
+}
+
+// TestResolveClientIdentity_DerivesDowngradedNegotiatedVersion covers the
+// derivation's downgrade arm: a session whose handshake requested a revision
+// outside the supported set was answered the newest supported one, and the
+// replayed negotiated attribute must reproduce that answer rather than echo
+// the stored request.
+func TestResolveClientIdentity_DerivesDowngradedNegotiatedVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	store, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3", mcpversions.Version20260728)
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	spanCtx, span := provider.Tracer("test").Start(ctx, "tools/call")
+	resolveClientIdentity(spanCtx, logger, store, payload, nil)
+	span.End()
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+
+	got := map[string]string{}
+	for _, kv := range ended[0].Attributes() {
+		got[string(kv.Key)] = kv.Value.AsString()
+	}
+
+	supported := mcpversions.SupportedHostedToolset()
+	require.Equal(t, mcpversions.Version20260728, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.Equal(t, supported[len(supported)-1], got[string(attr.McpNegotiatedProtocolVersionKey)])
 }

--- a/server/internal/mcp/types.go
+++ b/server/internal/mcp/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 )
 
 var (
@@ -97,12 +98,12 @@ func (m *McpInputs) toInternal() *mcpInputs {
 		apiKeyID:         m.APIKeyID,
 		// Internal clients (agent workflows) always use the project-default
 		// variation group, never filter by tag, have no fronting mcp_servers
-		// row to record, and carry no HTTP request to read a protocol version
-		// header from.
+		// row to record, and carry no HTTP request to declare a protocol
+		// version, so they resolve to the unversioned default.
 		toolVariationsGroupID: nil,
 		mcpServerID:           nil,
 		tags:                  nil,
-		protocolVersionHeader: "",
+		protocolVersion:       mcpversions.Resolve("", mcpversions.SupportedHostedToolset()),
 		toolSelection:         nil,
 	}
 }

--- a/server/internal/remotemcp/verifyurl.go
+++ b/server/internal/remotemcp/verifyurl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
@@ -41,7 +42,15 @@ const (
 	// sent to the remote URL. Identical to what the MCP Go SDK would emit for
 	// a minimal `mcp.InitializeParams` with our `clientInfo`; hardcoded so the
 	// probe does not depend on package-init marshalling.
-	verifyURLBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"roots":{}},"clientInfo":{"name":"gram-verify","version":"1"},"protocolVersion":"2025-06-18"}}`
+	//
+	// The requested protocol version is a Gram-as-client choice, deliberately
+	// independent of the supported sets Gram-as-server negotiates against: the
+	// probe only needs the upstream to answer some valid MCP message, and it
+	// never inspects which revision the upstream picks. Probing upstreams that
+	// speak only 2026-07-28 — a revision with no `initialize` at all — needs a
+	// modern-first probe with this request as the legacy fallback, which is
+	// future work rather than a version bump here.
+	verifyURLBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"roots":{}},"clientInfo":{"name":"gram-verify","version":"1"},"protocolVersion":"` + mcpversions.Version20250618 + `"}}`
 )
 
 // VerifyRemoteMcpURL issues an MCP initialize request against rawURL and


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-558/feat-negotiate-the-mcp-protocol-version-at-initialize-instead-of

Both MCP-serving surfaces previously answered a pinned `2025-03-26` regardless of what the client requested, so 99.3% of handshakes were told a revision they did not ask for, and features Gram already ships (`structuredContent`, batch rejection) were advertised under a revision in which they do not exist.

`initialize` now echoes a supported requested revision, answers anything else with the newest supported one, and treats an absent version as `2025-03-26` per the spec's rule for unversioned requests rather than handing the most fragile cohort the ceiling. The per-surface supported sets span `2024-11-05` through `2025-11-25`; `2026-07-28` is deliberately excluded because adding it is the entire behavioral switch for the advertise work (AIS-573).

Each request also resolves a `Resolution{Declared, InEffect}` pair once at handler entry: `Declared` feeds the census so the `none`/`other` cohorts stay countable, while `InEffect` is the single value future version-conditional behavior reads (AIS-559, AIS-561, AIS-567, AIS-568, AIS-571). A declaration outside the supported set resolves to the default for now, over-serving downward until AIS-559 replaces that arm with `UnsupportedProtocolVersionError` (`-32022`).

Two telemetry discontinuities land with the deploy: `gram.mcp.requested_protocol_version` and `gram.mcp.negotiated_protocol_version` stop being identical for most traffic (the `mcp.initialize` counter's negotiated dimension fans out from one value to four), and sessions that handshaked under the old pin are retro-attributed the answer negotiation now produces.

The verification probe still sends `2025-06-18`, now via the shared constant; probing `2026-07-28`-only upstreams is AIS-579.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Negotiates the MCP protocol version at initialize for hosted and platform servers. Previously both always answered 2025-03-26; now we echo a supported request, fall back to the newest supported when unsupported, and default an absent version to 2025-03-26 to match the spec and correctly label shipped features. Aligns with AIS-558.

- Adds per-surface supported sets `mcpversions.SupportedHostedToolset()` and `mcpversions.SupportedPlatformToolset()` spanning `2024-11-05` → `2025-11-25`; excludes `2026-07-28`.
- Introduces `mcpversions.DefaultInEffect`, `mcpversions.Resolution{Declared, InEffect}`, and `mcpversions.Resolve(...)`/`mcpversions.Negotiate(...)`; `initialize` overwrites `InEffect` with the negotiated answer, and the body’s `protocolVersion` wins over any `MCP-Protocol-Version` header on `initialize`.
- Telemetry and behavior split: census records `Resolution.Declared`; handlers branch on `Resolution.InEffect`. Sessions without headers derive negotiated values; internal callers resolve to the default.
- Updates hosted and platform `initialize` to return the negotiated version; `tools/list` and session identity replay read from `Resolution`. 
- Keeps the remote URL probe at `2025-06-18` via `mcpversions.Version20250618`; probing `2026-07-28`-only upstreams remains deferred (AIS-579). Tests add negotiation coverage and pin downgrade/fallback expectations to `2025-11-25` so ceiling changes fail loudly.

<sup>Written for commit 33c9845a10d66323f58f8913a8ceda1c71b2f063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

