### PR TITLE
feat: link remote identity providers to their detail page

### DIFF
--- a/.changeset/link-remote-identity-providers.md
+++ b/.changeset/link-remote-identity-providers.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Remote identity providers listed on an MCP server's Authentication settings now link through to their detail page. The rows were inert text, so reaching a provider's detail page meant navigating to Remote Identity Providers separately and finding it again by hand. Providers of every tenancy tier resolve through the same tenant-scoped detail page, which already renders an inherited platform provider read-only, and the name falls back to plain text for a viewer without organization read access.

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
@@ -1,0 +1,119 @@
+import type { Scope } from "@gram/client/models/components/rolegrant.js";
+import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RemoteIdentityProvidersField } from "./RemoteIdentityProvidersField";
+
+const { hasAnyScope } = vi.hoisted(() => ({ hasAnyScope: vi.fn() }));
+
+vi.mock("@/hooks/useRBAC", () => ({
+  useRBAC: () => ({
+    hasAnyScope: (scopes: Scope[]) => hasAnyScope(scopes) as boolean,
+    hasAllScopes: (scopes: Scope[]) => hasAnyScope(scopes) as boolean,
+    isLoading: false,
+  }),
+}));
+
+// The route helper resolves :orgSlug from the URL; stubbing it keeps the
+// expected href readable without standing up the org route tree.
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({
+    remoteIdentityProviders: {
+      issuerDetail: {
+        href: (id: string) => `/org-slug/remote-identity-providers/${id}`,
+      },
+    },
+  }),
+}));
+
+function issuer(overrides: Partial<RemoteSessionIssuer> = {}) {
+  return {
+    id: "issuer-1",
+    name: "Acme Identity",
+    issuer: "https://auth.example.com",
+    slug: "acme-identity",
+    organizationId: "org-1",
+    projectId: "project-1",
+    clientIdMetadataDocumentSupported: false,
+    oidc: true,
+    passthrough: false,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  } satisfies RemoteSessionIssuer;
+}
+
+function renderField(
+  issuers: RemoteSessionIssuer[],
+  handlers: { onEdit?: () => void; onDelete?: () => void } = {},
+) {
+  return render(
+    <MemoryRouter>
+      <RemoteIdentityProvidersField
+        associatedIssuers={issuers}
+        isLoading={false}
+        onAdd={vi.fn<() => void>()}
+        onEdit={handlers.onEdit ?? vi.fn<() => void>()}
+        onDelete={handlers.onDelete ?? vi.fn<() => void>()}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("RemoteIdentityProvidersField", () => {
+  beforeEach(() => {
+    hasAnyScope.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("links the provider name to its detail page", () => {
+    renderField([issuer()]);
+
+    expect(
+      screen.getByRole("link", { name: "Acme Identity" }).getAttribute("href"),
+    ).toBe("/org-slug/remote-identity-providers/issuer-1");
+  });
+
+  // Inherited organization and platform providers resolve through the same
+  // tenant-scoped detail page, which renders them read-only.
+  it.each([
+    ["organization", { projectId: "" }],
+    ["platform", { projectId: "", organizationId: "" }],
+  ])("links an inherited %s provider to the same route", (_tier, overrides) => {
+    renderField([issuer(overrides)]);
+
+    expect(
+      screen.getByRole("link", { name: "Acme Identity" }).getAttribute("href"),
+    ).toBe("/org-slug/remote-identity-providers/issuer-1");
+  });
+
+  // The detail page requires org:read/org:admin, so without them the name has
+  // to stay plain text rather than dead-end on an Unauthorized page.
+  it("renders the name unlinked without organization read scopes", () => {
+    hasAnyScope.mockImplementation(
+      (scopes: Scope[]) => !scopes.includes("org:read"),
+    );
+
+    renderField([issuer()]);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("Acme Identity")).toBeTruthy();
+  });
+
+  it("keeps Edit and Delete clickable beside the link", () => {
+    const onEdit = vi.fn<() => void>();
+    const onDelete = vi.fn<() => void>();
+    renderField([issuer()], { onEdit, onDelete });
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
@@ -2,10 +2,8 @@ import { AssetImage } from "@/components/asset-image";
 import { RequireScope } from "@/components/require-scope";
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/Field";
 import { Text } from "@/components/ui/Text";
-import {
-  formatRemoteSessionIssuerDisplay,
-  remoteSessionScopeTier,
-} from "@/lib/sources";
+import { remoteSessionScopeTier } from "@/lib/sources";
+import { IssuerLink } from "@/pages/remote-identity-providers/IssuerLink";
 import { ScopeBadge } from "@/pages/remote-identity-providers/ScopeBadge";
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
 import { Button } from "@/components/ui/Button";
@@ -105,7 +103,7 @@ function RemoteIdentityProviderRow({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <Text small className="truncate font-medium">
-              {formatRemoteSessionIssuerDisplay(issuer)}
+              <IssuerLink issuer={issuer} />
             </Text>
             <ScopeBadge
               projectId={issuer.projectId}

--- a/client/dashboard/src/pages/remote-identity-providers/IssuerLink.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/IssuerLink.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/utils";
+import { useRBAC } from "@/hooks/useRBAC";
+import { useOrgRoutes } from "@/routes";
+import { Link } from "react-router";
+import { issuerDisplayName } from "./issuerDisplay";
+
+// The subset of a remote identity provider needed to name it and route to it.
+// Structural, so the org-scoped and project-scoped issuer models both satisfy it.
+type LinkableIssuer = {
+  id: string;
+  name?: string | null | undefined;
+  issuer: string;
+};
+
+/**
+ * The provider's display name, linked to its detail page.
+ *
+ * All three tenancy tiers resolve through the tenant-scoped detail page, which
+ * renders an inherited platform provider read-only. The platform catalog route
+ * is reserved for platform admins.
+ *
+ * The detail page requires org:read/org:admin; without them the name renders as
+ * plain text.
+ */
+export function IssuerLink({
+  issuer,
+  className,
+}: {
+  issuer: LinkableIssuer;
+  className?: string;
+}): JSX.Element {
+  const orgRoutes = useOrgRoutes();
+  const { hasAnyScope } = useRBAC();
+  const label = issuerDisplayName(issuer);
+
+  if (!hasAnyScope(["org:read", "org:admin"])) {
+    return <>{label}</>;
+  }
+
+  return (
+    <Link
+      to={orgRoutes.remoteIdentityProviders.issuerDetail.href(issuer.id)}
+      className={cn("hover:text-primary hover:underline", className)}
+    >
+      {label}
+    </Link>
+  );
+}


### PR DESCRIPTION
Closes AGE-3283.

Wherever an MCP server's Authentication settings list a remote identity provider, the row was inert text. The only way to reach a provider's detail page was to navigate to Remote Identity Providers separately and find it again by hand. The provider's name is now a link.

## Changes

- **`IssuerLink`** (new, `pages/remote-identity-providers/`) — renders a provider's display name as a link to its detail page, reusing the existing `issuerDisplayName` helper so the label stays in sync with the other issuer surfaces.
- **`RemoteIdentityProvidersField`** — the row's name renders through `IssuerLink`. This also covers toolset-backed servers, since `ToolsetAuthenticationSection` reuses the same field.

Edit and Delete are siblings of the link, not descendants, so their clicks are unaffected.

## Two judgment calls

**All tiers route to the tenant-scoped detail page.** The issue suggested sending platform-tier providers to the `platform-remote-identity-providers` route. `RemoteIdentityProviderDetail` already renders an inherited platform provider read-only (`isPlatform` hides the Settings tab), whereas the platform catalog route sits behind `PlatformAdminOnly` and would dead-end everyone else. This also matches the Remote Identity Providers listing, which already links platform rows to the tenant route.

**The name falls back to plain text without organization read access.** The detail page requires `org:read`/`org:admin`, so linking unconditionally would send some viewers to an Unauthorized page.

## Surfaces deliberately left alone

`AttachRemoteIdentityProviderSheet` and `MigrateIssuerDialog` render names inside `<SelectItem>` options; `DeleteRemoteIdentityProviderDialog` is a type-to-confirm destructive step; `PlatformConvergenceTab` lists cross-org candidates the current org's route cannot resolve; `RemoteSessionClientDetail` already links its issuer via the breadcrumb. The connections and sessions surfaces only carry an issuer slug, no id.

## Testing

New `RemoteIdentityProvidersField.test.tsx` covers the href for a project-tier provider, the same href for inherited organization- and platform-tier providers, the unlinked fallback without organization scopes, and Edit/Delete still firing.

Manually verified against a local stack: hovering the name shows the detail URL, clicking it lands on the provider's Overview tab with the matching heading, the issuer URL beneath stays plain text, Edit opens the Modify sheet, and Delete detaches as before.
