### PR TITLE
feat: move dismissed risk findings listing to ClickHouse

### DIFF
--- a/server/internal/risk/chrepo/dismissed.go
+++ b/server/internal/risk/chrepo/dismissed.go
@@ -1,0 +1,161 @@
+package chrepo
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/google/uuid"
+)
+
+// ListDismissedRiskFindingsParams scopes one page of the Dismissed listing to
+// one tenant. Cursor* resume strictly after a prior page's last row, keyed on
+// the same (suppression time, id) pair the listing sorts by.
+type ListDismissedRiskFindingsParams struct {
+	OrganizationID string
+	ProjectID      string
+	CursorTime     *time.Time
+	CursorID       uuid.NullUUID
+	Limit          uint64
+}
+
+// DismissedRiskFindingRow is one row of the Dismissed listing: the Risk Events
+// listing's row shape — same projection, same store-side redaction, the raw
+// match never reaches this store — plus the suppression time the tab sorts and
+// paginates on.
+type DismissedRiskFindingRow struct {
+	RiskFindingListRow
+
+	// SuppressedAt is when the finding was dismissed: excluded_at, falling
+	// back to the legacy false_positive_at on rows the suppression backfill
+	// did not reach.
+	SuppressedAt time.Time
+}
+
+// dismissedStateCond selects the findings the Dismissed tab lists: user and
+// automated dismissals. Rule-suppressed findings are deliberately absent —
+// the tab shows what a person dismissed and can restore, and rule suppression
+// is managed from the exclusions surface instead.
+//
+// The second disjunct is the safety margin for rows the suppression backfill
+// did not reach: a pre-convergence dismissal carries only false_positive_at
+// and no excluded_reason at all. Both disjuncts guarantee suppressedAtExpr
+// resolves non-null — excluded_reason is only ever written alongside
+// excluded_at — which is what makes it usable as a total sort and cursor key.
+const dismissedStateCond = "(excluded_reason IN ('" + ExcludedReasonManual + "', '" + ExcludedReasonAutomated + "')" +
+	" OR (excluded_reason = '' AND false_positive_at IS NOT NULL))"
+
+// suppressedAtExpr is the effective suppression time: the converged
+// excluded_at, or the legacy false_positive_at for a row that predates the
+// backfill.
+const suppressedAtExpr = "coalesce(excluded_at, false_positive_at)"
+
+// dismissedStateColumns are the suppression columns dismissedStateCond and
+// suppressedAtExpr read off each id's latest copy. They ride along in the
+// dedup subquery's projection only; callers never select them.
+var dismissedStateColumns = []string{"dead_letter_reason", "excluded_reason", "excluded_at", "false_positive_at"}
+
+// dismissedRiskFindingsLatest builds the row source both the list and the count
+// read from: every id in the tenant resolved to its most-recently-inserted
+// copy, then gated on that latest state. innerColumns is what the dedup
+// subquery carries through (the suppression columns are always appended);
+// outerColumns is what the caller selects from it.
+//
+// Dedup must come first for the same reason it does in the Risk Events listing:
+// suppression state changes by appending a newer copy of the row, so gating
+// before the dedup would match a stale copy — here it would keep listing a
+// finding whose dismissal was since undone.
+func dismissedRiskFindingsLatest(p ListDismissedRiskFindingsParams, innerColumns []string, outerColumns ...string) squirrel.SelectBuilder {
+	latest := sq.Select(append(slices.Clone(innerColumns), dismissedStateColumns...)...).
+		From("risk_findings").
+		Where("organization_id = ?", p.OrganizationID).
+		Where("project_id = ?", p.ProjectID).
+		// LIMIT BY takes the first row per key in the current order, so
+		// inserted_at DESC makes that the latest copy.
+		OrderBy("inserted_at DESC").
+		Suffix("LIMIT 1 BY id")
+
+	return sq.Select(outerColumns...).
+		FromSelect(latest, "latest").
+		Where("dead_letter_reason = ''").
+		Where(dismissedStateCond)
+}
+
+// ListDismissedRiskFindings returns one page of dismissed findings, newest
+// suppression first, ordered by (suppression time, id) descending.
+//
+// The cursor is applied AFTER the dedup, unlike the Risk Events listing's
+// plain-id branch: an id's copies share their message_created_at but not their
+// suppression time — the pre-dismissal copy has none at all — so a cursor
+// applied first could drop the copy that carries the state this listing reads.
+func (q *Queries) ListDismissedRiskFindings(ctx context.Context, p ListDismissedRiskFindingsParams) ([]DismissedRiskFindingRow, error) {
+	outerColumns := append(slices.Clone(riskFindingListColumns), suppressedAtExpr+" AS suppressed_at")
+	sb := dismissedRiskFindingsLatest(p, riskFindingListColumns, outerColumns...)
+
+	if p.CursorTime != nil && p.CursorID.Valid {
+		// The cursor timestamp binds as a formatted string through
+		// toDateTime64 because the driver truncates a bound time.Time to whole
+		// seconds. Suppression times written by a SQL projection (the
+		// retroactive reconcile, the offline sweep) keep their sub-second
+		// component, and a truncated cursor would skip every row suppressed
+		// later in the cursor's second.
+		sb = sb.Where("("+suppressedAtExpr+", id) < (toDateTime64(?, 9), ?)", FormatCHTime(*p.CursorTime), p.CursorID.UUID)
+	}
+
+	sb = sb.OrderBy("suppressed_at DESC", "id DESC").Limit(p.Limit)
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build dismissed risk findings list query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query dismissed risk findings list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []DismissedRiskFindingRow
+	for rows.Next() {
+		var row DismissedRiskFindingRow
+		if err := rows.Scan(append(row.scanTargets(), &row.SuppressedAt)...); err != nil {
+			return nil, fmt.Errorf("scan dismissed risk findings list row: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read dismissed risk findings list: %w", err)
+	}
+
+	return out, nil
+}
+
+// CountDismissedRiskFindings is the Dismissed listing's total: the same
+// predicate as ListDismissedRiskFindings over the whole tenant, with no cursor
+// or page bound.
+func (q *Queries) CountDismissedRiskFindings(ctx context.Context, p ListDismissedRiskFindingsParams) (uint64, error) {
+	query, args, err := dismissedRiskFindingsLatest(p, []string{"id"}, "count() AS dismissed").ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("build dismissed risk findings count query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("query dismissed risk findings count: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var count uint64
+	if rows.Next() {
+		if err := rows.Scan(&count); err != nil {
+			return 0, fmt.Errorf("scan dismissed risk findings count: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("read dismissed risk findings count: %w", err)
+	}
+
+	return count, nil
+}

--- a/server/internal/risk/chrepo/list.go
+++ b/server/internal/risk/chrepo/list.go
@@ -47,6 +47,29 @@ type ListRiskFindingsParams struct {
 	Limit          uint64
 }
 
+// riskFindingListColumns is the projection every findings listing serves, in
+// RiskFindingListRow's scan order. The Dismissed listing (dismissed.go) selects
+// the same set so both tabs render from one row shape.
+var riskFindingListColumns = []string{
+	"id",
+	"message_created_at",
+	"chat_message_id",
+	"content_part_id",
+	"chat_id",
+	"external_user_id",
+	"assistant_id",
+	"risk_policy_id",
+	"risk_policy_version",
+	"rule_id",
+	"description",
+	"source",
+	"confidence",
+	"tags",
+	"start_pos",
+	"end_pos",
+	"match_redacted",
+}
+
 // RiskFindingListRow is one listing row served from ClickHouse. The match is
 // only ever the precomputed redacted display string — the raw value never
 // reaches this store.
@@ -68,6 +91,31 @@ type RiskFindingListRow struct {
 	StartPos          int32
 	EndPos            int32
 	MatchRedacted     string
+}
+
+// scanTargets returns the row's fields in riskFindingListColumns order. It is
+// what keeps the projection and the scan in lockstep across the two listings
+// that share this row shape.
+func (r *RiskFindingListRow) scanTargets() []any {
+	return []any{
+		&r.ID,
+		&r.MessageCreatedAt,
+		&r.ChatMessageID,
+		&r.ContentPartID,
+		&r.ChatID,
+		&r.ExternalUserID,
+		&r.AssistantID,
+		&r.RiskPolicyID,
+		&r.RiskPolicyVersion,
+		&r.RuleID,
+		&r.Description,
+		&r.Source,
+		&r.Confidence,
+		&r.Tags,
+		&r.StartPos,
+		&r.EndPos,
+		&r.MatchRedacted,
+	}
 }
 
 // listRiskFindingsBase applies the filters shared by the list and count reads
@@ -92,7 +140,17 @@ func listRiskFindingsBase(p ListRiskFindingsParams, columns ...string) (squirrel
 }
 
 // liveStateCond gates the latest copy of a finding to live rows only — not
-// excluded, not marked false positive. Applied after the per-id dedup.
+// suppressed, not marked a false positive. Applied after the per-id dedup.
+//
+// Two columns for one meaning, for the length of the suppression convergence.
+// excluded_at is where every suppression path records itself (exclusion rules,
+// manual dismissals, the offline sweep, with excluded_reason saying which);
+// false_positive_at is the legacy column that predates it. There is no backfill
+// giving the older rows an excluded_at: once the writer convergence is deployed
+// nothing writes a false_positive_at-only row again, and the rows that already
+// carry one expire under the table's 90-day created_at TTL. The contract phase
+// drops this half of the condition, and then the column, once that window
+// closes.
 const liveStateCond = "excluded_at IS NULL AND false_positive_at IS NULL"
 
 // ListRiskFindings returns one page of findings ordered by
@@ -107,26 +165,7 @@ const liveStateCond = "excluded_at IS NULL AND false_positive_at IS NULL"
 // (risk_policy_id, rule_id, tenant-fingerprint) keeping the newest occurrence,
 // which subsumes the id dedup (duplicates share the whole key).
 func (q *Queries) ListRiskFindings(ctx context.Context, p ListRiskFindingsParams) ([]RiskFindingListRow, error) {
-	columns := []string{
-		"id",
-		"message_created_at",
-		"chat_message_id",
-		"content_part_id",
-		"chat_id",
-		"external_user_id",
-		"assistant_id",
-		"risk_policy_id",
-		"risk_policy_version",
-		"rule_id",
-		"description",
-		"source",
-		"confidence",
-		"tags",
-		"start_pos",
-		"end_pos",
-		"match_redacted",
-	}
-	sb, err := listRiskFindingsBase(p, columns...)
+	sb, err := listRiskFindingsBase(p, riskFindingListColumns...)
 	if err != nil {
 		return nil, err
 	}
@@ -174,12 +213,12 @@ func (q *Queries) ListRiskFindings(ctx context.Context, p ListRiskFindingsParams
 		sb = sb.Column("excluded_at").Column("false_positive_at").
 			Column("fingerprint_tenant_hs256").
 			Suffix("LIMIT 1 BY id")
-		grouped := sq.Select(columns...).
+		grouped := sq.Select(riskFindingListColumns...).
 			FromSelect(sb, "latest").
 			Where(liveStateCond).
 			OrderBy("message_created_at DESC", "id DESC").
 			Suffix("LIMIT 1 BY (risk_policy_id, rule_id, " + uniqueMatchKey + ")")
-		outer := sq.Select(columns...).FromSelect(grouped, "deduped")
+		outer := sq.Select(riskFindingListColumns...).FromSelect(grouped, "deduped")
 		if hasCursor {
 			outer = outer.Where(cursorCond, *p.CursorTime, p.CursorID.UUID)
 		}
@@ -199,7 +238,7 @@ func (q *Queries) ListRiskFindings(ctx context.Context, p ListRiskFindingsParams
 		// support, so it renders through the suffix.
 		sb = sb.Column("excluded_at").Column("false_positive_at").
 			Suffix("LIMIT 1 BY id")
-		sb = sq.Select(columns...).
+		sb = sq.Select(riskFindingListColumns...).
 			FromSelect(sb, "latest").
 			Where(liveStateCond).
 			OrderBy("message_created_at DESC", "id DESC").
@@ -220,25 +259,7 @@ func (q *Queries) ListRiskFindings(ctx context.Context, p ListRiskFindingsParams
 	var out []RiskFindingListRow
 	for rows.Next() {
 		var row RiskFindingListRow
-		if err := rows.Scan(
-			&row.ID,
-			&row.MessageCreatedAt,
-			&row.ChatMessageID,
-			&row.ContentPartID,
-			&row.ChatID,
-			&row.ExternalUserID,
-			&row.AssistantID,
-			&row.RiskPolicyID,
-			&row.RiskPolicyVersion,
-			&row.RuleID,
-			&row.Description,
-			&row.Source,
-			&row.Confidence,
-			&row.Tags,
-			&row.StartPos,
-			&row.EndPos,
-			&row.MatchRedacted,
-		); err != nil {
+		if err := rows.Scan(row.scanTargets()...); err != nil {
 			return nil, fmt.Errorf("scan risk findings list row: %w", err)
 		}
 		out = append(out, row)

--- a/server/internal/risk/chrepo/overview.go
+++ b/server/internal/risk/chrepo/overview.go
@@ -46,6 +46,9 @@ func overviewFindings(p RiskOverviewWindowParams, columns ...string) squirrel.Se
 		Where("rn = 1").
 		Where("dead_letter_reason = ''").
 		Where("excluded_at IS NULL").
+		// Legacy suppression column, still filtered until the
+		// false_positive_at-only rows written before the suppression
+		// convergence age out under the table's 90-day TTL.
 		Where("false_positive_at IS NULL")
 }
 

--- a/server/internal/risk/chrepo/signals.go
+++ b/server/internal/risk/chrepo/signals.go
@@ -41,6 +41,9 @@ func signalFindings(p RiskSignalWindowParams, columns ...squirrel.Sqlizer) squir
 		Where("rn = 1").
 		Where("dead_letter_reason = ''").
 		Where("excluded_at IS NULL").
+		// Legacy suppression column, still filtered until the
+		// false_positive_at-only rows written before the suppression
+		// convergence age out under the table's 90-day TTL.
 		Where("false_positive_at IS NULL")
 }
 

--- a/server/internal/risk/chrepo/unmask.go
+++ b/server/internal/risk/chrepo/unmask.go
@@ -100,6 +100,9 @@ func (q *Queries) GetRiskFindingForUnmask(ctx context.Context, p GetRiskFindingF
 		FromSelect(latest, "latest").
 		Where("dead_letter_reason = ''").
 		Where("excluded_at IS NULL").
+		// Legacy suppression column, still filtered until the
+		// false_positive_at-only rows written before the suppression
+		// convergence age out under the table's 90-day TTL.
 		Where("false_positive_at IS NULL")
 
 	query, args, err := sb.ToSql()

--- a/server/internal/risk/false_positive.go
+++ b/server/internal/risk/false_positive.go
@@ -269,6 +269,11 @@ func fpMirrorSurface(source string) string {
 	}
 }
 
+// ListDismissedRiskResults serves the Dismissed tab from ClickHouse: findings
+// whose latest state is a manual or automated dismissal, newest dismissal
+// first. Rows arrive store-side redacted like the Risk Events listing — the raw
+// match never reaches ClickHouse — so results carry MatchRedacted and a nil
+// Match where the Postgres-backed listing returned the raw value.
 func (s *Service) ListDismissedRiskResults(ctx context.Context, payload *gen.ListDismissedRiskResultsPayload) (*gen.ListRiskResultsResult, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
@@ -277,47 +282,70 @@ func (s *Service) ListDismissedRiskResults(ctx context.Context, payload *gen.Lis
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
 	}
+	if s.findingsCH == nil {
+		return nil, oops.E(oops.CodeUnexpected, nil, "dismissed risk results are unavailable").LogError(ctx, s.logger)
+	}
 
 	cursor, err := parseRiskResultsCursor(payload.Cursor)
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid cursor")
 	}
 	pageSize := resolvePageSize(payload.Limit)
-	cursorFalsePositiveAt, cursorID := cursorToParams(cursor)
+	projectID := *authCtx.ProjectID
 
-	totalCount, err := s.repo.CountFalsePositiveRiskResults(ctx, *authCtx.ProjectID)
+	params := chrepo.ListDismissedRiskFindingsParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      projectID.String(),
+		CursorTime:     nil,
+		CursorID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		// resolvePageSize bounds pageSize to [1, 200], so the conversion
+		// cannot wrap.
+		Limit: uint64(conv.SafeInt32(pageSize)) + 1, // #nosec G115 -- non-negative by construction.
+	}
+	if cursor != nil {
+		// The cursor's time component is the suppression time on this listing,
+		// the same slot the Risk Events cursor fills with the message event
+		// time.
+		cursorTime := cursor.MessageCreatedAt
+		params.CursorTime = &cursorTime
+		params.CursorID = uuid.NullUUID{UUID: cursor.ID, Valid: true}
+	}
+
+	totalCount, err := s.findingsCH.CountDismissedRiskFindings(ctx, params)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "count dismissed risk results").LogError(ctx, s.logger)
 	}
 
-	rows, err := s.repo.ListFalsePositiveRiskResults(ctx, repo.ListFalsePositiveRiskResultsParams{
-		ProjectID:             *authCtx.ProjectID,
-		CursorFalsePositiveAt: cursorFalsePositiveAt,
-		CursorID:              cursorID,
-		PageLimit:             conv.SafeInt32(pageSize + 1),
-	})
+	rows, err := s.findingsCH.ListDismissedRiskFindings(ctx, params)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list dismissed risk results").LogError(ctx, s.logger)
 	}
 
+	listRows := make([]chrepo.RiskFindingListRow, 0, len(rows))
+	for _, row := range rows {
+		listRows = append(listRows, row.RiskFindingListRow)
+	}
+	titles, blocks := s.listDisplayEnrichment(ctx, projectID, listRows)
+
 	results := make([]*types.RiskResult, 0, len(rows))
 	var nextCursor *riskResultsCursor
 	for i, row := range rows {
-		chatID := row.ChatID.String()
-		// The Dismissed tab doesn't need durable content-part links, so this is
-		// always the zero NullUUID (see foundRowToResult's block_id comment for
-		// the same convention on tool-call blocks).
-		noContentPartID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
-		result := foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, uuid.Nil, row.ChatMessageID, noContentPartID, &chatID, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.CreatedAt)
-		falsePositiveAt := row.FalsePositiveAt.Time.Format(time.RFC3339)
-		result.FalsePositiveAt = &falsePositiveAt
+		result := chListRowToResult(row.RiskFindingListRow, titles, blocks)
+		// The dashboard renders the dismissal timestamp from this field. It
+		// carries the effective suppression time — excluded_at, or the legacy
+		// false_positive_at for a row the suppression backfill did not reach.
+		result.FalsePositiveAt = new(row.SuppressedAt.UTC().Format(time.RFC3339))
 		results = append(results, result)
 		if i == pageSize {
-			nextCursor = &riskResultsCursor{MessageCreatedAt: row.FalsePositiveAt.Time, ID: row.ID}
+			// Cursor from the LAST RETURNED row (not this extra row): the
+			// next-page predicate is a strict (suppressed_at, id) <, so a
+			// cursor pointing at the extra row would skip it entirely.
+			last := rows[pageSize-1]
+			nextCursor = &riskResultsCursor{MessageCreatedAt: last.SuppressedAt, ID: last.ID}
 		}
 	}
 
-	return s.paginateResults(results, nextCursor, pageSize, totalCount), nil
+	return s.paginateResults(results, nextCursor, pageSize, safeCount(totalCount)), nil
 }
 
 // payloadReason returns the dismissal reason as a plain string, defaulting to

--- a/server/internal/risk/false_positive_test.go
+++ b/server/internal/risk/false_positive_test.go
@@ -2,6 +2,7 @@ package risk_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -13,8 +14,31 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
+
+// chDismissalCopy builds the ClickHouse row mirrorFalsePositiveToClickHouse
+// appends when a result is dismissed: a fresh copy of the finding carrying the
+// suppression on excluded_at/excluded_reason plus the legacy false_positive_at.
+// A zero suppressedAt builds the undo copy instead — same id, no suppression at
+// all — which is what an unmark republish produces.
+func chDismissalCopy(t *testing.T, projectID uuid.UUID, orgID, policyID string, id, chatID, msgID uuid.UUID, suppressedAt time.Time) chrepo.RiskFindingRow {
+	t.Helper()
+
+	created := time.Now().UTC().AddDate(0, 0, -1)
+	row := chListFinding(t, projectID, orgID, chatID, msgID, policyID, created, created, "gitleaks", "aws-access-key-id", "alice@example.com", "AKIA**************LE", "fp-dismissal", "")
+	row.ID = id
+	if !suppressedAt.IsZero() {
+		at := suppressedAt
+		row.ExcludedAt = &at
+		row.ExcludedReason = chrepo.ExcludedReasonManual
+		row.ExcludedDetail = "noise"
+		row.FalsePositiveAt = &at
+	}
+	return row
+}
 
 func TestMarkUnmarkRiskResultsFalsePositive(t *testing.T) {
 	t.Parallel()
@@ -24,19 +48,34 @@ func TestMarkUnmarkRiskResultsFalsePositive(t *testing.T) {
 	ctx = withExactAccessGrants(t, ctx, ti.conn,
 		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
 	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
 
 	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("False Positive Test")})
 	require.NoError(t, err)
 	policyID, err2 := uuid.Parse(policy.ID)
 	require.NoError(t, err2)
 
-	_, msgID := seedChatMessage(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID)
-	seedRiskResult(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, policyID, 1, msgID, true)
+	chatID, msgID := seedChatMessage(t, ti, projectID, orgID)
+	seedRiskResult(t, ti, projectID, orgID, policyID, 1, msgID, true)
 
 	before, err := ti.service.ListRiskResults(ctx, &gen.ListRiskResultsPayload{PolicyID: &policy.ID})
 	require.NoError(t, err)
 	require.Len(t, before.Results, 1)
 	resultID := before.Results[0].ID
+	resultUUID, err := uuid.Parse(resultID)
+	require.NoError(t, err)
+
+	// The dismissed listing reads ClickHouse while the mark/unmark RPCs write
+	// Postgres and republish onto the findings topic. The harness wires
+	// findingsPub as nil, so the mirror never runs here and each state change's
+	// ClickHouse copy is appended by hand — the same rows
+	// mirrorFalsePositiveToClickHouse would produce.
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{
+		chDismissalCopy(t, projectID, orgID, policy.ID, resultUUID, chatID, msgID, time.Time{}),
+	}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	dismissCountBefore, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionRiskResultDismiss)
 	require.NoError(t, err)
@@ -57,18 +96,23 @@ func TestMarkUnmarkRiskResultsFalsePositive(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, afterMark.Results, "dismissed result must not appear in listRiskResults")
 
+	dismissedAt := time.Now().UTC()
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{
+		chDismissalCopy(t, projectID, orgID, policy.ID, resultUUID, chatID, msgID, dismissedAt),
+	}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
 	dismissed, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{})
 	require.NoError(t, err)
 	require.Len(t, dismissed.Results, 1)
 	require.Equal(t, resultID, dismissed.Results[0].ID)
 	require.NotNil(t, dismissed.Results[0].FalsePositiveAt)
+	require.Equal(t, int64(1), dismissed.TotalCount)
 
 	// The reason isn't surfaced on the API type today (no UI sends one yet),
 	// but it must still land in Postgres from the RPC payload.
-	resultUUID, err := uuid.Parse(resultID)
-	require.NoError(t, err)
 	dismissedRows, err := riskrepo.New(ti.conn).ListFalsePositiveRiskResults(ctx, riskrepo.ListFalsePositiveRiskResultsParams{
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: projectID,
 		PageLimit: 10,
 	})
 	require.NoError(t, err)
@@ -95,9 +139,15 @@ func TestMarkUnmarkRiskResultsFalsePositive(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, afterUnmark.Results, 1)
 
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{
+		chDismissalCopy(t, projectID, orgID, policy.ID, resultUUID, chatID, msgID, time.Time{}),
+	}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
 	dismissedAfterUnmark, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{})
 	require.NoError(t, err)
