### PR TITLE
fix(dashboard): search mcp_servers-backed servers in the command palette

### DIFF
--- a/.changeset/command-palette-mcp-servers.md
+++ b/.changeset/command-palette-mcp-servers.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The command palette's "MCP Servers" group now searches `mcp_servers`-backed servers as well as toolset-backed ones. Previously the group was built entirely from toolsets, so a remote-, tunneled-, or unproxied-backed server never appeared in ⌘K and could only be reached by navigating to the MCP list by hand. Both kinds are listed under the one heading, matching how the MCP list page presents them, and each row still matches on name and slug.

--- a/client/dashboard/src/components/command-palette/ResourceResults.test.tsx
+++ b/client/dashboard/src/components/command-palette/ResourceResults.test.tsx
@@ -1,0 +1,206 @@
+import { Command, CommandInput, CommandList } from "@/components/ui/Command";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  toolsets: [] as unknown[],
+  mcpServers: [] as unknown[],
+  goToToolsetDetails: vi.fn(),
+  goToMcpServerOverview: vi.fn(),
+}));
+
+// The palette's other groups are irrelevant here; stub them empty so this file
+// only exercises the MCP Servers group.
+vi.mock("@gram/client/react-query/assistantsList.js", () => ({
+  useAssistantsListSuspense: () => ({ data: { assistants: [] } }),
+}));
+vi.mock("@gram/client/react-query/latestDeployment.js", () => ({
+  useLatestDeploymentSuspense: () => ({ data: { deployment: undefined } }),
+}));
+vi.mock("@gram/client/react-query/listDeployments.js", () => ({
+  useListDeploymentsSuspense: () => ({ data: { items: [] } }),
+}));
+vi.mock("@gram/client/react-query/riskListCustomDetectionRules.js", () => ({
+  useRiskListCustomDetectionRulesSuspense: () => ({ data: { rules: [] } }),
+}));
+vi.mock("@gram/client/react-query/listMcpApprovalRequests.js", () => ({
+  useListMcpApprovalRequestsSuspense: () => ({ data: { requests: [] } }),
+}));
+vi.mock("@gram/client/react-query/riskListPolicies.js", () => ({
+  useRiskListPoliciesSuspense: () => ({ data: { policies: [] } }),
+}));
+vi.mock("@gram/client/react-query/plugins", () => ({
+  usePluginsSuspense: () => ({ data: { plugins: [] } }),
+}));
+vi.mock("@/pages/environments/useEnvironments", () => ({
+  useEnvironments: () => [],
+}));
+
+vi.mock("@gram/client/react-query/listToolsets.js", () => ({
+  useListToolsetsSuspense: () => ({ data: { toolsets: mocks.toolsets } }),
+}));
+vi.mock("@gram/client/react-query/mcpServers.js", () => ({
+  useMcpServersSuspense: () => ({ data: { mcpServers: mocks.mcpServers } }),
+}));
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSlugs: () => ({ orgSlug: "acme", projectSlug: "default" }),
+  useProjectSlugForRequests: () => "default",
+}));
+
+// Non-admin: keeps the risk/approval groups out of the tree entirely.
+vi.mock("@/hooks/useRBAC", () => ({
+  useRBAC: () => ({ hasAnyScope: () => false, hasScope: () => false }),
+}));
+
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({
+    mcp: {
+      details: { goTo: mocks.goToToolsetDetails },
+      x: { overview: { goTo: mocks.goToMcpServerOverview } },
+    },
+  }),
+}));
+
+vi.mock("@/components/ui/Icon", () => ({
+  Icon: ({ name }: { name: string }) => <span data-icon={name} />,
+}));
+
+import { ResourceResults } from "./ResourceResults";
+
+function toolset(name: string, slug: string) {
+  return { id: `toolset-${slug}`, name, slug };
+}
+
+function mcpServer(
+  name: string | undefined,
+  slug: string | undefined,
+  backing: Record<string, string>,
+) {
+  return { id: `server-${slug ?? "no-slug"}`, name, slug, ...backing };
+}
+
+const REMOTE = { remoteMcpServerId: "remote-1" };
+const TUNNELED = { tunneledMcpServerId: "tunneled-1" };
+const UNPROXIED = { unproxiedMcpServerId: "unproxied-1" };
+
+// Renders the palette's resource results inside a real cmdk root, so the
+// assertions run against cmdk's own filtering rather than a reimplementation
+// of it.
+function renderResults(query = "") {
+  const result = render(
+    <Command shouldFilter>
+      <CommandInput />
+      <CommandList>
+        <ResourceResults onNavigate={() => {}} query={query} />
+      </CommandList>
+    </Command>,
+  );
+  if (query) {
+    fireEvent.change(result.container.querySelector("input")!, {
+      target: { value: query },
+    });
+  }
+  return result;
+}
+
+describe("ResourceResults MCP Servers group", () => {
+  beforeEach(() => {
+    mocks.toolsets = [];
+    mocks.mcpServers = [];
+    mocks.goToToolsetDetails.mockClear();
+    mocks.goToMcpServerOverview.mockClear();
+  });
+  afterEach(cleanup);
+
+  it("lists toolset-backed and mcp_servers-backed servers under one heading", () => {
+    mocks.toolsets = [toolset("Hosted Server", "hosted-server")];
+    mocks.mcpServers = [
+      mcpServer("Remote Server", "remote-server", REMOTE),
+      mcpServer("Tunneled Server", "tunneled-server", TUNNELED),
+      mcpServer("Unproxied Server", "unproxied-server", UNPROXIED),
+    ];
+    renderResults();
+
+    expect(screen.getAllByText("MCP Servers")).not.toHaveLength(0);
+    expect(screen.getByText("Hosted Server")).toBeTruthy();
+    expect(screen.getByText("Remote Server")).toBeTruthy();
+    expect(screen.getByText("Tunneled Server")).toBeTruthy();
+    expect(screen.getByText("Unproxied Server")).toBeTruthy();
+  });
+
+  // The regression this guards: a toolset-backed mcp_servers row is the same
+  // server the toolsets fetch already returned, so surfacing both would show
+  // every hosted server twice.
+  it("omits toolset-backed mcp_servers rows so hosted servers aren't doubled", () => {
+    mocks.toolsets = [toolset("Hosted Server", "hosted-server")];
+    mocks.mcpServers = [
+      mcpServer("Hosted Server", "hosted-server-dupe", {
+        toolsetId: "toolset-hosted-server",
+      }),
+    ];
+    renderResults();
+
+    expect(screen.getAllByText("Hosted Server")).toHaveLength(1);
+    expect(screen.queryByText("hosted-server-dupe")).toBeNull();
+  });
+
+  it("renders nothing when both collections are empty", () => {
+    renderResults();
+    expect(screen.queryByText("MCP Servers")).toBeNull();
+  });
+
+  it("finds an mcp_servers-backed server by name", () => {
+    mocks.mcpServers = [
+      mcpServer("Linear", "linear-a1b2c3", REMOTE),
+      mcpServer("Notion", "notion-d4e5f6", REMOTE),
+    ];
+    renderResults("linear");
+
+    expect(screen.getByText("Linear")).toBeTruthy();
+    expect(screen.queryByText("Notion")).toBeNull();
+  });
+
+  // Servers get a generated slug suffix, so the slug is often the only thing a
+  // user can recall exactly — it has to be searchable, matching toolset rows.
+  it("finds an mcp_servers-backed server by slug", () => {
+    mocks.mcpServers = [
+      mcpServer("Linear", "linear-a1b2c3", REMOTE),
+      mcpServer("Notion", "notion-d4e5f6", REMOTE),
+    ];
+    renderResults("d4e5f6");
+
+    expect(screen.getByText("Notion")).toBeTruthy();
+    expect(screen.queryByText("Linear")).toBeNull();
+  });
+
+  it("navigates to the mcp_servers-backed route on select", () => {
+    mocks.mcpServers = [mcpServer("Remote Server", "remote-server", REMOTE)];
+    renderResults();
+
+    fireEvent.click(screen.getByText("Remote Server"));
+
+    expect(mocks.goToMcpServerOverview).toHaveBeenCalledWith("remote-server");
+    expect(mocks.goToToolsetDetails).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the toolset route for toolset-backed servers", () => {
+    mocks.toolsets = [toolset("Hosted Server", "hosted-server")];
+    renderResults();
+
+    fireEvent.click(screen.getByText("Hosted Server"));
+
+    expect(mocks.goToToolsetDetails).toHaveBeenCalledWith("hosted-server");
+    expect(mocks.goToMcpServerOverview).not.toHaveBeenCalled();
+  });
+
+  // name and slug are both optional on the McpServer wire type.
+  it("falls back to a label and the id route param when name/slug are absent", () => {
+    mocks.mcpServers = [mcpServer(undefined, undefined, REMOTE)];
+    renderResults();
+
+    fireEvent.click(screen.getByText("MCP Server"));
+
+    expect(mocks.goToMcpServerOverview).toHaveBeenCalledWith("server-no-slug");
+  });
+});

