### PR TITLE
feat: authorize requested organizations

### DIFF
--- a/.changeset/requested-organization-authorization.md
+++ b/.changeset/requested-organization-authorization.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add reusable authorization for securely checking a requested organization.

--- a/server/internal/authz/requested_organization.go
+++ b/server/internal/authz/requested_organization.go
@@ -1,0 +1,46 @@
+package authz
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// RequireUserOrganizationScope resolves a user's principals and grants in the
+// requested organization's namespace before evaluating an organization scope.
+// It intentionally does not use grants prepared for the active organization.
+func (e *Engine) RequireUserOrganizationScope(ctx context.Context, organizationID, userID string, scope Scope) error {
+	enforce, err := e.ShouldEnforce(ctx)
+	if err != nil {
+		return err
+	}
+	if !enforce {
+		authCtx, _ := contextvalues.GetAuthContext(ctx)
+		if authCtx.APIKeyID != "" {
+			// API keys are bound to their authenticated organization outside RBAC.
+			// This helper cannot authorize a requested organization for them.
+			return oops.C(oops.CodeForbidden)
+		}
+		return nil
+	}
+
+	principals, err := ResolveUserPrincipals(ctx, e.db, organizationID, userID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "resolve requested organization principals").LogError(ctx, e.logger, attr.SlogOrganizationID(organizationID), attr.SlogUserID(userID))
+	}
+
+	grants, err := LoadGrants(ctx, e.db, organizationID, principals)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "load requested organization grants").LogError(ctx, e.logger, attr.SlogOrganizationID(organizationID), attr.SlogUserID(userID))
+	}
+
+	return e.EvaluateLoadedGrants(ctx, grants, Check{
+		Scope:         scope,
+		ResourceKind:  "",
+		ResourceID:    organizationID,
+		Dimensions:    nil,
+		selectorMatch: selectorMatchNormal,
+	})
+}

--- a/server/internal/authz/requested_organization_test.go
+++ b/server/internal/authz/requested_organization_test.go
@@ -1,0 +1,86 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+)
+
+func TestRequireUserOrganizationScopeLoadsRequestedOrganizationRoleGrants(t *testing.T) {
+	t.Parallel()
+
+	activeOrganizationID := "org_requested_scope_active"
+	targetOrganizationID := "org_requested_scope_target"
+	userID := "user_requested_scope_member"
+	ctx := enterpriseSessionCtxWithOrg(t, activeOrganizationID)
+	conn := newTestDB(t)
+
+	seedOrganization(t, ctx, conn, activeOrganizationID)
+	seedOrganization(t, ctx, conn, targetOrganizationID)
+	seedActiveOrganizationUser(t, ctx, conn, targetOrganizationID, userID)
+	require.NoError(t, SeedSystemRoleGrants(ctx, conn, targetOrganizationID))
+	seedRoleAssignmentForUser(t, ctx, conn, targetOrganizationID, userID, SystemRoleMember)
+
+	ctx = GrantsToContext(ctx, []Grant{NewGrant(ScopeOrgRead, activeOrganizationID)})
+	engine := NewEngine(testenv.NewLogger(t), conn, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	require.NoError(t, engine.RequireUserOrganizationScope(ctx, targetOrganizationID, userID, ScopeOrgRead))
+}
+
+func TestRequireUserOrganizationScopeRejectsActiveOrganizationGrants(t *testing.T) {
+	t.Parallel()
+
+	activeOrganizationID := "org_requested_scope_only_active"
+	targetOrganizationID := "org_requested_scope_without_grants"
+	userID := "user_requested_scope_without_target_grants"
+	ctx := enterpriseSessionCtxWithOrg(t, activeOrganizationID)
+	conn := newTestDB(t)
+
+	seedOrganization(t, ctx, conn, activeOrganizationID)
+	seedOrganization(t, ctx, conn, targetOrganizationID)
+	seedActiveOrganizationUser(t, ctx, conn, targetOrganizationID, userID)
+	ctx = GrantsToContext(ctx, []Grant{NewGrant(ScopeOrgAdmin, WildcardResource)})
+	engine := NewEngine(testenv.NewLogger(t), conn, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	err := engine.RequireUserOrganizationScope(ctx, targetOrganizationID, userID, ScopeOrgRead)
+	require.Error(t, err)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeForbidden, shareable.Code)
+}
+
+func TestRequireUserOrganizationScopeSkipsSessionlessRequests(t *testing.T) {
+	t.Parallel()
+
+	ctx := enterpriseTestCtx(t.Context())
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.SessionID = nil
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	engine := NewEngine(testenv.NewLogger(t), nil, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	require.NoError(t, engine.RequireUserOrganizationScope(ctx, "org_requested_scope_target", authCtx.UserID, ScopeOrgRead))
+}
+
+func TestRequireUserOrganizationScopeRejectsAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := enterpriseTestCtx(t.Context())
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.APIKeyID = "api_key_requested_scope"
+	authCtx.SessionID = nil
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	engine := NewEngine(testenv.NewLogger(t), nil, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	err := engine.RequireUserOrganizationScope(ctx, "org_requested_scope_target", authCtx.UserID, ScopeOrgRead)
+	require.Error(t, err)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeForbidden, shareable.Code)
+}


### PR DESCRIPTION
## Summary
- add a reusable authorization helper for organization targets named in requests
- resolve principals and grants in the requested organization's namespace
- prevent active-organization wildcard grants from authorizing another organization

## Why this is needed
Authorization is normally prepared from the organization active in the session. That becomes unsafe if an endpoint independently accepts a different organization target:

1. The session is active in Organization A.
2. Gram prepares the actor's grants for A.
3. The request explicitly targets Organization B.
4. A wildcard organization grant from A could appear to satisfy a check against B.

```text
active A → load A grants → request targets B
                    wildcard grant ────────→ could authorize B
```

This PR adds a target-bound helper: when B is requested, it resolves the same session actor's principals and grants in B's namespace before evaluating access. It does not globally change `Engine.Require`, and authorization still happens before existence lookup to avoid organization enumeration. No pre-existing exploitable endpoint was confirmed; this isolates the safe primitive before later PRs add request-selected organization targeting.

## Verification
- focused authz tests
- product-feature/authz integration tests in the composed stack
- server lint
- `git diff --check`

## Stack
1. **AGE-3314 — this PR**
2. AGE-3317 — optional product-feature backend support
3. AGE-3316 — explicit dashboard callers
4. AGE-3315 — required product-feature organization contract

Linear: AGE-3314

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorizes organization scopes against the requested organization instead of the active one to prevent cross-org authorization via active-org wildcard grants. Supports Linear AGE-3314 by adding a reusable target-org helper.

- Adds `server/internal/authz` helper `RequireUserOrganizationScope(ctx, organizationID, userID, scope)`; resolves principals and loads grants in the requested org before evaluating the scope.
- Ignores active-organization grants; calls that previously passed via active-org wildcards may now be forbidden.
- Skips enforcement when no session; forbids API key requests since keys are bound to their authenticated org.
- Focused tests cover acceptance with target-org grants, rejection when only active-org grants exist, and API key/sessionless behavior.
- No callers updated; update any code that authorizes actions on a requested organization to use `RequireUserOrganizationScope`.

<sup>Written for commit 8a562d714b29d8991b58255d2927470e95b9bf71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

