### PR TITLE
fix: require product-feature organization scope

### DIFF
--- a/.changeset/require-product-feature-organization.md
+++ b/.changeset/require-product-feature-organization.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Require an explicit organization for every product-feature API request.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -31800,6 +31800,7 @@ paths:
           description: Organization whose product features to read.
           in: query
           name: organization_id
+          required: true
           schema:
             description: Organization whose product features to read.
             type: string
@@ -74713,6 +74714,7 @@ components:
           type: string
           description: Organization whose product feature to update.
       required:
+        - organization_id
         - feature_name
         - enabled
     SetProjectLogoForm:
@@ -74744,6 +74746,7 @@ components:
             - user_controlled
             - enforced
       required:
+        - organization_id
         - policy
     SetRootMcpEndpointRequestBody:
       type: object

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -8361,7 +8361,7 @@ examples:
   setProductFeature:
     speakeasy-default-set-product-feature:
       requestBody:
-        application/json: {"enabled": true, "feature_name": "tool_io_logs"}
+        application/json: {"enabled": true, "feature_name": "tool_io_logs", "organization_id": "<id>"}
       responses:
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": true}
@@ -8381,7 +8381,7 @@ examples:
   setRemoteSessionAutoRefreshPolicy:
     speakeasy-default-set-remote-session-auto-refresh-policy:
       requestBody:
-        application/json: {"policy": "enforced"}
+        application/json: {"organization_id": "<id>", "policy": "enforced"}
       responses:
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": false}

--- a/client/dashboard/src/sdk/src/funcs/featuresGet.ts
+++ b/client/dashboard/src/sdk/src/funcs/featuresGet.ts
@@ -46,7 +46,7 @@ import { Result } from "../types/fp.js";
  */
 export function featuresGet(
   client: GramCore,
-  request?: GetProductFeaturesRequest | undefined,
+  request: GetProductFeaturesRequest,
   security?: GetProductFeaturesSecurity | undefined,
   options?: RequestOptions,
 ): APIPromise<
