### PR TITLE
mig: add platform mcp lifecycle registry prerequisites

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3694,6 +3694,15 @@ CREATE TABLE IF NOT EXISTS mcp_registries (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 100),
   url TEXT NOT NULL CHECK (url <> '' AND CHAR_LENGTH(url) <= 500),
+  -- Operator-owned source configuration. Legacy rows remain readable during
+  -- the expand phase until the catalogue service backfills and enforces these.
+  source_type TEXT,
+  auth_profile TEXT,
+  enabled boolean,
+  certification_state TEXT,
+  certification_version TEXT,
+  priority INT,
+  source_key TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -3706,6 +3715,10 @@ CREATE TABLE IF NOT EXISTS mcp_registries (
 CREATE UNIQUE INDEX IF NOT EXISTS mcp_registries_url_key
   ON mcp_registries (url)
   WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_registries_source_key_key
+  ON mcp_registries (source_key)
+  WHERE source_key IS NOT NULL AND deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS toolset_origins (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
@@ -7080,6 +7093,8 @@ CREATE TABLE IF NOT EXISTS platform_mcp_readiness (
   CONSTRAINT platform_mcp_readiness_pkey PRIMARY KEY (id),
   CONSTRAINT platform_mcp_readiness_connection_generation_check
     CHECK ((connection_id IS NULL) = (connection_generation IS NULL)),
+  CONSTRAINT platform_mcp_readiness_connectionless_actor_check
+    CHECK (connection_id IS NOT NULL OR (user_id IS NOT NULL AND acting_surface IS NOT NULL)),
   CONSTRAINT platform_mcp_readiness_provider_authorization_fingerprint_check CHECK (provider_authorization_fingerprint <> ''),
   CONSTRAINT platform_mcp_readiness_state_check CHECK (state <> ''),
   CONSTRAINT platform_mcp_readiness_organization_id_fkey
@@ -7100,6 +7115,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_readiness_binding_key
 ON platform_mcp_readiness (registration_id, connection_id, connection_generation, provider_authorization_fingerprint)
 NULLS NOT DISTINCT;
 
+-- Retained alongside the legacy full index during expand so new external and
+-- future assistant writers have independent predicate-qualified arbiters.
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_readiness_external_binding_key
+ON platform_mcp_readiness (registration_id, connection_id, connection_generation, provider_authorization_fingerprint)
+WHERE connection_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_readiness_assistant_binding_key
+ON platform_mcp_readiness (registration_id, user_id, acting_surface, provider_authorization_fingerprint)
+WHERE connection_id IS NULL;
+
 CREATE INDEX IF NOT EXISTS platform_mcp_readiness_registration_checked_at_idx
 ON platform_mcp_readiness (registration_id, checked_at DESC);
 
@@ -7112,6 +7137,10 @@ ON platform_mcp_readiness (organization_id, project_id);
 
 CREATE INDEX IF NOT EXISTS platform_mcp_readiness_organization_connection_idx
 ON platform_mcp_readiness (organization_id, connection_id);
+
+CREATE INDEX IF NOT EXISTS platform_mcp_readiness_organization_actor_idx
+ON platform_mcp_readiness (organization_id, user_id, acting_surface)
+WHERE connection_id IS NULL;
 
 -- Session handoff links: short-lived capability URLs through which a rendered
 -- session-handoff document can be fetched by a cloud agent or another machine
@@ -7261,6 +7290,9 @@ CREATE TABLE IF NOT EXISTS platform_mcp_distributions (
   project_id uuid NOT NULL,
   registration_id uuid NOT NULL,
   default_plugin_id uuid NOT NULL,
+  -- Nullable during expand; later exact-plugin writers dual-write this and the
+  -- legacy default_plugin_id until compatibility readers become the rollback floor.
+  plugin_id uuid,
   plugin_server_id uuid,
   state TEXT NOT NULL,
   version BIGINT NOT NULL,
@@ -7281,19 +7313,25 @@ CREATE TABLE IF NOT EXISTS platform_mcp_distributions (
   CONSTRAINT platform_mcp_distributions_pkey PRIMARY KEY (id),
   CONSTRAINT platform_mcp_distributions_connection_generation_check
     CHECK ((connection_id IS NULL) = (connection_generation IS NULL)),
+  CONSTRAINT platform_mcp_distributions_connectionless_actor_check
+    CHECK (connection_id IS NOT NULL OR (user_id IS NOT NULL AND acting_surface IS NOT NULL)),
   CONSTRAINT platform_mcp_distributions_state_check CHECK (state <> ''),
   CONSTRAINT platform_mcp_distributions_version_check CHECK (version > 0),
   CONSTRAINT platform_mcp_distributions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_organization_project_fkey FOREIGN KEY (organization_id, project_id) REFERENCES projects (organization_id, id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_project_registration_fkey FOREIGN KEY (project_id, registration_id) REFERENCES platform_mcp_catalog_registrations (project_id, id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_project_default_plugin_fkey FOREIGN KEY (project_id, default_plugin_id) REFERENCES plugins (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_distributions_project_plugin_fkey FOREIGN KEY (project_id, plugin_id) REFERENCES plugins (project_id, id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_default_plugin_plugin_server_fkey FOREIGN KEY (default_plugin_id, plugin_server_id) REFERENCES plugin_servers (plugin_id, id) ON DELETE NO ACTION,
   CONSTRAINT platform_mcp_distributions_organization_connection_fkey FOREIGN KEY (organization_id, connection_id) REFERENCES platform_mcp_connections (organization_id, id) ON DELETE CASCADE
 );
 CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_identity_key ON platform_mcp_distributions (organization_id, project_id, registration_id, default_plugin_id);
 CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_project_registration_id_key ON platform_mcp_distributions (project_id, registration_id, id);
 CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_default_plugin_idx ON platform_mcp_distributions (project_id, default_plugin_id);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_plugin_identity_key ON platform_mcp_distributions (organization_id, project_id, registration_id, plugin_id) WHERE plugin_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_plugin_idx ON platform_mcp_distributions (project_id, plugin_id) WHERE plugin_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS platform_mcp_distributions_organization_connection_idx ON platform_mcp_distributions (organization_id, connection_id);
+CREATE INDEX IF NOT EXISTS platform_mcp_distributions_organization_actor_idx ON platform_mcp_distributions (organization_id, user_id, acting_surface) WHERE connection_id IS NULL;
 CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_plugin_server_idx ON platform_mcp_distributions (project_id, plugin_server_id) WHERE plugin_server_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS platform_mcp_selected_use_evidence (

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1200,13 +1200,20 @@ type McpMetadatum struct {
 }
 
 type McpRegistry struct {
-	ID        uuid.UUID
-	Name      string
-	Url       string
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-	DeletedAt pgtype.Timestamptz
-	Deleted   bool
+	ID                   uuid.UUID
+	Name                 string
+	Url                  string
+	SourceType           pgtype.Text
+	AuthProfile          pgtype.Text
+	Enabled              pgtype.Bool
+	CertificationState   pgtype.Text
+	CertificationVersion pgtype.Text
+	Priority             pgtype.Int4
+	SourceKey            pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	DeletedAt            pgtype.Timestamptz
+	Deleted              bool
 }
 
 // Research-agent output for an approval request. Findings are gathered and cited, never adjudicated — the admin decides.
@@ -1633,6 +1640,7 @@ type PlatformMcpDistribution struct {
 	ProjectID            uuid.UUID
 	RegistrationID       uuid.UUID
 	DefaultPluginID      uuid.UUID
+	PluginID             uuid.NullUUID
 	PluginServerID       uuid.NullUUID
 	State                string
 	Version              int64

--- a/server/internal/platformmcp/repo/models.go
+++ b/server/internal/platformmcp/repo/models.go
@@ -73,6 +73,7 @@ type PlatformMcpDistribution struct {
 	ProjectID            uuid.UUID
 	RegistrationID       uuid.UUID
 	DefaultPluginID      uuid.UUID
+	PluginID             uuid.NullUUID
 	PluginServerID       uuid.NullUUID
 	State                string
 	Version              int64

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -656,7 +656,7 @@ WHERE EXISTS (
       AND project.organization_id = $1
       AND project.deleted IS FALSE
 )
-RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
 `
 
 type CreatePlatformMCPDistributionParams struct {
@@ -692,6 +692,7 @@ func (q *Queries) CreatePlatformMCPDistribution(ctx context.Context, arg CreateP
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,
@@ -2133,7 +2134,7 @@ func (q *Queries) GetPlatformMCPConnectionForUpdate(ctx context.Context, arg Get
 }
 
 const getPlatformMCPDistribution = `-- name: GetPlatformMCPDistribution :one
-SELECT distribution.id, distribution.organization_id, distribution.project_id, distribution.registration_id, distribution.default_plugin_id, distribution.plugin_server_id, distribution.state, distribution.version, distribution.attachment_was_created, distribution.publication_state, distribution.publication_updated_at, distribution.connection_id, distribution.connection_generation, distribution.user_id, distribution.acting_surface, distribution.created_at, distribution.updated_at
+SELECT distribution.id, distribution.organization_id, distribution.project_id, distribution.registration_id, distribution.default_plugin_id, distribution.plugin_id, distribution.plugin_server_id, distribution.state, distribution.version, distribution.attachment_was_created, distribution.publication_state, distribution.publication_updated_at, distribution.connection_id, distribution.connection_generation, distribution.user_id, distribution.acting_surface, distribution.created_at, distribution.updated_at
 FROM platform_mcp_distributions AS distribution
 JOIN projects AS project
   ON project.id = distribution.project_id
@@ -2166,6 +2167,7 @@ func (q *Queries) GetPlatformMCPDistribution(ctx context.Context, arg GetPlatfor
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,
@@ -4875,7 +4877,7 @@ WHERE platform_mcp_distributions.id = $7
         AND project.organization_id = platform_mcp_distributions.organization_id
         AND project.deleted IS FALSE
   )
-RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
 `
 
 type UpdatePlatformMCPDistributionParams struct {
@@ -4913,6 +4915,7 @@ func (q *Queries) UpdatePlatformMCPDistribution(ctx context.Context, arg UpdateP
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,
@@ -4963,7 +4966,7 @@ WHERE platform_mcp_distributions.id = $2
         AND project.organization_id = platform_mcp_distributions.organization_id
         AND project.deleted IS FALSE
   )
-RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
 `
 
 type UpdatePlatformMCPDistributionPublicationParams struct {
@@ -4993,6 +4996,7 @@ func (q *Queries) UpdatePlatformMCPDistributionPublication(ctx context.Context, 
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,

--- a/server/migrations/20260820053103_platform-mcp-d1-lifecycle-registry-prerequisite.sql
+++ b/server/migrations/20260820053103_platform-mcp-d1-lifecycle-registry-prerequisite.sql
@@ -1,0 +1,22 @@
+-- atlas:txmode none
+
+-- Modify "mcp_registries" table
+ALTER TABLE "mcp_registries" ADD COLUMN "source_type" text NULL, ADD COLUMN "auth_profile" text NULL, ADD COLUMN "enabled" boolean NULL, ADD COLUMN "certification_state" text NULL, ADD COLUMN "certification_version" text NULL, ADD COLUMN "priority" integer NULL, ADD COLUMN "source_key" text NULL;
+-- Create index "mcp_registries_source_key_key" to table: "mcp_registries"
+CREATE UNIQUE INDEX CONCURRENTLY "mcp_registries_source_key_key" ON "mcp_registries" ("source_key") WHERE ((source_key IS NOT NULL) AND (deleted IS FALSE));
+-- Modify "platform_mcp_readiness" table
+ALTER TABLE "platform_mcp_readiness" ADD CONSTRAINT "platform_mcp_readiness_connectionless_actor_check" CHECK ((connection_id IS NOT NULL) OR ((user_id IS NOT NULL) AND (acting_surface IS NOT NULL)));
+-- Create index "platform_mcp_readiness_assistant_binding_key" to table: "platform_mcp_readiness"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_readiness_assistant_binding_key" ON "platform_mcp_readiness" ("registration_id", "user_id", "acting_surface", "provider_authorization_fingerprint") WHERE (connection_id IS NULL);
+-- Create index "platform_mcp_readiness_external_binding_key" to table: "platform_mcp_readiness"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_readiness_external_binding_key" ON "platform_mcp_readiness" ("registration_id", "connection_id", "connection_generation", "provider_authorization_fingerprint") WHERE (connection_id IS NOT NULL);
+-- Create index "platform_mcp_readiness_organization_actor_idx" to table: "platform_mcp_readiness"
+CREATE INDEX CONCURRENTLY "platform_mcp_readiness_organization_actor_idx" ON "platform_mcp_readiness" ("organization_id", "user_id", "acting_surface") WHERE (connection_id IS NULL);
+-- Modify "platform_mcp_distributions" table
+ALTER TABLE "platform_mcp_distributions" ADD CONSTRAINT "platform_mcp_distributions_connectionless_actor_check" CHECK ((connection_id IS NOT NULL) OR ((user_id IS NOT NULL) AND (acting_surface IS NOT NULL))), ADD COLUMN "plugin_id" uuid NULL, ADD CONSTRAINT "platform_mcp_distributions_project_plugin_fkey" FOREIGN KEY ("project_id", "plugin_id") REFERENCES "plugins" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Create index "platform_mcp_distributions_organization_actor_idx" to table: "platform_mcp_distributions"
+CREATE INDEX CONCURRENTLY "platform_mcp_distributions_organization_actor_idx" ON "platform_mcp_distributions" ("organization_id", "user_id", "acting_surface") WHERE (connection_id IS NULL);
+-- Create index "platform_mcp_distributions_plugin_identity_key" to table: "platform_mcp_distributions"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_distributions_plugin_identity_key" ON "platform_mcp_distributions" ("organization_id", "project_id", "registration_id", "plugin_id") WHERE (plugin_id IS NOT NULL);
+-- Create index "platform_mcp_distributions_project_plugin_idx" to table: "platform_mcp_distributions"
+CREATE INDEX CONCURRENTLY "platform_mcp_distributions_project_plugin_idx" ON "platform_mcp_distributions" ("project_id", "plugin_id") WHERE (plugin_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:04JyIgKPxiUZYTyDHDyystWPVn4RvFlXk/JPc+uuy48=
+h1:FDBq1SCxfZLxlFf5YGjFfNzJgOtaUEcp56NbB3CUUao=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -357,3 +357,4 @@ h1:04JyIgKPxiUZYTyDHDyystWPVn4RvFlXk/JPc+uuy48=
 20260818203516_mcp-approval-evidence-change-detection.sql h1:yNs/1liPkJfSG3clzyfd+6zGfhYbWVHVFo4rUfXOQ3Q=
 20260818203838_mcp-research-tool-calls.sql h1:fhhTuuxv18VW3fc5N07RpyZEygKdoaBGVCdx/oAUpxw=
 20260820013033_add-chat-session-links.sql h1:3UEJgkRNXr+31yQFpteFRyq48s1l7HYq+kttJm2Q0rQ=
+20260820053103_platform-mcp-d1-lifecycle-registry-prerequisite.sql h1:4Ci7OgdkcBEp3xDucTJcjzzqfrt4LopTeWolre7Ej50=


### PR DESCRIPTION
## Why

AGE-3166 and AGE-3217 need a backward-compatible persistence foundation before lifecycle tools, direct remote registration, catalogue aggregation, or assistant mutations can be enabled.

## What changed

- add nullable registry source-profile and certification metadata, including a live-row source-key uniqueness constraint;
- add actor-bound readiness uniqueness/indexes while retaining the existing legacy arbiter for expand-phase compatibility;
- require connectionless readiness and distribution rows to carry actor attribution;
- add nullable exact-plugin identity and project-scoped plugin integrity/indexes for the later compatibility rollout;
- regenerate SQLc models and query output.

No new MCP capability or runtime path is enabled in this PR.

## Validation

- `mise run db:reset && mise run db:migrate`
- `mise run db:hash`
- `mise run gen:sqlc-server`
- `hk fix`
- `mise run lint:server`
- `mise run lint:migrations`
- `mise exec -- go test ./server/internal/platformmcp -run '^$'`
- `mise exec -- go test ./server/internal/platformmcp -run '^TestOperationReceiptFromRowPreservesRegistrationAssociation$' -count=1`

The migration uses concurrent index creation and `NOT VALID` followed by validation for the new checks/FK. As a non-transactional migration, an interrupted deployment must follow the normal invalid-index recovery procedure before retrying.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds operator-owned registry metadata, actor-scoped readiness/distribution arbiters, and exact-plugin distribution identity to support AGE-3166 D1 tools. Legacy readers/writers still work; connectionless writes now require actor attribution.

- Registries: add nullable operator source fields (source_type, auth_profile, enabled, certification_state, certification_version, priority, source_key) and a partial-unique source_key (ignores NULL and deleted) for operator-owned sources.
- Readiness: retain legacy binding; add a connectionless actor check (user_id + acting_surface); split unique arbiters for external vs assistant writers; add an org+actor index for connectionless reads.
- Distributions: add nullable plugin_id with a project-scoped FK and unique identity; keep default_plugin_id identity for compatibility; require actor attribution when connectionless; add an org+actor index.
- Regenerate SQLc models/queries to include registry metadata and plugin_id in repository reads/writes.

**Rollout**
- Non-transactional migration with CONCURRENTLY-created indexes plus new checks and FK; if interrupted, drop invalid indexes before retrying.
- Required action: connectionless readiness or distribution inserts must set user_id and acting_surface.

<sup>Written for commit 8abefa1d1b2efdf75f61b27503bc63177493df6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

