### PR TITLE
feat: add Remote sessions setup for Claude Code on the web

### DIFF
--- a/.changeset/device-agent-cloud-sessions.md
+++ b/.changeset/device-agent-cloud-sessions.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Add a Cloud sessions walkthrough on Device Agent setup for Anthropic-hosted Claude Code on the web: custom network (`app.getgram.ai`), a pinned linux_amd64 setup script that writes managed.json, a SessionStart hook that only starts the agent, and org-default environment steps.

--- a/.changeset/device-agent-cloud-sessions.md
+++ b/.changeset/device-agent-cloud-sessions.md
@@ -2,4 +2,4 @@
 "dashboard": minor
 ---
 
-Add a Cloud sessions walkthrough on Device Agent setup for Anthropic-hosted Claude Code on the web: custom network (`app.getgram.ai`), a pinned linux_amd64 setup script that writes managed.json, a SessionStart hook that only starts the agent, and org-default environment steps.
+Add a Remote sessions platform walkthrough to Device Agent setup for Anthropic-hosted Claude Code on the web, including network access, a pinned agent bootstrap, per-session startup, and organization-default guidance.

--- a/.changeset/device-agent-cloud-sessions.md
+++ b/.changeset/device-agent-cloud-sessions.md
@@ -2,4 +2,4 @@
 "dashboard": minor
 ---
 
-Add a Remote sessions platform walkthrough to Device Agent setup for Anthropic-hosted Claude Code on the web, including network access, a pinned agent bootstrap, per-session startup, and organization-default guidance.
+Add a Remote sessions platform walkthrough to Device Agent setup for Anthropic-hosted Claude Code on the web, including network access, managed enrollment, a minimal verified CLI bootstrap, and organization-default guidance.

--- a/.changeset/device-agent-cloud-sessions.md
+++ b/.changeset/device-agent-cloud-sessions.md
@@ -2,4 +2,4 @@
 "dashboard": minor
 ---
 
-Add a Remote sessions platform walkthrough to Device Agent setup for Anthropic-hosted Claude Code on the web, including network access, managed enrollment, a minimal verified CLI bootstrap, and organization-default guidance.
+Add a Remote sessions platform walkthrough to Device Agent setup for Anthropic-hosted Claude Code on the web: network access, a verified pinned daemon install with managed enrollment, a SessionStart hook that revives the agent each session, and organization-default guidance.

