### PR TITLE
feat: add per-message pubsub batch results

### DIFF
--- a/infra/pkg/gcp/subscriber.go
+++ b/infra/pkg/gcp/subscriber.go
@@ -100,9 +100,83 @@ type MessageMetadata struct {
 	DeliveryAttempt *int
 }
 
+// BatchMessage is a decoded Pub/Sub message delivered as part of a batch.
+// Fail stages a nack for this message; the subscriber settles every message
+// after the batch handler returns.
+type BatchMessage[M any] struct {
+	// Message is the decoded message payload.
+	Message M
+
+	// Metadata contains the message's broker-assigned delivery metadata.
+	Metadata MessageMetadata
+
+	result *batchResult
+	index  int
+}
+
+// Fail stages a nack for this message. A nil error has no effect. The first
+// non-nil error wins when Fail is called more than once. Fail is safe to call
+// concurrently while the batch handler is running.
+func (m BatchMessage[M]) Fail(err error) {
+	if err == nil {
+		return
+	}
+	if m.result == nil {
+		panic("batch message is not associated with a receive batch")
+	}
+	m.result.fail(m.index, err)
+}
+
+type batchMessageState uint8
+
+const (
+	batchMessagePending batchMessageState = iota
+	batchMessageReady
+	batchMessageUnmarshalFailed
+)
+
+type batchMessageOutcome struct {
+	state   batchMessageState
+	failure error
+}
+
+type batchResult struct {
+	mu       sync.Mutex
+	outcomes []batchMessageOutcome
+	sealed   bool
+}
+
+func (r *batchResult) fail(index int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// A handler may retain a copied BatchMessage or return before joining its
+	// goroutines. Once settlement starts, late failures cannot alter it.
+	if r.sealed {
+		return
+	}
+	if index < 0 || index >= len(r.outcomes) {
+		panic(fmt.Sprintf("batch message index %d out of range", index))
+	}
+	if r.outcomes[index].state != batchMessageReady {
+		panic(fmt.Sprintf("batch message index %d is not deliverable", index))
+	}
+	if r.outcomes[index].failure == nil {
+		r.outcomes[index].failure = err
+	}
+}
+
+func (r *batchResult) seal() []batchMessageOutcome {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sealed = true
+	return r.outcomes
+}
+
 type Subscriber[M proto.Message] interface {
 	Receive(context.Context, func(context.Context, M, MessageMetadata) error) error
 	ReceiveBatch(context.Context, BatchReceiveSettings, func(context.Context, []M, []MessageMetadata) error) error
+	ReceiveBatchWithResult(context.Context, BatchReceiveSettings, func(context.Context, []BatchMessage[M]) error) error
 }
 
 // incomingMessage decouples per-message processing from the concrete
@@ -204,22 +278,68 @@ func (s *psSubscriber[M]) ReceiveBatch(ctx context.Context, settings BatchReceiv
 	}, f)
 }
 
