### PR TITLE
fix: scope product-feature callers by organization

### DIFF
--- a/.changeset/product-features-callers-org-scope.md
+++ b/.changeset/product-features-callers-org-scope.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Scope product-feature requests and organization-owned form state to the active organization.

--- a/client/dashboard/src/components/EnableLoggingOverlay.tsx
+++ b/client/dashboard/src/components/EnableLoggingOverlay.tsx
@@ -1,9 +1,11 @@
 import { RequireScope } from "@/components/require-scope";
+import { useOrganization } from "@/contexts/Auth";
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Icon } from "@/components/ui/Icon";
 import { FeatureName } from "@gram/client/models/components/setproductfeaturerequestbody.js";
 import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet.js";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
 interface EnableLoggingOverlayProps {
   onEnabled: () => void;
@@ -16,14 +18,36 @@ interface EnableLoggingOverlayProps {
 export function EnableLoggingOverlay({
   onEnabled,
 }: EnableLoggingOverlayProps): JSX.Element {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  return (
+    <EnableLoggingOverlayInner
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+      onEnabled={onEnabled}
+    />
+  );
+}
+
+function EnableLoggingOverlayInner({
+  organizationId,
+  isCurrentOrganization,
+  onEnabled,
+}: EnableLoggingOverlayProps & {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element {
   const [mutationError, setMutationError] = useState<string | null>(null);
   const { mutate: setLogsFeature, status: mutationStatus } =
     useFeaturesSetMutation({
       onSuccess: () => {
+        if (!isCurrentOrganization()) return;
         setMutationError(null);
         onEnabled();
       },
       onError: (err) => {
+        if (!isCurrentOrganization()) return;
         const message =
           err instanceof Error ? err.message : "Failed to enable logging";
         setMutationError(message);
@@ -37,6 +61,7 @@ export function EnableLoggingOverlay({
     setLogsFeature({
       request: {
         setProductFeatureRequestBody: {
+          organizationId,
           featureName: FeatureName.Logs,
           enabled: true,
         },

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useOrganization } from "@/contexts/Auth";
 
 import { AppRoute, useOrgRoutes } from "@/routes";
 import { NavButton, NavGroupProvider } from "@/components/nav-menu";
@@ -58,12 +59,17 @@ export function OrgSidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar>): React.JSX.Element {
   const orgRoutes = useOrgRoutes();
+  const organization = useOrganization();
   const { isLoading: rbacLoading } = useRBAC();
   const telemetry = useTelemetry();
-  const { data: productFeatures } = useProductFeatures(undefined, undefined, {
-    staleTime: 30_000,
-    throwOnError: false,
-  });
+  const { data: productFeatures } = useProductFeatures(
+    { organizationId: organization.id },
+    undefined,
+    {
+      staleTime: 30_000,
+      throwOnError: false,
+    },
+  );
   const isPlatformAdmin = useIsPlatformAdmin();
   const { enabled: isPlatformMcpDashboardEnabled } =
     usePlatformMcpDashboardVisibility();

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate } from "react-router";
+import { useOrganization } from "@/contexts/Auth";
 import { StatTile, StatTileGroup } from "@/components/chart/stat-tile";
 import { RankedBarList } from "@/components/chart/RankedBarList";
 import { Page } from "@/components/page-layout";
@@ -89,11 +90,12 @@ export function ProjectDashboard(): JSX.Element {
     [customRange, customRangeLabel, dateRange],
   );
 
+  const organization = useOrganization();
   const {
     data: featuresData,
     isPending: isFeaturesPending,
     isError: isFeaturesError,
-  } = useProductFeatures();
+  } = useProductFeatures({ organizationId: organization.id });
   const logsEnabled = featuresData?.logsEnabled === true;
 
   // The SDK's useGetProjectOverview omits the request body from its query

--- a/client/dashboard/src/hooks/useIsCurrentOrganization.test.tsx
+++ b/client/dashboard/src/hooks/useIsCurrentOrganization.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({ organizationId: "org-active" }));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: testState.organizationId }),
+}));
+
+import { useIsCurrentOrganization } from "./useIsCurrentOrganization";
+
+describe("useIsCurrentOrganization", () => {
+  it("checks a captured organization against the latest active organization", () => {
+    const { result, rerender } = renderHook(() =>
+      useIsCurrentOrganization("org-active"),
+    );
+    const isOriginalOrganizationCurrent = result.current;
+
+    expect(isOriginalOrganizationCurrent()).toBe(true);
+
+    testState.organizationId = "org-next";
+    rerender();
+
+    expect(isOriginalOrganizationCurrent()).toBe(false);
+  });
+});

--- a/client/dashboard/src/hooks/useIsCurrentOrganization.ts
+++ b/client/dashboard/src/hooks/useIsCurrentOrganization.ts
@@ -1,0 +1,15 @@
+import { useOrganization } from "@/contexts/Auth";
+import { useCallback, useRef } from "react";
+
+export function useIsCurrentOrganization(
+  organizationId: string,
+): () => boolean {
+  const activeOrganizationId = useOrganization().id;
+  const activeOrganizationIdRef = useRef(activeOrganizationId);
+  activeOrganizationIdRef.current = activeOrganizationId;
+
+  return useCallback(
+    () => activeOrganizationIdRef.current === organizationId,
+    [organizationId],
+  );
+}

--- a/client/dashboard/src/hooks/useOrganizationPlatformMCPOnboarding.test.ts
+++ b/client/dashboard/src/hooks/useOrganizationPlatformMCPOnboarding.test.ts
@@ -1,0 +1,27 @@
+import type { GramCore } from "@gram/client/core.js";
+import { describe, expect, it } from "vitest";
+import { buildOrganizationPlatformMCPOnboardingQuery } from "./useOrganizationPlatformMCPOnboarding";
+
+describe("buildOrganizationPlatformMCPOnboardingQuery", () => {
+  it("isolates onboarding state by organization", () => {
+    const client = {} as GramCore;
+
+    const first = buildOrganizationPlatformMCPOnboardingQuery(
+      client,
+      "org-first",
+    );
+    const second = buildOrganizationPlatformMCPOnboardingQuery(
+      client,
+      "org-second",
+    );
+
+    expect(first.queryKey).not.toEqual(second.queryKey);
+    expect(first.queryKey).toEqual([
+      "@gram/client",
+      "platformMcp",
+      "getOnboarding",
+      { gramSession: "" },
+      { organizationId: "org-first" },
+    ]);
+  });
+});

--- a/client/dashboard/src/hooks/useOrganizationPlatformMCPOnboarding.ts
+++ b/client/dashboard/src/hooks/useOrganizationPlatformMCPOnboarding.ts
@@ -1,0 +1,51 @@
+import type { GramCore } from "@gram/client/core.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import type { QueryHookOptions } from "@gram/client/react-query/_types.js";
+import {
+  buildPlatformMCPOnboardingQuery,
+  type PlatformMCPOnboardingQueryData,
+  type PlatformMCPOnboardingQueryError,
+} from "@gram/client/react-query/platformMCPOnboarding.js";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+export function buildOrganizationPlatformMCPOnboardingQuery(
+  client: GramCore,
+  organizationId: string,
+  options?: QueryHookOptions<
+    PlatformMCPOnboardingQueryData,
+    PlatformMCPOnboardingQueryError
+  >,
+): ReturnType<typeof buildPlatformMCPOnboardingQuery> {
+  const query = buildPlatformMCPOnboardingQuery(
+    client,
+    { gramSession: "" },
+    { sessionHeaderGramSession: "" },
+    options,
+  );
+
+  return {
+    ...query,
+    queryKey: [...query.queryKey, { organizationId }],
+  };
+}
+
+export function useOrganizationPlatformMCPOnboarding(
+  organizationId: string,
+  options?: QueryHookOptions<
+    PlatformMCPOnboardingQueryData,
+    PlatformMCPOnboardingQueryError
+  >,
+): UseQueryResult<
+  PlatformMCPOnboardingQueryData,
+  PlatformMCPOnboardingQueryError
+> {
+  const client = useGramContext();
+  return useQuery({
+    ...buildOrganizationPlatformMCPOnboardingQuery(
+      client,
+      organizationId,
+      options,
+    ),
+    ...options,
+  });
+}

--- a/client/dashboard/src/hooks/usePlatformMcpCta.ts
+++ b/client/dashboard/src/hooks/usePlatformMcpCta.ts
@@ -3,8 +3,8 @@ import { useOrganization, useUser } from "@/contexts/Auth";
 
 import type { RecordDashboardCtaEventRequestBody } from "@gram/client/models/components/recorddashboardctaeventrequestbody.js";
 import { createDismissedCtaStore } from "@/hooks/useDismissedCtaStore";
+import { useOrganizationPlatformMCPOnboarding } from "@/hooks/useOrganizationPlatformMCPOnboarding";
 import { useOrgRoutes } from "@/routes";
-import { usePlatformMCPOnboarding } from "@gram/client/react-query/platformMCPOnboarding.js";
 import { usePlatformMCPPackageStatus } from "@gram/client/react-query/platformMCPPackageStatus.js";
 import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
 import { useRBAC } from "@/hooks/useRBAC";
@@ -86,11 +86,11 @@ export function usePlatformMcpCta({
   const { enabled: dashboardEnabled, isLoading: dashboardLoading } =
     usePlatformMcpDashboardVisibility();
   const canQuery = dashboardEnabled && hasScope("org:admin");
-  const onboarding = usePlatformMCPOnboarding(
-    { gramSession: "" },
-    { sessionHeaderGramSession: "" },
-    { throwOnError: false, staleTime: 10_000, enabled: canQuery },
-  );
+  const onboarding = useOrganizationPlatformMCPOnboarding(organization.id, {
+    throwOnError: false,
+    staleTime: 10_000,
+    enabled: canQuery,
+  });
   const packageStatus = usePlatformMCPPackageStatus(undefined, undefined, {
     throwOnError: false,
     staleTime: 10_000,

--- a/client/dashboard/src/pages/org/ConsentToolFilteringSetting.test.tsx
+++ b/client/dashboard/src/pages/org/ConsentToolFilteringSetting.test.tsx
@@ -9,32 +9,54 @@ const testState = vi.hoisted(() => ({
   error: null as Error | null,
   isFetching: false,
   isLoading: false,
+  organizationId: "org-active",
   mutate: vi.fn(),
+  mutationOptions: undefined as
+    | {
+        onError?: (error: Error) => void;
+        onSuccess?: () => Promise<void>;
+      }
+    | undefined,
+  productFeaturesQuery: vi.fn(),
   refetch: vi.fn(),
 }));
+
+const handleAPIError = vi.hoisted(() => vi.fn());
+const invalidateAllProductFeatures = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/require-scope", () => ({
   RequireScope: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("@/lib/errors", () => ({ handleAPIError: vi.fn() }));
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: testState.organizationId }),
+}));
+
+vi.mock("@/lib/errors", () => ({ handleAPIError }));
 
 vi.mock("@gram/client/react-query/featuresSet.js", () => ({
-  useFeaturesSetMutation: () => ({
-    isPending: false,
-    mutate: testState.mutate,
-  }),
+  useFeaturesSetMutation: (options: {
+    onError?: (error: Error) => void;
+    onSuccess?: () => Promise<void>;
+  }) => {
+    testState.mutationOptions = options;
+    return { isPending: false, mutate: testState.mutate };
+  },
 }));
 
 vi.mock("@gram/client/react-query/productFeatures.js", () => ({
-  invalidateAllProductFeatures: vi.fn(),
-  useProductFeatures: () => ({
-    data: testState.data,
-    error: testState.error,
-    isFetching: testState.isFetching,
-    isLoading: testState.isLoading,
-    refetch: testState.refetch,
-  }),
+  invalidateAllProductFeatures,
+  useProductFeatures: (...args: unknown[]) => {
+    testState.productFeaturesQuery(...args);
+    return {
+      data: testState.data,
+      error: testState.error,
+      isFetching: testState.isFetching,
+      isLoading: testState.isLoading,
+      refetch: testState.refetch,
+    };
+  },
 }));
 
 vi.mock("@tanstack/react-query", async (importOriginal) => ({
@@ -43,7 +65,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: toastSuccess },
 }));
 
 import { ConsentToolFilteringSetting } from "./ConsentToolFilteringSetting";
@@ -53,23 +75,93 @@ beforeEach(() => {
   testState.error = null;
   testState.isFetching = false;
   testState.isLoading = false;
+  testState.organizationId = "org-active";
   testState.mutate.mockReset();
+  testState.mutationOptions = undefined;
+  testState.productFeaturesQuery.mockReset();
   testState.refetch.mockReset();
+  handleAPIError.mockReset();
+  invalidateAllProductFeatures.mockReset();
+  toastSuccess.mockReset();
 });
 
 afterEach(cleanup);
 
 describe("ConsentToolFilteringSetting", () => {
-  it("renders the current feature setting", () => {
+  it("reads and writes the active organization setting", () => {
     render(<ConsentToolFilteringSetting />);
 
-    expect(
-      screen
-        .getByRole("switch", {
-          name: "Tool filtering on consent screens",
-        })
-        .getAttribute("aria-checked"),
-    ).toBe("true");
+    expect(testState.productFeaturesQuery).toHaveBeenCalledWith(
+      { organizationId: "org-active" },
+      undefined,
+      expect.anything(),
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Tool filtering on consent screens",
+      }),
+    );
+
+    expect(testState.mutate).toHaveBeenCalledWith({
+      request: {
+        setProductFeatureRequestBody: {
+          organizationId: "org-active",
+          featureName: "consent_tool_filtering",
+          enabled: false,
+        },
+      },
+    });
+  });
+
+  it("ignores a deferred mutation completion after an organization switch", async () => {
+    const { rerender } = render(<ConsentToolFilteringSetting />);
+    const activeMutation = testState.mutationOptions;
+    expect(activeMutation?.onSuccess).toBeTypeOf("function");
+
+    testState.organizationId = "org-next";
+    rerender(<ConsentToolFilteringSetting />);
+    await activeMutation!.onSuccess!();
+
+    expect(invalidateAllProductFeatures).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(testState.productFeaturesQuery).toHaveBeenLastCalledWith(
+      { organizationId: "org-next" },
+      undefined,
+      expect.anything(),
+    );
+  });
+
+  it("ignores a mutation completion when the organization switches during invalidation", async () => {
+    let resolveInvalidation: (() => void) | undefined;
+    invalidateAllProductFeatures.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInvalidation = resolve;
+      }),
+    );
+    const { rerender } = render(<ConsentToolFilteringSetting />);
+    const activeMutation = testState.mutationOptions;
+    expect(activeMutation?.onSuccess).toBeTypeOf("function");
+
+    const completion = activeMutation!.onSuccess!();
+    testState.organizationId = "org-next";
+    rerender(<ConsentToolFilteringSetting />);
+    resolveInvalidation!();
+    await completion;
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stale mutation error after an organization switch", () => {
+    const { rerender } = render(<ConsentToolFilteringSetting />);
+    const activeMutation = testState.mutationOptions;
+    expect(activeMutation?.onError).toBeTypeOf("function");
+
+    testState.organizationId = "org-next";
+    rerender(<ConsentToolFilteringSetting />);
+    activeMutation!.onError!(new Error("stale failure"));
+
+    expect(handleAPIError).not.toHaveBeenCalled();
   });
 
   it("shows a retry state when product features fail to load", () => {

--- a/client/dashboard/src/pages/org/ConsentToolFilteringSetting.tsx
+++ b/client/dashboard/src/pages/org/ConsentToolFilteringSetting.tsx
@@ -2,6 +2,8 @@ import { RequireScope } from "@/components/require-scope";
 import { Button } from "@/components/ui/Button";
 import { Switch } from "@/components/ui/Switch";
 import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 import { handleAPIError } from "@/lib/errors";
 import { FeatureName } from "@gram/client/models/components/setproductfeaturerequestbody.js";
 import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet.js";
@@ -14,16 +16,37 @@ import { ListFilter } from "lucide-react";
 import { toast } from "sonner";
 
 export function ConsentToolFilteringSetting(): JSX.Element | null {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  return (
+    <ConsentToolFilteringSettingInner
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+    />
+  );
+}
+
+function ConsentToolFilteringSettingInner({
+  organizationId,
+  isCurrentOrganization,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element | null {
   const queryClient = useQueryClient();
-  const features = useProductFeatures(undefined, undefined, {
+  const features = useProductFeatures({ organizationId }, undefined, {
     throwOnError: false,
   });
   const mutation = useFeaturesSetMutation({
     onSuccess: async () => {
+      if (!isCurrentOrganization()) return;
       await invalidateAllProductFeatures(queryClient);
+      if (!isCurrentOrganization()) return;
       toast.success("Tool filtering setting updated");
     },
     onError: (error) => {
+      if (!isCurrentOrganization()) return;
       handleAPIError(error, "Failed to update tool filtering setting");
     },
   });
@@ -80,6 +103,7 @@ export function ConsentToolFilteringSetting(): JSX.Element | null {
               mutation.mutate({
                 request: {
                   setProductFeatureRequestBody: {
+                    organizationId,
                     featureName: FeatureName.ConsentToolFiltering,
                     enabled,
                   },

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -131,7 +131,9 @@ function OrgHomeInner() {
   // ProjectDashboard; staleTime dedupes re-runs and the fetch on navigation.
   const gramClient = useGramContext();
   const queryClient = useQueryClient();
-  const { data: featuresData } = useProductFeatures();
+  const { data: featuresData } = useProductFeatures({
+    organizationId: organization.id,
+  });
   const logsEnabled = featuresData?.logsEnabled === true;
   const prefetchProject =
     getPreferredProject(organization.projects) ??

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -291,7 +291,9 @@ export default function OrgIdentity(): JSX.Element {
 
 function OrgIdentityInner() {
   const organization = useOrganization();
-  const { data: features } = useProductFeatures();
+  const { data: features } = useProductFeatures({
+    organizationId: organization.id,
+  });
 
   const ssoFeatureEnabled = features?.ssoEnabled ?? false;
   const scimFeatureEnabled = features?.scimEnabled ?? false;

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -1,4 +1,5 @@
 import { SettingsPage } from "@/components/page-templates";
+import { useOrganization } from "@/contexts/Auth";
 import { LogDataRetentionBanner } from "@/components/observe/LoggingPageHeader";
 import { RequireScope } from "@/components/require-scope";
 import { Switch } from "@/components/ui/Switch";
@@ -12,13 +13,28 @@ import { OtelForwardingSection } from "./OtelForwardingSection";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { handleAPIError } from "@/lib/errors";
 import { SkillContentUploadSetting } from "./SkillContentUploadSetting";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
 export default function OrgLogs(): JSX.Element {
-  return <OrgLogsInner />;
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  return (
+    <OrgLogsInner
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+    />
+  );
 }
 
-function OrgLogsInner() {
-  const { data: featuresData } = useProductFeatures();
+function OrgLogsInner({
+  organizationId,
+  isCurrentOrganization,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}) {
+  const { data: featuresData } = useProductFeatures({ organizationId });
   const [logsEnabled, setLogsEnabled] = useState<boolean | null>(null);
   const [toolIoLogsEnabled, setToolIoLogsEnabled] = useState<boolean | null>(
     null,
@@ -47,6 +63,7 @@ function OrgLogsInner() {
   const { mutate: setLogsFeature, status: logsMutationStatus } =
     useFeaturesSetMutation({
       onSuccess: (_, variables) => {
+        if (!isCurrentOrganization()) return;
         const { featureName, enabled } =
           variables.request.setProductFeatureRequestBody;
         if (featureName === FeatureName.Logs) {
@@ -62,6 +79,7 @@ function OrgLogsInner() {
         }
       },
       onError: (error) => {
+        if (!isCurrentOrganization()) return;
         // On error the optimistic state above never runs, so the switch
         // reverts to the server value.
         handleAPIError(error, "Failed to update setting");
@@ -74,6 +92,7 @@ function OrgLogsInner() {
     setLogsFeature({
       request: {
         setProductFeatureRequestBody: {
+          organizationId,
           featureName: FeatureName.Logs,
           enabled,
         },
@@ -84,6 +103,7 @@ function OrgLogsInner() {
       setLogsFeature({
         request: {
           setProductFeatureRequestBody: {
+            organizationId,
             featureName: FeatureName.ToolIoLogs,
             enabled: false,
           },
@@ -96,6 +116,7 @@ function OrgLogsInner() {
     setLogsFeature({
       request: {
         setProductFeatureRequestBody: {
+          organizationId,
           featureName: FeatureName.ToolIoLogs,
           enabled,
         },
@@ -107,6 +128,7 @@ function OrgLogsInner() {
     setLogsFeature({
       request: {
         setProductFeatureRequestBody: {
+          organizationId,
           featureName: FeatureName.SessionCapture,
           enabled,
         },
@@ -118,6 +140,7 @@ function OrgLogsInner() {
     setLogsFeature({
       request: {
         setProductFeatureRequestBody: {
+          organizationId,
           featureName: FeatureName.HooksBrowserLogin,
           enabled,
         },
@@ -129,6 +152,7 @@ function OrgLogsInner() {
     setLogsFeature({
       request: {
         setProductFeatureRequestBody: {
+          organizationId,
           featureName: FeatureName.HooksFailOpen,
           enabled,
         },

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -4,6 +4,7 @@ import {
   AlertTitle,
   ErrorAlert,
 } from "@/components/ui/Alert";
+import { useOrganization } from "@/contexts/Auth";
 import { ArrowLeft, ChevronRight, CircleCheck } from "lucide-react";
 import {
   Sheet,
@@ -13,11 +14,9 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/Sheet";
-import {
-  invalidatePlatformMCPOnboarding,
-  usePlatformMCPOnboarding,
-} from "@gram/client/react-query/platformMCPOnboarding.js";
+import { invalidatePlatformMCPOnboarding } from "@gram/client/react-query/platformMCPOnboarding.js";
 import { useEffect, useRef, useState } from "react";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
 import { AgentPlatformPickerItem } from "@/pages/setup/components/agent-platform-picker-item";
 import { Badge } from "@/components/ui/Badge";
@@ -43,6 +42,7 @@ import { useDismissPlatformMCPOnboardingMutation } from "@gram/client/react-quer
 import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet.js";
 import { useFetcher } from "@/contexts/Fetcher";
 import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
+import { useOrganizationPlatformMCPOnboarding } from "@/hooks/useOrganizationPlatformMCPOnboarding";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRecordPlatformMCPAgentConfigurationCopiedMutation } from "@gram/client/react-query/recordPlatformMCPAgentConfigurationCopied.js";
 import { useRecordPlatformMCPInstallIntentMutation } from "@gram/client/react-query/recordPlatformMCPInstallIntent.js";
@@ -149,6 +149,48 @@ export function PlatformMCPOnboardingContent({
   initialSourceSurface?: SourceSurfaceValue;
   autoOpen?: boolean;
 } = {}): JSX.Element {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  return (
+    <PlatformMCPOnboardingContentInner
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+      currentProjectSlug={currentProjectSlug}
+      embeddedInProjectSetup={embeddedInProjectSetup}
+      onSetupComplete={onSetupComplete}
+      sheetOnly={sheetOnly}
+      setupOpen={setupOpen}
+      onSetupOpenChange={onSetupOpenChange}
+      initialSourceSurface={initialSourceSurface}
+      autoOpen={autoOpen}
+    />
+  );
+}
+
+function PlatformMCPOnboardingContentInner({
+  organizationId,
+  isCurrentOrganization,
+  currentProjectSlug,
+  embeddedInProjectSetup = false,
+  onSetupComplete,
+  sheetOnly = false,
+  setupOpen = false,
+  onSetupOpenChange,
+  initialSourceSurface,
+  autoOpen = false,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+  currentProjectSlug?: string;
+  embeddedInProjectSetup?: boolean;
+  onSetupComplete?: () => void;
+  sheetOnly?: boolean;
+  setupOpen?: boolean;
+  onSetupOpenChange?: (open: boolean) => void;
+  initialSourceSurface?: SourceSurfaceValue;
+  autoOpen?: boolean;
+}): JSX.Element {
   const queryClient = useQueryClient();
   const { fetch: authedFetch } = useFetcher();
   const [setupError, setSetupError] = useState<string | null>(null);
@@ -166,17 +208,13 @@ export function PlatformMCPOnboardingContent({
     initialSourceSurface ?? SourceSurface.PlatformMcpSettings,
   );
   const [searchParams, setSearchParams] = useSearchParams();
-  const onboarding = usePlatformMCPOnboarding(
-    { gramSession: "" },
-    { sessionHeaderGramSession: "" },
-    {
-      throwOnError: false,
-      staleTime: 10_000,
-      enabled: !sheetOnly || setupOpen,
-      refetchInterval: setupOpen || !sheetOnly ? 5_000 : false,
-      refetchIntervalInBackground: false,
-    },
-  );
+  const onboarding = useOrganizationPlatformMCPOnboarding(organizationId, {
+    throwOnError: false,
+    staleTime: 10_000,
+    enabled: !sheetOnly || setupOpen,
+    refetchInterval: setupOpen || !sheetOnly ? 5_000 : false,
+    refetchIntervalInBackground: false,
+  });
 
   useEffect(() => {
     if (!sheetOnly) return;
@@ -238,6 +276,7 @@ export function PlatformMCPOnboardingContent({
   });
   const setOrganizationAccess = useFeaturesSetMutation({
     onSuccess: async () => {
+      if (!isCurrentOrganization()) return;
       setAccessError(null);
       setDisableConfirmationOpen(false);
       await Promise.all([
@@ -246,6 +285,7 @@ export function PlatformMCPOnboardingContent({
       ]);
     },
     onError: () => {
+      if (!isCurrentOrganization()) return;
       setAccessError(
         "Could not update organization-wide Platform MCP access. Try again.",
       );
@@ -257,6 +297,7 @@ export function PlatformMCPOnboardingContent({
     setOrganizationAccess.mutate({
       request: {
         setProductFeatureRequestBody: {
+          organizationId,
           featureName: FeatureName.PlatformMcp,
           enabled,
         },

--- a/client/dashboard/src/pages/org/RemoteSessionRefreshPolicySetting.test.tsx
+++ b/client/dashboard/src/pages/org/RemoteSessionRefreshPolicySetting.test.tsx
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testState = vi.hoisted(() => ({
   isAdmin: true,
+  organizationId: "org-active",
   mutate: vi.fn(),
+  productFeaturesQuery: vi.fn(),
   mutationOptions: undefined as
     | {
         onError?: (error: Error) => void;
@@ -17,6 +19,11 @@ const testState = vi.hoisted(() => ({
 }));
 
 const invalidateAllProductFeatures = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: testState.organizationId }),
+}));
 
 vi.mock("@/components/require-scope", () => ({
   RequireScope: ({
@@ -28,12 +35,15 @@ vi.mock("@/components/require-scope", () => ({
 
 vi.mock("@gram/client/react-query/productFeatures.js", () => ({
   invalidateAllProductFeatures,
-  useProductFeatures: () => ({
-    data: testState.features,
-    error: null,
-    isLoading: false,
-    refetch: vi.fn(),
-  }),
+  useProductFeatures: (...args: unknown[]) => {
+    testState.productFeaturesQuery(...args);
+    return {
+      data: testState.features,
+      error: null,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+  },
 }));
 
 vi.mock(
@@ -55,26 +65,51 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: toastSuccess },
 }));
 
 import { RemoteSessionRefreshPolicySetting } from "./RemoteSessionRefreshPolicySetting";
 
 beforeEach(() => {
   testState.isAdmin = true;
+  testState.organizationId = "org-active";
   testState.mutate.mockReset();
+  testState.productFeaturesQuery.mockReset();
   testState.mutationOptions = undefined;
   testState.features.remoteSessionAutoRefreshEnabled = true;
   testState.features.remoteSessionAutoRefreshEnforcedEnabled = false;
   invalidateAllProductFeatures.mockReset();
+  toastSuccess.mockReset();
 });
 
 afterEach(cleanup);
 
 describe("RemoteSessionRefreshPolicySetting", () => {
+  it("ignores a deferred mutation completion after an organization switch", async () => {
+    const { rerender } = render(<RemoteSessionRefreshPolicySetting />);
+    const activeMutation = testState.mutationOptions;
+    expect(activeMutation?.onSuccess).toBeTypeOf("function");
+
+    testState.organizationId = "org-next";
+    rerender(<RemoteSessionRefreshPolicySetting />);
+    await activeMutation!.onSuccess!();
+
+    expect(invalidateAllProductFeatures).not.toHaveBeenCalled();
+    expect(testState.productFeaturesQuery).toHaveBeenLastCalledWith(
+      { organizationId: "org-next" },
+      undefined,
+      expect.anything(),
+    );
+  });
+
   it("shows the effective organization policy", () => {
     render(<RemoteSessionRefreshPolicySetting />);
 
+    expect(testState.productFeaturesQuery).toHaveBeenCalledWith(
+      { organizationId: "org-active" },
+      undefined,
+      expect.anything(),
+    );
     expect(
       (screen.getByLabelText("User controlled") as HTMLInputElement).checked,
     ).toBe(true);
@@ -86,6 +121,26 @@ describe("RemoteSessionRefreshPolicySetting", () => {
     ).toBe(false);
   });
 
+  it("ignores a mutation completion when the organization switches during invalidation", async () => {
+    let resolveInvalidation: (() => void) | undefined;
+    invalidateAllProductFeatures.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInvalidation = resolve;
+      }),
+    );
+    const { rerender } = render(<RemoteSessionRefreshPolicySetting />);
+    const activeMutation = testState.mutationOptions;
+    expect(activeMutation?.onSuccess).toBeTypeOf("function");
+
+    const completion = activeMutation!.onSuccess!();
+    testState.organizationId = "org-next";
+    rerender(<RemoteSessionRefreshPolicySetting />);
+    resolveInvalidation!();
+    await completion;
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
   it("lets organization admins require automatic refresh", () => {
     render(<RemoteSessionRefreshPolicySetting />);
 
@@ -94,6 +149,7 @@ describe("RemoteSessionRefreshPolicySetting", () => {
     expect(testState.mutate).toHaveBeenCalledWith({
       request: {
         setRemoteSessionAutoRefreshPolicyRequestBody: {
+          organizationId: "org-active",
           policy: "enforced",
         },
       },
@@ -102,10 +158,12 @@ describe("RemoteSessionRefreshPolicySetting", () => {
 
   it("refreshes product features after saving", async () => {
     render(<RemoteSessionRefreshPolicySetting />);
+    expect(testState.mutationOptions?.onSuccess).toBeTypeOf("function");
 
-    await testState.mutationOptions?.onSuccess?.();
+    await testState.mutationOptions!.onSuccess!();
 
     expect(invalidateAllProductFeatures).toHaveBeenCalledOnce();
+    expect(toastSuccess).toHaveBeenCalledOnce();
   });
 
   it("is read-only for organization members", () => {

--- a/client/dashboard/src/pages/org/RemoteSessionRefreshPolicySetting.tsx
+++ b/client/dashboard/src/pages/org/RemoteSessionRefreshPolicySetting.tsx
@@ -2,6 +2,7 @@ import {
   BrandMeshLayers,
   BRAND_MESH_SURFACE_CLASS,
 } from "@/components/brand-mesh";
+import { useOrganization } from "@/contexts/Auth";
 import { RequireScope } from "@/components/require-scope";
 import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -17,6 +18,7 @@ import { useSetRemoteSessionAutoRefreshPolicyMutation } from "@gram/client/react
 import { useQueryClient } from "@tanstack/react-query";
 import { Check, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
 const POLICY_OPTIONS = [
   {
@@ -49,16 +51,37 @@ function selectedPolicy(
 }
 
 export function RemoteSessionRefreshPolicySetting(): JSX.Element {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  return (
+    <RemoteSessionRefreshPolicySettingInner
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+    />
+  );
+}
+
+function RemoteSessionRefreshPolicySettingInner({
+  organizationId,
+  isCurrentOrganization,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element {
   const queryClient = useQueryClient();
-  const features = useProductFeatures(undefined, undefined, {
+  const features = useProductFeatures({ organizationId }, undefined, {
     throwOnError: false,
   });
   const mutation = useSetRemoteSessionAutoRefreshPolicyMutation({
     onSuccess: async () => {
+      if (!isCurrentOrganization()) return;
       await invalidateAllProductFeatures(queryClient);
+      if (!isCurrentOrganization()) return;
       toast.success("Automatic session refresh policy updated");
     },
     onError: (error) => {
+      if (!isCurrentOrganization()) return;
       handleAPIError(
         error,
         "Failed to update automatic session refresh policy",
@@ -154,6 +177,7 @@ export function RemoteSessionRefreshPolicySetting(): JSX.Element {
                       mutation.mutate({
                         request: {
                           setRemoteSessionAutoRefreshPolicyRequestBody: {
+                            organizationId,
                             policy: option.value,
                           },
                         },

--- a/client/dashboard/src/pages/org/SkillContentUploadSetting.test.tsx
+++ b/client/dashboard/src/pages/org/SkillContentUploadSetting.test.tsx
@@ -4,7 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testState = vi.hoisted(() => ({
   metadataOnly: false,
+  organizationId: "org-active",
+  mutationOptions: [] as Array<{ onSuccess?: () => Promise<void> }>,
   mutate: vi.fn(),
+  productFeaturesQuery: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: testState.organizationId }),
 }));
 
 vi.mock("@/components/require-scope", () => ({
@@ -14,19 +21,24 @@ vi.mock("@/components/require-scope", () => ({
 vi.mock("@/lib/errors", () => ({ handleAPIError: vi.fn() }));
 
 vi.mock("@gram/client/react-query/featuresSet.js", () => ({
-  useFeaturesSetMutation: () => ({
-    isPending: false,
-    mutate: testState.mutate,
-  }),
+  useFeaturesSetMutation: (options: { onSuccess?: () => Promise<void> }) => {
+    testState.mutationOptions.push(options);
+    return { isPending: false, mutate: testState.mutate };
+  },
 }));
 
+const invalidateAllProductFeatures = vi.hoisted(() => vi.fn());
+
 vi.mock("@gram/client/react-query/productFeatures.js", () => ({
-  invalidateAllProductFeatures: vi.fn(),
-  useProductFeatures: () => ({
-    data: {
-      skillCaptureMetadataOnly: testState.metadataOnly,
-    },
-  }),
+  invalidateAllProductFeatures,
+  useProductFeatures: (...args: unknown[]) => {
+    testState.productFeaturesQuery(...args);
+    return {
+      data: {
+        skillCaptureMetadataOnly: testState.metadataOnly,
+      },
+    };
+  },
 }));
 
 vi.mock("@tanstack/react-query", async (importOriginal) => ({
@@ -38,15 +50,51 @@ import { SkillContentUploadSetting } from "./SkillContentUploadSetting";
 
 beforeEach(() => {
   testState.metadataOnly = false;
+  testState.organizationId = "org-active";
+  testState.mutationOptions = [];
+  invalidateAllProductFeatures.mockReset();
   testState.mutate.mockReset();
+  testState.productFeaturesQuery.mockReset();
 });
 
 afterEach(cleanup);
 
 describe("SkillContentUploadSetting", () => {
+  it("ignores a deferred mutation completion after an organization switch", async () => {
+    const { rerender } = render(<SkillContentUploadSetting />);
+    const activeMutation = testState.mutationOptions.at(-1);
+    expect(activeMutation?.onSuccess).toBeTypeOf("function");
+
+    testState.organizationId = "org-next";
+    rerender(<SkillContentUploadSetting />);
+    await activeMutation!.onSuccess!();
+
+    expect(invalidateAllProductFeatures).not.toHaveBeenCalled();
+    expect(testState.productFeaturesQuery).toHaveBeenLastCalledWith(
+      { organizationId: "org-next" },
+      undefined,
+      expect.anything(),
+    );
+  });
+
+  it("invalidates product features after a current-organization update", async () => {
+    render(<SkillContentUploadSetting />);
+    const activeMutation = testState.mutationOptions.at(-1);
+    expect(activeMutation?.onSuccess).toBeTypeOf("function");
+
+    await activeMutation!.onSuccess!();
+
+    expect(invalidateAllProductFeatures).toHaveBeenCalledOnce();
+  });
+
   it("updates the metadata-only feature through the upload toggle", () => {
     render(<SkillContentUploadSetting />);
 
+    expect(testState.productFeaturesQuery).toHaveBeenCalledWith(
+      { organizationId: "org-active" },
+      undefined,
+      expect.anything(),
+    );
     const toggle = screen.getByRole("switch", {
       name: "Upload skill content",
     });
@@ -59,6 +107,7 @@ describe("SkillContentUploadSetting", () => {
         setProductFeatureRequestBody: {
           enabled: true,
           featureName: "skill_capture_metadata_only",
+          organizationId: "org-active",
         },
       },
     });

--- a/client/dashboard/src/pages/org/SkillContentUploadSetting.tsx
+++ b/client/dashboard/src/pages/org/SkillContentUploadSetting.tsx
@@ -1,4 +1,5 @@
 import { RequireScope } from "@/components/require-scope";
+import { useOrganization } from "@/contexts/Auth";
 import { Switch } from "@/components/ui/Switch";
 import { Text } from "@/components/ui/Text";
 import { handleAPIError } from "@/lib/errors";
@@ -11,21 +12,45 @@ import {
 import { Stack } from "@/components/ui/Stack";
 import { useQueryClient } from "@tanstack/react-query";
 import { FileText } from "lucide-react";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
 export function SkillContentUploadSetting({
   className,
 }: {
   className?: string;
 } = {}): JSX.Element | null {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  return (
+    <SkillContentUploadSettingInner
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+      className={className}
+    />
+  );
+}
+
+function SkillContentUploadSettingInner({
+  organizationId,
+  isCurrentOrganization,
+  className,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+  className?: string;
+}): JSX.Element | null {
   const queryClient = useQueryClient();
-  const { data: features } = useProductFeatures(undefined, undefined, {
+  const { data: features } = useProductFeatures({ organizationId }, undefined, {
     throwOnError: false,
   });
   const mutation = useFeaturesSetMutation({
     onSuccess: async () => {
+      if (!isCurrentOrganization()) return;
       await invalidateAllProductFeatures(queryClient);
     },
     onError: (error) => {
+      if (!isCurrentOrganization()) return;
       handleAPIError(error, "Failed to update setting");
     },
   });
@@ -63,6 +88,7 @@ export function SkillContentUploadSetting({
             mutation.mutate({
               request: {
                 setProductFeatureRequestBody: {
+                  organizationId,
                   featureName: FeatureName.SkillCaptureMetadataOnly,
                   enabled: !enabled,
                 },

--- a/client/dashboard/src/pages/org/encryption-keys/CreateExternalKeySheet.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/CreateExternalKeySheet.tsx
@@ -40,9 +40,11 @@ import {
 export function CreateExternalKeySheet({
   open,
   onOpenChange,
+  isCurrentOrganization,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  isCurrentOrganization: () => boolean;
 }): JSX.Element {
   const orgRoutes = useOrgRoutes();
   const queryClient = useQueryClient();
@@ -57,7 +59,9 @@ export function CreateExternalKeySheet({
 
   const createMutation = useCreateGcpKmsKeyMutation({
     onSuccess: async (created) => {
+      if (!isCurrentOrganization()) return;
       await invalidateAllListExternalKeys(queryClient);
+      if (!isCurrentOrganization()) return;
       toast.success("Encryption key created");
       onOpenChange(false);
       orgRoutes.encryptionKeys.keyDetail.goTo(
@@ -66,6 +70,7 @@ export function CreateExternalKeySheet({
       );
     },
     onError: (error) => {
+      if (!isCurrentOrganization()) return;
       console.error("Create external key failed", error);
     },
   });

--- a/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { useOrganization } from "@/contexts/Auth";
 import { ResourceListPage } from "@/components/page-templates";
 import { RequireScope } from "@/components/require-scope";
 import { Button } from "@/components/ui/Button";
@@ -20,18 +21,20 @@ import type { ExternalKeySummary } from "@gram/client/models/components/external
 import { useDeleteGcpKmsKeyMutation } from "@gram/client/react-query/deleteGcpKmsKey";
 import { invalidateAllGetGcpKmsKey } from "@gram/client/react-query/getGcpKmsKey";
 import {
+  buildListExternalKeysQuery,
   invalidateAllListExternalKeys,
-  useListExternalKeys,
 } from "@gram/client/react-query/listExternalKeys";
+import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { useVerifyGcpKmsKeyMutation } from "@gram/client/react-query/verifyGcpKmsKey";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { MoreHorizontal, Plus } from "lucide-react";
 import { useState } from "react";
 import { Outlet } from "react-router";
 import { toast } from "sonner";
 import { CreateExternalKeySheet } from "./CreateExternalKeySheet";
 import { providerLabel, providerSlug } from "./providers";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
 export function EncryptionKeysRoot(): JSX.Element {
   return <Outlet />;
@@ -51,8 +54,10 @@ export function EncryptionKeysPage(): JSX.Element {
 // passes. A gated-but-authorized org sees only the framed refusal, with no
 // header or toolbar.
 function EncryptionKeysGate(): JSX.Element {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
   const { data: features, isLoading: featuresLoading } = useProductFeatures(
-    undefined,
+    { organizationId: organization.id },
     undefined,
     { staleTime: 30_000, throwOnError: false },
   );
@@ -79,16 +84,33 @@ function EncryptionKeysGate(): JSX.Element {
     );
   }
 
-  return <EncryptionKeysOverview />;
+  return (
+    <EncryptionKeysOverview
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+    />
+  );
 }
 
-function EncryptionKeysOverview(): JSX.Element {
+function EncryptionKeysOverview({
+  organizationId,
+  isCurrentOrganization,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element {
   const orgRoutes = useOrgRoutes();
+  const client = useGramContext();
   const [createOpen, setCreateOpen] = useState(false);
   // GCP is the only provider with a detail page today, so scope the list to it
   // rather than linking rows to a route that cannot render them.
-  const { data, isLoading, isError, refetch } = useListExternalKeys({
+  const externalKeysQuery = buildListExternalKeysQuery(client, {
     provider: "gcp_kms",
+  });
+  const { data, isLoading, isError, refetch } = useQuery({
+    ...externalKeysQuery,
+    queryKey: [...externalKeysQuery.queryKey, { organizationId }],
   });
   const keys = data?.keys ?? [];
 
@@ -114,6 +136,7 @@ function EncryptionKeysOverview(): JSX.Element {
           isLoading={isLoading}
           isError={isError}
           onRetry={() => void refetch()}
+          isCurrentOrganization={isCurrentOrganization}
           detailHref={(key) =>
             orgRoutes.encryptionKeys.keyDetail.href(
               providerSlug(key.provider),
@@ -123,7 +146,11 @@ function EncryptionKeysOverview(): JSX.Element {
         />
       </ResourceListPage>
 
-      <CreateExternalKeySheet open={createOpen} onOpenChange={setCreateOpen} />
+      <CreateExternalKeySheet
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        isCurrentOrganization={isCurrentOrganization}
+      />
     </>
   );
 }
@@ -137,7 +164,10 @@ function EncryptionKeysOverview(): JSX.Element {
 // the first — and a verify is a real KMS round trip, so an operator working down
 // the list would leave the earlier rows' toasts spinning forever and never see
 // their outcome. mutateAsync keeps each toast id in its own call closure.
-function useVerifyGcpKmsKey(externalKey: ExternalKeySummary): {
+function useVerifyGcpKmsKey(
+  externalKey: ExternalKeySummary,
+  isCurrentOrganization: () => boolean,
+): {
   verify: () => void;
   isPending: boolean;
 } {
@@ -151,6 +181,10 @@ function useVerifyGcpKmsKey(externalKey: ExternalKeySummary): {
         request: { id: externalKey.id },
       })
       .then((result) => {
+        if (!isCurrentOrganization()) {
+          toast.dismiss(toastId);
+          return;
+        }
         if (!result.verified) {
           toast.error(result.detail || "Key could not be verified.", {
             id: toastId,
@@ -162,6 +196,10 @@ function useVerifyGcpKmsKey(externalKey: ExternalKeySummary): {
         });
       })
       .catch((error: unknown) => {
+        if (!isCurrentOrganization()) {
+          toast.dismiss(toastId);
+          return;
+        }
         toast.error(
           error instanceof Error ? error.message : "Verification failed.",
           { id: toastId },
@@ -178,12 +216,14 @@ function KeyTable({
   isError,
   onRetry,
   detailHref,
+  isCurrentOrganization,
 }: {
   keys: ExternalKeySummary[];
   isLoading: boolean;
   isError: boolean;
   onRetry: () => void;
   detailHref: (key: ExternalKeySummary) => string;
+  isCurrentOrganization: () => boolean;
 }): JSX.Element {
   if (isError) {
     return (
@@ -247,7 +287,10 @@ function KeyTable({
             </Text>
           </td>
           <td className="px-3 py-3 text-right">
-            <RowActions externalKey={key} />
+            <RowActions
+              externalKey={key}
+              isCurrentOrganization={isCurrentOrganization}
+            />
           </td>
         </DotRow>
       ))}
@@ -260,10 +303,15 @@ function KeyTable({
 // an item) never navigates to the detail page.
 function RowActions({
   externalKey,
+  isCurrentOrganization,
 }: {
   externalKey: ExternalKeySummary;
+  isCurrentOrganization: () => boolean;
 }): JSX.Element {
-  const { verify, isPending } = useVerifyGcpKmsKey(externalKey);
+  const { verify, isPending } = useVerifyGcpKmsKey(
+    externalKey,
+    isCurrentOrganization,
+  );
 
   return (
     <div className="relative z-20" onClick={(e) => e.stopPropagation()}>

--- a/client/dashboard/src/pages/org/external-services/ExternalServices.tsx
+++ b/client/dashboard/src/pages/org/external-services/ExternalServices.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { useOrganization } from "@/contexts/Auth";
 import { ResourceListPage } from "@/components/page-templates";
 import { RequireScope } from "@/components/require-scope";
 import { Dialog } from "@/components/ui/Dialog";
@@ -59,8 +60,9 @@ export function ExternalServicesPage(): JSX.Element {
 // passes. A gated-but-authorized org sees only the framed refusal, with no
 // header or toolbar.
 function ExternalServicesGate(): JSX.Element {
+  const organization = useOrganization();
   const { data: features, isLoading: featuresLoading } = useProductFeatures(
-    undefined,
+    { organizationId: organization.id },
     undefined,
     { staleTime: 30_000, throwOnError: false },
   );

--- a/client/dashboard/src/pages/platform-admin/Features.test.tsx
+++ b/client/dashboard/src/pages/platform-admin/Features.test.tsx
@@ -1,14 +1,43 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import PlatformAdminFeatures from "./Features";
 import type { ReactNode } from "react";
 import { queryKeyChatAnalysisSettings } from "@gram/client/react-query/chatAnalysisSettings.js";
+import { queryKeyProductFeatures } from "@gram/client/react-query/productFeatures.js";
+
+type ProductFeatureMutationState = {
+  error: Error | null;
+  isPending: boolean;
+  variables?: {
+    request: {
+      setProductFeatureRequestBody: {
+        featureName: string;
+        organizationId: string;
+      };
+    };
+  };
+};
+
+const invalidateAllProductFeatures = vi.hoisted(() => vi.fn());
 
 const mocks = vi.hoisted(() => ({
   businessMemoryError: null as Error | null,
   businessMemoryMutate: vi.fn(),
   organizationId: "org-target",
+  productFeatureMutate: vi.fn(),
+  productFeatureMutationInstances: [] as {
+    completeError: (error: Error) => void;
+    completeSuccess: () => Promise<void>;
+    organizationId: string;
+  }[],
+  productFeaturesQuery: vi.fn(),
   query: vi.fn(),
   triggerMutate: vi.fn(),
   workUnitsMutate: vi.fn(),
@@ -98,18 +127,58 @@ vi.mock("@gram/client/react-query/triggerChatAnalysis.js", () => ({
     mutate: mocks.triggerMutate,
   }),
 }));
-vi.mock("@gram/client/react-query/productFeatures.js", () => ({
-  invalidateAllProductFeatures: vi.fn(),
-  useProductFeatures: () => ({ data: null, error: null, isLoading: true }),
-}));
-vi.mock("@gram/client/react-query/featuresSet.js", () => ({
-  useFeaturesSetMutation: () => ({
-    error: null,
-    isPending: false,
-    mutate: vi.fn(),
-    variables: undefined,
+vi.mock(
+  "@gram/client/react-query/productFeatures.js",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@gram/client/react-query/productFeatures.js")
+    >()),
+    invalidateAllProductFeatures,
+    useProductFeatures: mocks.productFeaturesQuery,
   }),
-}));
+);
+vi.mock("@gram/client/react-query/featuresSet.js", async () => {
+  const { useState } = await import("react");
+  return {
+    useFeaturesSetMutation: (options: {
+      onError?: (error: Error) => void;
+      onSuccess?: () => void | Promise<void>;
+    }) => {
+      const [state, setState] = useState<ProductFeatureMutationState>(() =>
+        mocks.organizationId === "org-a"
+          ? {
+              error: new Error("A update failed"),
+              isPending: true,
+              variables: {
+                request: {
+                  setProductFeatureRequestBody: {
+                    featureName: "authz_challenge_logging",
+                    organizationId: "org-a",
+                  },
+                },
+              },
+            }
+          : { error: null, isPending: false, variables: undefined },
+      );
+      useState(() => {
+        const instance = {
+          organizationId: mocks.organizationId,
+          completeSuccess: async () => {
+            setState({ error: null, isPending: false, variables: undefined });
+            await options.onSuccess?.();
+          },
+          completeError: (error: Error) => {
+            setState((current) => ({ ...current, error, isPending: false }));
+            options.onError?.(error);
+          },
+        };
+        mocks.productFeatureMutationInstances.push(instance);
+        return instance;
+      });
+      return { ...state, mutate: mocks.productFeatureMutate };
+    },
+  };
+});
 vi.mock("@/hooks/useFeatureFlag", () => ({
   useFeatureFlag: () => ({ status: "disabled" }),
 }));
@@ -121,13 +190,22 @@ vi.mock("@tanstack/react-query", async (original) => ({
   useQueryClient: () => ({}),
 }));
 
-afterEach(() => {
-  cleanup();
+beforeEach(() => {
   vi.clearAllMocks();
   mocks.businessMemoryError = null;
   mocks.organizationId = "org-target";
+  mocks.productFeatureMutate.mockReset();
+  mocks.productFeatureMutationInstances = [];
+  mocks.productFeaturesQuery.mockReset();
+  mocks.productFeaturesQuery.mockReturnValue({
+    data: null,
+    error: null,
+    isLoading: true,
+  });
   mocks.workUnitsPending = false;
 });
+
+afterEach(cleanup);
 
 describe("PlatformAdminFeatures", () => {
   it("scopes every chat analysis request to the selected organization", () => {
@@ -267,6 +345,85 @@ describe("PlatformAdminFeatures", () => {
       ).disabled,
     ).toBe(false);
     expect(screen.queryByText("Update failed")).toBeNull();
+  });
+
+  it("scopes product-feature reads and writes to the selected organization", () => {
+    mocks.productFeaturesQuery.mockReturnValue({
+      data: {},
+      error: null,
+      isLoading: false,
+    });
+
+    render(<PlatformAdminFeatures />);
+
+    expect(mocks.productFeaturesQuery).toHaveBeenCalledWith({
+      organizationId: "org-target",
+    });
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Toggle Authz Challenge Logging" }),
+    );
+    expect(mocks.productFeatureMutate).toHaveBeenCalledWith({
+      request: {
+        setProductFeatureRequestBody: {
+          enabled: true,
+          featureName: "authz_challenge_logging",
+          organizationId: "org-target",
+        },
+      },
+    });
+  });
+
+  it("isolates pending product-feature mutation completions across an organization switch", async () => {
+    mocks.organizationId = "org-a";
+    mocks.productFeaturesQuery.mockReturnValue({
+      data: {},
+      error: null,
+      isLoading: false,
+    });
+
+    const { rerender } = render(<PlatformAdminFeatures />);
+    const orgAMutation = mocks.productFeatureMutationInstances[0];
+    const toggle = () =>
+      screen.getByRole("switch", { name: "Toggle Authz Challenge Logging" });
+
+    expect(orgAMutation?.organizationId).toBe("org-a");
+    expect((toggle() as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("A update failed")).toBeTruthy();
+
+    mocks.organizationId = "org-b";
+    rerender(<PlatformAdminFeatures />);
+
+    expect(mocks.productFeatureMutationInstances).toHaveLength(2);
+    expect(mocks.productFeatureMutationInstances[1]?.organizationId).toBe(
+      "org-b",
+    );
+    expect((toggle() as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByText("A update failed")).toBeNull();
+    expect(mocks.productFeaturesQuery).toHaveBeenLastCalledWith({
+      organizationId: "org-b",
+    });
+
+    await act(async () => {
+      await orgAMutation?.completeSuccess();
+      orgAMutation?.completeError(new Error("Late A failure"));
+    });
+
+    expect(invalidateAllProductFeatures).not.toHaveBeenCalled();
+    expect((toggle() as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByText("A update failed")).toBeNull();
+    expect(screen.queryByText("Late A failure")).toBeNull();
+  });
+
+  it("includes organization parameters in generated product-feature query keys", () => {
+    const first = queryKeyProductFeatures({ organizationId: "org-a" });
+    const second = queryKeyProductFeatures({ organizationId: "org-b" });
+    expect(first).not.toEqual(second);
+    expect(first).toEqual([
+      "@gram/client",
+      "features",
+      "get",
+      { organizationId: "org-a" },
+    ]);
   });
 
   it("includes organization scope in the generated settings query key", () => {

--- a/client/dashboard/src/pages/platform-admin/Features.tsx
+++ b/client/dashboard/src/pages/platform-admin/Features.tsx
@@ -26,8 +26,12 @@ import { useState } from "react";
 import { useTriggerChatAnalysisMutation } from "@gram/client/react-query/triggerChatAnalysis.js";
 import { useUpsertBusinessMemoryAnalysisSettingsMutation } from "@gram/client/react-query/upsertBusinessMemoryAnalysisSettings.js";
 import { useUpsertChatAnalysisSettingsMutation } from "@gram/client/react-query/upsertChatAnalysisSettings.js";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
 export default function PlatformAdminFeatures(): JSX.Element {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+
   return (
     <Page>
       <Page.Header>
@@ -45,7 +49,11 @@ export default function PlatformAdminFeatures(): JSX.Element {
           <Page.Section.Body>
             <PlatformAdminGate>
               <div className="space-y-8">
-                <ProductFeaturesSection />
+                <ProductFeaturesSection
+                  key={organization.id}
+                  organizationId={organization.id}
+                  isCurrentOrganization={isCurrentOrganization}
+                />
                 <ChatAnalysisSection />
                 <DeveloperSection />
               </div>
@@ -121,9 +129,21 @@ const PRODUCT_FEATURES: {
   },
 ];
 
-function ProductFeaturesSection(): JSX.Element {
+function ProductFeaturesSection({
+  organizationId,
+  isCurrentOrganization,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element {
   const queryClient = useQueryClient();
-  const { data: features, isLoading, error } = useProductFeatures();
+  const {
+    data: features,
+    isLoading,
+    error,
+  } = useProductFeatures({
+    organizationId,
+  });
   const platformMcp = useFeatureFlag(FEATURE_FLAGS.platformMcp);
   const visibleFeatures = PRODUCT_FEATURES.filter(
     (feature) =>
@@ -138,6 +158,7 @@ function ProductFeaturesSection(): JSX.Element {
     variables,
   } = useFeaturesSetMutation({
     onSuccess: () => {
+      if (!isCurrentOrganization()) return;
       void invalidateAllProductFeatures(queryClient);
     },
   });
@@ -186,6 +207,7 @@ function ProductFeaturesSection(): JSX.Element {
                     mutate({
                       request: {
                         setProductFeatureRequestBody: {
+                          organizationId,
                           featureName: feature.featureName,
                           enabled: next,
                         },

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -1,4 +1,5 @@
 import { StatTile, StatTileGroup } from "@/components/chart/stat-tile";
+import { useOrganization } from "@/contexts/Auth";
 import { InputField } from "@/components/moon/input-field";
 import { Page } from "@/components/page-layout";
 import { MCPStatusIndicator } from "@/components/mcp/MCPStatusIndicator";
@@ -215,7 +216,10 @@ export default function PluginDetail(): JSX.Element | null {
   );
 
   const showAssignments = usePluginAssignmentsVisible();
-  const { data: productFeatures } = useProductFeatures();
+  const organization = useOrganization();
+  const { data: productFeatures } = useProductFeatures({
+    organizationId: organization.id,
+  });
 
   // Device-agent reach powers the Installs stat. It's an admin-only, org-scoped
   // list, so it's fetched only for device-agent orgs and degrades quietly

--- a/client/dashboard/src/pages/plugins/use-plugin-assignments-visible.ts
+++ b/client/dashboard/src/pages/plugins/use-plugin-assignments-visible.ts
@@ -1,4 +1,5 @@
 import { useTelemetry } from "@/contexts/Telemetry";
+import { useOrganization } from "@/contexts/Auth";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 
 // Assignments only gate delivery for the device agent (agent.getPlugins);
@@ -12,8 +13,11 @@ import { useProductFeatures } from "@gram/client/react-query/productFeatures.js"
 // Shared by the plugin detail page and its sidebar nav so the two never drift
 // on whether the Assignments section exists.
 export function usePluginAssignmentsVisible(): boolean {
+  const organization = useOrganization();
   const isDeviceAgentEnabled =
     useTelemetry().isFeatureEnabled("gram-device-agent") ?? false;
-  const { data: productFeatures } = useProductFeatures();
+  const { data: productFeatures } = useProductFeatures({
+    organizationId: organization.id,
+  });
   return isDeviceAgentEnabled || (productFeatures?.deviceAgent ?? false);
 }

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -1,4 +1,5 @@
 import { ReleaseStageBadge } from "@/components/release-stage-badge";
+import { useOrganization } from "@/contexts/Auth";
 import { Heading } from "@/components/ui/Heading";
 import { SkeletonTable } from "@/components/ui/Skeleton";
 import { Text } from "@/components/ui/Text";
@@ -37,7 +38,10 @@ import {
 } from "./model-key-slots";
 
 export function ModelProviderKeysSection(): JSX.Element | null {
-  const { data: features } = useProductFeatures();
+  const organization = useOrganization();
+  const { data: features } = useProductFeatures({
+    organizationId: organization.id,
+  });
 
   if (!features) {
     return null;


### PR DESCRIPTION
## Summary
- pass active organization scope from every dashboard product-feature caller
- make product-feature query cache identity organization-specific
- remount organization-owned form and mutation state when the organization changes
- ignore deferred mutation callbacks from the previously selected organization

## Verification
- 14 focused dashboard tests
- dashboard type-check
- mutation checks for component remounting and stale callback guards
- `git diff --check`

## Stack
Depends on AGE-3317's optional backend contract. AGE-3315 is the final enforcement layer above this PR.

No visual change; no screenshot required.

Linear: AGE-3316

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all dashboard product-feature reads and writes to the active organization and prevents cross-org updates. Previously queries and mutation callbacks were global; now callers pass an organizationId, query keys include the org, and deferred callbacks are ignored after org switches. Connects to Linear AGE-3316; uses optional backend in AGE-3317 (AGE-3315 will enforce).

- Product features: call useProductFeatures({ organizationId }) everywhere; include organizationId in setProductFeatureRequestBody; gate onSuccess/onError with useIsCurrentOrganization(organization.id); remount org-owned components via key={organization.id}.
- Platform MCP: replace usePlatformMCPOnboarding with useOrganizationPlatformMCPOnboarding(organization.id) so onboarding query keys are per-org; CTA and settings use it; feature toggles write with organizationId and ignore late completions.
- Encryption keys: scope list query key by org by extending buildListExternalKeysQuery and wrapping with useQuery; create/verify invalidations and toasts guard with isCurrentOrganization; pass isCurrentOrganization through CreateExternalKeySheet and row actions.
- Org settings/pages and platform admin: logs, consent tool filtering, skill content upload, remote session refresh policy, external services, plugins, model provider keys, and platform-admin feature toggles now read/write with organizationId and isolate pending mutation state across org switches. Tests cover org scoping, query-key isolation, and stale-callback guards.

**Migration**
- Pass organizationId to all useProductFeatures callers.
- Include organizationId in setProductFeatureRequestBody and setRemoteSessionAutoRefreshPolicyRequestBody.
- Replace usePlatformMCPOnboarding with useOrganizationPlatformMCPOnboarding(organization.id).
- Gate mutation completion side effects with useIsCurrentOrganization(organization.id) where needed.

<sup>Written for commit e4a3c944b50d6a1e795bb94f308f0adb8ff0a73f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

