### PR TITLE
fix: stabilize telemetry ClickHouse tests

### DIFF
--- a/server/internal/telemetry/log_publisher_test.go
+++ b/server/internal/telemetry/log_publisher_test.go
@@ -12,6 +12,7 @@ import (
 
 	telemetryv1 "github.com/speakeasy-api/gram/infra/gen/gram/telemetry/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -64,8 +65,8 @@ func newShadowTestLogger(t *testing.T, ctx context.Context, ti *testInstance, pu
 }
 
 // fetchLog reads back exactly one telemetry_logs row for the given tool.
-// Callers must flush the async insert queue first
-// (testenv.FlushClickHouseAsyncInserts) so the single query is deterministic.
+// Callers using an async write path must flush the insert queue first with
+// testenv.FlushClickHouseAsyncInserts.
 func fetchLog(t *testing.T, ctx context.Context, client *repo.Queries, projectID, urn string, timestamp time.Time) repo.TelemetryLog {
 	t.Helper()
 
@@ -207,11 +208,15 @@ func TestLogPublisher_PublishFailureDoesNotAffectWrite(t *testing.T) {
 
 	toolInfo := newTestToolInfo(ti.orgID)
 	timestamp := time.Now().UTC()
-	require.NoError(t, telemLogger.LogBulk(ctx, []telemetry.LogParams{
+	// The deduped path uses the same publisher after a synchronous ClickHouse
+	// write. With no fingerprint attribute, it writes this row unchanged.
+	written, dropped, err := telemLogger.LogBulkDeduped(ctx, attr.CodexComplianceEventHashKey, []telemetry.LogParams{
 		{Timestamp: timestamp, ToolInfo: toolInfo, Attributes: attrs},
-	}))
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, 0, dropped)
 
-	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 	fetchLog(t, ctx, ti.chClient, toolInfo.ProjectID, toolInfo.URN, timestamp)
 	require.Len(t, capture.all(), 1)
 

--- a/server/internal/telemetry/repo/staging.go
+++ b/server/internal/telemetry/repo/staging.go
@@ -305,10 +305,11 @@ func (q *Queries) ListExistingTelemetryLogIDs(ctx context.Context, projectID str
 	return result, nil
 }
 
-// DeleteStagedTelemetryLogs removes promoted rows from staging (lightweight
-// delete). Safe to retry: deleting an already-deleted id is a no-op, and a
-// crash before this delete only leaves rows the next promotion pass skips via
-// the dedup guard.
+// DeleteStagedTelemetryLogs synchronously removes promoted rows from staging
+// with a lightweight delete. Waiting for every replica keeps the activity's
+// next drain pass from observing rows it already promoted. Safe to retry:
+// deleting an already-deleted id is a no-op, and a crash before this delete
+// only leaves rows the next promotion pass skips via the dedup guard.
 func (q *Queries) DeleteStagedTelemetryLogs(ctx context.Context, projectID string, ids []string) error {
 	if len(ids) == 0 {
 		return nil
@@ -322,6 +323,10 @@ func (q *Queries) DeleteStagedTelemetryLogs(ctx context.Context, projectID strin
 	if err != nil {
 		return fmt.Errorf("building staged telemetry logs delete query: %w", err)
 	}
+
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"lightweight_deletes_sync": 2,
+	}))
 
 	if err := q.conn.Exec(ctx, query, args...); err != nil {
 		return fmt.Errorf("deleting staged telemetry logs: %w", err)


### PR DESCRIPTION
## Issue

Two ClickHouse-backed tests failed intermittently in the sharded server suite:

- the Pub/Sub failure test could query before its fire-and-forget ClickHouse insert was observably committed, even though the behavior under test was only whether a failed publish acknowledgment affects the write
- staged telemetry promotion relied on the session default for lightweight-delete synchronization, allowing the activity's caller to observe a row that promotion had already reported as deleted

## Root cause and fix

`TestLogPublisher_PublishFailureDoesNotAffectWrite` coupled the shadow-publish contract to ClickHouse async-insert visibility. It now uses the synchronous telemetry write path, which reaches the same publisher without a fingerprint-based dedupe, and proves the row remains committed independently of the failed publish acknowledgment.

`DeleteStagedTelemetryLogs` now explicitly sets `lightweight_deletes_sync = 2`. The promotion activity therefore waits for the delete on every replica instead of depending on an implicit server or session default. A subsequent drain pass cannot re-observe a row the previous pass already promoted.

## Verification

- `mise run test:server ./internal/telemetry -run '^TestLogPublisher_PublishFailureDoesNotAffectWrite$' -count=100`
- `mise run test:server ./internal/background/activities -run '^TestPromoteStagedTelemetry_DefersRowClaimedByConcurrentAttempt$' -count=100`
- `mise run test:server ./internal/telemetry`
- `mise run test:server ./internal/background/activities`
- `mise lint:server`