-	require.Empty(t, dismissedAfterUnmark.Results)
+	require.Empty(t, dismissedAfterUnmark.Results, "the undo's ClickHouse copy supersedes the dismissal")
+	require.Equal(t, int64(0), dismissedAfterUnmark.TotalCount)
 }
 
 func TestMarkRiskResultsFalsePositive_RejectsEmptyIDs(t *testing.T) {
@@ -176,13 +226,14 @@ func TestMarkRiskResultsFalsePositive_RejectsBatchTooLarge(t *testing.T) {
 	require.Equal(t, oops.CodeInvalid, oopsErr.Code)
 }
 
-// TestMarkRiskResultsFalsePositive_ContentPartAnchoredFindingIsListable
-// guards against a real regression: ListFalsePositiveRiskResults originally
-// INNER JOINed chat_messages, which silently dropped any dismissed finding
-// anchored to a chat_content_part_id instead (per risk_results_anchor_check,
-// a result carries exactly one of the two) — such a finding could be marked
-// false positive but would never appear in the Dismissed tab, making it
-// permanently unrestorable through the UI.
+// TestMarkRiskResultsFalsePositive_ContentPartAnchoredFindingIsListable keeps
+// a past regression pinned on the ClickHouse listing. A finding anchored to a
+// content part rather than a chat message (per risk_results_anchor_check a
+// result carries exactly one of the two) was once dropped by the Postgres
+// listing's anchor join, leaving it dismissible but never listable and so
+// permanently unrestorable through the UI. ClickHouse carries the anchor as a
+// plain content_part_id column with no join to drop it, and this pins that the
+// result reaches the tab with the anchor intact.
 func TestMarkRiskResultsFalsePositive_ContentPartAnchoredFindingIsListable(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)
@@ -191,18 +242,20 @@ func TestMarkRiskResultsFalsePositive_ContentPartAnchoredFindingIsListable(t *te
 	ctx = withExactAccessGrants(t, ctx, ti.conn,
 		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
 	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
 
 	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Content Part False Positive Test")})
 	require.NoError(t, err)
 	policyID, err := uuid.Parse(policy.ID)
 	require.NoError(t, err)
 
-	chatID, msgID := seedChatMessage(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID)
+	chatID, msgID := seedChatMessage(t, ti, projectID, orgID)
 
 	repo := riskrepo.New(ti.conn)
 	partID, err := repo.CreateChatContentPartForTest(ctx, riskrepo.CreateChatContentPartForTestParams{
 		ChatID:              chatID,
-		ProjectID:           uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		ProjectID:           uuid.NullUUID{UUID: projectID, Valid: true},
 		Kind:                "prompt_attachment",
 		ContentAssetUrl:     "gs://test-bucket/content-part.txt",
 		ParentChatMessageID: uuid.NullUUID{UUID: msgID, Valid: true},
@@ -214,8 +267,8 @@ func TestMarkRiskResultsFalsePositive_ContentPartAnchoredFindingIsListable(t *te
 	match := "SECRET_ATTACHMENT_TOKEN"
 	_, err = repo.InsertRiskResults(ctx, []riskrepo.InsertRiskResultsParams{{
 		ID:                resultID,
-		ProjectID:         *authCtx.ProjectID,
-		OrganizationID:    authCtx.ActiveOrganizationID,
+		ProjectID:         projectID,
+		OrganizationID:    orgID,
 		RiskPolicyID:      policyID,
 		RiskPolicyVersion: 1,
 		ChatMessageID:     uuid.NullUUID{},
@@ -236,18 +289,223 @@ func TestMarkRiskResultsFalsePositive_ContentPartAnchoredFindingIsListable(t *te
 	})
 	require.NoError(t, err)
 
+	// The harness has no findings publisher, so the mirror the mark would
+	// normally trigger is appended by hand. A content-part-anchored finding
+	// carries its anchor in content_part_id with chat_message_id empty.
+	dismissedAt := time.Now().UTC()
+	dismissal := chDismissalCopy(t, projectID, orgID, policy.ID, resultID, chatID, msgID, dismissedAt)
+	dismissal.ChatMessageID = ""
+	dismissal.ContentPartID = partID.String()
+
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{dismissal}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
 	dismissed, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{})
 	require.NoError(t, err)
 	require.Len(t, dismissed.Results, 1, "a content-part-anchored dismissal must still be listable")
 	require.Equal(t, resultID.String(), dismissed.Results[0].ID)
 	require.NotNil(t, dismissed.Results[0].FalsePositiveAt)
+	require.NotNil(t, dismissed.Results[0].ChatContentPartID)
+	require.Equal(t, partID.String(), *dismissed.Results[0].ChatContentPartID)
+	require.Nil(t, dismissed.Results[0].ChatMessageID)
 
 	err = ti.service.UnmarkRiskResultsFalsePositive(ctx, &gen.UnmarkRiskResultsFalsePositivePayload{
 		ResultIds: []string{resultID.String()},
 	})
 	require.NoError(t, err)
 
+	restored := chDismissalCopy(t, projectID, orgID, policy.ID, resultID, chatID, msgID, time.Time{})
+	restored.ChatMessageID = ""
+	restored.ContentPartID = partID.String()
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{restored}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
 	afterUndo, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{})
 	require.NoError(t, err)
 	require.Empty(t, afterUndo.Results)
+}
+
+// TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction drives the
+// ClickHouse-backed Dismissed tab end to end: suppression-time ordering, cursor
+// pagination, the total count, the store-side redaction the tab now inherits
+// from the Risk Events listing, and the predicate's edges — automated sweep
+// rows and legacy false-positive-only rows are listed, while rule suppression,
+// open findings, dead-letter sentinels and other tenants are not.
+func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Dismissed CH Page")})
+	require.NoError(t, err)
+
+	// Relative times: the table's 90-day created_at TTL expires hardcoded
+	// dates at insert once the calendar catches up.
+	base := time.Now().UTC().AddDate(0, 0, -7).Truncate(time.Hour)
+	createdAt := base.Add(4 * time.Hour)
+
+	chatID, msgID := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+
+	finding := func(ruleID, matchRedacted string, messageCreatedAt time.Time) chrepo.RiskFindingRow {
+		return chListFinding(t, projectID, orgID, chatID, msgID, policy.ID, createdAt, messageCreatedAt, "gitleaks", ruleID, "alice@example.com", matchRedacted, "", "")
+	}
+
+	// The newest dismissal, and the only one carrying a user-supplied reason.
+	manualAt := base.Add(9 * time.Hour)
+	manual := finding("secret.github_pat", "AKIA**************LE", base.Add(time.Hour))
+	manual.ExcludedAt = &manualAt
+	manual.ExcludedReason = chrepo.ExcludedReasonManual
+	manual.ExcludedDetail = "noise"
+	manual.FalsePositiveAt = &manualAt
+
+	// Two dismissals sharing one suppression timestamp, straddling the page
+	// boundary below. Ties are the common case, not an exotic one:
+	// InsertRiskFindings binds excluded_at as a time.Time, which the driver
+	// stores at whole-second precision, so a bulk dismiss collapses onto a
+	// single second. Only the cursor's id tiebreak keeps such a pair from
+	// repeating or vanishing across pages.
+	tiedAt := base.Add(8 * time.Hour)
+	tiedA := finding("secret.slack_token", "xoxb****************ab", base.Add(2*time.Hour))
+	tiedA.ExcludedAt = &tiedAt
+	tiedA.ExcludedReason = chrepo.ExcludedReasonAutomated
+	tiedA.ExcludedDetail = "known test fixture"
+
+	tiedB := finding("secret.gcp_api_key", "AIza********************ZY", base.Add(150*time.Minute))
+	tiedB.ExcludedAt = &tiedAt
+	tiedB.ExcludedReason = chrepo.ExcludedReasonManual
+
+	// The oldest: a pre-convergence dismissal that only ever got
+	// false_positive_at, which the predicate's fallback disjunct picks up.
+	legacyAt := base.Add(7 * time.Hour)
+	legacy := finding("secret.aws_secret_key", "wJal********************EY", base.Add(3*time.Hour))
+	legacy.FalsePositiveAt = &legacyAt
+
+	// Not listed: rule suppression belongs to the exclusions surface, an open
+	// finding was never dismissed, and a dead-letter sentinel is not a finding.
+	ruleAt := base.Add(10 * time.Hour)
+	exclusionID := uuid.Must(uuid.NewV7())
+	ruleSuppressed := finding("secret.db_password", "hunt****ter", base.Add(4*time.Hour))
+	ruleSuppressed.ExcludedAt = &ruleAt
+	ruleSuppressed.ExclusionID = &exclusionID
+	ruleSuppressed.ExcludedReason = chrepo.ExcludedReasonRule
+
+	open := finding("secret.stripe_api_key", "sk_l**********ve", base.Add(5*time.Hour))
+
+	deadLetter := finding("", "", base.Add(6*time.Hour))
+	deadLetter.DeadLetterReason = "could-not-analyze"
+	deadLetter.Category = ""
+	deadLetter.ExcludedAt = &manualAt
+	deadLetter.ExcludedReason = chrepo.ExcludedReasonManual
+
+	foreign := chListFinding(t, uuid.New(), "org_"+uuid.NewString(), chatID, msgID, policy.ID, createdAt, base.Add(time.Hour), "gitleaks", "secret.github_pat", "alice@example.com", "AKIA**************LE", "", "")
+	foreign.ExcludedAt = &manualAt
+	foreign.ExcludedReason = chrepo.ExcludedReasonManual
+
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{
+		manual, tiedA, tiedB, legacy, ruleSuppressed, open, deadLetter, foreign,
+	}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	ids := func(result *gen.ListRiskResultsResult) []string {
+		out := make([]string, 0, len(result.Results))
+		for _, r := range result.Results {
+			out = append(out, r.ID)
+		}
+		return out
+	}
+
+	pageSize := 2
+	page1, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: &pageSize})
+	require.NoError(t, err)
+	require.Equal(t, int64(4), page1.TotalCount)
+	require.Len(t, page1.Results, 2)
+	require.Equal(t, manual.ID.String(), page1.Results[0].ID, "newest suppression first")
+	require.Contains(t, []string{tiedA.ID.String(), tiedB.ID.String()}, page1.Results[1].ID)
+	require.NotNil(t, page1.NextCursor)
+
+	// Store-side redaction: the Dismissed tab serves match_redacted like the
+	// Risk Events listing, never the raw match.
+	first := page1.Results[0]
+	require.Nil(t, first.Match)
+	require.Nil(t, first.Spans)
+	require.NotNil(t, first.MatchRedacted)
+	require.Equal(t, "AKIA**************LE", *first.MatchRedacted)
+
+	require.NotNil(t, first.FalsePositiveAt)
+	require.Equal(t, manualAt.Format(time.RFC3339), *first.FalsePositiveAt)
+
+	// Postgres display enrichment, same as the Risk Events listing.
+	require.NotNil(t, first.ChatTitle)
+	require.Equal(t, "test chat", *first.ChatTitle)
+	require.NotNil(t, first.UserID)
+	require.Equal(t, "alice@example.com", *first.UserID)
+
+	page2, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: &pageSize, Cursor: page1.NextCursor})
+	require.NoError(t, err)
+	require.Len(t, page2.Results, 2)
+	require.Equal(t, legacy.ID.String(), page2.Results[1].ID, "the legacy false-positive-only row is the fallback disjunct's job")
+	require.Nil(t, page2.NextCursor)
+	require.Equal(t, int64(4), page2.TotalCount)
+	require.NotNil(t, page2.Results[1].FalsePositiveAt)
+	require.Equal(t, legacyAt.Format(time.RFC3339), *page2.Results[1].FalsePositiveAt)
+
+	// The tied pair is split across the boundary exactly once: no repeat, no
+	// skip. Which of the two lands on which page is ClickHouse's UUID ordering
+	// to decide; the cursor only has to agree with it.
+	require.ElementsMatch(t,
+		[]string{manual.ID.String(), tiedA.ID.String(), tiedB.ID.String(), legacy.ID.String()},
+		append(ids(page1), ids(page2)...),
+	)
+}
+
+// TestListDismissedRiskResults_ClickHouseResolvesLatestCopy pins the
+// dedup-before-predicate order: suppression state changes by appending a newer
+// copy of a finding, so a restore must drop the id from the listing even though
+// its older, dismissed copy still matches the predicate on its own.
+func TestListDismissedRiskResults_ClickHouseResolvesLatestCopy(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Dismissed CH Latest Copy")})
+	require.NoError(t, err)
+
+	chatID, msgID := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+	chQueries := chrepo.New(ti.chConn)
+
+	restoredID := uuid.Must(uuid.NewV7())
+	stillDismissedID := uuid.Must(uuid.NewV7())
+	dismissedAt := time.Now().UTC().Add(-time.Hour)
+
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{
+		chDismissalCopy(t, projectID, orgID, policy.ID, restoredID, chatID, msgID, dismissedAt),
+		chDismissalCopy(t, projectID, orgID, policy.ID, stillDismissedID, chatID, msgID, dismissedAt),
+	}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// The undo's copy: same id, no suppression, inserted later.
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{
+		chDismissalCopy(t, projectID, orgID, policy.ID, restoredID, chatID, msgID, time.Time{}),
+	}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	dismissed, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{})
+	require.NoError(t, err)
+	require.Len(t, dismissed.Results, 1)
+	require.Equal(t, stillDismissedID.String(), dismissed.Results[0].ID)
+	require.Equal(t, int64(1), dismissed.TotalCount)
 }

