### PR TITLE
feat: support requested product-feature organizations

### DIFF
--- a/.changeset/product-features-backend-org-scope.md
+++ b/.changeset/product-features-backend-org-scope.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Allow product-feature APIs to target an authorized organization while preserving active-organization behavior for existing callers.

--- a/.changeset/requested-organization-authorization.md
+++ b/.changeset/requested-organization-authorization.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add reusable authorization for securely checking a requested organization.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -31797,6 +31797,13 @@ paths:
       operationId: getProductFeatures
       parameters:
         - allowEmptyValue: true
+          description: Organization whose product features to read.
+          in: query
+          name: organization_id
+          schema:
+            description: Organization whose product features to read.
+            type: string
+        - allowEmptyValue: true
           description: Session header
           in: header
           name: Gram-Session
@@ -74702,6 +74709,9 @@ components:
             - remote_session_auto_refresh_enforced
             - consent_tool_filtering
           maxLength: 60
+        organization_id:
+          type: string
+          description: Organization whose product feature to update.
       required:
         - feature_name
         - enabled
@@ -74723,6 +74733,9 @@ components:
     SetRemoteSessionAutoRefreshPolicyRequestBody:
       type: object
       properties:
+        organization_id:
+          type: string
+          description: Organization whose automatic remote-session refresh policy to update.
         policy:
           type: string
           description: Organization policy for automatic remote-session refresh

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -5358,6 +5358,9 @@ examples:
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": true}
   getProductFeatures:
     speakeasy-default-get-product-features:
+      parameters:
+        query:
+          organization_id: "<id>"
       responses:
         "200":
           application/json: {"ai_platform_push_integrations_enabled": false, "authz_challenge_logging_enabled": false, "consent_tool_filtering_enabled": false, "custom_model_keys_enabled": false, "customer_managed_encryption_keys_enabled": false, "device_agent": false, "hooks_browser_login_enabled": false, "hooks_fail_open_enabled": false, "logs_enabled": false, "platform_mcp_enabled": false, "remote_session_auto_refresh_enabled": false, "remote_session_auto_refresh_enforced_enabled": false, "scim_enabled": false, "session_capture_enabled": true, "skill_capture_metadata_only": false, "skills_enabled": false, "sso_enabled": false, "tool_io_logs_enabled": true}

--- a/client/dashboard/src/sdk/src/funcs/featuresGet.ts
+++ b/client/dashboard/src/sdk/src/funcs/featuresGet.ts
@@ -4,7 +4,7 @@
 
 import * as z from "zod/v4-mini";
 import { GramCore } from "../core.js";
-import { encodeSimple } from "../lib/encodings.js";
+import { encodeFormQuery, encodeSimple } from "../lib/encodings.js";
 import { matchStatusCode } from "../lib/http.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