-// batchLoop holds the buffering, count/byte/latency flushing, and drain logic
-// shared by ReceiveBatch. The latency timer is armed when a message starts a new
-// batch and stopped when the batch is detached, so the window is measured from
-// each batch's first message. On cancellation a drainer goroutine flushes the
-// in-flight batch while receive is still running, because ack/nack must reach
-// the live iterator: Subscriber.Receive only returns once every outstanding
-// message is acked/nacked, so the drain cannot wait until after it returns. The
-// delivery source is abstracted behind receive so the loop can be exercised in
-// tests (with a synthetic source and a fake clock) without a live pubsub
-// subscriber: receive must call deliver once per incoming message and return
-// when ctx is cancelled (or on a terminal error).
+// ReceiveBatchWithResult consumes messages in batches whose members may have
+// independent processing outcomes. Use ReceiveBatch when the batch is one unit
+// of work and any handler failure should retry every message. Use this method
+// when some messages may succeed while others fail; call BatchMessage.Fail to
+// stage a nack for only the messages that should be retried.
+//
+// Returning nil from f commits the staged nacks and acks every other message.
+// Returning an error, panicking, or completing after ctx is cancelled nacks the
+// whole batch. Messages that fail to unmarshal are nacked individually and
+// excluded from f.
+func (s *psSubscriber[M]) ReceiveBatchWithResult(ctx context.Context, settings BatchReceiveSettings, f func(context.Context, []BatchMessage[M]) error) error {
+	return s.batchLoopWithResult(ctx, settings, func(ctx context.Context, deliver func(incomingMessage)) error {
+		return s.sub.Receive(ctx, func(_ context.Context, m *pubsub.Message) {
+			deliver(incomingMessage{
+				id:              m.ID,
+				data:            m.Data,
+				attributes:      m.Attributes,
+				deliveryAttempt: m.DeliveryAttempt,
+				ack:             m.Ack,
+				nack:            m.Nack,
+			})
+		})
+	}, f)
+}
+
+// batchLoop adapts the all-or-nothing batch callback to the shared buffering
+// loop. The delivery source is injectable so tests can exercise count, byte,
+// latency, and shutdown flushing without a live Pub/Sub subscriber.
 func (s *psSubscriber[M]) batchLoop(
 	ctx context.Context,
 	settings BatchReceiveSettings,
 	receive func(ctx context.Context, deliver func(incomingMessage)) error,
 	f func(context.Context, []M, []MessageMetadata) error,
+) error {
+	return s.batchLoopMessages(ctx, settings, receive, func(ctx context.Context, batch []incomingMessage) {
+		s.handleBatch(ctx, batch, f)
+	})
+}
+
+func (s *psSubscriber[M]) batchLoopWithResult(
+	ctx context.Context,
+	settings BatchReceiveSettings,
+	receive func(ctx context.Context, deliver func(incomingMessage)) error,
+	f func(context.Context, []BatchMessage[M]) error,
+) error {
+	return s.batchLoopMessages(ctx, settings, receive, func(ctx context.Context, batch []incomingMessage) {
+		s.handleBatchWithResult(ctx, batch, f)
+	})
+}
+
+// batchLoopMessages holds the buffering, count/byte/latency flushing, and drain
+// logic shared by both batch handling modes. The latency timer is armed when a
+// message starts a new batch and stopped when the batch is detached, so the
+// window is measured from each batch's first message. On cancellation a drainer
+// goroutine flushes the in-flight batch while receive is still running, because
+// ack/nack must reach the live iterator: Subscriber.Receive only returns once
+// every outstanding message is settled.
+func (s *psSubscriber[M]) batchLoopMessages(
+	ctx context.Context,
+	settings BatchReceiveSettings,
+	receive func(ctx context.Context, deliver func(incomingMessage)) error,
+	handle func(context.Context, []incomingMessage),
 ) error {
 	size := settings.MaxMessages
 	if size <= 0 {
@@ -273,8 +393,8 @@ func (s *psSubscriber[M]) batchLoop(
 		return batch
 	}
 
-	// handlerMu serializes handleBatch so the latency callback and the
-	// size/byte-trigger path never invoke f concurrently. Buffering (under mu)
+	// handlerMu serializes batch handlers so the latency callback and the
+	// size/byte-trigger path never invoke one concurrently. Buffering (under mu)
 	// continues while a batch is in flight; only the handler call is serialized.
 	var handlerMu sync.Mutex
 	runBatch := func(batch []incomingMessage) {
@@ -283,7 +403,7 @@ func (s *psSubscriber[M]) batchLoop(
 		}
 		handlerMu.Lock()
 		defer handlerMu.Unlock()
-		s.handleBatch(ctx, batch, f)
+		handle(ctx, batch)
 	}
 	flush := func() { runBatch(take()) }
 
@@ -471,6 +591,105 @@ func (s *psSubscriber[M]) handleBatch(ctx context.Context, batch []incomingMessa
 	if err := f(ctx, msgs, metas); err != nil {
 		nackAll()
 		return
+	}
+}
+
+func (s *psSubscriber[M]) handleBatchWithResult(ctx context.Context, batch []incomingMessage, f func(context.Context, []BatchMessage[M]) error) {
+	if len(batch) == 0 {
+		return
+	}
+
+	result := &batchResult{
+		mu:       sync.Mutex{},
+		outcomes: make([]batchMessageOutcome, len(batch)),
+		sealed:   false,
+	}
+
+	nackReady := func() {
+		outcomes := result.seal()
+		for i, m := range batch {
+			if outcomes[i].state == batchMessageReady {
+				m.nack()
+			}
+		}
+	}
+
+	// Panics can occur while decoding or in the handler. Messages already
+	// rejected during decoding remain settled; every other message is nacked.
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.ErrorContext(ctx, "panic recovered while processing pubsub message batch with results",
+				attr.SlogErrorMessage(fmt.Sprintf("%v", r)),
+				attr.SlogErrorStack(string(debug.Stack())),
+				attr.SlogTopicProtoName(s.topicProtoName),
+				attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
+				attr.SlogSubscriberMessageID(batch[0].id),
+				attr.SlogSubscriberBatchSize(len(batch)),
+			)
+			outcomes := result.seal()
+			for i, m := range batch {
+				if outcomes[i].state != batchMessageUnmarshalFailed {
+					m.nack()
+				}
+			}
+		}
+	}()
+
+	messages := make([]BatchMessage[M], 0, len(batch))
+	for i, m := range batch {
+		msg := s.new()
+		if err := proto.Unmarshal(m.data, msg); err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"failed to unmarshal pubsub message",
+				attr.SlogError(err),
+				attr.SlogTopicProtoName(s.topicProtoName),
+				attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
+				attr.SlogSubscriberMessageID(m.id),
+				attr.SlogSubscriberDeliveryAttempt(m.deliveryAttempt),
+			)
+			m.nack()
+			result.outcomes[i].state = batchMessageUnmarshalFailed
+			continue
+		}
+
+		result.outcomes[i].state = batchMessageReady
+		messages = append(messages, BatchMessage[M]{
+			Message: msg,
+			Metadata: MessageMetadata{
+				ID:              m.id,
+				Attributes:      m.attributes,
+				DeliveryAttempt: m.deliveryAttempt,
+			},
+			result: result,
+			index:  i,
+		})
+	}
+
+	if len(messages) == 0 {
+		result.seal()
+		return
+	}
+
+	if err := f(ctx, messages); err != nil {
+		nackReady()
+		return
+	}
+	if ctx.Err() != nil {
+		nackReady()
+		return
+	}
+
+	outcomes := result.seal()
+	for i, m := range batch {
+		if outcomes[i].state != batchMessageReady {
+			continue
+		}
+		if outcomes[i].failure != nil {
+			m.nack()
+		} else {
+			m.ack()
+		}
 	}
 }
 

