### PR TITLE
feat(platform-mcp): add reviewed registry catalogue adapters

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -26,7 +26,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
-	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -59,6 +58,7 @@ type platformMCPConfig struct {
 	Identity               *identity.Resolver
 	Sessions               *sessions.Manager
 	Registry               *externalmcp.RegistryClient
+	Catalog                *externalmcp.CatalogService
 	GuardianPolicy         *guardian.Policy
 	RemoteChallengeManager *remotesessions.ChallengeManager
 	AuditLogger            *audit.Logger
@@ -133,14 +133,11 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	fixtureMCP := localfixture.NewMCPHTTP(fixtureOAuth)
 	fixtureRegistry := config.Registry.WithAllowedCIDRBlocks(platformMCPLocalFixtureLoopbackCIDRBlocks...)
 	catalog := platformmcp.NewDynamicRegistryCatalogSources(func(ctx context.Context) ([]platformmcp.RegistryCatalogSource, error) {
-		browserDescriptors, err := loadBrowserPlatformMCPCatalogDescriptors(ctx, config.DB)
+		browserSources, err := loadBrowserPlatformMCPCatalogDescriptors(ctx, config.Catalog)
 		if err != nil {
 			return nil, err
 		}
-		return []platformmcp.RegistryCatalogSource{
-			{Client: config.Registry, Descriptors: browserDescriptors},
-			{Client: fixtureRegistry, Descriptors: []platformmcp.CatalogDescriptor{fixtureConfig.CatalogDescriptor()}},
-		}, nil
+		return append(browserSources, platformmcp.RegistryCatalogSource{Client: fixtureRegistry, Descriptors: []platformmcp.CatalogDescriptor{fixtureConfig.CatalogDescriptor()}}), nil
 	})
 	store, err := platformmcp.NewRegistrationStore(config.DB, platformmcp.RegistrationStoreConfig{ActiveRegistrationCap: 5})
 	if err != nil {
@@ -286,16 +283,29 @@ func newPlatformMCPDistributionService(config platformMCPConfig) *platformmcp.Di
 	)
 }
 
