### PR TITLE
fix: stop tool call annotations flashing as chat prose

### DIFF
--- a/.changeset/steady-tool-call-headings.md
+++ b/.changeset/steady-tool-call-headings.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The terse activity phrase the assistant emits before a batch of tool calls no longer flashes into the chat as prose before moving into the tool group's heading. The phrase was classified by looking at whether the next message part was a tool call, but that part does not exist until after the phrase has finished streaming, so it rendered as a paragraph and was then yanked into the group. A still-streaming phrase is now held back until the group opens, and ordinary prose is released as soon as its opening word rules out an activity phrase. Long answers streaming in after the tools finish are judged as a whole rather than by their last line, which previously blinked each new line out of the render as it arrived.

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -95,6 +95,7 @@ import { dictationAdapter } from "@/elements/lib/dictation";
 import { EASE_OUT_QUINT } from "@/elements/lib/easing";
 import { groupAssistantMessageParts } from "@/elements/lib/messagePartGrouping";
 import {
+  isPartialToolCallAnnotation,
   stripTrailingAnnotationLine,
   trailingAnnotationLine,
 } from "@/elements/lib/toolCallAnnotation";
@@ -1895,27 +1896,32 @@ const withToolCallAnnotationSuppression = (
     const aui = useAui();
     const partQuery = aui.part.query;
     const partIndex = partQuery?.type === "index" ? partQuery.index : undefined;
+    const ownedByToolGroup = useAuiState(
+      ({ message }) =>
+        partIndex !== undefined &&
+        message.parts[partIndex + 1]?.type === "tool-call",
+    );
     // The tool call lands only after its annotation has finished streaming, so
     // waiting for parts[i + 1] means rendering the annotation as prose first
     // and yanking it into the group heading a moment later. While the message
-    // is still streaming and nothing follows this part yet, assume a trailing
-    // annotation belongs to the group that is about to open — and judge it
-    // with the streaming test, since a half-typed opener is not a gerund yet.
+    // is still streaming and nothing follows this part yet, hold a part that
+    // still looks like it is growing into an annotation.
     const streaming = useAuiState(
       ({ message }) =>
         partIndex !== undefined &&
         message.parts[partIndex + 1] === undefined &&
         message.status?.type === "running",
     );
-    const ownedByToolGroup = useAuiState(
-      ({ message }) =>
-        partIndex !== undefined &&
-        message.parts[partIndex + 1]?.type === "tool-call",
-    );
-    if (
-      (!ownedByToolGroup && !streaming) ||
-      !trailingAnnotationLine(props.text, { streaming })
-    ) {
+    // Whole-part test, not the trailing line: mid-stream every line is briefly
+    // one or two words long, so matching the tail would blink each new line of
+    // a long answer out of the render as it arrives. A multi-line part can
+    // never be an annotation, which is what makes the whole-part test safe.
+    if (streaming && !ownedByToolGroup) {
+      return isPartialToolCallAnnotation(props.text) ? null : (
+        <Inner {...props} />
+      );
+    }
+    if (!ownedByToolGroup || !trailingAnnotationLine(props.text)) {
       return <Inner {...props} />;
     }
     const remainder = stripTrailingAnnotationLine(props.text);

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -1895,12 +1895,27 @@ const withToolCallAnnotationSuppression = (
     const aui = useAui();
     const partQuery = aui.part.query;
     const partIndex = partQuery?.type === "index" ? partQuery.index : undefined;
-    const followedByToolCall = useAuiState(
+    // The tool call lands only after its annotation has finished streaming, so
+    // waiting for parts[i + 1] means rendering the annotation as prose first
+    // and yanking it into the group heading a moment later. While the message
+    // is still streaming and nothing follows this part yet, assume a trailing
+    // annotation belongs to the group that is about to open — and judge it
+    // with the streaming test, since a half-typed opener is not a gerund yet.
+    const streaming = useAuiState(
+      ({ message }) =>
+        partIndex !== undefined &&
+        message.parts[partIndex + 1] === undefined &&
+        message.status?.type === "running",
+    );
+    const ownedByToolGroup = useAuiState(
       ({ message }) =>
         partIndex !== undefined &&
         message.parts[partIndex + 1]?.type === "tool-call",
     );
-    if (!followedByToolCall || !trailingAnnotationLine(props.text)) {
+    if (
+      (!ownedByToolGroup && !streaming) ||
+      !trailingAnnotationLine(props.text, { streaming })
+    ) {
       return <Inner {...props} />;
     }
     const remainder = stripTrailingAnnotationLine(props.text);

--- a/client/dashboard/src/elements/components/assistant-ui/tool-group.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/tool-group.tsx
@@ -3,6 +3,7 @@ import { useMemo, type FC, type PropsWithChildren } from "react";
 import { useElements } from "@/elements/hooks/useElements";
 import { humanizeToolName } from "@/elements/lib/humanize";
 import {
+  isPartialToolCallAnnotation,
   isToolCallAnnotation,
   toolCallAnnotationTitle,
   trailingAnnotationLine,
@@ -56,7 +57,8 @@ export const ToolGroup: FC<PropsWithChildren<{ indices: number[] }>> = ({
       // mid-flight) doesn't end the run.
       if (
         part?.type === "text" &&
-        (part.text.trim().length === 0 || isToolCallAnnotation(part.text))
+        (part.text.trim().length === 0 ||
+          isPartialToolCallAnnotation(part.text))
       ) {
         continue;
       }

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPartialToolCallAnnotation,
+  isToolCallAnnotation,
+  trailingAnnotationLine,
+} from "./toolCallAnnotation";
+
+describe("isPartialToolCallAnnotation", () => {
+  it("accepts the prefixes an annotation streams through", () => {
+    // "Investigating failures" arrives a character at a time; every prefix
+    // must be held back, or the opening renders as prose and then retracts.
+    const target = "Investigating failures";
+    for (let i = 1; i <= target.length; i++) {
+      expect(isPartialToolCallAnnotation(target.slice(0, i))).toBe(true);
+    }
+  });
+
+  it("releases prose once a third word rules out a doing-phrase", () => {
+    expect(isPartialToolCallAnnotation("Let me check the logs")).toBe(false);
+    // Under three words the opener is still undecided.
+    expect(isPartialToolCallAnnotation("Let me")).toBe(true);
+  });
+
+  it("still rejects prose by shape", () => {
+    expect(isPartialToolCallAnnotation("**Checking**")).toBe(false);
+    expect(isPartialToolCallAnnotation("Checking.\nNext")).toBe(false);
+    expect(isPartialToolCallAnnotation("x".repeat(101))).toBe(false);
+  });
+
+  it("accepts everything the strict test accepts", () => {
+    for (const text of ["Investigating failures", "Deep diving into spend"]) {
+      expect(isToolCallAnnotation(text)).toBe(true);
+      expect(isPartialToolCallAnnotation(text)).toBe(true);
+    }
+  });
+});
+
+describe("trailingAnnotationLine", () => {
+  it("uses the strict test by default and the partial one when streaming", () => {
+    expect(trailingAnnotationLine("Here is what I found\nInvestig")).toBe(
+      undefined,
+    );
+    expect(
+      trailingAnnotationLine("Here is what I found\nInvestig", {
+        streaming: true,
+      }),
+    ).toBe("Investig");
+  });
+});

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
@@ -23,6 +23,11 @@ describe("isPartialToolCallAnnotation", () => {
     }
   });
 
+  it("reads a contraction opener through either apostrophe", () => {
+    expect(isPartialToolCallAnnotation("I'm fine")).toBe(false);
+    expect(isPartialToolCallAnnotation("I’m fine")).toBe(false);
+  });
+
   it("holds a lone opener, which may still be growing into a gerund", () => {
     // "I" is prose on its own and also the first character of
     // "Investigating"; only a following word settles which.

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
@@ -62,14 +62,12 @@ describe("isPartialToolCallAnnotation", () => {
 });
 
 describe("trailingAnnotationLine", () => {
-  it("uses the strict test by default and the partial one when streaming", () => {
+  it("matches only a settled annotation on the last line", () => {
+    expect(
+      trailingAnnotationLine("Here is what I found\nInvestigating spend"),
+    ).toBe("Investigating spend");
     expect(trailingAnnotationLine("Here is what I found\nInvestig")).toBe(
       undefined,
     );
-    expect(
-      trailingAnnotationLine("Here is what I found\nInvestig", {
-        streaming: true,
-      }),
-    ).toBe("Investig");
   });
 });

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.test.ts
@@ -15,10 +15,36 @@ describe("isPartialToolCallAnnotation", () => {
     }
   });
 
+  it("releases prose as soon as a settled opener rules out a verb", () => {
+    // Chat replies open this way constantly; withholding them would delay
+    // the first paint of every prose answer.
+    for (const text of ["Ok great", "Here is", "I found", "Let me"]) {
+      expect(isPartialToolCallAnnotation(text)).toBe(false);
+    }
+  });
+
+  it("holds a lone opener, which may still be growing into a gerund", () => {
+    // "I" is prose on its own and also the first character of
+    // "Investigating"; only a following word settles which.
+    expect(isPartialToolCallAnnotation("I")).toBe(true);
+    expect(isPartialToolCallAnnotation("Sure")).toBe(true);
+  });
+
+  it("still holds a two-word opener that could become a doing-phrase", () => {
+    // "Deep diving into spend" — word two has not arrived in full yet.
+    expect(isPartialToolCallAnnotation("Deep")).toBe(true);
+    expect(isPartialToolCallAnnotation("Deep divin")).toBe(true);
+  });
+
   it("releases prose once a third word rules out a doing-phrase", () => {
-    expect(isPartialToolCallAnnotation("Let me check the logs")).toBe(false);
+    expect(isPartialToolCallAnnotation("Cross reference the logs")).toBe(false);
     // Under three words the opener is still undecided.
-    expect(isPartialToolCallAnnotation("Let me")).toBe(true);
+    expect(isPartialToolCallAnnotation("Cross reference")).toBe(true);
+  });
+
+  it("matches a completed gerund ahead of the opener list", () => {
+    expect(isPartialToolCallAnnotation("Letting the job finish")).toBe(true);
+    expect(isPartialToolCallAnnotation("Noting the gap")).toBe(true);
   });
 
   it("still rejects prose by shape", () => {

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.ts
@@ -30,15 +30,104 @@ export function isToolCallAnnotation(text: string): boolean {
  * Mid-stream an annotation arrives a character at a time, so the strict test
  * above rejects its own prefixes — "Inv" is not a gerund yet. Judging a
  * still-streaming part with it renders the opening as prose and then retracts
- * it once the word completes. Accept a prefix whose first two words could
- * still turn into a doing-phrase; a third word settles the question.
+ * it once the word completes. Accept a prefix that could still turn into a
+ * doing-phrase: the strict test only inspects the first two words, so a third
+ * word settles the question, and an opener that cannot be a verb settles it
+ * immediately.
  */
 export function isPartialToolCallAnnotation(text: string): boolean {
   const trimmed = text.trim();
   if (!hasAnnotationShape(trimmed)) return false;
   const words = trimmed.split(/\s+/);
-  return isGerund(words[0]) || isGerund(words[1]) || words.length <= 2;
+  if (isGerund(words[0]) || isGerund(words[1])) return true;
+  if (words.length > 2) return false;
+  // Only the last word is still growing, so it could still gain its "ing" —
+  // "I" is prose on its own but also the first character of "Investigating".
+  // Judge the opener only once a following word has settled it.
+  return words.length === 1 || !isNonVerbOpener(words[0]);
 }
+
+/**
+ * Ordinary replies open with a pronoun, determiner or discourse marker far
+ * more often than with a verb, and none of those can grow into a participle.
+ * Without this, every prose answer's first two words are withheld until a
+ * third arrives. A word that already ends in "ing" is matched as a gerund
+ * before we get here, so "Letting" is unaffected by "let" appearing below.
+ */
+const NON_VERB_OPENERS = new Set([
+  "a",
+  "all",
+  "also",
+  "an",
+  "and",
+  "any",
+  "based",
+  "both",
+  "but",
+  "done",
+  "each",
+  "first",
+  "for",
+  "from",
+  "great",
+  "here",
+  "how",
+  "however",
+  "i",
+  "if",
+  "in",
+  "it",
+  "its",
+  "let",
+  "looks",
+  "my",
+  "next",
+  "no",
+  "not",
+  "note",
+  "of",
+  "ok",
+  "okay",
+  "on",
+  "or",
+  "our",
+  "perfect",
+  "seems",
+  "so",
+  "some",
+  "sorry",
+  "sure",
+  "thanks",
+  "that",
+  "the",
+  "their",
+  "then",
+  "there",
+  "these",
+  "they",
+  "this",
+  "those",
+  "to",
+  "we",
+  "what",
+  "when",
+  "where",
+  "which",
+  "why",
+  "with",
+  "yes",
+  "you",
+  "your",
+]);
+
+const isNonVerbOpener = (word: string | undefined) =>
+  !!word &&
+  NON_VERB_OPENERS.has(
+    word
+      .replace(/[^a-zA-Z'-]/g, "")
+      .split("'")[0]!
+      .toLowerCase(),
+  );
 
 /** Length, single-line and punctuation gates shared by both tests. */
 function hasAnnotationShape(trimmed: string): boolean {

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.ts
@@ -155,16 +155,10 @@ export function toolCallAnnotationTitle(text: string): string {
  * The last line still works as the annotation when it is terse; the remainder
  * renders as regular prose (see stripTrailingAnnotationLine).
  */
-export function trailingAnnotationLine(
-  text: string,
-  { streaming = false }: { streaming?: boolean } = {},
-): string | undefined {
+export function trailingAnnotationLine(text: string): string | undefined {
   const lines = text.trim().split("\n");
   const last = lines[lines.length - 1]?.trim() ?? "";
-  const matches = streaming
-    ? isPartialToolCallAnnotation(last)
-    : isToolCallAnnotation(last);
-  return matches ? last : undefined;
+  return isToolCallAnnotation(last) ? last : undefined;
 }
 
 /** The text minus its trailing annotation line (empty for a pure annotation). */

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.ts
@@ -19,6 +19,29 @@ export const TOOL_CALL_ANNOTATION_MAX_LENGTH = 100;
  */
 export function isToolCallAnnotation(text: string): boolean {
   const trimmed = text.trim();
+  if (!hasAnnotationShape(trimmed)) return false;
+  // Doing-phrase opener: one of the first two words is a present participle
+  // ("Investigating…", "Deep diving…", "Cross-referencing…").
+  const words = trimmed.split(/\s+/);
+  return isGerund(words[0]) || isGerund(words[1]);
+}
+
+/**
+ * Mid-stream an annotation arrives a character at a time, so the strict test
+ * above rejects its own prefixes — "Inv" is not a gerund yet. Judging a
+ * still-streaming part with it renders the opening as prose and then retracts
+ * it once the word completes. Accept a prefix whose first two words could
+ * still turn into a doing-phrase; a third word settles the question.
+ */
+export function isPartialToolCallAnnotation(text: string): boolean {
+  const trimmed = text.trim();
+  if (!hasAnnotationShape(trimmed)) return false;
+  const words = trimmed.split(/\s+/);
+  return isGerund(words[0]) || isGerund(words[1]) || words.length <= 2;
+}
+
+/** Length, single-line and punctuation gates shared by both tests. */
+function hasAnnotationShape(trimmed: string): boolean {
   if (
     trimmed.length === 0 ||
     trimmed.length > TOOL_CALL_ANNOTATION_MAX_LENGTH ||
@@ -27,14 +50,11 @@ export function isToolCallAnnotation(text: string): boolean {
     return false;
   }
   // Multi-sentence commentary or Markdown formatting → prose.
-  if (/[.!?] /.test(trimmed) || /[`*_#[\]]/.test(trimmed)) return false;
-  // Doing-phrase opener: one of the first two words is a present participle
-  // ("Investigating…", "Deep diving…", "Cross-referencing…").
-  const words = trimmed.split(/\s+/);
-  const isGerund = (word: string | undefined) =>
-    !!word && /ing$/i.test(word.replace(/[^a-zA-Z-]/g, ""));
-  return isGerund(words[0]) || isGerund(words[1]);
+  return !/[.!?] /.test(trimmed) && !/[`*_#[\]]/.test(trimmed);
 }
+
+const isGerund = (word: string | undefined) =>
+  !!word && /ing$/i.test(word.replace(/[^a-zA-Z-]/g, ""));
 
 /** Normalize an annotation for display as a group heading. */
 export function toolCallAnnotationTitle(text: string): string {
@@ -46,10 +66,16 @@ export function toolCallAnnotationTitle(text: string): string {
  * The last line still works as the annotation when it is terse; the remainder
  * renders as regular prose (see stripTrailingAnnotationLine).
  */
-export function trailingAnnotationLine(text: string): string | undefined {
+export function trailingAnnotationLine(
+  text: string,
+  { streaming = false }: { streaming?: boolean } = {},
+): string | undefined {
   const lines = text.trim().split("\n");
   const last = lines[lines.length - 1]?.trim() ?? "";
-  return isToolCallAnnotation(last) ? last : undefined;
+  const matches = streaming
+    ? isPartialToolCallAnnotation(last)
+    : isToolCallAnnotation(last);
+  return matches ? last : undefined;
 }
 
 /** The text minus its trailing annotation line (empty for a pure annotation). */

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.ts
@@ -124,6 +124,9 @@ const isNonVerbOpener = (word: string | undefined) =>
   !!word &&
   NON_VERB_OPENERS.has(
     word
+      // Models emit typographic apostrophes, so fold them in before the strip
+      // below discards them and leaves "I’m" as "im".
+      .replace(/[’‘]/g, "'")
       .replace(/[^a-zA-Z'-]/g, "")
       .split("'")[0]!
       .toLowerCase(),


### PR DESCRIPTION
## Summary

The assistant precedes each batch of tool calls with a terse activity phrase ("Investigating failures in the last 30 days"). That phrase is meant to render only as the tool group's heading — never as message prose. In practice it flashed as Markdown first and then jumped into the group.

Two separate causes, both a predicate judging text that had not finished arriving:

- `withToolCallAnnotationSuppression` asked whether `parts[i + 1]` was a tool call. During streaming that part does not exist yet — the tool call lands only after its annotation has finished streaming — so the phrase rendered as prose for its whole life, then unmounted and reappeared as the heading.
- `isToolCallAnnotation` requires a completed present participle, so it rejects its own prefixes: `Inv`, `Investigat`. Even with the first fix, the opening characters painted as prose and retracted once the word completed.

## Changes

- `toolCallAnnotation.ts`: extract the shared shape gates (length, single-line, punctuation) and add `isPartialToolCallAnnotation` — the same gates, but it also holds a prefix of two words or fewer whose opener could still become a gerund. A third word settles the question permanently, so no prefix can flip back.
- `trailingAnnotationLine(text, { streaming })` selects the strict or the permissive test.
- `thread.tsx`: suppress when the part is either confirmed-followed-by-a-tool-call or is the tail of a still-running message, judging the tail with the streaming test.
- `tool-group.tsx`: `isTrailingWhileStreaming` uses the same permissive test, so a half-typed next annotation no longer flips the group out of its running state for a frame and kills the shimmer.

## Tradeoffs

- A short prose reply opening with two words or fewer is withheld until its third word arrives — a slightly later first paint on the last line of a part, nothing more.
- A message that _ends_ on an annotation-shaped line with no tool call after it appears when the run completes rather than mid-stream. `isToolCallAnnotation` only requires a gerund in word one or two, so "Nothing else to report" qualifies; tightening that heuristic is a separate change.

## Validation

- `aube run -F dashboard type-check` — clean.
- `aube run test src/elements` — 20 files, 148 tests passing, including new coverage in `toolCallAnnotation.test.ts` that walks every prefix of a streaming annotation.
- Not yet eyeballed on a live streaming turn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tool call annotations flashing as chat prose during streaming and releases ordinary prose sooner. Previously the opener rendered as text until the next part arrived; now we detect partial annotations on the whole part, keep them with the running tool group, and ignore non‑verb openers.

- Adds `isPartialToolCallAnnotation` with shared shape gates; accepts gerunds or one/two-word prefixes, releases openings that cannot become verbs, and normalizes typographic apostrophes in opener checks; used in `client/dashboard/src/elements/components/assistant-ui/thread.tsx` whole-part suppression and `client/dashboard/src/elements/components/assistant-ui/tool-group.tsx` running-state check.
- In `thread.tsx`, holds a streaming part that still looks like an annotation when no following part exists, using whole-part detection to avoid per-line blink; once owned by the next tool call, falls back to `trailingAnnotationLine` and `stripTrailingAnnotationLine`.
- Adds tests in `client/dashboard/src/elements/lib/toolCallAnnotation.test.ts` for streaming prefixes, contraction openers (’ vs '), and `trailingAnnotationLine`; refactors `client/dashboard/src/elements/lib/toolCallAnnotation.ts` with shared gates and gerund checks.

**Behavior changes**
- Prose with common non-verb or contraction openers paints immediately; other two-word prefixes may delay until the third word.
- A message that ends on an annotation-shaped line without a subsequent tool call appears after the run completes, not mid-stream.

<sup>Written for commit 8008dd1652f9438d140252e2dd94b728fe5b4faa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

