### PR TITLE
feat: open organization support sessions from admin

### DIFF
--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -13,6 +13,7 @@ import {
   getProject,
   listOrganizations,
   logout,
+  organizationDashboardUrl,
   MAX_TRIAL_EXTENSION_DAYS,
   MAX_TRIAL_REARM_DAYS,
   MIN_TRIAL_EXTENSION_DAYS,
@@ -24,6 +25,14 @@ import {
 } from "@/lib/gramAdminApi";
 
 describe("toSearchParams", () => {
+  describe("organizationDashboardUrl", () => {
+    it("targets the same-origin handoff endpoint with an encoded organization id", () => {
+      expect(organizationDashboardUrl("org/id & value")).toBe(
+        "/admin/organization.open-dashboard?organization_id=org%2Fid+%26+value",
+      );
+    });
+  });
+
   it("repeats the key for each item of an array", () => {
     const qs = toSearchParams({ type: ["free", "pro"], q: "", page: 2 });
     expect(qs.toString()).toBe("type=free&type=pro&page=2");

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -174,6 +174,11 @@ export function getSession(): Promise<AdminSessionInfo> {
   return gramAdminFetch<AdminSessionInfo>("/admin/session.get");
 }
 
+export function organizationDashboardUrl(organizationId: string): string {
+  const query = new URLSearchParams({ organization_id: organizationId });
+  return `/admin/organization.open-dashboard?${query.toString()}`;
+}
+
 // Ends the admin session, then sends the browser into the OIDC flow.
 //
 // The endpoint deletes only the server-side record and leaves the `gram_admin`

--- a/client/admin/src/lib/impersonation.test.ts
+++ b/client/admin/src/lib/impersonation.test.ts
@@ -1,55 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { impersonationUrl, organizationFeaturesUrl } from "./impersonation";
-
-describe("impersonationUrl", () => {
-  it("carries the slug as the first path segment of `redirect`", () => {
-    const href = impersonationUrl("acme-placeholder");
-    expect(href).toBeDefined();
-
-    const redirect = new URL(href!).searchParams.get("redirect");
-    // Pinned from the Go side too, by org_slug_destination_test.go.
-    const slug = new URL(
-      redirect!,
-      "https://placeholder.invalid",
-    ).pathname.split("/")[1];
-    expect(slug).toBe("acme-placeholder");
-  });
-
-  it("targets the login endpoint on the configured app origin", () => {
-    const url = new URL(impersonationUrl("acme-placeholder")!);
-
-    expect(url.origin).toBe("https://app.gram.test");
-    expect(url.pathname).toBe("/rpc/auth.login");
-  });
-
-  it("returns undefined for a blank slug", () => {
-    expect(impersonationUrl("")).toBeUndefined();
-  });
-
-  it("keeps the redirect on the app's own origin whatever the slug holds", () => {
-    // Nothing on the server side was found to rule this slug out. Unencoded it
-    // makes the redirect `//host`, which is protocol-relative: resolved against
-    // the app it is another origin, and the operator leaves Gram.
-    const redirect = new URL(
-      impersonationUrl("/evil.invalid")!,
-    ).searchParams.get("redirect");
-
-    expect(new URL(redirect!, "https://app.gram.test").origin).toBe(
-      "https://app.gram.test",
-    );
-    expect(redirect).toBe("/%2Fevil.invalid");
-  });
-
-  it("lands on the organization itself and goes no further", () => {
-    // The features row shares this builder. A destination leaking into the
-    // plain link would drop the operator on a page nobody asked for.
-    const redirect = new URL(
-      impersonationUrl("acme-placeholder")!,
-    ).searchParams.get("redirect");
-    expect(redirect).toBe("/acme-placeholder");
-  });
-});
+import { organizationFeaturesUrl } from "./impersonation";
 
 describe("organizationFeaturesUrl", () => {
   it("carries the slug and the dashboard's features address in `redirect`", () => {

--- a/client/admin/src/lib/impersonation.ts
+++ b/client/admin/src/lib/impersonation.ts
@@ -30,10 +30,6 @@ function loginUrl(slug: string, destination: string): string | undefined {
   return url.toString();
 }
 
-export function impersonationUrl(slug: string): string | undefined {
-  return loginUrl(slug, "");
-}
-
 // Out of the admin app on purpose. Every `productfeatures` endpoint here reads
 // and writes the operator's own organization, which is fixed at login and has
 // no per-request override, so an in-app Features view would edit the wrong

--- a/client/admin/src/pages/organization/RecordHeader.test.tsx
+++ b/client/admin/src/pages/organization/RecordHeader.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { badgeTone } from "@/lib/badgeTone";
-import type { TrialState } from "@/lib/gramAdminApi";
+import { organizationDashboardUrl, type TrialState } from "@/lib/gramAdminApi";
 import { TRIAL_LABELS } from "@/lib/trialLabels";
 import { fmtDateShort } from "@/lib/utils";
 import { anOrganization } from "@/test/fixtures";
@@ -10,26 +10,11 @@ import { renderWithApp } from "@/test/harness";
 
 import { RecordHeader } from "./RecordHeader";
 
-const mocks = vi.hoisted(() => ({
-  impersonationUrl: vi.fn<(slug: string) => string | undefined>(),
-}));
-
-// The one dependency a test has to move. `__GRAM_APP_URL__` is substituted at
-// build time, so the not-configured case cannot be reached any other way.
-vi.mock("@/lib/impersonation", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/impersonation")>();
-  return { ...actual, impersonationUrl: mocks.impersonationUrl };
-});
-
-const APP_LINK = "https://app.example.test/rpc/auth.login?redirect=%2Ftest-org";
-
 beforeEach(() => {
   // UTC and this zone fall on different dates, so a created date read in the
   // reader's zone renders a day early and fails below. CI runs in UTC, where
   // that fault cannot appear at all.
   vi.stubEnv("TZ", "America/Los_Angeles");
-  mocks.impersonationUrl.mockReset();
-  mocks.impersonationUrl.mockReturnValue(APP_LINK);
 });
 
 afterEach(() => {
@@ -38,63 +23,37 @@ afterEach(() => {
 });
 
 describe("RecordHeader", () => {
-  it("omits Open in Gram when impersonationUrl returns undefined", async () => {
-    // Undefined whenever __GRAM_APP_URL__ is unset at build time. Rendering the
-    // anchor anyway gives the operator a link that takes focus and goes
-    // nowhere, which is worse than no link.
-    mocks.impersonationUrl.mockReturnValue(undefined);
-
-    await renderWithApp(<RecordHeader org={anOrganization()} />);
-
-    // By its words, not only by its role. An anchor rendered with no `href` is
-    // the shape this mistake takes, and such an anchor has no link role at all:
-    // an absence asserted by role alone passes while the dead control is on
-    // screen.
-    expect(screen.queryByText("Open in Gram")).toBeNull();
-    expect(screen.queryByRole("link", { name: /Open in Gram/ })).toBeNull();
-  });
-
-  it("shows Open in Gram when an app URL is configured", async () => {
-    await renderWithApp(<RecordHeader org={anOrganization()} />);
-
-    const link = screen.getByRole("link", { name: /Open in Gram/ });
-    expect(link.getAttribute("href")).toBe(APP_LINK);
-  });
-
-  it("leaves the record open behind Open in Gram, and names no referrer", async () => {
-    await renderWithApp(<RecordHeader org={anOrganization()} />);
-
-    const link = screen.getByRole("link", { name: /Open in Gram/ });
-    // The operator is reading a record and following a link out of it. Taking
-    // the tab loses the record they are working through.
-    expect(link.getAttribute("target")).toBe("_blank");
-    // The admin address carries the organization the operator is looking at.
-    // `noopener` is implied for `_blank`; suppressing the referrer is not.
-    expect(link.getAttribute("rel")).toContain("noreferrer");
-  });
-
-  it("says Open in Gram leaves the app, in the nav's words", async () => {
-    await renderWithApp(<RecordHeader org={anOrganization()} />);
-
-    const link = screen.getByRole("link", { name: /Open in Gram/ });
-    // Written out, not read off the constant. The same words are asserted
-    // against the nav's Features row, which is the only thing holding two links
-    // that say the same fact to one wording.
-    expect(link.textContent).toBe("Open in Gram (opens in the Gram dashboard)");
-    // Appended, not substituted. An `aria-label` would take "Open in Gram" away
-    // from a screen reader and leave the aside standing in for the label.
-    expect(link.querySelector(".sr-only")?.textContent).toBe(
-      " (opens in the Gram dashboard)",
-    );
-  });
-
-  it("impersonates through the record's slug, not its id", async () => {
-    // The server reads the first path segment of `redirect` back as the
-    // organization, so an id there lands the operator nowhere.
+  it("shows the Open in Dashboard secondary action", async () => {
     const org = anOrganization();
     await renderWithApp(<RecordHeader org={org} />);
 
-    expect(mocks.impersonationUrl).toHaveBeenCalledWith(org.slug);
+    const button = screen.getByRole("button", { name: /Open in Dashboard/ });
+    const form = button.closest("form");
+    expect(form?.getAttribute("method")).toBe("post");
+    expect(form?.getAttribute("action")).toBe(organizationDashboardUrl(org.id));
+  });
+
+  it("leaves the admin record open in its original tab", async () => {
+    await renderWithApp(<RecordHeader org={anOrganization()} />);
+
+    const form = screen
+      .getByRole("button", { name: /Open in Dashboard/ })
+      .closest("form");
+    expect(form?.getAttribute("target")).toBe("_blank");
+    expect(form?.getAttribute("rel")).toContain("noopener");
+    expect(form?.getAttribute("rel")).toContain("noreferrer");
+  });
+
+  it("identifies the new dashboard tab for assistive technology", async () => {
+    await renderWithApp(<RecordHeader org={anOrganization()} />);
+
+    const button = screen.getByRole("button", { name: /Open in Dashboard/ });
+    expect(button.textContent).toBe(
+      "Open in Dashboard (opens in the Gram dashboard)",
+    );
+    expect(button.querySelector(".sr-only")?.textContent).toBe(
+      " (opens in the Gram dashboard)",
+    );
   });
 
   it("shows the account type and created date on the meta line", async () => {

--- a/client/admin/src/pages/organization/RecordHeader.test.tsx
+++ b/client/admin/src/pages/organization/RecordHeader.test.tsx
@@ -40,8 +40,7 @@ describe("RecordHeader", () => {
       .getByRole("button", { name: /Open in Dashboard/ })
       .closest("form");
     expect(form?.getAttribute("target")).toBe("_blank");
-    expect(form?.getAttribute("rel")).toContain("noopener");
-    expect(form?.getAttribute("rel")).toContain("noreferrer");
+    expect(form?.getAttribute("rel")).toBe("noopener");
   });
 
   it("identifies the new dashboard tab for assistive technology", async () => {

--- a/client/admin/src/pages/organization/RecordHeader.tsx
+++ b/client/admin/src/pages/organization/RecordHeader.tsx
@@ -4,8 +4,11 @@ import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { badgeTone } from "@/lib/badgeTone";
-import type { AdminOrganization } from "@/lib/gramAdminApi";
-import { impersonationUrl, LEAVES_THE_APP } from "@/lib/impersonation";
+import {
+  organizationDashboardUrl,
+  type AdminOrganization,
+} from "@/lib/gramAdminApi";
+import { LEAVES_THE_APP } from "@/lib/impersonation";
 import { fmtDateShort } from "@/lib/utils";
 import { OrganizationActions } from "@/pages/organizations/OrganizationActions";
 
@@ -21,8 +24,6 @@ function Dot(): JSX.Element {
 }
 
 export function RecordHeader({ org }: { org: AdminOrganization }): JSX.Element {
-  const gramUrl = impersonationUrl(org.slug);
-
   return (
     <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-3">
       <div className="min-w-0">
@@ -51,18 +52,19 @@ export function RecordHeader({ org }: { org: AdminOrganization }): JSX.Element {
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
-        {/* Absent rather than dead when no app origin is configured. */}
-        {gramUrl && (
-          <Button asChild variant="outline" size="xs">
-            {/* The record's other way out of the admin app, marked the way the
-                nav's Features row is. Appended rather than an `aria-label`,
-                which would take the visible words away and leave the aside. */}
-            <a href={gramUrl} target="_blank" rel="noreferrer">
-              Open in Gram
-              <span className="sr-only">{LEAVES_THE_APP}</span>
-            </a>
+        {/* POST makes the admin origin check protect handoff issuance. The
+            named target keeps the organization record open in this tab. */}
+        <form
+          method="post"
+          action={organizationDashboardUrl(org.id)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Button type="submit" variant="outline" size="xs">
+            Open in Dashboard
+            <span className="sr-only">{LEAVES_THE_APP}</span>
           </Button>
-        )}
+        </form>
         {/* Lifecycle only. The action that resolves the trial belongs beside
             the deadline it acts on, in the callout. */}
         <OrganizationActions org={org} layout="buttons" actions="lifecycle" />

--- a/client/admin/src/pages/organization/RecordHeader.tsx
+++ b/client/admin/src/pages/organization/RecordHeader.tsx
@@ -58,6 +58,8 @@ export function RecordHeader({ org }: { org: AdminOrganization }): JSX.Element {
           method="post"
           action={organizationDashboardUrl(org.id)}
           target="_blank"
+          // Keep the referrer: noreferrer makes Chromium send Origin: null for
+          // this POST, which the admin CSRF middleware correctly rejects.
           rel="noopener"
         >
           <Button type="submit" variant="outline" size="xs">

--- a/client/admin/src/pages/organization/RecordHeader.tsx
+++ b/client/admin/src/pages/organization/RecordHeader.tsx
@@ -58,7 +58,7 @@ export function RecordHeader({ org }: { org: AdminOrganization }): JSX.Element {
           method="post"
           action={organizationDashboardUrl(org.id)}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
         >
           <Button type="submit" variant="outline" size="xs">
             Open in Dashboard

--- a/client/admin/src/pages/organization/RecordLayout.test.tsx
+++ b/client/admin/src/pages/organization/RecordLayout.test.tsx
@@ -100,7 +100,7 @@ describe("RecordLayout", () => {
       });
 
       expect(
-        await screen.findByRole("link", { name: /Open in Gram/ }),
+        await screen.findByRole("button", { name: /Open in Dashboard/ }),
       ).toBeTruthy();
       const callout = await screen.findByRole("status");
       expect(callout.textContent).toContain("Trial ends");


### PR DESCRIPTION
## Summary
- add the visible secondary organization-header action **Open in Dashboard**
- open the support flow in a new tab while leaving the admin record open
- target the same-origin admin handoff endpoint with the encoded organization ID
- remove the old build-time dashboard URL dependency from this organization action

Implements the admin UI entry point for AGE-3313. It reuses the trusted one-hour support-session mechanism from the preceding stack PRs.

## Validation
- `aube run -F admin type-check`
- `aube run -F admin lint`
- `aube run -F admin test`
- `git diff --check`