--- a/client/dashboard/src/components/command-palette/ResourceResults.tsx
+++ b/client/dashboard/src/components/command-palette/ResourceResults.tsx
@@ -99,8 +99,10 @@ function ResultItem({
 function McpServersGroup({ onNavigate }: GroupProps) {
   const routes = useRoutes();
   const gramProject = useProjectSlugForRequests();
-  const { data: toolsetsData } = useListToolsetsSuspense();
-  // Key by project so a cached list can't outlive a project switch.
+  // Both lists are keyed by project: the SDK folds gramProject into the query
+  // key, so omitting it shares one cache entry across every project and a
+  // switch renders the previous project's rows until the refetch lands.
+  const { data: toolsetsData } = useListToolsetsSuspense({ gramProject });
   const { data: mcpServersData } = useMcpServersSuspense({ gramProject });
   const toolsets = toolsetsData.toolsets ?? [];
   const mcpServers = useMemo(

--- a/client/dashboard/src/components/command-palette/ResourceResults.tsx
+++ b/client/dashboard/src/components/command-palette/ResourceResults.tsx
@@ -1,6 +1,7 @@
 import { CommandGroup, CommandItem } from "@/components/ui/Command";
-import { useSlugs } from "@/contexts/Sdk";
+import { useProjectSlugForRequests, useSlugs } from "@/contexts/Sdk";
 import { useRBAC } from "@/hooks/useRBAC";
+import { mcpServerRouteParam } from "@/lib/sources";
 import { useEnvironments } from "@/pages/environments/useEnvironments";
 import { BUILTIN_RULES_BY_CATEGORY } from "@/pages/security/detection-rules-data";
 import { useRoutes } from "@/routes";
@@ -8,6 +9,7 @@ import { useAssistantsListSuspense } from "@gram/client/react-query/assistantsLi
 import { useLatestDeploymentSuspense } from "@gram/client/react-query/latestDeployment.js";
 import { useListDeploymentsSuspense } from "@gram/client/react-query/listDeployments.js";
 import { useListToolsetsSuspense } from "@gram/client/react-query/listToolsets.js";
+import { useMcpServersSuspense } from "@gram/client/react-query/mcpServers.js";
 import { useRiskListCustomDetectionRulesSuspense } from "@gram/client/react-query/riskListCustomDetectionRules.js";
 import { useListMcpApprovalRequestsSuspense } from "@gram/client/react-query/listMcpApprovalRequests.js";
 import { useRiskListPoliciesSuspense } from "@gram/client/react-query/riskListPolicies.js";
@@ -79,11 +81,39 @@ function ResultItem({
   );
 }
 
+// TODO(AGE-1902): collapse the two fetches once Hosted (toolset-backed) MCP
+// servers also source from mcp_servers.
+//
+// The palette mirrors the /mcp listing (see pages/mcp/MCP.tsx): "MCP Servers"
+// is one user-facing collection assembled from two backing stores, so both are
+// searched under a single heading. mcp_servers rows are filtered to the
+// non-toolset backends for the same reason the listing does it — a
+// toolset-backed mcp_servers row is the *same* server the toolsets fetch
+// already returned, so including it would double every hosted server in the
+// results. With that filter the two sets are disjoint and no dedupe is needed.
+//
+// Both fetches share this group's Suspense/error boundary, so either failing
+// hides the whole group. That's deliberate: half an "MCP Servers" list is worse
+// than none, because a user who searches and finds nothing concludes the server
+// doesn't exist.
 function McpServersGroup({ onNavigate }: GroupProps) {
   const routes = useRoutes();
-  const { data } = useListToolsetsSuspense();
-  const toolsets = data.toolsets ?? [];
-  if (!toolsets.length) return null;
+  const gramProject = useProjectSlugForRequests();
+  const { data: toolsetsData } = useListToolsetsSuspense();
+  // Key by project so a cached list can't outlive a project switch.
+  const { data: mcpServersData } = useMcpServersSuspense({ gramProject });
+  const toolsets = toolsetsData.toolsets ?? [];
+  const mcpServers = useMemo(
+    () =>
+      (mcpServersData.mcpServers ?? []).filter(
+        (server) =>
+          !!server.remoteMcpServerId ||
+          !!server.tunneledMcpServerId ||
+          !!server.unproxiedMcpServerId,
+      ),
+    [mcpServersData],
+  );
+  if (!toolsets.length && !mcpServers.length) return null;
   return (
     <CommandGroup heading="MCP Servers">
       {toolsets.map((toolset) => (
@@ -95,6 +125,19 @@ function McpServersGroup({ onNavigate }: GroupProps) {
           icon="network"
           onSelect={() => {
             routes.mcp.details.goTo(toolset.slug);
+            onNavigate();
+          }}
+        />
+      ))}
+      {mcpServers.map((server) => (
+        <ResultItem
+          key={server.id}
+          value={`mcp ${server.name ?? ""} ${server.slug ?? ""} ${server.id}`}
+          label={server.name || "MCP Server"}
+          sublabel={server.slug}
+          icon="network"
+          onSelect={() => {
+            routes.mcp.x.overview.goTo(mcpServerRouteParam(server));
             onNavigate();
           }}
         />


### PR DESCRIPTION
Closes AGE-3284.

## Problem

The command palette's "MCP Servers" group was backed entirely by toolsets, so a server backed by `mcp_servers` — remote, tunneled, or unproxied — never appeared in ⌘K. Searching for one returned nothing and the only way to reach it was navigating to the MCP list by hand.

This is easy to hit: a project whose servers are all `mcp_servers`-backed has an "MCP Servers" group that silently omits every one of them.

## Change

`McpServersGroup` now lists both collections under the single existing heading, mirroring how `/mcp` already presents them in one grid.

Two decisions worth a reviewer's attention, both of which were open questions on the ticket:

**Dedupe is handled by a filter, not a merge pass.** `mcp_servers` rows are filtered to the non-toolset backings, exactly as `pages/mcp/MCP.tsx` does. A toolset-backed `mcp_servers` row is the *same* server the toolsets fetch already returned, so including it would list every hosted server twice. With that filter the two sets are disjoint and there is nothing to dedupe.

**Scoping uses the project-scoped `listMcpServers`,** not `listMcpServersForOrg`. The palette is project-scoped, and `listMcpServers` carries the project payload while the org variant is session-only. (`listMcpServersForOrg` is used under `pages/access/` because grant rules genuinely are org-scoped.) The project is passed explicitly so a cached list can't outlive a project switch.

Rows keep name *and* slug in the cmdk `value` string, matching the toolset rows, so either one matches. `name` and `slug` are both optional on the `McpServer` wire type, so the label falls back to "MCP Server" and the route param falls back to the id via the existing `mcpServerRouteParam` helper.

## Trade-off

Both fetches now share the group's Suspense/error boundary, so if either endpoint fails the whole group is hidden rather than half of it. That is deliberate — a partial "MCP Servers" list is worse than none, because a user who searches and finds nothing concludes the server doesn't exist. The alternative, two independently-isolated groups, costs a duplicated heading. Verified in the browser that the failure path degrades cleanly via `CommandErrorBoundary` rather than blanking the palette.

## Testing

New `ResourceResults.test.tsx` — 8 cases rendering `ResourceResults` inside a real cmdk root, so the search assertions run against cmdk's own scorer rather than a reimplementation of it: both collections under one heading, toolset-backed rows excluded, empty state, search by name, search by slug, per-backing navigation targets, and the missing-name/missing-slug fallback.

Reverting the component makes 5 of the 8 fail, so they are real regression guards rather than decoration.

Also verified manually against a local project whose three MCP servers are all `mcp_servers`-backed — none of them appeared in ⌘K before this change, all of them do now, and selecting one lands on `/mcp/x/<slug>/overview`.
