### PR TITLE
chore: point pr-demo-gif skill at the seeded default project

### DIFF
--- a/.agents/skills/pr-demo-gif/SKILL.md
+++ b/.agents/skills/pr-demo-gif/SKILL.md
@@ -12,10 +12,10 @@ Capture only the changed dashboard behavior and post it as a PR comment. Use one
 ## Prerequisites
 
 - Discover the dashboard URL with `mise run zero:summary` — read the address from the **Gram dashboard** row (don't assume a port). The same table shows whether each service is RUNNING; if the dashboard or server is STOPPED, start the stack with `mise start` first. Dev-idp auto-login is enabled, and the local TLS cert is browser-trusted (mkcert CA in the NSS store, set up by `mise run zero:tls` — rerun that if you see cert errors).
-- Use the **`ecommerce-api`** project for all flows (`default` is empty). Before recording, verify the database is seeded by probing it directly (the connection string is in the **Database** row of `zero:summary`):
+- Use the **`default`** project for all flows — `mise run seed` (the demo seed retargeted at your dev org) provisions exactly one project. Before recording, verify the database is seeded by probing it directly (the connection string is in the **Database** row of `zero:summary`; drop its `&search_path=public` parameter, which `psql` rejects with `invalid URI query parameter`):
 
   ```bash
-  psql "<database-url>" -c "SELECT p.slug, om.gram_account_type FROM projects p JOIN organization_metadata om ON om.id = p.organization_id WHERE p.slug = 'ecommerce-api' AND NOT p.deleted;"
+  psql "postgres://gram:gram@127.0.0.1:<port>/gram?sslmode=disable" -c "SELECT p.slug, om.gram_account_type FROM projects p JOIN organization_metadata om ON om.id = p.organization_id WHERE p.slug = 'default' AND NOT p.deleted;"
   ```
 
   Expect one row with `gram_account_type = 'enterprise'`. Otherwise run `mise run seed` before continuing.


### PR DESCRIPTION
`mise run seed` now runs `gram demo-seed --local` (#5440), which provisions a
single project, `default`. The `ecommerce-api` project the `pr-demo-gif` skill
told agents to use no longer exists, so the skill's preflight check always
failed and the demo flow stalled before recording anything.

- Point the skill at `default` and explain that the seed makes exactly one project.
- Fix the `psql` invocation: `zero:summary` prints the database URL with
  `&search_path=public`, which `psql` rejects with
  `invalid URI query parameter: "search_path"`.

Doc-only; the skill lives in `.agents/skills/` and is symlinked into
`.claude/.codex/.opencode/.cursor`, so the single edit covers every harness.

Also removed a leftover untracked `.mise-tasks/seed/chat-detail.mts` from the
local checkout (deleted from the repo in #5440) — no diff here, it was never
tracked on this branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points the `pr-demo-gif` skill at the seeded `default` project and fixes the `psql` example so the preflight check passes and the demo flow records again. Previously the skill required `ecommerce-api` (no longer seeded) and `psql` failed on the provided URL.

- Old → new: use `default` (seed now provisions exactly one project) instead of `ecommerce-api`.
- Corrects `psql` usage: drop the `&search_path=public` query parameter from the `zero:summary` database URL; the example query now targets the `default` slug.
- Doc-only change in `.agents/skills/pr-demo-gif/SKILL.md`; symlinked into local harnesses, so no runtime code changes.

<sup>Written for commit c4cac1178703819176f5ff8a05542b18caa63f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

