### PR TITLE
fix: disable trial runtime gates after demotion

### DIFF
--- a/.changeset/trial-runtime-gates.md
+++ b/.changeset/trial-runtime-gates.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Disable trial runtime gates after demotion and restore them when the trial is re-armed or converted to PAYG.

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
@@ -319,10 +320,11 @@ func newAdminCommand() *cli.Command {
 
 			adminWorkOSClient := newAdminWorkOSOrganizationCreator(ctx, logger, guardianPolicy, c)
 			adminTrialKeyReviver := newAdminTrialKeyReviver(ctx, logger, tracerProvider, guardianPolicy, db, redisClient, c)
+			productFeatures := productfeatures.NewClient(logger, tracerProvider, db, redisClient)
 			loopsWorkflowClient := loops.NewWorkflowClient(ctx, logger, guardianPolicy, c.String("loops-api-key"))
 			trialNotifier := trialemails.NewService(db, loopsWorkflowClient, logger, c.String("site-url"))
 
-			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminTrialKeyReviver, trialNotifier))
+			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminTrialKeyReviver, trialNotifier, productFeatures))
 
 			srv := &http.Server{
 				Addr:              c.String("address"),

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -61,7 +61,8 @@ type Service struct {
 	// CreateOrganization reports rather than working around.
 	workos orgprovision.WorkOSOrganizationCreator
 
-	openRouter TrialKeyReviver
+	openRouter      TrialKeyReviver
+	productFeatures *productfeatures.Client
 
 	audit *audit.Logger
 
@@ -109,6 +110,7 @@ func NewService(
 	workosClient orgprovision.WorkOSOrganizationCreator,
 	openRouter TrialKeyReviver,
 	trialNotifier trialemails.Notifier,
+	productFeatures *productfeatures.Client,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("admin"))
 
@@ -136,7 +138,8 @@ func NewService(
 		allowedOrigins: allowedOrigins,
 		workos:         workosClient,
 		openRouter:     openRouter,
-		audit:          audit.NewLogger(),
+		productFeatures: productFeatures,
+		audit:           audit.NewLogger(),
 		loginStates: cache.NewTypedObjectCache[LoginState](
 			logger.With(attr.SlogCacheNamespace("admin_login_state")),
 			adminCache,
@@ -1061,6 +1064,10 @@ func (s *Service) rearmTrialLocked(
 		return nil, oops.E(oops.CodeUnexpected, err, "restore organization from trial").LogError(ctx, logger)
 	}
 
+	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, payload.ID, true); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "restore trial runtime features").LogError(ctx, logger)
+	}
+
 	actor, operatorEmail := adminActor(ctx)
 	if err := s.audit.LogOrganizationEnterpriseTrialRearmed(ctx, tx, audit.LogOrganizationEnterpriseTrialRearmedEvent{
 		OrganizationID: payload.ID,
@@ -1082,6 +1089,9 @@ func (s *Service) rearmTrialLocked(
 	}
 
 	s.recapRevivedKeys(ctx, logger, lockedKeys, payload.ID, uncapped)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		s.productFeatures.UpdateFeatureCache(ctx, payload.ID, feature, true)
+	}
 
 	// Speakeasy-only, and the only place the email meets the entry's subject.
 	logger.InfoContext(ctx, "re-armed enterprise trial",

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -129,15 +129,15 @@ func NewService(
 	)
 
 	return &Service{
-		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/admin"),
-		logger:         logger,
-		db:             db,
-		oidc:           oidcClient,
-		sessions:       sessionStore,
-		verifier:       NewVerifier(logger, sessionStore, oidcClient, adminCache),
-		allowedOrigins: allowedOrigins,
-		workos:         workosClient,
-		openRouter:     openRouter,
+		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/admin"),
+		logger:          logger,
+		db:              db,
+		oidc:            oidcClient,
+		sessions:        sessionStore,
+		verifier:        NewVerifier(logger, sessionStore, oidcClient, adminCache),
+		allowedOrigins:  allowedOrigins,
+		workos:          workosClient,
+		openRouter:      openRouter,
 		productFeatures: productFeatures,
 		audit:           audit.NewLogger(),
 		loginStates: cache.NewTypedObjectCache[LoginState](

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -213,11 +215,32 @@ func seedDemotedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, org
 	return endsAt
 }
 
+func seedDisabledTrialRuntimeFeatures(t *testing.T, ctx context.Context, svc *Service, conn *pgxpool.Pool, orgID string) {
+	t.Helper()
+	q := featurerepo.New(conn)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		_, err := q.EnableFeature(ctx, featurerepo.EnableFeatureParams{
+			OrganizationID: orgID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+		_, err = q.DeleteFeature(ctx, featurerepo.DeleteFeatureParams{
+			OrganizationID: orgID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+		enabled, err := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, err)
+		require.False(t, enabled)
+	}
+}
+
 func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn, provisioner := newRearmService(t)
 	seedDemotedTrial(t, ctx, conn, "org_rearm", "enterprise")
+	seedDisabledTrialRuntimeFeatures(t, ctx, svc, conn, "org_rearm")
 	beforeTrial := readTrial(t, ctx, conn, "org_rearm")
 	beforeOrg := readOrgState(t, ctx, conn, "org_rearm")
 
@@ -237,6 +260,11 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	state := readOrgState(t, ctx, conn, "org_rearm")
 	require.Equal(t, "enterprise", state.GramAccountType)
 	require.True(t, state.Whitelisted, "a re-armed organization must be whitelisted again")
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, err := svc.productFeatures.IsFeatureEnabled(ctx, "org_rearm", feature)
+		require.NoError(t, err)
+		require.Truef(t, enabled, "re-arm should restore %s", feature)
+	}
 
 	after := readTrial(t, ctx, conn, "org_rearm")
 	require.False(t, after.DemotedAt.Valid, "re-arming must clear demoted_at")

--- a/server/internal/admin/setup_test.go
+++ b/server/internal/admin/setup_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/organizations/orgprovision"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
@@ -47,12 +48,15 @@ func newTestAdminService(t *testing.T) (context.Context, *Service, *pgxpool.Pool
 	logger := testenv.NewLogger(t)
 	conn, err := infra.CloneTestDatabase(t, "admintestdb")
 	require.NoError(t, err)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
 
 	svc := &Service{
-		logger: logger,
-		db:     conn,
-		audit:  audit.NewLogger(),
-		trial:  trialemails.NoopNotifier{},
+		logger:          logger,
+		db:              conn,
+		audit:           audit.NewLogger(),
+		trial:           trialemails.NoopNotifier{},
+		productFeatures: productfeatures.NewClient(logger, testenv.NewTracerProvider(t), conn, redisClient),
 	}
 
 	return ctx, svc, conn

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -435,6 +435,7 @@ func NewActivities(
 			openrouterProvisioner,
 			auditLogger,
 			&TemporalTrialEmailNotifier{TemporalEnv: temporalEnv},
+			productFeatures,
 		),
 		evaluateOrgSpendRules: spend_rules.NewEvaluateOrg(logger, tracerProvider, db, spendRulesCH, cacheAdapter, features),
 		// The judge draws on the same per-(org, model) bucket and the same

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities/keybillinglock"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
@@ -20,12 +21,13 @@ import (
 )
 
 type DemoteExpiredTrials struct {
-	logger     *slog.Logger
-	db         *pgxpool.Pool
-	repo       *trialsrepo.Queries
-	openRouter openrouter.Provisioner
-	audit      *audit.Logger
-	notifier   trialemails.Notifier
+	logger          *slog.Logger
+	db              *pgxpool.Pool
+	repo            *trialsrepo.Queries
+	openRouter      openrouter.Provisioner
+	audit           *audit.Logger
+	notifier        trialemails.Notifier
+	productFeatures *productfeatures.Client
 }
 
 func NewDemoteExpiredTrials(
@@ -34,14 +36,16 @@ func NewDemoteExpiredTrials(
 	openRouterProvisioner openrouter.Provisioner,
 	auditLogger *audit.Logger,
 	notifier trialemails.Notifier,
+	productFeatures *productfeatures.Client,
 ) *DemoteExpiredTrials {
 	return &DemoteExpiredTrials{
-		logger:     logger.With(attr.SlogComponent("demote_expired_trials")),
-		db:         db,
-		repo:       trialsrepo.New(db),
-		openRouter: openRouterProvisioner,
-		audit:      auditLogger,
-		notifier:   notifier,
+		logger:          logger.With(attr.SlogComponent("demote_expired_trials")),
+		db:              db,
+		repo:            trialsrepo.New(db),
+		openRouter:      openRouterProvisioner,
+		audit:           auditLogger,
+		notifier:        notifier,
+		productFeatures: productFeatures,
 	}
 }
 
@@ -100,6 +104,10 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 		}
 	}
 
+	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, dbtx, args.OrganizationID, false); err != nil {
+		return fmt.Errorf("disable trial runtime features: %w", err)
+	}
+
 	organization, err := tx.DemoteOrganizationToFree(ctx, args.OrganizationID)
 	if err != nil {
 		return fmt.Errorf("demote organization to free: %w", err)
@@ -120,6 +128,9 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit trial demotion: %w", err)
+	}
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		d.productFeatures.UpdateFeatureCache(ctx, args.OrganizationID, feature, false)
 	}
 	if d.notifier != nil {
 		if err := d.notifier.TrialInactive(ctx, args.OrganizationID); err != nil {

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -3,6 +3,7 @@ package activities_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
@@ -63,12 +66,13 @@ func (p *trialProvisioner) DisableAPIKeyWithDB(ctx context.Context, _ openrouter
 }
 
 type trialTestInstance struct {
-	conn        *pgxpool.Pool
-	trials      *trialsrepo.Queries
-	orgs        *orgrepo.Queries
-	provisioner *trialProvisioner
-	notifier    *recordingTrialNotifier
-	activity    *activities.DemoteExpiredTrials
+	conn            *pgxpool.Pool
+	trials          *trialsrepo.Queries
+	orgs            *orgrepo.Queries
+	productFeatures *productfeatures.Client
+	provisioner     *trialProvisioner
+	notifier        *recordingTrialNotifier
+	activity        *activities.DemoteExpiredTrials
 }
 
 func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
@@ -81,19 +85,24 @@ func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
 
 	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), disabled: nil, failWith: nil}
 	notifier := &recordingTrialNotifier{inactive: nil}
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	productFeatures := productfeatures.NewClient(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, redisClient)
 
 	return ctx, &trialTestInstance{
-		conn:        conn,
-		trials:      trialsrepo.New(conn),
-		orgs:        orgrepo.New(conn),
-		provisioner: provisioner,
-		notifier:    notifier,
+		conn:            conn,
+		trials:          trialsrepo.New(conn),
+		orgs:            orgrepo.New(conn),
+		productFeatures: productFeatures,
+		provisioner:     provisioner,
+		notifier:        notifier,
 		activity: activities.NewDemoteExpiredTrials(
 			testenv.NewLogger(t),
 			conn,
 			provisioner,
 			audit.NewLogger(),
 			notifier,
+			productFeatures,
 		),
 	}
 }
@@ -135,6 +144,25 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	ctx, ti := newTrialTestInstance(t)
 	endsAt := time.Now().Add(-time.Hour).UTC()
 	orgID := newTrialOrg(t, ctx, ti, endsAt)
+	tx := testenv.BeginTx(t, ctx, ti.conn)
+	require.NoError(t, productfeatures.SeedOrganizationDefaultsTx(ctx, tx, orgID))
+	q := featurerepo.New(tx)
+	features := slices.Concat(productfeatures.TrialRuntimeFeatures, []productfeatures.Feature{
+		productfeatures.FeatureSSO,
+		productfeatures.FeatureAuthzChallengeLogging,
+	})
+	for _, feature := range features {
+		_, err := q.EnableFeature(ctx, featurerepo.EnableFeatureParams{
+			OrganizationID: orgID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, tx.Commit(ctx))
+	for _, feature := range features {
+		_, err := ti.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, err)
+	}
 
 	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)
@@ -156,6 +184,19 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 
 	require.ElementsMatch(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.disabled)
 	require.Equal(t, []string{orgID}, ti.notifier.inactive)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, err := ti.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, err)
+		require.Falsef(t, enabled, "demotion should disable %s", feature)
+	}
+	for _, feature := range []productfeatures.Feature{
+		productfeatures.FeatureSSO,
+		productfeatures.FeatureAuthzChallengeLogging,
+	} {
+		enabled, err := ti.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, err)
+		require.Truef(t, enabled, "demotion should preserve %s", feature)
+	}
 
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
 	require.NoError(t, err)

