### PR TITLE
fix: keep the palette's Ask Project Assistant row visible for unmatched queries

### DIFF
--- a/client/dashboard/src/components/command-palette/CommandPalette.test.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPalette.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const palette = vi.hoisted(() => ({
+  isOpen: true,
+  close: vi.fn(),
+  actions: [] as unknown[],
+  contextBadge: undefined,
+}));
+
+vi.mock("@/contexts/CommandPalette", () => ({
+  useCommandPalette: () => palette,
+}));
+vi.mock("@/contexts/Sdk", () => ({
+  useSlugs: () => ({ orgSlug: "acme", projectSlug: "widgets" }),
+}));
+vi.mock("react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("./recentlyVisited", () => ({
+  useRecentsUserId: () => "user_1",
+  useRecentlyVisited: () => [],
+  getRecentLabelOverride: () => undefined,
+}));
+vi.mock("./ResourceResults", () => ({
+  ResourceResults: () => null,
+}));
+
+import { CommandPalette } from "./CommandPalette";
+
+afterEach(cleanup);
+
+describe("CommandPalette", () => {
+  it("offers the Project Assistant for a query that matches nothing", async () => {
+    render(<CommandPalette />);
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Ask AI or search resources and pages…"),
+      "zzzzznomatch",
+    );
+
+    // Query by role: cmdk marks a group with no matching items `hidden`, which
+    // drops its subtree from the accessibility tree — so this fails if the row
+    // renders inside a hidden group (a text query would still find it).
+    const row = screen.getByRole("option", { name: /Ask Project Assistant/ });
+    expect(row.textContent).toContain("“zzzzznomatch”");
+  });
+});

--- a/client/dashboard/src/components/command-palette/CommandPalette.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPalette.tsx
@@ -106,9 +106,6 @@ export function CommandPalette(): JSX.Element {
   // moves to the bottom once the user starts typing (see below), so both branch
   // on whether there's an active query.
   const hasQuery = trimmedQuery.length > 0;
-  const askAiLabel = trimmedQuery
-    ? `Ask AI: "${trimmedQuery}"`
-    : "Ask the Project Assistant…";
 
   const handleAskAi = () => {
     requestAskAi(trimmedQuery);
@@ -117,6 +114,10 @@ export function CommandPalette(): JSX.Element {
 
   // Free-form AI escape hatch — always offered regardless of the filter
   // (forceMount) so the typed query can always be sent to the assistant.
+  // forceMount is needed on the *group* too: cmdk hides a group whose id isn't
+  // in `filtered.groups` while a search is active, which would hide the
+  // forceMounted row inside it exactly when the query matches nothing — the
+  // case where it matters most.
   // Project Assistant is project-scoped, so only at the project level. Rendered
   // near the top when the palette is idle (discoverable) but pushed below the
   // results while searching: cmdk auto-selects the first item in DOM order after
@@ -124,7 +125,7 @@ export function CommandPalette(): JSX.Element {
   // the highlight from the closest result and force an extra ↓ keypress to reach
   // it (AGE-2807).
   const askAiGroup = inProject ? (
-    <CommandGroup heading="Assistant">
+    <CommandGroup forceMount heading="Assistant">
       <CommandItem
         forceMount
         value="__ask_ai__"
@@ -132,7 +133,16 @@ export function CommandPalette(): JSX.Element {
         className="flex items-center gap-2"
       >
         <Icon name="sparkles" className="text-primary size-4 shrink-0" />
-        <span className="truncate">{askAiLabel}</span>
+        <div className="flex min-w-0 flex-col">
+          <span className="shimmer truncate">
+            {hasQuery ? "Ask Project Assistant" : "Ask the Project Assistant…"}
+          </span>
+          {hasQuery && (
+            <span className="text-muted-foreground truncate text-xs">
+              &ldquo;{trimmedQuery}&rdquo;
+            </span>
+          )}
+        </div>
       </CommandItem>
     </CommandGroup>
   ) : null;
@@ -174,7 +184,9 @@ export function CommandPalette(): JSX.Element {
         }}
       />
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+        {/* The Ask row is always mounted inside a project, so an unmatched
+            query there is an offer to ask the assistant, not a dead end. */}
+        {!inProject && <CommandEmpty>No results found.</CommandEmpty>}
 
         {/* Recently visited pages (most-recent first), client-side localStorage.
             Only a zero-state affordance: once the user types, hide it so search


### PR DESCRIPTION
### Problem

Typing a query the palette can't match gave no sign that ↵ would hand it to the Project Assistant — the list just read "No results found."

The Ask row *was* rendered with `forceMount`, but that only pins the **item**. cmdk hides a **group** whose id isn't in `filtered.groups` while a search is active, so the group wrapping the row collapsed exactly when nothing matched — the case where the row matters most.

### Change

- `forceMount` on the Assistant `CommandGroup`, so the row survives a zero-match query.
- The row now reads as an offer: **Ask Project Assistant** (shimmer) over the typed query in quotes.
- Inside a project, "No results found." is suppressed — the Ask row is the answer, not a dead end.

### Test

`CommandPalette.test.tsx` types an unmatched query and asserts the row via `getByRole("option")`. The role query is the point: a hidden group drops its subtree from the accessibility tree, so this fails without the group `forceMount` (a `getByText` query would pass either way).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Command Palette’s Ask Project Assistant row visible when a query matches nothing. Previously, unmatched queries collapsed the containing `cmdk` group and showed “No results found.”; now the group is force-mounted so Enter reliably hands the query to the assistant.

- Apply `forceMount` to the `CommandGroup` wrapping the Ask row so `cmdk` doesn’t hide it during active search with zero matches.
- Update the row copy: “Ask Project Assistant” (shimmer) with the typed query shown below in quotes; idle shows “Ask the Project Assistant…”.
- Mount the Ask row only in project scope and suppress “No results found.” inside a project to make the Ask row the affordance.
- Verify accessibility: test queries by role to ensure the option stays in the accessibility tree; fails without group `forceMount`.
- Preserve selection behavior: while searching, the row stays below matches to avoid stealing the initial highlight.

<sup>Written for commit 4918108244c83dd9ff91b84e866a5cb55ec4ed56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