--- a/infra/pkg/gcp/subscriber_test.go
+++ b/infra/pkg/gcp/subscriber_test.go
@@ -295,6 +295,126 @@ func TestHandleBatch_AllBadMessagesHandlerNotCalled(t *testing.T) {
 	require.True(t, cbad.nacked)
 }
 
+func TestHandleBatchWithResult_FailedMessageNackedIndividually(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	m1, c1 := newBatchMessage("msg-1", data, nil)
+	m2, c2 := newBatchMessage("msg-2", data, nil)
+	m3, c3 := newBatchMessage("msg-3", data, nil)
+
+	s.handleBatchWithResult(t.Context(), []incomingMessage{m1, m2, m3}, func(_ context.Context, msgs []BatchMessage[*emptypb.Empty]) error {
+		require.Len(t, msgs, 3)
+		require.Equal(t, "msg-3", msgs[2].Metadata.ID)
+
+		// Reordering the handler's view must not detach the staged failure from
+		// the underlying Pub/Sub message.
+		msgs[0], msgs[2] = msgs[2], msgs[0]
+		msgs[0].Fail(errors.New("retry message 3"))
+		return nil
+	})
+
+	require.True(t, c1.acked)
+	require.False(t, c1.nacked)
+	require.True(t, c2.acked)
+	require.False(t, c2.nacked)
+	require.False(t, c3.acked)
+	require.True(t, c3.nacked)
+}
+
+func TestHandleBatchWithResult_HandlerErrorNacksWholeBatch(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	m1, c1 := newBatchMessage("msg-1", data, nil)
+	m2, c2 := newBatchMessage("msg-2", data, nil)
+
+	s.handleBatchWithResult(t.Context(), []incomingMessage{m1, m2}, func(_ context.Context, msgs []BatchMessage[*emptypb.Empty]) error {
+		msgs[0].Fail(errors.New("individual failure"))
+		return errors.New("batch failure")
+	})
+
+	require.False(t, c1.acked)
+	require.True(t, c1.nacked)
+	require.False(t, c2.acked)
+	require.True(t, c2.nacked)
+}
+
+func TestHandleBatchWithResult_PanicNacksWholeBatch(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	m1, c1 := newBatchMessage("msg-1", data, nil)
+	m2, c2 := newBatchMessage("msg-2", data, nil)
+
+	s.handleBatchWithResult(t.Context(), []incomingMessage{m1, m2}, func(_ context.Context, msgs []BatchMessage[*emptypb.Empty]) error {
+		msgs[0].Fail(errors.New("individual failure"))
+		panic("boom")
+	})
+
+	require.False(t, c1.acked)
+	require.True(t, c1.nacked)
+	require.False(t, c2.acked)
+	require.True(t, c2.nacked)
+}
+
+func TestHandleBatchWithResult_CancellationNacksWholeBatch(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	m1, c1 := newBatchMessage("msg-1", data, nil)
+	m2, c2 := newBatchMessage("msg-2", data, nil)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	s.handleBatchWithResult(ctx, []incomingMessage{m1, m2}, func(context.Context, []BatchMessage[*emptypb.Empty]) error {
+		cancel()
+		return nil
+	})
+
+	require.False(t, c1.acked)
+	require.True(t, c1.nacked)
+	require.False(t, c2.acked)
+	require.True(t, c2.nacked)
+}
+
+func TestHandleBatchWithResult_UnmarshalFailurePreservesResultIndexes(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	good1, cgood1 := newBatchMessage("msg-good-1", data, nil)
+	bad, cbad := newBatchMessage("msg-bad", []byte("not-a-valid-proto-wire-format-\xff\xff"), nil)
+	good2, cgood2 := newBatchMessage("msg-good-2", data, nil)
+
+	s.handleBatchWithResult(t.Context(), []incomingMessage{good1, bad, good2}, func(_ context.Context, msgs []BatchMessage[*emptypb.Empty]) error {
+		require.Len(t, msgs, 2)
+		require.Equal(t, "msg-good-2", msgs[1].Metadata.ID)
+		msgs[1].Fail(errors.New("retry second valid message"))
+		return nil
+	})
+
+	require.True(t, cgood1.acked)
+	require.False(t, cgood1.nacked)
+	require.False(t, cbad.acked)
+	require.True(t, cbad.nacked)
+	require.False(t, cgood2.acked)
+	require.True(t, cgood2.nacked)
+}
+
 // batchCapture records, in order, the message IDs handed to a batch handler so
 // tests can assert which messages flushed together. Safe for the handler to call
 // from the receive goroutine while the test goroutine reads snapshots.

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -772,3 +772,77 @@ func mustReceiveBatch[M proto.Message](
 ) {
 	must.Nil(receiveBatch(g, msg, subscription, settings, handler, options...))
 }