--- a/server/internal/productfeatures/bundle_test.go
+++ b/server/internal/productfeatures/bundle_test.go
@@ -40,6 +40,47 @@ func TestSeedEnterpriseTrialBundleTx_Idempotent(t *testing.T) {
 	}
 }
 
+func TestSetTrialRuntimeFeaturesTx_TogglesOnlyRuntimeFeatures(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestProductFeaturesService(t)
+	organizationID := activeOrganizationID(t, ctx)
+	seedOrganization(t, ctx, ti.conn, organizationID)
+
+	tx := testenv.BeginTx(t, ctx, ti.conn)
+	require.NoError(t, productfeatures.SeedOrganizationDefaultsTx(ctx, tx, organizationID))
+	require.NoError(t, productfeatures.SeedEnterpriseTrialBundleTx(ctx, tx, organizationID))
+	require.NoError(t, tx.Commit(ctx))
+
+	assertEnabled := func(want bool) {
+		t.Helper()
+		q := featurerepo.New(ti.conn)
+		for _, feature := range productfeatures.TrialRuntimeFeatures {
+			enabled, err := q.IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+				OrganizationID: organizationID,
+				FeatureName:    string(feature),
+			})
+			require.NoError(t, err)
+			require.Equalf(t, want, enabled, "feature %s", feature)
+		}
+		ssoEnabled, err := q.IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(productfeatures.FeatureSSO),
+		})
+		require.NoError(t, err)
+		require.True(t, ssoEnabled)
+	}
+
+	for range 2 {
+		for _, enabled := range []bool{false, true} {
+			tx := testenv.BeginTx(t, ctx, ti.conn)
+			require.NoError(t, productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, organizationID, enabled))
+			require.NoError(t, tx.Commit(ctx))
+			assertEnabled(enabled)
+		}
+	}
+}
+
 func TestSeedPaygEntitlementsTxPreservesExplicitDisable(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -209,6 +209,42 @@ var EnterpriseTrialBundle = []Feature{
 	FeatureCustomerManagedEncryptionKeys,
 }
 
+// TrialRuntimeFeatures are disabled when an enterprise trial expires and
+// restored when the organization returns to a paid or trial state.
+var TrialRuntimeFeatures = []Feature{
+	FeatureLogs,
+	FeatureToolIOLogs,
+	FeatureSessionCapture,
+	FeaturePlatformMCP,
+}
+
+// SetTrialRuntimeFeaturesTx toggles the runtime capabilities whose trial state
+// must not outlive an expired trial. It does not modify any other entitlement.
+func SetTrialRuntimeFeaturesTx(ctx context.Context, tx pgx.Tx, organizationID string, enabled bool) error {
+	q := repo.New(tx)
+	for _, feature := range TrialRuntimeFeatures {
+		if enabled {
+			if _, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
+				OrganizationID: organizationID,
+				FeatureName:    string(feature),
+			}); err != nil {
+				return fmt.Errorf("enable %s: %w", feature, err)
+			}
+			continue
+		}
+
+		if _, err := q.DeleteFeature(ctx, repo.DeleteFeatureParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		}); errors.Is(err, pgx.ErrNoRows) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("disable %s: %w", feature, err)
+		}
+	}
+	return nil
+}
+
 // SeedEnterpriseTrialBundleTx enables the enterprise trial entitlements in the
 // caller's transaction. Idempotent, so a replayed signup is safe. The feature
 // cache is left untouched: the organization is created in the same transaction,

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -448,13 +448,19 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 	}
 
 	newlyEnabled := []productfeatures.Feature(nil)