--- a/server/internal/risk/list_ch.go
+++ b/server/internal/risk/list_ch.go
@@ -258,7 +258,7 @@ func chListRowToResult(row chrepo.RiskFindingListRow, titles map[uuid.UUID]strin
 		MatchRedacted:     conv.PtrEmpty(row.MatchRedacted),
 		// The ClickHouse listing filters false_positive_at IS NULL, so a
 		// served row is never dismissed; only ListDismissedRiskResults
-		// populates this.
+		// populates this, which it does after calling this mapper.
 		FalsePositiveAt: nil,
 		// Message event time, not scan time: the Postgres listing exposes
 		// message_created_at as CreatedAt, and the sort order and cursor both

--- a/server/internal/risk/list_ch_test.go
+++ b/server/internal/risk/list_ch_test.go
@@ -132,6 +132,60 @@ func TestListRiskResults_ClickHousePageOrderingAndRedaction(t *testing.T) {
 	require.Equal(t, int64(3), page2.TotalCount)
 }
 
+// TestListRiskResults_ClickHouseLegacyFalsePositiveOnlyRowIsHidden pins the
+// live listing's transitional suppression semantics. A dismissal written before
+// the suppression convergence carries only the legacy false_positive_at, and no
+// backfill is coming to give it an excluded_at copy — such rows simply stop
+// being written once the converged writers deploy, then expire under the
+// table's 90-day TTL. Until that window closes the listing must keep honoring
+// the legacy column, so a false-positive-only row stays hidden here exactly
+// like a converged one.
+func TestListRiskResults_ClickHouseLegacyFalsePositiveOnlyRowIsHidden(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ti.flags.SetFlag(feature.FlagRiskListFromClickHouse, authCtx.ActiveOrganizationID, true)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("List CH Legacy FP")})
+	require.NoError(t, err)
+
+	base := time.Now().UTC().AddDate(0, 0, -7).Truncate(time.Hour)
+	chatID, msgID := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+	dismissedAt := base.Add(2 * time.Hour)
+
+	legacyFP := chListFinding(t, projectID, orgID, chatID, msgID, policy.ID, base.Add(4*time.Hour), base.Add(time.Hour), "gitleaks", "secret.github_pat", "alice@example.com", "<redacted len=7 sha=aaaaaaaa>", "fp-legacy", "")
+	legacyFP.FalsePositiveAt = &dismissedAt
+
+	// The converged shape of the same dismissal, hidden by excluded_at.
+	converged := chListFinding(t, projectID, orgID, chatID, msgID, policy.ID, base.Add(4*time.Hour), base.Add(90*time.Minute), "gitleaks", "secret.github_pat", "alice@example.com", "<redacted len=7 sha=bbbbbbbb>", "fp-converged", "")
+	converged.ExcludedAt = &dismissedAt
+	converged.ExcludedReason = chrepo.ExcludedReasonManual
+	converged.FalsePositiveAt = &dismissedAt
+
+	// An untouched finding, so the assertion distinguishes "both suppressed
+	// rows are hidden" from "the listing returned nothing at all".
+	open := chListFinding(t, projectID, orgID, chatID, msgID, policy.ID, base.Add(4*time.Hour), base.Add(30*time.Minute), "gitleaks", "secret.slack_token", "alice@example.com", "<redacted len=6 sha=cccccccc>", "fp-open", "")
+
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{legacyFP, converged, open}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	page, err := ti.service.ListRiskResults(ctx, &gen.ListRiskResultsPayload{PolicyID: &policy.ID})
+	require.NoError(t, err)
+	ids := make([]string, 0, len(page.Results))
+	for _, r := range page.Results {
+		ids = append(ids, r.ID)
+	}
+	require.Equal(t, []string{open.ID.String()}, ids, "both the legacy and the converged dismissal stay hidden")
+	require.Equal(t, int64(1), page.TotalCount)
+}
+
 // TestListRiskResults_ClickHouseFilters exercises the pushed-down filters:
 // category, rule and user substrings, assistant scoping, the enabled-policy
 // pushdown (disabled policies hidden by default, surfaced by an explicit


