### PR TITLE
feat: issue organization support handoffs from admin

### DIFF
--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -125,9 +125,10 @@ func newAdminCommand() *cli.Command {
 			EnvVars:  []string{"GRAM_SSL_CERT_FILE"},
 		},
 		&cli.StringFlag{
-			Name:    "site-url",
-			Usage:   "The URL of the site",
-			EnvVars: []string{"GRAM_SITE_URL"},
+			Name:     "site-url",
+			Usage:    "The URL of the site",
+			EnvVars:  []string{"GRAM_SITE_URL"},
+			Required: true,
 		},
 		&cli.StringFlag{
 			Name:     "database-url",
@@ -290,6 +291,14 @@ func newAdminCommand() *cli.Command {
 		Usage: "Start the Gram admin server",
 		Flags: flags,
 		Action: func(c *cli.Context) error {
+			siteURL, err := url.Parse(c.String("site-url"))
+			if err != nil || siteURL.Host == "" || (siteURL.Scheme != "http" && siteURL.Scheme != "https") {
+				return fmt.Errorf("invalid site-url: must be an absolute HTTP(S) URL")
+			}
+			if c.String("environment") == "prod" && siteURL.Scheme != "https" {
+				return fmt.Errorf("invalid site-url: HTTPS is required in production")
+			}
+
 			serviceName := "gram-admin"
 			serviceEnv := c.String("environment")
 			appinfo := o11y.PullAppInfo(c.Context)
@@ -429,7 +438,7 @@ func newAdminCommand() *cli.Command {
 			trialNotifier := trialemails.NewService(db, loopsWorkflowClient, logger, c.String("site-url"))
 
 			billingOperations := usage.NewBillingOperations(logger, db, stripeClient, billingTelemetry, audit.NewLogger())
-			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminOpenRouter, trialNotifier, productFeatures, chatAnalysisSignaler, billingOperations))
+			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminOpenRouter, trialNotifier, productFeatures, chatAnalysisSignaler, billingOperations, siteURL))
 
 			srv := &http.Server{
 				Addr:              c.String("address"),

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -40,6 +40,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/organizations/orgprovision"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/supporthandoff"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
@@ -49,14 +50,16 @@ import (
 )
 
 type Service struct {
-	tracer         trace.Tracer
-	logger         *slog.Logger
-	db             *pgxpool.Pool
-	verifier       *Verifier
-	loginStates    cache.TypedCacheObject[LoginState]
-	oidc           *OIDCClient
-	sessions       *SessionStore
-	allowedOrigins []string
+	tracer               trace.Tracer
+	logger               *slog.Logger
+	db                   *pgxpool.Pool
+	verifier             *Verifier
+	loginStates          cache.TypedCacheObject[LoginState]
+	oidc                 *OIDCClient
+	sessions             *SessionStore
+	allowedOrigins       []string
+	dashboardURL         *url.URL
+	supportHandoffIssuer supportHandoffIssuer
 
 	// workos creates organizations in the identity provider. Deployments with
 	// no WorkOS configuration get orgprovision.Unavailable, whose failure
@@ -147,6 +150,7 @@ func NewService(
 	productFeatures *productfeatures.Client,
 	chatAnalysisSignaler analysis.Signaler,
 	billing BillingOperations,
+	dashboardURL *url.URL,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("admin"))
 
@@ -165,13 +169,17 @@ func NewService(
 	)
 
 	return &Service{
-		tracer:               tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/admin"),
-		logger:               logger,
-		db:                   db,
-		oidc:                 oidcClient,
-		sessions:             sessionStore,
-		verifier:             NewVerifier(logger, sessionStore, oidcClient, adminCache),
-		allowedOrigins:       allowedOrigins,
+		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/admin"),
+		logger:         logger,
+		db:             db,
+		oidc:           oidcClient,
+		sessions:       sessionStore,
+		verifier:       NewVerifier(logger, sessionStore, oidcClient, adminCache),
+		allowedOrigins: allowedOrigins,
+		dashboardURL:   dashboardURL,
+		supportHandoffIssuer: supporthandoff.NewIssuer(
+			supporthandoff.NewStore(adminCache),
+		),
 		workos:               workosClient,
 		openRouter:           openRouter,
 		openRouterUsage:      openRouter,
@@ -229,6 +237,11 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		http.MethodPost,
 		"/admin/organization.chatAnalysisTrigger",
 		oops.ErrHandle(service.logger, service.handleTriggerChatAnalysis).ServeHTTP,
+	)
+	mux.Handle(
+		http.MethodPost,
+		"/admin/organization.open-dashboard",
+		oops.ErrHandle(service.logger, service.handleOpenOrganizationInDashboard).ServeHTTP,
 	)
 }
 

--- a/server/internal/admin/support_handoff_handler.go
+++ b/server/internal/admin/support_handoff_handler.go
@@ -1,0 +1,76 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"goa.design/goa/v3/security"
+
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+)
+
+type supportHandoffIssuer interface {
+	Issue(ctx context.Context, organizationID string) (string, error)
+}
+
+func (s *Service) handleOpenOrganizationInDashboard(w http.ResponseWriter, r *http.Request) error {
+	scheme := security.APIKeyScheme{
+		Name:           constants.AdminAuthSecurityScheme,
+		Scopes:         []string{},
+		RequiredScopes: []string{},
+	}
+	ctx, err := s.verifier.Authorize(r.Context(), "", &scheme)
+	if err != nil {
+		return fmt.Errorf("admin auth: %w", err)
+	}
+	if _, ok := contextvalues.GetAdminAuthContext(ctx); !ok {
+		return oops.C(oops.CodeUnauthorized)
+	}
+
+	organizationID := strings.TrimSpace(r.URL.Query().Get("organization_id"))
+	if organizationID == "" {
+		return oops.E(oops.CodeInvalid, nil, "organization_id is required")
+	}
+	if s.dashboardURL == nil || s.dashboardURL.Scheme == "" || s.dashboardURL.Host == "" {
+		return oops.E(oops.CodeUnexpected, nil, "dashboard URL is not configured").LogError(ctx, s.logger)
+	}
+
+	organization, err := orgRepo.New(s.db).GetOrganizationMetadata(ctx, organizationID)
+	switch err {
+	case nil:
+	default:
+		if errors.Is(err, pgx.ErrNoRows) {
+			return oops.C(oops.CodeNotFound)
+		}
+		return oops.E(oops.CodeUnexpected, err, "load support target").LogError(ctx, s.logger)
+	}
+	if organization.DisabledAt.Valid {
+		return oops.C(oops.CodeNotFound)
+	}
+
+	token, err := s.supportHandoffIssuer.Issue(ctx, organization.ID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "issue support handoff").LogError(ctx, s.logger)
+	}
+
+	query := url.Values{}
+	query.Set("support_handoff", token)
+	query.Set("redirect", "/"+organization.Slug)
+	destination := url.URL{
+		Scheme:   s.dashboardURL.Scheme,
+		Host:     s.dashboardURL.Host,
+		Path:     "/rpc/auth.login",
+		RawQuery: query.Encode(),
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	http.Redirect(w, r.WithContext(ctx), destination.String(), http.StatusSeeOther)
+	return nil
+}