+
+// receiveBatchWithResult registers a BatchResultHandler whose messages can
+// stage individual failures without changing the all-or-nothing BatchHandler
+// contract.
+//
+//nolint:unused // Available for result-aware stream registrations.
+func receiveBatchWithResult[M proto.Message](
+	g receiverGroup,
+	msg M,
+	subscription proto.Message,
+	settings gcp.BatchReceiveSettings,
+	handler streams.BatchResultHandler[M],
+	options ...gcp.SubscriberOption,
+) error {
+	sub, msgName, subName, ctx, err := setupSubscriber(g, msg, subscription, options...)
+	if err != nil {
+		return err
+	}
+
+	g.group.Go(func() error {
+		if err := sub.ReceiveBatchWithResult(ctx, settings, func(ctx context.Context, msgs []gcp.BatchMessage[M]) (err error) {
+			ctx, span := g.tracer.Start(ctx, "stream.handleBatch", trace.WithAttributes(
+				attr.TopicProtoName(msgName),
+				attr.SubscriptionProtoName(subName),
+				attr.SubscriberBatchSize(len(msgs)),
+			))
+
+			defer func() {
+				if err != nil {
+					span.RecordError(err)
+					span.SetStatus(codes.Error, err.Error())
+				}
+				span.End()
+			}()
+
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic recovered in batch result handler: %v", r)
+					g.logger.ErrorContext(ctx, "panic recovered in batch result handler",
+						attr.SlogError(err),
+						attr.SlogErrorStack(string(debug.Stack())),
+					)
+				}
+			}()
+
+			err = handler.HandleBatchWithResult(ctx, msgs)
+			if err != nil {
+				return fmt.Errorf("handle message batch with result: %w", err)
+			}
+			if err = ctx.Err(); err != nil {
+				return fmt.Errorf("handle message batch with result: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("subscriber receive batch with result error: %w", err)
+		}
+
+		return nil
+	})
+
+	return nil
+}
+
+//nolint:unused // Available for result-aware stream registrations.
+func mustReceiveBatchWithResult[M proto.Message](
+	g receiverGroup,
+	msg M,
+	subscription proto.Message,
+	settings gcp.BatchReceiveSettings,
+	handler streams.BatchResultHandler[M],
+	options ...gcp.SubscriberOption,
+) {
+	must.Nil(receiveBatchWithResult(g, msg, subscription, settings, handler, options...))
+}

--- a/server/internal/streams/handlers.go
+++ b/server/internal/streams/handlers.go
@@ -28,3 +28,20 @@ type BatchHandlerFunc[M any] func(context.Context, []M, []gcp.MessageMetadata) e
 func (f BatchHandlerFunc[M]) HandleBatch(ctx context.Context, msgs []M, metas []gcp.MessageMetadata) error {
 	return f(ctx, msgs, metas)
 }
+
+// BatchMessage is a decoded message whose Fail method stages a nack until its
+// batch handler returns.
+type BatchMessage[M any] = gcp.BatchMessage[M]
+
+// BatchResultHandler processes a batch while allowing individual messages to
+// stage failures. Returning nil nacks failed messages and acks the rest.
+// Returning an error nacks the whole batch.
+type BatchResultHandler[M any] interface {
+	HandleBatchWithResult(context.Context, []BatchMessage[M]) error
+}
+
+type BatchResultHandlerFunc[M any] func(context.Context, []BatchMessage[M]) error
+
+func (f BatchResultHandlerFunc[M]) HandleBatchWithResult(ctx context.Context, msgs []BatchMessage[M]) error {
+	return f(ctx, msgs)
+}


### PR DESCRIPTION
## Summary

- add a result-aware Pub/Sub batch API that stages per-message failures
- preserve the existing all-or-nothing batch handler for unit-of-work batches
- wire result-aware handlers into the streams runner with panic and cancellation safeguards
- cover selective nack, whole-batch override, malformed messages, panic, and cancellation

## Verification

- `mise exec -- go test ./infra/pkg/gcp`
- `mise run test:server ./cmd/gram ./internal/streams/`
- `mise lint:server`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-message Pub/Sub batch results to `infra/pkg/gcp` while preserving the existing all-or-nothing batch flow. Previously, `ReceiveBatch` acked or nacked the entire batch; now `ReceiveBatchWithResult` lets handlers mark individual messages as failed, reducing retries to only those messages.

- New APIs and types: `Subscriber.ReceiveBatchWithResult`, `BatchMessage[M]` with `.Fail(error)`, `streams.BatchResultHandler`, and `server/cmd/gram` helpers `receiveBatchWithResult`/`mustReceiveBatchWithResult`.
- Ack/Nack semantics: returning nil acks messages not failed via `.Fail` and nacks only failed ones; returning an error, panicking, or handling after cancellation nacks the whole batch. Unmarshal failures are nacked immediately and excluded from the handler.
- Safety and behavior: handler panics are recovered and logged; per-message failures are concurrency-safe; settlement is sealed before acks/nacks to prevent late changes; handler execution remains serialized while buffering continues.

**Adoption**
- No migration required; `ReceiveBatch` behavior is unchanged.
- To use per-message results, switch to `ReceiveBatchWithResult` (or `receiveBatchWithResult` in `server/cmd/gram`) and implement `streams.BatchResultHandler`. Call `BatchMessage.Fail(err)` for messages that should be retried.

<sup>Written for commit f334c28e51138bdf62c5dc79eda349a797e00966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