@@ -107,6 +107,10 @@ async function $do(
 
   const path = pathToFunc("/rpc/productFeatures.get")();
 
+  const query = encodeFormQuery({
+    "organization_id": payload?.organization_id,
+  });
+
   const headers = new Headers(compactMap({
     Accept: "application/json",
     "Gram-Session": encodeSimple("Gram-Session", payload?.["Gram-Session"], {
@@ -146,6 +150,7 @@ async function $do(
     baseURL: options?.serverURL,
     path: path,
     headers: headers,
+    query: query,
     body: body,
     userAgent: client._options.userAgent,
     timeoutMs: options?.timeoutMs || client._options.timeoutMs || -1,

--- a/client/dashboard/src/sdk/src/models/components/setproductfeaturerequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/setproductfeaturerequestbody.ts
@@ -42,6 +42,10 @@ export type SetProductFeatureRequestBody = {
    * Name of the feature to update
    */
   featureName: FeatureName;
+  /**
+   * Organization whose product feature to update.
+   */
+  organizationId?: string | undefined;
 };
 
 /** @internal */
@@ -52,6 +56,7 @@ export const FeatureName$outboundSchema: z.ZodMiniEnum<typeof FeatureName> = z
 export type SetProductFeatureRequestBody$Outbound = {
   enabled: boolean;
   feature_name: string;
+  organization_id?: string | undefined;
 };
 
 /** @internal */
@@ -62,10 +67,12 @@ export const SetProductFeatureRequestBody$outboundSchema: z.ZodMiniType<
   z.object({
     enabled: z.boolean(),
     featureName: FeatureName$outboundSchema,
+    organizationId: z.optional(z.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
       featureName: "feature_name",
+      organizationId: "organization_id",
     });
   }),
 );

--- a/client/dashboard/src/sdk/src/models/components/setremotesessionautorefreshpolicyrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/setremotesessionautorefreshpolicyrequestbody.ts
@@ -3,6 +3,7 @@
  */
 
 import * as z from "zod/v4-mini";
+import { remap as remap$ } from "../../lib/primitives.js";
 import { ClosedEnum } from "../../types/enums.js";
 
 /**
@@ -22,6 +23,10 @@ export type SetRemoteSessionAutoRefreshPolicyRequestBodyPolicy = ClosedEnum<
 
 export type SetRemoteSessionAutoRefreshPolicyRequestBody = {
   /**
+   * Organization whose automatic remote-session refresh policy to update.
+   */
+  organizationId?: string | undefined;
+  /**
    * Organization policy for automatic remote-session refresh
    */
   policy: SetRemoteSessionAutoRefreshPolicyRequestBodyPolicy;
@@ -34,6 +39,7 @@ export const SetRemoteSessionAutoRefreshPolicyRequestBodyPolicy$outboundSchema:
 
 /** @internal */
 export type SetRemoteSessionAutoRefreshPolicyRequestBody$Outbound = {
+  organization_id?: string | undefined;
   policy: string;
 };
 
@@ -42,9 +48,17 @@ export const SetRemoteSessionAutoRefreshPolicyRequestBody$outboundSchema:
   z.ZodMiniType<
     SetRemoteSessionAutoRefreshPolicyRequestBody$Outbound,
     SetRemoteSessionAutoRefreshPolicyRequestBody
-  > = z.object({
-    policy: SetRemoteSessionAutoRefreshPolicyRequestBodyPolicy$outboundSchema,
-  });
+  > = z.pipe(
+    z.object({
+      organizationId: z.optional(z.string()),
+      policy: SetRemoteSessionAutoRefreshPolicyRequestBodyPolicy$outboundSchema,
+    }),
+    z.transform((v) => {
+      return remap$(v, {
+        organizationId: "organization_id",
+      });
+    }),
+  );
 
 export function setRemoteSessionAutoRefreshPolicyRequestBodyToJSON(
   setRemoteSessionAutoRefreshPolicyRequestBody:

--- a/client/dashboard/src/sdk/src/models/operations/getproductfeatures.ts
+++ b/client/dashboard/src/sdk/src/models/operations/getproductfeatures.ts
@@ -11,6 +11,10 @@ export type GetProductFeaturesSecurity = {
 
 export type GetProductFeaturesRequest = {
   /**
+   * Organization whose product features to read.
+   */
+  organizationId?: string | undefined;
+  /**
    * Session header
    */
   gramSession?: string | undefined;
@@ -46,6 +50,7 @@ export function getProductFeaturesSecurityToJSON(
 
 /** @internal */
 export type GetProductFeaturesRequest$Outbound = {
+  organization_id?: string | undefined;
   "Gram-Session"?: string | undefined;
 };
 
@@ -55,10 +60,12 @@ export const GetProductFeaturesRequest$outboundSchema: z.ZodMiniType<
   GetProductFeaturesRequest
 > = z.pipe(
   z.object({
+    organizationId: z.optional(z.string()),
     gramSession: z.optional(z.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
+      organizationId: "organization_id",
       gramSession: "Gram-Session",
     });
   }),

--- a/client/dashboard/src/sdk/src/react-query/productFeatures.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/productFeatures.core.ts
@@ -46,7 +46,10 @@ export function buildProductFeaturesQuery(
   queryFn: (context: QueryFunctionContext) => Promise<ProductFeaturesQueryData>;
 } {
   return {
-    queryKey: queryKeyProductFeatures({ gramSession: request?.gramSession }),
+    queryKey: queryKeyProductFeatures({
+      organizationId: request?.organizationId,
+      gramSession: request?.gramSession,
+    }),
     queryFn: async function productFeaturesQueryFn(
       ctx,
     ): Promise<ProductFeaturesQueryData> {
@@ -72,7 +75,10 @@ export function buildProductFeaturesQuery(
 }
 
 export function queryKeyProductFeatures(
-  parameters: { gramSession?: string | undefined },
+  parameters: {
+    organizationId?: string | undefined;
+    gramSession?: string | undefined;
+  },
 ): QueryKey {
   return ["@gram/client", "features", "get", parameters];
 }

--- a/client/dashboard/src/sdk/src/react-query/productFeatures.ts
+++ b/client/dashboard/src/sdk/src/react-query/productFeatures.ts
@@ -109,7 +109,12 @@ export function useProductFeaturesSuspense(
 
 export function setProductFeaturesData(
   client: QueryClient,
-  queryKeyBase: [parameters: { gramSession?: string | undefined }],
+  queryKeyBase: [
+    parameters: {
+      organizationId?: string | undefined;
+      gramSession?: string | undefined;
+    },
+  ],
   data: ProductFeaturesQueryData,
 ): ProductFeaturesQueryData | undefined {
   const key = queryKeyProductFeatures(...queryKeyBase);
@@ -120,7 +125,10 @@ export function setProductFeaturesData(
 export function invalidateProductFeatures(
   client: QueryClient,
   queryKeyBase: TupleToPrefixes<
-    [parameters: { gramSession?: string | undefined }]
+    [parameters: {
+      organizationId?: string | undefined;
+      gramSession?: string | undefined;
+    }]
   >,
   filters?: Omit<InvalidateQueryFilters, "queryKey" | "predicate" | "exact">,
 ): Promise<void> {

--- a/server/design/productfeatures/design.go
+++ b/server/design/productfeatures/design.go
@@ -17,6 +17,7 @@ var _ = Service("features", func() {
 		Description("Get the current state of all product feature flags.")
 
 		Payload(func() {
+			Attribute("organization_id", String, "Organization whose product features to read.")
 			security.SessionPayload()
 		})
 
@@ -44,6 +45,7 @@ var _ = Service("features", func() {
 
 		HTTP(func() {
 			GET("/rpc/productFeatures.get")
+			Param("organization_id")
 			security.SessionHeader()
 			Response(StatusOK)
 		})
@@ -57,6 +59,7 @@ var _ = Service("features", func() {
 		Description("Enable or disable an organization feature flag.")
 
 		Payload(func() {
+			Attribute("organization_id", String, "Organization whose product feature to update.")
 			Attribute("feature_name", String, "Name of the feature to update", func() {
 				MaxLength(60)
 				Enum("logs", "tool_io_logs", "session_capture", "authz_challenge_logging", "sso", "scim", "hooks_browser_login", "hooks_fail_open", "custom_model_keys", "skills", "skill_capture_metadata_only", "ai_platform_push_integrations", "platform_mcp", "customer_managed_encryption_keys", "remote_session_auto_refresh", "remote_session_auto_refresh_enforced", "consent_tool_filtering")
@@ -81,6 +84,7 @@ var _ = Service("features", func() {
 		Description("Set the organization policy for automatic remote-session refresh.")
 
 		Payload(func() {
+			Attribute("organization_id", String, "Organization whose automatic remote-session refresh policy to update.")
 			Attribute("policy", String, "Organization policy for automatic remote-session refresh", func() {
 				Enum("disabled", "user_controlled", "enforced")
 			})

--- a/server/gen/features/service.go
+++ b/server/gen/features/service.go
@@ -49,7 +49,9 @@ var MethodNames = [3]string{"getProductFeatures", "setProductFeature", "setRemot
 // GetProductFeaturesPayload is the payload type of the features service
 // getProductFeatures method.
 type GetProductFeaturesPayload struct {
-	SessionToken *string
+	// Organization whose product features to read.
+	OrganizationID *string
+	SessionToken   *string
 }
 
 // GetProductFeaturesResult is the result type of the features service
@@ -106,6 +108,8 @@ type GetProductFeaturesResult struct {
 // SetProductFeaturePayload is the payload type of the features service
 // setProductFeature method.
 type SetProductFeaturePayload struct {
+	// Organization whose product feature to update.
+	OrganizationID *string
 	// Name of the feature to update
 	FeatureName string
 	// Whether the feature should be enabled
@@ -116,6 +120,8 @@ type SetProductFeaturePayload struct {
 // SetRemoteSessionAutoRefreshPolicyPayload is the payload type of the features
 // service setRemoteSessionAutoRefreshPolicy method.
 type SetRemoteSessionAutoRefreshPolicyPayload struct {
+	// Organization whose automatic remote-session refresh policy to update.
+	OrganizationID *string
 	// Organization policy for automatic remote-session refresh
 	Policy       string
 	SessionToken *string

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -1840,8 +1840,9 @@ func ParseEndpoint(
 
 		featuresFlags = flag.NewFlagSet("features", flag.ContinueOnError)
 
-		featuresGetProductFeaturesFlags            = flag.NewFlagSet("get-product-features", flag.ExitOnError)
-		featuresGetProductFeaturesSessionTokenFlag = featuresGetProductFeaturesFlags.String("session-token", "", "")
+		featuresGetProductFeaturesFlags              = flag.NewFlagSet("get-product-features", flag.ExitOnError)
+		featuresGetProductFeaturesOrganizationIDFlag = featuresGetProductFeaturesFlags.String("organization-id", "", "")
+		featuresGetProductFeaturesSessionTokenFlag   = featuresGetProductFeaturesFlags.String("session-token", "", "")
 
 		featuresSetProductFeatureFlags            = flag.NewFlagSet("set-product-feature", flag.ExitOnError)
 		featuresSetProductFeatureBodyFlag         = featuresSetProductFeatureFlags.String("body", "REQUIRED", "")
@@ -7671,7 +7672,7 @@ func ParseEndpoint(
 			switch epn {
 			case "get-product-features":
 				endpoint = c.GetProductFeatures()
-				data, err = featuresc.BuildGetProductFeaturesPayload(*featuresGetProductFeaturesSessionTokenFlag)
+				data, err = featuresc.BuildGetProductFeaturesPayload(*featuresGetProductFeaturesOrganizationIDFlag, *featuresGetProductFeaturesSessionTokenFlag)
 			case "set-product-feature":
 				endpoint = c.SetProductFeature()
 				data, err = featuresc.BuildSetProductFeaturePayload(*featuresSetProductFeatureBodyFlag, *featuresSetProductFeatureSessionTokenFlag)
@@ -16203,6 +16204,7 @@ func featuresUsage() {
 func featuresGetProductFeaturesUsage() {
 	// Header with flags
 	fmt.Fprintf(os.Stderr, "%s [flags] features get-product-features", os.Args[0])
+	fmt.Fprint(os.Stderr, " -organization-id STRING")
 	fmt.Fprint(os.Stderr, " -session-token STRING")
 	fmt.Fprintln(os.Stderr)
 
@@ -16211,11 +16213,12 @@ func featuresGetProductFeaturesUsage() {
 	fmt.Fprintln(os.Stderr, `Get the current state of all product feature flags.`)
 
 	// Flags list
+	fmt.Fprintln(os.Stderr, `    -organization-id STRING: `)
 	fmt.Fprintln(os.Stderr, `    -session-token STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "features get-product-features --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "features get-product-features --organization-id \"abc123\" --session-token \"abc123\"")
 }
 
 func featuresSetProductFeatureUsage() {
@@ -16235,7 +16238,7 @@ func featuresSetProductFeatureUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "features set-product-feature --body '{\n      \"enabled\": false,\n      \"feature_name\": \"aaa\"\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "features set-product-feature --body '{\n      \"enabled\": false,\n      \"feature_name\": \"aaa\",\n      \"organization_id\": \"abc123\"\n   }' --session-token \"abc123\"")
 }
 
 func featuresSetRemoteSessionAutoRefreshPolicyUsage() {
@@ -16255,7 +16258,7 @@ func featuresSetRemoteSessionAutoRefreshPolicyUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "features set-remote-session-auto-refresh-policy --body '{\n      \"policy\": \"user_controlled\"\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "features set-remote-session-auto-refresh-policy --body '{\n      \"organization_id\": \"abc123\",\n      \"policy\": \"user_controlled\"\n   }' --session-token \"abc123\"")
 }
 
 // projectsUsage displays the usage of the projects command and its subcommands.

--- a/server/gen/http/features/client/cli.go
+++ b/server/gen/http/features/client/cli.go
@@ -18,7 +18,13 @@ import (
 
 // BuildGetProductFeaturesPayload builds the payload for the features
 // getProductFeatures endpoint from CLI flags.
-func BuildGetProductFeaturesPayload(featuresGetProductFeaturesSessionToken string) (*features.GetProductFeaturesPayload, error) {
+func BuildGetProductFeaturesPayload(featuresGetProductFeaturesOrganizationID string, featuresGetProductFeaturesSessionToken string) (*features.GetProductFeaturesPayload, error) {
+	var organizationID *string
+	{
+		if featuresGetProductFeaturesOrganizationID != "" {
+			organizationID = &featuresGetProductFeaturesOrganizationID
+		}
+	}
 	var sessionToken *string
 	{
 		if featuresGetProductFeaturesSessionToken != "" {
@@ -26,6 +32,7 @@ func BuildGetProductFeaturesPayload(featuresGetProductFeaturesSessionToken strin
 		}
 	}
 	v := &features.GetProductFeaturesPayload{}
+	v.OrganizationID = organizationID
 	v.SessionToken = sessionToken
 
 	return v, nil
@@ -39,7 +46,7 @@ func BuildSetProductFeaturePayload(featuresSetProductFeatureBody string, feature
 	{
 		err = json.Unmarshal([]byte(featuresSetProductFeatureBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"enabled\": false,\n      \"feature_name\": \"aaa\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"enabled\": false,\n      \"feature_name\": \"aaa\",\n      \"organization_id\": \"abc123\"\n   }'")
 		}
 		if !(body.FeatureName == "logs" || body.FeatureName == "tool_io_logs" || body.FeatureName == "session_capture" || body.FeatureName == "authz_challenge_logging" || body.FeatureName == "sso" || body.FeatureName == "scim" || body.FeatureName == "hooks_browser_login" || body.FeatureName == "hooks_fail_open" || body.FeatureName == "custom_model_keys" || body.FeatureName == "skills" || body.FeatureName == "skill_capture_metadata_only" || body.FeatureName == "ai_platform_push_integrations" || body.FeatureName == "platform_mcp" || body.FeatureName == "customer_managed_encryption_keys" || body.FeatureName == "remote_session_auto_refresh" || body.FeatureName == "remote_session_auto_refresh_enforced" || body.FeatureName == "consent_tool_filtering") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.feature_name", body.FeatureName, []any{"logs", "tool_io_logs", "session_capture", "authz_challenge_logging", "sso", "scim", "hooks_browser_login", "hooks_fail_open", "custom_model_keys", "skills", "skill_capture_metadata_only", "ai_platform_push_integrations", "platform_mcp", "customer_managed_encryption_keys", "remote_session_auto_refresh", "remote_session_auto_refresh_enforced", "consent_tool_filtering"}))
@@ -58,8 +65,9 @@ func BuildSetProductFeaturePayload(featuresSetProductFeatureBody string, feature
 		}
 	}
 	v := &features.SetProductFeaturePayload{
-		FeatureName: body.FeatureName,
-		Enabled:     body.Enabled,
+		OrganizationID: body.OrganizationID,
+		FeatureName:    body.FeatureName,
+		Enabled:        body.Enabled,
 	}
 	v.SessionToken = sessionToken
 
@@ -74,7 +82,7 @@ func BuildSetRemoteSessionAutoRefreshPolicyPayload(featuresSetRemoteSessionAutoR
 	{
 		err = json.Unmarshal([]byte(featuresSetRemoteSessionAutoRefreshPolicyBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"policy\": \"user_controlled\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"organization_id\": \"abc123\",\n      \"policy\": \"user_controlled\"\n   }'")
 		}
 		if !(body.Policy == "disabled" || body.Policy == "user_controlled" || body.Policy == "enforced") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.policy", body.Policy, []any{"disabled", "user_controlled", "enforced"}))
@@ -90,7 +98,8 @@ func BuildSetRemoteSessionAutoRefreshPolicyPayload(featuresSetRemoteSessionAutoR
 		}
 	}
 	v := &features.SetRemoteSessionAutoRefreshPolicyPayload{
-		Policy: body.Policy,
+		OrganizationID: body.OrganizationID,
+		Policy:         body.Policy,
 	}
 	v.SessionToken = sessionToken
 

--- a/server/gen/http/features/client/encode_decode.go
+++ b/server/gen/http/features/client/encode_decode.go
@@ -46,6 +46,11 @@ func EncodeGetProductFeaturesRequest(encoder func(*http.Request) goahttp.Encoder
 			head := *p.SessionToken
 			req.Header.Set("Gram-Session", head)
 		}
+		values := req.URL.Query()
+		if p.OrganizationID != nil {
+			values.Add("organization_id", *p.OrganizationID)
+		}
+		req.URL.RawQuery = values.Encode()
 		return nil
 	}
 }

--- a/server/gen/http/features/client/types.go
+++ b/server/gen/http/features/client/types.go
@@ -15,6 +15,8 @@ import (
 // SetProductFeatureRequestBody is the type of the "features" service
 // "setProductFeature" endpoint HTTP request body.
 type SetProductFeatureRequestBody struct {
+	// Organization whose product feature to update.
+	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
 	// Name of the feature to update
 	FeatureName string `form:"feature_name" json:"feature_name" xml:"feature_name"`
 	// Whether the feature should be enabled
@@ -24,6 +26,8 @@ type SetProductFeatureRequestBody struct {
 // SetRemoteSessionAutoRefreshPolicyRequestBody is the type of the "features"
 // service "setRemoteSessionAutoRefreshPolicy" endpoint HTTP request body.
 type SetRemoteSessionAutoRefreshPolicyRequestBody struct {
+	// Organization whose automatic remote-session refresh policy to update.
+	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
 	// Organization policy for automatic remote-session refresh
 	Policy string `form:"policy" json:"policy" xml:"policy"`
 }
@@ -646,8 +650,9 @@ type SetRemoteSessionAutoRefreshPolicyGatewayErrorResponseBody struct {
 // payload of the "setProductFeature" endpoint of the "features" service.
 func NewSetProductFeatureRequestBody(p *features.SetProductFeaturePayload) *SetProductFeatureRequestBody {
 	body := &SetProductFeatureRequestBody{
-		FeatureName: p.FeatureName,
-		Enabled:     p.Enabled,
+		OrganizationID: p.OrganizationID,
+		FeatureName:    p.FeatureName,
+		Enabled:        p.Enabled,
 	}
 	return body
 }
@@ -657,7 +662,8 @@ func NewSetProductFeatureRequestBody(p *features.SetProductFeaturePayload) *SetP
 // "features" service.
 func NewSetRemoteSessionAutoRefreshPolicyRequestBody(p *features.SetRemoteSessionAutoRefreshPolicyPayload) *SetRemoteSessionAutoRefreshPolicyRequestBody {
 	body := &SetRemoteSessionAutoRefreshPolicyRequestBody{
-		Policy: p.Policy,
+		OrganizationID: p.OrganizationID,
+		Policy:         p.Policy,
 	}
 	return body
 }

--- a/server/gen/http/features/server/encode_decode.go
+++ b/server/gen/http/features/server/encode_decode.go
@@ -37,13 +37,18 @@ func DecodeGetProductFeaturesRequest(mux goahttp.Muxer, decoder func(*http.Reque
 	return func(r *http.Request) (*features.GetProductFeaturesPayload, error) {
 		var payload *features.GetProductFeaturesPayload
 		var (
-			sessionToken *string
+			organizationID *string
+			sessionToken   *string
 		)
+		organizationIDRaw := r.URL.Query().Get("organization_id")
+		if organizationIDRaw != "" {
+			organizationID = &organizationIDRaw
+		}
 		sessionTokenRaw := r.Header.Get("Gram-Session")
 		if sessionTokenRaw != "" {
 			sessionToken = &sessionTokenRaw
 		}
-		payload = NewGetProductFeaturesPayload(sessionToken)
+		payload = NewGetProductFeaturesPayload(organizationID, sessionToken)
 		if payload.SessionToken != nil {
 			if strings.Contains(*payload.SessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/features/server/types.go
+++ b/server/gen/http/features/server/types.go
@@ -17,6 +17,8 @@ import (
 // SetProductFeatureRequestBody is the type of the "features" service
 // "setProductFeature" endpoint HTTP request body.
 type SetProductFeatureRequestBody struct {
+	// Organization whose product feature to update.
+	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
 	// Name of the feature to update
 	FeatureName *string `form:"feature_name,omitempty" json:"feature_name,omitempty" xml:"feature_name,omitempty"`
 	// Whether the feature should be enabled
@@ -26,6 +28,8 @@ type SetProductFeatureRequestBody struct {
 // SetRemoteSessionAutoRefreshPolicyRequestBody is the type of the "features"
 // service "setRemoteSessionAutoRefreshPolicy" endpoint HTTP request body.
 type SetRemoteSessionAutoRefreshPolicyRequestBody struct {
+	// Organization whose automatic remote-session refresh policy to update.
+	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
 	// Organization policy for automatic remote-session refresh
 	Policy *string `form:"policy,omitempty" json:"policy,omitempty" xml:"policy,omitempty"`
 }
@@ -1115,8 +1119,9 @@ func NewSetRemoteSessionAutoRefreshPolicyGatewayErrorResponseBody(res *goa.Servi
 
 // NewGetProductFeaturesPayload builds a features service getProductFeatures
 // endpoint payload.
-func NewGetProductFeaturesPayload(sessionToken *string) *features.GetProductFeaturesPayload {
+func NewGetProductFeaturesPayload(organizationID *string, sessionToken *string) *features.GetProductFeaturesPayload {
 	v := &features.GetProductFeaturesPayload{}
+	v.OrganizationID = organizationID
 	v.SessionToken = sessionToken
 
 	return v
@@ -1126,8 +1131,9 @@ func NewGetProductFeaturesPayload(sessionToken *string) *features.GetProductFeat
 // endpoint payload.
 func NewSetProductFeaturePayload(body *SetProductFeatureRequestBody, sessionToken *string) *features.SetProductFeaturePayload {
 	v := &features.SetProductFeaturePayload{
-		FeatureName: *body.FeatureName,
-		Enabled:     *body.Enabled,
+		OrganizationID: body.OrganizationID,
+		FeatureName:    *body.FeatureName,
+		Enabled:        *body.Enabled,
 	}
 	v.SessionToken = sessionToken
 
@@ -1138,7 +1144,8 @@ func NewSetProductFeaturePayload(body *SetProductFeatureRequestBody, sessionToke
 // setRemoteSessionAutoRefreshPolicy endpoint payload.
 func NewSetRemoteSessionAutoRefreshPolicyPayload(body *SetRemoteSessionAutoRefreshPolicyRequestBody, sessionToken *string) *features.SetRemoteSessionAutoRefreshPolicyPayload {
 	v := &features.SetRemoteSessionAutoRefreshPolicyPayload{
-		Policy: *body.Policy,
+		OrganizationID: body.OrganizationID,
+		Policy:         *body.Policy,
 	}
 	v.SessionToken = sessionToken
 

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -33204,6 +33204,13 @@ paths:
             operationId: getProductFeatures
             parameters:
                 - allowEmptyValue: true
+                  description: Organization whose product features to read.
+                  in: query
+                  name: organization_id
+                  schema:
+                    description: Organization whose product features to read.
+                    type: string
+                - allowEmptyValue: true
                   description: Session header
                   in: header
                   name: Gram-Session
@@ -75864,6 +75871,9 @@ components:
                         - remote_session_auto_refresh_enforced
                         - consent_tool_filtering
                     maxLength: 60
+                organization_id:
+                    type: string
+                    description: Organization whose product feature to update.
             required:
                 - feature_name
                 - enabled
@@ -75885,6 +75895,9 @@ components:
         SetRemoteSessionAutoRefreshPolicyRequestBody:
             type: object
             properties:
+                organization_id:
+                    type: string
+                    description: Organization whose automatic remote-session refresh policy to update.
                 policy:
                     type: string
                     description: Organization policy for automatic remote-session refresh

--- a/server/internal/authz/requested_organization.go
+++ b/server/internal/authz/requested_organization.go
@@ -1,0 +1,46 @@
+package authz
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// RequireUserOrganizationScope resolves a user's principals and grants in the
+// requested organization's namespace before evaluating an organization scope.
+// It intentionally does not use grants prepared for the active organization.
+func (e *Engine) RequireUserOrganizationScope(ctx context.Context, organizationID, userID string, scope Scope) error {
+	enforce, err := e.ShouldEnforce(ctx)
+	if err != nil {
+		return err
+	}
+	if !enforce {
+		authCtx, _ := contextvalues.GetAuthContext(ctx)
+		if authCtx.APIKeyID != "" {
+			// API keys are bound to their authenticated organization outside RBAC.
+			// This helper cannot authorize a requested organization for them.
+			return oops.C(oops.CodeForbidden)
+		}
+		return nil
+	}
+
+	principals, err := ResolveUserPrincipals(ctx, e.db, organizationID, userID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "resolve requested organization principals").LogError(ctx, e.logger, attr.SlogOrganizationID(organizationID), attr.SlogUserID(userID))
+	}
+
+	grants, err := LoadGrants(ctx, e.db, organizationID, principals)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "load requested organization grants").LogError(ctx, e.logger, attr.SlogOrganizationID(organizationID), attr.SlogUserID(userID))
+	}
+
+	return e.EvaluateLoadedGrants(ctx, grants, Check{
+		Scope:         scope,
+		ResourceKind:  "",
+		ResourceID:    organizationID,
+		Dimensions:    nil,
+		selectorMatch: selectorMatchNormal,
+	})
+}

--- a/server/internal/authz/requested_organization_test.go
+++ b/server/internal/authz/requested_organization_test.go
@@ -1,0 +1,86 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+)
+
+func TestRequireUserOrganizationScopeLoadsRequestedOrganizationRoleGrants(t *testing.T) {
+	t.Parallel()
+
+	activeOrganizationID := "org_requested_scope_active"
+	targetOrganizationID := "org_requested_scope_target"
+	userID := "user_requested_scope_member"
+	ctx := enterpriseSessionCtxWithOrg(t, activeOrganizationID)
+	conn := newTestDB(t)
+
+	seedOrganization(t, ctx, conn, activeOrganizationID)
+	seedOrganization(t, ctx, conn, targetOrganizationID)
+	seedActiveOrganizationUser(t, ctx, conn, targetOrganizationID, userID)
+	require.NoError(t, SeedSystemRoleGrants(ctx, conn, targetOrganizationID))
+	seedRoleAssignmentForUser(t, ctx, conn, targetOrganizationID, userID, SystemRoleMember)
+
+	ctx = GrantsToContext(ctx, []Grant{NewGrant(ScopeOrgRead, activeOrganizationID)})
+	engine := NewEngine(testenv.NewLogger(t), conn, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	require.NoError(t, engine.RequireUserOrganizationScope(ctx, targetOrganizationID, userID, ScopeOrgRead))
+}
+
+func TestRequireUserOrganizationScopeRejectsActiveOrganizationGrants(t *testing.T) {
+	t.Parallel()
+
+	activeOrganizationID := "org_requested_scope_only_active"
+	targetOrganizationID := "org_requested_scope_without_grants"
+	userID := "user_requested_scope_without_target_grants"
+	ctx := enterpriseSessionCtxWithOrg(t, activeOrganizationID)
+	conn := newTestDB(t)
+
+	seedOrganization(t, ctx, conn, activeOrganizationID)
+	seedOrganization(t, ctx, conn, targetOrganizationID)
+	seedActiveOrganizationUser(t, ctx, conn, targetOrganizationID, userID)
+	ctx = GrantsToContext(ctx, []Grant{NewGrant(ScopeOrgAdmin, WildcardResource)})
+	engine := NewEngine(testenv.NewLogger(t), conn, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	err := engine.RequireUserOrganizationScope(ctx, targetOrganizationID, userID, ScopeOrgRead)
+	require.Error(t, err)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeForbidden, shareable.Code)
+}
+
+func TestRequireUserOrganizationScopeSkipsSessionlessRequests(t *testing.T) {
+	t.Parallel()
+
+	ctx := enterpriseTestCtx(t.Context())
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.SessionID = nil
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	engine := NewEngine(testenv.NewLogger(t), nil, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	require.NoError(t, engine.RequireUserOrganizationScope(ctx, "org_requested_scope_target", authCtx.UserID, ScopeOrgRead))
+}
+
+func TestRequireUserOrganizationScopeRejectsAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := enterpriseTestCtx(t.Context())
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.APIKeyID = "api_key_requested_scope"
+	authCtx.SessionID = nil
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	engine := NewEngine(testenv.NewLogger(t), nil, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	err := engine.RequireUserOrganizationScope(ctx, "org_requested_scope_target", authCtx.UserID, ScopeOrgRead)
+	require.Error(t, err)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeForbidden, shareable.Code)
+}

--- a/server/internal/productfeatures/getproductfeatures_test.go
+++ b/server/internal/productfeatures/getproductfeatures_test.go
@@ -24,7 +24,8 @@ func TestProductFeaturesService_GetProductFeatures_DeviceAgent(t *testing.T) {
 	require.True(t, ok)
 	orgID := authCtx.ActiveOrganizationID
 
-	res, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	res, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.False(t, res.DeviceAgent, "no device has synced yet")
 
@@ -43,7 +44,8 @@ func TestProductFeaturesService_GetProductFeatures_DeviceAgent(t *testing.T) {
 		Email:          "dev@example.com",
 	}))
 
-	res, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	res, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.True(t, res.DeviceAgent, "a device has synced")
 }
@@ -52,15 +54,18 @@ func TestProductFeaturesService_PlatformMCP(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestProductFeaturesService(t)
 
-	res, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	res, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.False(t, res.PlatformMcpEnabled)
 
 	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: string(productfeatures.FeaturePlatformMCP),
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeaturePlatformMCP),
+		Enabled:        true,
 	}))
-	res, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	res, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.True(t, res.PlatformMcpEnabled)
 }
@@ -69,14 +74,17 @@ func TestProductFeaturesService_SkillCaptureMetadataOnly(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestProductFeaturesService(t)
 
-	res, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	res, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.False(t, res.SkillCaptureMetadataOnly)
 	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: string(productfeatures.FeatureSkillCaptureMetadataOnly),
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkillCaptureMetadataOnly),
+		Enabled:        true,
 	}))
-	res, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	res, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.True(t, res.SkillCaptureMetadataOnly)
 }

--- a/server/internal/productfeatures/hooksfailopen_test.go
+++ b/server/internal/productfeatures/hooksfailopen_test.go
@@ -23,8 +23,9 @@ func TestSetProductFeatureHooksFailOpenEnableRecordsAudit(t *testing.T) {
 	require.NoError(t, err)
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "hooks_fail_open",
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "hooks_fail_open",
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
@@ -47,8 +48,9 @@ func TestSetProductFeatureHooksFailOpenDisableRecordsAudit(t *testing.T) {
 	ctx, ti := newTestProductFeaturesService(t)
 
 	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "hooks_fail_open",
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "hooks_fail_open",
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
@@ -56,8 +58,9 @@ func TestSetProductFeatureHooksFailOpenDisableRecordsAudit(t *testing.T) {
 	require.NoError(t, err)
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "hooks_fail_open",
-		Enabled:     false,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "hooks_fail_open",
+		Enabled:        false,
 	})
 	require.NoError(t, err)
 
@@ -73,8 +76,9 @@ func TestSetProductFeatureHooksFailOpenNoOpSkipsAudit(t *testing.T) {
 	ctx, ti := newTestProductFeaturesService(t)
 
 	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "hooks_fail_open",
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "hooks_fail_open",
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
@@ -82,8 +86,9 @@ func TestSetProductFeatureHooksFailOpenNoOpSkipsAudit(t *testing.T) {
 	require.NoError(t, err)
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "hooks_fail_open",
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "hooks_fail_open",
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
@@ -103,8 +108,9 @@ func TestSetProductFeatureDisableWhenNeverEnabledIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "hooks_fail_open",
-		Enabled:     false,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "hooks_fail_open",
+		Enabled:        false,
 	})
 	require.NoError(t, err)
 
@@ -121,8 +127,9 @@ func TestSetProductFeatureOtherFeatureSkipsHooksFailOpenAudit(t *testing.T) {
 	require.NoError(t, err)
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "logs",
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "logs",
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
@@ -135,17 +142,20 @@ func TestGetProductFeaturesHooksFailOpen(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestProductFeaturesService(t)
 
-	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.False(t, result.HooksFailOpenEnabled, "fail open must default to off")
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: "hooks_fail_open",
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "hooks_fail_open",
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
-	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx)})
 	require.NoError(t, err)
 	require.True(t, result.HooksFailOpenEnabled)
 }

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -77,16 +77,48 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	)
 }
 
-func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProductFeaturePayload) error {
+func (s *Service) authorizeOrganization(ctx context.Context, requestedOrganizationID *string, scope authz.Scope) (*contextvalues.AuthContext, string, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
-		return oops.C(oops.CodeUnauthorized)
-	}
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
-		return fmt.Errorf("require org admin: %w", err)
+	if !ok || authCtx == nil {
+		return nil, "", oops.C(oops.CodeUnauthorized)
 	}
 
-	orgID := authCtx.ActiveOrganizationID
+	organizationID := authCtx.ActiveOrganizationID
+	if requestedOrganizationID != nil {
+		organizationID = *requestedOrganizationID
+	}
+	if organizationID == "" {
+		return nil, "", oops.C(oops.CodeUnauthorized)
+	}
+
+	if organizationID == authCtx.ActiveOrganizationID {
+		check := authz.Check{Scope: scope, ResourceKind: "", ResourceID: organizationID, Dimensions: nil}
+		if err := s.authz.Require(ctx, check); err != nil {
+			return nil, "", fmt.Errorf("require %s: %w", scope, err)
+		}
+		return authCtx, organizationID, nil
+	}
+
+	if err := s.authz.RequireUserOrganizationScope(ctx, organizationID, authCtx.UserID, scope); err != nil {
+		return nil, "", fmt.Errorf("require %s for requested organization: %w", scope, err)
+	}
+
+	if _, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, organizationID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", oops.E(oops.CodeNotFound, err, "organization not found")
+		}
+		return nil, "", oops.E(oops.CodeUnexpected, err, "get organization metadata").LogError(ctx, s.logger, attr.SlogOrganizationID(organizationID))
+	}
+
+	return authCtx, organizationID, nil
+}
+
+func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProductFeaturePayload) error {
+	authCtx, orgID, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgAdmin)
+	if err != nil {
+		return err
+	}
+
 	if payload.FeatureName == string(FeatureSkills) && !payload.Enabled {
 		return nil
 	}
@@ -160,7 +192,7 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 	}
 
 	cacheEntry := FeatureCache{
-		OrganizationID: authCtx.ActiveOrganizationID,
+		OrganizationID: orgID,
 		Feature:        Feature(payload.FeatureName),
 		Enabled:        payload.Enabled,
 	}
@@ -168,7 +200,7 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 	if cacheErr := s.featureCache.Store(ctx, cacheEntry); cacheErr != nil {
 		s.logger.WarnContext(ctx, "failed to cache feature flag state",
 			attr.SlogError(cacheErr),
-			attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
+			attr.SlogOrganizationID(orgID),
 			attr.SlogProductFeatureName(payload.FeatureName),
 		)
 	}
@@ -177,14 +209,10 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 }
 
 func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload *gen.SetRemoteSessionAutoRefreshPolicyPayload) error {
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
-		return oops.C(oops.CodeUnauthorized)
+	_, orgID, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgAdmin)
+	if err != nil {
+		return err
 	}
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
-		return fmt.Errorf("require org admin: %w", err)
-	}
-
 	var visible, enforced bool
 	switch payload.Policy {
 	case "disabled":
@@ -198,7 +226,7 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin remote session refresh policy transaction").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeUnexpected, err, "begin remote session refresh policy transaction").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -206,7 +234,7 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 	setFeatureState := func(feature Feature, enabled bool) error {
 		if enabled {
 			_, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
-				OrganizationID: authCtx.ActiveOrganizationID,
+				OrganizationID: orgID,
 				FeatureName:    string(feature),
 			})
 			if err != nil {
@@ -216,7 +244,7 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 		}
 
 		_, err := q.DeleteFeature(ctx, repo.DeleteFeatureParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
+			OrganizationID: orgID,
 			FeatureName:    string(feature),
 		})
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -229,13 +257,13 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 	}
 
 	if err := setFeatureState(FeatureRemoteSessionAutoRefresh, visible); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "set remote session refresh visibility").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeUnexpected, err, "set remote session refresh visibility").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
 	if err := setFeatureState(FeatureRemoteSessionAutoRefreshEnforced, enforced); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "set remote session refresh enforcement").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeUnexpected, err, "set remote session refresh enforcement").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit remote session refresh policy").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeUnexpected, err, "commit remote session refresh policy").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
 
 	for _, state := range []struct {
@@ -246,14 +274,14 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 		{feature: FeatureRemoteSessionAutoRefreshEnforced, enabled: enforced},
 	} {
 		cacheEntry := FeatureCache{
-			OrganizationID: authCtx.ActiveOrganizationID,
+			OrganizationID: orgID,
 			Feature:        state.feature,
 			Enabled:        state.enabled,
 		}
 		if cacheErr := s.featureCache.Store(ctx, cacheEntry); cacheErr != nil {
 			s.logger.WarnContext(ctx, "failed to cache remote session refresh policy",
 				attr.SlogError(cacheErr),
-				attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
+				attr.SlogOrganizationID(orgID),
 				attr.SlogProductFeatureName(string(state.feature)),
 			)
 		}
@@ -263,15 +291,10 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 }
 
 func (s *Service) GetProductFeatures(ctx context.Context, payload *gen.GetProductFeaturesPayload) (*gen.GetProductFeaturesResult, error) {
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
-		return nil, oops.C(oops.CodeUnauthorized)
+	_, orgID, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgRead)
+	if err != nil {
+		return nil, err
 	}
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgRead, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
-		return nil, fmt.Errorf("require org read: %w", err)
-	}
-
-	orgID := authCtx.ActiveOrganizationID
 
 	// Helper function to check if a feature is enabled (cache first, then DB)
 	isEnabled := func(feature Feature) bool {

--- a/server/internal/productfeatures/organizationscope_test.go
+++ b/server/internal/productfeatures/organizationscope_test.go
@@ -1,0 +1,303 @@
+package productfeatures_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+
+	gen "github.com/speakeasy-api/gram/server/gen/features"
+	agentrepo "github.com/speakeasy-api/gram/server/internal/agent/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestProductFeaturesService_RequestedOrganizationIsolation(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	activeOrganizationID := activeOrganizationID(t, ctx)
+	targetOrganizationID := uuid.NewString()
+	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
+	seedRequestedOrganizationRole(t, ctx, ti, targetOrganizationID, authz.SystemRoleAdmin)
+
+	q := repo.New(ti.conn)
+	_, err := q.EnableFeature(ctx, repo.EnableFeatureParams{OrganizationID: activeOrganizationID, FeatureName: string(productfeatures.FeatureLogs)})
+	require.NoError(t, err)
+
+	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID)})
+	require.NoError(t, err)
+	require.False(t, result.LogsEnabled)
+	activeResult, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(activeOrganizationID)})
+	require.NoError(t, err)
+	require.True(t, activeResult.LogsEnabled)
+
+	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		FeatureName:    string(productfeatures.FeatureLogs),
+		Enabled:        true,
+	}))
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	client := productfeatures.NewClient(testenv.NewLogger(t), testenv.NewTracerProvider(t), ti.conn, redisClient)
+	activeEnabled, err := client.IsFeatureEnabled(ctx, activeOrganizationID, productfeatures.FeatureLogs)
+	require.NoError(t, err)
+	require.True(t, activeEnabled)
+	targetEnabled, err := client.IsFeatureEnabled(ctx, targetOrganizationID, productfeatures.FeatureLogs)
+	require.NoError(t, err)
+	require.True(t, targetEnabled)
+
+	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		FeatureName:    string(productfeatures.FeatureLogs),
+		Enabled:        false,
+	}))
+	activeEnabled, err = client.IsFeatureEnabled(ctx, activeOrganizationID, productfeatures.FeatureLogs)
+	require.NoError(t, err)
+	require.True(t, activeEnabled, "target cache update must not affect the active organization")
+	targetEnabled, err = client.IsFeatureEnabled(ctx, targetOrganizationID, productfeatures.FeatureLogs)
+	require.NoError(t, err)
+	require.False(t, targetEnabled)
+
+	require.NoError(t, agentrepo.New(ti.conn).UpsertDeviceAgentSync(ctx, agentrepo.UpsertDeviceAgentSyncParams{
+		OrganizationID: targetOrganizationID,
+		Email:          "device@example.com",
+	}))
+	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID)})
+	require.NoError(t, err)
+	require.True(t, result.DeviceAgent)
+	activeResult, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(activeOrganizationID)})
+	require.NoError(t, err)
+	require.False(t, activeResult.DeviceAgent)
+}
+
+func TestProductFeaturesService_RemoteSessionPolicyTargetsRequestedOrganization(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	activeOrganizationID := activeOrganizationID(t, ctx)
+	targetOrganizationID := uuid.NewString()
+	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
+	seedRequestedOrganizationRole(t, ctx, ti, targetOrganizationID, authz.SystemRoleAdmin)
+	q := repo.New(ti.conn)
+	_, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
+		OrganizationID: activeOrganizationID,
+		FeatureName:    string(productfeatures.FeatureRemoteSessionAutoRefresh),
+	})
+	require.NoError(t, err)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	featureClient := productfeatures.NewClient(testenv.NewLogger(t), testenv.NewTracerProvider(t), ti.conn, redisClient)
+
+	for _, tc := range []struct {
+		policy            string
+		visible, enforced bool
+	}{
+		{policy: "user_controlled", visible: true},
+		{policy: "enforced", enforced: true},
+		{policy: "disabled"},
+	} {
+		require.NoError(t, ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
+			OrganizationID: conv.PtrEmpty(targetOrganizationID),
+			Policy:         tc.policy,
+		}))
+		visible, err := q.IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{OrganizationID: targetOrganizationID, FeatureName: string(productfeatures.FeatureRemoteSessionAutoRefresh)})
+		require.NoError(t, err)
+		require.Equal(t, tc.visible, visible, tc.policy)
+		enforced, err := q.IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{OrganizationID: targetOrganizationID, FeatureName: string(productfeatures.FeatureRemoteSessionAutoRefreshEnforced)})
+		require.NoError(t, err)
+		require.Equal(t, tc.enforced, enforced, tc.policy)
+
+		cachedVisible, err := featureClient.IsFeatureEnabled(ctx, targetOrganizationID, productfeatures.FeatureRemoteSessionAutoRefresh)
+		require.NoError(t, err)
+		require.Equal(t, tc.visible, cachedVisible, tc.policy)
+		cachedEnforced, err := featureClient.IsFeatureEnabled(ctx, targetOrganizationID, productfeatures.FeatureRemoteSessionAutoRefreshEnforced)
+		require.NoError(t, err)
+		require.Equal(t, tc.enforced, cachedEnforced, tc.policy)
+
+		activeVisible, err := q.IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{OrganizationID: activeOrganizationID, FeatureName: string(productfeatures.FeatureRemoteSessionAutoRefresh)})
+		require.NoError(t, err)
+		require.True(t, activeVisible, "target policy must not alter the active organization")
+		activeEnforced, err := q.IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{OrganizationID: activeOrganizationID, FeatureName: string(productfeatures.FeatureRemoteSessionAutoRefreshEnforced)})
+		require.NoError(t, err)
+		require.False(t, activeEnforced, "target policy must not alter the active organization enforced state")
+	}
+}
+
+func TestProductFeaturesService_AuthorizesBeforeOrganizationLookup(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	activeOrganizationID := activeOrganizationID(t, ctx)
+	targetOrganizationID := uuid.NewString()
+	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
+
+	readActiveOnly := authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, activeOrganizationID))
+	_, err := ti.service.GetProductFeatures(readActiveOnly, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID)})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	adminActiveOnly := authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, activeOrganizationID))
+	err = ti.service.SetProductFeature(adminActiveOnly, &gen.SetProductFeaturePayload{OrganizationID: conv.PtrEmpty(targetOrganizationID), FeatureName: string(productfeatures.FeatureLogs), Enabled: true})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	err = ti.service.SetRemoteSessionAutoRefreshPolicy(adminActiveOnly, &gen.SetRemoteSessionAutoRefreshPolicyPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID), Policy: "enforced"})
+	requireOopsCode(t, err, oops.CodeForbidden)
+
+	unknownOrganizationID := uuid.NewString()
+	_, err = ti.service.GetProductFeatures(readActiveOnly, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(unknownOrganizationID)})
+	requireOopsCode(t, err, oops.CodeForbidden, "unauthorized unknown target must not be enumerable")
+	err = ti.service.SetProductFeature(adminActiveOnly, &gen.SetProductFeaturePayload{OrganizationID: conv.PtrEmpty(unknownOrganizationID), FeatureName: string(productfeatures.FeatureLogs), Enabled: true})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	err = ti.service.SetRemoteSessionAutoRefreshPolicy(adminActiveOnly, &gen.SetRemoteSessionAutoRefreshPolicyPayload{OrganizationID: conv.PtrEmpty(unknownOrganizationID), Policy: "enforced"})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestProductFeaturesService_HooksFailOpenAuditTargetsRequestedOrganization(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	activeOrganizationID := activeOrganizationID(t, ctx)
+	targetOrganizationID := uuid.NewString()
+	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
+	seedRequestedOrganizationRole(t, ctx, ti, targetOrganizationID, authz.SystemRoleAdmin)
+	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		FeatureName:    string(productfeatures.FeatureHooksFailOpen),
+		Enabled:        true,
+	}))
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOrganizationHooksFailOpenEnabled)
+	require.NoError(t, err)
+	require.Equal(t, targetOrganizationID, record.OrganizationID)
+	require.Equal(t, targetOrganizationID, record.SubjectID)
+	require.Equal(t, targetOrganizationID, record.SubjectSlug)
+	require.NotEqual(t, activeOrganizationID, record.OrganizationID)
+}
+
+func TestProductFeaturesHTTP_UsesRequestedOrganizationPersistedGrants(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.SessionID)
+	session, err := ti.sessionManager.GetSession(ctx, *authCtx.SessionID)
+	require.NoError(t, err)
+	activeOrganizationID := session.ActiveOrganizationID
+	targetOrganizationID := uuid.NewString()
+	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
+	seedRequestedOrganizationRoleForUser(t, ctx, ti, activeOrganizationID, session.UserID, authz.SystemRoleAdmin)
+
+	mux := goahttp.NewMuxer()
+	productfeatures.Attach(mux, ti.service)
+	do := func(method, target, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequestWithContext(t.Context(), method, target, bytes.NewBufferString(body))
+		_, preloaded := contextvalues.GetAuthContext(req.Context())
+		require.False(t, preloaded, "request must traverse session authentication and grant preparation")
+		req.Header.Set("Gram-Session", session.SessionID)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	for name, response := range map[string]*httptest.ResponseRecorder{
+		"get":           do(http.MethodGet, "/rpc/productFeatures.get?organization_id="+targetOrganizationID, ""),
+		"set":           do(http.MethodPost, "/rpc/productFeatures.set", `{"organization_id":"`+targetOrganizationID+`","feature_name":"hooks_fail_open","enabled":true}`),
+		"remote policy": do(http.MethodPost, "/rpc/productFeatures.setRemoteSessionAutoRefreshPolicy", `{"organization_id":"`+targetOrganizationID+`","policy":"enforced"}`),
+	} {
+		require.Equal(t, http.StatusForbidden, response.Code, "%s: %s", name, response.Body.String())
+	}
+
+	seedRequestedOrganizationRoleForUser(t, ctx, ti, targetOrganizationID, session.UserID, authz.SystemRoleAdmin)
+	for name, response := range map[string]*httptest.ResponseRecorder{
+		"get":           do(http.MethodGet, "/rpc/productFeatures.get?organization_id="+targetOrganizationID, ""),
+		"set":           do(http.MethodPost, "/rpc/productFeatures.set", `{"organization_id":"`+targetOrganizationID+`","feature_name":"hooks_fail_open","enabled":true}`),
+		"remote policy": do(http.MethodPost, "/rpc/productFeatures.setRemoteSessionAutoRefreshPolicy", `{"organization_id":"`+targetOrganizationID+`","policy":"enforced"}`),
+	} {
+		require.Equal(t, http.StatusOK, response.Code, "%s: %s", name, response.Body.String())
+	}
+
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOrganizationHooksFailOpenEnabled)
+	require.NoError(t, err)
+	require.Equal(t, session.UserID, record.ActorID)
+	require.Equal(t, targetOrganizationID, record.OrganizationID)
+}
+
+func seedRequestedOrganizationRole(t *testing.T, ctx context.Context, ti *testInstance, organizationID, role string) {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	seedRequestedOrganizationRoleForUser(t, ctx, ti, organizationID, authCtx.UserID, role)
+}
+
+func seedRequestedOrganizationRoleForUser(t *testing.T, ctx context.Context, ti *testInstance, organizationID, userID, role string) {
+	t.Helper()
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	_, err := orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	_, err = accessrepo.New(ti.conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       userID,
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGText("membership-" + userID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     role,
+	})
+	require.NoError(t, err)
+}
+
+func requireOopsCode(t *testing.T, err error, code oops.Code, msgAndArgs ...any) {
+	t.Helper()
+	require.Error(t, err, msgAndArgs...)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, code, shareable.Code, msgAndArgs...)
+}
+
+func TestProductFeaturesService_OmittedOrganizationUsesActiveOrganization(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	organizationID := activeOrganizationID(t, ctx)
+
+	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	require.NoError(t, err)
+	require.False(t, result.LogsEnabled)
+
+	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		FeatureName: string(productfeatures.FeatureLogs),
+		Enabled:     true,
+	}))
+	enabled, err := repo.New(ti.conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+		OrganizationID: organizationID,
+		FeatureName:    string(productfeatures.FeatureLogs),
+	})
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	require.NoError(t, ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
+		Policy: "enforced",
+	}))
+	enforced, err := repo.New(ti.conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+		OrganizationID: organizationID,
+		FeatureName:    string(productfeatures.FeatureRemoteSessionAutoRefreshEnforced),
+	})
+	require.NoError(t, err)
+	require.True(t, enforced)
+}

--- a/server/internal/productfeatures/setproductfeature_test.go
+++ b/server/internal/productfeatures/setproductfeature_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
@@ -28,8 +29,9 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 		require.NotNil(t, authCtx)
 
 		err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     true,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        true,
 		})
 		require.NoError(t, err)
 
@@ -53,15 +55,17 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 
 		// First enable the feature
 		err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     true,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        true,
 		})
 		require.NoError(t, err)
 
 		// Then disable it
 		err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     false,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        false,
 		})
 		require.NoError(t, err)
 
@@ -87,8 +91,9 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 
 		// Enable
 		err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     true,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        true,
 		})
 		require.NoError(t, err)
 
@@ -101,8 +106,9 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 
 		// Disable
 		err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     false,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        false,
 		})
 		require.NoError(t, err)
 
@@ -115,8 +121,9 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 
 		// Enable again
 		err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     true,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        true,
 		})
 		require.NoError(t, err)
 
@@ -136,14 +143,37 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 		ctxWithoutAuth := t.Context()
 
 		err := ti.service.SetProductFeature(ctxWithoutAuth, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     true,
+			OrganizationID: conv.PtrEmpty("test-organization"),
+			FeatureName:    "logs",
+			Enabled:        true,
 		})
 		require.Error(t, err)
 
 		var oopsErr *oops.ShareableError
 		require.ErrorAs(t, err, &oopsErr)
 		require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
+	})
+
+	t.Run("uses requested organization without active organization ID", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti := newTestProductFeaturesService(t)
+
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok)
+		require.NotNil(t, authCtx)
+
+		targetOrganizationID := authCtx.ActiveOrganizationID
+		seedRequestedOrganizationRole(t, ctx, ti, targetOrganizationID, authz.SystemRoleAdmin)
+		// The requested target is independent from the session active organization.
+		authCtx.ActiveOrganizationID = ""
+		ctxWithoutOrg := contextvalues.SetAuthContext(ctx, authCtx)
+
+		err := ti.service.SetProductFeature(ctxWithoutOrg, &gen.SetProductFeaturePayload{
+			OrganizationID: conv.PtrEmpty(targetOrganizationID),
+			FeatureName:    "logs",
+			Enabled:        true,
+		})
+		require.NoError(t, err)
 	})
 
 	t.Run("unauthorized without organization ID", func(t *testing.T) {
@@ -154,7 +184,6 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, authCtx)
 
-		// Set organization ID to empty string
 		authCtx.ActiveOrganizationID = ""
 		ctxWithoutOrg := contextvalues.SetAuthContext(ctx, authCtx)
 
@@ -198,22 +227,25 @@ func TestProductFeaturesService_SetRemoteSessionAutoRefreshPolicy(t *testing.T) 
 	}
 
 	err := ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
-		Policy:       "user_controlled",
-		SessionToken: nil,
+		OrganizationID: requestedOrganizationID(ctx),
+		Policy:         "user_controlled",
+		SessionToken:   nil,
 	})
 	require.NoError(t, err)
 	requirePolicy(true, false)
 
 	err = ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
-		Policy:       "enforced",
-		SessionToken: nil,
+		OrganizationID: requestedOrganizationID(ctx),
+		Policy:         "enforced",
+		SessionToken:   nil,
 	})
 	require.NoError(t, err)
 	requirePolicy(false, true)
 
 	err = ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
-		Policy:       "disabled",
-		SessionToken: nil,
+		OrganizationID: requestedOrganizationID(ctx),
+		Policy:         "disabled",
+		SessionToken:   nil,
 	})
 	require.NoError(t, err)
 	requirePolicy(false, false)
@@ -229,8 +261,9 @@ func TestProductFeaturesService_SetRemoteSessionAutoRefreshPolicyRequiresOrgAdmi
 	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, authCtx.ActiveOrganizationID))
 
 	err := ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
-		Policy:       "enforced",
-		SessionToken: nil,
+		OrganizationID: requestedOrganizationID(ctx),
+		Policy:         "enforced",
+		SessionToken:   nil,
 	})
 	require.Error(t, err)
 
@@ -276,8 +309,9 @@ func TestProductFeaturesClient_IsFeatureEnabled(t *testing.T) {
 
 		// Enable the feature first
 		err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     true,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        true,
 		})
 		require.NoError(t, err)
 
@@ -367,8 +401,9 @@ func TestProductFeaturesClient_IsFeatureEnabled(t *testing.T) {
 
 		// Enable the feature
 		err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     true,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        true,
 		})
 		require.NoError(t, err)
 
@@ -378,8 +413,9 @@ func TestProductFeaturesClient_IsFeatureEnabled(t *testing.T) {
 
 		// Disable the feature
 		err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-			FeatureName: "logs",
-			Enabled:     false,
+			OrganizationID: requestedOrganizationID(ctx),
+			FeatureName:    "logs",
+			Enabled:        false,
 		})
 		require.NoError(t, err)
 

--- a/server/internal/productfeatures/setup_test.go
+++ b/server/internal/productfeatures/setup_test.go
@@ -48,6 +48,14 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func requestedOrganizationID(ctx context.Context) *string {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil {
+		return conv.PtrEmpty("test-organization")
+	}
+	return conv.PtrEmpty(authCtx.ActiveOrganizationID)
+}
+
 type testInstance struct {
 	service        *productfeatures.Service
 	conn           *pgxpool.Pool

--- a/server/internal/productfeatures/skills_test.go
+++ b/server/internal/productfeatures/skills_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -27,17 +28,20 @@ func TestProductFeaturesService_SkillsAlwaysEnabled(t *testing.T) {
 	ctx, ti := newTestProductFeaturesService(t)
 	organizationID := activeOrganizationID(t, ctx)
 	seedOrganization(t, ctx, ti.conn, organizationID)
-	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{SessionToken: nil})
+	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx), SessionToken: nil})
 	require.NoError(t, err)
 	require.True(t, result.SkillsEnabled)
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: string(productfeatures.FeatureSkills),
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
-	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{SessionToken: nil})
+	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx), SessionToken: nil})
 	require.NoError(t, err)
 	require.True(t, result.SkillsEnabled)
 }
@@ -59,8 +63,9 @@ func TestProductFeaturesService_EnableSkillsPatchesExistingRBACGrants(t *testing
 	upsertGrant(t, ctx, q, organizationID, member, authz.ScopeSkillBlockedRead, "project-excluded")
 
 	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: string(productfeatures.FeatureSkills),
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 
@@ -72,20 +77,23 @@ func TestProductFeaturesService_EnableSkillsPatchesExistingRBACGrants(t *testing
 	require.Equal(t, 1, grantsAfterEnable[grantKey(member, authz.ScopeSkillBlockedRead, "project-excluded")])
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: string(productfeatures.FeatureSkills),
-		Enabled:     true,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, grantsAfterEnable, organizationGrantKeys(t, ctx, q, organizationID))
 
 	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: string(productfeatures.FeatureSkills),
-		Enabled:     false,
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        false,
 	})
 	require.NoError(t, err)
 	require.Equal(t, grantsAfterEnable, organizationGrantKeys(t, ctx, q, organizationID))
 
-	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{SessionToken: nil})
+	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
+		OrganizationID: requestedOrganizationID(ctx), SessionToken: nil})
 	require.NoError(t, err)
 	require.True(t, result.SkillsEnabled)
 }
@@ -204,4 +212,30 @@ func organizationGrantKeys(t *testing.T, ctx context.Context, q *accessrepo.Quer
 
 func grantKey(principal fmt.Stringer, scope authz.Scope, resourceID string) string {
 	return principal.String() + "|" + string(scope) + "|" + resourceID
+}
+
+func TestProductFeaturesService_EnableSkillsTargetsRequestedOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestProductFeaturesService(t)
+	activeOrganizationID := activeOrganizationID(t, ctx)
+	targetOrganizationID := uuid.NewString()
+	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
+	seedRequestedOrganizationRole(t, ctx, ti, targetOrganizationID, authz.SystemRoleAdmin)
+
+	q := accessrepo.New(ti.conn)
+	admin := systemRolePrincipal(t, ctx, q, authz.SystemRoleAdmin)
+	deleteGrant(t, ctx, q, activeOrganizationID, admin, authz.ScopeSkillWrite, authz.WildcardResource)
+	deleteGrant(t, ctx, q, targetOrganizationID, admin, authz.ScopeSkillWrite, authz.WildcardResource)
+
+	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        true,
+	}))
+
+	activeGrants := organizationGrantKeys(t, ctx, q, activeOrganizationID)
+	targetGrants := organizationGrantKeys(t, ctx, q, targetOrganizationID)
+	require.Zero(t, activeGrants[grantKey(admin, authz.ScopeSkillWrite, authz.WildcardResource)])
+	require.Equal(t, 1, targetGrants[grantKey(admin, authz.ScopeSkillWrite, authz.WildcardResource)])
 }


### PR DESCRIPTION
## Summary
- let all three product-feature methods securely target an explicitly requested organization
- preserve active-organization behavior when the request omits the new parameter, keeping this migration layer deployable
- regenerate Goa, OpenAPI, CLI, TypeScript SDK, and React Query artifacts
- cover authorization ordering, unknown targets, cache isolation, Skills grants, device-agent derivation, remote-session policy, and audit attribution

## Why this is needed

Product-feature methods previously derived their organization entirely from the active session. That becomes ambiguous once callers need to operate on an explicitly selected organization:

1. The session is active in Organization A.
2. A caller intends to inspect or update Organization B.
3. The request has no way to identify B.
4. Database operations, caches, policy state, and audit attribution therefore remain scoped to A.

```text
session active in A → product-feature request → reads or mutates A
caller selects B ────────────────────────────╳ no explicit target
```

The previous PR in the stack, [#5466](https://github.com/speakeasy-api/gram/pull/5466), adds target-bound organization authorization. This PR puts that helper to work in the three product-feature methods, ensuring an explicit target is authorized using grants from that organization rather than grants prepared for the session's active organization.

This PR adds optional `organization_id` support and consistently uses the selected organization for authorization, persistence, caches, Skills grants, device-agent state, remote-session policy, and audit attribution. Requested targets are authorized before existence lookup to avoid organization enumeration.

The parameter remains optional in this compatibility layer so existing callers continue using the active organization while the next PR updates dashboard callers. The final PR then makes the parameter required and removes the fallback.

## Verification
- 37 focused product-feature tests
- dashboard type-check against the optional generated SDK
- SDK generation check
- `git diff --check`

## Stack
Depends on AGE-3314. AGE-3316 migrates every dashboard caller; AGE-3315 then removes the temporary fallback and requires organization scope.

Linear: AGE-3317

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable product-feature endpoints to target a requested organization while preserving active-organization defaults. Previously all methods used the active organization; now they use an authorized requested organization when provided, and still work when the active organization is unset.

- API: Add optional organization_id to GET productFeatures.get (query) and to setProductFeature and setRemoteSessionAutoRefreshPolicy (bodies). Regenerate Goa, OpenAPI, CLI, `dashboard` SDK, and React Query; CLI adds --organization-id to get; React Query keys now include organizationId.
- Authorization and safety: Authorize the requested organization first using org:read/org:admin grants from that organization. Unauthorized targets return Forbidden (including unknown orgs); authorized-but-missing targets return NotFound. Uses persisted session grants and supports empty active organization.
- Behavior and isolation: The requested organization scopes cache keys, Skills grants, device-agent detection, remote-session auto-refresh policy (visible/enforced), and audit attribution. Cache updates are isolated per organization.
- Rollout: No migration required; existing callers keep active-organization behavior. AGE-3316 will migrate `dashboard` callers; AGE-3315 will remove the fallback and require organization scope. Aligns with Linear AGE-3317.

<sup>Written for commit ef2c7869760b6bff867684d887dfcbc29e7e51ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

