### PR TITLE
chore: remove the member facepile from org home project list

### DIFF
--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -25,9 +25,6 @@ vi.mock("@/components/require-scope", () => ({
 vi.mock("@/components/project-menu", () => ({
   ProjectAvatar: () => <span />,
 }));
-vi.mock("@/components/member-facepile", () => ({
-  MemberFacepile: () => <span />,
-}));
 vi.mock("@/components/ui/ContextMenu", () => ({
   ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
   ContextMenuTrigger: ({ children }: { children: ReactNode }) => (
@@ -113,9 +110,6 @@ vi.mock("@gram/client/react-query/auditLogs.js", () => ({
 }));
 vi.mock("@gram/client/react-query/challengeBuckets.js", () => ({
   useChallengeBuckets: () => ({ data: { buckets: [] }, isLoading: false }),
-}));
-vi.mock("@gram/client/react-query/members.js", () => ({
-  useMembers: () => ({ data: { members: [] } }),
 }));
 vi.mock("@gram/client/react-query/productFeatures.js", () => ({
   useProductFeatures: () => ({ data: { logsEnabled: false } }),

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -1,6 +1,5 @@
 import { InputDialog } from "@/components/input-dialog";
 import { Page } from "@/components/page-layout";
-import { MemberFacepile } from "@/components/member-facepile";
 import { ProjectAvatar } from "@/components/project-menu";
 import { DEFAULT_DATE_RANGE_PRESET } from "@/components/observe/useDateRangeFilter";
 import { buildProjectOverviewQuery } from "@/components/project/projectOverviewQuery";
@@ -32,14 +31,12 @@ import {
 } from "@/pages/access/challengeHelpers";
 import { OrgWelcomeBanner } from "@/pages/org/OrgWelcomeBanner";
 import { useOrgRoutes } from "@/routes";
-import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import type { AuditLog } from "@gram/client/models/components/auditlog.js";
 import type { ChallengeBucket } from "@gram/client/models/components/challengebucket.js";
 import { Outcome } from "@gram/client/models/operations/listchallengebuckets.js";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useAuditLogs } from "@gram/client/react-query/auditLogs.js";
 import { useChallengeBuckets } from "@gram/client/react-query/challengeBuckets.js";
-import { useMembers } from "@gram/client/react-query/members.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -80,7 +77,6 @@ import { ActionIconTile } from "@/components/auditlogs/feed";
 const PROJECT_LIMIT = 6;
 const AUDIT_PREVIEW_LIMIT = 8;
 const CHALLENGE_PREVIEW_LIMIT = 3;
-const FACEPILE_LIMIT = 10;
 
 type OrgProject = ReturnType<typeof useOrganization>["projects"][number];
 
@@ -157,48 +153,19 @@ function OrgHomeInner() {
     queryClient,
   ]);
 
-  // Fetch org-wide audit log once. We use it to drive (a) the left rail
-  // preview, (b) each project's "most recent action", and (c) the facepile
-  // of active actors per project — all from one network call.
+  // Fetch org-wide audit log once. We use it to drive both the left rail
+  // preview and each project's "most recent action" from one network call.
   const { data: auditData } = useAuditLogs();
   const auditLogs = useMemo(() => auditData?.result.logs ?? [], [auditData]);
 
-  const { data: membersData } = useMembers();
-  const memberById = useMemo(() => {
-    const map = new Map<string, AccessMember>();
-    for (const m of membersData?.members ?? []) map.set(m.id, m);
-    return map;
-  }, [membersData]);
-
-  const { latestActionByProjectSlug, activeActorsByProjectSlug } =
-    useMemo(() => {
-      const latest = new Map<string, AuditLog>();
-      const actors = new Map<string, string[]>();
-      for (const log of auditLogs) {
-        if (!log.projectSlug) continue;
-        if (!latest.has(log.projectSlug)) latest.set(log.projectSlug, log);
-        if (log.actorType !== "user") continue;
-        const list = actors.get(log.projectSlug) ?? [];
-        // Preserve recency order; dedupe.
-        if (!list.includes(log.actorId)) {
-          list.push(log.actorId);
-          actors.set(log.projectSlug, list);
-        }
-      }
-      return {
-        latestActionByProjectSlug: latest,
-        activeActorsByProjectSlug: actors,
-      };
-    }, [auditLogs]);
-
-  // Fallback facepile when a project has no audit activity yet — show a
-  // stable, deterministic slice of org members so a fresh project still feels
-  // populated. Sorted by joinedAt so the choice is reproducible across loads.
-  const fallbackMembers = useMemo(() => {
-    return [...(membersData?.members ?? [])]
-      .sort((a, b) => a.joinedAt.getTime() - b.joinedAt.getTime())
-      .slice(0, FACEPILE_LIMIT);
-  }, [membersData]);
+  const latestActionByProjectSlug = useMemo(() => {
+    const latest = new Map<string, AuditLog>();
+    for (const log of auditLogs) {
+      if (!log.projectSlug) continue;
+      if (!latest.has(log.projectSlug)) latest.set(log.projectSlug, log);
+    }
+    return latest;
+  }, [auditLogs]);
 
   const filteredProjects = useMemo(
     () =>
@@ -247,23 +214,10 @@ function OrgHomeInner() {
     void navigate(`/${orgSlug}/projects/${result.project.slug}`);
   };
 
-  const getFacepileMembers = (projectSlug: string): AccessMember[] => {
-    const actorIds = activeActorsByProjectSlug.get(projectSlug) ?? [];
-    const resolved: AccessMember[] = [];
-    for (const id of actorIds) {
-      const m = memberById.get(id);
-      if (m) resolved.push(m);
-      if (resolved.length >= FACEPILE_LIMIT) break;
-    }
-    if (resolved.length > 0) return resolved;
-    return fallbackMembers;
-  };
-
   const renderProjectItem = (project: OrgProject) => {
     const props = {
       project,
       latestLog: latestActionByProjectSlug.get(project.slug),
-      facepile: getFacepileMembers(project.slug),
       isFavorite: isFavorite(project.id),
       onToggleFavorite: () => toggleFavorite(project.id),
     };
@@ -577,13 +531,11 @@ function ViewModeButton({
 function ProjectRow({
   project,
   latestLog,
-  facepile,
   isFavorite,
   onToggleFavorite,
 }: {
   project: OrgProject;
   latestLog: AuditLog | undefined;
-  facepile: AccessMember[];
   isFavorite: boolean;
   onToggleFavorite: () => void;
 }) {
@@ -593,8 +545,8 @@ function ProjectRow({
   return (
     <TableRowContextMenu actions={actions}>
       {/* Below `md` the row stacks: identity and summary first, then the
-          facepile and actions on their own line — side by side there is not
-          enough width for the summary without it running under the faces. */}
+          actions on their own line — side by side there is not enough width
+          for the summary. */}
       <div
         className={cn(
           "group hover:bg-muted/40 relative flex flex-col gap-3 px-4 py-4 transition-colors md:flex-row md:items-center md:gap-4",
@@ -629,18 +581,7 @@ function ProjectRow({
           </div>
         </div>
 
-        <div className="flex items-center justify-between gap-3 pl-13 md:justify-end md:pl-0">
-          <div
-            className="relative z-10 flex"
-            onClick={(e) => {
-              // Keep clicks on the facepile from triggering the row's Link overlay.
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-          >
-            <MemberFacepile members={facepile} maxFaces={5} />
-          </div>
-
+        <div className="flex items-center justify-end gap-3 pl-13 md:pl-0">
           <ProjectRowActions
             actions={actions}
             isFavorite={isFavorite}
@@ -664,13 +605,11 @@ function ProjectRow({
 function ProjectCard({
   project,
   latestLog,
-  facepile,
   isFavorite,
   onToggleFavorite,
 }: {
   project: OrgProject;
   latestLog: AuditLog | undefined;
-  facepile: AccessMember[];
   isFavorite: boolean;
   onToggleFavorite: () => void;
 }) {
@@ -707,16 +646,7 @@ function ProjectCard({
           <RecentActionBlock log={latestLog} />
         </div>
 
-        <div className="flex items-center justify-between gap-2">
-          <div
-            className="relative z-10 min-w-0"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-          >
-            <MemberFacepile members={facepile} maxFaces={3} />
-          </div>
+        <div className="flex items-center justify-end gap-2">
           <ProjectRowActions
             actions={actions}
             isFavorite={isFavorite}


### PR DESCRIPTION
Removes the member facepile from the project cards and rows on org home.

The faces were inferred, not authoritative. Each project resolved its actors from recent org-wide audit logs, and any project without audit activity fell back to an arbitrary `joinedAt`-sorted slice of org members — so a project could display people who had never touched it. The signal was misleading and did not earn the space it took.

**Changes**

- Drop `MemberFacepile` (and its click-swallowing overlay wrapper) from `ProjectRow` and `ProjectCard`, along with the `facepile` prop.
- Remove the supporting derivation: `memberById`, `activeActorsByProjectSlug`, `fallbackMembers`, `getFacepileMembers`, and `FACEPILE_LIMIT`.
- Drop the now-unused `useMembers()` call, so org home makes one fewer request. The audit-log memo collapses to a single `latestActionByProjectSlug` map.
- Action rows switch from `justify-between` to `justify-end` now that the actions menu is the only child.

`MemberFacepile` itself is untouched — it is still used by the access roles tab and the plugin assignment views, where membership is real data rather than inference.

**Verification**

- `aube run -F dashboard type-check` passes.
- `OrgHome.test.tsx` passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the member facepile from the org home project list because it inferred participants and could show unrelated members. Previously rows/cards showed a facepile from audit logs or a fallback of org members; now they show no facepile and only the actions, reducing noise and a network request.

- Drop `MemberFacepile` (and its click-swallowing overlay) from `ProjectRow` and `ProjectCard`, and remove the `facepile` prop.
- Remove facepile derivation and constants: `memberById`, `activeActorsByProjectSlug`, `fallbackMembers`, `getFacepileMembers`, `FACEPILE_LIMIT`.
- Stop calling `useMembers()`, so org home makes one fewer request. Audit log memo now only builds `latestActionByProjectSlug`.
- Adjust layout: action area switches from `justify-between` to `justify-end`.
- Tests updated to stop mocking `MemberFacepile` and `useMembers()`.
- `MemberFacepile` remains in use where membership is authoritative (access roles and plugin assignment views).

<sup>Written for commit 03834dae8b7497689c1e542a31c162357a24dd5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