--- a/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
@@ -52,11 +52,25 @@ describe("buildCloudSetupScript", () => {
 
   it("pins linux_amd64 binaries and the helper .deb from the release bucket", () => {
     expect(script).toContain(`${RELEASES_BASE}/v0.1.20`);
-    expect(script).toContain("$BASE/speakeasyd_0.1.20_linux_amd64");
-    expect(script).toContain("$BASE/speakeasy_0.1.20_linux_amd64");
     expect(script).toContain("speakeasy-helper_0.1.20_linux_amd64.deb");
     expect(script).toContain("apt-get install -y");
     expect(script).not.toContain("linux_arm64");
+    expect(script).toContain("checksums.txt");
+    expect(script).toContain("fetch_and_verify");
+    expect(script).toContain("sha256sum -c -");
+    expect(script).toContain(
+      'fetch_and_verify "speakeasyd_0.1.20_linux_amd64"',
+    );
+    expect(script).toContain('fetch_and_verify "speakeasy_0.1.20_linux_amd64"');
+    expect(script).toContain(
+      'fetch_and_verify "speakeasy-helper_0.1.20_linux_amd64.deb"',
+    );
+  });
+
+  it("writes managed.json 0640 and group-readable by the session user", () => {
+    expect(script).toContain("chmod 0640 /etc/speakeasy/managed.json");
+    expect(script).toContain('chgrp "$(id -gn 1000 2>/dev/null || echo root)"');
+    expect(script).not.toContain("chmod 0644");
   });
 
   it("writes managed.json only — no Claude settings and no process start", () => {

--- a/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
@@ -16,7 +16,7 @@ const input = {
 };
 
 describe("buildCloudSetupCommand", () => {
-  it("renders a minimal, valid bootstrap for the device-agent CLI", () => {
+  it("renders a valid script that installs the pinned daemon", () => {
     const script = buildCloudSetupCommand(input);
     const result = spawnSync("bash", ["-n"], {
       input: script,
@@ -26,22 +26,53 @@ describe("buildCloudSetupCommand", () => {
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);
     expect(script).toContain(
-      `${RELEASES_BASE}/v1.2.3/speakeasy_1.2.3_linux_amd64`,
+      `${RELEASES_BASE}/v\${VERSION}/speakeasyd_\${VERSION}_linux_amd64`,
     );
+    expect(script).toContain("VERSION='1.2.3'");
+    expect(script).toContain(`SHA256='${"a".repeat(64)}'`);
     expect(script).toContain("sha256sum -c -");
-    expect(script).toContain("'remote-session@example.test'");
-    expect(script).toContain("'spk_org_test_token'");
-    expect(script).toContain('"$CLI" setup --anthropic-cloud');
+    expect(script).toContain("chmod 0755 /usr/local/bin/speakeasyd");
   });
 
-  it("leaves machine provisioning and SessionStart setup to the CLI", () => {
+  it("writes managed enrollment for the daemon to read at startup", () => {
     const script = buildCloudSetupCommand(input);
 
-    expect(script).not.toContain("managed.json");
-    expect(script).not.toContain("managed-settings.json");
-    expect(script).not.toContain("speakeasyd");
+    expect(script).toContain("/etc/speakeasy/managed.json");
+    expect(script).toContain(`EMAIL='remote-session@example.test'`);
+    expect(script).toContain(`ORG_TOKEN='spk_org_test_token'`);
+    expect(script).toContain(`"auto_update": "disabled"`);
+    expect(script).toContain("chmod 0644 /etc/speakeasy/managed.json");
+  });
+
+  it("registers a singleton SessionStart hook that revives the daemon", () => {
+    const script = buildCloudSetupCommand(input);
+    const settingsJSON = script.match(/<<'JSON'\n([\s\S]*?)\nJSON\n/)?.[1];
+
+    expect(settingsJSON).toBeDefined();
+    const settings = JSON.parse(settingsJSON ?? "") as {
+      hooks: {
+        SessionStart: {
+          matcher: string;
+          hooks: { type: string; command: string; async: boolean }[];
+        }[];
+      };
+    };
+    const [entry] = settings.hooks.SessionStart;
+    expect(entry?.matcher).toBe("startup|resume");
+    const [hook] = entry?.hooks ?? [];
+    expect(hook?.type).toBe("command");
+    expect(hook?.async).toBe(true);
+    expect(hook?.command).toContain("flock -n /run/speakeasyd.lock");
+    expect(hook?.command).toContain("/usr/local/bin/speakeasyd");
+  });
+
+  it("leaves everything after daemon start to the agent's own sync loop", () => {
+    const script = buildCloudSetupCommand(input);
+
+    expect(script).not.toContain("setup --anthropic-cloud");
+    expect(script).not.toContain("remote-session start");
     expect(script).not.toContain("speakeasy-helper");
-    expect(script).not.toContain("SessionStart");
+    expect(script).not.toContain("managed-settings.json");
   });
 
   it("supports the inline token-generation sentinel", () => {
@@ -53,7 +84,7 @@ describe("buildCloudSetupCommand", () => {
     ).toContain(CLOUD_ORG_TOKEN_SENTINEL);
   });
 
-  it("quotes identity values before passing them through the environment", () => {
+  it("shell-quotes identity values", () => {
     const script = buildCloudSetupCommand({
       ...input,
       email: "remote'session@example.test",
@@ -70,16 +101,22 @@ describe("buildCloudSetupCommand", () => {
     expect(script).toContain(`token'\\''with-quote`);
   });
 
-  it("rejects invalid dynamic release data and email", () => {
+  it("rejects invalid release data, email, and JSON-breaking values", () => {
     expect(() =>
       buildCloudSetupCommand({ ...input, version: "1.2.3; rm -rf /" }),
     ).toThrow(/valid pinned device agent version/);
     expect(() =>
       buildCloudSetupCommand({ ...input, sha256: "not-a-checksum" }),
-    ).toThrow(/valid device agent CLI checksum/);
+    ).toThrow(/valid device agent daemon checksum/);
     expect(() => buildCloudSetupCommand({ ...input, email: "@" })).toThrow(
       /valid remote session identity email/,
     );
+    expect(() =>
+      buildCloudSetupCommand({ ...input, email: 'quo"te@example.test' }),
+    ).toThrow(/valid remote session identity email/);
+    expect(() =>
+      buildCloudSetupCommand({ ...input, orgToken: 'tok"en' }),
+    ).toThrow(/valid org token/);
   });
 });
 

--- a/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
@@ -2,202 +2,90 @@ import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 import {
-  buildCloudAgentBootstrapScript,
-  buildCloudAgentHookInstallScript,
-  buildCloudAgentStartCommand,
-  buildCloudAgentStartHook,
   buildCloudDefaultEnvironmentSnippet,
-  buildCloudManagedConfig,
-  buildCloudSetupScript,
-  CLOUD_AGENT_BOOTSTRAP_PATH,
+  buildCloudSetupCommand,
   CLOUD_ORG_TOKEN_SENTINEL,
   RELEASES_BASE,
 } from "./cloud-setup";
 
 const input = {
-  version: "0.1.20",
-  orgSlug: "acme-corp",
-  orgName: "Acme Corporation",
+  version: "1.2.3",
+  sha256: "a".repeat(64),
+  email: "remote-session@example.test",
   orgToken: "spk_org_test_token",
-  email: "claude-code-web@acme.example",
 };
 
-function managedJsonFromScript(script: string): Record<string, unknown> {
-  const match = script.match(
-    /<<'SPEAKEASY_MANAGED_JSON'\n([\s\S]*?)\nSPEAKEASY_MANAGED_JSON/,
-  );
-  expect(match?.[1]).toBeDefined();
-  return JSON.parse(match![1]!) as Record<string, unknown>;
-}
-
-describe("buildCloudManagedConfig", () => {
-  it("writes the ephemeral-VM identity contract", () => {
-    expect(buildCloudManagedConfig(input)).toEqual({
-      v: 1,
-      email: "claude-code-web@acme.example",
-      org_token: "spk_org_test_token",
-      org_slug: "acme-corp",
-      org_name: "Acme Corporation",
-      auto_update: "disabled",
-      hide_ui: true,
+describe("buildCloudSetupCommand", () => {
+  it("renders a minimal, valid bootstrap for the device-agent CLI", () => {
+    const script = buildCloudSetupCommand(input);
+    const result = spawnSync("bash", ["-n"], {
+      input: script,
+      encoding: "utf8",
     });
-  });
 
-  it("trims the required reporting identity", () => {
-    expect(
-      buildCloudManagedConfig({ ...input, email: "  ai@acme.example  " }),
-    ).toMatchObject({ email: "ai@acme.example" });
-  });
-
-  it("rejects an empty reporting identity", () => {
-    expect(() => buildCloudManagedConfig({ ...input, email: "  " })).toThrow(
-      /valid remote session identity email is required/,
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(script).toContain(
+      `${RELEASES_BASE}/v1.2.3/speakeasy_1.2.3_linux_amd64`,
     );
-  });
-
-  it("rejects a malformed reporting identity", () => {
-    expect(() => buildCloudManagedConfig({ ...input, email: "@" })).toThrow(
-      /valid remote session identity email is required/,
-    );
-  });
-});
-
-describe("buildCloudSetupScript", () => {
-  const script = buildCloudSetupScript(input);
-
-  it("renders syntactically valid Bash for setup and per-session startup", () => {
-    for (const candidate of [
-      script,
-      buildCloudAgentBootstrapScript(),
-      buildCloudAgentHookInstallScript(),
-    ]) {
-      const result = spawnSync("bash", ["-n"], {
-        input: candidate,
-        encoding: "utf8",
-      });
-      expect(result.stderr).toBe("");
-      expect(result.status).toBe(0);
-    }
-
-    const installer = buildCloudAgentHookInstallScript();
-    const python = installer.match(/python3 <<'PY'\n([\s\S]*?)\nPY/)?.[1];
-    expect(python).toBeDefined();
-    const pythonResult = spawnSync(
-      "python3",
-      [
-        "-c",
-        "import sys; compile(sys.stdin.read(), '<hook-installer>', 'exec')",
-      ],
-      {
-        input: python,
-        encoding: "utf8",
-      },
-    );
-    expect(pythonResult.stderr).toBe("");
-    expect(pythonResult.status).toBe(0);
-  });
-
-  it("pins linux_amd64 binaries and the helper .deb from the release bucket", () => {
-    expect(script).toContain(`${RELEASES_BASE}/v0.1.20`);
-    expect(script).toContain("speakeasy-helper_0.1.20_linux_amd64.deb");
-    expect(script).toContain("apt-get install -y");
-    expect(script).not.toContain("linux_arm64");
-    expect(script).toContain("checksums.txt");
-    expect(script).toContain("fetch_and_verify");
     expect(script).toContain("sha256sum -c -");
-    expect(script).toContain(
-      'fetch_and_verify "speakeasyd_0.1.20_linux_amd64"',
-    );
-    expect(script).toContain('fetch_and_verify "speakeasy_0.1.20_linux_amd64"');
-    expect(script).toContain(
-      'fetch_and_verify "speakeasy-helper_0.1.20_linux_amd64.deb"',
-    );
+    expect(script).toContain("'remote-session@example.test'");
+    expect(script).toContain("'spk_org_test_token'");
+    expect(script).toContain('"$CLI" setup --anthropic-cloud');
   });
 
-  it("writes managed.json using the agent's documented Linux permissions", () => {
-    expect(script).toContain("chmod 0644 /etc/speakeasy/managed.json");
-    expect(script).not.toContain("chgrp");
-    expect(script).not.toContain("id -gn 1000");
-  });
+  it("leaves machine provisioning and SessionStart setup to the CLI", () => {
+    const script = buildCloudSetupCommand(input);
 
-  it("writes managed.json and the bootstrap, but no Claude settings", () => {
-    const json = managedJsonFromScript(script);
-    expect(json).toEqual(buildCloudManagedConfig(input));
-    expect(script).toContain("/etc/speakeasy/managed.json");
-    expect(script).toContain(`cat >${CLOUD_AGENT_BOOTSTRAP_PATH}`);
-    expect(script).toContain(`chmod 0755 ${CLOUD_AGENT_BOOTSTRAP_PATH}`);
-    expect(script).not.toContain("settings.json");
+    expect(script).not.toContain("managed.json");
     expect(script).not.toContain("managed-settings.json");
-    expect(script).not.toContain("agenthooks");
-    expect(script).not.toContain("-service start");
-    expect(script).not.toContain(`\n${CLOUD_AGENT_BOOTSTRAP_PATH}\n`);
+    expect(script).not.toContain("speakeasyd");
+    expect(script).not.toContain("speakeasy-helper");
+    expect(script).not.toContain("SessionStart");
   });
 
-  it("embeds a minted token sentinel unchanged so the UI can slot a button", () => {
-    const withSentinel = buildCloudSetupScript({
+  it("supports the inline token-generation sentinel", () => {
+    expect(
+      buildCloudSetupCommand({
+        ...input,
+        orgToken: CLOUD_ORG_TOKEN_SENTINEL,
+      }),
+    ).toContain(CLOUD_ORG_TOKEN_SENTINEL);
+  });
+
+  it("quotes identity values before passing them through the environment", () => {
+    const script = buildCloudSetupCommand({
       ...input,
-      orgToken: CLOUD_ORG_TOKEN_SENTINEL,
+      email: "remote'session@example.test",
+      orgToken: "token'with-quote",
     });
-    expect(managedJsonFromScript(withSentinel).org_token).toBe(
-      CLOUD_ORG_TOKEN_SENTINEL,
-    );
+    const result = spawnSync("bash", ["-n"], {
+      input: script,
+      encoding: "utf8",
+    });
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(script).toContain(`remote'\\''session@example.test`);
+    expect(script).toContain(`token'\\''with-quote`);
   });
 
-  it("refuses to interpolate a non-semver version into the root script", () => {
+  it("rejects invalid dynamic release data and email", () => {
     expect(() =>
-      buildCloudSetupScript({ ...input, version: "1.0.0; rm -rf /" }),
-    ).toThrow(/refusing to interpolate agent version/);
-  });
-});
-
-describe("buildCloudAgentStartHook", () => {
-  const bootstrap = buildCloudAgentBootstrapScript();
-  const command = buildCloudAgentStartCommand();
-  const hook = buildCloudAgentStartHook();
-  const parsed = JSON.parse(hook) as {
-    hooks: {
-      SessionStart: {
-        matcher: string;
-        hooks: { type: string; command: string; timeout: number }[];
-      }[];
-    };
-  };
-
-  it("keeps process management in the installed bootstrap", () => {
-    expect(command).toBe(CLOUD_AGENT_BOOTSTRAP_PATH);
-    expect(bootstrap).toContain("CLAUDE_CODE_REMOTE:-}");
-    expect(bootstrap).toContain("/usr/local/bin/speakeasyd");
-    expect(bootstrap).toContain("/usr/lib/speakeasy/speakeasy-helper");
-    expect(bootstrap).toContain("grep -q 'pending:'");
-    expect(bootstrap).toContain('"$CLI" sync');
-    expect(bootstrap).toContain("policy synced");
-    expect(bootstrap).not.toContain("agenthooks");
-    expect(parsed.hooks.SessionStart[0]?.hooks[0]?.type).toBe("command");
-    expect(parsed.hooks.SessionStart[0]?.hooks[0]?.command).toBe(command);
-    expect(parsed.hooks.SessionStart[0]?.matcher).toBe("startup|resume");
-    expect(parsed.hooks.SessionStart[0]?.hooks[0]?.timeout).toBe(45);
-  });
-
-  it("installs the canonical hook into managed settings idempotently", () => {
-    const installer = buildCloudAgentHookInstallScript();
-    expect(installer).toContain("/etc/claude-code/managed-settings.json");
-    expect(installer).toContain(CLOUD_AGENT_BOOTSTRAP_PATH);
-    expect(installer).toContain('handler.get("command") == command');
-    expect(installer).toContain("if not installed:");
-    expect(installer).not.toContain("agenthooks run");
-  });
-
-  it("does not paste Speakeasy observability commands into settings.json", () => {
-    expect(hook).not.toContain("agenthooks run");
-    expect(hook).not.toContain("CLAUDE_PLUGIN_ROOT");
-    expect(hook.toLowerCase()).not.toContain("observability");
+      buildCloudSetupCommand({ ...input, version: "1.2.3; rm -rf /" }),
+    ).toThrow(/valid pinned device agent version/);
+    expect(() =>
+      buildCloudSetupCommand({ ...input, sha256: "not-a-checksum" }),
+    ).toThrow(/valid device agent CLI checksum/);
+    expect(() => buildCloudSetupCommand({ ...input, email: "@" })).toThrow(
+      /valid remote session identity email/,
+    );
   });
 });
 
 describe("buildCloudDefaultEnvironmentSnippet", () => {
-  it("uses a placeholder env id rather than inventing one", () => {
-    const snippet = buildCloudDefaultEnvironmentSnippet();
-    expect(JSON.parse(snippet)).toEqual({
+  it("uses a placeholder environment id", () => {
+    expect(JSON.parse(buildCloudDefaultEnvironmentSnippet())).toEqual({
       remote: { defaultEnvironmentId: "env_…" },
     });
   });

--- a/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCloudAgentBootstrapScript,
+  buildCloudAgentHookInstallScript,
   buildCloudAgentStartCommand,
   buildCloudAgentStartHook,
   buildCloudDefaultEnvironmentSnippet,
@@ -65,7 +66,11 @@ describe("buildCloudSetupScript", () => {
   const script = buildCloudSetupScript(input);
 
   it("renders syntactically valid Bash for setup and per-session startup", () => {
-    for (const candidate of [script, buildCloudAgentBootstrapScript()]) {
+    for (const candidate of [
+      script,
+      buildCloudAgentBootstrapScript(),
+      buildCloudAgentHookInstallScript(),
+    ]) {
       const result = spawnSync("bash", ["-n"], {
         input: candidate,
         encoding: "utf8",
@@ -73,6 +78,23 @@ describe("buildCloudSetupScript", () => {
       expect(result.stderr).toBe("");
       expect(result.status).toBe(0);
     }
+
+    const installer = buildCloudAgentHookInstallScript();
+    const python = installer.match(/python3 <<'PY'\n([\s\S]*?)\nPY/)?.[1];
+    expect(python).toBeDefined();
+    const pythonResult = spawnSync(
+      "python3",
+      [
+        "-c",
+        "import sys; compile(sys.stdin.read(), '<hook-installer>', 'exec')",
+      ],
+      {
+        input: python,
+        encoding: "utf8",
+      },
+    );
+    expect(pythonResult.stderr).toBe("");
+    expect(pythonResult.status).toBe(0);
   });
 
   it("pins linux_amd64 binaries and the helper .deb from the release bucket", () => {
@@ -154,6 +176,15 @@ describe("buildCloudAgentStartHook", () => {
     expect(parsed.hooks.SessionStart[0]?.hooks[0]?.command).toBe(command);
     expect(parsed.hooks.SessionStart[0]?.matcher).toBe("startup|resume");
     expect(parsed.hooks.SessionStart[0]?.hooks[0]?.timeout).toBe(45);
+  });
+
+  it("installs the canonical hook into managed settings idempotently", () => {
+    const installer = buildCloudAgentHookInstallScript();
+    expect(installer).toContain("/etc/claude-code/managed-settings.json");
+    expect(installer).toContain(CLOUD_AGENT_BOOTSTRAP_PATH);
+    expect(installer).toContain('handler.get("command") == command');
+    expect(installer).toContain("if not installed:");
+    expect(installer).not.toContain("agenthooks run");
   });
 
   it("does not paste Speakeasy observability commands into settings.json", () => {

--- a/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
@@ -41,7 +41,7 @@ describe("buildCloudSetupCommand", () => {
     expect(script).toContain(`EMAIL='remote-session@example.test'`);
     expect(script).toContain(`ORG_TOKEN='spk_org_test_token'`);
     expect(script).toContain(`"auto_update": "disabled"`);
-    expect(script).toContain("chmod 0644 /etc/speakeasy/managed.json");
+    expect(script).toContain("chmod 0600 /etc/speakeasy/managed.json");
   });
 
   it("registers a singleton SessionStart hook that revives the daemon", () => {
@@ -116,6 +116,12 @@ describe("buildCloudSetupCommand", () => {
     ).toThrow(/valid remote session identity email/);
     expect(() =>
       buildCloudSetupCommand({ ...input, orgToken: 'tok"en' }),
+    ).toThrow(/valid org token/);
+    expect(() =>
+      buildCloudSetupCommand({ ...input, email: "bell\x07@example.test" }),
+    ).toThrow(/valid remote session identity email/);
+    expect(() =>
+      buildCloudSetupCommand({ ...input, orgToken: "tok\x01en" }),
     ).toThrow(/valid org token/);
   });
 });

--- a/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
@@ -1,11 +1,14 @@
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildCloudAgentBootstrapScript,
   buildCloudAgentStartCommand,
   buildCloudAgentStartHook,
   buildCloudDefaultEnvironmentSnippet,
   buildCloudManagedConfig,
   buildCloudSetupScript,
+  CLOUD_AGENT_BOOTSTRAP_PATH,
   CLOUD_ORG_TOKEN_SENTINEL,
   RELEASES_BASE,
 } from "./cloud-setup";
@@ -15,6 +18,7 @@ const input = {
   orgSlug: "acme-corp",
   orgName: "Acme Corporation",
   orgToken: "spk_org_test_token",
+  email: "claude-code-web@acme.example",
 };
 
 function managedJsonFromScript(script: string): Record<string, unknown> {
@@ -29,6 +33,7 @@ describe("buildCloudManagedConfig", () => {
   it("writes the ephemeral-VM identity contract", () => {
     expect(buildCloudManagedConfig(input)).toEqual({
       v: 1,
+      email: "claude-code-web@acme.example",
       org_token: "spk_org_test_token",
       org_slug: "acme-corp",
       org_name: "Acme Corporation",
@@ -37,18 +42,38 @@ describe("buildCloudManagedConfig", () => {
     });
   });
 
-  it("includes email when provided and omits it otherwise", () => {
+  it("trims the required reporting identity", () => {
     expect(
-      buildCloudManagedConfig({ ...input, email: "ai@acme.example" }),
+      buildCloudManagedConfig({ ...input, email: "  ai@acme.example  " }),
     ).toMatchObject({ email: "ai@acme.example" });
-    expect(
-      buildCloudManagedConfig({ ...input, email: "  " }),
-    ).not.toHaveProperty("email");
+  });
+
+  it("rejects an empty reporting identity", () => {
+    expect(() => buildCloudManagedConfig({ ...input, email: "  " })).toThrow(
+      /valid remote session identity email is required/,
+    );
+  });
+
+  it("rejects a malformed reporting identity", () => {
+    expect(() => buildCloudManagedConfig({ ...input, email: "@" })).toThrow(
+      /valid remote session identity email is required/,
+    );
   });
 });
 
 describe("buildCloudSetupScript", () => {
   const script = buildCloudSetupScript(input);
+
+  it("renders syntactically valid Bash for setup and per-session startup", () => {
+    for (const candidate of [script, buildCloudAgentBootstrapScript()]) {
+      const result = spawnSync("bash", ["-n"], {
+        input: candidate,
+        encoding: "utf8",
+      });
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+    }
+  });
 
   it("pins linux_amd64 binaries and the helper .deb from the release bucket", () => {
     expect(script).toContain(`${RELEASES_BASE}/v0.1.20`);
@@ -67,22 +92,23 @@ describe("buildCloudSetupScript", () => {
     );
   });
 
-  it("writes managed.json 0640 and group-readable by the session user", () => {
-    expect(script).toContain("chmod 0640 /etc/speakeasy/managed.json");
-    expect(script).toContain('chgrp "$(id -gn 1000 2>/dev/null || echo root)"');
-    expect(script).not.toContain("chmod 0644");
+  it("writes managed.json using the agent's documented Linux permissions", () => {
+    expect(script).toContain("chmod 0644 /etc/speakeasy/managed.json");
+    expect(script).not.toContain("chgrp");
+    expect(script).not.toContain("id -gn 1000");
   });
 
-  it("writes managed.json only — no Claude settings and no process start", () => {
+  it("writes managed.json and the bootstrap, but no Claude settings", () => {
     const json = managedJsonFromScript(script);
     expect(json).toEqual(buildCloudManagedConfig(input));
     expect(script).toContain("/etc/speakeasy/managed.json");
+    expect(script).toContain(`cat >${CLOUD_AGENT_BOOTSTRAP_PATH}`);
+    expect(script).toContain(`chmod 0755 ${CLOUD_AGENT_BOOTSTRAP_PATH}`);
     expect(script).not.toContain("settings.json");
     expect(script).not.toContain("managed-settings.json");
     expect(script).not.toContain("agenthooks");
-    expect(script).not.toMatch(/speakeasyd\s+>>/);
     expect(script).not.toContain("-service start");
-    expect(script).not.toContain("speakeasy-helper >>");
+    expect(script).not.toContain(`\n${CLOUD_AGENT_BOOTSTRAP_PATH}\n`);
   });
 
   it("embeds a minted token sentinel unchanged so the UI can slot a button", () => {
@@ -103,21 +129,31 @@ describe("buildCloudSetupScript", () => {
 });
 
 describe("buildCloudAgentStartHook", () => {
+  const bootstrap = buildCloudAgentBootstrapScript();
   const command = buildCloudAgentStartCommand();
   const hook = buildCloudAgentStartHook();
   const parsed = JSON.parse(hook) as {
-    hooks: { SessionStart: { hooks: { type: string; command: string }[] }[] };
+    hooks: {
+      SessionStart: {
+        matcher: string;
+        hooks: { type: string; command: string; timeout: number }[];
+      }[];
+    };
   };
 
-  it("gates on CLAUDE_CODE_REMOTE and only starts the agent", () => {
-    expect(command).toContain("CLAUDE_CODE_REMOTE:-}");
-    expect(command).toContain('= "true"');
-    expect(command).toContain("speakeasyd >>");
-    expect(command).toContain("speakeasy-helper");
-    expect(command).not.toContain("agenthooks");
-    expect(command).not.toContain("managed.json");
+  it("keeps process management in the installed bootstrap", () => {
+    expect(command).toBe(CLOUD_AGENT_BOOTSTRAP_PATH);
+    expect(bootstrap).toContain("CLAUDE_CODE_REMOTE:-}");
+    expect(bootstrap).toContain("/usr/local/bin/speakeasyd");
+    expect(bootstrap).toContain("/usr/lib/speakeasy/speakeasy-helper");
+    expect(bootstrap).toContain("grep -q 'pending:'");
+    expect(bootstrap).toContain('"$CLI" sync');
+    expect(bootstrap).toContain("policy synced");
+    expect(bootstrap).not.toContain("agenthooks");
     expect(parsed.hooks.SessionStart[0]?.hooks[0]?.type).toBe("command");
     expect(parsed.hooks.SessionStart[0]?.hooks[0]?.command).toBe(command);
+    expect(parsed.hooks.SessionStart[0]?.matcher).toBe("startup|resume");
+    expect(parsed.hooks.SessionStart[0]?.hooks[0]?.timeout).toBe(45);
   });
 
   it("does not paste Speakeasy observability commands into settings.json", () => {

--- a/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCloudAgentStartCommand,
+  buildCloudAgentStartHook,
+  buildCloudDefaultEnvironmentSnippet,
+  buildCloudManagedConfig,
+  buildCloudSetupScript,
+  CLOUD_ORG_TOKEN_SENTINEL,
+  RELEASES_BASE,
+} from "./cloud-setup";
+
+const input = {
+  version: "0.1.20",
+  orgSlug: "acme-corp",
+  orgName: "Acme Corporation",
+  orgToken: "spk_org_test_token",
+};
+
+function managedJsonFromScript(script: string): Record<string, unknown> {
+  const match = script.match(
+    /<<'SPEAKEASY_MANAGED_JSON'\n([\s\S]*?)\nSPEAKEASY_MANAGED_JSON/,
+  );
+  expect(match?.[1]).toBeDefined();
+  return JSON.parse(match![1]!) as Record<string, unknown>;
+}
+
+describe("buildCloudManagedConfig", () => {
+  it("writes the ephemeral-VM identity contract", () => {
+    expect(buildCloudManagedConfig(input)).toEqual({
+      v: 1,
+      org_token: "spk_org_test_token",
+      org_slug: "acme-corp",
+      org_name: "Acme Corporation",
+      auto_update: "disabled",
+      hide_ui: true,
+    });
+  });
+
+  it("includes email when provided and omits it otherwise", () => {
+    expect(
+      buildCloudManagedConfig({ ...input, email: "ai@acme.example" }),
+    ).toMatchObject({ email: "ai@acme.example" });
+    expect(
+      buildCloudManagedConfig({ ...input, email: "  " }),
+    ).not.toHaveProperty("email");
+  });
+});
+
+describe("buildCloudSetupScript", () => {
+  const script = buildCloudSetupScript(input);
+
+  it("pins linux_amd64 binaries and the helper .deb from the release bucket", () => {
+    expect(script).toContain(`${RELEASES_BASE}/v0.1.20`);
+    expect(script).toContain("$BASE/speakeasyd_0.1.20_linux_amd64");
+    expect(script).toContain("$BASE/speakeasy_0.1.20_linux_amd64");
+    expect(script).toContain("speakeasy-helper_0.1.20_linux_amd64.deb");
+    expect(script).toContain("apt-get install -y");
+    expect(script).not.toContain("linux_arm64");
+  });
+
+  it("writes managed.json only — no Claude settings and no process start", () => {
+    const json = managedJsonFromScript(script);
+    expect(json).toEqual(buildCloudManagedConfig(input));
+    expect(script).toContain("/etc/speakeasy/managed.json");
+    expect(script).not.toContain("settings.json");
+    expect(script).not.toContain("managed-settings.json");
+    expect(script).not.toContain("agenthooks");
+    expect(script).not.toMatch(/speakeasyd\s+>>/);
+    expect(script).not.toContain("-service start");
+    expect(script).not.toContain("speakeasy-helper >>");
+  });
+
+  it("embeds a minted token sentinel unchanged so the UI can slot a button", () => {
+    const withSentinel = buildCloudSetupScript({
+      ...input,
+      orgToken: CLOUD_ORG_TOKEN_SENTINEL,
+    });
+    expect(managedJsonFromScript(withSentinel).org_token).toBe(
+      CLOUD_ORG_TOKEN_SENTINEL,
+    );
+  });
+
+  it("refuses to interpolate a non-semver version into the root script", () => {
+    expect(() =>
+      buildCloudSetupScript({ ...input, version: "1.0.0; rm -rf /" }),
+    ).toThrow(/refusing to interpolate agent version/);
+  });
+});
+
+describe("buildCloudAgentStartHook", () => {
+  const command = buildCloudAgentStartCommand();
+  const hook = buildCloudAgentStartHook();
+  const parsed = JSON.parse(hook) as {
+    hooks: { SessionStart: { hooks: { type: string; command: string }[] }[] };
+  };
+
+  it("gates on CLAUDE_CODE_REMOTE and only starts the agent", () => {
+    expect(command).toContain("CLAUDE_CODE_REMOTE:-}");
+    expect(command).toContain('= "true"');
+    expect(command).toContain("speakeasyd >>");
+    expect(command).toContain("speakeasy-helper");
+    expect(command).not.toContain("agenthooks");
+    expect(command).not.toContain("managed.json");
+    expect(parsed.hooks.SessionStart[0]?.hooks[0]?.type).toBe("command");
+    expect(parsed.hooks.SessionStart[0]?.hooks[0]?.command).toBe(command);
+  });
+
+  it("does not paste Speakeasy observability commands into settings.json", () => {
+    expect(hook).not.toContain("agenthooks run");
+    expect(hook).not.toContain("CLAUDE_PLUGIN_ROOT");
+    expect(hook.toLowerCase()).not.toContain("observability");
+  });
+});
+
+describe("buildCloudDefaultEnvironmentSnippet", () => {
+  it("uses a placeholder env id rather than inventing one", () => {
+    const snippet = buildCloudDefaultEnvironmentSnippet();
+    expect(JSON.parse(snippet)).toEqual({
+      remote: { defaultEnvironmentId: "env_…" },
+    });
+  });
+});

--- a/client/dashboard/src/pages/device-agent/cloud-setup.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.ts
@@ -11,6 +11,10 @@ export const PINNED_AGENT_VERSION =
 
 export const RELEASE_SHA256 = /^[0-9a-f]{64}$/;
 
+// Email and token land inside a JSON heredoc the script expands, so beyond
+// shell quoting they must not carry JSON-breaking characters.
+const JSON_SAFE_VALUE = /^[^"\\\s]+$/;
+
 export type CloudSetupCommandInput = {
   version: string;
   sha256: string;
@@ -18,33 +22,84 @@ export type CloudSetupCommandInput = {
   orgToken: string;
 };
 
+/**
+ * Renders the Anthropic environment's setup script. It runs once as root
+ * before the filesystem snapshot and does exactly three things: install the
+ * pinned daemon, write managed enrollment, and register a SessionStart hook
+ * that revives the daemon in each session. Everything after daemon start is
+ * the agent's normal policy-sync loop — plugin install, tool config, and
+ * enforcement all ride the same infrastructure as any other machine.
+ */
 export function buildCloudSetupCommand(input: CloudSetupCommandInput): string {
   const email = input.email.trim();
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+  if (
+    !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ||
+    !JSON_SAFE_VALUE.test(email)
+  ) {
     throw new Error("a valid remote session identity email is required");
+  }
+  if (!input.orgToken || !JSON_SAFE_VALUE.test(input.orgToken)) {
+    throw new Error("a valid org token is required");
   }
   if (!PINNED_AGENT_VERSION.test(input.version)) {
     throw new Error("a valid pinned device agent version is required");
   }
   if (!RELEASE_SHA256.test(input.sha256)) {
-    throw new Error("a valid device agent CLI checksum is required");
+    throw new Error("a valid device agent daemon checksum is required");
   }
-
-  const cliURL = `${RELEASES_BASE}/v${input.version}/speakeasy_${input.version}_linux_amd64`;
 
   return `#!/usr/bin/env bash
 set -euo pipefail
 
-CLI="$(mktemp)"
-trap 'rm -f "$CLI"' EXIT
+# Values from the Gram dashboard.
+VERSION=${shellQuote(input.version)}
+SHA256=${shellQuote(input.sha256)}
+EMAIL=${shellQuote(email)}
+ORG_TOKEN=${shellQuote(input.orgToken)}
 
-curl -fsSL -o "$CLI" ${shellQuote(cliURL)}
-printf '%s  %s\\n' ${shellQuote(input.sha256)} "$CLI" | sha256sum -c -
-chmod 0755 "$CLI"
+# 1) Install the device agent daemon (pinned, checksum-verified).
+curl -fsSL -o /usr/local/bin/speakeasyd \\
+  "${RELEASES_BASE}/v\${VERSION}/speakeasyd_\${VERSION}_linux_amd64"
+printf '%s  /usr/local/bin/speakeasyd\\n' "$SHA256" | sha256sum -c -
+chmod 0755 /usr/local/bin/speakeasyd
 
-SPEAKEASY_EMAIL=${shellQuote(email)} \\
-SPEAKEASY_ORG_TOKEN=${shellQuote(input.orgToken)} \\
-"$CLI" setup --anthropic-cloud
+# 2) Managed enrollment: the identity the daemon reads at startup, and the
+#    same file that answers daemonless identity lookups from hooks.
+install -d -m 0755 /etc/speakeasy
+cat > /etc/speakeasy/managed.json <<JSON
+{
+  "v": 1,
+  "email": "\${EMAIL}",
+  "org_token": "\${ORG_TOKEN}",
+  "auto_update": "disabled",
+  "hide_ui": true
+}
+JSON
+chmod 0644 /etc/speakeasy/managed.json
+
+# 3) SessionStart hook: starts the daemon in each session (Anthropic
+#    snapshots files, not processes). flock holds the lock for the daemon's
+#    lifetime, so a startup/resume double-fire can never double-start it.
+install -d /root/.local/state/speakeasy/logs
+install -d /root/.claude
+cat > /root/.claude/settings.json <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "setsid flock -n /run/speakeasyd.lock /usr/local/bin/speakeasyd >>/root/.local/state/speakeasy/logs/speakeasyd.log 2>&1 &",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
 `;
 }
 

--- a/client/dashboard/src/pages/device-agent/cloud-setup.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.ts
@@ -12,8 +12,10 @@ export const PINNED_AGENT_VERSION =
 export const RELEASE_SHA256 = /^[0-9a-f]{64}$/;
 
 // Email and token land inside a JSON heredoc the script expands, so beyond
-// shell quoting they must not carry JSON-breaking characters.
-const JSON_SAFE_VALUE = /^[^"\\\s]+$/;
+// shell quoting they must not carry JSON-breaking characters (quotes,
+// backslashes, whitespace, or control characters).
+// eslint-disable-next-line no-control-regex
+const JSON_SAFE_VALUE = /^[^"\\\s\x00-\x1f]+$/;
 
 export type CloudSetupCommandInput = {
   version: string;
@@ -64,7 +66,8 @@ printf '%s  /usr/local/bin/speakeasyd\\n' "$SHA256" | sha256sum -c -
 chmod 0755 /usr/local/bin/speakeasyd
 
 # 2) Managed enrollment: the identity the daemon reads at startup, and the
-#    same file that answers daemonless identity lookups from hooks.
+#    same file that answers daemonless identity lookups from hooks. Everything
+#    in this VM runs as root, so keep the org token root-only.
 install -d -m 0755 /etc/speakeasy
 cat > /etc/speakeasy/managed.json <<JSON
 {
@@ -75,7 +78,7 @@ cat > /etc/speakeasy/managed.json <<JSON
   "hide_ui": true
 }
 JSON
-chmod 0644 /etc/speakeasy/managed.json
+chmod 0600 /etc/speakeasy/managed.json
 
 # 3) SessionStart hook: starts the daemon in each session (Anthropic
 #    snapshots files, not processes). flock holds the lock for the daemon's

--- a/client/dashboard/src/pages/device-agent/cloud-setup.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.ts
@@ -15,6 +15,7 @@ export const CLOUD_ORG_TOKEN_SENTINEL = "__SLOT_orgToken__";
 export const CLOUD_AGENT_BOOTSTRAP_PATH = "/usr/local/bin/speakeasy-bootstrap";
 
 const CLOUD_HELPER_PATH = "/usr/lib/speakeasy/speakeasy-helper";
+const CLAUDE_MANAGED_SETTINGS_PATH = "/etc/claude-code/managed-settings.json";
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 // Same charset the OS-tile snippets require: a manifest version is inlined
@@ -193,31 +194,77 @@ export function buildCloudAgentStartCommand(): string {
   return CLOUD_AGENT_BOOTSTRAP_PATH;
 }
 
-/**
- * SessionStart snippet to merge into org Managed Settings or repo
- * `.claude/settings.json`. Starts the agent only — not observability policy.
- */
+function cloudAgentStartHookEntry() {
+  return {
+    matcher: "startup|resume",
+    hooks: [
+      {
+        type: "command",
+        command: buildCloudAgentStartCommand(),
+        timeout: 45,
+      },
+    ],
+  };
+}
+
+/** Canonical SessionStart shape installed by buildCloudAgentHookInstallScript. */
 export function buildCloudAgentStartHook(): string {
   return `${JSON.stringify(
     {
       hooks: {
-        SessionStart: [
-          {
-            matcher: "startup|resume",
-            hooks: [
-              {
-                type: "command",
-                command: buildCloudAgentStartCommand(),
-                timeout: 45,
-              },
-            ],
-          },
-        ],
+        SessionStart: [cloudAgentStartHookEntry()],
       },
     },
     null,
     2,
   )}\n`;
+}
+
+/**
+ * Setup-script fragment that installs the SessionStart hook into Claude's
+ * system-managed settings. The device agent's managed reconciler preserves
+ * admin-authored hooks while adding or updating its observability handlers.
+ */
+export function buildCloudAgentHookInstallScript(): string {
+  const hookEntry = JSON.stringify(cloudAgentStartHookEntry(), null, 2);
+
+  return `#!/usr/bin/env bash
+# Append this to the Anthropic environment Setup script after the agent install.
+set -euo pipefail
+
+python3 <<'PY'
+import json
+import os
+import tempfile
+from pathlib import Path
+
+path = Path("${CLAUDE_MANAGED_SETTINGS_PATH}")
+settings = json.loads(path.read_text()) if path.exists() else {}
+session_start = settings.setdefault("hooks", {}).setdefault("SessionStart", [])
+hook = ${hookEntry}
+command = hook["hooks"][0]["command"]
+
+installed = any(
+    handler.get("command") == command
+    for entry in session_start
+    for handler in entry.get("hooks", [])
+)
+if not installed:
+    session_start.append(hook)
+
+path.parent.mkdir(parents=True, exist_ok=True)
+fd, temporary_path = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+try:
+    with os.fdopen(fd, "w") as file:
+        json.dump(settings, file, indent=2)
+        file.write("\\n")
+    os.chmod(temporary_path, 0o644)
+    os.replace(temporary_path, path)
+except BaseException:
+    os.unlink(temporary_path)
+    raise
+PY
+`;
 }
 
 /** Placeholder merge snippet; the env id is copied from Claude after create. */

--- a/client/dashboard/src/pages/device-agent/cloud-setup.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.ts
@@ -17,7 +17,8 @@ export const CLOUD_SESSIONS_ANCHOR = "cloud-sessions";
 // Same charset the OS-tile snippets require: a manifest version is inlined
 // into a root shell script, so reject anything that isn't strict semver
 // (optionally with a prerelease suffix).
-const PINNED_AGENT_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+export const PINNED_AGENT_VERSION =
+  /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
 
 export type CloudSetupScriptInput = {
   version: string;
@@ -78,24 +79,31 @@ set -euo pipefail
 VERSION="${version}"
 BASE="${base}"
 
-install -d -m 0755 /usr/local/bin
-curl -fSL -o /usr/local/bin/speakeasyd "$BASE/${daemon}"
-curl -fSL -o /usr/local/bin/speakeasy "$BASE/${cli}"
-chmod 0755 /usr/local/bin/speakeasyd /usr/local/bin/speakeasy
-
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 cd "$TMP"
-PKG="${helperPkg}"
-curl -fSL -o "$PKG" "$BASE/$PKG"
-curl -fsSL "$BASE/checksums.txt" | grep " $PKG$" | sha256sum -c -
-DEBIAN_FRONTEND=noninteractive apt-get install -y "./$PKG"
+curl -fsSL -o checksums.txt "$BASE/checksums.txt"
+fetch_and_verify() {
+  curl -fSL -o "$1" "$BASE/$1"
+  grep " $1$" checksums.txt | sha256sum -c -
+}
+
+install -d -m 0755 /usr/local/bin
+fetch_and_verify "${daemon}"
+install -m 0755 "${daemon}" /usr/local/bin/speakeasyd
+fetch_and_verify "${cli}"
+install -m 0755 "${cli}" /usr/local/bin/speakeasy
+fetch_and_verify "${helperPkg}"
+DEBIAN_FRONTEND=noninteractive apt-get install -y "./${helperPkg}"
 
 install -d -m 0755 /etc/speakeasy
 cat >/etc/speakeasy/managed.json <<'SPEAKEASY_MANAGED_JSON'
 ${managedJson}
 SPEAKEASY_MANAGED_JSON
-chmod 0644 /etc/speakeasy/managed.json
+# 0640 matches the fleet managed.json contract. Setup is root; SessionStart
+# starts speakeasyd as the session user (typically uid 1000 on this Ubuntu VM).
+chmod 0640 /etc/speakeasy/managed.json
+chgrp "$(id -gn 1000 2>/dev/null || echo root)" /etc/speakeasy/managed.json
 `;
 }
 

--- a/client/dashboard/src/pages/device-agent/cloud-setup.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.ts
@@ -1,0 +1,159 @@
+// Builders for the Claude Code on the web (Anthropic-hosted VM) device-agent
+// path. Kept pure so the install contract is unit-tested: the setup script
+// only lays down binaries + helper + managed.json; SessionStart only starts
+// the agent. We never emit Claude observability hook commands here.
+
+export const RELEASES_BASE =
+  "https://storage.googleapis.com/speakeasy-device-agent-releases-prod";
+
+export const MANIFEST_URL = `${RELEASES_BASE}/releases.json`;
+
+/** Sentinel spliced into the setup script until an org_token is minted. */
+export const CLOUD_ORG_TOKEN_SENTINEL = "__SLOT_orgToken__";
+
+/** Anchor for the Cloud sessions section and the onboarding alert jump-link. */
+export const CLOUD_SESSIONS_ANCHOR = "cloud-sessions";
+
+// Same charset the OS-tile snippets require: a manifest version is inlined
+// into a root shell script, so reject anything that isn't strict semver
+// (optionally with a prerelease suffix).
+const PINNED_AGENT_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+
+export type CloudSetupScriptInput = {
+  version: string;
+  orgSlug: string;
+  orgName: string;
+  orgToken: string;
+  /** Required for getPlugins. Omit for degraded mode (daemon runs, syncs nothing). */
+  email?: string;
+};
+
+export function buildCloudManagedConfig(
+  input: Omit<CloudSetupScriptInput, "version">,
+): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    v: 1,
+  };
+  const email = input.email?.trim();
+  if (email) {
+    config.email = email;
+  }
+  config.org_token = input.orgToken;
+  config.org_slug = input.orgSlug;
+  config.org_name = input.orgName;
+  config.auto_update = "disabled";
+  config.hide_ui = true;
+  return config;
+}
+
+function assertPinnedAgentVersion(version: string): string {
+  if (!PINNED_AGENT_VERSION.test(version)) {
+    throw new Error(
+      `refusing to interpolate agent version into a root shell script: ${version}`,
+    );
+  }
+  return version;
+}
+
+/**
+ * Anthropic environment setup script (runs as root, cache miss only).
+ * Installs linux_amd64 binaries + the helper .deb and writes managed.json.
+ * Does not start the agent and does not write Claude settings.
+ */
+export function buildCloudSetupScript(input: CloudSetupScriptInput): string {
+  const version = assertPinnedAgentVersion(input.version);
+  const managedJson = JSON.stringify(buildCloudManagedConfig(input), null, 2);
+  const base = `${RELEASES_BASE}/v${version}`;
+  const daemon = `speakeasyd_${version}_linux_amd64`;
+  const cli = `speakeasy_${version}_linux_amd64`;
+  const helperPkg = `speakeasy-helper_${version}_linux_amd64.deb`;
+
+  return `#!/usr/bin/env bash
+# Speakeasy device agent — Anthropic-hosted Claude Code environment.
+# Runs as root on a cache miss only. Does not start the agent: Anthropic
+# snapshots the filesystem and skips this script on later sessions, so
+# SessionStart is what brings the daemon up.
+set -euo pipefail
+
+VERSION="${version}"
+BASE="${base}"
+
+install -d -m 0755 /usr/local/bin
+curl -fSL -o /usr/local/bin/speakeasyd "$BASE/${daemon}"
+curl -fSL -o /usr/local/bin/speakeasy "$BASE/${cli}"
+chmod 0755 /usr/local/bin/speakeasyd /usr/local/bin/speakeasy
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+PKG="${helperPkg}"
+curl -fSL -o "$PKG" "$BASE/$PKG"
+curl -fsSL "$BASE/checksums.txt" | grep " $PKG$" | sha256sum -c -
+DEBIAN_FRONTEND=noninteractive apt-get install -y "./$PKG"
+
+install -d -m 0755 /etc/speakeasy
+cat >/etc/speakeasy/managed.json <<'SPEAKEASY_MANAGED_JSON'
+${managedJson}
+SPEAKEASY_MANAGED_JSON
+chmod 0644 /etc/speakeasy/managed.json
+`;
+}
+
+/**
+ * Idempotent start for a VM with no service manager. Mirrors the measured
+ * ephemeral-vm bootstrap: start speakeasyd as the current user, and the
+ * helper as root when possible. Gated so pasting into laptop Managed
+ * Settings is a no-op outside Claude Code on the web.
+ */
+export function buildCloudAgentStartCommand(): string {
+  return [
+    '[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0',
+    'if ! pgrep -u "$(id -u)" -x speakeasyd >/dev/null 2>&1; then',
+    '  speakeasyd >>"${TMPDIR:-/tmp}/speakeasyd.log" 2>&1 &',
+    "fi",
+    "if ! { [ -S /run/com.speakeasy.helper.sock ] && pgrep -f '(^|/)speakeasy-helper($| )' >/dev/null 2>&1; }; then",
+    '  if [ "$(id -u)" = "0" ]; then',
+    '    speakeasy-helper >>"${TMPDIR:-/tmp}/speakeasy-helper.log" 2>&1 &',
+    "  elif command -v sudo >/dev/null 2>&1; then",
+    '    sudo -n speakeasy-helper >>"${TMPDIR:-/tmp}/speakeasy-helper.log" 2>&1 &',
+    "  fi",
+    "fi",
+  ].join("\n");
+}
+
+/**
+ * SessionStart snippet to merge into org Managed Settings or repo
+ * `.claude/settings.json`. Starts the agent only — not observability policy.
+ */
+export function buildCloudAgentStartHook(): string {
+  return `${JSON.stringify(
+    {
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: buildCloudAgentStartCommand(),
+                timeout: 30,
+              },
+            ],
+          },
+        ],
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+/** Placeholder merge snippet; the env id is copied from Claude after create. */
+export function buildCloudDefaultEnvironmentSnippet(): string {
+  return `${JSON.stringify(
+    {
+      remote: { defaultEnvironmentId: "env_…" },
+    },
+    null,
+    2,
+  )}\n`;
+}

--- a/client/dashboard/src/pages/device-agent/cloud-setup.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.ts
@@ -1,7 +1,7 @@
 // Builders for the Claude Code on the web (Anthropic-hosted VM) device-agent
 // path. Kept pure so the install contract is unit-tested: the setup script
-// only lays down binaries + helper + managed.json; SessionStart only starts
-// the agent. We never emit Claude observability hook commands here.
+// lays down binaries, managed.json, and the per-session bootstrap; SessionStart
+// only invokes that bootstrap. We never emit Claude observability hooks here.
 
 export const RELEASES_BASE =
   "https://storage.googleapis.com/speakeasy-device-agent-releases-prod";
@@ -11,8 +11,11 @@ export const MANIFEST_URL = `${RELEASES_BASE}/releases.json`;
 /** Sentinel spliced into the setup script until an org_token is minted. */
 export const CLOUD_ORG_TOKEN_SENTINEL = "__SLOT_orgToken__";
 
-/** Anchor for the Cloud sessions section and the onboarding alert jump-link. */
-export const CLOUD_SESSIONS_ANCHOR = "cloud-sessions";
+/** Stable path provisioned by the setup script and invoked by SessionStart. */
+export const CLOUD_AGENT_BOOTSTRAP_PATH = "/usr/local/bin/speakeasy-bootstrap";
+
+const CLOUD_HELPER_PATH = "/usr/lib/speakeasy/speakeasy-helper";
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 // Same charset the OS-tile snippets require: a manifest version is inlined
 // into a root shell script, so reject anything that isn't strict semver
@@ -25,20 +28,22 @@ export type CloudSetupScriptInput = {
   orgSlug: string;
   orgName: string;
   orgToken: string;
-  /** Required for getPlugins. Omit for degraded mode (daemon runs, syncs nothing). */
-  email?: string;
+  /** Identity used by agent.getPlugins and remote-session reporting. */
+  email: string;
 };
 
 export function buildCloudManagedConfig(
   input: Omit<CloudSetupScriptInput, "version">,
 ): Record<string, unknown> {
+  const email = input.email.trim();
+  if (!EMAIL_PATTERN.test(email)) {
+    throw new Error("a valid remote session identity email is required");
+  }
+
   const config: Record<string, unknown> = {
     v: 1,
+    email,
   };
-  const email = input.email?.trim();
-  if (email) {
-    config.email = email;
-  }
   config.org_token = input.orgToken;
   config.org_slug = input.orgSlug;
   config.org_name = input.orgName;
@@ -57,13 +62,83 @@ function assertPinnedAgentVersion(version: string): string {
 }
 
 /**
+ * Idempotent, cloud-only bootstrap installed into the cached filesystem.
+ * It mirrors the device-agent ephemeral-VM contract: the helper runs as root,
+ * the daemon runs as the same user as Claude, and startup waits for the first
+ * policy sync without making a transient agent failure block Claude entirely.
+ */
+export function buildCloudAgentBootstrapScript(): string {
+  return `#!/usr/bin/env bash
+# Start Speakeasy enforcement for an Anthropic-hosted Claude Code session.
+set -uo pipefail
+
+if [ "\${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+LOG_DIR="\${SPEAKEASY_LOG_DIR:-\${TMPDIR:-/tmp}}"
+WAIT_SECS="\${SPEAKEASY_WAIT_SECS:-30}"
+HELPER="${CLOUD_HELPER_PATH}"
+DAEMON="/usr/local/bin/speakeasyd"
+CLI="/usr/local/bin/speakeasy"
+
+log() { printf 'speakeasy-bootstrap: %s\\n' "$*" >&2; }
+
+EXPECT_ROOT=0
+if [ -S /run/com.speakeasy.helper.sock ] && pgrep -f '(^|/)speakeasy-helper($| )' >/dev/null 2>&1; then
+  EXPECT_ROOT=1
+else
+  if [ ! -x "$HELPER" ]; then
+    log "helper not found at $HELPER; managed enforcement will fall back to the user layer"
+  elif [ "$(id -u)" = "0" ]; then
+    "$HELPER" >>"$LOG_DIR/speakeasy-helper.log" 2>&1 &
+    EXPECT_ROOT=1
+  elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    sudo -n "$HELPER" >>"$LOG_DIR/speakeasy-helper.log" 2>&1 &
+    EXPECT_ROOT=1
+  else
+    log "cannot start the root helper; managed enforcement will fall back to the user layer"
+  fi
+fi
+
+if ! pgrep -u "$(id -u)" -x speakeasyd >/dev/null 2>&1; then
+  "$DAEMON" >>"$LOG_DIR/speakeasyd.log" 2>&1 &
+fi
+
+deadline=$((SECONDS + WAIT_SECS))
+last_sync_nudge=-5
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if status=$("$CLI" status 2>/dev/null) && printf '%s' "$status" | grep -q '^synced:'; then
+    if [ "$EXPECT_ROOT" = "1" ] && printf '%s' "$status" | grep -q 'pending:'; then
+      if [ -S /run/com.speakeasy.helper.sock ] && [ $((SECONDS - last_sync_nudge)) -ge 5 ]; then
+        last_sync_nudge=$SECONDS
+        "$CLI" sync >/dev/null 2>&1 || true
+      fi
+      sleep 0.5
+      continue
+    fi
+    log "policy synced"
+    exit 0
+  fi
+  sleep 0.5
+done
+
+log "policy did not sync within \${WAIT_SECS}s; check $LOG_DIR/speakeasyd.log"
+"$CLI" status 2>&1 || true
+exit 0
+`;
+}
+
+/**
  * Anthropic environment setup script (runs as root, cache miss only).
- * Installs linux_amd64 binaries + the helper .deb and writes managed.json.
- * Does not start the agent and does not write Claude settings.
+ * Installs linux_amd64 binaries + the helper .deb, writes managed.json, and
+ * installs the bootstrap that SessionStart invokes. It does not start the
+ * agent and does not write Claude settings.
  */
 export function buildCloudSetupScript(input: CloudSetupScriptInput): string {
   const version = assertPinnedAgentVersion(input.version);
   const managedJson = JSON.stringify(buildCloudManagedConfig(input), null, 2);
+  const bootstrapScript = buildCloudAgentBootstrapScript();
   const base = `${RELEASES_BASE}/v${version}`;
   const daemon = `speakeasyd_${version}_linux_amd64`;
   const cli = `speakeasy_${version}_linux_amd64`;
@@ -96,37 +171,26 @@ install -m 0755 "${cli}" /usr/local/bin/speakeasy
 fetch_and_verify "${helperPkg}"
 DEBIAN_FRONTEND=noninteractive apt-get install -y "./${helperPkg}"
 
+cat >${CLOUD_AGENT_BOOTSTRAP_PATH} <<'SPEAKEASY_BOOTSTRAP'
+${bootstrapScript}SPEAKEASY_BOOTSTRAP
+chmod 0755 ${CLOUD_AGENT_BOOTSTRAP_PATH}
+
 install -d -m 0755 /etc/speakeasy
 cat >/etc/speakeasy/managed.json <<'SPEAKEASY_MANAGED_JSON'
 ${managedJson}
 SPEAKEASY_MANAGED_JSON
-# 0640 matches the fleet managed.json contract. Setup is root; SessionStart
-# starts speakeasyd as the session user (typically uid 1000 on this Ubuntu VM).
-chmod 0640 /etc/speakeasy/managed.json
-chgrp "$(id -gn 1000 2>/dev/null || echo root)" /etc/speakeasy/managed.json
+# The daemon runs as Claude's session user and must be able to read this file.
+chmod 0644 /etc/speakeasy/managed.json
 `;
 }
 
 /**
- * Idempotent start for a VM with no service manager. Mirrors the measured
- * ephemeral-vm bootstrap: start speakeasyd as the current user, and the
- * helper as root when possible. Gated so pasting into laptop Managed
- * Settings is a no-op outside Claude Code on the web.
+ * SessionStart invokes the bootstrap installed by the environment setup
+ * script. Process management stays in that script instead of being embedded
+ * as a multiline JSON command.
  */
 export function buildCloudAgentStartCommand(): string {
-  return [
-    '[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0',
-    'if ! pgrep -u "$(id -u)" -x speakeasyd >/dev/null 2>&1; then',
-    '  speakeasyd >>"${TMPDIR:-/tmp}/speakeasyd.log" 2>&1 &',
-    "fi",
-    "if ! { [ -S /run/com.speakeasy.helper.sock ] && pgrep -f '(^|/)speakeasy-helper($| )' >/dev/null 2>&1; }; then",
-    '  if [ "$(id -u)" = "0" ]; then',
-    '    speakeasy-helper >>"${TMPDIR:-/tmp}/speakeasy-helper.log" 2>&1 &',
-    "  elif command -v sudo >/dev/null 2>&1; then",
-    '    sudo -n speakeasy-helper >>"${TMPDIR:-/tmp}/speakeasy-helper.log" 2>&1 &',
-    "  fi",
-    "fi",
-  ].join("\n");
+  return CLOUD_AGENT_BOOTSTRAP_PATH;
 }
 
 /**
@@ -139,11 +203,12 @@ export function buildCloudAgentStartHook(): string {
       hooks: {
         SessionStart: [
           {
+            matcher: "startup|resume",
             hooks: [
               {
                 type: "command",
                 command: buildCloudAgentStartCommand(),
-                timeout: 30,
+                timeout: 45,
               },
             ],
           },

--- a/client/dashboard/src/pages/device-agent/cloud-setup.ts
+++ b/client/dashboard/src/pages/device-agent/cloud-setup.ts
@@ -1,270 +1,55 @@
-// Builders for the Claude Code on the web (Anthropic-hosted VM) device-agent
-// path. Kept pure so the install contract is unit-tested: the setup script
-// lays down binaries, managed.json, and the per-session bootstrap; SessionStart
-// only invokes that bootstrap. We never emit Claude observability hooks here.
-
 export const RELEASES_BASE =
   "https://storage.googleapis.com/speakeasy-device-agent-releases-prod";
 
 export const MANIFEST_URL = `${RELEASES_BASE}/releases.json`;
 
-/** Sentinel spliced into the setup script until an org_token is minted. */
+/** Sentinel spliced into the startup script until an org_token is minted. */
 export const CLOUD_ORG_TOKEN_SENTINEL = "__SLOT_orgToken__";
 
-/** Stable path provisioned by the setup script and invoked by SessionStart. */
-export const CLOUD_AGENT_BOOTSTRAP_PATH = "/usr/local/bin/speakeasy-bootstrap";
-
-const CLOUD_HELPER_PATH = "/usr/lib/speakeasy/speakeasy-helper";
-const CLAUDE_MANAGED_SETTINGS_PATH = "/etc/claude-code/managed-settings.json";
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-// Same charset the OS-tile snippets require: a manifest version is inlined
-// into a root shell script, so reject anything that isn't strict semver
-// (optionally with a prerelease suffix).
 export const PINNED_AGENT_VERSION =
   /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
 
-export type CloudSetupScriptInput = {
+export const RELEASE_SHA256 = /^[0-9a-f]{64}$/;
+
+export type CloudSetupCommandInput = {
   version: string;
-  orgSlug: string;
-  orgName: string;
-  orgToken: string;
-  /** Identity used by agent.getPlugins and remote-session reporting. */
+  sha256: string;
   email: string;
+  orgToken: string;
 };
 
-export function buildCloudManagedConfig(
-  input: Omit<CloudSetupScriptInput, "version">,
-): Record<string, unknown> {
+export function buildCloudSetupCommand(input: CloudSetupCommandInput): string {
   const email = input.email.trim();
-  if (!EMAIL_PATTERN.test(email)) {
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     throw new Error("a valid remote session identity email is required");
   }
-
-  const config: Record<string, unknown> = {
-    v: 1,
-    email,
-  };
-  config.org_token = input.orgToken;
-  config.org_slug = input.orgSlug;
-  config.org_name = input.orgName;
-  config.auto_update = "disabled";
-  config.hide_ui = true;
-  return config;
-}
-
-function assertPinnedAgentVersion(version: string): string {
-  if (!PINNED_AGENT_VERSION.test(version)) {
-    throw new Error(
-      `refusing to interpolate agent version into a root shell script: ${version}`,
-    );
+  if (!PINNED_AGENT_VERSION.test(input.version)) {
+    throw new Error("a valid pinned device agent version is required");
   }
-  return version;
-}
+  if (!RELEASE_SHA256.test(input.sha256)) {
+    throw new Error("a valid device agent CLI checksum is required");
+  }
 
-/**
- * Idempotent, cloud-only bootstrap installed into the cached filesystem.
- * It mirrors the device-agent ephemeral-VM contract: the helper runs as root,
- * the daemon runs as the same user as Claude, and startup waits for the first
- * policy sync without making a transient agent failure block Claude entirely.
- */
-export function buildCloudAgentBootstrapScript(): string {
-  return `#!/usr/bin/env bash
-# Start Speakeasy enforcement for an Anthropic-hosted Claude Code session.
-set -uo pipefail
-
-if [ "\${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-  exit 0
-fi
-
-LOG_DIR="\${SPEAKEASY_LOG_DIR:-\${TMPDIR:-/tmp}}"
-WAIT_SECS="\${SPEAKEASY_WAIT_SECS:-30}"
-HELPER="${CLOUD_HELPER_PATH}"
-DAEMON="/usr/local/bin/speakeasyd"
-CLI="/usr/local/bin/speakeasy"
-
-log() { printf 'speakeasy-bootstrap: %s\\n' "$*" >&2; }
-
-EXPECT_ROOT=0
-if [ -S /run/com.speakeasy.helper.sock ] && pgrep -f '(^|/)speakeasy-helper($| )' >/dev/null 2>&1; then
-  EXPECT_ROOT=1
-else
-  if [ ! -x "$HELPER" ]; then
-    log "helper not found at $HELPER; managed enforcement will fall back to the user layer"
-  elif [ "$(id -u)" = "0" ]; then
-    "$HELPER" >>"$LOG_DIR/speakeasy-helper.log" 2>&1 &
-    EXPECT_ROOT=1
-  elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-    sudo -n "$HELPER" >>"$LOG_DIR/speakeasy-helper.log" 2>&1 &
-    EXPECT_ROOT=1
-  else
-    log "cannot start the root helper; managed enforcement will fall back to the user layer"
-  fi
-fi
-
-if ! pgrep -u "$(id -u)" -x speakeasyd >/dev/null 2>&1; then
-  "$DAEMON" >>"$LOG_DIR/speakeasyd.log" 2>&1 &
-fi
-
-deadline=$((SECONDS + WAIT_SECS))
-last_sync_nudge=-5
-while [ "$SECONDS" -lt "$deadline" ]; do
-  if status=$("$CLI" status 2>/dev/null) && printf '%s' "$status" | grep -q '^synced:'; then
-    if [ "$EXPECT_ROOT" = "1" ] && printf '%s' "$status" | grep -q 'pending:'; then
-      if [ -S /run/com.speakeasy.helper.sock ] && [ $((SECONDS - last_sync_nudge)) -ge 5 ]; then
-        last_sync_nudge=$SECONDS
-        "$CLI" sync >/dev/null 2>&1 || true
-      fi
-      sleep 0.5
-      continue
-    fi
-    log "policy synced"
-    exit 0
-  fi
-  sleep 0.5
-done
-
-log "policy did not sync within \${WAIT_SECS}s; check $LOG_DIR/speakeasyd.log"
-"$CLI" status 2>&1 || true
-exit 0
-`;
-}
-
-/**
- * Anthropic environment setup script (runs as root, cache miss only).
- * Installs linux_amd64 binaries + the helper .deb, writes managed.json, and
- * installs the bootstrap that SessionStart invokes. It does not start the
- * agent and does not write Claude settings.
- */
-export function buildCloudSetupScript(input: CloudSetupScriptInput): string {
-  const version = assertPinnedAgentVersion(input.version);
-  const managedJson = JSON.stringify(buildCloudManagedConfig(input), null, 2);
-  const bootstrapScript = buildCloudAgentBootstrapScript();
-  const base = `${RELEASES_BASE}/v${version}`;
-  const daemon = `speakeasyd_${version}_linux_amd64`;
-  const cli = `speakeasy_${version}_linux_amd64`;
-  const helperPkg = `speakeasy-helper_${version}_linux_amd64.deb`;
+  const cliURL = `${RELEASES_BASE}/v${input.version}/speakeasy_${input.version}_linux_amd64`;
 
   return `#!/usr/bin/env bash
-# Speakeasy device agent — Anthropic-hosted Claude Code environment.
-# Runs as root on a cache miss only. Does not start the agent: Anthropic
-# snapshots the filesystem and skips this script on later sessions, so
-# SessionStart is what brings the daemon up.
 set -euo pipefail
 
-VERSION="${version}"
-BASE="${base}"
+CLI="$(mktemp)"
+trap 'rm -f "$CLI"' EXIT
 
-TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
-cd "$TMP"
-curl -fsSL -o checksums.txt "$BASE/checksums.txt"
-fetch_and_verify() {
-  curl -fSL -o "$1" "$BASE/$1"
-  grep " $1$" checksums.txt | sha256sum -c -
-}
+curl -fsSL -o "$CLI" ${shellQuote(cliURL)}
+printf '%s  %s\\n' ${shellQuote(input.sha256)} "$CLI" | sha256sum -c -
+chmod 0755 "$CLI"
 
-install -d -m 0755 /usr/local/bin
-fetch_and_verify "${daemon}"
-install -m 0755 "${daemon}" /usr/local/bin/speakeasyd
-fetch_and_verify "${cli}"
-install -m 0755 "${cli}" /usr/local/bin/speakeasy
-fetch_and_verify "${helperPkg}"
-DEBIAN_FRONTEND=noninteractive apt-get install -y "./${helperPkg}"
-
-cat >${CLOUD_AGENT_BOOTSTRAP_PATH} <<'SPEAKEASY_BOOTSTRAP'
-${bootstrapScript}SPEAKEASY_BOOTSTRAP
-chmod 0755 ${CLOUD_AGENT_BOOTSTRAP_PATH}
-
-install -d -m 0755 /etc/speakeasy
-cat >/etc/speakeasy/managed.json <<'SPEAKEASY_MANAGED_JSON'
-${managedJson}
-SPEAKEASY_MANAGED_JSON
-# The daemon runs as Claude's session user and must be able to read this file.
-chmod 0644 /etc/speakeasy/managed.json
+SPEAKEASY_EMAIL=${shellQuote(email)} \\
+SPEAKEASY_ORG_TOKEN=${shellQuote(input.orgToken)} \\
+"$CLI" setup --anthropic-cloud
 `;
 }
 
-/**
- * SessionStart invokes the bootstrap installed by the environment setup
- * script. Process management stays in that script instead of being embedded
- * as a multiline JSON command.
- */
-export function buildCloudAgentStartCommand(): string {
-  return CLOUD_AGENT_BOOTSTRAP_PATH;
-}
-
-function cloudAgentStartHookEntry() {
-  return {
-    matcher: "startup|resume",
-    hooks: [
-      {
-        type: "command",
-        command: buildCloudAgentStartCommand(),
-        timeout: 45,
-      },
-    ],
-  };
-}
-
-/** Canonical SessionStart shape installed by buildCloudAgentHookInstallScript. */
-export function buildCloudAgentStartHook(): string {
-  return `${JSON.stringify(
-    {
-      hooks: {
-        SessionStart: [cloudAgentStartHookEntry()],
-      },
-    },
-    null,
-    2,
-  )}\n`;
-}
-
-/**
- * Setup-script fragment that installs the SessionStart hook into Claude's
- * system-managed settings. The device agent's managed reconciler preserves
- * admin-authored hooks while adding or updating its observability handlers.
- */
-export function buildCloudAgentHookInstallScript(): string {
-  const hookEntry = JSON.stringify(cloudAgentStartHookEntry(), null, 2);
-
-  return `#!/usr/bin/env bash
-# Append this to the Anthropic environment Setup script after the agent install.
-set -euo pipefail
-
-python3 <<'PY'
-import json
-import os
-import tempfile
-from pathlib import Path
-
-path = Path("${CLAUDE_MANAGED_SETTINGS_PATH}")
-settings = json.loads(path.read_text()) if path.exists() else {}
-session_start = settings.setdefault("hooks", {}).setdefault("SessionStart", [])
-hook = ${hookEntry}
-command = hook["hooks"][0]["command"]
-
-installed = any(
-    handler.get("command") == command
-    for entry in session_start
-    for handler in entry.get("hooks", [])
-)
-if not installed:
-    session_start.append(hook)
-
-path.parent.mkdir(parents=True, exist_ok=True)
-fd, temporary_path = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-try:
-    with os.fdopen(fd, "w") as file:
-        json.dump(settings, file, indent=2)
-        file.write("\\n")
-    os.chmod(temporary_path, 0o644)
-    os.replace(temporary_path, path)
-except BaseException:
-    os.unlink(temporary_path)
-    raise
-PY
-`;
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 /** Placeholder merge snippet; the env id is copied from Claude after create. */

--- a/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
@@ -356,8 +356,8 @@ export function RemoteNetworkAccessStep(): React.JSX.Element {
     <div className="flex flex-col gap-4">
       <Text muted>
         Create a <strong>shared</strong> Anthropic-hosted environment in{" "}
-        <InlineLink href="https://claude.ai/admin-settings">
-          Claude admin settings
+        <InlineLink href="https://claude.ai/admin-settings/cloud-environments">
+          Cloud environments
         </InlineLink>{" "}
         for Claude Code on the web.
       </Text>
@@ -384,8 +384,8 @@ export function RemoteOrganizationDefaultStep(): React.JSX.Element {
       <Text small muted>
         Anthropic has no lock-members-to-this-environment switch. After creating
         the shared environment at{" "}
-        <InlineLink href="https://claude.ai/admin-settings">
-          Claude admin settings
+        <InlineLink href="https://claude.ai/admin-settings/cloud-environments">
+          Cloud environments
         </InlineLink>
         , set it as the org default at{" "}
         <InlineLink href="https://claude.ai/admin-settings/claude-code">

--- a/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
@@ -3,13 +3,15 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
 import { Button } from "@/components/ui/Button";
 import { Dialog } from "@/components/ui/Dialog";
 import { Icon } from "@/components/ui/Icon";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
 import { Link as ExternalLink } from "@/components/ui/Link";
 import { Text } from "@/components/ui/Text";
 import { useOrganization } from "@/contexts/Auth";
 import { useAgentToken } from "@/hooks/useAgentToken";
 import { useOrgRoutes } from "@/routes";
 import { useQuery } from "@tanstack/react-query";
-import React, { useState } from "react";
+import React, { useId, useState } from "react";
 import { Link } from "react-router";
 
 import {
@@ -17,12 +19,12 @@ import {
   buildCloudDefaultEnvironmentSnippet,
   buildCloudSetupScript,
   CLOUD_ORG_TOKEN_SENTINEL,
-  CLOUD_SESSIONS_ANCHOR,
   MANIFEST_URL,
   PINNED_AGENT_VERSION,
 } from "./cloud-setup";
 
 const LINK_CLASS = "underline underline-offset-2 hover:text-foreground";
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type ReleasesManifest = {
   latest: Record<string, { version: string }>;
@@ -65,35 +67,17 @@ function InlineLink({
   );
 }
 
-function CloudSetupStep({
-  n,
-  title,
-  children,
-}: {
-  n: number;
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-baseline gap-3">
-        <span className="text-eyebrow">{String(n).padStart(2, "0")}</span>
-        <Text className="font-medium">{title}</Text>
-      </div>
-      {children}
-    </div>
-  );
-}
-
 function GenerateInlineButton({
   onClick,
   pending,
   disabled,
+  disabledReason,
   existing,
 }: {
   onClick: () => void;
   pending: boolean;
   disabled?: boolean;
+  disabledReason?: string;
   existing: boolean;
 }) {
   const label = existing ? "Rotate token" : "Generate token";
@@ -106,7 +90,7 @@ function GenerateInlineButton({
       disabled={pending || disabled}
       title={
         disabled
-          ? "Generating an agent token requires the org:admin role."
+          ? disabledReason
           : existing
             ? "An agent token already exists — this rotates it and splices the new token into the setup script."
             : undefined
@@ -124,6 +108,8 @@ function GenerateInlineButton({
 function CloudSetupScript({ version }: { version: string }) {
   const { name: orgName, slug: orgSlug } = useOrganization();
   const apiKeysHref = useOrgRoutes().apiKeys.href();
+  const identityEmailId = useId();
+  const [identityEmail, setIdentityEmail] = useState("");
   const [rotateConfirmOpen, setRotateConfirmOpen] = useState(false);
 
   const buildScript = (orgToken: string) =>
@@ -132,6 +118,7 @@ function CloudSetupScript({ version }: { version: string }) {
       orgSlug: orgSlug || "acme-corp",
       orgName: orgName || "Acme Corporation",
       orgToken,
+      email: identityEmail.trim(),
     });
 
   const {
@@ -144,7 +131,10 @@ function CloudSetupScript({ version }: { version: string }) {
     generate,
   } = useAgentToken({ buildCopyText: buildScript });
 
-  const script = buildScript(generatedToken ?? CLOUD_ORG_TOKEN_SENTINEL);
+  const hasIdentityEmail = EMAIL_PATTERN.test(identityEmail.trim());
+  const script = hasIdentityEmail
+    ? buildScript(generatedToken ?? CLOUD_ORG_TOKEN_SENTINEL)
+    : "# Enter a reporting email above to generate the setup script.";
 
   const handleGenerateOrRotate = () => {
     if (hasExistingAgentKey) {
@@ -162,7 +152,12 @@ function CloudSetupScript({ version }: { version: string }) {
             <GenerateInlineButton
               onClick={handleGenerateOrRotate}
               pending={isPending}
-              disabled={!canGenerate}
+              disabled={!canGenerate || !hasIdentityEmail}
+              disabledReason={
+                hasIdentityEmail
+                  ? "Generating an agent token requires the org:admin role."
+                  : "Enter the reporting email before generating a token."
+              }
               existing={hasExistingAgentKey}
             />
           ),
@@ -171,13 +166,30 @@ function CloudSetupScript({ version }: { version: string }) {
       };
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-5">
       <Text small muted>
         Paste this into the environment&apos;s <strong>Setup script</strong>{" "}
-        field. It runs as root on a cache miss only. Do not put the token in
-        Anthropic&apos;s Environment variables field — it belongs in{" "}
-        <code>managed.json</code> on disk.
+        field. It installs the agent, its root helper, a per-session bootstrap,
+        and <code>managed.json</code>. It runs as root on a cache miss only.
       </Text>
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor={identityEmailId}>Shared session identity</Label>
+        <Input
+          id={identityEmailId}
+          type="email"
+          value={identityEmail}
+          onChange={setIdentityEmail}
+          placeholder="claude-code-web@your-company.com"
+          validate={(value) =>
+            EMAIL_PATTERN.test(value.trim()) || "Enter a valid email"
+          }
+        />
+        <Text small muted>
+          Every session using this shared environment receives the policy and
+          attribution of this identity. Use a dedicated org member or service
+          account with the intended permissions, not your own email.
+        </Text>
+      </div>
       <CodeBlock language="bash" slots={slots}>
         {script}
       </CodeBlock>
@@ -187,10 +199,10 @@ function CloudSetupScript({ version }: { version: string }) {
           {hasExistingAgentKey ? "Rotate token" : "Generate token"}
         </strong>{" "}
         to mint the <code>org_token</code>. Pin this version; auto-update is
-        disabled because the VM lives minutes. After pasting, add an{" "}
-        <code>email</code> field to <code>managed.json</code> (a shared org
-        mailbox is fine) if you want policy to sync — without it the daemon
-        starts but fetches nothing.
+        disabled because the VM lives minutes. Do not put the token in
+        Anthropic&apos;s Environment variables field: anyone who can use the
+        environment can read either surface, and the agent expects the token in{" "}
+        <code>managed.json</code>.
       </Text>
 
       {generatedToken && (
@@ -204,7 +216,7 @@ function CloudSetupScript({ version }: { version: string }) {
             {autoCopied
               ? "We've copied the full setup script — with the new org_token — to your clipboard."
               : "The new org_token is spliced into the script above — copy it now."}{" "}
-            Anyone who can open the Claude environment can read this token.
+            Anyone who can use the Claude environment can read this token.
             Manage or revoke agent tokens under Settings →{" "}
             <Link to={apiKeysHref} className={LINK_CLASS}>
               API Keys
@@ -232,16 +244,17 @@ function CloudSetupScript({ version }: { version: string }) {
           <Dialog.Header>
             <Dialog.Title>Rotate device agent token?</Dialog.Title>
             <Dialog.Description>
-              This expires the token currently baked into your Claude Code
+              This expires the token currently stored in your Claude Code
               environment.
             </Dialog.Description>
           </Dialog.Header>
           <Alert variant="error">
-            <AlertTitle>Cloud sessions will stop syncing policy</AlertTitle>
+            <AlertTitle>Remote sessions will stop syncing policy</AlertTitle>
             <AlertDescription>
-              Re-paste the updated setup script and recreate the shared
-              environment (or wait for a cache miss) so every session picks up
-              the new <code>org_token</code>. Until then, policy will not sync.
+              Save the updated setup script in the shared environment. Anthropic
+              rebuilds the cached filesystem when the script changes, so
+              subsequent sessions pick up the new <code>org_token</code>. Until
+              then, policy will not sync.
             </AlertDescription>
           </Alert>
           <Dialog.Footer>
@@ -267,7 +280,7 @@ function CloudSetupScript({ version }: { version: string }) {
   );
 }
 
-function SetupScriptStep() {
+export function RemoteSetupScriptStep(): React.JSX.Element {
   const { version, isError, isLoading } = usePinnedAgentVersion();
 
   if (version) {
@@ -299,95 +312,88 @@ function SetupScriptStep() {
   );
 }
 
-/**
- * Cloud sessions walkthrough for Anthropic-hosted Claude Code on the web.
- * Rendered below the OS tiles on DeviceAgentSetup (standalone page and
- * onboarding Instrument agents).
- */
-export function DeviceAgentCloudSetup(): React.JSX.Element {
+export function RemoteNetworkAccessStep(): React.JSX.Element {
   return (
-    <div id={CLOUD_SESSIONS_ANCHOR} className="flex flex-col gap-8">
-      <div>
-        <p className="text-eyebrow mb-2">Cloud sessions</p>
-        <h2 className="text-display-xs font-thin">Claude Code on the web</h2>
-        <Text small muted className="mt-2">
-          Claude Code on the web is an Anthropic Ubuntu 24.04 x86_64 VM. Paste
-          the pieces below into a <strong>shared</strong> Anthropic-hosted
-          environment (Team/Enterprise). The agent then pulls org policy from
-          Gram and writes Claude&apos;s config — you do not paste Speakeasy
-          observability hooks yourself. Self-hosted <code>ccpool_…</code>{" "}
-          environments are not covered here.
-        </Text>
-      </div>
+    <div className="flex flex-col gap-4">
+      <Text muted>
+        Create a <strong>shared</strong> Anthropic-hosted environment in{" "}
+        <InlineLink href="https://claude.ai/admin-settings">
+          Claude admin settings
+        </InlineLink>{" "}
+        for Claude Code on the web. Self-hosted <code>ccpool_…</code>{" "}
+        environments use their runner image instead and are not covered by this
+        walkthrough.
+      </Text>
+      <Text small muted>
+        Trusted network access does not include Gram. Set{" "}
+        <strong className="text-foreground">Custom</strong>, check{" "}
+        <strong className="text-foreground">
+          Also include default list of common package managers
+        </strong>{" "}
+        so GCS and package registries remain available, and add{" "}
+        <code>app.getgram.ai</code> on its own line. Without that host the agent
+        cannot fetch policy or send hook events.
+      </Text>
+    </div>
+  );
+}
 
-      <CloudSetupStep n={1} title="Network access">
-        <Text small muted>
-          Trusted network access does not include Gram. Set{" "}
-          <strong className="text-foreground">Custom</strong>, check{" "}
-          <strong className="text-foreground">
-            Also include default list of common package managers
-          </strong>{" "}
-          (keeps GCS for the agent binaries and the usual registries), and add{" "}
-          <code>app.getgram.ai</code> on its own line. Without that host the
-          daemon cannot call <code>agent.getPlugins</code> or ingest hooks.
-        </Text>
-      </CloudSetupStep>
+export function RemoteSessionStartStep(): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-4">
+      <Text small muted>
+        Anthropic caches files from the setup script but not running processes.
+        Add this to org{" "}
+        <InlineLink href="https://claude.ai/admin-settings/claude-code">
+          Managed Settings
+        </InlineLink>{" "}
+        or the repo&apos;s <code>.claude/settings.json</code> so every new or
+        resumed session invokes the bootstrap installed in the previous step.
+      </Text>
+      <CodeBlock language="json">{buildCloudAgentStartHook()}</CodeBlock>
+      <Text small muted>
+        The hook only invokes <code>/usr/local/bin/speakeasy-bootstrap</code>.
+        That script is cloud-gated, starts the daemon as Claude&apos;s user,
+        starts the root helper when available, and waits for the first policy
+        sync. The device agent then writes Claude&apos;s managed observability
+        hooks itself.
+      </Text>
+    </div>
+  );
+}
 
-      <CloudSetupStep n={2} title="Setup script">
-        <SetupScriptStep />
-      </CloudSetupStep>
-
-      <CloudSetupStep n={3} title="Start the agent">
-        <Text small muted>
-          Anthropic snapshots the filesystem and skips the setup script on later
-          sessions; running processes are not in the snapshot. Merge this
-          SessionStart hook into org{" "}
-          <InlineLink href="https://claude.ai/admin-settings/claude-code">
-            Managed Settings
-          </InlineLink>{" "}
-          or repo <code>.claude/settings.json</code>. User{" "}
-          <code>~/.claude/settings.json</code> does not load in cloud. It only
-          starts the agent — it is not Claude hook policy.
-        </Text>
-        <CodeBlock language="json">{buildCloudAgentStartHook()}</CodeBlock>
-      </CloudSetupStep>
-
-      <CloudSetupStep n={4} title="Make this the org default">
-        <Text small muted>
-          Anthropic has no lock-members-to-this-environment switch. After
-          creating the shared environment at{" "}
-          <InlineLink href="https://claude.ai/admin-settings">
-            Claude admin settings
-          </InlineLink>
-          , set it as the org default at{" "}
-          <InlineLink href="https://claude.ai/admin-settings/claude-code">
-            claude.ai/admin-settings/claude-code
-          </InlineLink>
-          . That fills the selector on web, desktop, and mobile when a member
-          has not picked one — members can still choose a personal or Default
-          environment.
-        </Text>
-        <Text small muted>
-          For CLI <code>claude --cloud</code>, merge this into Managed Settings
-          (copy the <code>env_…</code> id from Claude after you create the
-          environment). It wins over a user <code>/remote-env</code> value.{" "}
-          <code>--environment</code> cannot target Anthropic-hosted{" "}
-          <code>env_…</code> ids.
-        </Text>
-        <CodeBlock language="json">
-          {buildCloudDefaultEnvironmentSnippet()}
-        </CodeBlock>
-      </CloudSetupStep>
-
+export function RemoteOrganizationDefaultStep(): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-4">
+      <Text small muted>
+        Anthropic has no lock-members-to-this-environment switch. After creating
+        the shared environment at{" "}
+        <InlineLink href="https://claude.ai/admin-settings">
+          Claude admin settings
+        </InlineLink>
+        , set it as the org default at{" "}
+        <InlineLink href="https://claude.ai/admin-settings/claude-code">
+          Claude Code admin settings
+        </InlineLink>
+        . This preselects it on web, desktop, and mobile when a member has not
+        chosen another environment.
+      </Text>
+      <Text small muted>
+        For CLI <code>claude --cloud</code>, merge this into Managed Settings
+        after replacing <code>env_…</code> with the shared environment&apos;s
+        ID. The managed value overrides a user&apos;s <code>/remote-env</code>{" "}
+        default.
+      </Text>
+      <CodeBlock language="json">
+        {buildCloudDefaultEnvironmentSnippet()}
+      </CodeBlock>
       <Alert variant="info">
-        <AlertTitle>First session may be pending</AlertTitle>
+        <AlertTitle>The first session may briefly show pending</AlertTitle>
         <AlertDescription>
-          Managed Claude hooks point at the observability plugin under{" "}
-          <code>$HOME</code>. A fresh VM reports <code>pending</code> until
-          Claude clones the marketplace. Server-managed{" "}
-          <code>enabledPlugins</code> already does that clone in cloud sessions;
-          enforcement arms on the next agent tick (~0.3s if the bundle is
-          already there, otherwise after the first clone).
+          On a fresh VM, Claude must clone the org&apos;s observability plugin
+          before the agent can enforce its managed hooks. Server-managed{" "}
+          <code>enabledPlugins</code> triggers that clone; the agent reconciles
+          again after the bundle appears.
         </AlertDescription>
       </Alert>
     </div>

--- a/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
@@ -1,0 +1,395 @@
+import { CodeBlock } from "@/components/code";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Icon } from "@/components/ui/Icon";
+import { Link as ExternalLink } from "@/components/ui/Link";
+import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
+import { useAgentToken } from "@/hooks/useAgentToken";
+import { useOrgRoutes } from "@/routes";
+import { useQuery } from "@tanstack/react-query";
+import React, { useState } from "react";
+import { Link } from "react-router";
+
+import {
+  buildCloudAgentStartHook,
+  buildCloudDefaultEnvironmentSnippet,
+  buildCloudSetupScript,
+  CLOUD_ORG_TOKEN_SENTINEL,
+  CLOUD_SESSIONS_ANCHOR,
+  MANIFEST_URL,
+} from "./cloud-setup";
+
+const LINK_CLASS = "underline underline-offset-2 hover:text-foreground";
+
+type ReleasesManifest = {
+  latest: Record<string, { version: string }>;
+};
+
+const INLINABLE_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+
+function usePinnedAgentVersion() {
+  const query = useQuery<ReleasesManifest>({
+    queryKey: ["device-agent-releases"],
+    queryFn: async () => {
+      const res = await fetch(MANIFEST_URL, {
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) throw new Error(`release manifest: HTTP ${res.status}`);
+      return res.json() as Promise<ReleasesManifest>;
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+  const raw = query.data?.latest?.speakeasyd?.version;
+  const version = raw && INLINABLE_VERSION.test(raw) ? raw : null;
+  return { version, isError: query.isError, isLoading: query.isPending };
+}
+
+function InlineLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={LINK_CLASS}
+    >
+      {children}
+    </a>
+  );
+}
+
+function CloudSetupStep({
+  n,
+  title,
+  children,
+}: {
+  n: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-3">
+        <span className="text-eyebrow">{String(n).padStart(2, "0")}</span>
+        <Text className="font-medium">{title}</Text>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function GenerateInlineButton({
+  onClick,
+  pending,
+  disabled,
+  existing,
+}: {
+  onClick: () => void;
+  pending: boolean;
+  disabled?: boolean;
+  existing: boolean;
+}) {
+  const label = existing ? "Rotate token" : "Generate token";
+  const pendingLabel = existing ? "Rotating…" : "Generating…";
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={onClick}
+      disabled={pending || disabled}
+      title={
+        disabled
+          ? "Generating an agent token requires the org:admin role."
+          : existing
+            ? "An agent token already exists — this rotates it and splices the new token into the setup script."
+            : undefined
+      }
+      className="-my-1 inline-flex h-6 items-center px-2 py-0 align-middle text-xs"
+    >
+      <Button.LeftIcon>
+        <Icon name="key-round" className="h-3 w-3" />
+      </Button.LeftIcon>
+      <Button.Text>{pending ? pendingLabel : label}</Button.Text>
+    </Button>
+  );
+}
+
+function CloudSetupScript({ version }: { version: string }) {
+  const { name: orgName, slug: orgSlug } = useOrganization();
+  const apiKeysHref = useOrgRoutes().apiKeys.href();
+  const [rotateConfirmOpen, setRotateConfirmOpen] = useState(false);
+
+  const buildScript = (orgToken: string) =>
+    buildCloudSetupScript({
+      version,
+      orgSlug: orgSlug || "acme-corp",
+      orgName: orgName || "Acme Corporation",
+      orgToken,
+    });
+
+  const {
+    generatedToken,
+    autoCopied,
+    isPending,
+    isError,
+    canGenerate,
+    hasExistingAgentKey,
+    generate,
+  } = useAgentToken({ buildCopyText: buildScript });
+
+  const script = buildScript(generatedToken ?? CLOUD_ORG_TOKEN_SENTINEL);
+
+  const handleGenerateOrRotate = () => {
+    if (hasExistingAgentKey) {
+      setRotateConfirmOpen(true);
+      return;
+    }
+    generate();
+  };
+
+  const slots = generatedToken
+    ? undefined
+    : {
+        [CLOUD_ORG_TOKEN_SENTINEL]: {
+          node: (
+            <GenerateInlineButton
+              onClick={handleGenerateOrRotate}
+              pending={isPending}
+              disabled={!canGenerate}
+              existing={hasExistingAgentKey}
+            />
+          ),
+          copyText: "spk_org_REPLACE_ME",
+        },
+      };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text small muted>
+        Paste this into the environment&apos;s <strong>Setup script</strong>{" "}
+        field. It runs as root on a cache miss only. Do not put the token in
+        Anthropic&apos;s Environment variables field — it belongs in{" "}
+        <code>managed.json</code> on disk.
+      </Text>
+      <CodeBlock language="bash" slots={slots}>
+        {script}
+      </CodeBlock>
+      <Text small muted>
+        Click{" "}
+        <strong className="text-foreground">
+          {hasExistingAgentKey ? "Rotate token" : "Generate token"}
+        </strong>{" "}
+        to mint the <code>org_token</code>. Pin this version; auto-update is
+        disabled because the VM lives minutes. Add an <code>email</code> field
+        (a shared org mailbox is fine) if you want policy to sync — without it
+        the daemon starts but fetches nothing.
+      </Text>
+
+      {generatedToken && (
+        <Alert variant="warning">
+          <AlertTitle>
+            {autoCopied
+              ? "Setup script copied to your clipboard"
+              : "Copy your setup script now"}
+          </AlertTitle>
+          <AlertDescription>
+            {autoCopied
+              ? "We've copied the full setup script — with the new org_token — to your clipboard."
+              : "The new org_token is spliced into the script above — copy it now."}{" "}
+            Anyone who can open the Claude environment can read this token.
+            Manage or revoke agent tokens under Settings →{" "}
+            <Link to={apiKeysHref} className={LINK_CLASS}>
+              API Keys
+            </Link>
+            .
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {isError && (
+        <Alert variant="error">
+          <AlertTitle>Couldn't generate a token</AlertTitle>
+          <AlertDescription>
+            Try again, or create one under Settings →{" "}
+            <Link to={apiKeysHref} className={LINK_CLASS}>
+              API Keys
+            </Link>{" "}
+            with the Agent scope.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Dialog open={rotateConfirmOpen} onOpenChange={setRotateConfirmOpen}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Rotate device agent token?</Dialog.Title>
+            <Dialog.Description>
+              This expires the token currently baked into your Claude Code
+              environment.
+            </Dialog.Description>
+          </Dialog.Header>
+          <Alert variant="error">
+            <AlertTitle>Cloud sessions will stop syncing policy</AlertTitle>
+            <AlertDescription>
+              Re-paste the updated setup script and recreate the shared
+              environment (or wait for a cache miss) so every session picks up
+              the new <code>org_token</code>. Until then, policy will not sync.
+            </AlertDescription>
+          </Alert>
+          <Dialog.Footer>
+            <Button
+              variant="tertiary"
+              onClick={() => setRotateConfirmOpen(false)}
+            >
+              <Button.Text>Cancel</Button.Text>
+            </Button>
+            <Button
+              variant="destructive-primary"
+              onClick={() => {
+                setRotateConfirmOpen(false);
+                generate();
+              }}
+            >
+              <Button.Text>Rotate token</Button.Text>
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    </div>
+  );
+}
+
+function SetupScriptStep() {
+  const { version, isError, isLoading } = usePinnedAgentVersion();
+
+  if (version) {
+    return <CloudSetupScript version={version} />;
+  }
+
+  if (isLoading) {
+    return (
+      <Text small muted>
+        Loading the latest release…
+      </Text>
+    );
+  }
+
+  return (
+    <Text small muted>
+      {isError
+        ? "Couldn't load the latest release — open the "
+        : "Loading the latest release… or open the "}
+      <ExternalLink
+        href={MANIFEST_URL}
+        target="_blank"
+        iconSuffixName="external-link"
+      >
+        release manifest
+      </ExternalLink>{" "}
+      for the current version, then refresh this page.
+    </Text>
+  );
+}
+
+/**
+ * Cloud sessions walkthrough for Anthropic-hosted Claude Code on the web.
+ * Rendered below the OS tiles on DeviceAgentSetup (standalone page and
+ * onboarding Instrument agents).
+ */
+export function DeviceAgentCloudSetup(): React.JSX.Element {
+  return (
+    <div id={CLOUD_SESSIONS_ANCHOR} className="flex flex-col gap-8">
+      <div>
+        <p className="text-eyebrow mb-2">Cloud sessions</p>
+        <h2 className="text-display-xs font-thin">Claude Code on the web</h2>
+        <Text small muted className="mt-2">
+          Claude Code on the web is an Anthropic Ubuntu 24.04 x86_64 VM. Paste
+          the pieces below into a <strong>shared</strong> Anthropic-hosted
+          environment (Team/Enterprise). The agent then pulls org policy from
+          Gram and writes Claude&apos;s config — you do not paste Speakeasy
+          observability hooks yourself. Self-hosted <code>ccpool_…</code>{" "}
+          environments are not covered here.
+        </Text>
+      </div>
+
+      <CloudSetupStep n={1} title="Network access">
+        <Text small muted>
+          Trusted network access does not include Gram. Set{" "}
+          <strong className="text-foreground">Custom</strong>, check{" "}
+          <strong className="text-foreground">
+            Also include default list of common package managers
+          </strong>{" "}
+          (keeps GCS for the agent binaries and the usual registries), and add{" "}
+          <code>app.getgram.ai</code> on its own line. Without that host the
+          daemon cannot call <code>agent.getPlugins</code> or ingest hooks.
+        </Text>
+      </CloudSetupStep>
+
+      <CloudSetupStep n={2} title="Setup script">
+        <SetupScriptStep />
+      </CloudSetupStep>
+
+      <CloudSetupStep n={3} title="Start the agent">
+        <Text small muted>
+          Anthropic snapshots the filesystem and skips the setup script on later
+          sessions; running processes are not in the snapshot. Merge this
+          SessionStart hook into org{" "}
+          <InlineLink href="https://claude.ai/admin-settings/claude-code">
+            Managed Settings
+          </InlineLink>{" "}
+          or repo <code>.claude/settings.json</code>. User{" "}
+          <code>~/.claude/settings.json</code> does not load in cloud. It only
+          starts the agent — it is not Claude hook policy.
+        </Text>
+        <CodeBlock language="json">{buildCloudAgentStartHook()}</CodeBlock>
+      </CloudSetupStep>
+
+      <CloudSetupStep n={4} title="Make this the org default">
+        <Text small muted>
+          Anthropic has no lock-members-to-this-environment switch. After
+          creating the shared environment at{" "}
+          <InlineLink href="https://claude.ai/admin-settings">
+            Claude admin settings
+          </InlineLink>
+          , set it as the org default at{" "}
+          <InlineLink href="https://claude.ai/admin-settings/claude-code">
+            claude.ai/admin-settings/claude-code
+          </InlineLink>
+          . That fills the selector on web, desktop, and mobile when a member
+          has not picked one — members can still choose a personal or Default
+          environment.
+        </Text>
+        <Text small muted>
+          For CLI <code>claude --cloud</code>, merge this into Managed Settings
+          (copy the <code>env_…</code> id from Claude after you create the
+          environment). It wins over a user <code>/remote-env</code> value.{" "}
+          <code>--environment</code> cannot target Anthropic-hosted{" "}
+          <code>env_…</code> ids.
+        </Text>
+        <CodeBlock language="json">
+          {buildCloudDefaultEnvironmentSnippet()}
+        </CodeBlock>
+      </CloudSetupStep>
+
+      <Alert variant="info">
+        <AlertTitle>First session may be pending</AlertTitle>
+        <AlertDescription>
+          Managed Claude hooks point at the observability plugin under{" "}
+          <code>$HOME</code>. A fresh VM reports <code>pending</code> until
+          Claude clones the marketplace. Server-managed{" "}
+          <code>enabledPlugins</code> already does that clone in cloud sessions;
+          enforcement arms on the next agent tick (~0.3s if the bundle is
+          already there, otherwise after the first clone).
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
@@ -7,7 +7,6 @@ import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
 import { Link as ExternalLink } from "@/components/ui/Link";
 import { Text } from "@/components/ui/Text";
-import { useOrganization } from "@/contexts/Auth";
 import { useAgentToken } from "@/hooks/useAgentToken";
 import { useOrgRoutes } from "@/routes";
 import { useQuery } from "@tanstack/react-query";
@@ -15,22 +14,32 @@ import React, { useId, useState } from "react";
 import { Link } from "react-router";
 
 import {
-  buildCloudAgentHookInstallScript,
   buildCloudDefaultEnvironmentSnippet,
-  buildCloudSetupScript,
+  buildCloudSetupCommand,
   CLOUD_ORG_TOKEN_SENTINEL,
   MANIFEST_URL,
   PINNED_AGENT_VERSION,
+  RELEASE_SHA256,
 } from "./cloud-setup";
 
 const LINK_CLASS = "underline underline-offset-2 hover:text-foreground";
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type ReleasesManifest = {
-  latest: Record<string, { version: string }>;
+  latest: Record<
+    string,
+    {
+      version: string;
+      artifacts: {
+        goos: string;
+        goarch: string;
+        sha256: string;
+      }[];
+    }
+  >;
 };
 
-function usePinnedAgentVersion() {
+function usePinnedAgentCLI() {
   const query = useQuery<ReleasesManifest>({
     queryKey: ["device-agent-releases"],
     queryFn: async () => {
@@ -43,9 +52,23 @@ function usePinnedAgentVersion() {
     staleTime: 5 * 60 * 1000,
     retry: 1,
   });
-  const raw = query.data?.latest?.speakeasyd?.version;
-  const version = raw && PINNED_AGENT_VERSION.test(raw) ? raw : null;
-  return { version, isError: query.isError, isLoading: query.isPending };
+  const release = query.data?.latest?.speakeasy;
+  const version =
+    release?.version && PINNED_AGENT_VERSION.test(release.version)
+      ? release.version
+      : null;
+  const artifact = release?.artifacts.find(
+    (candidate) => candidate.goos === "linux" && candidate.goarch === "amd64",
+  );
+  const sha256 =
+    artifact?.sha256 && RELEASE_SHA256.test(artifact.sha256)
+      ? artifact.sha256
+      : null;
+  return {
+    release: version && sha256 ? { version, sha256 } : null,
+    isError: query.isError,
+    isLoading: query.isPending,
+  };
 }
 
 function InlineLink({
@@ -105,18 +128,22 @@ function GenerateInlineButton({
   );
 }
 
-function CloudSetupScript({ version }: { version: string }) {
-  const { name: orgName, slug: orgSlug } = useOrganization();
+function CloudSetupScript({
+  version,
+  sha256,
+}: {
+  version: string;
+  sha256: string;
+}) {
   const apiKeysHref = useOrgRoutes().apiKeys.href();
   const identityEmailId = useId();
   const [identityEmail, setIdentityEmail] = useState("");
   const [rotateConfirmOpen, setRotateConfirmOpen] = useState(false);
 
   const buildScript = (orgToken: string) =>
-    buildCloudSetupScript({
+    buildCloudSetupCommand({
       version,
-      orgSlug: orgSlug || "acme-corp",
-      orgName: orgName || "Acme Corporation",
+      sha256,
       orgToken,
       email: identityEmail.trim(),
     });
@@ -170,18 +197,17 @@ function CloudSetupScript({ version }: { version: string }) {
       <Alert variant="info">
         <AlertTitle>Remote sessions use managed enrollment</AlertTitle>
         <AlertDescription>
-          The device agent supports personal enrollment, where a one-shot OAuth
-          login stores only the user&apos;s email, and managed enrollment, where
-          an admin provides both an identity and an agent-scoped{" "}
-          <code>org_token</code>. A headless shared VM cannot use interactive
-          OAuth, and policy sync requires the org token, so this setup uses
-          managed enrollment.
+          Interactive machines can enroll through a browser sign-in. A headless
+          shared VM cannot, so this flow uses managed enrollment: an admin
+          provides the shared reporting identity and an agent-scoped{" "}
+          <code>org_token</code>.
         </AlertDescription>
       </Alert>
       <Text small muted>
         Paste this into the environment&apos;s <strong>Setup script</strong>{" "}
-        field. It installs the agent, its root helper, a per-session bootstrap,
-        and <code>managed.json</code>. It runs as root on a cache miss only.
+        field. It only downloads and verifies the device-agent CLI, then lets{" "}
+        <code>speakeasy setup --anthropic-cloud</code> configure the machine and
+        install the SessionStart hook.
       </Text>
       <div className="flex flex-col gap-1.5">
         <Label htmlFor={identityEmailId}>Shared session identity</Label>
@@ -210,10 +236,9 @@ function CloudSetupScript({ version }: { version: string }) {
           {hasExistingAgentKey ? "Rotate token" : "Generate token"}
         </strong>{" "}
         to mint the <code>org_token</code>. Pin this version; auto-update is
-        disabled because the VM lives minutes. Do not put the token in
-        Anthropic&apos;s Environment variables field: anyone who can use the
-        environment can read either surface, and the agent expects the token in{" "}
-        <code>managed.json</code>.
+        disabled because the VM lives minutes. Anyone who can use the
+        environment can read the token from the setup script or the resulting
+        agent configuration.
       </Text>
 
       {generatedToken && (
@@ -292,10 +317,12 @@ function CloudSetupScript({ version }: { version: string }) {
 }
 
 export function RemoteSetupScriptStep(): React.JSX.Element {
-  const { version, isError, isLoading } = usePinnedAgentVersion();
+  const { release, isError, isLoading } = usePinnedAgentCLI();
 
-  if (version) {
-    return <CloudSetupScript version={version} />;
+  if (release) {
+    return (
+      <CloudSetupScript version={release.version} sha256={release.sha256} />
+    );
   }
 
   if (isLoading) {
@@ -331,9 +358,7 @@ export function RemoteNetworkAccessStep(): React.JSX.Element {
         <InlineLink href="https://claude.ai/admin-settings">
           Claude admin settings
         </InlineLink>{" "}
-        for Claude Code on the web. Self-hosted <code>ccpool_…</code>{" "}
-        environments use their runner image instead and are not covered by this
-        walkthrough.
+        for Claude Code on the web.
       </Text>
       <Text small muted>
         Trusted network access does not include Gram. Set{" "}
@@ -347,29 +372,6 @@ export function RemoteNetworkAccessStep(): React.JSX.Element {
       <CodeBlock language="text">app.getgram.ai</CodeBlock>
       <Text small muted>
         Without this host the agent cannot fetch policy or send hook events.
-      </Text>
-    </div>
-  );
-}
-
-export function RemoteSessionStartStep(): React.JSX.Element {
-  return (
-    <div className="flex flex-col gap-4">
-      <Text small muted>
-        Append this block to the same Anthropic{" "}
-        <strong className="text-foreground">Setup script</strong> from the
-        previous step. It installs a system-managed SessionStart hook into the
-        cached VM filesystem, so every new or resumed session invokes the
-        bootstrap automatically.
-      </Text>
-      <CodeBlock language="bash">
-        {buildCloudAgentHookInstallScript()}
-      </CodeBlock>
-      <Text small muted>
-        The installed hook only invokes{" "}
-        <code>/usr/local/bin/speakeasy-bootstrap</code>. The device agent
-        preserves this admin-authored hook while adding its own managed
-        observability hooks.
       </Text>
     </div>
   );

--- a/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
@@ -19,6 +19,7 @@ import {
   CLOUD_ORG_TOKEN_SENTINEL,
   CLOUD_SESSIONS_ANCHOR,
   MANIFEST_URL,
+  PINNED_AGENT_VERSION,
 } from "./cloud-setup";
 
 const LINK_CLASS = "underline underline-offset-2 hover:text-foreground";
@@ -26,8 +27,6 @@ const LINK_CLASS = "underline underline-offset-2 hover:text-foreground";
 type ReleasesManifest = {
   latest: Record<string, { version: string }>;
 };
-
-const INLINABLE_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
 
 function usePinnedAgentVersion() {
   const query = useQuery<ReleasesManifest>({
@@ -43,7 +42,7 @@ function usePinnedAgentVersion() {
     retry: 1,
   });
   const raw = query.data?.latest?.speakeasyd?.version;
-  const version = raw && INLINABLE_VERSION.test(raw) ? raw : null;
+  const version = raw && PINNED_AGENT_VERSION.test(raw) ? raw : null;
   return { version, isError: query.isError, isLoading: query.isPending };
 }
 
@@ -188,9 +187,10 @@ function CloudSetupScript({ version }: { version: string }) {
           {hasExistingAgentKey ? "Rotate token" : "Generate token"}
         </strong>{" "}
         to mint the <code>org_token</code>. Pin this version; auto-update is
-        disabled because the VM lives minutes. Add an <code>email</code> field
-        (a shared org mailbox is fine) if you want policy to sync — without it
-        the daemon starts but fetches nothing.
+        disabled because the VM lives minutes. After pasting, add an{" "}
+        <code>email</code> field to <code>managed.json</code> (a shared org
+        mailbox is fine) if you want policy to sync — without it the daemon
+        starts but fetches nothing.
       </Text>
 
       {generatedToken && (

--- a/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
@@ -39,7 +39,7 @@ type ReleasesManifest = {
   >;
 };
 
-function usePinnedAgentCLI() {
+function usePinnedAgentDaemon() {
   const query = useQuery<ReleasesManifest>({
     queryKey: ["device-agent-releases"],
     queryFn: async () => {
@@ -52,7 +52,7 @@ function usePinnedAgentCLI() {
     staleTime: 5 * 60 * 1000,
     retry: 1,
   });
-  const release = query.data?.latest?.speakeasy;
+  const release = query.data?.latest?.speakeasyd;
   const version =
     release?.version && PINNED_AGENT_VERSION.test(release.version)
       ? release.version
@@ -205,9 +205,10 @@ function CloudSetupScript({
       </Alert>
       <Text small muted>
         Paste this into the environment&apos;s <strong>Setup script</strong>{" "}
-        field. It only downloads and verifies the device-agent CLI, then lets{" "}
-        <code>speakeasy setup --anthropic-cloud</code> configure the machine and
-        install the SessionStart hook.
+        field. It installs the pinned agent, writes managed enrollment, and
+        registers a SessionStart hook that starts the agent in each session.
+        From there the agent&apos;s normal policy sync installs plugins and
+        keeps enforcement reconciled — the same flow as any other machine.
       </Text>
       <div className="flex flex-col gap-1.5">
         <Label htmlFor={identityEmailId}>Shared session identity</Label>
@@ -317,7 +318,7 @@ function CloudSetupScript({
 }
 
 export function RemoteSetupScriptStep(): React.JSX.Element {
-  const { release, isError, isLoading } = usePinnedAgentCLI();
+  const { release, isError, isLoading } = usePinnedAgentDaemon();
 
   if (release) {
     return (

--- a/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-cloud-setup.tsx
@@ -15,7 +15,7 @@ import React, { useId, useState } from "react";
 import { Link } from "react-router";
 
 import {
-  buildCloudAgentStartHook,
+  buildCloudAgentHookInstallScript,
   buildCloudDefaultEnvironmentSnippet,
   buildCloudSetupScript,
   CLOUD_ORG_TOKEN_SENTINEL,
@@ -167,6 +167,17 @@ function CloudSetupScript({ version }: { version: string }) {
 
   return (
     <div className="flex flex-col gap-5">
+      <Alert variant="info">
+        <AlertTitle>Remote sessions use managed enrollment</AlertTitle>
+        <AlertDescription>
+          The device agent supports personal enrollment, where a one-shot OAuth
+          login stores only the user&apos;s email, and managed enrollment, where
+          an admin provides both an identity and an agent-scoped{" "}
+          <code>org_token</code>. A headless shared VM cannot use interactive
+          OAuth, and policy sync requires the org token, so this setup uses
+          managed enrollment.
+        </AlertDescription>
+      </Alert>
       <Text small muted>
         Paste this into the environment&apos;s <strong>Setup script</strong>{" "}
         field. It installs the agent, its root helper, a per-session bootstrap,
@@ -330,9 +341,12 @@ export function RemoteNetworkAccessStep(): React.JSX.Element {
         <strong className="text-foreground">
           Also include default list of common package managers
         </strong>{" "}
-        so GCS and package registries remain available, and add{" "}
-        <code>app.getgram.ai</code> on its own line. Without that host the agent
-        cannot fetch policy or send hook events.
+        so GCS and package registries remain available, and add this host on its
+        own line:
+      </Text>
+      <CodeBlock language="text">app.getgram.ai</CodeBlock>
+      <Text small muted>
+        Without this host the agent cannot fetch policy or send hook events.
       </Text>
     </div>
   );
@@ -342,21 +356,20 @@ export function RemoteSessionStartStep(): React.JSX.Element {
   return (
     <div className="flex flex-col gap-4">
       <Text small muted>
-        Anthropic caches files from the setup script but not running processes.
-        Add this to org{" "}
-        <InlineLink href="https://claude.ai/admin-settings/claude-code">
-          Managed Settings
-        </InlineLink>{" "}
-        or the repo&apos;s <code>.claude/settings.json</code> so every new or
-        resumed session invokes the bootstrap installed in the previous step.
+        Append this block to the same Anthropic{" "}
+        <strong className="text-foreground">Setup script</strong> from the
+        previous step. It installs a system-managed SessionStart hook into the
+        cached VM filesystem, so every new or resumed session invokes the
+        bootstrap automatically.
       </Text>
-      <CodeBlock language="json">{buildCloudAgentStartHook()}</CodeBlock>
+      <CodeBlock language="bash">
+        {buildCloudAgentHookInstallScript()}
+      </CodeBlock>
       <Text small muted>
-        The hook only invokes <code>/usr/local/bin/speakeasy-bootstrap</code>.
-        That script is cloud-gated, starts the daemon as Claude&apos;s user,
-        starts the root helper when available, and waits for the first policy
-        sync. The device agent then writes Claude&apos;s managed observability
-        hooks itself.
+        The installed hook only invokes{" "}
+        <code>/usr/local/bin/speakeasy-bootstrap</code>. The device agent
+        preserves this admin-authored hook while adding its own managed
+        observability hooks.
       </Text>
     </div>
   );

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -22,6 +22,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ChevronRight, Download } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router";
+import { DeviceAgentCloudSetup } from "./device-agent-cloud-setup";
 
 // Public, unauthenticated bucket the release pipeline publishes to. The
 // manifest (releases.json) lists the current version + per-platform URLs;
@@ -1283,6 +1284,10 @@ export function DeviceAgentSetup(): React.JSX.Element {
             {OS_ORDER.map((os) => (
               <OsTile key={os} os={os} onClick={() => setSheetOs(os)} />
             ))}
+          </div>
+
+          <div className="border-border mt-4 border-t pt-8">
+            <DeviceAgentCloudSetup />
           </div>
 
           {/* Sheet must live inside Page.Section.Body: Page.Section only

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -1081,7 +1081,7 @@ function buildSteps(platform: PlatformKey): SetupStep[] {
         body: <RemoteSetupScriptStep />,
       },
       {
-        title: "Start the agent in every session",
+        title: "Install the per-session startup hook",
         body: <RemoteSessionStartStep />,
       },
       {

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -25,7 +25,6 @@ import { Link } from "react-router";
 import {
   RemoteNetworkAccessStep,
   RemoteOrganizationDefaultStep,
-  RemoteSessionStartStep,
   RemoteSetupScriptStep,
 } from "./device-agent-cloud-setup";
 
@@ -1079,10 +1078,6 @@ function buildSteps(platform: PlatformKey): SetupStep[] {
       {
         title: "Install and configure the agent",
         body: <RemoteSetupScriptStep />,
-      },
-      {
-        title: "Install the per-session startup hook",
-        body: <RemoteSessionStartStep />,
       },
       {
         title: "Make it the organization default",

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -22,7 +22,12 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ChevronRight, Download } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router";
-import { DeviceAgentCloudSetup } from "./device-agent-cloud-setup";
+import {
+  RemoteNetworkAccessStep,
+  RemoteOrganizationDefaultStep,
+  RemoteSessionStartStep,
+  RemoteSetupScriptStep,
+} from "./device-agent-cloud-setup";
 
 // Public, unauthenticated bucket the release pipeline publishes to. The
 // manifest (releases.json) lists the current version + per-platform URLs;
@@ -79,8 +84,9 @@ const platformKey = (a: { goos: string; goarch: string }) =>
 // All the per-OS specifics live in this one table.
 // ---------------------------------------------------------------------------
 type OsKey = "macos" | "windows" | "linux";
+type PlatformKey = OsKey | "remote";
 
-const OS_ORDER: OsKey[] = ["macos", "windows", "linux"];
+const PLATFORM_ORDER: PlatformKey[] = ["macos", "windows", "linux", "remote"];
 
 // A manifest-supplied version is rendered directly into a copy-paste
 // shell/PowerShell snippet. Quoting alone doesn't make that safe — double
@@ -124,7 +130,7 @@ function psVersionAssign(version: string | null) {
 type BaseOsSpec = {
   label: string;
   tileDesc: string;
-  logo: string;
+  logo?: string;
   // Per-logo size: the Apple/Windows marks fill their square viewBox
   // edge-to-edge, while Tux is a taller, non-square figure — it runs a touch
   // larger (and is object-contain'd) to sit at the same optical size without
@@ -218,6 +224,15 @@ speakeasyd -service start`,
     hasHelperPackage: true,
   },
 };
+
+const REMOTE_PLATFORM_CONFIG: BaseOsSpec = {
+  label: "Remote sessions",
+  tileDesc: "Claude Code on the web",
+};
+
+function platformConfig(platform: PlatformKey): BaseOsSpec {
+  return platform === "remote" ? REMOTE_PLATFORM_CONFIG : OS_CONFIG[platform];
+}
 
 function SubHeading({ children }: { children: React.ReactNode }) {
   return <Text className="mb-2 font-medium">{children}</Text>;
@@ -1048,22 +1063,51 @@ function SetupTab({
 
 type SetupStep = { title: string; body: React.ReactNode };
 
-// buildSteps assembles the ordered setup steps for an OS. macOS installs from
+// buildSteps assembles the ordered setup steps for a platform. Remote sessions
+// have their own cloud-environment flow; local platforms follow the OS-specific
+// installation path below. macOS installs from
 // a signed .pkg (one combined install step, no chmod/move or separate service
 // registration); Windows/Linux still ship raw binaries via a download script,
 // so the list length (and numbering) varies by OS.
-function buildSteps(os: OsKey): SetupStep[] {
-  if (os === "macos") {
+function buildSteps(platform: PlatformKey): SetupStep[] {
+  if (platform === "remote") {
     return [
-      { title: "Download and install the agent", body: <MacInstallStep /> },
-      { title: "Verify it's running", body: <MacVerifyStep /> },
-      { title: "Set the user's identity", body: <IdentityStep os={os} /> },
+      {
+        title: "Configure the shared environment",
+        body: <RemoteNetworkAccessStep />,
+      },
+      {
+        title: "Install and configure the agent",
+        body: <RemoteSetupScriptStep />,
+      },
+      {
+        title: "Start the agent in every session",
+        body: <RemoteSessionStartStep />,
+      },
+      {
+        title: "Make it the organization default",
+        body: <RemoteOrganizationDefaultStep />,
+      },
     ];
   }
 
-  const cfg = OS_CONFIG[os];
+  if (platform === "macos") {
+    return [
+      { title: "Download and install the agent", body: <MacInstallStep /> },
+      { title: "Verify it's running", body: <MacVerifyStep /> },
+      {
+        title: "Set the user's identity",
+        body: <IdentityStep os={platform} />,
+      },
+    ];
+  }
+
+  const cfg = OS_CONFIG[platform];
   const steps: SetupStep[] = [
-    { title: "Download the binaries", body: <DownloadStep os={os} /> },
+    {
+      title: "Download the binaries",
+      body: <DownloadStep os={platform} />,
+    },
   ];
   if (cfg.chmodMove) {
     steps.push({
@@ -1092,32 +1136,32 @@ function buildSteps(os: OsKey): SetupStep[] {
   }
   steps.push({
     title: "Set the user's identity",
-    body: <IdentityStep os={os} />,
+    body: <IdentityStep os={platform} />,
   });
   return steps;
 }
 
-// DeviceAgentSetupSheet walks through the per-OS setup as a sequence of steps,
-// matching the platform-instrumentation sheet used elsewhere in onboarding:
+// DeviceAgentSetupSheet walks through the selected platform as a sequence of
+// steps, matching the platform-instrumentation sheet used elsewhere in onboarding:
 // progress dots up top, one step visible at a time, back/next in the footer.
 function DeviceAgentSetupSheet({
-  os,
+  platform,
   open,
   onOpenChange,
 }: {
-  os: OsKey | null;
+  platform: PlatformKey | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
   const [stepIdx, setStepIdx] = useState(0);
 
-  // Reset to the first step whenever a fresh OS is opened.
+  // Reset to the first step whenever a platform is opened.
   useEffect(() => {
     if (open) setStepIdx(0);
-  }, [open, os]);
+  }, [open, platform]);
 
-  const steps = os ? buildSteps(os) : [];
-  const cfg = os ? OS_CONFIG[os] : null;
+  const steps = platform ? buildSteps(platform) : [];
+  const cfg = platform ? platformConfig(platform) : null;
   const total = steps.length;
   const isLast = stepIdx === total - 1;
 
@@ -1133,7 +1177,7 @@ function DeviceAgentSetupSheet({
       >
         <SheetHeader className="sr-only">
           <SheetTitle>
-            Install the Speakeasy device agent on {cfg?.label}
+            Set up the Speakeasy device agent for {cfg?.label}
           </SheetTitle>
           <SheetDescription>
             Step-by-step setup for the device agent.
@@ -1214,10 +1258,16 @@ function DeviceAgentSetupSheet({
   );
 }
 
-// OsTile is a clickable platform card, styled like the agent-platform tiles in
-// the manual instrumentation step. Clicking it opens the setup sheet.
-function OsTile({ os, onClick }: { os: OsKey; onClick: () => void }) {
-  const cfg = OS_CONFIG[os];
+// PlatformTile is a clickable setup card. Local operating systems use their
+// platform marks; Remote sessions uses a cloud icon but opens the same sheet.
+function PlatformTile({
+  platform,
+  onClick,
+}: {
+  platform: PlatformKey;
+  onClick: () => void;
+}) {
+  const cfg = platformConfig(platform);
   return (
     <button
       type="button"
@@ -1225,15 +1275,19 @@ function OsTile({ os, onClick }: { os: OsKey; onClick: () => void }) {
       className="border-border bg-card hover:border-foreground/20 flex w-full items-center gap-4 border p-4 text-left transition-all"
     >
       <div className="bg-secondary flex h-14 w-14 flex-shrink-0 items-center justify-center">
-        <img
-          src={cfg.logo}
-          alt={`${cfg.label} logo`}
-          className={cn(
-            cfg.logoSize ?? "h-8 w-8",
-            "object-contain",
-            cfg.invertLogoInDark && "dark:invert",
-          )}
-        />
+        {platform === "remote" ? (
+          <Icon name="cloud" className="h-7 w-7" />
+        ) : (
+          <img
+            src={cfg.logo}
+            alt={`${cfg.label} logo`}
+            className={cn(
+              cfg.logoSize ?? "h-8 w-8",
+              "object-contain",
+              cfg.invertLogoInDark && "dark:invert",
+            )}
+          />
+        )}
       </div>
       <div className="min-w-0 flex-1 space-y-1">
         <p className="text-foreground text-sm font-medium">{cfg.label}</p>
@@ -1244,12 +1298,11 @@ function OsTile({ os, onClick }: { os: OsKey; onClick: () => void }) {
   );
 }
 
-// DeviceAgentSetup is the shared device-agent setup UI: pick your OS from the
-// tile grid, then walk the per-OS install + identity steps in a sheet. Rendered
-// both on the standalone Device Agent page and inside the onboarding
-// "Instrument agents" step (Device Agent tab), so setup lives in one place.
+// DeviceAgentSetup is the shared device-agent setup UI: pick a local OS or
+// Remote sessions from the tile grid, then walk its steps in a sheet. Rendered
+// both on the standalone Device Agent page and inside onboarding.
 export function DeviceAgentSetup(): React.JSX.Element {
-  const [sheetOs, setSheetOs] = useState<OsKey | null>(null);
+  const [sheetPlatform, setSheetPlatform] = useState<PlatformKey | null>(null);
 
   return (
     <Page.Section>
@@ -1257,9 +1310,9 @@ export function DeviceAgentSetup(): React.JSX.Element {
           title above the tab strip, so suppress the section-level one. */}
       <Page.Section.Title area="">Install the agent</Page.Section.Title>
       <Page.Section.Description>
-        The Speakeasy device agent runs on-device and enforces your org's
-        required AI-tool plugins and MCP configuration, then reports compliance
-        back to Speakeasy.
+        The Speakeasy device agent runs alongside your AI tools, enforces your
+        org&apos;s required plugins and MCP configuration, and reports
+        compliance back to Speakeasy.
       </Page.Section.Description>
       <Page.Section.Body>
         <div className="flex flex-col gap-4">
@@ -1274,20 +1327,20 @@ export function DeviceAgentSetup(): React.JSX.Element {
               <strong className="text-foreground font-medium">
                 Fleet (MDM)
               </strong>{" "}
-              path in each platform's walkthrough covers it.
+              path in each local platform&apos;s walkthrough covers it.
             </Text>
           </div>
           <Text small muted>
             Pick the platform you're installing on to walk through setup.
           </Text>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-            {OS_ORDER.map((os) => (
-              <OsTile key={os} os={os} onClick={() => setSheetOs(os)} />
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {PLATFORM_ORDER.map((platform) => (
+              <PlatformTile
+                key={platform}
+                platform={platform}
+                onClick={() => setSheetPlatform(platform)}
+              />
             ))}
-          </div>
-
-          <div className="border-border mt-4 border-t pt-8">
-            <DeviceAgentCloudSetup />
           </div>
 
           {/* Sheet must live inside Page.Section.Body: Page.Section only
@@ -1295,10 +1348,10 @@ export function DeviceAgentSetup(): React.JSX.Element {
               and drops anything else, so a Sheet placed as a direct Section
               child never mounts. */}
           <DeviceAgentSetupSheet
-            os={sheetOs}
-            open={sheetOs !== null}
+            platform={sheetPlatform}
+            open={sheetPlatform !== null}
             onOpenChange={(open) => {
-              if (!open) setSheetOs(null);
+              if (!open) setSheetPlatform(null);
             }}
           />
         </div>

--- a/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
@@ -8,6 +8,7 @@ import { AgentPlatformPickerItem } from "../agent-platform-picker-item";
 import { PlatformInstrumentationSheet } from "../platform-instrumentation-sheet";
 import { platformStatusBadge } from "../platform-status-badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
+import { CLOUD_SESSIONS_ANCHOR } from "@/pages/device-agent/cloud-setup";
 import { DeviceAgentSetup } from "@/pages/device-agent/device-agent-setup";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
 
@@ -36,6 +37,12 @@ export function InstrumentAgentsStep({
   const openCoworkManualSetup = () => {
     setActiveTab("manual");
     setDrawerPlatformId("claude-cowork");
+  };
+
+  const scrollToCloudSessions = () => {
+    document
+      .getElementById(CLOUD_SESSIONS_ANCHOR)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   const availablePlatforms = AGENT_PLATFORMS.filter(
@@ -80,19 +87,29 @@ export function InstrumentAgentsStep({
 
         <TabsContent value="device-agent" className="space-y-4">
           <Alert variant="info">
-            <AlertTitle>Claude Cowork still needs manual setup</AlertTitle>
+            <AlertTitle>
+              Cowork and Claude Code on the web need extra setup
+            </AlertTitle>
             <AlertDescription>
-              The device agent instruments coding assistants that run on a
-              developer's machine — Cowork runs in Claude.ai's own cloud
-              sandbox, so it isn't covered here.{" "}
+              The OS tiles below cover coding assistants on a developer machine.
+              Claude Code on the web runs in an Anthropic-hosted VM — follow{" "}
+              <button
+                type="button"
+                onClick={scrollToCloudSessions}
+                className="text-foreground underline underline-offset-2"
+              >
+                Cloud sessions
+              </button>{" "}
+              further down this page. Cowork still isn&apos;t covered by the
+              device agent.{" "}
               <button
                 type="button"
                 onClick={openCoworkManualSetup}
                 className="text-foreground underline underline-offset-2"
               >
                 Set it up manually
-              </button>{" "}
-              alongside your device agent rollout.
+              </button>
+              .
             </AlertDescription>
           </Alert>
           <DeviceAgentSetup />

--- a/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
@@ -8,7 +8,6 @@ import { AgentPlatformPickerItem } from "../agent-platform-picker-item";
 import { PlatformInstrumentationSheet } from "../platform-instrumentation-sheet";
 import { platformStatusBadge } from "../platform-status-badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
-import { CLOUD_SESSIONS_ANCHOR } from "@/pages/device-agent/cloud-setup";
 import { DeviceAgentSetup } from "@/pages/device-agent/device-agent-setup";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
 
@@ -37,12 +36,6 @@ export function InstrumentAgentsStep({
   const openCoworkManualSetup = () => {
     setActiveTab("manual");
     setDrawerPlatformId("claude-cowork");
-  };
-
-  const scrollToCloudSessions = () => {
-    document
-      .getElementById(CLOUD_SESSIONS_ANCHOR)
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   const availablePlatforms = AGENT_PLATFORMS.filter(
@@ -87,21 +80,10 @@ export function InstrumentAgentsStep({
 
         <TabsContent value="device-agent" className="space-y-4">
           <Alert variant="info">
-            <AlertTitle>
-              Cowork and Claude Code on the web need extra setup
-            </AlertTitle>
+            <AlertTitle>Cowork needs separate setup</AlertTitle>
             <AlertDescription>
-              The OS tiles below cover coding assistants on a developer machine.
-              Claude Code on the web runs in an Anthropic-hosted VM — follow{" "}
-              <button
-                type="button"
-                onClick={scrollToCloudSessions}
-                className="text-foreground underline underline-offset-2"
-              >
-                Cloud sessions
-              </button>{" "}
-              further down this page. Cowork still isn&apos;t covered by the
-              device agent.{" "}
+              The Remote sessions tile below covers Claude Code on the web.
+              Cowork isn&apos;t covered by the device agent.{" "}
               <button
                 type="button"
                 onClick={openCoworkManualSetup}


### PR DESCRIPTION
## Summary

- Add a clickable Remote sessions platform walkthrough for Anthropic-hosted Claude Code on the web.
- The generated setup script is fully self-contained: it installs the pinned, checksum-verified `speakeasyd`, writes managed enrollment (`/etc/speakeasy/managed.json`), and registers an async, `flock`-guarded SessionStart hook in `/root/.claude/settings.json` that revives the daemon in each session (Anthropic snapshots files, not processes).
- From daemon start, everything rides the device agent's existing policy-sync loop — plugin marketplace install, tool config, and enforcement work exactly as on any other machine. No cloud-specific device-agent code is required (superseded [speakeasy-api/device-agent#171](https://github.com/speakeasy-api/device-agent/pull/171) is closed).
- The dashboard keeps the shared identity input and agent-token generation/rotation, and covers custom network access plus optionally setting the shared environment as the organization default.

DNO-925

## Test plan

- [x] `aube run -F dashboard test src/pages/device-agent/cloud-setup.test.ts` (script passes `bash -n`; hook settings JSON parses; singleton `flock` guard asserted)
- [x] `aube run -F dashboard type-check`
- [ ] End-to-end in an Anthropic cloud environment: setup script completes, first session starts the daemon, plugins install mid-session, telemetry flows

Made with [Cursor](https://cursor.com)