--- a/server/internal/admin/support_handoff_handler_test.go
+++ b/server/internal/admin/support_handoff_handler_test.go
@@ -1,0 +1,124 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+type fakeSupportHandoffIssuer struct {
+	token          string
+	organizationID string
+	err            error
+}
+
+func (f *fakeSupportHandoffIssuer) Issue(_ context.Context, organizationID string) (string, error) {
+	f.organizationID = organizationID
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.token, nil
+}
+
+func TestHandleOpenOrganizationInDashboard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("requires a valid admin session", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newTestSessionService(t, newTestOIDCClient(t, userinfoOK("sub-unauthorized", "operator@example.com")))
+		rec := callOpenOrganization(t, svc, "target-org", "")
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("issues a target-bound handoff to the runtime dashboard origin", func(t *testing.T) {
+		t.Parallel()
+
+		svc, sessionID, issuer := newOpenOrganizationService(t)
+		seedOrg(t, t.Context(), svc.db, orgFixture{id: "target-org", name: "Target Organization", slug: "target-slug"})
+
+		rec := callOpenOrganization(t, svc, "target-org", sessionID)
+		require.Equal(t, http.StatusSeeOther, rec.Code)
+		require.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+		require.Equal(t, "target-org", issuer.organizationID)
+
+		destination, err := url.Parse(rec.Header().Get("Location"))
+		require.NoError(t, err)
+		require.Equal(t, "https://dashboard.example.com", destination.Scheme+"://"+destination.Host)
+		require.Equal(t, "/rpc/auth.login", destination.Path)
+		require.Equal(t, "opaque-token", destination.Query().Get("support_handoff"))
+		require.Equal(t, "/target-slug", destination.Query().Get("redirect"))
+	})
+
+	t.Run("rejects missing and disabled organizations before issuing", func(t *testing.T) {
+		t.Parallel()
+
+		disabledAt := time.Now().UTC()
+		svc, sessionID, issuer := newOpenOrganizationService(t)
+		seedOrg(t, t.Context(), svc.db, orgFixture{id: "disabled-org", name: "Disabled Organization", slug: "disabled-slug", disabledAt: &disabledAt})
+
+		for _, organizationID := range []string{"missing-org", "disabled-org"} {
+			rec := callOpenOrganization(t, svc, organizationID, sessionID)
+			require.Equal(t, http.StatusNotFound, rec.Code)
+		}
+		require.Empty(t, issuer.organizationID)
+	})
+
+	t.Run("fails closed when issuance fails", func(t *testing.T) {
+		t.Parallel()
+
+		svc, sessionID, issuer := newOpenOrganizationService(t)
+		seedOrg(t, t.Context(), svc.db, orgFixture{id: "target-org", name: "Target Organization", slug: "target-slug"})
+		issuer.err = errors.New("issuer unavailable")
+
+		rec := callOpenOrganization(t, svc, "target-org", sessionID)
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		require.Empty(t, rec.Header().Get("Location"))
+	})
+}
+
+func newOpenOrganizationService(t *testing.T) (*Service, string, *fakeSupportHandoffIssuer) {
+	t.Helper()
+
+	ctx := t.Context()
+	svc := newTestSessionService(t, newTestOIDCClient(t, userinfoOK("sub-support", "operator@example.com")))
+	conn, err := infra.CloneTestDatabase(t, "adminsupporthandoff")
+	require.NoError(t, err)
+	svc.db = conn
+	svc.dashboardURL = &url.URL{Scheme: "https", Host: "dashboard.example.com", Path: "/ignored", RawQuery: "ignored=true"}
+	issuer := &fakeSupportHandoffIssuer{token: "opaque-token"}
+	svc.supportHandoffIssuer = issuer
+
+	sessionID, err := svc.sessions.Store(ctx, StoreParams{
+		Email:        "operator@example.com",
+		Name:         "Test Operator",
+		OIDCSubject:  "sub-support",
+		HD:           testAdminHD,
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	return svc, sessionID, issuer
+}
+
+func callOpenOrganization(t *testing.T, svc *Service, organizationID, sessionID string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/organization.open-dashboard?organization_id="+url.QueryEscape(organizationID), nil)
+	if sessionID != "" {
+		req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+	}
+	rec := httptest.NewRecorder()
+	SessionMiddleware(oops.ErrHandle(svc.logger, svc.handleOpenOrganizationInDashboard)).ServeHTTP(rec, req)
+	return rec
+}


### PR DESCRIPTION
## Summary
- add an admin-session-authorized endpoint that issues the trusted support handoff introduced by the base migration
- reject missing or disabled target organizations before issuance
- resolve the dashboard origin at runtime from `GRAM_SITE_URL` and return a no-store redirect
- keep the opaque handoff and organization target out of browser-controlled identity inputs

Implements the admin API entry point for AGE-3313 on top of the migrated dashboard support-session mechanism and its focused one-hour lifetime follow-up.

## Validation
- `mise run test:server ./internal/admin ./cmd/gram`
- `mise lint:server`
- `git diff --check`
