### PR TITLE
chore: reuse gcl caches across worktrees

### DIFF
--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -36,6 +36,15 @@ for item in "${copy_from_main[@]}"; do
   [ -e "$src" ] && rsync -a "$src" .
 done
 
+gcl="${main_worktree}/server/bin/gcl"
+if [ -x "$gcl" ]; then
+  mkdir -p "${current_worktree}/server/bin"
+  rsync -a "$gcl" "${current_worktree}/server/bin/"
+  if [ -f "${gcl}.fingerprint" ]; then
+    rsync -a "${gcl}.fingerprint" "${current_worktree}/server/bin/"
+  fi
+fi
+
 mise trust
 if ! mise run install:aube --offline; then
   echo "Offline install failed, falling back to online install..."

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -36,6 +36,7 @@ for item in "${copy_from_main[@]}"; do
   [ -e "$src" ] && rsync -a "$src" .
 done
 
+# Seed the custom linter so lint:server can reuse it when build inputs match.
 gcl="${main_worktree}/server/bin/gcl"
 if [ -x "$gcl" ]; then
   mkdir -p "${current_worktree}/server/bin"

--- a/.mise-tasks/lint/server.sh
+++ b/.mise-tasks/lint/server.sh
@@ -5,16 +5,122 @@
 
 #USAGE flag "--long" help="Enable more detailed reporting"
 
-set -e
+set -eo pipefail
 
 args=(--show-stats=false --output.text.print-issued-lines=false)
 if [ "${usage_long:-false}" = "true" ]; then
     args=()
 fi
 
-if [ ! -x ./bin/gcl ] || [ -n "$(find ../glint .custom-gcl.yml ../go.mod ../go.sum -newer ./bin/gcl -type f 2>/dev/null)" ]; then
-    golangci-lint custom --destination ./bin --name gcl
-    ./bin/gcl cache clean
+gcl_fingerprint_file=./bin/gcl.fingerprint
+
+gcl_input_fingerprint() (
+    cd ..
+    paths=$(find glint server/.custom-gcl.yml go.mod go.sum -type f -print | LC_ALL=C sort)
+    {
+        printf 'paths\n%s\ncontents\n' "$paths"
+        printf '%s\n' "$paths" | git hash-object --stdin-paths
+    } | git hash-object --stdin
+)
+
+gcl_inputs=$(gcl_input_fingerprint)
+gcl_stamp=
+if [ -r "$gcl_fingerprint_file" ]; then
+    IFS= read -r gcl_stamp < "$gcl_fingerprint_file"
 fi
 
