### PR TITLE
fix: refresh standalone admin sessions

### DIFF
--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -364,9 +364,8 @@ describe("logout", () => {
     expect(window.location.href).toContain("prompt=select_account");
   });
 
-  // The 401 handler retries with prompt=none, which the provider honours
-  // silently. Taking it here would sign the operator back in behind the Logout
-  // they just pressed.
+  // Taking the read-side 401 handler here would start a new login behind the
+  // Logout the operator just pressed.
   it("reports a 401 instead of signing the operator back in", async () => {
     vi.stubGlobal(
       "fetch",

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -87,11 +87,9 @@ async function gramAdminRequest(
   const res = await fetch(url, { ...init, headers });
 
   if (res.status === 401 && redirectOnUnauthorized) {
-    // Top-level redirect into the OIDC flow. Use prompt=none so the identity
-    // provider returns silently when the operator already has a session with
-    // it. The gram admin backend falls back to interactive login if the
-    // provider returns error=login_required (see Callback in
-    // server/internal/admin/impl.go).
+    // Top-level redirect into the OIDC flow. Interactive consent ensures the
+    // provider returns a refresh token; without one the one-hour access token
+    // would send the operator through login again on every expiry.
     //
     // return_to must stay a relative path. sanitizeReturnTo in
     // server/internal/admin/oauth.go keeps an absolute URL only when its origin
@@ -103,7 +101,7 @@ async function gramAdminRequest(
       window.location.pathname + window.location.search,
     );
     redirectingToLogin = true;
-    window.location.href = `/admin/auth.login?return_to=${returnTo}&prompt=none`;
+    window.location.href = `/admin/auth.login?return_to=${returnTo}&prompt=consent`;
     // Setting window.location starts the navigation but does not stop the code
     // that follows it. Throw to unwind the in-flight call.
     throw new GramAdminError(401, null, "redirecting to admin login");
@@ -169,10 +167,8 @@ export function getSession(): Promise<AdminSessionInfo> {
 // Ends the admin session, then sends the browser into the OIDC flow.
 //
 // The endpoint deletes only the server-side record and leaves the `gram_admin`
-// cookie in the browser. The next request would therefore 401, and the 401
-// handler retries with prompt=none, which the identity provider honours
-// silently and signs the operator straight back in. Asking for select_account
-// instead forces the account chooser, so logging out is visible.
+// cookie in the browser. Asking for select_account after deleting the session
+// makes logout visible and lets the operator choose a different account.
 export async function logout(): Promise<void> {
   await gramAdminSend("/admin/auth.logout", { method: "POST" });
   window.location.href = "/admin/auth.login?prompt=select_account";

--- a/mock-oidc/handlers.go
+++ b/mock-oidc/handlers.go
@@ -75,7 +75,7 @@ func (s *Server) discovery(w http.ResponseWriter, _ *http.Request) {
 		"userinfo_endpoint":                     iss + "/userinfo",
 		"jwks_uri":                              iss + "/jwks.json",
 		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		"subject_types_supported":               []string{"public"},
 		"id_token_signing_alg_values_supported": []string{"RS256"},
 		"scopes_supported":                      []string{"openid", "email", "profile"},
@@ -277,8 +277,9 @@ func (s *Server) tokenHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.PostForm.Get("grant_type") != "authorization_code" {
-		writeTokenError(w, http.StatusBadRequest, "unsupported_grant_type", "only authorization_code is supported")
+	grantType := r.PostForm.Get("grant_type")
+	if grantType != "authorization_code" && grantType != "refresh_token" {
+		writeTokenError(w, http.StatusBadRequest, "unsupported_grant_type", "supported grants are authorization_code and refresh_token")
 		return
 	}
 
@@ -291,6 +292,33 @@ func (s *Server) tokenHandler(w http.ResponseWriter, r *http.Request) {
 	client, found := s.provider.cfg.FindClient(clientID)
 	if !found || client.ClientSecret != clientSecret {
 		writeTokenError(w, http.StatusUnauthorized, "invalid_client", "client authentication failed")
+		return
+	}
+
+	if grantType == "refresh_token" {
+		refreshToken := r.PostForm.Get("refresh_token")
+		entry, ok := s.provider.LookupRefreshToken(refreshToken, clientID)
+		if !ok {
+			writeTokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token is invalid")
+			return
+		}
+
+		accessToken, accessExpires, err := s.provider.MintAccessToken(entry.user, entry.scope)
+		if err != nil {
+			s.logger.ErrorContext(r.Context(), "mint access token", o11y.ErrAttr(err))
+			writeTokenError(w, http.StatusInternalServerError, "server_error", "could not mint token")
+			return
+		}
+		resp := map[string]any{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    int(time.Until(accessExpires).Seconds()),
+		}
+		if entry.scope != "" {
+			resp["scope"] = entry.scope
+		}
+		writeJSON(w, http.StatusOK, resp)
 		return
 	}
 
@@ -324,6 +352,13 @@ func (s *Server) tokenHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	refreshToken, err := s.provider.MintRefreshToken(clientID, entry.user, entry.scope)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "mint refresh token", o11y.ErrAttr(err))
+		writeTokenError(w, http.StatusInternalServerError, "server_error", "could not mint token")
+		return
+	}
+
 	idToken, err := s.provider.SignIDToken(entry.user, clientID, entry.nonce, accessExpires)
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "sign id token", o11y.ErrAttr(err))
@@ -337,10 +372,11 @@ func (s *Server) tokenHandler(w http.ResponseWriter, r *http.Request) {
 	)
 
 	resp := map[string]any{
-		"access_token": accessToken,
-		"token_type":   "Bearer",
-		"expires_in":   int(time.Until(accessExpires).Seconds()),
-		"id_token":     idToken,
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
+		"token_type":    "Bearer",
+		"expires_in":    int(time.Until(accessExpires).Seconds()),
+		"id_token":      idToken,
 	}
 	if entry.scope != "" {
 		resp["scope"] = entry.scope

--- a/mock-oidc/integration_test.go
+++ b/mock-oidc/integration_test.go
@@ -93,7 +93,7 @@ func TestDiscoveryAndIDToken(t *testing.T) {
 		Scopes:       []string{oidc.ScopeOpenID, "email", "profile"},
 	}
 
-	authURL := oauth2Cfg.AuthCodeURL("xyz", oauth2.AccessTypeOnline)
+	authURL := oauth2Cfg.AuthCodeURL("xyz", oauth2.AccessTypeOffline)
 
 	// Disable redirect-following so we can extract the code.
 	jar, _ := cookiejar.New(nil)
@@ -151,6 +151,23 @@ func TestDiscoveryAndIDToken(t *testing.T) {
 	token, err := oauth2Cfg.Exchange(ctx, code)
 	if err != nil {
 		t.Fatalf("token exchange: %v", err)
+	}
+	if token.RefreshToken == "" {
+		t.Fatal("token exchange did not return a refresh token")
+	}
+
+	refreshed, err := oauth2Cfg.TokenSource(ctx, &oauth2.Token{
+		RefreshToken: token.RefreshToken,
+		Expiry:       time.Now().Add(-time.Minute),
+	}).Token()
+	if err != nil {
+		t.Fatalf("refresh token exchange: %v", err)
+	}
+	if refreshed.AccessToken == "" || refreshed.AccessToken == token.AccessToken {
+		t.Fatal("refresh did not return a new access token")
+	}
+	if refreshed.RefreshToken != token.RefreshToken {
+		t.Fatalf("refresh token changed: got %q, want %q", refreshed.RefreshToken, token.RefreshToken)
 	}
 
 	rawIDToken, ok := token.Extra("id_token").(string)

--- a/mock-oidc/provider.go
+++ b/mock-oidc/provider.go
@@ -53,14 +53,16 @@ type tokenEntry struct {
 }
 
 type refreshTokenEntry struct {
-	clientID string
-	user     User
-	scope    string
+	clientID  string
+	user      User
+	scope     string
+	expiresAt time.Time
 }
 
 const (
-	codeTTL  = 60 * time.Second
-	tokenTTL = time.Hour
+	codeTTL         = 60 * time.Second
+	tokenTTL        = time.Hour
+	refreshTokenTTL = 24 * time.Hour
 )
 
 func NewProvider(cfg *Config, logger *slog.Logger, issuer string, privateKey *rsa.PrivateKey) (*Provider, error) {
@@ -235,7 +237,12 @@ func (p *Provider) MintRefreshToken(clientID string, user User, scope string) (s
 		return "", err
 	}
 	p.mu.Lock()
-	p.refreshTokens[tok] = &refreshTokenEntry{clientID: clientID, user: user, scope: scope}
+	p.refreshTokens[tok] = &refreshTokenEntry{
+		clientID:  clientID,
+		user:      user,
+		scope:     scope,
+		expiresAt: time.Now().Add(refreshTokenTTL),
+	}
 	p.mu.Unlock()
 	return tok, nil
 }
@@ -245,6 +252,10 @@ func (p *Provider) LookupRefreshToken(tok, clientID string) (*refreshTokenEntry,
 	defer p.mu.Unlock()
 	entry, ok := p.refreshTokens[tok]
 	if !ok || entry.clientID != clientID {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(p.refreshTokens, tok)
 		return nil, false
 	}
 	return entry, true
@@ -294,6 +305,11 @@ func (p *Provider) Sweep() {
 	for k, v := range p.accessTokens {
 		if now.After(v.expiresAt) {
 			delete(p.accessTokens, k)
+		}
+	}
+	for k, v := range p.refreshTokens {
+		if now.After(v.expiresAt) {
+			delete(p.refreshTokens, k)
 		}
 	}
 }

--- a/mock-oidc/provider.go
+++ b/mock-oidc/provider.go
@@ -27,9 +27,10 @@ type Provider struct {
 
 	hmacKey []byte
 
-	mu           sync.Mutex
-	codes        map[string]*codeEntry
-	accessTokens map[string]*tokenEntry
+	mu            sync.Mutex
+	codes         map[string]*codeEntry
+	accessTokens  map[string]*tokenEntry
+	refreshTokens map[string]*refreshTokenEntry
 }
 
 type codeEntry struct {
@@ -49,6 +50,12 @@ type tokenEntry struct {
 	user      User
 	scope     string
 	expiresAt time.Time
+}
+
+type refreshTokenEntry struct {
+	clientID string
+	user     User
+	scope    string
 }
 
 const (
@@ -71,15 +78,16 @@ func NewProvider(cfg *Config, logger *slog.Logger, issuer string, privateKey *rs
 	kid := base64.RawURLEncoding.EncodeToString(sum[:])
 
 	return &Provider{
-		cfg:          cfg,
-		logger:       logger,
-		issuer:       issuer,
-		privateKey:   privateKey,
-		publicKey:    pub,
-		keyID:        kid,
-		hmacKey:      hmacKey,
-		codes:        make(map[string]*codeEntry),
-		accessTokens: make(map[string]*tokenEntry),
+		cfg:           cfg,
+		logger:        logger,
+		issuer:        issuer,
+		privateKey:    privateKey,
+		publicKey:     pub,
+		keyID:         kid,
+		hmacKey:       hmacKey,
+		codes:         make(map[string]*codeEntry),
+		accessTokens:  make(map[string]*tokenEntry),
+		refreshTokens: make(map[string]*refreshTokenEntry),
 	}, nil
 }
 
@@ -216,6 +224,27 @@ func (p *Provider) LookupAccessToken(tok string) (*tokenEntry, bool) {
 	}
 	if time.Now().After(entry.expiresAt) {
 		delete(p.accessTokens, tok)
+		return nil, false
+	}
+	return entry, true
+}
+
+func (p *Provider) MintRefreshToken(clientID string, user User, scope string) (string, error) {
+	tok, err := randomToken(32)
+	if err != nil {
+		return "", err
+	}
+	p.mu.Lock()
+	p.refreshTokens[tok] = &refreshTokenEntry{clientID: clientID, user: user, scope: scope}
+	p.mu.Unlock()
+	return tok, nil
+}
+
+func (p *Provider) LookupRefreshToken(tok, clientID string) (*refreshTokenEntry, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	entry, ok := p.refreshTokens[tok]
+	if !ok || entry.clientID != clientID {
 		return nil, false
 	}
 	return entry, true

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -116,10 +116,11 @@ func NewService(
 		trialNotifier = trialemails.NoopNotifier{}
 	}
 
+	adminCache := cache.NewRedisCacheAdapter(redisClient)
 	sessionStore := NewSessionStore(
 		cache.NewTypedObjectCache[Session](
 			logger.With(attr.SlogCacheNamespace("admin_session")),
-			cache.NewRedisCacheAdapter(redisClient),
+			adminCache,
 			cache.SuffixNone,
 		),
 		encryptionClient,
@@ -131,14 +132,14 @@ func NewService(
 		db:             db,
 		oidc:           oidcClient,
 		sessions:       sessionStore,
-		verifier:       NewVerifier(logger, sessionStore, oidcClient),
+		verifier:       NewVerifier(logger, sessionStore, oidcClient, adminCache),
 		allowedOrigins: allowedOrigins,
 		workos:         workosClient,
 		openRouter:     openRouter,
 		audit:          audit.NewLogger(),
 		loginStates: cache.NewTypedObjectCache[LoginState](
 			logger.With(attr.SlogCacheNamespace("admin_login_state")),
-			cache.NewRedisCacheAdapter(redisClient),
+			adminCache,
 			cache.SuffixNone,
 		),
 		trial: trialNotifier,

--- a/server/internal/admin/oidc.go
+++ b/server/internal/admin/oidc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -75,6 +76,12 @@ func (g *OIDCClient) AuthCodeURL(state, pkceChallenge, prompt string) string {
 		oauth2.AccessTypeOffline,
 		oauth2.SetAuthURLParam("code_challenge", pkceChallenge),
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	}
+	// Google generally issues a refresh token only when consent is explicit.
+	// Silent re-authentication must remain silent, but every interactive flow
+	// should obtain a refresh token so the one-hour access token can be renewed.
+	if prompt != "none" && !strings.Contains(prompt, "consent") {
+		prompt = strings.TrimSpace(prompt + " consent")
 	}
 	if prompt != "" {
 		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
@@ -177,7 +184,7 @@ func (g *OIDCClient) Refresh(ctx context.Context, refreshToken string) (*oauth2.
 	})
 	tok, err := ts.Token()
 	if err != nil {
-		return nil, fmt.Errorf("refresh  token: %w", err)
+		return nil, fmt.Errorf("refresh token: %w", err)
 	}
 	return tok, nil
 }

--- a/server/internal/admin/oidc.go
+++ b/server/internal/admin/oidc.go
@@ -174,7 +174,11 @@ func ExtractIDToken(tok *oauth2.Token) (string, error) {
 }
 
 // Refresh obtains a new access token using the stored refresh token.
-// Failure is treated as an authentication failure by the caller.
+func isInvalidGrant(err error) bool {
+	var retrieveErr *oauth2.RetrieveError
+	return errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant"
+}
+
 func (g *OIDCClient) Refresh(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, g.httpClient)
 	ts := g.oauth2Config.TokenSource(ctx, &oauth2.Token{

--- a/server/internal/admin/oidc.go
+++ b/server/internal/admin/oidc.go
@@ -80,9 +80,11 @@ func (g *OIDCClient) AuthCodeURL(state, pkceChallenge, prompt string) string {
 	// Google generally issues a refresh token only when consent is explicit.
 	// Silent re-authentication must remain silent, but every interactive flow
 	// should obtain a refresh token so the one-hour access token can be renewed.
-	if prompt != "none" && !strings.Contains(prompt, "consent") {
-		prompt = strings.TrimSpace(prompt + " consent")
+	promptTokens := strings.Fields(prompt)
+	if !slices.Contains(promptTokens, "none") && !slices.Contains(promptTokens, "consent") {
+		promptTokens = append(promptTokens, "consent")
 	}
+	prompt = strings.Join(promptTokens, " ")
 	if prompt != "" {
 		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
 	}

--- a/server/internal/admin/oidc.go
+++ b/server/internal/admin/oidc.go
@@ -173,12 +173,12 @@ func ExtractIDToken(tok *oauth2.Token) (string, error) {
 	return raw, nil
 }
 
-// Refresh obtains a new access token using the stored refresh token.
 func isInvalidGrant(err error) bool {
 	var retrieveErr *oauth2.RetrieveError
 	return errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant"
 }
 
+// Refresh obtains a new access token using the stored refresh token.
 func (g *OIDCClient) Refresh(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, g.httpClient)
 	ts := g.oauth2Config.TokenSource(ctx, &oauth2.Token{

--- a/server/internal/admin/session.go
+++ b/server/internal/admin/session.go
@@ -149,14 +149,22 @@ func (s *SessionStore) Delete(ctx context.Context, sessionID string) error {
 	return nil
 }
 
-// UpdateAccessToken re-encrypts and persists a freshly refreshed OAuth
-// access token onto an existing session record.
-func (s *SessionStore) UpdateAccessToken(ctx context.Context, session Session, accessToken string, expiresAt time.Time) (Session, error) {
-	enc, err := s.enc.Encrypt([]byte(accessToken))
+// UpdateTokens encrypts and persists a refreshed OAuth token pair. Providers
+// may omit the refresh token when it did not rotate; retain the existing one
+// in that case.
+func (s *SessionStore) UpdateTokens(ctx context.Context, session Session, accessToken, refreshToken string, expiresAt time.Time) (Session, error) {
+	accessEnc, err := s.enc.Encrypt([]byte(accessToken))
 	if err != nil {
 		return session, fmt.Errorf("encrypt access token: %w", err)
 	}
-	session.AccessTokenEnc = enc
+	if refreshToken != "" {
+		refreshEnc, err := s.enc.Encrypt([]byte(refreshToken))
+		if err != nil {
+			return session, fmt.Errorf("encrypt refresh token: %w", err)
+		}
+		session.RefreshTokenEnc = refreshEnc
+	}
+	session.AccessTokenEnc = accessEnc
 	session.AccessTokenExpiresAt = expiresAt
 	if err := s.cache.Store(ctx, session); err != nil {
 		return session, fmt.Errorf("store admin session: %w", err)

--- a/server/internal/admin/session.go
+++ b/server/internal/admin/session.go
@@ -149,10 +149,19 @@ func (s *SessionStore) Delete(ctx context.Context, sessionID string) error {
 	return nil
 }
 
+func (s *SessionStore) DeleteIfUnchanged(ctx context.Context, session Session) (bool, error) {
+	deleted, err := s.cache.CompareAndDelete(ctx, session)
+	if err != nil {
+		return false, fmt.Errorf("compare and delete admin session: %w", err)
+	}
+	return deleted, nil
+}
+
 // UpdateTokens encrypts and persists a refreshed OAuth token pair. Providers
 // may omit the refresh token when it did not rotate; retain the existing one
 // in that case.
 func (s *SessionStore) UpdateTokens(ctx context.Context, session Session, accessToken, refreshToken string, expiresAt time.Time) (Session, error) {
+	expected := session
 	accessEnc, err := s.enc.Encrypt([]byte(accessToken))
 	if err != nil {
 		return session, fmt.Errorf("encrypt access token: %w", err)
@@ -166,10 +175,19 @@ func (s *SessionStore) UpdateTokens(ctx context.Context, session Session, access
 	}
 	session.AccessTokenEnc = accessEnc
 	session.AccessTokenExpiresAt = expiresAt
-	if err := s.cache.Store(ctx, session); err != nil {
-		return session, fmt.Errorf("store admin session: %w", err)
+	swapped, err := s.cache.CompareAndSwap(ctx, expected, session)
+	if err != nil {
+		return expected, fmt.Errorf("compare and swap admin session tokens: %w", err)
 	}
-	return session, nil
+	if swapped {
+		return session, nil
+	}
+
+	current, err := s.Get(ctx, expected.SessionID)
+	if err != nil {
+		return current, fmt.Errorf("reload concurrently updated admin session: %w", err)
+	}
+	return current, nil
 }
 
 // DecryptAccessToken returns the plaintext OAuth access token for the given

--- a/server/internal/admin/session_handler_test.go
+++ b/server/internal/admin/session_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -28,6 +29,13 @@ const testAdminHD = "example.com"
 // 401 simulates a token the provider has revoked.
 func newTestOIDCClient(t *testing.T, userinfo http.HandlerFunc) *OIDCClient {
 	t.Helper()
+	return newTestOIDCClientWithToken(t, userinfo, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+}
+
+func newTestOIDCClientWithToken(t *testing.T, userinfo, token http.HandlerFunc) *OIDCClient {
+	t.Helper()
 
 	var issuer string
 
@@ -43,6 +51,7 @@ func newTestOIDCClient(t *testing.T, userinfo http.HandlerFunc) *OIDCClient {
 		})
 	})
 	mux.HandleFunc("/userinfo", userinfo)
+	mux.HandleFunc("/token", token)
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -165,6 +174,64 @@ func TestHandleGetSession_ReturnsIdentity(t *testing.T) {
 	var got sessionInfo
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Equal(t, sessionInfo{Email: "operator@example.com", Name: "Test Operator"}, got)
+}
+
+func TestHandleGetSession_RefreshesExpiredTokens(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	oidcClient := newTestOIDCClientWithToken(
+		t,
+		userinfoOK("sub-refresh", "operator@example.com"),
+		func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
+			require.Equal(t, "old-refresh-token", r.PostForm.Get("refresh_token"))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "new-access-token",
+				"refresh_token": "new-refresh-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		},
+	)
+	svc := newTestSessionService(t, oidcClient)
+
+	sessionID, err := svc.sessions.Store(ctx, StoreParams{
+		Email:        "operator@example.com",
+		Name:         "Test Operator",
+		OIDCSubject:  "sub-refresh",
+		HD:           testAdminHD,
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, callSessionGet(t, svc, sessionID).Code)
+
+	session, err := svc.sessions.Get(ctx, sessionID)
+	require.NoError(t, err)
+	accessToken, err := svc.sessions.DecryptAccessToken(session)
+	require.NoError(t, err)
+	require.Equal(t, "new-access-token", accessToken)
+	refreshToken, err := svc.sessions.DecryptRefreshToken(session)
+	require.NoError(t, err)
+	require.Equal(t, "new-refresh-token", refreshToken)
+	require.True(t, session.AccessTokenExpiresAt.After(time.Now()))
+}
+
+func TestAuthCodeURLRequestsConsentForInteractiveLogin(t *testing.T) {
+	t.Parallel()
+
+	client := newTestOIDCClient(t, userinfoOK("sub-consent", "operator@example.com"))
+	interactive, err := url.Parse(client.AuthCodeURL("state", "challenge", ""))
+	require.NoError(t, err)
+	require.Equal(t, "consent", interactive.Query().Get("prompt"))
+
+	silent, err := url.Parse(client.AuthCodeURL("state", "challenge", "none"))
+	require.NoError(t, err)
+	require.Equal(t, "none", silent.Query().Get("prompt"))
 }
 
 func TestHandleGetSession_NoCookie(t *testing.T) {

--- a/server/internal/admin/session_handler_test.go
+++ b/server/internal/admin/session_handler_test.go
@@ -255,6 +255,130 @@ func TestHandleGetSession_RefreshesExpiredTokens(t *testing.T) {
 	require.True(t, session.AccessTokenExpiresAt.After(time.Now()))
 }
 
+func TestSessionStore_UpdateTokensAdoptsConcurrentWinner(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := newTestSessionService(t, newTestOIDCClient(t, userinfoOK("sub-cas", "operator@example.com")))
+	sessionID, err := svc.sessions.Store(ctx, StoreParams{
+		Email:        "operator@example.com",
+		Name:         "Test Operator",
+		OIDCSubject:  "sub-cas",
+		HD:           testAdminHD,
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+
+	first, err := svc.sessions.Get(ctx, sessionID)
+	require.NoError(t, err)
+	stale := first
+	_, err = svc.sessions.UpdateTokens(ctx, first, "winner-access-token", "winner-refresh-token", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	winner, err := svc.sessions.Get(ctx, sessionID)
+	require.NoError(t, err)
+	adopted, err := svc.sessions.UpdateTokens(ctx, stale, "stale-access-token", "stale-refresh-token", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	require.Equal(t, winner, adopted)
+	accessToken, err := svc.sessions.DecryptAccessToken(adopted)
+	require.NoError(t, err)
+	require.Equal(t, "winner-access-token", accessToken)
+	refreshToken, err := svc.sessions.DecryptRefreshToken(adopted)
+	require.NoError(t, err)
+	require.Equal(t, "winner-refresh-token", refreshToken)
+	persisted, err := svc.sessions.Get(ctx, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, winner, persisted)
+	deleted, err := svc.sessions.DeleteIfUnchanged(ctx, stale)
+	require.NoError(t, err)
+	require.False(t, deleted)
+	persisted, err = svc.sessions.Get(ctx, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, winner, persisted)
+}
+
+func TestHandleGetSession_AdoptsConcurrentRefreshWinner(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	usedAccessToken := make(chan string, 1)
+	var svc *Service
+	var sessionID string
+	oidcClient := newTestOIDCClientWithToken(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			usedAccessToken <- r.Header.Get("Authorization")
+			userinfoOK("sub-cas-verifier", "operator@example.com")(w, r)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			snapshot, err := svc.sessions.Get(r.Context(), sessionID)
+			if !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, err = svc.sessions.UpdateTokens(r.Context(), snapshot, "winner-access-token", "winner-refresh-token", time.Now().Add(time.Hour))
+			if !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "stale-access-token",
+				"refresh_token": "stale-refresh-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		},
+	)
+	svc = newTestSessionService(t, oidcClient)
+	var err error
+	sessionID, err = svc.sessions.Store(ctx, StoreParams{
+		Email:        "operator@example.com",
+		Name:         "Test Operator",
+		OIDCSubject:  "sub-cas-verifier",
+		HD:           testAdminHD,
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, callSessionGet(t, svc, sessionID).Code)
+	require.Equal(t, "Bearer winner-access-token", <-usedAccessToken)
+	persisted, err := svc.sessions.Get(ctx, sessionID)
+	require.NoError(t, err)
+	refreshToken, err := svc.sessions.DecryptRefreshToken(persisted)
+	require.NoError(t, err)
+	require.Equal(t, "winner-refresh-token", refreshToken)
+}
+
+func TestSessionStore_UpdateTokensDoesNotRecreateDeletedSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := newTestSessionService(t, newTestOIDCClient(t, userinfoOK("sub-deleted", "operator@example.com")))
+	sessionID, err := svc.sessions.Store(ctx, StoreParams{
+		Email:        "operator@example.com",
+		Name:         "Test Operator",
+		OIDCSubject:  "sub-deleted",
+		HD:           testAdminHD,
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	snapshot, err := svc.sessions.Get(ctx, sessionID)
+	require.NoError(t, err)
+	require.NoError(t, svc.sessions.Delete(ctx, sessionID))
+
+	_, err = svc.sessions.UpdateTokens(ctx, snapshot, "new-access-token", "new-refresh-token", time.Now().Add(time.Hour))
+	require.Error(t, err)
+	_, err = svc.sessions.Get(ctx, sessionID)
+	require.Error(t, err)
+}
+
 func TestHandleGetSession_ClassifiesRefreshFailures(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/admin/session_handler_test.go
+++ b/server/internal/admin/session_handler_test.go
@@ -271,6 +271,7 @@ func TestHandleGetSession_ClassifiesRefreshFailures(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := t.Context()
 			oidcClient := newTestOIDCClientWithToken(
 				t,

--- a/server/internal/admin/session_handler_test.go
+++ b/server/internal/admin/session_handler_test.go
@@ -230,6 +230,7 @@ func TestHandleGetSession_SerializesConcurrentRefreshes(t *testing.T) {
 
 	ctx := t.Context()
 	var refreshes atomic.Int32
+	releaseRefresh := make(chan struct{})
 	oidcClient := newTestOIDCClientWithToken(
 		t,
 		userinfoOK("sub-concurrent-refresh", "operator@example.com"),
@@ -237,7 +238,7 @@ func TestHandleGetSession_SerializesConcurrentRefreshes(t *testing.T) {
 			refreshes.Add(1)
 			assert.NoError(t, r.ParseForm())
 			assert.Equal(t, "old-refresh-token", r.PostForm.Get("refresh_token"))
-			time.Sleep(100 * time.Millisecond)
+			<-releaseRefresh
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"access_token":  "new-access-token",
@@ -276,6 +277,10 @@ func TestHandleGetSession_SerializesConcurrentRefreshes(t *testing.T) {
 		}()
 	}
 	close(start)
+	require.Eventually(t, func() bool {
+		return refreshes.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+	close(releaseRefresh)
 	wg.Wait()
 	close(codes)
 

--- a/server/internal/admin/session_handler_test.go
+++ b/server/internal/admin/session_handler_test.go
@@ -5,10 +5,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	goahttp "goa.design/goa/v3/http"
 
@@ -97,10 +100,11 @@ func newTestSessionService(t *testing.T, oidcClient *OIDCClient) *Service {
 	enc, err := encryption.NewWithBytes(make([]byte, 32))
 	require.NoError(t, err)
 
+	adminCache := cache.NewRedisCacheAdapter(redisClient)
 	sessions := NewSessionStore(
 		cache.NewTypedObjectCache[Session](
 			logger,
-			cache.NewRedisCacheAdapter(redisClient),
+			adminCache,
 			cache.SuffixNone,
 		),
 		enc,
@@ -110,7 +114,7 @@ func newTestSessionService(t *testing.T, oidcClient *OIDCClient) *Service {
 		logger:   logger,
 		oidc:     oidcClient,
 		sessions: sessions,
-		verifier: NewVerifier(logger, sessions, oidcClient),
+		verifier: NewVerifier(logger, sessions, oidcClient, adminCache),
 		trial:    trialemails.NoopNotifier{},
 	}
 }
@@ -184,9 +188,9 @@ func TestHandleGetSession_RefreshesExpiredTokens(t *testing.T) {
 		t,
 		userinfoOK("sub-refresh", "operator@example.com"),
 		func(w http.ResponseWriter, r *http.Request) {
-			require.NoError(t, r.ParseForm())
-			require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
-			require.Equal(t, "old-refresh-token", r.PostForm.Get("refresh_token"))
+			assert.NoError(t, r.ParseForm())
+			assert.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
+			assert.Equal(t, "old-refresh-token", r.PostForm.Get("refresh_token"))
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"access_token":  "new-access-token",
@@ -221,6 +225,66 @@ func TestHandleGetSession_RefreshesExpiredTokens(t *testing.T) {
 	require.True(t, session.AccessTokenExpiresAt.After(time.Now()))
 }
 
+func TestHandleGetSession_SerializesConcurrentRefreshes(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	var refreshes atomic.Int32
+	oidcClient := newTestOIDCClientWithToken(
+		t,
+		userinfoOK("sub-concurrent-refresh", "operator@example.com"),
+		func(w http.ResponseWriter, r *http.Request) {
+			refreshes.Add(1)
+			assert.NoError(t, r.ParseForm())
+			assert.Equal(t, "old-refresh-token", r.PostForm.Get("refresh_token"))
+			time.Sleep(100 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "new-access-token",
+				"refresh_token": "new-refresh-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		},
+	)
+	svc := newTestSessionService(t, oidcClient)
+	sessionID, err := svc.sessions.Store(ctx, StoreParams{
+		Email:        "operator@example.com",
+		Name:         "Test Operator",
+		OIDCSubject:  "sub-concurrent-refresh",
+		HD:           testAdminHD,
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+
+	const requests = 5
+	start := make(chan struct{})
+	codes := make(chan int, requests)
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			req := httptest.NewRequest(http.MethodGet, "/admin/session.get", nil)
+			req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+			rec := httptest.NewRecorder()
+			SessionMiddleware(oops.ErrHandle(svc.logger, svc.handleGetSession)).ServeHTTP(rec, req)
+			codes <- rec.Code
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(codes)
+
+	for code := range codes {
+		require.Equal(t, http.StatusOK, code)
+	}
+	require.EqualValues(t, 1, refreshes.Load())
+}
+
 func TestAuthCodeURLRequestsConsentForInteractiveLogin(t *testing.T) {
 	t.Parallel()
 
@@ -229,7 +293,7 @@ func TestAuthCodeURLRequestsConsentForInteractiveLogin(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "consent", interactive.Query().Get("prompt"))
 
-	silent, err := url.Parse(client.AuthCodeURL("state", "challenge", "none"))
+	silent, err := url.Parse(client.AuthCodeURL("state", "challenge", "  none  "))
 	require.NoError(t, err)
 	require.Equal(t, "none", silent.Query().Get("prompt"))
 }

--- a/server/internal/admin/session_handler_test.go
+++ b/server/internal/admin/session_handler_test.go
@@ -135,6 +135,36 @@ func callSessionGet(t *testing.T, svc *Service, sessionID string) *httptest.Resp
 	return rec
 }
 
+func callSessionGetConcurrently(t *testing.T, svc *Service, sessionID string, requests int, beforeWait func()) []int {
+	t.Helper()
+
+	start := make(chan struct{})
+	codes := make(chan int, requests)
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			req := httptest.NewRequest(http.MethodGet, "/admin/session.get", nil)
+			req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+			rec := httptest.NewRecorder()
+			SessionMiddleware(oops.ErrHandle(svc.logger, svc.handleGetSession)).ServeHTTP(rec, req)
+			codes <- rec.Code
+		}()
+	}
+	close(start)
+	beforeWait()
+	wg.Wait()
+	close(codes)
+
+	results := make([]int, 0, requests)
+	for code := range codes {
+		results = append(results, code)
+	}
+	return results
+}
+
 // TestAttach_MountsSessionRoute proves the hand-written route reaches the
 // handler on the same muxer that carries the generated admin routes. A missing
 // or conflicting pattern would give 404 instead of 401.
@@ -225,6 +255,55 @@ func TestHandleGetSession_RefreshesExpiredTokens(t *testing.T) {
 	require.True(t, session.AccessTokenExpiresAt.After(time.Now()))
 }
 
+func TestHandleGetSession_ClassifiesRefreshFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		status      int
+		oauthError  string
+		wantStatus  int
+		wantSession bool
+	}{
+		{name: "invalid grant", status: http.StatusBadRequest, oauthError: "invalid_grant", wantStatus: http.StatusUnauthorized, wantSession: false},
+		{name: "provider unavailable", status: http.StatusServiceUnavailable, oauthError: "server_error", wantStatus: http.StatusInternalServerError, wantSession: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			oidcClient := newTestOIDCClientWithToken(
+				t,
+				userinfoOK("sub-refresh-failure", "operator@example.com"),
+				func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(tt.status)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": tt.oauthError})
+				},
+			)
+			svc := newTestSessionService(t, oidcClient)
+			sessionID, err := svc.sessions.Store(ctx, StoreParams{
+				Email:        "operator@example.com",
+				Name:         "Test Operator",
+				OIDCSubject:  "sub-refresh-failure",
+				HD:           testAdminHD,
+				AccessToken:  "old-access-token",
+				RefreshToken: "old-refresh-token",
+				ExpiresAt:    time.Now().Add(-time.Minute),
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wantStatus, callSessionGet(t, svc, sessionID).Code)
+			_, err = svc.sessions.Get(ctx, sessionID)
+			if tt.wantSession {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestHandleGetSession_SerializesConcurrentRefreshes(t *testing.T) {
 	t.Parallel()
 
@@ -260,34 +339,56 @@ func TestHandleGetSession_SerializesConcurrentRefreshes(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	const requests = 5
-	start := make(chan struct{})
-	codes := make(chan int, requests)
-	var wg sync.WaitGroup
-	for range requests {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			<-start
-			req := httptest.NewRequest(http.MethodGet, "/admin/session.get", nil)
-			req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
-			rec := httptest.NewRecorder()
-			SessionMiddleware(oops.ErrHandle(svc.logger, svc.handleGetSession)).ServeHTTP(rec, req)
-			codes <- rec.Code
-		}()
-	}
-	close(start)
-	require.Eventually(t, func() bool {
-		return refreshes.Load() == 1
-	}, time.Second, 10*time.Millisecond)
-	close(releaseRefresh)
-	wg.Wait()
-	close(codes)
-
-	for code := range codes {
+	codes := callSessionGetConcurrently(t, svc, sessionID, 5, func() {
+		assert.Eventually(t, func() bool {
+			return refreshes.Load() == 1
+		}, time.Second, 10*time.Millisecond)
+		close(releaseRefresh)
+	})
+	for _, code := range codes {
 		require.Equal(t, http.StatusOK, code)
 	}
 	require.EqualValues(t, 1, refreshes.Load())
+}
+
+func TestHandleGetSession_SharesConcurrentReauthentication(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	var refreshes atomic.Int32
+	releaseRefresh := make(chan struct{})
+	oidcClient := newTestOIDCClientWithToken(
+		t,
+		userinfoOK("sub-concurrent-reauth", "operator@example.com"),
+		func(w http.ResponseWriter, _ *http.Request) {
+			refreshes.Add(1)
+			<-releaseRefresh
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant"})
+		},
+	)
+	svc := newTestSessionService(t, oidcClient)
+	sessionID, err := svc.sessions.Store(ctx, StoreParams{
+		Email:        "operator@example.com",
+		Name:         "Test Operator",
+		OIDCSubject:  "sub-concurrent-reauth",
+		HD:           testAdminHD,
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+
+	codes := callSessionGetConcurrently(t, svc, sessionID, 3, func() {
+		assert.Eventually(t, func() bool {
+			return refreshes.Load() > 0
+		}, time.Second, 10*time.Millisecond)
+		close(releaseRefresh)
+	})
+	for _, code := range codes {
+		require.Equal(t, http.StatusUnauthorized, code)
+	}
 }
 
 func TestAuthCodeURLRequestsConsentForInteractiveLogin(t *testing.T) {

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -3,13 +3,17 @@ package admin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"time"
 
 	"goa.design/goa/v3/security"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -23,13 +27,15 @@ type Verifier struct {
 	logger   *slog.Logger
 	sessions *SessionStore
 	oidc     *OIDCClient
+	locks    cache.Cache
 }
 
-func NewVerifier(logger *slog.Logger, sessions *SessionStore, oidc *OIDCClient) *Verifier {
+func NewVerifier(logger *slog.Logger, sessions *SessionStore, oidc *OIDCClient, locks cache.Cache) *Verifier {
 	return &Verifier{
 		logger:   logger.With(attr.SlogComponent("adminauth")),
 		sessions: sessions,
 		oidc:     oidc,
+		locks:    locks,
 	}
 }
 
@@ -60,25 +66,14 @@ func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.A
 	}
 
 	if NeedsRefresh(session.AccessTokenExpiresAt) {
-		refreshToken, err := v.sessions.DecryptRefreshToken(session)
-		if err != nil {
-			return ctx, oops.E(oops.CodeUnexpected, err, "decrypt admin session").LogError(ctx, v.logger)
-		}
-		if refreshToken == "" {
-			// No refresh token captured at login; re-auth required.
-			_ = v.sessions.Delete(ctx, session.SessionID)
-			return ctx, oops.C(oops.CodeUnauthorized)
-		}
-		tok, err := v.oidc.Refresh(ctx, refreshToken)
-		if err != nil {
+		session, accessToken, err = v.refreshSession(ctx, session)
+		switch {
+		case errors.Is(err, errAdminSessionRefreshRequired):
 			_ = v.sessions.Delete(ctx, session.SessionID)
 			return ctx, oops.C(oops.CodeUnauthorized).LogError(ctx, v.logger, attr.SlogError(err))
+		case err != nil:
+			return ctx, oops.E(oops.CodeUnexpected, err, "refresh admin session").LogError(ctx, v.logger)
 		}
-		session, err = v.sessions.UpdateTokens(ctx, session, tok.AccessToken, tok.RefreshToken, tok.Expiry)
-		if err != nil {
-			return ctx, oops.E(oops.CodeUnexpected, err, "persist refreshed admin session").LogError(ctx, v.logger)
-		}
-		accessToken = tok.AccessToken
 	}
 
 	info, err := v.oidc.Userinfo(ctx, accessToken)
@@ -112,4 +107,95 @@ func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.A
 	)
 
 	return ctx, nil
+}
+
+var errAdminSessionRefreshRequired = errors.New("admin session requires reauthentication")
+
+const (
+	adminRefreshUpstreamTimeout = 10 * time.Second
+	adminRefreshLockTTL         = 12 * time.Second
+	adminRefreshWaitBudget      = 12 * time.Second
+	adminRefreshWaitPoll        = 200 * time.Millisecond
+	adminRefreshReleaseTimeout  = 5 * time.Second
+)
+
+func adminSessionRefreshLockKey(sessionID string) string {
+	return "adminSession:refresh:" + sessionID
+}
+
+// refreshSession serializes refresh-token grants per admin session. Refresh
+// tokens may be single-use, so waiters adopt the holder's persisted token pair
+// instead of presenting the same refresh token again.
+func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session, string, error) {
+	lockKey := adminSessionRefreshLockKey(session.SessionID)
+	acquiredAt := time.Now()
+	held, err := v.locks.Add(ctx, lockKey, adminRefreshLockTTL)
+	if err != nil {
+		return session, "", fmt.Errorf("acquire admin refresh lock: %w", err)
+	}
+	if !held {
+		return v.awaitRefreshedSession(ctx, session.SessionID)
+	}
+
+	defer o11y.LogDefer(ctx, v.logger, func() error {
+		// Past the lease TTL this key may belong to a new holder.
+		if time.Since(acquiredAt) >= adminRefreshLockTTL {
+			return nil
+		}
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), adminRefreshReleaseTimeout)
+		defer cancel()
+		return v.locks.Delete(releaseCtx, lockKey)
+	})
+
+	// The caller's snapshot predates lock acquisition. Re-read so a refresh that
+	// completed while this request was acquiring is adopted rather than replayed.
+	current, err := v.sessions.Get(ctx, session.SessionID)
+	if err != nil {
+		return session, "", fmt.Errorf("re-read admin session before refresh: %w", err)
+	}
+	if !NeedsRefresh(current.AccessTokenExpiresAt) {
+		accessToken, err := v.sessions.DecryptAccessToken(current)
+		return current, accessToken, err
+	}
+
+	refreshToken, err := v.sessions.DecryptRefreshToken(current)
+	if err != nil {
+		return current, "", fmt.Errorf("decrypt admin refresh token: %w", err)
+	}
+	if refreshToken == "" {
+		return current, "", errAdminSessionRefreshRequired
+	}
+
+	refreshCtx, cancel := context.WithTimeout(ctx, adminRefreshUpstreamTimeout)
+	defer cancel()
+	tok, err := v.oidc.Refresh(refreshCtx, refreshToken)
+	if err != nil {
+		return current, "", fmt.Errorf("%w: %v", errAdminSessionRefreshRequired, err)
+	}
+	current, err = v.sessions.UpdateTokens(ctx, current, tok.AccessToken, tok.RefreshToken, tok.Expiry)
+	if err != nil {
+		return current, "", fmt.Errorf("persist refreshed admin session: %w", err)
+	}
+	return current, tok.AccessToken, nil
+}
+
+func (v *Verifier) awaitRefreshedSession(ctx context.Context, sessionID string) (Session, string, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, adminRefreshWaitBudget)
+	defer cancel()
+	ticker := time.NewTicker(adminRefreshWaitPoll)
+	defer ticker.Stop()
+
+	for {
+		current, err := v.sessions.Get(waitCtx, sessionID)
+		if err == nil && !NeedsRefresh(current.AccessTokenExpiresAt) {
+			accessToken, err := v.sessions.DecryptAccessToken(current)
+			return current, accessToken, err
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return Session{SessionID: sessionID}, "", fmt.Errorf("wait for concurrent admin session refresh: %w", waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
 }

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -7,13 +7,13 @@ import (
 	"log/slog"
 	"time"
 
+	redisCache "github.com/go-redis/cache/v9"
 	"goa.design/goa/v3/security"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -69,7 +69,6 @@ func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.A
 		session, accessToken, err = v.refreshSession(ctx, session)
 		switch {
 		case errors.Is(err, errAdminSessionRefreshRequired):
-			_ = v.sessions.Delete(ctx, session.SessionID)
 			return ctx, oops.C(oops.CodeUnauthorized).LogError(ctx, v.logger, attr.SlogError(err))
 		case err != nil:
 			return ctx, oops.E(oops.CodeUnexpected, err, "refresh admin session").LogError(ctx, v.logger)
@@ -114,9 +113,8 @@ var errAdminSessionRefreshRequired = errors.New("admin session requires reauthen
 const (
 	adminRefreshUpstreamTimeout = 10 * time.Second
 	adminRefreshLockTTL         = 12 * time.Second
-	adminRefreshWaitBudget      = 12 * time.Second
+	adminRefreshWaitBudget      = adminRefreshLockTTL + adminRefreshUpstreamTimeout + time.Second
 	adminRefreshWaitPoll        = 200 * time.Millisecond
-	adminRefreshReleaseTimeout  = 5 * time.Second
 )
 
 func adminSessionRefreshLockKey(sessionID string) string {
@@ -128,7 +126,6 @@ func adminSessionRefreshLockKey(sessionID string) string {
 // instead of presenting the same refresh token again.
 func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session, string, error) {
 	lockKey := adminSessionRefreshLockKey(session.SessionID)
-	acquiredAt := time.Now()
 	held, err := v.locks.Add(ctx, lockKey, adminRefreshLockTTL)
 	if err != nil {
 		return session, "", fmt.Errorf("acquire admin refresh lock: %w", err)
@@ -136,20 +133,17 @@ func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session
 	if !held {
 		return v.awaitRefreshedSession(ctx, session.SessionID)
 	}
+	return v.refreshSessionLocked(ctx, session)
+}
 
-	defer o11y.LogDefer(ctx, v.logger, func() error {
-		// Past the lease TTL this key may belong to a new holder.
-		if time.Since(acquiredAt) >= adminRefreshLockTTL {
-			return nil
-		}
-		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), adminRefreshReleaseTimeout)
-		defer cancel()
-		return v.locks.Delete(releaseCtx, lockKey)
-	})
+func (v *Verifier) refreshSessionLocked(ctx context.Context, session Session) (Session, string, error) {
 
 	// The caller's snapshot predates lock acquisition. Re-read so a refresh that
 	// completed while this request was acquiring is adopted rather than replayed.
 	current, err := v.sessions.Get(ctx, session.SessionID)
+	if errors.Is(err, redisCache.ErrCacheMiss) {
+		return session, "", errAdminSessionRefreshRequired
+	}
 	if err != nil {
 		return session, "", fmt.Errorf("re-read admin session before refresh: %w", err)
 	}
@@ -163,6 +157,9 @@ func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session
 		return current, "", fmt.Errorf("decrypt admin refresh token: %w", err)
 	}
 	if refreshToken == "" {
+		if err := v.sessions.Delete(ctx, current.SessionID); err != nil {
+			return current, "", fmt.Errorf("delete unrefreshable admin session: %w", err)
+		}
 		return current, "", errAdminSessionRefreshRequired
 	}
 
@@ -170,7 +167,13 @@ func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session
 	defer cancel()
 	tok, err := v.oidc.Refresh(refreshCtx, refreshToken)
 	if err != nil {
-		return current, "", fmt.Errorf("%w: %w", errAdminSessionRefreshRequired, err)
+		if !isInvalidGrant(err) {
+			return current, "", fmt.Errorf("refresh oidc access token: %w", err)
+		}
+		if err := v.sessions.Delete(ctx, current.SessionID); err != nil {
+			return current, "", fmt.Errorf("delete rejected admin session: %w", err)
+		}
+		return current, "", errAdminSessionRefreshRequired
 	}
 	current, err = v.sessions.UpdateTokens(ctx, current, tok.AccessToken, tok.RefreshToken, tok.Expiry)
 	if err != nil {
@@ -187,9 +190,23 @@ func (v *Verifier) awaitRefreshedSession(ctx context.Context, sessionID string) 
 
 	for {
 		current, err := v.sessions.Get(waitCtx, sessionID)
-		if err == nil && !NeedsRefresh(current.AccessTokenExpiresAt) {
+		switch {
+		case errors.Is(err, redisCache.ErrCacheMiss):
+			return current, "", errAdminSessionRefreshRequired
+		case err != nil:
+			return current, "", fmt.Errorf("poll admin session during refresh: %w", err)
+		case !NeedsRefresh(current.AccessTokenExpiresAt):
 			accessToken, err := v.sessions.DecryptAccessToken(current)
 			return current, accessToken, err
+		}
+
+		lockKey := adminSessionRefreshLockKey(sessionID)
+		held, err := v.locks.Add(waitCtx, lockKey, adminRefreshLockTTL)
+		if err != nil {
+			return current, "", fmt.Errorf("reacquire admin refresh lock: %w", err)
+		}
+		if held {
+			return v.refreshSessionLocked(waitCtx, current)
 		}
 
 		select {

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -166,29 +166,74 @@ func (v *Verifier) refreshSessionLocked(ctx context.Context, session Session, lo
 		return current, "", fmt.Errorf("decrypt admin refresh token: %w", err)
 	}
 	if refreshToken == "" {
-		if err := v.sessions.Delete(ctx, current.SessionID); err != nil {
+		deleted, err := v.sessions.DeleteIfUnchanged(ctx, current)
+		if err != nil {
 			return current, "", fmt.Errorf("delete unrefreshable admin session: %w", err)
+		}
+		if !deleted {
+			return v.awaitRefreshedSession(ctx, current.SessionID)
 		}
 		return current, "", errAdminSessionRefreshRequired
 	}
 
+	renewed, err := v.locks.RenewLease(ctx, lockKey, owner, adminRefreshLockTTL)
+	if err != nil {
+		return current, "", fmt.Errorf("renew admin refresh lease before provider call: %w", err)
+	}
+	if !renewed {
+		return v.awaitRefreshedSession(ctx, current.SessionID)
+	}
+
 	refreshCtx, cancel := context.WithTimeout(ctx, adminRefreshUpstreamTimeout)
 	defer cancel()
-	tok, err := v.oidc.Refresh(refreshCtx, refreshToken)
+	tok, refreshErr := v.oidc.Refresh(refreshCtx, refreshToken)
+	renewed, err = v.locks.RenewLease(ctx, lockKey, owner, adminRefreshLockTTL)
 	if err != nil {
-		if !isInvalidGrant(err) {
-			return current, "", fmt.Errorf("refresh oidc access token: %w", err)
+		return current, "", fmt.Errorf("renew admin refresh lease after provider call: %w", err)
+	}
+	if !renewed {
+		return v.awaitRefreshedSession(ctx, current.SessionID)
+	}
+	if refreshErr != nil {
+		if !isInvalidGrant(refreshErr) {
+			return current, "", fmt.Errorf("refresh oidc access token: %w", refreshErr)
 		}
-		if err := v.sessions.Delete(ctx, current.SessionID); err != nil {
+		deleted, err := v.sessions.DeleteIfUnchanged(ctx, current)
+		if err != nil {
 			return current, "", fmt.Errorf("delete rejected admin session: %w", err)
 		}
-		return current, "", errAdminSessionRefreshRequired
+		if deleted {
+			return current, "", errAdminSessionRefreshRequired
+		}
+
+		current, err = v.sessions.Get(ctx, current.SessionID)
+		if errors.Is(err, redisCache.ErrCacheMiss) {
+			return current, "", errAdminSessionRefreshRequired
+		}
+		if err != nil {
+			return current, "", fmt.Errorf("reload admin session after rejected refresh: %w", err)
+		}
+		if NeedsRefresh(current.AccessTokenExpiresAt) {
+			return current, "", errors.New("admin session changed but still requires refresh")
+		}
+		accessToken, err := v.sessions.DecryptAccessToken(current)
+		if err != nil {
+			return current, "", fmt.Errorf("decrypt concurrently refreshed admin access token: %w", err)
+		}
+		return current, accessToken, nil
 	}
 	current, err = v.sessions.UpdateTokens(ctx, current, tok.AccessToken, tok.RefreshToken, tok.Expiry)
+	if errors.Is(err, redisCache.ErrCacheMiss) {
+		return current, "", errAdminSessionRefreshRequired
+	}
 	if err != nil {
 		return current, "", fmt.Errorf("persist refreshed admin session: %w", err)
 	}
-	return current, tok.AccessToken, nil
+	accessToken, err := v.sessions.DecryptAccessToken(current)
+	if err != nil {
+		return current, "", fmt.Errorf("decrypt persisted admin access token: %w", err)
+	}
+	return current, accessToken, nil
 }
 
 func (v *Verifier) awaitRefreshedSession(ctx context.Context, sessionID string) (Session, string, error) {

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -170,7 +170,7 @@ func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session
 	defer cancel()
 	tok, err := v.oidc.Refresh(refreshCtx, refreshToken)
 	if err != nil {
-		return current, "", fmt.Errorf("%w: %v", errAdminSessionRefreshRequired, err)
+		return current, "", fmt.Errorf("%w: %w", errAdminSessionRefreshRequired, err)
 	}
 	current, err = v.sessions.UpdateTokens(ctx, current, tok.AccessToken, tok.RefreshToken, tok.Expiry)
 	if err != nil {
@@ -194,7 +194,8 @@ func (v *Verifier) awaitRefreshedSession(ctx context.Context, sessionID string) 
 
 		select {
 		case <-waitCtx.Done():
-			return Session{SessionID: sessionID}, "", fmt.Errorf("wait for concurrent admin session refresh: %w", waitCtx.Err())
+			var session Session
+			return session, "", fmt.Errorf("wait for concurrent admin session refresh: %w", waitCtx.Err())
 		case <-ticker.C:
 		}
 	}

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	redisCache "github.com/go-redis/cache/v9"
+	"github.com/google/uuid"
 	"goa.design/goa/v3/security"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -27,10 +29,10 @@ type Verifier struct {
 	logger   *slog.Logger
 	sessions *SessionStore
 	oidc     *OIDCClient
-	locks    cache.Cache
+	locks    *cache.RedisCacheAdapter
 }
 
-func NewVerifier(logger *slog.Logger, sessions *SessionStore, oidc *OIDCClient, locks cache.Cache) *Verifier {
+func NewVerifier(logger *slog.Logger, sessions *SessionStore, oidc *OIDCClient, locks *cache.RedisCacheAdapter) *Verifier {
 	return &Verifier{
 		logger:   logger.With(attr.SlogComponent("adminauth")),
 		sessions: sessions,
@@ -115,6 +117,7 @@ const (
 	adminRefreshLockTTL         = 12 * time.Second
 	adminRefreshWaitBudget      = adminRefreshLockTTL + adminRefreshUpstreamTimeout + time.Second
 	adminRefreshWaitPoll        = 200 * time.Millisecond
+	adminRefreshReleaseTimeout  = 5 * time.Second
 )
 
 func adminSessionRefreshLockKey(sessionID string) string {
@@ -126,17 +129,23 @@ func adminSessionRefreshLockKey(sessionID string) string {
 // instead of presenting the same refresh token again.
 func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session, string, error) {
 	lockKey := adminSessionRefreshLockKey(session.SessionID)
-	held, err := v.locks.Add(ctx, lockKey, adminRefreshLockTTL)
+	owner := uuid.NewString()
+	held, err := v.locks.AcquireLease(ctx, lockKey, owner, adminRefreshLockTTL)
 	if err != nil {
 		return session, "", fmt.Errorf("acquire admin refresh lock: %w", err)
 	}
 	if !held {
 		return v.awaitRefreshedSession(ctx, session.SessionID)
 	}
-	return v.refreshSessionLocked(ctx, session)
+	return v.refreshSessionLocked(ctx, session, lockKey, owner)
 }
 
-func (v *Verifier) refreshSessionLocked(ctx context.Context, session Session) (Session, string, error) {
+func (v *Verifier) refreshSessionLocked(ctx context.Context, session Session, lockKey, owner string) (Session, string, error) {
+	defer o11y.LogDefer(ctx, v.logger, func() error {
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), adminRefreshReleaseTimeout)
+		defer cancel()
+		return v.locks.ReleaseLease(releaseCtx, lockKey, owner)
+	})
 
 	// The caller's snapshot predates lock acquisition. Re-read so a refresh that
 	// completed while this request was acquiring is adopted rather than replayed.
@@ -201,12 +210,13 @@ func (v *Verifier) awaitRefreshedSession(ctx context.Context, sessionID string) 
 		}
 
 		lockKey := adminSessionRefreshLockKey(sessionID)
-		held, err := v.locks.Add(waitCtx, lockKey, adminRefreshLockTTL)
+		owner := uuid.NewString()
+		held, err := v.locks.AcquireLease(waitCtx, lockKey, owner, adminRefreshLockTTL)
 		if err != nil {
 			return current, "", fmt.Errorf("reacquire admin refresh lock: %w", err)
 		}
 		if held {
-			return v.refreshSessionLocked(waitCtx, current)
+			return v.refreshSessionLocked(waitCtx, current, lockKey, owner)
 		}
 
 		select {

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -74,7 +74,7 @@ func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.A
 			_ = v.sessions.Delete(ctx, session.SessionID)
 			return ctx, oops.C(oops.CodeUnauthorized).LogError(ctx, v.logger, attr.SlogError(err))
 		}
-		session, err = v.sessions.UpdateAccessToken(ctx, session, tok.AccessToken, tok.Expiry)
+		session, err = v.sessions.UpdateTokens(ctx, session, tok.AccessToken, tok.RefreshToken, tok.Expiry)
 		if err != nil {
 			return ctx, oops.E(oops.CodeUnexpected, err, "persist refreshed admin session").LogError(ctx, v.logger)
 		}

--- a/server/internal/cache/cache.go
+++ b/server/internal/cache/cache.go
@@ -44,6 +44,13 @@ type Cache interface {
 	DeleteByPrefix(ctx context.Context, prefix string) error
 }
 
+// CompareAndSwapCache is an optional capability for atomically replacing a
+// cache value only when its serialized value still matches an expected value.
+type CompareAndSwapCache interface {
+	CompareAndSwap(ctx context.Context, key string, expected, replacement any, ttl time.Duration) (bool, error)
+	CompareAndDelete(ctx context.Context, key string, expected any) (bool, error)
+}
+
 type TypedCacheObject[T CacheableObject[T]] struct {
 	logger    *slog.Logger
 	cache     Cache
@@ -150,6 +157,37 @@ func (d *TypedCacheObject[T]) Store(ctx context.Context, obj T) error {
 		return fmt.Errorf("store: %s: %w", d.fullKey(obj.CacheKey()), err)
 	}
 	return nil
+}
+
+// CompareAndSwap atomically replaces expected when the cached value has not changed.
+func (d *TypedCacheObject[T]) CompareAndSwap(ctx context.Context, expected, replacement T) (bool, error) {
+	if expected.CacheKey() != replacement.CacheKey() {
+		return false, errors.New("compare and swap cache keys differ")
+	}
+	cas, ok := d.cache.(CompareAndSwapCache)
+	if !ok {
+		return false, errors.New("cache does not support compare and swap")
+	}
+	key := d.fullKey(expected.CacheKey())
+	swapped, err := cas.CompareAndSwap(ctx, key, expected, replacement, replacement.TTL())
+	if err != nil {
+		return false, fmt.Errorf("compare and swap %s: %w", key, err)
+	}
+	return swapped, nil
+}
+
+// CompareAndDelete atomically deletes expected when the cached value has not changed.
+func (d *TypedCacheObject[T]) CompareAndDelete(ctx context.Context, expected T) (bool, error) {
+	cas, ok := d.cache.(CompareAndSwapCache)
+	if !ok {
+		return false, errors.New("cache does not support compare and delete")
+	}
+	key := d.fullKey(expected.CacheKey())
+	deleted, err := cas.CompareAndDelete(ctx, key, expected)
+	if err != nil {
+		return false, fmt.Errorf("compare and delete %s: %w", key, err)
+	}
+	return deleted, nil
 }
 
 func (d *TypedCacheObject[T]) Update(ctx context.Context, obj T) error {

--- a/server/internal/cache/redis.go
+++ b/server/internal/cache/redis.go
@@ -75,6 +75,29 @@ func (r *RedisCacheAdapter) Add(ctx context.Context, key string, ttl time.Durati
 	return ok, nil
 }
 
+// AcquireLease sets a caller-provided ownership token only when key is absent.
+func (r *RedisCacheAdapter) AcquireLease(ctx context.Context, key, owner string, ttl time.Duration) (bool, error) {
+	ok, err := r.client.SetNX(ctx, key, owner, ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("acquire lease %s: %w", key, err)
+	}
+	return ok, nil
+}
+
+// ReleaseLease atomically deletes key only if it is still owned by owner.
+func (r *RedisCacheAdapter) ReleaseLease(ctx context.Context, key, owner string) error {
+	const compareAndDelete = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`
+	if err := r.client.Eval(ctx, compareAndDelete, []string{key}, owner).Err(); err != nil {
+		return fmt.Errorf("release lease %s: %w", key, err)
+	}
+	return nil
+}
+
 func (r *RedisCacheAdapter) Mutate(ctx context.Context, key string, value any, ttl time.Duration, fn func(exists bool) error) error {
 	var lastErr error
 	for range mutateMaxRetries {

--- a/server/internal/cache/redis.go
+++ b/server/internal/cache/redis.go
@@ -12,7 +12,10 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var _ Cache = (*RedisCacheAdapter)(nil)
+var (
+	_ Cache               = (*RedisCacheAdapter)(nil)
+	_ CompareAndSwapCache = (*RedisCacheAdapter)(nil)
+)
 
 const mutateMaxRetries = 5
 
@@ -84,6 +87,21 @@ func (r *RedisCacheAdapter) AcquireLease(ctx context.Context, key, owner string,
 	return ok, nil
 }
 
+// RenewLease extends key only if it is still owned by owner.
+func (r *RedisCacheAdapter) RenewLease(ctx context.Context, key, owner string, ttl time.Duration) (bool, error) {
+	const compareAndExpire = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+end
+return 0
+`
+	renewed, err := r.client.Eval(ctx, compareAndExpire, []string{key}, owner, ttl.Milliseconds()).Int64()
+	if err != nil {
+		return false, fmt.Errorf("renew lease %s: %w", key, err)
+	}
+	return renewed == 1, nil
+}
+
 // ReleaseLease atomically deletes key only if it is still owned by owner.
 func (r *RedisCacheAdapter) ReleaseLease(ctx context.Context, key, owner string) error {
 	const compareAndDelete = `
@@ -96,6 +114,49 @@ return 0
 		return fmt.Errorf("release lease %s: %w", key, err)
 	}
 	return nil
+}
+
+// CompareAndSwap atomically replaces key when its serialized value matches expected.
+func (r *RedisCacheAdapter) CompareAndSwap(ctx context.Context, key string, expected, replacement any, ttl time.Duration) (bool, error) {
+	expectedRaw, err := r.cache.Marshal(expected)
+	if err != nil {
+		return false, fmt.Errorf("marshal expected value: %w", err)
+	}
+	replacementRaw, err := r.cache.Marshal(replacement)
+	if err != nil {
+		return false, fmt.Errorf("marshal replacement value: %w", err)
+	}
+	const compareAndSwap = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  redis.call("SET", KEYS[1], ARGV[2], "PX", ARGV[3])
+  return 1
+end
+return 0
+`
+	swapped, err := r.client.Eval(ctx, compareAndSwap, []string{key}, expectedRaw, replacementRaw, ttl.Milliseconds()).Int64()
+	if err != nil {
+		return false, fmt.Errorf("compare and swap %s: %w", key, err)
+	}
+	return swapped == 1, nil
+}
+
+// CompareAndDelete atomically deletes key when its serialized value matches expected.
+func (r *RedisCacheAdapter) CompareAndDelete(ctx context.Context, key string, expected any) (bool, error) {
+	expectedRaw, err := r.cache.Marshal(expected)
+	if err != nil {
+		return false, fmt.Errorf("marshal expected value: %w", err)
+	}
+	const compareAndDelete = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`
+	deleted, err := r.client.Eval(ctx, compareAndDelete, []string{key}, expectedRaw).Int64()
+	if err != nil {
+		return false, fmt.Errorf("compare and delete %s: %w", key, err)
+	}
+	return deleted == 1, nil
 }
 
 func (r *RedisCacheAdapter) Mutate(ctx context.Context, key string, value any, ttl time.Duration, fn func(exists bool) error) error {


### PR DESCRIPTION
## Summary

- request explicit consent when establishing standalone admin sessions so the identity provider returns a refresh token
- persist refreshed access tokens and rotated refresh tokens together
- add refresh-token grant support to the local OIDC provider and cover session refresh behavior

## Testing

- `go test ./mock-oidc ./server/internal/admin`
- `aube run -F admin test`
- `aube run -F admin type-check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hourly re-prompts for standalone admin by obtaining refresh tokens and safely refreshing access tokens. Previously, sessions lacked refresh tokens and expired hourly; now interactive login requests consent to get a refresh token, and refreshes are serialized and fenced to avoid duplicate grants and racey updates.

- Client: on 401, redirect to `/admin/auth.login?prompt=consent`; logout keeps the cookie but redirects with `prompt=select_account` so sign-out is visible.
- Server: interactive OIDC flows auto-add consent; the verifier serializes per-session refresh with Redis leases (acquire/renew/release) and waiters adopt the winner’s persisted tokens; token updates use compare-and-swap and optionally retain a non-rotated refresh token; `invalid_grant` deletes the session and returns 401; upstream errors/timeouts return 500 and keep the session.
- Cache: added CAS to the typed cache and Redis adapter, plus lease helpers to gate refresh; session store supports compare-and-swap updates and compare-and-delete.
- `mock-oidc`: advertises `refresh_token`, issues refresh tokens on code exchange, and supports the refresh grant; integration tests cover consent, refresh (including non-rotating tokens), and concurrency.

- Rollout: operators with existing sessions must sign in once to seed a refresh token.

<sup>Written for commit 033c92c8d95f239787bc8e0438875222e71ff3b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

