### PR TITLE
chore: retry failed server tests once in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1496,7 +1496,24 @@ jobs:
         run: mise run install:go
 
       - name: Test
-        run: mise run test:server --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        # --rerun-fails=1 gives a failing test one more attempt before the
+        # shard is marked failed, so a flaky test does not block the PR.
+        run: mise run test:server --shard=${{ matrix.shard }}/${{ strategy.job-total }} --rerun-fails=1
+
+      # A retried test leaves the check green, so without this a flake is
+      # invisible unless someone reads the raw log.
+      - name: Report retried tests
+        if: always()
+        working-directory: server
+        run: |
+          [ -s rerun-report.txt ] || exit 0
+          {
+            echo "### Retried tests (shard ${{ matrix.shard }})"
+            echo
+            echo '```'
+            cat rerun-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Standalone gate for the demo seed: TestDemoSeedSafety proves the seed
   # cannot touch other tenants' data, cleans up stray demo-org rows, and stays

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ flags.local.csv
 node_modules
 bin
 junit-report.xml
+rerun-report.txt
 report.md
 .mise-tasks/local
 .assets

--- a/.mise-tasks/test/server.sh
+++ b/.mise-tasks/test/server.sh
@@ -6,6 +6,7 @@
 cover=false
 open_html=false
 shard=""
+rerun_fails=""
 args=()
 
 for arg in "$@"; do
@@ -19,6 +20,9 @@ for arg in "$@"; do
     --shard=*)
       shard="${arg#--shard=}"
       shift ;;
+    --rerun-fails=*)
+      rerun_fails="${arg#--rerun-fails=}"
+      shift ;;
     *)
       args+=("$arg") ;;
   esac
@@ -31,7 +35,7 @@ fi
 # --shard=<index>/<total> runs a deterministic subset of the packages that have
 # tests, so CI can spread the suite over several runners. See ci/cmd/shard for
 # how packages are distributed.
-if [ -n "$shard" ]; then
+if [ -n "$shard" ] || [ -n "$rerun_fails" ]; then
   # Only package patterns are sharded. Everything else reaches 'go test' in the
   # order it was given, including values that follow a flag — the 'TestFoo' in
   # '-run TestFoo' is not a package. Build tags also go to the shard tool so it
@@ -64,17 +68,21 @@ if [ -n "$shard" ]; then
     esac
   done
 
-  shard_packages=$(go run github.com/speakeasy-api/gram/ci/cmd/shard \
-    -i "$shard" "${tags[@]}" "${patterns[@]}") || exit $?
+  packages=("${patterns[@]}")
 
-  packages=()
-  while IFS= read -r line; do
-    [ -n "$line" ] && packages+=("$line")
-  done <<< "$shard_packages"
+  if [ -n "$shard" ]; then
+    shard_packages=$(go run github.com/speakeasy-api/gram/ci/cmd/shard \
+      -i "$shard" "${tags[@]}" "${patterns[@]}") || exit $?
 