### PR DESCRIPTION
## What

Moves the dismissed-findings listing (`risk.listDismissedResults`) from Postgres to ClickHouse, as part of the suppression convergence (follows #5421). Wire contract unchanged — no Goa/SDK changes.

- New CH listing/count in `chrepo/dismissed.go`: latest-copy dedup, gated on `excluded_reason IN ('manual','automated')` with a legacy fallback for pre-convergence rows carrying only `false_positive_at`. Rule-suppressed rows stay out of the tab for now.
- Live read filters keep the dual `excluded_at IS NULL AND false_positive_at IS NULL` condition; legacy rows age out under the 90-day TTL, after which the `false_positive_at` half drops (no backfill planned).

Behavior notes for reviewers: the dismissed tab now returns redacted matches (`match_redacted`, like the Risk Events listing) instead of raw plaintext, and dismissals reach it eventually-consistently via the findings mirror rather than in-transaction.

## Testing

New CH listing tests (ordering, cursor across tied timestamps, redaction, latest-copy resolution, legacy FP-only row hidden from live listing); mark/unmark tests reworked onto the CH path. Full `server/internal/risk/...` tree green; build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Dismissed tab (`risk.listDismissedResults`) from Postgres to ClickHouse. Previously it returned raw matches and reflected updates in-transaction; now it serves redacted matches like the Risk Events listing and updates appear eventually via the findings mirror.

- Selects manual/automated dismissals only; rule-suppressed rows remain out of this tab.
- Sorts and paginates by (suppressed_at, id) DESC where suppressed_at = COALESCE(excluded_at, false_positive_at); handles timestamp ties with id as a tiebreaker.
- Deduplicates per id before applying state predicates so restores drop from the tab even if an older dismissed copy exists.
- Live Risk Events listing keeps `excluded_at IS NULL AND false_positive_at IS NULL` until legacy-only rows age out under the 90‑day TTL; no backfill.

**Review notes**
- New listing/count in `server/internal/risk/chrepo/dismissed.go`; shared projection in `chrepo/list.go`; cursor applied after dedup with `toDateTime64` to preserve sub-second precision.
- `overview.go`, `signals.go`, and `unmask.go` continue filtering `false_positive_at IS NULL` during the TTL window.
- Tests cover CH ordering, cursor across tied timestamps, redaction, latest-copy resolution, and legacy FP-only behavior.

**Rollout / migration**
- No Goa/SDK or schema changes; no data backfill required.
- Ensure the findings publisher is running so Postgres writes are mirrored to ClickHouse; expect eventual consistency in the Dismissed tab.
- UI/clients must render `match_redacted` for the Dismissed tab and must not rely on `Match` being populated.

<sup>Written for commit edbb77a9f289ed9807e236453a50b2e24f6f9166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

