### PR TITLE
feat: add directory audiences to plugin assignments

### DIFF
--- a/client/dashboard/src/components/plugin-detail-sidebar-nav.tsx
+++ b/client/dashboard/src/components/plugin-detail-sidebar-nav.tsx
@@ -22,6 +22,7 @@ import {
   type PluginSection,
 } from "@/pages/plugins/plugin-detail-sections";
 import {
+  audienceMapByUrn,
   describePrincipal,
   individualMemberFacepile,
   isIndividualMemberPrincipal,
@@ -32,6 +33,7 @@ import {
 import { usePluginAssignmentsVisible } from "@/pages/plugins/use-plugin-assignments-visible";
 import { useRoutes } from "@/routes";
 import { useMembers } from "@gram/client/react-query/members";
+import { useAudiences } from "@gram/client/react-query/audiences";
 import { usePlugin } from "@gram/client/react-query/plugin";
 import { usePublishStatus } from "@gram/client/react-query/publishStatus";
 import { useRoles } from "@gram/client/react-query/roles";
@@ -57,6 +59,7 @@ export function PluginDetailSidebarNav(): React.JSX.Element | null {
   const { data: publishStatus } = usePublishStatus();
   const { data: membersData } = useMembers();
   const { data: rolesData } = useRoles();
+  const { data: audiencesData } = useAudiences();
   const showAssignments = usePluginAssignmentsVisible();
 
   const memberByUrn = React.useMemo(
@@ -66,6 +69,10 @@ export function PluginDetailSidebarNav(): React.JSX.Element | null {
   const roleByUrn = React.useMemo(
     () => roleMapByUrn(rolesData?.roles ?? []),
     [rolesData?.roles],
+  );
+  const audienceByUrn = React.useMemo(
+    () => audienceMapByUrn(audiencesData?.audiences ?? []),
+    [audiencesData?.audiences],
   );
 
   if (!pluginId) return null;
@@ -179,6 +186,7 @@ export function PluginDetailSidebarNav(): React.JSX.Element | null {
                   assignment.principalUrn,
                   roleByUrn,
                   memberByUrn,
+                  audienceByUrn,
                 );
                 const PrincipalIcon = principalIcon(kind);
                 return (

--- a/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
@@ -188,7 +188,16 @@ describe("MultiSelect disabled selected options", () => {
     render(
       <MultiSelect
         options={[
-          { label: "Legacy assignment", value: "legacy", disabled: true },
+          {
+            heading: "Legacy assignments",
+            options: [
+              {
+                label: "Legacy assignment",
+                value: "legacy",
+                disabled: true,
+              },
+            ],
+          },
         ]}
         defaultValue={["legacy"]}
         onValueChange={onValueChange}

--- a/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
@@ -184,7 +184,7 @@ describe("MultiSelect option descriptions", () => {
 
 describe("MultiSelect disabled selected options", () => {
   it("allows a selected disabled option to be removed", () => {
-    const onValueChange = vi.fn();
+    const onValueChange = vi.fn<(values: string[]) => void>();
     render(
       <MultiSelect
         options={[

--- a/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
@@ -213,3 +213,27 @@ describe("MultiSelect disabled selected options", () => {
     expect(onValueChange).toHaveBeenCalledWith([]);
   });
 });
+
+describe("MultiSelect group icons", () => {
+  it("renders an icon beside a group heading", () => {
+    const GroupIcon = ({ className }: { className?: string }) => (
+      <span data-testid="group-icon" className={className} />
+    );
+    render(
+      <MultiSelect
+        options={[
+          {
+            heading: "Directory groups",
+            icon: GroupIcon,
+            options: [{ label: "Engineering", value: "engineering" }],
+          },
+        ]}
+        onValueChange={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Select options"));
+
+    expect(screen.getByTestId("group-icon")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
@@ -181,3 +181,26 @@ describe("MultiSelect option descriptions", () => {
     expect(labels.some((label) => label.includes("Manual"))).toBe(false);
   });
 });
+
+describe("MultiSelect disabled selected options", () => {
+  it("allows a selected disabled option to be removed", () => {
+    const onValueChange = vi.fn();
+    render(
+      <MultiSelect
+        options={[
+          { label: "Legacy assignment", value: "legacy", disabled: true },
+        ]}
+        defaultValue={["legacy"]}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove Legacy assignment from selection",
+      }),
+    );
+
+    expect(onValueChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/client/dashboard/src/components/ui/MultiSelect/index.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.tsx
@@ -109,6 +109,8 @@ interface MultiSelectOption {
 interface MultiSelectGroup {
   /** Group heading */
   heading: string;
+  /** Optional icon shown beside the group heading. */
+  icon?: React.ComponentType<{ className?: string }>;
   /** Options in this group */
   options: MultiSelectOption[];
 }
@@ -1291,18 +1293,29 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                   </CommandGroup>
                 )}
                 {isGroupedOptions(filteredOptions) ? (
-                  filteredOptions.map((group) => (
-                    <CommandGroup key={group.heading} heading={group.heading}>
-                      {group.options.map((option) => (
-                        <MultiSelectOptionItem
-                          key={option.value}
-                          option={option}
-                          isSelected={selectedValues.includes(option.value)}
-                          onToggle={() => toggleOption(option.value)}
-                        />
-                      ))}
-                    </CommandGroup>
-                  ))
+                  filteredOptions.map((group) => {
+                    const GroupIcon = group.icon;
+                    return (
+                      <CommandGroup
+                        key={group.heading}
+                        heading={
+                          <span className="flex items-center gap-1.5">
+                            {GroupIcon && <GroupIcon className="h-3.5 w-3.5" />}
+                            {group.heading}
+                          </span>
+                        }
+                      >
+                        {group.options.map((option) => (
+                          <MultiSelectOptionItem
+                            key={option.value}
+                            option={option}
+                            isSelected={selectedValues.includes(option.value)}
+                            onToggle={() => toggleOption(option.value)}
+                          />
+                        ))}
+                      </CommandGroup>
+                    );
+                  })
                 ) : (
                   <CommandGroup>
                     {filteredOptions.map((option) => (

--- a/client/dashboard/src/components/ui/MultiSelect/index.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.tsx
@@ -762,6 +762,18 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
       }
     };
 
+    // A disabled option cannot be newly selected from the menu, but an
+    // already-selected option must still be removable. This lets callers show
+    // legacy or unavailable values without making them permanent selections.
+    const removeOption = (optionValue: string) => {
+      if (disabled) return;
+      const newSelectedValues = selectedValues.filter(
+        (value) => value !== optionValue,
+      );
+      setSelectedValues(newSelectedValues);
+      onValueChange(newSelectedValues);
+    };
+
     const trimmedSearchValue = searchValue.trim();
     const canCreateFromSearch = React.useMemo(() => {
       if (!creatable || !trimmedSearchValue) return false;
@@ -1060,7 +1072,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                               tabIndex={0}
                               onClick={(event) => {
                                 event.stopPropagation();
-                                toggleOption(value);
+                                removeOption(value);
                               }}
                               onKeyDown={(event) => {
                                 if (
@@ -1069,7 +1081,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                                 ) {
                                   event.preventDefault();
                                   event.stopPropagation();
-                                  toggleOption(value);
+                                  removeOption(value);
                                 }
                               }}
                               aria-label={`Remove ${option.label} from selection`}

--- a/client/dashboard/src/pages/plugins/PluginAssignmentRow.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentRow.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@/components/ui/Text";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import type { PluginAudience } from "@gram/client/models/components/pluginaudience.js";
 import type { Role } from "@gram/client/models/components/role.js";
 import {
   describePrincipal,
@@ -15,6 +16,7 @@ function principalDescription(
   kind: PrincipalKind,
   roleByUrn: Map<string, Role>,
   memberByUrn: Map<string, AccessMember>,
+  audienceByUrn: Map<string, PluginAudience>,
 ): string {
   switch (kind) {
     case "everyone":
@@ -28,6 +30,20 @@ function principalDescription(
     }
     case "user":
       return memberByUrn.get(urn)?.email ?? "Organization member";
+    case "directory_group": {
+      const memberCount = audienceByUrn.get(urn)?.memberCount;
+      if (memberCount !== undefined) {
+        return `${memberCount} ${memberCount === 1 ? "member" : "members"}`;
+      }
+      return "Directory group";
+    }
+    case "directory_attribute": {
+      const memberCount = audienceByUrn.get(urn)?.memberCount;
+      if (memberCount !== undefined) {
+        return `${memberCount} ${memberCount === 1 ? "member" : "members"}`;
+      }
+      return "Directory attribute";
+    }
     case "unknown":
       return "";
   }
@@ -39,14 +55,27 @@ export function PluginAssignmentRow({
   urn,
   roleByUrn,
   memberByUrn,
+  audienceByUrn,
 }: {
   urn: string;
   roleByUrn: Map<string, Role>;
   memberByUrn: Map<string, AccessMember>;
+  audienceByUrn: Map<string, PluginAudience>;
 }): JSX.Element {
-  const { kind, label } = describePrincipal(urn, roleByUrn, memberByUrn);
+  const { kind, label } = describePrincipal(
+    urn,
+    roleByUrn,
+    memberByUrn,
+    audienceByUrn,
+  );
   const IconComponent = principalIcon(kind);
-  const description = principalDescription(urn, kind, roleByUrn, memberByUrn);
+  const description = principalDescription(
+    urn,
+    kind,
+    roleByUrn,
+    memberByUrn,
+    audienceByUrn,
+  );
 
   return (
     <div className="flex items-center gap-3 py-3">

--- a/client/dashboard/src/pages/plugins/PluginAssignmentRow.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentRow.tsx
@@ -4,6 +4,7 @@ import type { PluginAudience } from "@gram/client/models/components/pluginaudien
 import type { Role } from "@gram/client/models/components/role.js";
 import {
   describePrincipal,
+  memberCountDescription,
   principalIcon,
   type PrincipalKind,
 } from "./principals";
@@ -26,23 +27,17 @@ function principalDescription(
     case "role": {
       const role = roleByUrn.get(urn);
       if (!role) return "Role";
-      return `${role.memberCount} ${role.memberCount === 1 ? "member" : "members"}`;
+      return memberCountDescription(role.memberCount) ?? "Role";
     }
     case "user":
       return memberByUrn.get(urn)?.email ?? "Organization member";
     case "directory_group": {
       const memberCount = audienceByUrn.get(urn)?.memberCount;
-      if (memberCount !== undefined) {
-        return `${memberCount} ${memberCount === 1 ? "member" : "members"}`;
-      }
-      return "Directory group";
+      return memberCountDescription(memberCount) ?? "Directory group";
     }
     case "directory_attribute": {
       const memberCount = audienceByUrn.get(urn)?.memberCount;
-      if (memberCount !== undefined) {
-        return `${memberCount} ${memberCount === 1 ? "member" : "members"}`;
-      }
-      return "Directory attribute";
+      return memberCountDescription(memberCount) ?? "Directory attribute";
     }
     case "unknown":
       return "";

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsList.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsList.tsx
@@ -1,6 +1,7 @@
 import { MemberFacepile } from "@/components/member-facepile";
 import { Text } from "@/components/ui/Text";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import type { PluginAudience } from "@gram/client/models/components/pluginaudience.js";
 import type { PluginAssignment } from "@gram/client/models/components/pluginassignment.js";
 import type { Role } from "@gram/client/models/components/role.js";
 import { Users } from "lucide-react";
@@ -18,10 +19,12 @@ export function PluginAssignmentsList({
   assignments,
   roleByUrn,
   memberByUrn,
+  audienceByUrn,
 }: {
   assignments: PluginAssignment[];
   roleByUrn: Map<string, Role>;
   memberByUrn: Map<string, AccessMember>;
+  audienceByUrn: Map<string, PluginAudience>;
 }): JSX.Element {
   const rowAssignments = assignments.filter(
     (a) => !isIndividualMemberPrincipal(a.principalUrn),
@@ -37,6 +40,7 @@ export function PluginAssignmentsList({
           urn={assignment.principalUrn}
           roleByUrn={roleByUrn}
           memberByUrn={memberByUrn}
+          audienceByUrn={audienceByUrn}
         />
       ))}
       {facepileMembers.length > 0 && (

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -271,7 +271,7 @@ function AssignmentsEditor({
           hideSelectAll
           modalPopover
           maxCount={20}
-          popoverClassName="w-[var(--radix-popover-trigger-width)] min-w-0 max-w-none [&_[cmdk-group-heading]]:px-0 [&_[cmdk-group-heading]]:py-0.5 [&_[cmdk-input-wrapper]]:px-0 [&_[cmdk-item]]:px-0 [&_[cmdk-item]]:py-1 [&_[data-slot=command-group]]:p-0 [&_[data-slot=command-list]]:p-0"
+          popoverClassName="w-[var(--radix-popover-trigger-width)] min-w-0 max-w-none [&_[cmdk-group-heading]]:px-0 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-input-wrapper]]:px-0 [&_[cmdk-item]]:px-0 [&_[cmdk-item]]:py-1 [&_[data-slot=command-group]]:p-0 [&_[data-slot=command-group]+[data-slot=command-group]]:pt-2 [&_[data-slot=command-list]]:p-0"
         />
         {audiencesQuery.isPending && (
           <Text muted small className="mt-2">

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -1,12 +1,5 @@
 import { MultiSelect } from "@/components/ui/MultiSelect";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/Select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -33,19 +26,15 @@ import {
   principalIcon,
 } from "./principals";
 
-const audienceTypeOptions: {
+const audienceGroups: {
   value: PluginAudienceKind;
-  label: string;
+  heading: string;
 }[] = [
-  { value: "everyone", label: "Everyone" },
-  { value: "role", label: "Role" },
-  { value: "directory_group", label: "Directory group" },
-  { value: "directory_attribute", label: "Directory attribute" },
+  { value: "everyone", heading: "Everyone" },
+  { value: "role", heading: "Roles" },
+  { value: "directory_group", heading: "Directory groups" },
+  { value: "directory_attribute", heading: "Directory attributes" },
 ];
-
-function isAudienceType(value: string): value is PluginAudienceKind {
-  return audienceTypeOptions.some((type) => type.value === value);
-}
 
 function existingAssignmentOption(
   urn: string,
@@ -65,6 +54,7 @@ function existingAssignmentOption(
 function availableAudienceOptions(
   audienceType: PluginAudienceKind,
   audiences: PluginAudience[],
+  disabled: boolean,
 ) {
   return audiences
     .filter((audience) => audience.kind === audienceType)
@@ -73,6 +63,7 @@ function availableAudienceOptions(
       value: audience.principalUrn,
       description: memberCountDescription(audience.memberCount),
       icon: principalIcon(audience.kind),
+      disabled,
     }));
 }
 
@@ -162,28 +153,46 @@ function AssignmentsEditor({
     [assignments],
   );
   const [selected, setSelected] = useState<string[]>(initialUrns);
-  const [audienceType, setAudienceType] =
-    useState<PluginAudienceKind>("everyone");
 
   const audienceByUrn = useMemo(() => audienceMapByUrn(audiences), [audiences]);
-  const selectedForAudienceType = useMemo(
+  const canSelectAudiences =
+    !audiencesQuery.isPending && !audiencesQuery.isError;
+  const availableAudienceGroups = useMemo(
     () =>
-      selected.filter(
-        (urn) => audienceKindForPrincipal(urn, audienceByUrn) === audienceType,
-      ),
-    [audienceByUrn, audienceType, selected],
+      audienceGroups.map((group) => ({
+        heading: group.heading,
+        options: availableAudienceOptions(
+          group.value,
+          audiences,
+          !canSelectAudiences,
+        ),
+      })),
+    [audiences, canSelectAudiences],
   );
-  const availableOptions = useMemo(
-    () => availableAudienceOptions(audienceType, audiences),
-    [audienceType, audiences],
-  );
-  const unavailableOptions = useMemo(
-    () => unavailableAudienceOptions(audienceType, selected, audienceByUrn),
-    [audienceByUrn, audienceType, selected],
+  const unavailableAudienceGroups = useMemo(
+    () =>
+      audienceGroups.map((group) => ({
+        heading: group.heading,
+        options: unavailableAudienceOptions(
+          group.value,
+          selected,
+          audienceByUrn,
+        ),
+      })),
+    [audienceByUrn, selected],
   );
   const options = useMemo(
-    () => [...availableOptions, ...unavailableOptions],
-    [availableOptions, unavailableOptions],
+    () =>
+      availableAudienceGroups
+        .map((group, index) => ({
+          heading: group.heading,
+          options: [
+            ...group.options,
+            ...unavailableAudienceGroups[index]!.options,
+          ],
+        }))
+        .filter((group) => group.options.length > 0),
+    [availableAudienceGroups, unavailableAudienceGroups],
   );
   const legacyOptions = useMemo(
     () =>
@@ -199,21 +208,16 @@ function AssignmentsEditor({
     [audienceByUrn, selected],
   );
 
-  const handleAudienceSelection = (values: string[]) => {
-    setSelected((current) => [
-      ...current.filter(
-        (urn) => audienceKindForPrincipal(urn, audienceByUrn) !== audienceType,
-      ),
-      ...values,
-    ]);
-  };
-
-  const handleLegacySelection = (values: string[]) => {
-    setSelected((current) => [
-      ...current.filter((urn) => audienceKindForPrincipal(urn, audienceByUrn)),
-      ...values,
-    ]);
-  };
+  const groupedOptions = useMemo(
+    () =>
+      legacyOptions.length > 0
+        ? [
+            ...options,
+            { heading: "Legacy assignments", options: legacyOptions },
+          ]
+        : options,
+    [legacyOptions, options],
+  );
 
   const mutation = useSetPluginAssignmentsMutation({
     onSuccess: () => {
@@ -240,49 +244,19 @@ function AssignmentsEditor({
   return (
     <>
       <div className="flex-1 overflow-y-auto px-6 py-4">
-        <label
-          className="mb-2 block text-sm font-medium"
-          htmlFor="audience-type"
-        >
-          Audience type
-        </label>
-        <Select
-          value={audienceType}
-          onValueChange={(value) => {
-            if (isAudienceType(value)) setAudienceType(value);
-          }}
-        >
-          <SelectTrigger id="audience-type" className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {audienceTypeOptions.map((type) => (
-              <SelectItem key={type.value} value={type.value}>
-                {type.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <label className="mb-2 mt-5 block text-sm font-medium">
-          {
-            audienceTypeOptions.find((type) => type.value === audienceType)
-              ?.label
-          }
+        <label className="mb-2 block text-sm font-medium">
+          Assigned audiences
         </label>
         <MultiSelect
-          key={audienceType}
-          options={[{ heading: "Available audiences", options }]}
-          defaultValue={selectedForAudienceType}
-          onValueChange={handleAudienceSelection}
-          placeholder={`Select ${audienceTypeOptions
-            .find((type) => type.value === audienceType)
-            ?.label.toLowerCase()}`}
+          options={groupedOptions}
+          defaultValue={selected}
+          onValueChange={setSelected}
+          placeholder="Select audiences"
           badgeClassName="h-6 gap-1.5 px-1.5 font-sans text-xs normal-case tracking-normal"
           searchable
           hideSelectAll
           modalPopover
           maxCount={20}
-          disabled={audiencesQuery.isPending || audiencesQuery.isError}
         />
         {audiencesQuery.isPending && (
           <Text muted small className="mt-2">
@@ -295,30 +269,9 @@ function AssignmentsEditor({
           </Text>
         )}
         <Text muted small className="mt-2">
-          Choose a type, then select the specific audiences that should receive
-          this plugin. Assignments apply when a device next syncs.
+          Select the specific audiences that should receive this plugin.
+          Assignments apply when a device next syncs.
         </Text>
-        {legacyOptions.length > 0 && (
-          <>
-            <label className="mb-2 mt-5 block text-sm font-medium">
-              Legacy assignments
-            </label>
-            <MultiSelect
-              options={legacyOptions}
-              defaultValue={legacyOptions.map((option) => option.value)}
-              onValueChange={handleLegacySelection}
-              placeholder="No legacy assignments"
-              badgeClassName="h-6 gap-1.5 px-1.5 font-sans text-xs normal-case tracking-normal"
-              searchable={false}
-              hideSelectAll
-              modalPopover
-              maxCount={20}
-            />
-            <Text muted small className="mt-2">
-              These assignments can be removed but not added again.
-            </Text>
-          </>
-        )}
       </div>
       <SheetFooter className="px-6 pb-6">
         <Button

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -16,13 +16,22 @@ import {
 } from "@/components/ui/Sheet";
 import { Text } from "@/components/ui/Text";
 import type { PluginAssignment } from "@gram/client/models/components/pluginassignment.js";
-import type { PluginAudienceKind } from "@gram/client/models/components/pluginaudience.js";
+import type {
+  PluginAudience,
+  PluginAudienceKind,
+} from "@gram/client/models/components/pluginaudience.js";
 import { useAudiences } from "@gram/client/react-query/audiences";
 import { useSetPluginAssignmentsMutation } from "@gram/client/react-query/setPluginAssignments";
 import { Button } from "@/components/ui/Button";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { audienceMapByUrn, principalIcon } from "./principals";
+import {
+  audienceKindForPrincipal,
+  audienceMapByUrn,
+  describePrincipal,
+  memberCountDescription,
+  principalIcon,
+} from "./principals";
 
 const audienceTypeOptions: {
   value: PluginAudienceKind;
@@ -38,11 +47,53 @@ function isAudienceType(value: string): value is PluginAudienceKind {
   return audienceTypeOptions.some((type) => type.value === value);
 }
 
-function memberCountDescription(
-  memberCount: number | undefined,
-): string | undefined {
-  if (memberCount === undefined) return undefined;
-  return `${memberCount} ${memberCount === 1 ? "member" : "members"}`;
+function existingAssignmentOption(
+  urn: string,
+  audienceByUrn: Map<string, PluginAudience>,
+  description: string,
+) {
+  const principal = describePrincipal(urn, new Map(), new Map(), audienceByUrn);
+  return {
+    label: principal.label,
+    value: urn,
+    description,
+    icon: principalIcon(principal.kind),
+    disabled: true,
+  };
+}
+
+function availableAudienceOptions(
+  audienceType: PluginAudienceKind,
+  audiences: PluginAudience[],
+) {
+  return audiences
+    .filter((audience) => audience.kind === audienceType)
+    .map((audience) => ({
+      label: audience.displayName,
+      value: audience.principalUrn,
+      description: memberCountDescription(audience.memberCount),
+      icon: principalIcon(audience.kind),
+    }));
+}
+
+function unavailableAudienceOptions(
+  audienceType: PluginAudienceKind,
+  selected: string[],
+  audienceByUrn: Map<string, PluginAudience>,
+) {
+  return selected
+    .filter(
+      (urn) =>
+        audienceKindForPrincipal(urn, audienceByUrn) === audienceType &&
+        !audienceByUrn.has(urn),
+    )
+    .map((urn) =>
+      existingAssignmentOption(
+        urn,
+        audienceByUrn,
+        "Unavailable. Remove this assignment to stop using it.",
+      ),
+    );
 }
 
 export function PluginAssignmentsSheet({
@@ -99,7 +150,8 @@ function AssignmentsEditor({
   onOpenChange: (open: boolean) => void;
   onSaved: () => void;
 }): JSX.Element {
-  const { data: audiencesData } = useAudiences();
+  const audiencesQuery = useAudiences();
+  const { data: audiencesData } = audiencesQuery;
   const audiences = useMemo(
     () => audiencesData?.audiences ?? [],
     [audiencesData?.audiences],
@@ -116,25 +168,49 @@ function AssignmentsEditor({
   const audienceByUrn = useMemo(() => audienceMapByUrn(audiences), [audiences]);
   const selectedForAudienceType = useMemo(
     () =>
-      selected.filter((urn) => audienceByUrn.get(urn)?.kind === audienceType),
+      selected.filter(
+        (urn) => audienceKindForPrincipal(urn, audienceByUrn) === audienceType,
+      ),
+    [audienceByUrn, audienceType, selected],
+  );
+  const availableOptions = useMemo(
+    () => availableAudienceOptions(audienceType, audiences),
+    [audienceType, audiences],
+  );
+  const unavailableOptions = useMemo(
+    () => unavailableAudienceOptions(audienceType, selected, audienceByUrn),
     [audienceByUrn, audienceType, selected],
   );
   const options = useMemo(
+    () => [...availableOptions, ...unavailableOptions],
+    [availableOptions, unavailableOptions],
+  );
+  const legacyOptions = useMemo(
     () =>
-      audiences
-        .filter((audience) => audience.kind === audienceType)
-        .map((audience) => ({
-          label: audience.displayName,
-          value: audience.principalUrn,
-          description: memberCountDescription(audience.memberCount),
-          icon: principalIcon(audience.kind),
-        })),
-    [audienceType, audiences],
+      selected
+        .filter((urn) => !audienceKindForPrincipal(urn, audienceByUrn))
+        .map((urn) =>
+          existingAssignmentOption(
+            urn,
+            audienceByUrn,
+            "Legacy assignment. Remove it to stop using this audience.",
+          ),
+        ),
+    [audienceByUrn, selected],
   );
 
   const handleAudienceSelection = (values: string[]) => {
     setSelected((current) => [
-      ...current.filter((urn) => audienceByUrn.get(urn)?.kind !== audienceType),
+      ...current.filter(
+        (urn) => audienceKindForPrincipal(urn, audienceByUrn) !== audienceType,
+      ),
+      ...values,
+    ]);
+  };
+
+  const handleLegacySelection = (values: string[]) => {
+    setSelected((current) => [
+      ...current.filter((urn) => audienceKindForPrincipal(urn, audienceByUrn)),
       ...values,
     ]);
   };
@@ -206,11 +282,43 @@ function AssignmentsEditor({
           hideSelectAll
           modalPopover
           maxCount={20}
+          disabled={audiencesQuery.isPending || audiencesQuery.isError}
         />
+        {audiencesQuery.isPending && (
+          <Text muted small className="mt-2">
+            Loading audiences…
+          </Text>
+        )}
+        {audiencesQuery.isError && (
+          <Text small className="mt-2 text-destructive">
+            Unable to load audiences. Close the sheet and try again.
+          </Text>
+        )}
         <Text muted small className="mt-2">
           Choose a type, then select the specific audiences that should receive
           this plugin. Assignments apply when a device next syncs.
         </Text>
+        {legacyOptions.length > 0 && (
+          <>
+            <label className="mb-2 mt-5 block text-sm font-medium">
+              Legacy assignments
+            </label>
+            <MultiSelect
+              options={legacyOptions}
+              defaultValue={legacyOptions.map((option) => option.value)}
+              onValueChange={handleLegacySelection}
+              placeholder="No legacy assignments"
+              badgeClassName="h-6 gap-1.5 px-1.5 font-sans text-xs normal-case tracking-normal"
+              searchable={false}
+              hideSelectAll
+              modalPopover
+              maxCount={20}
+            />
+            <Text muted small className="mt-2">
+              These assignments can be removed but not added again.
+            </Text>
+          </>
+        )}
       </div>
       <SheetFooter className="px-6 pb-6">
         <Button

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -225,7 +225,6 @@ function AssignmentsEditor({
             ...options,
             {
               heading: "Legacy assignments",
-              icon: principalIcon("user"),
               options: legacyOptions,
             },
           ]

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -29,11 +29,20 @@ import {
 const audienceGroups: {
   value: PluginAudienceKind;
   heading: string;
+  icon: ReturnType<typeof principalIcon>;
 }[] = [
-  { value: "everyone", heading: "Everyone" },
-  { value: "role", heading: "Roles" },
-  { value: "directory_group", heading: "Directory groups" },
-  { value: "directory_attribute", heading: "Directory attributes" },
+  { value: "everyone", heading: "Everyone", icon: principalIcon("everyone") },
+  { value: "role", heading: "Roles", icon: principalIcon("role") },
+  {
+    value: "directory_group",
+    heading: "Directory groups",
+    icon: principalIcon("directory_group"),
+  },
+  {
+    value: "directory_attribute",
+    heading: "Directory attributes",
+    icon: principalIcon("directory_attribute"),
+  },
 ];
 
 function existingAssignmentOption(
@@ -46,7 +55,6 @@ function existingAssignmentOption(
     label: principal.label,
     value: urn,
     description,
-    icon: principalIcon(principal.kind),
     disabled: true,
   };
 }
@@ -62,7 +70,6 @@ function availableAudienceOptions(
       label: audience.displayName,
       value: audience.principalUrn,
       description: memberCountDescription(audience.memberCount),
-      icon: principalIcon(audience.kind),
       disabled,
     }));
 }
@@ -161,6 +168,7 @@ function AssignmentsEditor({
     () =>
       audienceGroups.map((group) => ({
         heading: group.heading,
+        icon: group.icon,
         options: availableAudienceOptions(
           group.value,
           audiences,
@@ -173,6 +181,7 @@ function AssignmentsEditor({
     () =>
       audienceGroups.map((group) => ({
         heading: group.heading,
+        icon: group.icon,
         options: unavailableAudienceOptions(
           group.value,
           selected,
@@ -186,6 +195,7 @@ function AssignmentsEditor({
       availableAudienceGroups
         .map((group, index) => ({
           heading: group.heading,
+          icon: group.icon,
           options: [
             ...group.options,
             ...unavailableAudienceGroups[index]!.options,
@@ -213,7 +223,11 @@ function AssignmentsEditor({
       legacyOptions.length > 0
         ? [
             ...options,
-            { heading: "Legacy assignments", options: legacyOptions },
+            {
+              heading: "Legacy assignments",
+              icon: principalIcon("user"),
+              options: legacyOptions,
+            },
           ]
         : options,
     [legacyOptions, options],
@@ -257,6 +271,7 @@ function AssignmentsEditor({
           hideSelectAll
           modalPopover
           maxCount={20}
+          popoverClassName="w-[var(--radix-popover-trigger-width)] min-w-0 max-w-none [&_[cmdk-group-heading]]:px-0 [&_[cmdk-group-heading]]:py-0.5 [&_[cmdk-input-wrapper]]:px-0 [&_[cmdk-item]]:px-0 [&_[cmdk-item]]:py-1 [&_[data-slot=command-group]]:p-0 [&_[data-slot=command-list]]:p-0"
         />
         {audiencesQuery.isPending && (
           <Text muted small className="mt-2">

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -271,7 +271,7 @@ function AssignmentsEditor({
           hideSelectAll
           modalPopover
           maxCount={20}
-          popoverClassName="w-[var(--radix-popover-trigger-width)] min-w-0 max-w-none [&_[cmdk-group-heading]]:px-0 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-input-wrapper]]:px-0 [&_[cmdk-item]]:px-0 [&_[cmdk-item]]:py-1 [&_[data-slot=command-group]]:p-0 [&_[data-slot=command-group]+[data-slot=command-group]]:pt-2 [&_[data-slot=command-list]]:p-0"
+          popoverClassName="w-[var(--radix-popover-trigger-width)] min-w-0 max-w-none [&_[cmdk-group-heading]]:px-0 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-input-wrapper]]:px-0 [&_[cmdk-item]]:py-1 [&_[cmdk-item]]:pl-2 [&_[cmdk-item]]:pr-0 [&_[data-slot=command-group]]:p-0 [&_[data-slot=command-group]+[data-slot=command-group]]:pt-2 [&_[data-slot=command-list]]:p-0"
         />
         {audiencesQuery.isPending && (
           <Text muted small className="mt-2">

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -1,5 +1,12 @@
 import { MultiSelect } from "@/components/ui/MultiSelect";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
+import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -9,17 +16,34 @@ import {
 } from "@/components/ui/Sheet";
 import { Text } from "@/components/ui/Text";
 import type { PluginAssignment } from "@gram/client/models/components/pluginassignment.js";
+import type { PluginAudienceKind } from "@gram/client/models/components/pluginaudience.js";
+import { useAudiences } from "@gram/client/react-query/audiences";
 import { useSetPluginAssignmentsMutation } from "@gram/client/react-query/setPluginAssignments";
-import { useMembers } from "@gram/client/react-query/members";
-import { useRoles } from "@gram/client/react-query/roles";
 import { Button } from "@/components/ui/Button";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import {
-  normalizeToPrincipalUrn,
-  principalIcon,
-  WILDCARD_PRINCIPAL,
-} from "./principals";
+import { principalIcon } from "./principals";
+
+const audienceTypeOptions: {
+  value: PluginAudienceKind;
+  label: string;
+}[] = [
+  { value: "everyone", label: "Everyone" },
+  { value: "role", label: "Role" },
+  { value: "directory_group", label: "Directory group" },
+  { value: "directory_attribute", label: "Directory attribute" },
+];
+
+function isAudienceType(value: string): value is PluginAudienceKind {
+  return audienceTypeOptions.some((type) => type.value === value);
+}
+
+function memberCountDescription(
+  memberCount: number | undefined,
+): string | undefined {
+  if (memberCount === undefined) return undefined;
+  return `${memberCount} ${memberCount === 1 ? "member" : "members"}`;
+}
 
 export function PluginAssignmentsSheet({
   pluginId,
@@ -75,12 +99,10 @@ function AssignmentsEditor({
   onOpenChange: (open: boolean) => void;
   onSaved: () => void;
 }): JSX.Element {
-  const { data: rolesData } = useRoles();
-  const { data: membersData } = useMembers();
-  const roles = useMemo(() => rolesData?.roles ?? [], [rolesData?.roles]);
-  const members = useMemo(
-    () => membersData?.members ?? [],
-    [membersData?.members],
+  const { data: audiencesData } = useAudiences();
+  const audiences = useMemo(
+    () => audiencesData?.audiences ?? [],
+    [audiencesData?.audiences],
   );
 
   const initialUrns = useMemo(
@@ -88,55 +110,38 @@ function AssignmentsEditor({
     [assignments],
   );
   const [selected, setSelected] = useState<string[]>(initialUrns);
+  const [audienceType, setAudienceType] =
+    useState<PluginAudienceKind>("everyone");
 
-  // Options provide friendly labels for every principal a plugin can already be
-  // assigned to, so current assignments (seeded via defaultValue) render as
-  // names rather than raw URNs. New emails are added via the creatable input.
-  const options = useMemo(() => {
-    const everyone = {
-      label: "Everyone",
-      value: WILDCARD_PRINCIPAL,
-      icon: principalIcon("everyone"),
-    };
-    const roleOptions = roles.map((role) => ({
-      label: role.name,
-      value: role.principalUrn,
-      icon: principalIcon("role"),
-    }));
-    const memberOptions = members.map((member) => ({
-      label: member.name ? `${member.name} (${member.email})` : member.email,
-      value: member.principalUrn,
-      icon: principalIcon("user"),
-    }));
+  const audienceByUrn = useMemo(
+    () =>
+      new Map(audiences.map((audience) => [audience.principalUrn, audience])),
+    [audiences],
+  );
+  const selectedForAudienceType = useMemo(
+    () =>
+      selected.filter((urn) => audienceByUrn.get(urn)?.kind === audienceType),
+    [audienceByUrn, audienceType, selected],
+  );
+  const options = useMemo(
+    () =>
+      audiences
+        .filter((audience) => audience.kind === audienceType)
+        .map((audience) => ({
+          label: audience.displayName,
+          value: audience.principalUrn,
+          description: memberCountDescription(audience.memberCount),
+          icon: principalIcon(audience.kind),
+        })),
+    [audienceType, audiences],
+  );
 
-    // Surface existing email assignments as their own options so they show the
-    // address as a label and stay selected. Members already cover user: URNs.
-    const knownValues = new Set([
-      everyone.value,
-      ...roleOptions.map((o) => o.value),
-      ...memberOptions.map((o) => o.value),
+  const handleAudienceSelection = (values: string[]) => {
+    setSelected((current) => [
+      ...current.filter((urn) => audienceByUrn.get(urn)?.kind !== audienceType),
+      ...values,
     ]);
-    const emailOptions = initialUrns
-      .filter((urn) => urn.startsWith("email:") && !knownValues.has(urn))
-      .map((urn) => ({
-        label: urn.slice("email:".length),
-        value: urn,
-        icon: principalIcon("email"),
-      }));
-
-    return [
-      { heading: "General", options: [everyone] },
-      ...(roleOptions.length
-        ? [{ heading: "Roles", options: roleOptions }]
-        : []),
-      ...(memberOptions.length
-        ? [{ heading: "Users", options: memberOptions }]
-        : []),
-      ...(emailOptions.length
-        ? [{ heading: "Emails", options: emailOptions }]
-        : []),
-    ];
-  }, [roles, members, initialUrns]);
+  };
 
   const mutation = useSetPluginAssignmentsMutation({
     onSuccess: () => {
@@ -149,27 +154,12 @@ function AssignmentsEditor({
   });
 
   const handleSave = () => {
-    // Canonicalize the picked values into principal URNs. Anything that is
-    // neither a known URN nor a valid email (e.g. a typo typed into the picker)
-    // blocks the save so we never persist an assignment that can't deliver.
-    const normalized: string[] = [];
-    const invalid: string[] = [];
-    for (const value of selected) {
-      const urn = normalizeToPrincipalUrn(value);
-      if (urn) normalized.push(urn);
-      else invalid.push(value);
-    }
-    if (invalid.length > 0) {
-      toast.error(`Not a valid role, user, or email: ${invalid.join(", ")}`);
-      return;
-    }
-
     mutation.mutate({
       security: { sessionHeaderGramSession: "" },
       request: {
         setPluginAssignmentsForm: {
           pluginId,
-          principalUrns: Array.from(new Set(normalized)),
+          principalUrns: Array.from(new Set(selected)),
         },
       },
     });
@@ -178,26 +168,52 @@ function AssignmentsEditor({
   return (
     <>
       <div className="flex-1 overflow-y-auto px-6 py-4">
-        <label className="mb-2 block text-sm font-medium">
-          Assigned principals
+        <label
+          className="mb-2 block text-sm font-medium"
+          htmlFor="audience-type"
+        >
+          Audience type
+        </label>
+        <Select
+          value={audienceType}
+          onValueChange={(value) => {
+            if (isAudienceType(value)) setAudienceType(value);
+          }}
+        >
+          <SelectTrigger id="audience-type" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {audienceTypeOptions.map((type) => (
+              <SelectItem key={type.value} value={type.value}>
+                {type.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <label className="mb-2 mt-5 block text-sm font-medium">
+          {
+            audienceTypeOptions.find((type) => type.value === audienceType)
+              ?.label
+          }
         </label>
         <MultiSelect
-          options={options}
-          defaultValue={initialUrns}
-          onValueChange={setSelected}
-          placeholder="Add roles, users, or emails"
-          // Selections here are names and email addresses, so the badge's
-          // default mono/uppercase token styling has to be undone.
+          key={audienceType}
+          options={[{ heading: "Available audiences", options }]}
+          defaultValue={selectedForAudienceType}
+          onValueChange={handleAudienceSelection}
+          placeholder={`Select ${audienceTypeOptions
+            .find((type) => type.value === audienceType)
+            ?.label.toLowerCase()}`}
           badgeClassName="h-6 gap-1.5 px-1.5 font-sans text-xs normal-case tracking-normal"
-          creatable
           searchable
           hideSelectAll
           modalPopover
           maxCount={20}
         />
         <Text muted small className="mt-2">
-          Type an email and select “Create” to assign it directly. Role and user
-          assignments deliver once the recipient runs the device agent.
+          Choose a type, then select the specific audiences that should receive
+          this plugin. Assignments apply when a device next syncs.
         </Text>
       </div>
       <SheetFooter className="px-6 pb-6">

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -22,7 +22,7 @@ import { useSetPluginAssignmentsMutation } from "@gram/client/react-query/setPlu
 import { Button } from "@/components/ui/Button";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { principalIcon } from "./principals";
+import { audienceMapByUrn, principalIcon } from "./principals";
 
 const audienceTypeOptions: {
   value: PluginAudienceKind;
@@ -113,11 +113,7 @@ function AssignmentsEditor({
   const [audienceType, setAudienceType] =
     useState<PluginAudienceKind>("everyone");
 
-  const audienceByUrn = useMemo(
-    () =>
-      new Map(audiences.map((audience) => [audience.principalUrn, audience])),
-    [audiences],
-  );
+  const audienceByUrn = useMemo(() => audienceMapByUrn(audiences), [audiences]);
   const selectedForAudienceType = useMemo(
     () =>
       selected.filter((urn) => audienceByUrn.get(urn)?.kind === audienceType),

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -36,6 +36,7 @@ import { useRemovePluginServerMutation } from "@gram/client/react-query/removePl
 import { useListToolsets } from "@gram/client/react-query/listToolsets";
 import { useMcpEndpoints } from "@gram/client/react-query/mcpEndpoints.js";
 import { useMcpServers } from "@gram/client/react-query/mcpServers";
+import { useAudiences } from "@gram/client/react-query/audiences";
 import { useMembers } from "@gram/client/react-query/members";
 import { useRoles } from "@gram/client/react-query/roles";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
@@ -90,7 +91,12 @@ import {
   PLUGIN_SKILLS_SECTION_ID,
 } from "./plugin-detail-sections";
 import { countPluginInstalls } from "./plugin-reach";
-import { describePrincipal, memberMapByUrn, roleMapByUrn } from "./principals";
+import {
+  audienceMapByUrn,
+  describePrincipal,
+  memberMapByUrn,
+  roleMapByUrn,
+} from "./principals";
 import { PublishDialog } from "./PublishDialog";
 import { SectionEmptyState } from "./SectionEmptyState";
 import { usePluginAssignmentsVisible } from "./use-plugin-assignments-visible";
@@ -205,6 +211,7 @@ export default function PluginDetail(): JSX.Element | null {
   // Query dedupes these with the sheet's own calls.
   const { data: rolesData } = useRoles();
   const { data: membersData } = useMembers();
+  const { data: audiencesData } = useAudiences();
   const roleByUrn = useMemo(
     () => roleMapByUrn(rolesData?.roles ?? []),
     [rolesData?.roles],
@@ -212,6 +219,10 @@ export default function PluginDetail(): JSX.Element | null {
   const memberByUrn = useMemo(
     () => memberMapByUrn(membersData?.members ?? []),
     [membersData?.members],
+  );
+  const audienceByUrn = useMemo(
+    () => audienceMapByUrn(audiencesData?.audiences ?? []),
+    [audiencesData?.audiences],
   );
 
   const showAssignments = usePluginAssignmentsVisible();
@@ -502,6 +513,7 @@ export default function PluginDetail(): JSX.Element | null {
           a.principalUrn,
           roleByUrn,
           memberByUrn,
+          audienceByUrn,
         );
         const email = memberByUrn.get(a.principalUrn)?.email ?? "";
         return (
@@ -529,6 +541,7 @@ export default function PluginDetail(): JSX.Element | null {
         assignments={filteredAssignments}
         roleByUrn={roleByUrn}
         memberByUrn={memberByUrn}
+        audienceByUrn={audienceByUrn}
       />
     );
   }

--- a/client/dashboard/src/pages/plugins/principals.test.ts
+++ b/client/dashboard/src/pages/plugins/principals.test.ts
@@ -1,7 +1,9 @@
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import type { PluginAudience } from "@gram/client/models/components/pluginaudience.js";
 import type { Role } from "@gram/client/models/components/role.js";
 import { describe, expect, it } from "vitest";
 import {
+  audienceMapByUrn,
   describePrincipal,
   memberMapByUrn,
   normalizeToPrincipalUrn,
@@ -21,6 +23,12 @@ const member = {
 
 const roleByUrn = roleMapByUrn([role]);
 const memberByUrn = memberMapByUrn([member]);
+const directoryAudience = {
+  principalUrn: "directory_group:00000000-0000-0000-0000-000000000000",
+  displayName: "Engineering",
+  kind: "directory_group",
+  memberCount: 2,
+} as PluginAudience;
 
 describe("normalizeToPrincipalUrn", () => {
   it("passes through the wildcard", () => {
@@ -98,5 +106,16 @@ describe("describePrincipal", () => {
     expect(
       describePrincipal("role:organization:missing", roleByUrn, memberByUrn),
     ).toEqual({ kind: "role", label: "role:organization:missing" });
+  });
+
+  it("resolves a directory audience to its display name", () => {
+    expect(
+      describePrincipal(
+        directoryAudience.principalUrn,
+        roleByUrn,
+        memberByUrn,
+        audienceMapByUrn([directoryAudience]),
+      ),
+    ).toEqual({ kind: "directory_group", label: "Engineering" });
   });
 });

--- a/client/dashboard/src/pages/plugins/principals.test.ts
+++ b/client/dashboard/src/pages/plugins/principals.test.ts
@@ -3,6 +3,7 @@ import type { PluginAudience } from "@gram/client/models/components/pluginaudien
 import type { Role } from "@gram/client/models/components/role.js";
 import { describe, expect, it } from "vitest";
 import {
+  audienceKindForPrincipal,
   audienceMapByUrn,
   describePrincipal,
   memberMapByUrn,
@@ -117,5 +118,16 @@ describe("describePrincipal", () => {
         audienceMapByUrn([directoryAudience]),
       ),
     ).toEqual({ kind: "directory_group", label: "Engineering" });
+  });
+
+  it("labels an unavailable directory audience and retains its kind", () => {
+    const unavailableUrn = "directory_group:deleted-group";
+    expect(describePrincipal(unavailableUrn, roleByUrn, memberByUrn)).toEqual({
+      kind: "directory_group",
+      label: `Unavailable directory group (${unavailableUrn})`,
+    });
+    expect(audienceKindForPrincipal(unavailableUrn, new Map())).toBe(
+      "directory_group",
+    );
   });
 });

--- a/client/dashboard/src/pages/plugins/principals.ts
+++ b/client/dashboard/src/pages/plugins/principals.ts
@@ -1,8 +1,9 @@
 import type { FacepileMember } from "@/components/member-facepile";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import type { PluginAudience } from "@gram/client/models/components/pluginaudience.js";
 import type { PluginAssignment } from "@gram/client/models/components/pluginassignment.js";
 import type { Role } from "@gram/client/models/components/role.js";
-import { Globe, Mail, Shield, User } from "lucide-react";
+import { Globe, Mail, Shield, Tag, User, UsersRound } from "lucide-react";
 import { z } from "zod";
 
 // A plugin assignment targets a principal identified by a URN. The agent's
@@ -17,8 +18,17 @@ export const WILDCARD_PRINCIPAL = "*";
 const EMAIL_PREFIX = "email:";
 const ROLE_PREFIX = "role:";
 const USER_PREFIX = "user:";
+const DIRECTORY_GROUP_PREFIX = "directory_group:";
+const DIRECTORY_ATTRIBUTE_PREFIX = "directory_attribute:";
 
-export type PrincipalKind = "everyone" | "email" | "role" | "user" | "unknown";
+export type PrincipalKind =
+  | "everyone"
+  | "email"
+  | "role"
+  | "user"
+  | "directory_group"
+  | "directory_attribute"
+  | "unknown";
 
 const principalKindIcon: Record<
   PrincipalKind,
@@ -28,6 +38,8 @@ const principalKindIcon: Record<
   email: Mail,
   role: Shield,
   user: User,
+  directory_group: UsersRound,
+  directory_attribute: Tag,
   unknown: User,
 };
 
@@ -44,12 +56,17 @@ export function describePrincipal(
   urn: string,
   roleByUrn: Map<string, Role>,
   memberByUrn: Map<string, AccessMember>,
+  audienceByUrn: Map<string, PluginAudience> = new Map(),
 ): { kind: PrincipalKind; label: string } {
   if (urn === WILDCARD_PRINCIPAL)
     return { kind: "everyone", label: "Everyone" };
   if (urn === "user:all") return { kind: "everyone", label: "All users" };
   if (urn.startsWith(EMAIL_PREFIX)) {
     return { kind: "email", label: urn.slice(EMAIL_PREFIX.length) };
+  }
+  const audience = audienceByUrn.get(urn);
+  if (audience) {
+    return { kind: audience.kind, label: audience.displayName };
   }
   if (urn.startsWith("role:")) {
     return { kind: "role", label: roleByUrn.get(urn)?.name ?? urn };
@@ -97,6 +114,14 @@ export function memberMapByUrn(
   return new Map(members.map((m) => [m.principalUrn, m]));
 }
 
+export function audienceMapByUrn(
+  audiences: PluginAudience[],
+): Map<string, PluginAudience> {
+  return new Map(
+    audiences.map((audience) => [audience.principalUrn, audience]),
+  );
+}
+
 const emailSchema = z.string().email();
 
 // normalizeToPrincipalUrn canonicalizes a raw picker value into a principal URN
@@ -112,7 +137,11 @@ export function normalizeToPrincipalUrn(value: string): string | null {
   // generic mutation error.
   if (
     (trimmed.startsWith(ROLE_PREFIX) && trimmed.length > ROLE_PREFIX.length) ||
-    (trimmed.startsWith(USER_PREFIX) && trimmed.length > USER_PREFIX.length)
+    (trimmed.startsWith(USER_PREFIX) && trimmed.length > USER_PREFIX.length) ||
+    (trimmed.startsWith(DIRECTORY_GROUP_PREFIX) &&
+      trimmed.length > DIRECTORY_GROUP_PREFIX.length) ||
+    (trimmed.startsWith(DIRECTORY_ATTRIBUTE_PREFIX) &&
+      trimmed.length > DIRECTORY_ATTRIBUTE_PREFIX.length)
   ) {
     return trimmed;
   }

--- a/client/dashboard/src/pages/plugins/principals.ts
+++ b/client/dashboard/src/pages/plugins/principals.ts
@@ -68,6 +68,18 @@ export function describePrincipal(
   if (audience) {
     return { kind: audience.kind, label: audience.displayName };
   }
+  if (urn.startsWith(DIRECTORY_GROUP_PREFIX)) {
+    return {
+      kind: "directory_group",
+      label: `Unavailable directory group (${urn})`,
+    };
+  }
+  if (urn.startsWith(DIRECTORY_ATTRIBUTE_PREFIX)) {
+    return {
+      kind: "directory_attribute",
+      label: `Unavailable directory attribute (${urn})`,
+    };
+  }
   if (urn.startsWith("role:")) {
     return { kind: "role", label: roleByUrn.get(urn)?.name ?? urn };
   }
@@ -120,6 +132,26 @@ export function audienceMapByUrn(
   return new Map(
     audiences.map((audience) => [audience.principalUrn, audience]),
   );
+}
+
+export function memberCountDescription(
+  memberCount: number | undefined,
+): string | undefined {
+  if (memberCount === undefined) return undefined;
+  return `${memberCount} ${memberCount === 1 ? "member" : "members"}`;
+}
+
+export function audienceKindForPrincipal(
+  urn: string,
+  audienceByUrn: Map<string, PluginAudience>,
+): PluginAudience["kind"] | undefined {
+  const audience = audienceByUrn.get(urn);
+  if (audience) return audience.kind;
+  if (urn === WILDCARD_PRINCIPAL) return "everyone";
+  if (urn.startsWith(ROLE_PREFIX)) return "role";
+  if (urn.startsWith(DIRECTORY_GROUP_PREFIX)) return "directory_group";
+  if (urn.startsWith(DIRECTORY_ATTRIBUTE_PREFIX)) return "directory_attribute";
+  return undefined;
 }
 
 const emailSchema = z.string().email();


### PR DESCRIPTION
## Why?

Plugin assignments need to support the same directory-derived audiences available to the delivery system, so administrators can target a group or attribute audience without working with raw principal URNs.

## What?

Add audience-type selection to the plugin assignment sheet, populate choices from the audience API, and resolve directory audience names and member counts throughout plugin assignment displays.

## Notes

Existing assignments remain intact when switching audience types.

<img width="1424" height="189" alt="image" src="https://github.com/user-attachments/assets/80ad1992-6b89-4421-aaa2-3f5deec788d4" />
<img width="464" height="340" alt="image" src="https://github.com/user-attachments/assets/519095e8-2777-404b-85c3-c8f59c1f4dbc" />
<img width="426" height="227" alt="image" src="https://github.com/user-attachments/assets/8edb57d8-8370-4fb4-8ae0-1cd6cf216217" />
<img width="435" height="592" alt="image" src="https://github.com/user-attachments/assets/964359b4-bb4b-4bf6-919e-ea0f1755076b" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds directory-group and directory-attribute audiences to plugin assignments so admins select typed audiences with live counts. Previously you could target roles/users/emails; now you choose Everyone, Roles, Directory groups, or Directory attributes—new user/email assignments are disallowed, and existing user/email or unavailable directory selections remain visible, disabled, and removable.

- API/SDK: exposes active audiences via GET `/rpc/plugins.listAudiences`; adds `PluginAudience` and `useAudiences` in `@gram/client/react-query/audiences`.
- Dashboard: assignment sheet groups choices under Everyone, Roles, Directory groups, and Directory attributes with icons, search, loading/error states, and live counts; assignment rows, lists, and the detail sidebar resolve audience labels and member counts.
- Components: `MultiSelect` allows removing a selected disabled option and supports optional group-heading icons.
- Compatibility: preserves all existing assignments (including unavailable/legacy); no schema changes; visibility gate and React Query cache behavior unchanged.
- Tests: add coverage for directory audience resolution, principal labels/counts, audience mapping/rendering, disabled-option removal, and group-heading icons; types the `MultiSelect` test callback. Aligns with Linear AGE-3251.

<sup>Written for commit 3d81df333e29ae1703c11c4f7647f0f289a6f7bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