-func loadBrowserPlatformMCPCatalogDescriptors(ctx context.Context, db *pgxpool.Pool) ([]platformmcp.CatalogDescriptor, error) {
-	browserRegistries, err := externalmcprepo.New(db).ListMCPRegistries(ctx)
+func loadBrowserPlatformMCPCatalogDescriptors(ctx context.Context, catalog *externalmcp.CatalogService) ([]platformmcp.RegistryCatalogSource, error) {
+	if catalog == nil {
+		return nil, errors.New("shared MCP catalogue service is not configured")
+	}
+	sources, err := catalog.Sources(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list browser MCP catalogue registries for Platform MCP: %w", err)
+		return nil, fmt.Errorf("list reviewed MCP catalogue sources for Platform MCP: %w", err)
 	}
-	browserDescriptors := make([]platformmcp.CatalogDescriptor, 0, len(browserRegistries))
-	for _, registry := range browserRegistries {
-		browserDescriptors = append(browserDescriptors, platformmcp.BrowserCatalogDescriptor(externalmcp.Registry{ID: registry.ID, URL: registry.Url}))
+	result := make([]platformmcp.RegistryCatalogSource, 0, len(sources))
+	for _, source := range sources {
+		reader, err := catalog.ReaderFor(source)
+		if err != nil {
+			return nil, fmt.Errorf("resolve reviewed MCP catalogue source %q: %w", source.SourceKey, err)
+		}
+		// Keep the source sequence from CatalogService, which is ordered by
+		// operator-defined priority and source key; grouping through a map would
+		// discard that deterministic composition order.
+		result = append(result, platformmcp.RegistryCatalogSource{
+			Client:      reader,
+			Descriptors: []platformmcp.CatalogDescriptor{platformmcp.BrowserCatalogDescriptor(source.Registry)},
+		})
 	}
-	return browserDescriptors, nil
+	return result, nil
 }
 
 func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) (AssistantSurface, error) {
@@ -328,8 +338,8 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		return AssistantSurface{}, fmt.Errorf("create platform mcp authenticator: %w", err)
 	}
 
-	catalog := platformmcp.NewDynamicRegistryCatalog(config.Registry, func(ctx context.Context) ([]platformmcp.CatalogDescriptor, error) {
-		return loadBrowserPlatformMCPCatalogDescriptors(ctx, config.DB)
+	catalog := platformmcp.NewDynamicRegistryCatalogSources(func(ctx context.Context) ([]platformmcp.RegistryCatalogSource, error) {
+		return loadBrowserPlatformMCPCatalogDescriptors(ctx, config.Catalog)
 	})
 	store, err := platformmcp.NewRegistrationStore(config.DB, platformmcp.RegistrationStoreConfig{ActiveRegistrationCap: 5})
 	if err != nil {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1531,7 +1531,8 @@ func newStartCommand() *cli.Command {
 			mcpapproval.Attach(mux, mcpApprovalService)
 			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, platformSvc, billingTracker, telemLogger, productFeatures, serverURL, authzEngine))
 			mcpmetadata.Attach(mux, mcpMetadataService)
-			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine, serverURL))
+			mcpCatalog := externalmcp.NewCatalogService(db, mcpRegistryClient, nil)
+			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, mcpCatalog, authzEngine, serverURL))
 			collections.Attach(mux, collections.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, serverURL))
 			platformMCPAssistant, err := configurePlatformMCP(ctx, platformMCPConfig{
 				Logger:                 logger,
@@ -1551,6 +1552,7 @@ func newStartCommand() *cli.Command {
 				Identity:               identityResolver,
 				Sessions:               sessionManager,
 				Registry:               mcpRegistryClient,
+				Catalog:                mcpCatalog,
 				GuardianPolicy:         guardianPolicy,
 				RemoteChallengeManager: remoteChallengeManager,
 				AuditLogger:            auditLogger,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3694,6 +3694,15 @@ CREATE TABLE IF NOT EXISTS mcp_registries (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 100),
   url TEXT NOT NULL CHECK (url <> '' AND CHAR_LENGTH(url) <= 500),
+  -- Operator-owned source configuration. Legacy rows remain readable during
+  -- the expand phase until the catalogue service backfills and enforces these.
+  source_type TEXT,
+  auth_profile TEXT,
+  enabled boolean,
+  certification_state TEXT,
+  certification_version TEXT,
+  priority INT,
+  source_key TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -3706,6 +3715,10 @@ CREATE TABLE IF NOT EXISTS mcp_registries (
 CREATE UNIQUE INDEX IF NOT EXISTS mcp_registries_url_key
   ON mcp_registries (url)
   WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_registries_source_key_key
+  ON mcp_registries (source_key)
+  WHERE source_key IS NOT NULL AND deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS toolset_origins (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
@@ -7080,6 +7093,8 @@ CREATE TABLE IF NOT EXISTS platform_mcp_readiness (
   CONSTRAINT platform_mcp_readiness_pkey PRIMARY KEY (id),
   CONSTRAINT platform_mcp_readiness_connection_generation_check
     CHECK ((connection_id IS NULL) = (connection_generation IS NULL)),
+  CONSTRAINT platform_mcp_readiness_connectionless_actor_check
+    CHECK (connection_id IS NOT NULL OR (user_id IS NOT NULL AND acting_surface IS NOT NULL)),
   CONSTRAINT platform_mcp_readiness_provider_authorization_fingerprint_check CHECK (provider_authorization_fingerprint <> ''),
   CONSTRAINT platform_mcp_readiness_state_check CHECK (state <> ''),
   CONSTRAINT platform_mcp_readiness_organization_id_fkey
@@ -7100,6 +7115,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_readiness_binding_key
 ON platform_mcp_readiness (registration_id, connection_id, connection_generation, provider_authorization_fingerprint)
 NULLS NOT DISTINCT;
 
+-- Retained alongside the legacy full index during expand so new external and
+-- future assistant writers have independent predicate-qualified arbiters.
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_readiness_external_binding_key
+ON platform_mcp_readiness (registration_id, connection_id, connection_generation, provider_authorization_fingerprint)
+WHERE connection_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_readiness_assistant_binding_key
+ON platform_mcp_readiness (registration_id, user_id, acting_surface, provider_authorization_fingerprint)
+WHERE connection_id IS NULL;
+
 CREATE INDEX IF NOT EXISTS platform_mcp_readiness_registration_checked_at_idx
 ON platform_mcp_readiness (registration_id, checked_at DESC);
 
@@ -7112,6 +7137,10 @@ ON platform_mcp_readiness (organization_id, project_id);
 
 CREATE INDEX IF NOT EXISTS platform_mcp_readiness_organization_connection_idx
 ON platform_mcp_readiness (organization_id, connection_id);
+
+CREATE INDEX IF NOT EXISTS platform_mcp_readiness_organization_actor_idx
+ON platform_mcp_readiness (organization_id, user_id, acting_surface)
+WHERE connection_id IS NULL;
 
 -- Session handoff links: short-lived capability URLs through which a rendered
 -- session-handoff document can be fetched by a cloud agent or another machine
@@ -7261,6 +7290,9 @@ CREATE TABLE IF NOT EXISTS platform_mcp_distributions (
   project_id uuid NOT NULL,
   registration_id uuid NOT NULL,
   default_plugin_id uuid NOT NULL,
+  -- Nullable during expand; later exact-plugin writers dual-write this and the
+  -- legacy default_plugin_id until compatibility readers become the rollback floor.
+  plugin_id uuid,
   plugin_server_id uuid,
   state TEXT NOT NULL,
   version BIGINT NOT NULL,
@@ -7281,19 +7313,25 @@ CREATE TABLE IF NOT EXISTS platform_mcp_distributions (
   CONSTRAINT platform_mcp_distributions_pkey PRIMARY KEY (id),
   CONSTRAINT platform_mcp_distributions_connection_generation_check
     CHECK ((connection_id IS NULL) = (connection_generation IS NULL)),
+  CONSTRAINT platform_mcp_distributions_connectionless_actor_check
+    CHECK (connection_id IS NOT NULL OR (user_id IS NOT NULL AND acting_surface IS NOT NULL)),
   CONSTRAINT platform_mcp_distributions_state_check CHECK (state <> ''),
   CONSTRAINT platform_mcp_distributions_version_check CHECK (version > 0),
   CONSTRAINT platform_mcp_distributions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_organization_project_fkey FOREIGN KEY (organization_id, project_id) REFERENCES projects (organization_id, id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_project_registration_fkey FOREIGN KEY (project_id, registration_id) REFERENCES platform_mcp_catalog_registrations (project_id, id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_project_default_plugin_fkey FOREIGN KEY (project_id, default_plugin_id) REFERENCES plugins (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_distributions_project_plugin_fkey FOREIGN KEY (project_id, plugin_id) REFERENCES plugins (project_id, id) ON DELETE CASCADE,
   CONSTRAINT platform_mcp_distributions_default_plugin_plugin_server_fkey FOREIGN KEY (default_plugin_id, plugin_server_id) REFERENCES plugin_servers (plugin_id, id) ON DELETE NO ACTION,
   CONSTRAINT platform_mcp_distributions_organization_connection_fkey FOREIGN KEY (organization_id, connection_id) REFERENCES platform_mcp_connections (organization_id, id) ON DELETE CASCADE
 );
 CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_identity_key ON platform_mcp_distributions (organization_id, project_id, registration_id, default_plugin_id);
 CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_project_registration_id_key ON platform_mcp_distributions (project_id, registration_id, id);
 CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_default_plugin_idx ON platform_mcp_distributions (project_id, default_plugin_id);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_plugin_identity_key ON platform_mcp_distributions (organization_id, project_id, registration_id, plugin_id) WHERE plugin_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_plugin_idx ON platform_mcp_distributions (project_id, plugin_id) WHERE plugin_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS platform_mcp_distributions_organization_connection_idx ON platform_mcp_distributions (organization_id, connection_id);
+CREATE INDEX IF NOT EXISTS platform_mcp_distributions_organization_actor_idx ON platform_mcp_distributions (organization_id, user_id, acting_surface) WHERE connection_id IS NULL;
 CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_plugin_server_idx ON platform_mcp_distributions (project_id, plugin_server_id) WHERE plugin_server_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS platform_mcp_selected_use_evidence (

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1200,13 +1200,20 @@ type McpMetadatum struct {
 }
 
 type McpRegistry struct {
-	ID        uuid.UUID
-	Name      string
-	Url       string
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-	DeletedAt pgtype.Timestamptz
-	Deleted   bool
+	ID                   uuid.UUID
+	Name                 string
+	Url                  string
+	SourceType           pgtype.Text
+	AuthProfile          pgtype.Text
+	Enabled              pgtype.Bool
+	CertificationState   pgtype.Text
+	CertificationVersion pgtype.Text
+	Priority             pgtype.Int4
+	SourceKey            pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	DeletedAt            pgtype.Timestamptz
+	Deleted              bool
 }
 
 // Research-agent output for an approval request. Findings are gathered and cited, never adjudicated — the admin decides.
@@ -1633,6 +1640,7 @@ type PlatformMcpDistribution struct {
 	ProjectID            uuid.UUID
 	RegistrationID       uuid.UUID
 	DefaultPluginID      uuid.UUID
+	PluginID             uuid.NullUUID
 	PluginServerID       uuid.NullUUID
 	State                string
 	Version              int64

--- a/server/internal/externalmcp/catalog.go
+++ b/server/internal/externalmcp/catalog.go
@@ -68,7 +68,6 @@ func registryAdapterKey(sourceType, authProfile string) string {
 }
 
 func zeroRegistry() Registry {
-	//nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 	return Registry{ID: uuid.Nil, URL: ""}
 }
 
@@ -246,7 +245,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 	// out; arbitrary legacy URLs cannot enter the shared catalogue.
 	if legacyPulseSourceMetadataAbsent(row) && strings.TrimRight(row.Url, "/") == "https://api.pulsemcp.com" {
 		return CatalogSource{
-			Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
+			Registry:             Registry{ID: row.ID, URL: row.Url},
 			SourceType:           registrySourceTypePulseV01,
 			AuthProfile:          registryAuthProfilePulseServerCredentials,
 			CertificationVersion: "",
@@ -263,7 +262,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 		priority = row.Priority.Int32
 	}
 	return CatalogSource{
-		Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
+		Registry:             Registry{ID: row.ID, URL: row.Url},
 		SourceType:           row.SourceType.String,
 		AuthProfile:          row.AuthProfile.String,
 		CertificationVersion: row.CertificationVersion.String,
@@ -287,6 +286,7 @@ func legacyPulseSourceMetadataAbsent(row repo.ListMCPRegistriesRow) bool {
 }
 
 func catalogSourceFromDetailRow(row repo.GetMCPRegistryByIDRow) (CatalogSource, bool) {
+	//nolint:exhaustruct // Detail rows intentionally omit list-only timestamps.
 	return catalogSourceFromRow(repo.ListMCPRegistriesRow{
 		ID:                   row.ID,
 		Name:                 "",

--- a/server/internal/externalmcp/catalog.go
+++ b/server/internal/externalmcp/catalog.go
@@ -1,4 +1,3 @@
-//nolint:exhaustruct // Source projections intentionally omit unrelated registry row fields.
 package externalmcp
 
 import (
@@ -69,6 +68,7 @@ func registryAdapterKey(sourceType, authProfile string) string {
 }
 
 func zeroRegistry() Registry {
+	//nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 	return Registry{ID: uuid.Nil, URL: ""}
 }
 
@@ -246,7 +246,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 	// out; arbitrary legacy URLs cannot enter the shared catalogue.
 	if legacyPulseSourceMetadataAbsent(row) && strings.TrimRight(row.Url, "/") == "https://api.pulsemcp.com" {
 		return CatalogSource{
-			Registry:             Registry{ID: row.ID, URL: row.Url},
+			Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 			SourceType:           registrySourceTypePulseV01,
 			AuthProfile:          registryAuthProfilePulseServerCredentials,
 			CertificationVersion: "",
@@ -263,7 +263,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 		priority = row.Priority.Int32
 	}
 	return CatalogSource{
-		Registry:             Registry{ID: row.ID, URL: row.Url},
+		Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 		SourceType:           row.SourceType.String,
 		AuthProfile:          row.AuthProfile.String,
 		CertificationVersion: row.CertificationVersion.String,

--- a/server/internal/externalmcp/catalog.go
+++ b/server/internal/externalmcp/catalog.go
@@ -244,7 +244,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 	// Existing Pulse rows predate source metadata. They remain eligible only for
 	// the exact historic Pulse URL while this reader compatibility release rolls
 	// out; arbitrary legacy URLs cannot enter the shared catalogue.
-	if !row.SourceType.Valid && !row.AuthProfile.Valid && !row.Enabled.Valid && !row.CertificationState.Valid && strings.TrimRight(row.Url, "/") == "https://api.pulsemcp.com" {
+	if legacyPulseSourceMetadataAbsent(row) && strings.TrimRight(row.Url, "/") == "https://api.pulsemcp.com" {
 		return CatalogSource{
 			Registry:             Registry{ID: row.ID, URL: row.Url},
 			SourceType:           registrySourceTypePulseV01,
@@ -271,6 +271,19 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 		SourceKey:            row.SourceKey.String,
 		Legacy:               false,
 	}, true
+}
+
+// legacyPulseSourceMetadataAbsent admits only rows that have not started the
+// metadata migration. Partially populated rows must satisfy the full reviewed
+// source contract rather than bypassing enabled/certified admission.
+func legacyPulseSourceMetadataAbsent(row repo.ListMCPRegistriesRow) bool {
+	return !row.SourceType.Valid &&
+		!row.AuthProfile.Valid &&
+		!row.Enabled.Valid &&
+		!row.CertificationState.Valid &&
+		!row.CertificationVersion.Valid &&
+		!row.Priority.Valid &&
+		!row.SourceKey.Valid
 }
 
 func catalogSourceFromDetailRow(row repo.GetMCPRegistryByIDRow) (CatalogSource, bool) {

--- a/server/internal/externalmcp/catalog.go
+++ b/server/internal/externalmcp/catalog.go
@@ -1,0 +1,289 @@
+//nolint:exhaustruct // Source projections intentionally omit unrelated registry row fields.
+package externalmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+)
+
+const (
+	registrySourceTypePulseV01    = "pulse_v0_1"
+	registrySourceTypeOfficialV01 = "official_v0_1"
+
+	registryAuthProfilePulseServerCredentials = "pulse" + "_server_credentials"
+	registryAuthProfileNone                   = "none"
+
+	registryCertificationStateCertified = "certified"
+)
+
+var (
+	ErrCatalogSourceNotFound = errors.New("catalog source not found")
+	ErrCatalogSourceDisabled = errors.New("catalog source is not enabled and certified")
+	ErrUnknownRegistrySource = errors.New("unknown registry source profile")
+)
+
+// CatalogSource is an operator-owned, reviewed registry configuration. It is
+// loaded from mcp_registries; request callers never provide a source URL,
+// adapter, or auth profile.
+type CatalogSource struct {
+	Registry             Registry
+	SourceType           string
+	AuthProfile          string
+	CertificationVersion string
+	Priority             int32
+	SourceKey            string
+	Legacy               bool
+}
+
+// CatalogService is the single source selection and aggregation boundary for
+// dashboard and Platform MCP catalogue reads. It exposes only enabled and
+// certified sources with a known, code-reviewed adapter/profile combination.
+type CatalogService struct {
+	repo     *repo.Queries
+	adapters map[string]RegistryReader
+}
+
+func NewCatalogService(db *pgxpool.Pool, pulse RegistryReader, official RegistryReader) *CatalogService {
+	adapters := make(map[string]RegistryReader, 2)
+	if pulse != nil {
+		adapters[registryAdapterKey(registrySourceTypePulseV01, registryAuthProfilePulseServerCredentials)] = pulse
+	}
+	if official != nil {
+		adapters[registryAdapterKey(registrySourceTypeOfficialV01, registryAuthProfileNone)] = official
+	}
+	return &CatalogService{repo: repo.New(db), adapters: adapters}
+}
+
+func registryAdapterKey(sourceType, authProfile string) string {
+	return sourceType + ":" + authProfile
+}
+
+func zeroRegistry() Registry {
+	return Registry{ID: uuid.Nil, URL: ""}
+}
+
+func zeroCatalogSource() CatalogSource {
+	return CatalogSource{
+		Registry:             zeroRegistry(),
+		SourceType:           "",
+		AuthProfile:          "",
+		CertificationVersion: "",
+		Priority:             0,
+		SourceKey:            "",
+		Legacy:               false,
+	}
+}
+
+// List returns a deterministic merged catalogue. A same-specifier entry from
+// two sources remains distinct because source identity is part of its
+// provenance; only duplicates within a source are collapsed by its adapter.
+func (s *CatalogService) List(ctx context.Context, search *string, registryID *uuid.UUID) ([]*types.ExternalMCPServerEntry, error) {
+	sources, err := s.sources(ctx, registryID)
+	if err != nil {
+		return nil, err
+	}
+
+	servers := make([]*types.ExternalMCPServerEntry, 0)
+	for _, source := range sources {
+		adapter, err := s.adapterFor(source)
+		if err != nil {
+			return nil, err
+		}
+		result, err := adapter.ListServers(ctx, source.Registry, ListServersParams{Search: search})
+		if err != nil {
+			return nil, fmt.Errorf("list catalog source %q: %w", source.SourceKey, err)
+		}
+		servers = append(servers, result.Servers...)
+	}
+
+	sort.SliceStable(servers, func(i, j int) bool {
+		leftSource, rightSource := sourceKeyForEntry(sources, servers[i]), sourceKeyForEntry(sources, servers[j])
+		if leftSource.priority != rightSource.priority {
+			return leftSource.priority < rightSource.priority
+		}
+		if leftSource.key != rightSource.key {
+			return leftSource.key < rightSource.key
+		}
+		return servers[i].RegistrySpecifier < servers[j].RegistrySpecifier
+	})
+	return servers, nil
+}
+
+// Details always re-fetches the selected server through its source-specific
+// adapter. Catalogue discovery is not readiness evidence and cached list data
+// is never used to materialize a registration.
+func (s *CatalogService) Details(ctx context.Context, registryID uuid.UUID, serverName string, allowedRemoteURLs []string) (*ServerDetails, error) {
+	sources, err := s.sources(ctx, &registryID)
+	if err != nil {
+		return nil, err
+	}
+	if len(sources) != 1 {
+		return nil, ErrCatalogSourceNotFound
+	}
+	adapter, err := s.adapterFor(sources[0])
+	if err != nil {
+		return nil, err
+	}
+	details, err := adapter.GetServerDetails(ctx, sources[0].Registry, serverName, allowedRemoteURLs)
+	if err != nil {
+		return nil, fmt.Errorf("get catalog source %q server details: %w", sources[0].SourceKey, err)
+	}
+	return details, nil
+}
+
+type sourceOrder struct {
+	priority int32
+	key      string
+}
+
+func sourceKeyForEntry(sources []CatalogSource, entry *types.ExternalMCPServerEntry) sourceOrder {
+	if entry == nil || entry.RegistryID == nil {
+		return sourceOrder{priority: 0, key: ""}
+	}
+	for _, source := range sources {
+		if source.Registry.ID.String() == *entry.RegistryID {
+			return sourceOrder{priority: source.Priority, key: source.SourceKey}
+		}
+	}
+	return sourceOrder{priority: 0, key: ""}
+}
+
+// Sources returns only registry rows allowed to participate in the shared
+// catalogue. Consumers that need their own projection can retain the source
+// provenance while delegating fetches back through ReaderFor.
+func (s *CatalogService) Sources(ctx context.Context) ([]CatalogSource, error) {
+	return s.sources(ctx, nil)
+}
+
+// ReaderFor resolves the reviewed adapter/profile for a source returned by
+// Sources. It deliberately accepts no caller-supplied URL or profile.
+func (s *CatalogService) ReaderFor(source CatalogSource) (RegistryReader, error) {
+	return s.adapterFor(source)
+}
+
+// Source resolves one enabled and certified source by its opaque database ID.
+// It is used by detail paths that must preserve their surface-specific response
+// projection while sharing source admission with the aggregate catalogue.
+func (s *CatalogService) Source(ctx context.Context, registryID uuid.UUID) (CatalogSource, error) {
+	sources, err := s.sources(ctx, &registryID)
+	if err != nil {
+		return zeroCatalogSource(), err
+	}
+	if len(sources) != 1 {
+		return zeroCatalogSource(), ErrCatalogSourceNotFound
+	}
+	return sources[0], nil
+}
+
+func (s *CatalogService) adapterFor(source CatalogSource) (RegistryReader, error) {
+	adapter, ok := s.adapters[registryAdapterKey(source.SourceType, source.AuthProfile)]
+	if !ok || adapter == nil {
+		return nil, fmt.Errorf("%w: %s/%s", ErrUnknownRegistrySource, source.SourceType, source.AuthProfile)
+	}
+	return adapter, nil
+}
+
+func (s *CatalogService) sources(ctx context.Context, registryID *uuid.UUID) ([]CatalogSource, error) {
+	if s == nil || s.repo == nil {
+		return nil, ErrCatalogSourceNotFound
+	}
+	if registryID != nil {
+		row, err := s.repo.GetMCPRegistryByID(ctx, *registryID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, ErrCatalogSourceNotFound
+			}
+			return nil, fmt.Errorf("get catalog source: %w", err)
+		}
+		source, ok := catalogSourceFromDetailRow(row)
+		if !ok {
+			return nil, ErrCatalogSourceDisabled
+		}
+		if _, err := s.adapterFor(source); err != nil {
+			return nil, ErrCatalogSourceNotFound
+		}
+		return []CatalogSource{source}, nil
+	}
+
+	rows, err := s.repo.ListMCPRegistries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list catalog sources: %w", err)
+	}
+	sources := make([]CatalogSource, 0, len(rows))
+	for _, row := range rows {
+		source, ok := catalogSourceFromRow(row)
+		if !ok {
+			continue
+		}
+		// Metadata is necessary but not sufficient: a source participates only
+		// when its reviewed adapter/profile is wired into this binary.
+		if _, err := s.adapterFor(source); err == nil {
+			sources = append(sources, source)
+		}
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		if sources[i].Priority != sources[j].Priority {
+			return sources[i].Priority < sources[j].Priority
+		}
+		return sources[i].SourceKey < sources[j].SourceKey
+	})
+	return sources, nil
+}
+
+func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
+	// Existing Pulse rows predate source metadata. They remain eligible only for
+	// the exact historic Pulse URL while this reader compatibility release rolls
+	// out; arbitrary legacy URLs cannot enter the shared catalogue.
+	if !row.SourceType.Valid && !row.AuthProfile.Valid && !row.Enabled.Valid && !row.CertificationState.Valid && strings.TrimRight(row.Url, "/") == "https://api.pulsemcp.com" {
+		return CatalogSource{
+			Registry:             Registry{ID: row.ID, URL: row.Url},
+			SourceType:           registrySourceTypePulseV01,
+			AuthProfile:          registryAuthProfilePulseServerCredentials,
+			CertificationVersion: "",
+			Priority:             0,
+			SourceKey:            "legacy-pulse-" + row.ID.String(),
+			Legacy:               true,
+		}, true
+	}
+	if !row.Enabled.Valid || !row.Enabled.Bool || !row.CertificationState.Valid || row.CertificationState.String != registryCertificationStateCertified || !row.SourceType.Valid || !row.AuthProfile.Valid || !row.SourceKey.Valid || strings.TrimSpace(row.SourceKey.String) == "" {
+		return zeroCatalogSource(), false
+	}
+	priority := int32(0)
+	if row.Priority.Valid {
+		priority = row.Priority.Int32
+	}
+	return CatalogSource{
+		Registry:             Registry{ID: row.ID, URL: row.Url},
+		SourceType:           row.SourceType.String,
+		AuthProfile:          row.AuthProfile.String,
+		CertificationVersion: row.CertificationVersion.String,
+		Priority:             priority,
+		SourceKey:            row.SourceKey.String,
+		Legacy:               false,
+	}, true
+}
+
+func catalogSourceFromDetailRow(row repo.GetMCPRegistryByIDRow) (CatalogSource, bool) {
+	return catalogSourceFromRow(repo.ListMCPRegistriesRow{
+		ID:                   row.ID,
+		Name:                 "",
+		Url:                  row.Url,
+		SourceType:           row.SourceType,
+		AuthProfile:          row.AuthProfile,
+		Enabled:              row.Enabled,
+		CertificationState:   row.CertificationState,
+		CertificationVersion: row.CertificationVersion,
+		Priority:             row.Priority,
+		SourceKey:            row.SourceKey,
+	})
+}

--- a/server/internal/externalmcp/catalog_test.go
+++ b/server/internal/externalmcp/catalog_test.go
@@ -1,0 +1,61 @@
+package externalmcp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+)
+
+func TestCatalogSourceFromRowAdmitsOnlyCertifiedReviewedSources(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	base := repo.ListMCPRegistriesRow{
+		ID:                 id,
+		Url:                "https://registry.example.test",
+		SourceType:         pgtype.Text{String: registrySourceTypePulseV01, Valid: true},
+		AuthProfile:        pgtype.Text{String: registryAuthProfilePulseServerCredentials, Valid: true},
+		Enabled:            pgtype.Bool{Bool: true, Valid: true},
+		CertificationState: pgtype.Text{String: registryCertificationStateCertified, Valid: true},
+		SourceKey:          pgtype.Text{String: "reviewed-pulse", Valid: true},
+	}
+
+	source, ok := catalogSourceFromRow(base)
+	require.True(t, ok)
+	require.Equal(t, "reviewed-pulse", source.SourceKey)
+	require.False(t, source.Legacy)
+
+	for _, mutate := range []func(*repo.ListMCPRegistriesRow){
+		func(row *repo.ListMCPRegistriesRow) { row.Enabled.Bool = false },
+		func(row *repo.ListMCPRegistriesRow) { row.CertificationState.String = "pending" },
+		func(row *repo.ListMCPRegistriesRow) { row.SourceKey = pgtype.Text{} },
+		func(row *repo.ListMCPRegistriesRow) { row.AuthProfile = pgtype.Text{} },
+	} {
+		row := base
+		mutate(&row)
+		_, ok := catalogSourceFromRow(row)
+		require.False(t, ok)
+	}
+}
+
+func TestCatalogSourceFromRowLimitsLegacyCompatibilityToPulse(t *testing.T) {
+	t.Parallel()
+
+	legacyPulse := repo.ListMCPRegistriesRow{ID: uuid.New(), Url: "https://api.pulsemcp.com/"}
+	source, ok := catalogSourceFromRow(legacyPulse)
+	require.True(t, ok)
+	require.True(t, source.Legacy)
+	require.Equal(t, registrySourceTypePulseV01, source.SourceType)
+
+	for _, rawURL := range []string{
+		"https://registry.example.test",
+		"https://api.pulsemcp.com.evil.test",
+	} {
+		_, ok := catalogSourceFromRow(repo.ListMCPRegistriesRow{ID: uuid.New(), Url: rawURL})
+		require.False(t, ok)
+	}
+}

--- a/server/internal/externalmcp/catalog_test.go
+++ b/server/internal/externalmcp/catalog_test.go
@@ -58,4 +58,27 @@ func TestCatalogSourceFromRowLimitsLegacyCompatibilityToPulse(t *testing.T) {
 		_, ok := catalogSourceFromRow(repo.ListMCPRegistriesRow{ID: uuid.New(), Url: rawURL})
 		require.False(t, ok)
 	}
+
+	for _, mutate := range []func(*repo.ListMCPRegistriesRow){
+		func(row *repo.ListMCPRegistriesRow) {
+			row.SourceType = pgtype.Text{String: registrySourceTypePulseV01, Valid: true}
+		},
+		func(row *repo.ListMCPRegistriesRow) {
+			row.AuthProfile = pgtype.Text{String: registryAuthProfilePulseServerCredentials, Valid: true}
+		},
+		func(row *repo.ListMCPRegistriesRow) { row.Enabled = pgtype.Bool{Bool: false, Valid: true} },
+		func(row *repo.ListMCPRegistriesRow) {
+			row.CertificationState = pgtype.Text{String: "pending", Valid: true}
+		},
+		func(row *repo.ListMCPRegistriesRow) {
+			row.CertificationVersion = pgtype.Text{String: "v1", Valid: true}
+		},
+		func(row *repo.ListMCPRegistriesRow) { row.Priority = pgtype.Int4{Int32: 1, Valid: true} },
+		func(row *repo.ListMCPRegistriesRow) { row.SourceKey = pgtype.Text{String: "partial", Valid: true} },
+	} {
+		row := legacyPulse
+		mutate(&row)
+		_, ok := catalogSourceFromRow(row)
+		require.False(t, ok)
+	}
 }

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -41,13 +41,14 @@ type Service struct {
 	authz          *authz.Engine
 	sessions       *sessions.Manager
 	registryClient *RegistryClient
+	catalog        *CatalogService
 	serverURL      *url.URL
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, registryClient *RegistryClient, authzEngine *authz.Engine, serverURL *url.URL) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, registryClient *RegistryClient, catalog *CatalogService, authzEngine *authz.Engine, serverURL *url.URL) *Service {
 	logger = logger.With(attr.SlogComponent("external_mcp"))
 
 	return &Service{
@@ -59,6 +60,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		authz:          authzEngine,
 		sessions:       sessions,
 		registryClient: registryClient,
+		catalog:        catalog,
 		serverURL:      serverURL,
 	}
 }
@@ -159,77 +161,34 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 		return nil, fmt.Errorf("require build read: %w", err)
 	}
 
-	// If a specific registry is requested, fetch just that one
+	var registryID *uuid.UUID
 	if payload.RegistryID != nil {
-		registryID, err := uuid.Parse(*payload.RegistryID)
+		parsed, err := uuid.Parse(*payload.RegistryID)
 		if err != nil {
 			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 		}
-
-		registry, err := s.repo.GetMCPRegistryByID(ctx, registryID)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.C(oops.CodeNotFound)
-			}
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get registry").LogError(ctx, s.logger)
-		}
-
-		result, err := s.registryClient.ListServers(ctx, Registry{
-			ID:  registry.ID,
-			URL: registry.Url,
-		}, ListServersParams{
-			Search: payload.Search,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch servers from registry").LogError(ctx, s.logger)
-		}
-
-		return &gen.ListCatalogResult{
-			Servers:    result.Servers,
-			NextCursor: nil,
-		}, nil
+		registryID = &parsed
 	}
-
-	// Fetch all registries from the database
-	registries, err := s.repo.ListMCPRegistries(ctx)
+	if s.catalog == nil {
+		return nil, oops.E(oops.CodeUnexpected, nil, "catalogue service is not configured").LogError(ctx, s.logger)
+	}
+	servers, err := s.catalog.List(ctx, payload.Search, registryID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list registries").LogError(ctx, s.logger)
-	}
-
-	// Aggregate servers from all registries
-	var allServers []*types.ExternalMCPServerEntry
-	for _, registry := range registries {
-		result, err := s.registryClient.ListServers(ctx, Registry{
-			ID:  registry.ID,
-			URL: registry.Url,
-		}, ListServersParams{
-			Search: payload.Search,
-		})
-		if err != nil {
-			s.logger.WarnContext(ctx, "failed to fetch servers from registry",
-				attr.SlogMCPRegistryID(registry.ID.String()),
-				attr.SlogMCPRegistryURL(registry.Url),
-				attr.SlogError(err),
-			)
-			continue
+		if errors.Is(err, ErrCatalogSourceNotFound) || errors.Is(err, ErrCatalogSourceDisabled) {
+			return nil, oops.C(oops.CodeNotFound)
 		}
-		allServers = append(allServers, result.Servers...)
+		return nil, oops.E(oops.CodeUnexpected, err, "list reviewed catalogue").LogError(ctx, s.logger)
 	}
 
-	// Cap at 100 servers for v0. Multi-registry pagination is tracked in
-	// AGE-2153; until then anything past the cap is silently dropped, so warn.
-	if len(allServers) > 100 {
+	// Preserve the existing public cap until cursor pagination is upgraded.
+	if len(servers) > 100 {
 		s.logger.WarnContext(ctx, "catalog result truncated to cap",
-			attr.SlogStatsMCPServerCount(len(allServers)),
+			attr.SlogStatsMCPServerCount(len(servers)),
 			attr.SlogPaginationLimit(100),
 		)
-		allServers = allServers[:100]
+		servers = servers[:100]
 	}
-
-	return &gen.ListCatalogResult{
-		Servers:    allServers,
-		NextCursor: nil,
-	}, nil
+	return &gen.ListCatalogResult{Servers: servers, NextCursor: nil}, nil
 }
 
 func (s *Service) GetServerDetails(ctx context.Context, payload *gen.GetServerDetailsPayload) (*types.ExternalMCPServer, error) {
@@ -247,16 +206,39 @@ func (s *Service) GetServerDetails(ctx context.Context, payload *gen.GetServerDe
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 	}
 
-	registry, err := s.repo.GetMCPRegistryByID(ctx, registryID)
+	if s.catalog == nil {
+		return nil, oops.E(oops.CodeUnexpected, nil, "catalogue service is not configured").LogError(ctx, s.logger)
+	}
+	// Authorize the source through the same reviewed admission boundary as
+	// listCatalog, while retaining the dashboard's existing full-detail shape.
+	source, err := s.catalog.Source(ctx, registryID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, ErrCatalogSourceNotFound) || errors.Is(err, ErrCatalogSourceDisabled) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get registry").LogError(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve reviewed catalogue source").LogError(ctx, s.logger)
+	}
+	reader, err := s.catalog.ReaderFor(source)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve catalogue source adapter").LogError(ctx, s.logger)
 	}
 
-	// Fetch all server details in a single HTTP call
-	details, err := s.fetchServerDetails(ctx, registry, payload.ServerSpecifier)
+	var details *serverDetailsResult
+	if _, ok := reader.(*RegistryClient); ok {
+		// Preserve the dashboard's existing Pulse detail projection, which includes
+		// every remote and the Pulse-specific per-remote tool metadata.
+		details, err = s.fetchServerDetails(ctx, source.Registry, payload.ServerSpecifier)
+	} else {
+		// Source-specific adapters normalize their selected detail result through
+		// the shared catalogue boundary, keeping reader selection aligned with
+		// source admission as new certified sources are enabled.
+		registryDetails, detailErr := s.catalog.Details(ctx, registryID, payload.ServerSpecifier, nil)
+		if detailErr != nil {
+			err = detailErr
+		} else {
+			details = serverDetailsResultFromRegistryDetails(registryDetails)
+		}
+	}
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch server details from registry").LogError(ctx, s.logger)
 	}
@@ -312,9 +294,47 @@ type serverDetailsResult struct {
 	Remotes     []*types.ExternalMCPRemote
 }
 
+func serverDetailsResultFromRegistryDetails(details *ServerDetails) *serverDetailsResult {
+	if details == nil {
+		return nil
+	}
+
+	var tools []*types.ExternalMCPTool
+	if details.Tools != nil {
+		tools = make([]*types.ExternalMCPTool, 0, len(details.Tools))
+		for i := range details.Tools {
+			tool := &details.Tools[i]
+			tools = append(tools, &types.ExternalMCPTool{
+				Name:        &tool.Name,
+				Description: &tool.Description,
+				InputSchema: tool.InputSchema,
+				Annotations: tool.Annotations,
+			})
+		}
+	}
+
+	var remotes []*types.ExternalMCPRemote
+	if details.RemoteURL != "" {
+		remotes = []*types.ExternalMCPRemote{{
+			URL:           details.RemoteURL,
+			TransportType: string(details.TransportType),
+			Headers:       toExternalMCPRemoteHeaders(details.Headers),
+			Variables:     toExternalMCPRemoteVariables(details.Variables),
+		}}
+	}
+
+	return &serverDetailsResult{
+		Name:        details.Name,
+		Description: details.Description,
+		Version:     details.Version,
+		Tools:       tools,
+		Remotes:     remotes,
+	}
+}
+
 // fetchServerDetails fetches all server details from the registry in a single HTTP call.
-func (s *Service) fetchServerDetails(ctx context.Context, registry repo.GetMCPRegistryByIDRow, serverName string) (*serverDetailsResult, error) {
-	reqURL := fmt.Sprintf("%s/v0.1/servers/%s/versions/latest", registry.Url, url.PathEscape(serverName))
+func (s *Service) fetchServerDetails(ctx context.Context, registry Registry, serverName string) (*serverDetailsResult, error) {
+	reqURL := fmt.Sprintf("%s/v0.1/servers/%s/versions/latest", registry.URL, url.PathEscape(serverName))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -334,9 +334,13 @@ func serverDetailsResultFromRegistryDetails(details *ServerDetails) *serverDetai
 
 // fetchServerDetails fetches all server details from the registry in a single HTTP call.
 func (s *Service) fetchServerDetails(ctx context.Context, registry Registry, serverName string) (*serverDetailsResult, error) {
-	reqURL := fmt.Sprintf("%s/v0.1/servers/%s/versions/latest", registry.URL, url.PathEscape(serverName))
+	registryURL, err := reviewedRegistryDetailsURL(registry.URL)
+	if err != nil {
+		return nil, err
+	}
+	requestURL := registryURL.JoinPath("v0.1", "servers", url.PathEscape(serverName), "versions", "latest")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}

--- a/server/internal/externalmcp/official.go
+++ b/server/internal/externalmcp/official.go
@@ -1,0 +1,249 @@
+package externalmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	externalmcptypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+)
+
+const (
+	officialRegistryListPageSize = 50
+	officialRegistryMaxPages     = 10
+)
+
+// OfficialRegistryAdapter implements the public read-only v0.1 Official MCP
+// Registry contract. It is deliberately not composed into production until its
+// source profile is certified and enabled by a later rollout.
+type OfficialRegistryAdapter struct {
+	httpClient *guardian.HTTPClient
+	logger     *slog.Logger
+}
+
+var _ RegistryReader = (*OfficialRegistryAdapter)(nil)
+
+func NewOfficialRegistryAdapter(logger *slog.Logger, policy *guardian.Policy) *OfficialRegistryAdapter {
+	return &OfficialRegistryAdapter{
+		httpClient: policy.PooledClient(guardian.WithDefaultRetryConfig()),
+		logger:     logger,
+	}
+}
+
+type officialListResponse struct {
+	Servers  []officialServerEntry `json:"servers"`
+	Metadata struct {
+		NextCursor *string `json:"nextCursor"`
+	} `json:"metadata"`
+}
+
+type officialServerEntry struct {
+	Server serverJSON `json:"server"`
+	Meta   struct {
+		Official struct {
+			Status string `json:"status"`
+		} `json:"io.modelcontextprotocol.registry/official"`
+	} `json:"_meta"`
+}
+
+func (a *OfficialRegistryAdapter) ListServers(ctx context.Context, registry Registry, params ListServersParams) (ListServersResult, error) {
+	if a == nil || a.httpClient == nil {
+		return ListServersResult{}, fmt.Errorf("official registry adapter is not configured")
+	}
+	base, err := url.Parse(registry.URL)
+	if err != nil {
+		return ListServersResult{}, fmt.Errorf("parse official registry URL: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	servers := make([]*types.ExternalMCPServerEntry, 0, officialRegistryListPageSize)
+	cursor := ""
+	for range officialRegistryMaxPages {
+		requestURL := base.JoinPath("v0.1", "servers")
+		query := requestURL.Query()
+		query.Set("version", "latest")
+		query.Set("limit", fmt.Sprintf("%d", officialRegistryListPageSize))
+		if params.Search != nil && *params.Search != "" {
+			query.Set("search", *params.Search)
+		}
+		if cursor != "" {
+			query.Set("cursor", cursor)
+		}
+		requestURL.RawQuery = query.Encode()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), http.NoBody)
+		if err != nil {
+			return ListServersResult{}, fmt.Errorf("create official registry list request: %w", err)
+		}
+		resp, err := a.httpClient.Do(req)
+		if err != nil {
+			return ListServersResult{}, fmt.Errorf("fetch official registry list: %w", err)
+		}
+		body, readErr := readBoundedBody(resp.Body)
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			a.logger.WarnContext(ctx, "close official registry list response", attr.SlogError(closeErr))
+		}
+		if readErr != nil {
+			return ListServersResult{}, fmt.Errorf("read official registry list: %w", readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return ListServersResult{}, fmt.Errorf("official registry returned status %d", resp.StatusCode)
+		}
+		var page officialListResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return ListServersResult{}, fmt.Errorf("decode official registry list: %w", err)
+		}
+		for _, entry := range page.Servers {
+			if entry.Meta.Official.Status == "deleted" || entry.Server.Name == "" {
+				continue
+			}
+			if _, exists := seen[entry.Server.Name]; exists {
+				continue
+			}
+			seen[entry.Server.Name] = struct{}{}
+			servers = append(servers, officialEntry(registry.ID, entry.Server))
+		}
+		if page.Metadata.NextCursor == nil || *page.Metadata.NextCursor == "" {
+			cursor = ""
+			break
+		}
+		cursor = *page.Metadata.NextCursor
+	}
+	if cursor != "" {
+		return ListServersResult{}, fmt.Errorf("official registry exceeded %d-page catalogue bound", officialRegistryMaxPages)
+	}
+	sort.Slice(servers, func(i, j int) bool { return servers[i].RegistrySpecifier < servers[j].RegistrySpecifier })
+	return ListServersResult{Servers: servers}, nil
+}
+
+func officialEntry(registryID uuid.UUID, server serverJSON) *types.ExternalMCPServerEntry {
+	registryIDString := registryID.String()
+	remotes := make([]*types.ExternalMCPRemote, 0, len(server.Remotes))
+	for _, remote := range server.Remotes {
+		remotes = append(remotes, &types.ExternalMCPRemote{
+			URL:           remote.URL,
+			TransportType: remote.Type,
+			Headers:       toExternalMCPRemoteHeaders(remote.Headers),
+			Variables:     toExternalMCPRemoteVariables(remote.Variables),
+		})
+	}
+	return &types.ExternalMCPServerEntry{
+		Repository:                          toExternalMCPRepository(server.Repository),
+		Packages:                            toExternalMCPPackages(server.Packages),
+		RegistrySpecifier:                   server.Name,
+		Version:                             server.Version,
+		Description:                         server.Description,
+		ToolsetID:                           nil,
+		McpServerID:                         nil,
+		RegistryID:                          &registryIDString,
+		OrganizationMcpCollectionRegistryID: nil,
+		Title:                               server.Title,
+		IconURL:                             officialIconURL(server),
+		Meta:                                nil,
+		ToolCount:                           0,
+		IsReadOnly:                          false,
+		SupportsDcr:                         false,
+		Remotes:                             remotes,
+	}
+}
+
+func officialIconURL(server serverJSON) *string {
+	if len(server.Icons) == 0 || server.Icons[0].Src == "" {
+		return nil
+	}
+	return &server.Icons[0].Src
+}
+
+func (a *OfficialRegistryAdapter) GetServerDetails(ctx context.Context, registry Registry, serverName string, allowedRemoteURLs []string) (*ServerDetails, error) {
+	if a == nil || a.httpClient == nil {
+		return nil, fmt.Errorf("official registry adapter is not configured")
+	}
+	base, err := url.Parse(registry.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parse official registry URL: %w", err)
+	}
+	requestURL := base.JoinPath("v0.1", "servers", url.PathEscape(serverName), "versions", "latest")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create official registry detail request: %w", err)
+	}
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch official registry detail: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("official registry returned status %d", resp.StatusCode)
+	}
+	body, err := readBoundedBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read official registry detail: %w", err)
+	}
+	var detail struct {
+		Server serverJSON `json:"server"`
+	}
+	if err := json.Unmarshal(body, &detail); err != nil {
+		return nil, fmt.Errorf("decode official registry detail: %w", err)
+	}
+	remote, ok := selectOfficialRemote(detail.Server.Remotes, allowedRemoteURLs)
+	if !ok {
+		return &ServerDetails{
+			Name:          detail.Server.Name,
+			Description:   detail.Server.Description,
+			Version:       detail.Server.Version,
+			RemoteURL:     "",
+			TransportType: "",
+			Tools:         nil,
+			Headers:       nil,
+			Variables:     nil,
+		}, nil
+	}
+	return &ServerDetails{
+		Name:          detail.Server.Name,
+		Description:   detail.Server.Description,
+		Version:       detail.Server.Version,
+		RemoteURL:     remote.URL,
+		TransportType: externalmcptypes.TransportType(remote.Type),
+		Tools:         nil,
+		Headers:       remote.Headers,
+		Variables:     remote.Variables,
+	}, nil
+}
+
+func selectOfficialRemote(remotes []serverRemoteJSON, allowed []string) (serverRemoteJSON, bool) {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, rawURL := range allowed {
+		allowedSet[rawURL] = struct{}{}
+	}
+	var fallback *serverRemoteJSON
+	for i := range remotes {
+		remote := &remotes[i]
+		if len(allowedSet) > 0 {
+			if _, ok := allowedSet[remote.URL]; !ok {
+				continue
+			}
+		}
+		if strings.EqualFold(remote.Type, string(externalmcptypes.TransportTypeStreamableHTTP)) {
+			return *remote, true
+		}
+		if fallback == nil && strings.EqualFold(remote.Type, string(externalmcptypes.TransportTypeSSE)) {
+			fallback = remote
+		}
+	}
+	if fallback == nil {
+		return serverRemoteJSON{URL: "", Type: "", Headers: nil, Variables: nil}, false
+	}
+	return *fallback, true
+}

--- a/server/internal/externalmcp/official.go
+++ b/server/internal/externalmcp/official.go
@@ -170,9 +170,9 @@ func (a *OfficialRegistryAdapter) GetServerDetails(ctx context.Context, registry
 	if a == nil || a.httpClient == nil {
 		return nil, fmt.Errorf("official registry adapter is not configured")
 	}
-	base, err := url.Parse(registry.URL)
+	base, err := reviewedRegistryDetailsURL(registry.URL)
 	if err != nil {
-		return nil, fmt.Errorf("parse official registry URL: %w", err)
+		return nil, err
 	}
 	requestURL := base.JoinPath("v0.1", "servers", url.PathEscape(serverName), "versions", "latest")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), http.NoBody)

--- a/server/internal/externalmcp/official_test.go
+++ b/server/internal/externalmcp/official_test.go
@@ -1,0 +1,127 @@
+package externalmcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	externalmcptypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func newOfficialRegistryAdapter(t *testing.T) *OfficialRegistryAdapter {
+	t.Helper()
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+	return NewOfficialRegistryAdapter(testenv.NewLogger(t), policy)
+}
+
+func TestOfficialRegistryAdapterListServersPaginatesAndFiltersDeleted(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.1/servers" || r.URL.Query().Get("version") != "latest" || r.URL.Query().Get("limit") != "50" || r.URL.Query().Get("search") != "github" {
+			http.Error(w, "unexpected list request", http.StatusBadRequest)
+			return
+		}
+		requests = append(requests, r.URL.Query().Get("cursor"))
+
+		page := officialListResponse{}
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			page.Servers = []officialServerEntry{
+				officialTestEntry("alpha", "active"),
+				officialTestEntry("removed", "deleted"),
+			}
+			next := "second-page"
+			page.Metadata.NextCursor = &next
+		case "second-page":
+			page.Servers = []officialServerEntry{
+				officialTestEntry("alpha", "active"),
+				officialTestEntry("beta", "active"),
+			}
+		default:
+			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(page); err != nil {
+			t.Errorf("encode official registry list response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	search := "github"
+	result, err := newOfficialRegistryAdapter(t).ListServers(t.Context(), Registry{ID: uuid.New(), URL: server.URL}, ListServersParams{Search: &search})
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "beta"}, registrySpecifiers(result.Servers))
+	require.Equal(t, []string{"", "second-page"}, requests)
+}
+
+func TestOfficialRegistryAdapterListServersBoundsPagination(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		page := officialListResponse{Servers: []officialServerEntry{officialTestEntry("server-"+strconv.Itoa(requests), "active")}}
+		next := "next-" + strconv.Itoa(requests)
+		page.Metadata.NextCursor = &next
+		if err := json.NewEncoder(w).Encode(page); err != nil {
+			t.Errorf("encode bounded official registry list response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := newOfficialRegistryAdapter(t).ListServers(t.Context(), Registry{ID: uuid.New(), URL: server.URL}, ListServersParams{})
+	require.ErrorContains(t, err, "exceeded 10-page catalogue bound")
+	require.Equal(t, officialRegistryMaxPages, requests)
+}
+
+func TestOfficialRegistryAdapterGetServerDetailsPrefersAllowedStreamableHTTP(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.1/servers/example/versions/latest" {
+			http.Error(w, "unexpected detail request", http.StatusBadRequest)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(struct {
+			Server serverJSON `json:"server"`
+		}{Server: serverJSON{
+			Name:        "example",
+			Description: "Example",
+			Version:     "1.0.0",
+			Remotes: []serverRemoteJSON{
+				{URL: "https://example.test/events", Type: "sse"},
+				{URL: "https://example.test/mcp", Type: "streamable-http"},
+			},
+		}}); err != nil {
+			t.Errorf("encode official registry detail response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	details, err := newOfficialRegistryAdapter(t).GetServerDetails(
+		context.Background(),
+		Registry{ID: uuid.New(), URL: server.URL},
+		"example",
+		[]string{"https://example.test/events", "https://example.test/mcp"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.test/mcp", details.RemoteURL)
+	require.Equal(t, externalmcptypes.TransportTypeStreamableHTTP, details.TransportType)
+}
+
+func officialTestEntry(name, status string) officialServerEntry {
+	entry := officialServerEntry{Server: serverJSON{Name: name, Version: "1.0.0"}}
+	entry.Meta.Official.Status = status
+	return entry
+}

--- a/server/internal/externalmcp/official_test.go
+++ b/server/internal/externalmcp/official_test.go
@@ -88,7 +88,7 @@ func TestOfficialRegistryAdapterListServersBoundsPagination(t *testing.T) {
 func TestOfficialRegistryAdapterGetServerDetailsPrefersAllowedStreamableHTTP(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v0.1/servers/example/versions/latest" {
 			http.Error(w, "unexpected detail request", http.StatusBadRequest)
 			return
@@ -109,9 +109,11 @@ func TestOfficialRegistryAdapterGetServerDetailsPrefersAllowedStreamableHTTP(t *
 	}))
 	t.Cleanup(server.Close)
 
-	details, err := newOfficialRegistryAdapter(t).GetServerDetails(
+	adapter := newOfficialRegistryAdapter(t)
+	adapter.httpClient = server.Client()
+	details, err := adapter.GetServerDetails(
 		context.Background(),
-		Registry{ID: uuid.New(), URL: server.URL},
+		Registry{ID: uuid.New(), URL: server.URL + "/"},
 		"example",
 		[]string{"https://example.test/events", "https://example.test/mcp"},
 	)

--- a/server/internal/externalmcp/queries.sql
+++ b/server/internal/externalmcp/queries.sql
@@ -1,11 +1,35 @@
 -- name: ListMCPRegistries :many
-SELECT id, name, url, created_at, updated_at
+SELECT
+  id,
+  name,
+  url,
+  source_type,
+  auth_profile,
+  enabled,
+  certification_state,
+  certification_version,
+  priority,
+  source_key,
+  created_at,
+  updated_at
 FROM mcp_registries
 WHERE deleted IS FALSE
 ORDER BY name ASC;
 
 -- name: GetMCPRegistryByID :one
-SELECT id, name, url, created_at, updated_at
+SELECT
+  id,
+  name,
+  url,
+  source_type,
+  auth_profile,
+  enabled,
+  certification_state,
+  certification_version,
+  priority,
+  source_key,
+  created_at,
+  updated_at
 FROM mcp_registries
 WHERE id = @id AND deleted IS FALSE;
 

--- a/server/internal/externalmcp/registryclient.go
+++ b/server/internal/externalmcp/registryclient.go
@@ -707,6 +707,20 @@ func (c *RegistryClient) ClearCache(ctx context.Context, registryURL string) err
 	return nil
 }
 
+// reviewedRegistryDetailsURL validates the operator-owned source before a
+// detail fetch. Unlike local development fixtures, reviewed catalogue sources
+// are production trust inputs and must never be fetched over plaintext HTTP.
+func reviewedRegistryDetailsURL(rawURL string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, fmt.Errorf("parse reviewed registry URL: %w", err)
+	}
+	if parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil || parsed.Fragment != "" {
+		return nil, fmt.Errorf("reviewed registry URL must be an absolute HTTPS URL without userinfo or fragment")
+	}
+	return parsed, nil
+}
+
 // ServerDetails contains detailed information about an MCP server including connection info.
 // Headers and variables are copied from the selected server-owned remote. Callers
 // must still validate configuration values against these declarations; they must
@@ -725,9 +739,9 @@ type ServerDetails struct {
 // GetServerDetails fetches server details including the remote URL from the registry.
 // If allowedRemoteURLs is provided and non-empty, only remotes with matching URLs are considered.
 func (c *RegistryClient) GetServerDetails(ctx context.Context, registry Registry, serverName string, allowedRemoteURLs []string) (*ServerDetails, error) {
-	u, err := url.Parse(registry.URL)
+	u, err := reviewedRegistryDetailsURL(registry.URL)
 	if err != nil {
-		return nil, oops.Permanent(fmt.Errorf("parse external mcp registry url: %w", err))
+		return nil, oops.Permanent(err)
 	}
 	u = u.JoinPath("v0.1", "servers", url.PathEscape(serverName), "versions", "latest")
 

--- a/server/internal/externalmcp/registryclient.go
+++ b/server/internal/externalmcp/registryclient.go
@@ -30,6 +30,15 @@ type RegistryBackend interface {
 	Authorize(req *http.Request) error
 }
 
+// RegistryReader is the narrow, normalized registry contract consumed by both
+// dashboard and Platform MCP catalogue projections. RegistryClient remains the
+// Pulse-compatible transport implementation; CatalogService selects an adapter
+// before delegating to it.
+type RegistryReader interface {
+	ListServers(ctx context.Context, registry Registry, params ListServersParams) (ListServersResult, error)
+	GetServerDetails(ctx context.Context, registry Registry, serverName string, allowedRemoteURLs []string) (*ServerDetails, error)
+}
+
 // RegistryClient handles communication with external MCP registries.
 type RegistryClient struct {
 	policy       *guardian.Policy

--- a/server/internal/externalmcp/registryclient_test.go
+++ b/server/internal/externalmcp/registryclient_test.go
@@ -546,7 +546,7 @@ func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Contains(t, r.URL.Path, "/v0.1/servers/test-server/versions/latest")
 
@@ -572,7 +572,7 @@ func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
-		URL: server.URL,
+		URL: server.URL + "/",
 	}
 
 	details, err := client.GetServerDetails(ctx, registry, "test-server", []string{})
@@ -594,7 +594,7 @@ func TestGetServerDetails_OnlySSE(t *testing.T) {
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Contains(t, r.URL.Path, "/v0.1/servers/test-server/versions/latest")
 
@@ -642,7 +642,7 @@ func TestGetServerDetails_PrefersStreamableHTTPOverSSE(t *testing.T) {
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Contains(t, r.URL.Path, "/v0.1/servers/test-server/versions/latest")
 
@@ -691,7 +691,7 @@ func TestGetServerDetails_SelectedRemotesFiltersToSSE(t *testing.T) {
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Contains(t, r.URL.Path, "/v0.1/servers/test-server/versions/latest")
 
@@ -742,7 +742,7 @@ func TestGetServerDetails_SelectedRemotesStillPrefersStreamableHTTP(t *testing.T
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Contains(t, r.URL.Path, "/v0.1/servers/test-server/versions/latest")
 
@@ -783,6 +783,24 @@ func TestGetServerDetails_SelectedRemotesStillPrefersStreamableHTTP(t *testing.T
 	// Should prefer streamable-http when both are allowed
 	require.Equal(t, "https://example.com/streamable", details.RemoteURL)
 	require.Equal(t, types.TransportTypeStreamableHTTP, details.TransportType)
+}
+
+func TestReviewedRegistryDetailsURLRequiresHTTPS(t *testing.T) {
+	t.Parallel()
+
+	for _, rawURL := range []string{
+		"http://registry.example.test",
+		"https://user:password@registry.example.test",
+		"https://registry.example.test#fragment",
+		"registry.example.test",
+	} {
+		_, err := reviewedRegistryDetailsURL(rawURL)
+		require.Error(t, err, rawURL)
+	}
+
+	parsed, err := reviewedRegistryDetailsURL("https://registry.example.test/base/")
+	require.NoError(t, err)
+	require.Equal(t, "https://registry.example.test/base/", parsed.String())
 }
 
 func activeServerEntry(name string) serverEntry {

--- a/server/internal/externalmcp/repo/queries.sql.go
+++ b/server/internal/externalmcp/repo/queries.sql.go
@@ -608,17 +608,36 @@ func (q *Queries) GetExternalMCPToolsRequiringOAuth(ctx context.Context, deploym
 }
 
 const getMCPRegistryByID = `-- name: GetMCPRegistryByID :one
-SELECT id, name, url, created_at, updated_at
+SELECT
+  id,
+  name,
+  url,
+  source_type,
+  auth_profile,
+  enabled,
+  certification_state,
+  certification_version,
+  priority,
+  source_key,
+  created_at,
+  updated_at
 FROM mcp_registries
 WHERE id = $1 AND deleted IS FALSE
 `
 
 type GetMCPRegistryByIDRow struct {
-	ID        uuid.UUID
-	Name      string
-	Url       string
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
+	ID                   uuid.UUID
+	Name                 string
+	Url                  string
+	SourceType           pgtype.Text
+	AuthProfile          pgtype.Text
+	Enabled              pgtype.Bool
+	CertificationState   pgtype.Text
+	CertificationVersion pgtype.Text
+	Priority             pgtype.Int4
+	SourceKey            pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 func (q *Queries) GetMCPRegistryByID(ctx context.Context, id uuid.UUID) (GetMCPRegistryByIDRow, error) {
@@ -628,6 +647,13 @@ func (q *Queries) GetMCPRegistryByID(ctx context.Context, id uuid.UUID) (GetMCPR
 		&i.ID,
 		&i.Name,
 		&i.Url,
+		&i.SourceType,
+		&i.AuthProfile,
+		&i.Enabled,
+		&i.CertificationState,
+		&i.CertificationVersion,
+		&i.Priority,
+		&i.SourceKey,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -943,18 +969,37 @@ func (q *Queries) ListExternalMCPToolDefinitions(ctx context.Context, deployment
 }
 
 const listMCPRegistries = `-- name: ListMCPRegistries :many
-SELECT id, name, url, created_at, updated_at
+SELECT
+  id,
+  name,
+  url,
+  source_type,
+  auth_profile,
+  enabled,
+  certification_state,
+  certification_version,
+  priority,
+  source_key,
+  created_at,
+  updated_at
 FROM mcp_registries
 WHERE deleted IS FALSE
 ORDER BY name ASC
 `
 
 type ListMCPRegistriesRow struct {
-	ID        uuid.UUID
-	Name      string
-	Url       string
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
+	ID                   uuid.UUID
+	Name                 string
+	Url                  string
+	SourceType           pgtype.Text
+	AuthProfile          pgtype.Text
+	Enabled              pgtype.Bool
+	CertificationState   pgtype.Text
+	CertificationVersion pgtype.Text
+	Priority             pgtype.Int4
+	SourceKey            pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 func (q *Queries) ListMCPRegistries(ctx context.Context) ([]ListMCPRegistriesRow, error) {
@@ -970,6 +1015,13 @@ func (q *Queries) ListMCPRegistries(ctx context.Context) ([]ListMCPRegistriesRow
 			&i.ID,
 			&i.Name,
 			&i.Url,
+			&i.SourceType,
+			&i.AuthProfile,
+			&i.Enabled,
+			&i.CertificationState,
+			&i.CertificationVersion,
+			&i.Priority,
+			&i.SourceKey,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {

--- a/server/internal/externalmcp/setup_test.go
+++ b/server/internal/externalmcp/setup_test.go
@@ -79,7 +79,8 @@ func newTestExternalMCPService(t *testing.T) (context.Context, *testInstance) {
 	serverURL, err := url.Parse(testServerURL)
 	require.NoError(t, err)
 
-	svc := externalmcp.NewService(logger, tracerProvider, conn, sessionManager, mcpRegistryClient, authzEngine, serverURL)
+	catalog := externalmcp.NewCatalogService(conn, mcpRegistryClient, nil)
+	svc := externalmcp.NewService(logger, tracerProvider, conn, sessionManager, mcpRegistryClient, catalog, authzEngine, serverURL)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/platformmcp/catalog.go
+++ b/server/internal/platformmcp/catalog.go
@@ -82,13 +82,13 @@ type RegistryCatalogSource struct {
 	// development-CA-aware client; normal browser-catalogue registries share the
 	// standard client. It is never chosen from Platform MCP input. Every source is
 	// strict: search fails closed rather than presenting a partial reviewed catalog.
-	Client      *externalmcp.RegistryClient
+	Client      externalmcp.RegistryReader
 	Descriptors []CatalogDescriptor
 }
 
 type registryCatalogDescriptor struct {
 	CatalogDescriptor
-	client *externalmcp.RegistryClient
+	client externalmcp.RegistryReader
 }
 
 type RegistryCatalog struct {

--- a/server/internal/platformmcp/repo/models.go
+++ b/server/internal/platformmcp/repo/models.go
@@ -73,6 +73,7 @@ type PlatformMcpDistribution struct {
 	ProjectID            uuid.UUID
 	RegistrationID       uuid.UUID
 	DefaultPluginID      uuid.UUID
+	PluginID             uuid.NullUUID
 	PluginServerID       uuid.NullUUID
 	State                string
 	Version              int64

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -656,7 +656,7 @@ WHERE EXISTS (
       AND project.organization_id = $1
       AND project.deleted IS FALSE
 )
-RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
 `
 
 type CreatePlatformMCPDistributionParams struct {
@@ -692,6 +692,7 @@ func (q *Queries) CreatePlatformMCPDistribution(ctx context.Context, arg CreateP
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,
@@ -2133,7 +2134,7 @@ func (q *Queries) GetPlatformMCPConnectionForUpdate(ctx context.Context, arg Get
 }
 
 const getPlatformMCPDistribution = `-- name: GetPlatformMCPDistribution :one
-SELECT distribution.id, distribution.organization_id, distribution.project_id, distribution.registration_id, distribution.default_plugin_id, distribution.plugin_server_id, distribution.state, distribution.version, distribution.attachment_was_created, distribution.publication_state, distribution.publication_updated_at, distribution.connection_id, distribution.connection_generation, distribution.user_id, distribution.acting_surface, distribution.created_at, distribution.updated_at
+SELECT distribution.id, distribution.organization_id, distribution.project_id, distribution.registration_id, distribution.default_plugin_id, distribution.plugin_id, distribution.plugin_server_id, distribution.state, distribution.version, distribution.attachment_was_created, distribution.publication_state, distribution.publication_updated_at, distribution.connection_id, distribution.connection_generation, distribution.user_id, distribution.acting_surface, distribution.created_at, distribution.updated_at
 FROM platform_mcp_distributions AS distribution
 JOIN projects AS project
   ON project.id = distribution.project_id
@@ -2166,6 +2167,7 @@ func (q *Queries) GetPlatformMCPDistribution(ctx context.Context, arg GetPlatfor
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,
@@ -4875,7 +4877,7 @@ WHERE platform_mcp_distributions.id = $7
         AND project.organization_id = platform_mcp_distributions.organization_id
         AND project.deleted IS FALSE
   )
-RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
 `
 
 type UpdatePlatformMCPDistributionParams struct {
@@ -4913,6 +4915,7 @@ func (q *Queries) UpdatePlatformMCPDistribution(ctx context.Context, arg UpdateP
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,
@@ -4963,7 +4966,7 @@ WHERE platform_mcp_distributions.id = $2
         AND project.organization_id = platform_mcp_distributions.organization_id
         AND project.deleted IS FALSE
   )
-RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, default_plugin_id, plugin_id, plugin_server_id, state, version, attachment_was_created, publication_state, publication_updated_at, connection_id, connection_generation, user_id, acting_surface, created_at, updated_at
 `
 
 type UpdatePlatformMCPDistributionPublicationParams struct {
@@ -4993,6 +4996,7 @@ func (q *Queries) UpdatePlatformMCPDistributionPublication(ctx context.Context, 
 		&i.ProjectID,
 		&i.RegistrationID,
 		&i.DefaultPluginID,
+		&i.PluginID,
 		&i.PluginServerID,
 		&i.State,
 		&i.Version,

--- a/server/migrations/20260820053103_platform-mcp-d1-lifecycle-registry-prerequisite.sql
+++ b/server/migrations/20260820053103_platform-mcp-d1-lifecycle-registry-prerequisite.sql
@@ -1,0 +1,22 @@
+-- atlas:txmode none
+
+-- Modify "mcp_registries" table
+ALTER TABLE "mcp_registries" ADD COLUMN "source_type" text NULL, ADD COLUMN "auth_profile" text NULL, ADD COLUMN "enabled" boolean NULL, ADD COLUMN "certification_state" text NULL, ADD COLUMN "certification_version" text NULL, ADD COLUMN "priority" integer NULL, ADD COLUMN "source_key" text NULL;
+-- Create index "mcp_registries_source_key_key" to table: "mcp_registries"
+CREATE UNIQUE INDEX CONCURRENTLY "mcp_registries_source_key_key" ON "mcp_registries" ("source_key") WHERE ((source_key IS NOT NULL) AND (deleted IS FALSE));
+-- Modify "platform_mcp_readiness" table
+ALTER TABLE "platform_mcp_readiness" ADD CONSTRAINT "platform_mcp_readiness_connectionless_actor_check" CHECK ((connection_id IS NOT NULL) OR ((user_id IS NOT NULL) AND (acting_surface IS NOT NULL)));
+-- Create index "platform_mcp_readiness_assistant_binding_key" to table: "platform_mcp_readiness"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_readiness_assistant_binding_key" ON "platform_mcp_readiness" ("registration_id", "user_id", "acting_surface", "provider_authorization_fingerprint") WHERE (connection_id IS NULL);
+-- Create index "platform_mcp_readiness_external_binding_key" to table: "platform_mcp_readiness"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_readiness_external_binding_key" ON "platform_mcp_readiness" ("registration_id", "connection_id", "connection_generation", "provider_authorization_fingerprint") WHERE (connection_id IS NOT NULL);
+-- Create index "platform_mcp_readiness_organization_actor_idx" to table: "platform_mcp_readiness"
+CREATE INDEX CONCURRENTLY "platform_mcp_readiness_organization_actor_idx" ON "platform_mcp_readiness" ("organization_id", "user_id", "acting_surface") WHERE (connection_id IS NULL);
+-- Modify "platform_mcp_distributions" table
+ALTER TABLE "platform_mcp_distributions" ADD CONSTRAINT "platform_mcp_distributions_connectionless_actor_check" CHECK ((connection_id IS NOT NULL) OR ((user_id IS NOT NULL) AND (acting_surface IS NOT NULL))), ADD COLUMN "plugin_id" uuid NULL, ADD CONSTRAINT "platform_mcp_distributions_project_plugin_fkey" FOREIGN KEY ("project_id", "plugin_id") REFERENCES "plugins" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Create index "platform_mcp_distributions_organization_actor_idx" to table: "platform_mcp_distributions"
+CREATE INDEX CONCURRENTLY "platform_mcp_distributions_organization_actor_idx" ON "platform_mcp_distributions" ("organization_id", "user_id", "acting_surface") WHERE (connection_id IS NULL);
+-- Create index "platform_mcp_distributions_plugin_identity_key" to table: "platform_mcp_distributions"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_distributions_plugin_identity_key" ON "platform_mcp_distributions" ("organization_id", "project_id", "registration_id", "plugin_id") WHERE (plugin_id IS NOT NULL);
+-- Create index "platform_mcp_distributions_project_plugin_idx" to table: "platform_mcp_distributions"
+CREATE INDEX CONCURRENTLY "platform_mcp_distributions_project_plugin_idx" ON "platform_mcp_distributions" ("project_id", "plugin_id") WHERE (plugin_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:04JyIgKPxiUZYTyDHDyystWPVn4RvFlXk/JPc+uuy48=
+h1:FDBq1SCxfZLxlFf5YGjFfNzJgOtaUEcp56NbB3CUUao=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -357,3 +357,4 @@ h1:04JyIgKPxiUZYTyDHDyystWPVn4RvFlXk/JPc+uuy48=
 20260818203516_mcp-approval-evidence-change-detection.sql h1:yNs/1liPkJfSG3clzyfd+6zGfhYbWVHVFo4rUfXOQ3Q=
 20260818203838_mcp-research-tool-calls.sql h1:fhhTuuxv18VW3fc5N07RpyZEygKdoaBGVCdx/oAUpxw=
 20260820013033_add-chat-session-links.sql h1:3UEJgkRNXr+31yQFpteFRyq48s1l7HYq+kttJm2Q0rQ=
+20260820053103_platform-mcp-d1-lifecycle-registry-prerequisite.sql h1:4Ci7OgdkcBEp3xDucTJcjzzqfrt4LopTeWolre7Ej50=


### PR DESCRIPTION
## Why

Platform MCP and the dashboard need one operator-controlled catalogue boundary before new registry sources can be certified and enabled.

## What changed

- Add a shared catalogue service that admits only enabled, certified, code-reviewed source and auth-profile combinations.
- Preserve a narrow temporary compatibility path for the exact historical Pulse registry URL; arbitrary legacy URLs stay excluded.
- Add the public Official MCP Registry v0.1 reader with bounded pagination, deleted-entry filtering, and remote selection. It is deliberately not wired into production source composition yet.
- Route dashboard and Platform MCP browser catalogue reads through the same source admission boundary; keep the local fixture separate and fixture-only.
- Add focused unit coverage for source admission and Official registry adapter behavior.

## Review notes

- Stacked on #<PREREQUISITE>; base branch is `tristan/age-3166-mig-platform-mcp-lifecycle-registry-prerequisite`.
- No `mcp_registries` source is inserted or enabled here. Certification and production enablement remain a later rollout.
- The dashboard retains its richer Pulse detail projection; other future certified readers use the normalized reader detail path.

## Validation

- `hk fix`
- `mise run lint:server`
- `git diff --check`
- Focused external MCP tests were attempted natively but the local ClickHouse test container timed out during harness startup, before tests ran.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reviewed, operator-controlled MCP catalogue boundary and adapters so the dashboard and Platform MCP list only enabled, certified sources over HTTPS. Previously all `mcp_registries` rows were queried directly; now only allowlisted adapter/profile pairs are admitted, with a temporary compatibility path for the exact historical Pulse URL.

- Introduces `externalmcp.CatalogService`: selects by source type/auth profile, enabled flag, and certification state; enforces an adapter allowlist; orders by priority then source key; merges results; exposes Sources/ReaderFor/Source/List/Details; returns NotFound for non‑admitted `registry_id`; preserves the 100‑item cap.
- Routes `ListCatalog` and `GetServerDetails` through this admission boundary; preserves Pulse‑specific details via `externalmcp.RegistryClient`, normalizes others via `CatalogService.Details`; validates detail fetches with absolute HTTPS URLs (no userinfo or fragment); tests use TLS.
- Adds `externalmcp.OfficialRegistryAdapter` (v0.1) with bounded pagination (50 x 10 pages), deleted‑entry filtering, name deduplication, and remote selection (prefers streamable‑http, falls back to sse, supports allowed‑URL filtering); not wired into production composition yet.
- Wires `CatalogService` at startup and into `externalmcp.Service`; browser/Platform MCP catalogue now composes multiple sources with per‑source `RegistryReader`; expands registry SQL reads to include source metadata; no migration action.

**Rollout**
- Operators must configure reviewed `mcp_registries` rows with `source_type`, `auth_profile`, enabled=true, `certification_state='certified'`, and a non‑empty `source_key`; only allowlisted adapter/profile pairs are admitted.
- Legacy compatibility admits only the exact `https://api.pulsemcp.com` URL when metadata is absent; other legacy URLs remain excluded.
- Linear AGE-3217: advances the certifiable, operator‑controlled catalogue rollout; no new sources are inserted or enabled by this PR.

<sup>Written for commit fe324725b77774c1b5083ee3b3245a59570a620b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