-  if [ ${#packages[@]} -eq 0 ]; then
-    echo "Shard $shard: no packages to test."
-    exit 0
+    packages=()
+    while IFS= read -r line; do
+      [ -n "$line" ] && packages+=("$line")
+    done <<< "$shard_packages"
+
+    if [ ${#packages[@]} -eq 0 ]; then
+      echo "Shard $shard: no packages to test."
+      exit 0
+    fi
   fi
 
   args=("${flags[@]}" "${packages[@]}")
@@ -84,7 +92,25 @@ if [ "$cover" = true ]; then
   args=("-coverprofile=cover.out" "-covermode=atomic" "${args[@]}")
 fi
 
-gotestsum --junitfile junit-report.xml --format-hide-empty-pkg -- "${args[@]}"
+gotestsum_flags=(--junitfile junit-report.xml --format-hide-empty-pkg)
+
+# --rerun-fails=<n> re-runs only the tests that failed, up to n more times, so a
+# flaky test does not fail the run on its own. gotestsum needs the packages
+# separately from the 'go test' flags to do that, and skips reruns entirely when
+# the first attempt failed more than --rerun-fails-max-failures times (i.e. the
+# suite is broken rather than flaky).
+if [ -n "$rerun_fails" ]; then
+  gotestsum_flags+=(
+    --rerun-fails="$rerun_fails"
+    --packages="${packages[*]}"
+    # Names the tests that only passed on a retry. Without it a flake is
+    # invisible: the run is green and nothing says a test had to be re-run.
+    --rerun-fails-report=rerun-report.txt
+  )
+  args=("${flags[@]}")
+fi
+
+gotestsum "${gotestsum_flags[@]}" -- "${args[@]}"
 test_exit_code=$?
 
 if [ "$cover" = true ] && [ -f "cover.out" ]; then

--- a/.mise-tasks/test/server.sh
+++ b/.mise-tasks/test/server.sh
@@ -32,6 +32,14 @@ if [ ${#args[@]} -eq 0 ]; then
   args=("-tags=inv.debug" "./...")
 fi
 
+# A rerun invokes 'go test' again for the failed package alone, which overwrites
+# cover.out with a profile covering only that package. Rather than report
+# coverage that is quietly missing everything else, refuse the combination.
+if [ "$cover" = true ] && [ -n "$rerun_fails" ]; then
+  echo "--cover and --rerun-fails cannot be combined: a rerun overwrites the coverage profile." >&2
+  exit 1
+fi
+
 # --shard=<index>/<total> runs a deterministic subset of the packages that have
 # tests, so CI can spread the suite over several runners. See ci/cmd/shard for
 # how packages are distributed.
@@ -107,6 +115,8 @@ if [ -n "$rerun_fails" ]; then
     # invisible: the run is green and nothing says a test had to be re-run.
     --rerun-fails-report=rerun-report.txt
   )
+  # gotestsum builds the 'go test' command itself for every attempt, so the
+  # packages move to --packages and only the flags stay behind.
   args=("${flags[@]}")
 fi
 


### PR DESCRIPTION
The sharded `server-test` job sometimes fails on a flaky test, which blocks the PR until someone re-runs the whole shard.

`gotestsum` already runs the suite, so this uses its native `--rerun-fails` rather than a job-level retry: only the tests that failed are re-run (`go test -run '^TestFoo$'` in their package), so a retry costs seconds instead of re-doing container start-up, migrations, and the whole shard. gotestsum's `--rerun-fails-max-failures` default (10) means a wholesale shard breakage is not retried at all.

## Changes

- `.mise-tasks/test/server.sh`: new opt-in `--rerun-fails=<n>` flag. `gotestsum` needs the packages separately from the `go test` flags to rerun, so the flag/pattern split that the `--shard` path already did now also runs for this path. Off by default — local `mise run test:server` behaviour is unchanged, so flakes stay visible while debugging.
- `.github/workflows/pr.yaml`: the shard step passes `--rerun-fails=1`, and a new `Report retried tests` step appends `--rerun-fails-report` output to the GitHub job summary. Without it a retried flake leaves a green check and no trace. It runs with `if: always()` so the report also appears when the shard failed anyway.
- `.gitignore`: `rerun-report.txt`, alongside the existing `junit-report.xml`.

## Verification

Against a temporary package with a test that fails on its first attempt only (deleted before commit):

| Case | Result |
| --- | --- |
| Fails once, then passes | `DONE 2 runs, 3 tests, 1 failure`, exit 0 |
| Always fails | rerun attempted, exit 1 |
| `--shard=1/1 --rerun-fails=1` | exit 1 on a real failure — the two paths compose |
| Clean run | no report file, summary untouched |
| Retried flake | summary gets the report block |

The summary step was verified by extracting the `run:` body straight out of the workflow YAML and executing it against a real report file.

## Trade-off

A retried flake now passes CI silently apart from the job summary, and nothing aggregates flakes across runs — spotting a repeat offender still means reading summaries by hand. The junit XML this job already produces is the better feed if we later want flake tracking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries failing server tests once in CI to reduce shard flakes, and blocks combining coverage with reruns to avoid corrupt coverage. Previously a flaky test failed the shard; now only failed tests rerun once and the job summary lists retried tests.

- **Details**
  - `.mise-tasks/test/server.sh`: adds opt-in `--rerun-fails=<n>`; separates packages from flags so `gotestsum` can rerun failures; composes with `--shard`; writes `--rerun-fails-report=rerun-report.txt`; rejects `--cover` when `--rerun-fails` is set (reruns overwrite `cover.out`).
  - `.github/workflows/pr.yaml`: passes `--rerun-fails=1` to server shards and appends `rerun-report.txt` to `$GITHUB_STEP_SUMMARY` (`if: always()`).
  - `.gitignore`: ignores `rerun-report.txt`.
  - Safeguards/side effects: `gotestsum` default `--rerun-fails-max-failures=10` avoids retrying a broken shard; a retried flake yields a green check and is visible only in the job summary. No migration required; local opt-in remains `mise run test:server --rerun-fails=1` (error if combined with `--cover`).

<sup>Written for commit f698984be7ff68fb41eff1477c21593eff22e3e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