-exec ./bin/gcl run --max-issues-per-linter=0 "${args[@]}" ./...
+gcl_binary=
+if [ -x ./bin/gcl ]; then
+    gcl_binary=$(git hash-object ./bin/gcl)
+fi
+
+if [ "$gcl_stamp" != "${gcl_inputs}:${gcl_binary}" ]; then
+    echo "Building gcl..."
+    build_started=$SECONDS
+    golangci-lint custom --destination ./bin --name gcl
+    gcl_binary=$(git hash-object ./bin/gcl)
+    gcl_stamp="${gcl_inputs}:${gcl_binary}"
+    printf '%s\n' "$gcl_stamp" > "$gcl_fingerprint_file"
+    echo "Built gcl in $((SECONDS - build_started))s"
+fi
+
+current_worktree=$(git rev-parse --show-toplevel)
+common_git_dir=$(cd "$(git rev-parse --git-common-dir)" && pwd)
+lint_config=$(git hash-object .golangci.yaml)
+lint_cache_key=$(printf '%s\n%s\n' "$gcl_stamp" "$lint_config" | git hash-object --stdin)
+
+# golangci-lint includes absolute filenames in its cache keys. Run worktrees
+# with the same binary and lint configuration through one stable path so they
+# share cache entries. Including the cache key in that path also prevents stale
+# reuse after either input changes. The lock prevents another worktree from
+# retargeting the symlink while linting is in progress.
+stable_worktree="${common_git_dir}/gcl-lint-worktree-${lint_cache_key}"
+lint_lock="${stable_worktree}.lock"
+
+acquire_lint_lock() {
+    local owner
+    while ! ln -s "$$" "$lint_lock" 2>/dev/null; do
+        owner=$(readlink "$lint_lock" 2>/dev/null || true)
+        case "$owner" in
+            ''|*[!0-9]*) ;;
+            *)
+                if kill -0 "$owner" 2>/dev/null; then
+                    sleep 1
+                    continue
+                fi
+                ;;
+        esac
+        rm -f "$lint_lock"
+    done
+}
+
+release_lint_lock() {
+    local owner
+    owner=$(readlink "$lint_lock" 2>/dev/null || true)
+    if [ "$owner" = "$$" ]; then
+        rm -f "$stable_worktree" "$lint_lock"
+    fi
+}
+
+acquire_lint_lock
+trap release_lint_lock EXIT
+rm -f "$stable_worktree"
+ln -s "$current_worktree" "$stable_worktree"
+cd "${stable_worktree}/server"
+
+# Generated packages produce no diagnostics after golangci-lint's generated
+# file filter, but making them initial packages more than doubles cold runtime.
+package_dirs=$(go list -f '{{.Dir}}' ./...)
+server_prefix="${PWD}/"
+lint_packages=(.)
+lint_roots=' '
+while IFS= read -r package_dir; do
+    case "$package_dir" in
+        "$PWD/gen"|"$PWD/gen/"*|"$PWD") ;;
+        "$PWD"/*)
+            relative_package=${package_dir#"$server_prefix"}
+            package_root=${relative_package%%/*}
+            case "$lint_roots" in
+                *" $package_root "*) ;;
+                *)
+                    lint_packages+=("./${package_root}/...")
+                    lint_roots="${lint_roots}${package_root} "
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unexpected server package path: $package_dir" >&2
+            exit 1
+            ;;
+    esac
+done <<< "$package_dirs"
+
+if ./bin/gcl run --max-issues-per-linter=0 "${args[@]}" "${lint_packages[@]}"; then
+    lint_status=0
+else
+    lint_status=$?
+fi
+
+release_lint_lock
+trap - EXIT
+exit "$lint_status"

--- a/.mise-tasks/lint/server.sh
+++ b/.mise-tasks/lint/server.sh
@@ -56,17 +56,24 @@ lint_cache_key=$(printf '%s\n%s\n' "$gcl_stamp" "$lint_config" | git hash-object
 # retargeting the symlink while linting is in progress.
 stable_worktree="${common_git_dir}/gcl-lint-worktree-${lint_cache_key}"
 lint_lock="${stable_worktree}.lock"
+lock_start=$(LC_ALL=C ps -p "$$" -o lstart=)
+lock_owner="$$:${lock_start}"
 
 acquire_lint_lock() {
-    local owner
-    while ! ln -s "$$" "$lint_lock" 2>/dev/null; do
+    local current_start owner owner_pid owner_start
+    while ! ln -s "$lock_owner" "$lint_lock" 2>/dev/null; do
         owner=$(readlink "$lint_lock" 2>/dev/null || true)
-        case "$owner" in
+        owner_pid=${owner%%:*}
+        owner_start=${owner#*:}
+        case "$owner_pid" in
             ''|*[!0-9]*) ;;
             *)
-                if kill -0 "$owner" 2>/dev/null; then
-                    sleep 1
-                    continue
+                if [ "$owner_start" != "$owner" ]; then
+                    current_start=$(LC_ALL=C ps -p "$owner_pid" -o lstart= 2>/dev/null || true)
+                    if [ -n "$current_start" ] && [ "$current_start" = "$owner_start" ]; then
+                        sleep 1
+                        continue
+                    fi
                 fi
                 ;;
         esac
@@ -77,7 +84,7 @@ acquire_lint_lock() {
 release_lint_lock() {
     local owner
     owner=$(readlink "$lint_lock" 2>/dev/null || true)
-    if [ "$owner" = "$$" ]; then
+    if [ "$owner" = "$lock_owner" ]; then
         rm -f "$stable_worktree" "$lint_lock"
     fi
 }


### PR DESCRIPTION
## Summary

- fingerprint the custom `gcl` binary and its build inputs instead of relying on worktree mtimes
- copy reusable `gcl` artifacts when initializing a worktree
- share lint caches safely across worktrees through a locked, configuration-specific stable path
- avoid treating generated packages as initial lint targets while retaining generated dependencies

## Performance

Representative local cold-cache measurements on the same worktree:

| Initial package targets | Packages | Wall time | Peak memory |
| --- | ---: | ---: | ---: |
| `./...` | 672 | 5m 10.9s | 10.1 GB |
| Excluding `server/gen` as initial targets | 444 | 2m 12.3s | 8.6 GB |

This reduced cold lint wall time by 57% and peak memory by 15%. Both runs had the same 12,775 issues after generated-file filtering and the same final diagnostics. A subsequent warm-cache `mise run lint:server` completed in 8.0s. Absolute timings vary with available CPU and memory; the package and diagnostic counts are deterministic for the measured revision.

## Verification

- `bash -n .mise-tasks/lint/server.sh .mise-tasks/git/workinit.sh`
- `mise run lint:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses `gcl` build and lint caches across Git worktrees to reduce cold lint time and avoid unnecessary rebuilds. Previously each worktree rebuilt `gcl` from mtimes and kept its own absolute-path cache; now we fingerprint inputs + binary, seed artifacts on worktree init, and run under a stable, locked path to share cache safely.

- Fingerprints `gcl` from `glint`, `server/.custom-gcl.yml`, `go.mod`, `go.sum`, and the built binary; rebuilds only when the fingerprint changes and writes `./bin/gcl.fingerprint`.
- Seeds `server/bin/gcl` and its fingerprint from the main worktree during `workinit` so new worktrees start warm.
- Shares `golangci-lint` cache across worktrees by chdir-ing through a stable symlink under the common git dir, keyed by the `gcl` stamp and `.golangci.yaml`; the lock validates PID and process start time to avoid stale locks and cleans up on exit.
- Excludes `server/gen` from initial lint targets while retaining generated dependencies to cut cold-run time without losing diagnostics.

<sup>Written for commit 8a85baaf435ca56aab55c647966253524d410634. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