-	if _, err := trialsrepo.New(tx).GetTrial(ctx, organizationID); errors.Is(err, pgx.ErrNoRows) {
+	trial, err := trialsrepo.New(tx).GetTrial(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
 		newlyEnabled, err = productfeatures.SeedPaygEntitlementsTx(ctx, tx, organizationID)
 		if err != nil {
 			return stripeWebhookResult{}, fmt.Errorf("seed PAYG entitlements: %w", err)
 		}
 	} else if err != nil {
 		return stripeWebhookResult{}, fmt.Errorf("read trial state for PAYG activation: %w", err)
+	} else if trial.DemotedAt.Valid {
+		if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, organizationID, true); err != nil {
+			return stripeWebhookResult{}, fmt.Errorf("restore demoted trial runtime features: %w", err)
+		}
+		newlyEnabled = append(newlyEnabled, productfeatures.TrialRuntimeFeatures...)
 	}
 
 	anchorDay := conv.SafeInt32(checkout.BillingCycleAnchor.UTC().Day())

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1057,6 +1057,62 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.NotContains(t, string(record.AfterSnapshot), "subscription_activation")
 }
 
+func TestStripeCheckoutCompletionRestoresDemotedTrialRuntimeFeatures(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	featureCache := configurePaygCheckout(t, service, "event_demoted_trial", "subscription_demoted_trial", "trialing")
+	ctx := t.Context()
+	tx := testenv.BeginTx(t, ctx, db)
+	q := featurerepo.New(tx)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		_, err := q.EnableFeature(ctx, featurerepo.EnableFeatureParams{
+			OrganizationID: stripeWebhookOrganizationID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, tx.Commit(ctx))
+
+	err := trialsrepo.New(db).CreateTrial(ctx, trialsrepo.CreateTrialParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		Tier:           "enterprise",
+		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(-time.Hour), Valid: true},
+	})
+	require.NoError(t, err)
+	_, err = trialsrepo.New(db).MarkTrialDemoted(ctx, stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		_, err := featurerepo.New(db).DeleteFeature(ctx, featurerepo.DeleteFeatureParams{
+			OrganizationID: stripeWebhookOrganizationID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+	}
+
+	preparedAt := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
+	_, err = service.prepareStripeCheckoutIntent(
+		ctx,
+		stripeWebhookOrganizationID,
+		"customer_placeholder",
+		preparedAt,
+		newStripeCheckoutIntent(stripeWebhookOrganizationID, preparedAt, nil),
+		pgtype.Text{String: "", Valid: false},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "demoted_trial").Code)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, err := featurerepo.New(db).IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+			OrganizationID: stripeWebhookOrganizationID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+		require.Truef(t, enabled, "PAYG activation should restore %s", feature)
+	}
+	require.ElementsMatch(t, productfeatures.TrialRuntimeFeatures, featureCache.snapshot())
+}
+
 func TestStripeCheckoutCompletionPreservesTrialFeatureChoices(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Disable session capture, Logs, Tool I/O Logs, and Platform MCP when an enterprise trial is demoted.
- Restore these runtime gates on trial re-arm and demoted-trial PAYG conversion.
- Refresh the feature cache after committed lifecycle changes.

## Testing

- `mise run test:server`
- `mise lint:server`

Fixes AGE-3197

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables trial runtime gates immediately when an enterprise trial is demoted and restores them on trial re‑arm or on PAYG conversion of a demoted trial. Previously, session capture, logs/telemetry, tool I/O logs, and platform MCP could continue after demotion; now they stop within the demotion transaction and feature caches refresh for instant effect.

- Adds `productfeatures.TrialRuntimeFeatures` and `productfeatures.SetTrialRuntimeFeaturesTx` to toggle logs, tool I/O logs, session capture, and platform MCP in one DB transaction; leaves non‑runtime entitlements (e.g., SSO) unchanged.
- Demotion path: disables runtime features in‑transaction, then updates the feature cache; continues to disable OpenRouter keys and send the inactive‑trial email; does not change SSO, SCIM, or other enterprise features.
- Trial re‑arm: restores runtime features in‑transaction and updates the feature cache.
- PAYG activation for demoted trials: restores runtime features and includes them in the cache update alongside PAYG entitlements.
- Wires a `productfeatures.Client` into `admin.NewService` and demotion activities to perform cache updates; adds focused tests across admin, activities, product features, and Stripe webhook paths.
- No data/schema migrations; behavior applies on the next demotion, re‑arm, or PAYG activation event. Fulfills Linear AGE‑3197.

<sup>Written for commit 6e2b67495aa1bc96a0f3b4b8f3a5a55da1b0f4ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