@@ -73,7 +73,7 @@ export function featuresGet(
 
 async function $do(
   client: GramCore,
-  request?: GetProductFeaturesRequest | undefined,
+  request: GetProductFeaturesRequest,
   security?: GetProductFeaturesSecurity | undefined,
   options?: RequestOptions,
 ): Promise<
@@ -95,8 +95,7 @@ async function $do(
 > {
   const parsed = safeParse(
     request,
-    (value) =>
-      z.parse(z.optional(GetProductFeaturesRequest$outboundSchema), value),
+    (value) => z.parse(GetProductFeaturesRequest$outboundSchema, value),
     "Input validation failed",
   );
   if (!parsed.ok) {
@@ -108,12 +107,12 @@ async function $do(
   const path = pathToFunc("/rpc/productFeatures.get")();
 
   const query = encodeFormQuery({
-    "organization_id": payload?.organization_id,
+    "organization_id": payload.organization_id,
   });
 
   const headers = new Headers(compactMap({
     Accept: "application/json",
-    "Gram-Session": encodeSimple("Gram-Session", payload?.["Gram-Session"], {
+    "Gram-Session": encodeSimple("Gram-Session", payload["Gram-Session"], {
       explode: false,
       charEncoding: "none",
     }),

--- a/client/dashboard/src/sdk/src/models/components/setproductfeaturerequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/setproductfeaturerequestbody.ts
@@ -45,7 +45,7 @@ export type SetProductFeatureRequestBody = {
   /**
    * Organization whose product feature to update.
    */
-  organizationId?: string | undefined;
+  organizationId: string;
 };
 
 /** @internal */
@@ -56,7 +56,7 @@ export const FeatureName$outboundSchema: z.ZodMiniEnum<typeof FeatureName> = z
 export type SetProductFeatureRequestBody$Outbound = {
   enabled: boolean;
   feature_name: string;
-  organization_id?: string | undefined;
+  organization_id: string;
 };
 
 /** @internal */
@@ -67,7 +67,7 @@ export const SetProductFeatureRequestBody$outboundSchema: z.ZodMiniType<
   z.object({
     enabled: z.boolean(),
     featureName: FeatureName$outboundSchema,
-    organizationId: z.optional(z.string()),
+    organizationId: z.string(),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/client/dashboard/src/sdk/src/models/components/setremotesessionautorefreshpolicyrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/setremotesessionautorefreshpolicyrequestbody.ts
@@ -25,7 +25,7 @@ export type SetRemoteSessionAutoRefreshPolicyRequestBody = {
   /**
    * Organization whose automatic remote-session refresh policy to update.
    */
-  organizationId?: string | undefined;
+  organizationId: string;
   /**
    * Organization policy for automatic remote-session refresh
    */
@@ -39,7 +39,7 @@ export const SetRemoteSessionAutoRefreshPolicyRequestBodyPolicy$outboundSchema:
 
 /** @internal */
 export type SetRemoteSessionAutoRefreshPolicyRequestBody$Outbound = {
-  organization_id?: string | undefined;
+  organization_id: string;
   policy: string;
 };
 
@@ -50,7 +50,7 @@ export const SetRemoteSessionAutoRefreshPolicyRequestBody$outboundSchema:
     SetRemoteSessionAutoRefreshPolicyRequestBody
   > = z.pipe(
     z.object({
-      organizationId: z.optional(z.string()),
+      organizationId: z.string(),
       policy: SetRemoteSessionAutoRefreshPolicyRequestBodyPolicy$outboundSchema,
     }),
     z.transform((v) => {

--- a/client/dashboard/src/sdk/src/models/operations/getproductfeatures.ts
+++ b/client/dashboard/src/sdk/src/models/operations/getproductfeatures.ts
@@ -13,7 +13,7 @@ export type GetProductFeaturesRequest = {
   /**
    * Organization whose product features to read.
    */
-  organizationId?: string | undefined;
+  organizationId: string;
   /**
    * Session header
    */
@@ -50,7 +50,7 @@ export function getProductFeaturesSecurityToJSON(
 
 /** @internal */
 export type GetProductFeaturesRequest$Outbound = {
-  organization_id?: string | undefined;
+  organization_id: string;
   "Gram-Session"?: string | undefined;
 };
 
@@ -60,7 +60,7 @@ export const GetProductFeaturesRequest$outboundSchema: z.ZodMiniType<
   GetProductFeaturesRequest
 > = z.pipe(
   z.object({
-    organizationId: z.optional(z.string()),
+    organizationId: z.string(),
     gramSession: z.optional(z.string()),
   }),
   z.transform((v) => {

--- a/client/dashboard/src/sdk/src/react-query/productFeatures.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/productFeatures.core.ts
@@ -22,7 +22,7 @@ export type ProductFeaturesQueryData = GetProductFeaturesResponseBody;
 export function prefetchProductFeatures(
   queryClient: QueryClient,
   client$: GramCore,
-  request?: GetProductFeaturesRequest | undefined,
+  request: GetProductFeaturesRequest,
   security?: GetProductFeaturesSecurity | undefined,
   options?: RequestOptions,
 ): Promise<void> {
@@ -38,7 +38,7 @@ export function prefetchProductFeatures(
 
 export function buildProductFeaturesQuery(
   client$: GramCore,
-  request?: GetProductFeaturesRequest | undefined,
+  request: GetProductFeaturesRequest,
   security?: GetProductFeaturesSecurity | undefined,
   options?: RequestOptions,
 ): {
@@ -47,8 +47,8 @@ export function buildProductFeaturesQuery(
 } {
   return {
     queryKey: queryKeyProductFeatures({
-      organizationId: request?.organizationId,
-      gramSession: request?.gramSession,
+      organizationId: request.organizationId,
+      gramSession: request.gramSession,
     }),
     queryFn: async function productFeaturesQueryFn(
       ctx,
@@ -75,10 +75,7 @@ export function buildProductFeaturesQuery(
 }
 
 export function queryKeyProductFeatures(
-  parameters: {
-    organizationId?: string | undefined;
-    gramSession?: string | undefined;
-  },
+  parameters: { organizationId: string; gramSession?: string | undefined },
 ): QueryKey {
   return ["@gram/client", "features", "get", parameters];
 }

--- a/client/dashboard/src/sdk/src/react-query/productFeatures.ts
+++ b/client/dashboard/src/sdk/src/react-query/productFeatures.ts
@@ -62,7 +62,7 @@ export type ProductFeaturesQueryError =
  * Get the current state of all product feature flags.
  */
 export function useProductFeatures(
-  request?: GetProductFeaturesRequest | undefined,
+  request: GetProductFeaturesRequest,
   security?: GetProductFeaturesSecurity | undefined,
   options?: QueryHookOptions<
     ProductFeaturesQueryData,
@@ -88,7 +88,7 @@ export function useProductFeatures(
  * Get the current state of all product feature flags.
  */
 export function useProductFeaturesSuspense(
-  request?: GetProductFeaturesRequest | undefined,
+  request: GetProductFeaturesRequest,
   security?: GetProductFeaturesSecurity | undefined,
   options?: SuspenseQueryHookOptions<
     ProductFeaturesQueryData,
@@ -110,10 +110,7 @@ export function useProductFeaturesSuspense(
 export function setProductFeaturesData(
   client: QueryClient,
   queryKeyBase: [
-    parameters: {
-      organizationId?: string | undefined;
-      gramSession?: string | undefined;
-    },
+    parameters: { organizationId: string; gramSession?: string | undefined },
   ],
   data: ProductFeaturesQueryData,
 ): ProductFeaturesQueryData | undefined {
@@ -125,10 +122,7 @@ export function setProductFeaturesData(
 export function invalidateProductFeatures(
   client: QueryClient,
   queryKeyBase: TupleToPrefixes<
-    [parameters: {
-      organizationId?: string | undefined;
-      gramSession?: string | undefined;
-    }]
+    [parameters: { organizationId: string; gramSession?: string | undefined }]
   >,
   filters?: Omit<InvalidateQueryFilters, "queryKey" | "predicate" | "exact">,
 ): Promise<void> {

--- a/client/dashboard/src/sdk/src/sdk/features.ts
+++ b/client/dashboard/src/sdk/src/sdk/features.ts
@@ -29,7 +29,7 @@ export class Features extends ClientSDK {
    * Get the current state of all product feature flags.
    */
   async get(
-    request?: GetProductFeaturesRequest | undefined,
+    request: GetProductFeaturesRequest,
     security?: GetProductFeaturesSecurity | undefined,
     options?: RequestOptions,
   ): Promise<GetProductFeaturesResponseBody> {

--- a/server/design/productfeatures/design.go
+++ b/server/design/productfeatures/design.go
@@ -18,6 +18,7 @@ var _ = Service("features", func() {
 
 		Payload(func() {
 			Attribute("organization_id", String, "Organization whose product features to read.")
+			Required("organization_id")
 			security.SessionPayload()
 		})
 
@@ -65,7 +66,7 @@ var _ = Service("features", func() {
 				Enum("logs", "tool_io_logs", "session_capture", "authz_challenge_logging", "sso", "scim", "hooks_browser_login", "hooks_fail_open", "custom_model_keys", "skills", "skill_capture_metadata_only", "ai_platform_push_integrations", "platform_mcp", "customer_managed_encryption_keys", "remote_session_auto_refresh", "remote_session_auto_refresh_enforced", "consent_tool_filtering")
 			})
 			Attribute("enabled", Boolean, "Whether the feature should be enabled")
-			Required("feature_name", "enabled")
+			Required("organization_id", "feature_name", "enabled")
 
 			security.SessionPayload()
 		})
@@ -88,7 +89,7 @@ var _ = Service("features", func() {
 			Attribute("policy", String, "Organization policy for automatic remote-session refresh", func() {
 				Enum("disabled", "user_controlled", "enforced")
 			})
-			Required("policy")
+			Required("organization_id", "policy")
 
 			security.SessionPayload()
 		})

--- a/server/gen/features/service.go
+++ b/server/gen/features/service.go
@@ -50,7 +50,7 @@ var MethodNames = [3]string{"getProductFeatures", "setProductFeature", "setRemot
 // getProductFeatures method.
 type GetProductFeaturesPayload struct {
 	// Organization whose product features to read.
-	OrganizationID *string
+	OrganizationID string
 	SessionToken   *string
 }
 
@@ -109,7 +109,7 @@ type GetProductFeaturesResult struct {
 // setProductFeature method.
 type SetProductFeaturePayload struct {
 	// Organization whose product feature to update.
-	OrganizationID *string
+	OrganizationID string
 	// Name of the feature to update
 	FeatureName string
 	// Whether the feature should be enabled
@@ -121,7 +121,7 @@ type SetProductFeaturePayload struct {
 // service setRemoteSessionAutoRefreshPolicy method.
 type SetRemoteSessionAutoRefreshPolicyPayload struct {
 	// Organization whose automatic remote-session refresh policy to update.
-	OrganizationID *string
+	OrganizationID string
 	// Organization policy for automatic remote-session refresh
 	Policy       string
 	SessionToken *string

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -1841,7 +1841,7 @@ func ParseEndpoint(
 		featuresFlags = flag.NewFlagSet("features", flag.ContinueOnError)
 
 		featuresGetProductFeaturesFlags              = flag.NewFlagSet("get-product-features", flag.ExitOnError)
-		featuresGetProductFeaturesOrganizationIDFlag = featuresGetProductFeaturesFlags.String("organization-id", "", "")
+		featuresGetProductFeaturesOrganizationIDFlag = featuresGetProductFeaturesFlags.String("organization-id", "REQUIRED", "")
 		featuresGetProductFeaturesSessionTokenFlag   = featuresGetProductFeaturesFlags.String("session-token", "", "")
 
 		featuresSetProductFeatureFlags            = flag.NewFlagSet("set-product-feature", flag.ExitOnError)

--- a/server/gen/http/features/client/cli.go
+++ b/server/gen/http/features/client/cli.go
@@ -19,11 +19,9 @@ import (
 // BuildGetProductFeaturesPayload builds the payload for the features
 // getProductFeatures endpoint from CLI flags.
 func BuildGetProductFeaturesPayload(featuresGetProductFeaturesOrganizationID string, featuresGetProductFeaturesSessionToken string) (*features.GetProductFeaturesPayload, error) {
-	var organizationID *string
+	var organizationID string
 	{
-		if featuresGetProductFeaturesOrganizationID != "" {
-			organizationID = &featuresGetProductFeaturesOrganizationID
-		}
+		organizationID = featuresGetProductFeaturesOrganizationID
 	}
 	var sessionToken *string
 	{

--- a/server/gen/http/features/client/encode_decode.go
+++ b/server/gen/http/features/client/encode_decode.go
@@ -47,9 +47,7 @@ func EncodeGetProductFeaturesRequest(encoder func(*http.Request) goahttp.Encoder
 			req.Header.Set("Gram-Session", head)
 		}
 		values := req.URL.Query()
-		if p.OrganizationID != nil {
-			values.Add("organization_id", *p.OrganizationID)
-		}
+		values.Add("organization_id", p.OrganizationID)
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}

--- a/server/gen/http/features/client/types.go
+++ b/server/gen/http/features/client/types.go
@@ -16,7 +16,7 @@ import (
 // "setProductFeature" endpoint HTTP request body.
 type SetProductFeatureRequestBody struct {
 	// Organization whose product feature to update.
-	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
+	OrganizationID string `form:"organization_id" json:"organization_id" xml:"organization_id"`
 	// Name of the feature to update
 	FeatureName string `form:"feature_name" json:"feature_name" xml:"feature_name"`
 	// Whether the feature should be enabled
@@ -27,7 +27,7 @@ type SetProductFeatureRequestBody struct {
 // service "setRemoteSessionAutoRefreshPolicy" endpoint HTTP request body.
 type SetRemoteSessionAutoRefreshPolicyRequestBody struct {
 	// Organization whose automatic remote-session refresh policy to update.
-	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
+	OrganizationID string `form:"organization_id" json:"organization_id" xml:"organization_id"`
 	// Organization policy for automatic remote-session refresh
 	Policy string `form:"policy" json:"policy" xml:"policy"`
 }

--- a/server/gen/http/features/server/encode_decode.go
+++ b/server/gen/http/features/server/encode_decode.go
@@ -37,16 +37,20 @@ func DecodeGetProductFeaturesRequest(mux goahttp.Muxer, decoder func(*http.Reque
 	return func(r *http.Request) (*features.GetProductFeaturesPayload, error) {
 		var payload *features.GetProductFeaturesPayload
 		var (
-			organizationID *string
+			organizationID string
 			sessionToken   *string
+			err            error
 		)
-		organizationIDRaw := r.URL.Query().Get("organization_id")
-		if organizationIDRaw != "" {
-			organizationID = &organizationIDRaw
+		organizationID = r.URL.Query().Get("organization_id")
+		if organizationID == "" {
+			err = goa.MergeErrors(err, goa.MissingFieldError("organization_id", "query string"))
 		}
 		sessionTokenRaw := r.Header.Get("Gram-Session")
 		if sessionTokenRaw != "" {
 			sessionToken = &sessionTokenRaw
+		}
+		if err != nil {
+			return payload, err
 		}
 		payload = NewGetProductFeaturesPayload(organizationID, sessionToken)
 		if payload.SessionToken != nil {

--- a/server/gen/http/features/server/types.go
+++ b/server/gen/http/features/server/types.go
@@ -1119,7 +1119,7 @@ func NewSetRemoteSessionAutoRefreshPolicyGatewayErrorResponseBody(res *goa.Servi
 
 // NewGetProductFeaturesPayload builds a features service getProductFeatures
 // endpoint payload.
-func NewGetProductFeaturesPayload(organizationID *string, sessionToken *string) *features.GetProductFeaturesPayload {
+func NewGetProductFeaturesPayload(organizationID string, sessionToken *string) *features.GetProductFeaturesPayload {
 	v := &features.GetProductFeaturesPayload{}
 	v.OrganizationID = organizationID
 	v.SessionToken = sessionToken
@@ -1131,7 +1131,7 @@ func NewGetProductFeaturesPayload(organizationID *string, sessionToken *string) 
 // endpoint payload.
 func NewSetProductFeaturePayload(body *SetProductFeatureRequestBody, sessionToken *string) *features.SetProductFeaturePayload {
 	v := &features.SetProductFeaturePayload{
-		OrganizationID: body.OrganizationID,
+		OrganizationID: *body.OrganizationID,
 		FeatureName:    *body.FeatureName,
 		Enabled:        *body.Enabled,
 	}
@@ -1144,7 +1144,7 @@ func NewSetProductFeaturePayload(body *SetProductFeatureRequestBody, sessionToke
 // setRemoteSessionAutoRefreshPolicy endpoint payload.
 func NewSetRemoteSessionAutoRefreshPolicyPayload(body *SetRemoteSessionAutoRefreshPolicyRequestBody, sessionToken *string) *features.SetRemoteSessionAutoRefreshPolicyPayload {
 	v := &features.SetRemoteSessionAutoRefreshPolicyPayload{
-		OrganizationID: body.OrganizationID,
+		OrganizationID: *body.OrganizationID,
 		Policy:         *body.Policy,
 	}
 	v.SessionToken = sessionToken
@@ -1155,6 +1155,9 @@ func NewSetRemoteSessionAutoRefreshPolicyPayload(body *SetRemoteSessionAutoRefre
 // ValidateSetProductFeatureRequestBody runs the validations defined on
 // SetProductFeatureRequestBody
 func ValidateSetProductFeatureRequestBody(body *SetProductFeatureRequestBody) (err error) {
+	if body.OrganizationID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("organization_id", "body"))
+	}
 	if body.FeatureName == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("feature_name", "body"))
 	}
@@ -1177,6 +1180,9 @@ func ValidateSetProductFeatureRequestBody(body *SetProductFeatureRequestBody) (e
 // ValidateSetRemoteSessionAutoRefreshPolicyRequestBody runs the validations
 // defined on SetRemoteSessionAutoRefreshPolicyRequestBody
 func ValidateSetRemoteSessionAutoRefreshPolicyRequestBody(body *SetRemoteSessionAutoRefreshPolicyRequestBody) (err error) {
+	if body.OrganizationID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("organization_id", "body"))
+	}
 	if body.Policy == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("policy", "body"))
 	}

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -33207,6 +33207,7 @@ paths:
                   description: Organization whose product features to read.
                   in: query
                   name: organization_id
+                  required: true
                   schema:
                     description: Organization whose product features to read.
                     type: string
@@ -75875,6 +75876,7 @@ components:
                     type: string
                     description: Organization whose product feature to update.
             required:
+                - organization_id
                 - feature_name
                 - enabled
         SetProjectLogoForm:
@@ -75906,6 +75908,7 @@ components:
                         - user_controlled
                         - enforced
             required:
+                - organization_id
                 - policy
         SetRootMcpEndpointRequestBody:
             type: object

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -77,16 +77,12 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	)
 }
 
-func (s *Service) authorizeOrganization(ctx context.Context, requestedOrganizationID *string, scope authz.Scope) (*contextvalues.AuthContext, string, error) {
+func (s *Service) authorizeOrganization(ctx context.Context, organizationID string, scope authz.Scope) (*contextvalues.AuthContext, string, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil {
 		return nil, "", oops.C(oops.CodeUnauthorized)
 	}
 
-	organizationID := authCtx.ActiveOrganizationID
-	if requestedOrganizationID != nil {
-		organizationID = *requestedOrganizationID
-	}
 	if organizationID == "" {
 		return nil, "", oops.C(oops.CodeUnauthorized)
 	}

--- a/server/internal/productfeatures/organizationscope_test.go
+++ b/server/internal/productfeatures/organizationscope_test.go
@@ -3,6 +3,7 @@ package productfeatures_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,15 +42,15 @@ func TestProductFeaturesService_RequestedOrganizationIsolation(t *testing.T) {
 	_, err := q.EnableFeature(ctx, repo.EnableFeatureParams{OrganizationID: activeOrganizationID, FeatureName: string(productfeatures.FeatureLogs)})
 	require.NoError(t, err)
 
-	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID)})
+	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: targetOrganizationID})
 	require.NoError(t, err)
 	require.False(t, result.LogsEnabled)
-	activeResult, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(activeOrganizationID)})
+	activeResult, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: activeOrganizationID})
 	require.NoError(t, err)
 	require.True(t, activeResult.LogsEnabled)
 
 	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		OrganizationID: targetOrganizationID,
 		FeatureName:    string(productfeatures.FeatureLogs),
 		Enabled:        true,
 	}))
@@ -64,7 +65,7 @@ func TestProductFeaturesService_RequestedOrganizationIsolation(t *testing.T) {
 	require.True(t, targetEnabled)
 
 	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		OrganizationID: targetOrganizationID,
 		FeatureName:    string(productfeatures.FeatureLogs),
 		Enabled:        false,
 	}))
@@ -79,10 +80,10 @@ func TestProductFeaturesService_RequestedOrganizationIsolation(t *testing.T) {
 		OrganizationID: targetOrganizationID,
 		Email:          "device@example.com",
 	}))
-	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID)})
+	result, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: targetOrganizationID})
 	require.NoError(t, err)
 	require.True(t, result.DeviceAgent)
-	activeResult, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(activeOrganizationID)})
+	activeResult, err = ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{OrganizationID: activeOrganizationID})
 	require.NoError(t, err)
 	require.False(t, activeResult.DeviceAgent)
 }
@@ -113,7 +114,7 @@ func TestProductFeaturesService_RemoteSessionPolicyTargetsRequestedOrganization(
 		{policy: "disabled"},
 	} {
 		require.NoError(t, ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
-			OrganizationID: conv.PtrEmpty(targetOrganizationID),
+			OrganizationID: targetOrganizationID,
 			Policy:         tc.policy,
 		}))
 		visible, err := q.IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{OrganizationID: targetOrganizationID, FeatureName: string(productfeatures.FeatureRemoteSessionAutoRefresh)})
@@ -147,20 +148,20 @@ func TestProductFeaturesService_AuthorizesBeforeOrganizationLookup(t *testing.T)
 	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
 
 	readActiveOnly := authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, activeOrganizationID))
-	_, err := ti.service.GetProductFeatures(readActiveOnly, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID)})
+	_, err := ti.service.GetProductFeatures(readActiveOnly, &gen.GetProductFeaturesPayload{OrganizationID: targetOrganizationID})
 	requireOopsCode(t, err, oops.CodeForbidden)
 	adminActiveOnly := authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, activeOrganizationID))
-	err = ti.service.SetProductFeature(adminActiveOnly, &gen.SetProductFeaturePayload{OrganizationID: conv.PtrEmpty(targetOrganizationID), FeatureName: string(productfeatures.FeatureLogs), Enabled: true})
+	err = ti.service.SetProductFeature(adminActiveOnly, &gen.SetProductFeaturePayload{OrganizationID: targetOrganizationID, FeatureName: string(productfeatures.FeatureLogs), Enabled: true})
 	requireOopsCode(t, err, oops.CodeForbidden)
-	err = ti.service.SetRemoteSessionAutoRefreshPolicy(adminActiveOnly, &gen.SetRemoteSessionAutoRefreshPolicyPayload{OrganizationID: conv.PtrEmpty(targetOrganizationID), Policy: "enforced"})
+	err = ti.service.SetRemoteSessionAutoRefreshPolicy(adminActiveOnly, &gen.SetRemoteSessionAutoRefreshPolicyPayload{OrganizationID: targetOrganizationID, Policy: "enforced"})
 	requireOopsCode(t, err, oops.CodeForbidden)
 
 	unknownOrganizationID := uuid.NewString()
-	_, err = ti.service.GetProductFeatures(readActiveOnly, &gen.GetProductFeaturesPayload{OrganizationID: conv.PtrEmpty(unknownOrganizationID)})
+	_, err = ti.service.GetProductFeatures(readActiveOnly, &gen.GetProductFeaturesPayload{OrganizationID: unknownOrganizationID})
 	requireOopsCode(t, err, oops.CodeForbidden, "unauthorized unknown target must not be enumerable")
-	err = ti.service.SetProductFeature(adminActiveOnly, &gen.SetProductFeaturePayload{OrganizationID: conv.PtrEmpty(unknownOrganizationID), FeatureName: string(productfeatures.FeatureLogs), Enabled: true})
+	err = ti.service.SetProductFeature(adminActiveOnly, &gen.SetProductFeaturePayload{OrganizationID: unknownOrganizationID, FeatureName: string(productfeatures.FeatureLogs), Enabled: true})
 	requireOopsCode(t, err, oops.CodeForbidden)
-	err = ti.service.SetRemoteSessionAutoRefreshPolicy(adminActiveOnly, &gen.SetRemoteSessionAutoRefreshPolicyPayload{OrganizationID: conv.PtrEmpty(unknownOrganizationID), Policy: "enforced"})
+	err = ti.service.SetRemoteSessionAutoRefreshPolicy(adminActiveOnly, &gen.SetRemoteSessionAutoRefreshPolicyPayload{OrganizationID: unknownOrganizationID, Policy: "enforced"})
 	requireOopsCode(t, err, oops.CodeForbidden)
 }
 
@@ -172,7 +173,7 @@ func TestProductFeaturesService_HooksFailOpenAuditTargetsRequestedOrganization(t
 	seedOrganization(t, ctx, ti.conn, targetOrganizationID)
 	seedRequestedOrganizationRole(t, ctx, ti, targetOrganizationID, authz.SystemRoleAdmin)
 	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		OrganizationID: targetOrganizationID,
 		FeatureName:    string(productfeatures.FeatureHooksFailOpen),
 		Enabled:        true,
 	}))
@@ -271,33 +272,37 @@ func requireOopsCode(t *testing.T, err error, code oops.Code, msgAndArgs ...any)
 	require.Equal(t, code, shareable.Code, msgAndArgs...)
 }
 
-func TestProductFeaturesService_OmittedOrganizationUsesActiveOrganization(t *testing.T) {
+func TestProductFeaturesHTTP_RequiresOrganizationID(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestProductFeaturesService(t)
-	organizationID := activeOrganizationID(t, ctx)
-
-	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{})
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.SessionID)
+	session, err := ti.sessionManager.GetSession(ctx, *authCtx.SessionID)
 	require.NoError(t, err)
-	require.False(t, result.LogsEnabled)
 
-	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		FeatureName: string(productfeatures.FeatureLogs),
-		Enabled:     true,
-	}))
-	enabled, err := repo.New(ti.conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
-		OrganizationID: organizationID,
-		FeatureName:    string(productfeatures.FeatureLogs),
-	})
+	mux := goahttp.NewMuxer()
+	productfeatures.Attach(mux, ti.service)
+	setBody, err := json.Marshal(map[string]any{"feature_name": "logs", "enabled": true})
 	require.NoError(t, err)
-	require.True(t, enabled)
+	policyBody, err := json.Marshal(map[string]any{"policy": "enforced"})
+	require.NoError(t, err)
 
-	require.NoError(t, ti.service.SetRemoteSessionAutoRefreshPolicy(ctx, &gen.SetRemoteSessionAutoRefreshPolicyPayload{
-		Policy: "enforced",
-	}))
-	enforced, err := repo.New(ti.conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
-		OrganizationID: organizationID,
-		FeatureName:    string(productfeatures.FeatureRemoteSessionAutoRefreshEnforced),
-	})
-	require.NoError(t, err)
-	require.True(t, enforced)
+	do := func(method, target, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequestWithContext(t.Context(), method, target, bytes.NewBufferString(body))
+		req.Header.Set("Gram-Session", session.SessionID)
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	for name, response := range map[string]*httptest.ResponseRecorder{
+		"get":           do(http.MethodGet, "/rpc/productFeatures.get", ""),
+		"set":           do(http.MethodPost, "/rpc/productFeatures.set", string(setBody)),
+		"remote policy": do(http.MethodPost, "/rpc/productFeatures.setRemoteSessionAutoRefreshPolicy", string(policyBody)),
+	} {
+		require.Equal(t, http.StatusBadRequest, response.Code, "%s: %s", name, response.Body.String())
+	}
 }

--- a/server/internal/productfeatures/setproductfeature_test.go
+++ b/server/internal/productfeatures/setproductfeature_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
@@ -143,7 +142,7 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 		ctxWithoutAuth := t.Context()
 
 		err := ti.service.SetProductFeature(ctxWithoutAuth, &gen.SetProductFeaturePayload{
-			OrganizationID: conv.PtrEmpty("test-organization"),
+			OrganizationID: "test-organization",
 			FeatureName:    "logs",
 			Enabled:        true,
 		})
@@ -169,7 +168,7 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 		ctxWithoutOrg := contextvalues.SetAuthContext(ctx, authCtx)
 
 		err := ti.service.SetProductFeature(ctxWithoutOrg, &gen.SetProductFeaturePayload{
-			OrganizationID: conv.PtrEmpty(targetOrganizationID),
+			OrganizationID: targetOrganizationID,
 			FeatureName:    "logs",
 			Enabled:        true,
 		})

--- a/server/internal/productfeatures/setup_test.go
+++ b/server/internal/productfeatures/setup_test.go
@@ -48,12 +48,12 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func requestedOrganizationID(ctx context.Context) *string {
+func requestedOrganizationID(ctx context.Context) string {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil {
-		return conv.PtrEmpty("test-organization")
+		return "test-organization"
 	}
-	return conv.PtrEmpty(authCtx.ActiveOrganizationID)
+	return authCtx.ActiveOrganizationID
 }
 
 type testInstance struct {

--- a/server/internal/productfeatures/skills_test.go
+++ b/server/internal/productfeatures/skills_test.go
@@ -229,7 +229,7 @@ func TestProductFeaturesService_EnableSkillsTargetsRequestedOrganization(t *test
 	deleteGrant(t, ctx, q, targetOrganizationID, admin, authz.ScopeSkillWrite, authz.WildcardResource)
 
 	require.NoError(t, ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
-		OrganizationID: conv.PtrEmpty(targetOrganizationID),
+		OrganizationID: targetOrganizationID,
 		FeatureName:    string(productfeatures.FeatureSkills),
 		Enabled:        true,
 	}))


### PR DESCRIPTION
## Summary
- require `organization_id` on all three product-feature methods
- remove the transitional active-organization fallback after all dashboard callers supply scope
- regenerate Goa, OpenAPI, CLI, TypeScript SDK, and React Query artifacts
- verify omitted organization scope fails at the HTTP contract boundary

## Verification
- 37 focused product-feature tests
- 270 combined authz and product-feature tests on the final stack
- 14 focused dashboard tests
- server lint, dashboard type-check, and SDK generation check
- `git diff --check`

## Stack
Final layer above AGE-3314, AGE-3317, and AGE-3316.

Linear: AGE-3315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires explicit organization scope on all product-feature APIs and removes the active-organization fallback (Linear AGE-3315). Previously, omitting organization_id used the active org; now omission returns 400 on get, set, and setRemoteSessionAutoRefreshPolicy.

- Migration
  - Dashboard SDK/`react-query`: pass organizationId to all product-features calls. The request object is now required for `features.get`, `useProductFeatures`, `useProductFeaturesSuspense`, and prefetch/build/invalidate helpers.
  - CLI: `features get` now requires `--organization-id`.

- Review notes
  - Goa design marks `organization_id` required across get/set/remote-policy; OpenAPI/CLI/TypeScript SDK/`react-query` artifacts regenerated.
  - Server: HTTP decoding validates missing `organization_id` in query/body and returns 400; removed active-org fallback; auth still precedes org lookup.
  - Tests assert 400 for omitted `organization_id` on all three endpoints and maintain cross-organization isolation.
  - Changeset added for patch releases to `server` and `dashboard`.

<sup>Written for commit 3b4f84f2f5c0270b74f27ff0a514ffaf1da5ccd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

