### PR TITLE
chore: remove gram-user-session-cimd feature flag

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1481,7 +1481,7 @@ func newStartCommand() *cli.Command {
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			remoteSessionsCache := cache.NewRedisCacheAdapter(redisClient)
 			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, db, encryptionClient, guardianPolicy, remoteSessionsCache))
-			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, guardianPolicy, encryptionClient, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), ratelimit.NewRedisStore(redisClient), featureFlags))
+			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, guardianPolicy, encryptionClient, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), ratelimit.NewRedisStore(redisClient)))
 			tokenexchange.Attach(mux, tokenexchange.NewService(logger, tracerProvider, db, sessionManager, authzEngine, c.String("environment")))
 			remotesessions.Attach(mux, remoteSessionsService)
 			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger))

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -36,13 +36,6 @@ const (
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
 
-	// FlagUserSessionCIMD gates inbound OAuth Client ID Metadata Document
-	// (CIMD) support on the user-session authorization server: URL-shaped
-	// client_id values on /mcp/{slug}/authorize are resolved by fetching the
-	// metadata document instead of requiring RFC 7591 DCR. Evaluated
-	// server-side per organization with distinctID = the issuer's org ID and
-	// no groups.
-	FlagUserSessionCIMD Flag = "gram-user-session-cimd"
 	// FlagPlatformMCP controls the engineering rollout of Platform MCP. The
 	// durable platform_mcp product feature remains the organization-admin opt-in
 	// once this release flag permits access.

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -81,8 +81,8 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 		return writeAuthorizeOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
-	// URL-shaped client_ids resolve via CIMD here (flag-gated, inside the
-	// resolver). All resolution failures render inline per RFC 6749
+	// URL-shaped client_ids resolve via CIMD here (admission-gated, inside
+	// the resolver). All resolution failures render inline per RFC 6749
 	// §4.1.2.1 — the redirect_uri of an unresolved client cannot be
 	// trusted — and a document fetch failure aborts the request per
 	// draft-ietf-oauth-client-id-metadata-document-02 §5.1 (fail closed,
@@ -109,13 +109,6 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 			// stop retrying.
 			logger.InfoContext(ctx, "cimd document fetch failed", attr.SlogError(err))
 			return writeAuthorizeError(ctx, w, logger, http.StatusServiceUnavailable, "temporarily_unavailable", "failed to fetch client metadata document")
-		}
-		if errors.Is(err, errCIMDDisabled) {
-			// Same wire response as an unknown client so the rejection does
-			// not leak per-organization flag state; the log line is what
-			// distinguishes a flag-off rejection during an incident.
-			logger.InfoContext(ctx, "rejecting url-shaped client_id while cimd flag is disabled")
-			return writeAuthorizeError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
 		if errors.Is(err, pgx.ErrNoRows) {
 			return writeAuthorizeError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")

--- a/server/internal/mcp/authnchallenge_cimd_admission_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_admission_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
@@ -40,12 +40,7 @@ func setIssuerAdmissionMode(t *testing.T, ctx context.Context, ti *testInstance,
 	if mode == "" {
 		return
 	}
-	// Every other field is left absent so the query's COALESCE keeps the
-	// stored value. A Valid-but-empty pgtype.Text would overwrite it.
-	_, err := usersessions_repo.New(ti.conn).UpdateUserSessionIssuer(ctx, usersessions_repo.UpdateUserSessionIssuerParams{
-		Slug:                          conv.PtrToPGText(nil),
-		AuthnChallengeMode:            conv.PtrToPGText(nil),
-		SessionDuration:               conv.PtrToPGInterval(nil),
+	err := testrepo.New(ti.conn).SetUserSessionIssuerCIMDAdmissionMode(ctx, testrepo.SetUserSessionIssuerCIMDAdmissionModeParams{
 		ClientIDMetadataAdmissionMode: conv.ToPGText(string(mode)),
 		ID:                            toolset.UserSessionIssuerID.UUID,
 		ProjectID:                     toolset.ProjectID,
@@ -144,8 +139,7 @@ func requireAuthorizeErrorDescription(t *testing.T, w *httptest.ResponseRecorder
 func TestCIMDAdmission_DefaultReportsWithoutEnforcing(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, _, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, _ := newTestCIMDService(t)
 	// A separate, never-configured issuer: the harness toolset is put in
 	// open mode, and there is no path back to NULL once a mode is written.
 	fresh := seedFreshIssuerToolset(t, ctx, ti)
@@ -167,8 +161,7 @@ func TestCIMDAdmission_DefaultReportsWithoutEnforcing(t *testing.T) {
 func TestCIMDAdmission_PresetsDeniesUnknownURLWithoutFetching(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 
 	verifier := pkceVerifier(t)
@@ -191,8 +184,7 @@ func TestCIMDAdmission_PresetsDeniesUnknownURLWithoutFetching(t *testing.T) {
 func TestCIMDAdmission_ReportingMatchesPresetsExceptForEnforcement(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	// Two issuers, neither listing the URL, differing only in mode.
 	reporting := seedFreshIssuerToolset(t, ctx, ti)
@@ -225,8 +217,7 @@ func TestCIMDAdmission_ReportingMatchesPresetsExceptForEnforcement(t *testing.T)
 func TestCIMDAdmission_PresetsDenialIsActionable(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, t.Context(), ti, toolset, admission.ModePresets)
 
 	verifier := pkceVerifier(t)
@@ -242,8 +233,7 @@ func TestCIMDAdmission_PresetsDenialIsActionable(t *testing.T) {
 func TestCIMDAdmission_CustomURLAdmitted(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
 
@@ -259,8 +249,7 @@ func TestCIMDAdmission_CustomURLAdmitted(t *testing.T) {
 func TestCIMDAdmission_CustomURLIsPerIssuer(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 
 	// Allow the URL on a DIFFERENT live issuer in the same project. The
@@ -286,8 +275,7 @@ func TestCIMDAdmission_CustomURLIsPerIssuer(t *testing.T) {
 func TestCIMDAdmission_DisabledDeniesEverything(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModeDisabled)
 	// Even an explicitly-allowed URL is denied while the mode is disabled.
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
@@ -305,8 +293,7 @@ func TestCIMDAdmission_DisabledDeniesEverything(t *testing.T) {
 func TestCIMDAdmission_OpenAdmitsArbitraryValidDocument(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModeOpen)
 
 	verifier := pkceVerifier(t)
@@ -321,8 +308,7 @@ func TestCIMDAdmission_OpenAdmitsArbitraryValidDocument(t *testing.T) {
 func TestCIMDAdmission_UnrecognizedModeFailsClosed(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.Mode("allow-everything"))
 
 	verifier := pkceVerifier(t)
@@ -338,8 +324,7 @@ func TestCIMDAdmission_UnrecognizedModeFailsClosed(t *testing.T) {
 func TestCIMDAdmission_DisabledOmitsMetadataAdvertisement(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, _, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, _, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModeDisabled)
 
 	metadata := fetchASMetadata(t, ti, toolset.McpSlug.String)
@@ -353,8 +338,7 @@ func TestCIMDAdmission_DisabledOmitsMetadataAdvertisement(t *testing.T) {
 func TestCIMDAdmission_PresetsAdvertisesSupport(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, _, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, _, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 
 	metadata := fetchASMetadata(t, ti, toolset.McpSlug.String)
@@ -366,8 +350,7 @@ func TestCIMDAdmission_PresetsAdvertisesSupport(t *testing.T) {
 func TestCIMDAdmission_DefaultAdvertisesSupport(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, _, _, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, _, _ := newTestCIMDService(t)
 	fresh := seedFreshIssuerToolset(t, ctx, ti)
 
 	metadata := fetchASMetadata(t, ti, fresh.McpSlug.String)
@@ -388,8 +371,7 @@ func TestCIMDAdmission_DefaultAdvertisesSupport(t *testing.T) {
 func TestCIMDAdmission_PortlessLoopbackRedirectMatches(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
 
@@ -409,8 +391,7 @@ func TestCIMDAdmission_PortlessLoopbackRedirectMatches(t *testing.T) {
 func TestCIMDAdmission_PortlessLoopbackStillBindsPath(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
 
@@ -439,8 +420,7 @@ func TestCIMDAdmission_PortlessLoopbackStillBindsPath(t *testing.T) {
 func TestCIMDAdmission_ChatGPTDocumentShapeAccepted(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
 
@@ -468,8 +448,7 @@ func TestCIMDAdmission_ChatGPTDocumentShapeAccepted(t *testing.T) {
 func TestCIMDAdmission_ExplicitConfidentialAuthMethodStillRejected(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
 
@@ -524,8 +503,7 @@ func requireTokenOAuthError(t *testing.T, w *httptest.ResponseRecorder, wantCode
 func TestCIMDAdmission_TokenRejectsWhenDisabled(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModeOpen)
 
 	// Establish the CIMD client row while the issuer still admits it.
@@ -557,8 +535,7 @@ func TestCIMDAdmission_TokenRejectsWhenDisabled(t *testing.T) {
 func TestCIMDAdmission_TokenAllowsWhenPresetsNoLongerListsClient(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
 

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -1,7 +1,7 @@
 // Integration tests for inbound CIMD (Client ID Metadata Documents) on the
 // user-session OAuth surface: a URL-shaped client_id presented to
 // /mcp/{slug}/authorize is resolved by fetching the metadata document from
-// an httptest TLS server, gated by the gram-user-session-cimd flag.
+// an httptest TLS server.
 
 package mcp_test
 
@@ -22,9 +22,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
@@ -148,16 +146,15 @@ func (ds *cimdDocServer) certPool() *x509.CertPool {
 }
 
 // newTestCIMDService builds a doc server plus an mcp service whose guardian
-// policy trusts the doc server's TLS certificate, seeds a public
-// issuer-gated toolset, and returns the org id used as the flag distinctID.
-// The flag is NOT enabled here — tests opt in via ti.features.SetFlag.
+// policy trusts the doc server's TLS certificate and seeds a public
+// issuer-gated toolset.
 //
 // The seeded issuer is put in "open" admission mode. These tests exercise
 // DOCUMENT validation, and the doc server's URL is (necessarily) not a
 // catalog preset, so the default "presets" mode would deny every one of them
 // before a document was ever fetched. Admission itself is covered by
 // authnchallenge_cimd_admission_test.go, which seeds modes explicitly.
-func newTestCIMDService(t *testing.T) (context.Context, *testInstance, *cimdDocServer, toolsets_repo.Toolset, string) {
+func newTestCIMDService(t *testing.T) (context.Context, *testInstance, *cimdDocServer, toolsets_repo.Toolset) {
 	t.Helper()
 
 	ds := startCIMDDocServer(t)
@@ -177,10 +174,7 @@ func newTestCIMDService(t *testing.T) (context.Context, *testInstance, *cimdDocS
 	})
 	require.NoError(t, err)
 
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-
-	return ctx, ti, ds, toolset, authCtx.ActiveOrganizationID
+	return ctx, ti, ds, toolset
 }
 
 func doCIMDAuthorize(t *testing.T, ti *testInstance, mcpSlug, clientID, redirectURI, codeChallenge string) *httptest.ResponseRecorder {
@@ -220,8 +214,7 @@ func requireAuthorizeOAuthError(t *testing.T, w *httptest.ResponseRecorder, stat
 func TestOAuthCIMD_FullFlow(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:51423/callback"
@@ -304,38 +297,34 @@ func TestOAuthCIMD_FullFlow(t *testing.T) {
 	require.NotEmpty(t, tokenBody["access_token"])
 }
 
-func TestOAuthCIMD_FlagOff_RejectsURLClientID(t *testing.T) {
+// TestOAuthCIMD_DisabledAfterResolution_RejectsAtAuthorize pins the
+// off-switch semantics: once the issuer's admission mode is switched to
+// disabled, even a previously-resolved CIMD client is rejected on new
+// authorize flows. Admission runs before the row-cache read, so the cached
+// row must not buy the client past a policy that no longer admits it — and
+// the denial must cost no document fetch.
+func TestOAuthCIMD_DisabledAfterResolution_RejectsAtAuthorize(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, _ := newTestCIMDService(t)
-
-	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
-	requireAuthorizeOAuthError(t, w, http.StatusUnauthorized, "invalid_client")
-}
-
-// TestOAuthCIMD_FlagOffAfterResolution_RejectsAtAuthorize pins the
-// off-switch semantics: once the flag is disabled, even a
-// previously-resolved CIMD client is rejected on new authorize flows.
-func TestOAuthCIMD_FlagOffAfterResolution_RejectsAtAuthorize(t *testing.T) {
-	t.Parallel()
-
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	redirectURI := "http://127.0.0.1:33418/callback"
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	require.Equal(t, http.StatusFound, w.Code)
+	require.Equal(t, int64(1), ds.requests.Load())
 
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, false)
+	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModeDisabled)
+
 	w = doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusUnauthorized, "invalid_client")
+	requireAuthorizeErrorDescription(t, w, "does not accept client ID metadata documents")
+	require.Equal(t, int64(1), ds.requests.Load(), "a denied client_id must not cost an outbound document fetch")
 }
 
 func TestOAuthCIMD_ConfidentialAuthMethodRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["token_endpoint_auth_method"] = "client_secret_basic" })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
@@ -345,8 +334,7 @@ func TestOAuthCIMD_ConfidentialAuthMethodRejected(t *testing.T) {
 func TestOAuthCIMD_DocumentClientIDMismatchRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_id"] = ds.srv.URL + "/oauth/other.json" })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
@@ -356,8 +344,7 @@ func TestOAuthCIMD_DocumentClientIDMismatchRejected(t *testing.T) {
 func TestOAuthCIMD_CrossOriginRedirectURIRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{"https://elsewhere.example.com/callback"} })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "https://elsewhere.example.com/callback", pkceChallenge(pkceVerifier(t)))
@@ -367,8 +354,7 @@ func TestOAuthCIMD_CrossOriginRedirectURIRejected(t *testing.T) {
 func TestOAuthCIMD_UnregisteredRedirectURIRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/other-path", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
@@ -381,8 +367,7 @@ func TestOAuthCIMD_UnregisteredRedirectURIRejected(t *testing.T) {
 func TestOAuthCIMD_NonLoopbackPortVarianceRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{ds.srv.URL + "/callback"} })
 
 	docURL, err := url.Parse(ds.srv.URL)
@@ -396,8 +381,7 @@ func TestOAuthCIMD_NonLoopbackPortVarianceRejected(t *testing.T) {
 func TestOAuthCIMD_UnknownExtensionFieldsAccepted(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["software_statement"] = "eyJhbGciOiJub25lIn0.e30." })
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_id_expires_at"] = 4102444800 })
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["x_vendor_extension"] = map[string]any{"nested": true} })
@@ -412,8 +396,7 @@ func TestOAuthCIMD_UnknownExtensionFieldsAccepted(t *testing.T) {
 func TestOAuthCIMD_TokenRejectsSecretForCIMDClient(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 
 	mcpSlug := toolset.McpSlug.String
 	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
@@ -439,11 +422,10 @@ func TestOAuthCIMD_TokenRejectsSecretForCIMDClient(t *testing.T) {
 	require.Equal(t, "invalid_client", body["error"])
 }
 
-func TestOAuthCIMD_ASMetadataAdvertisesSupportWhenFlagOn(t *testing.T) {
+func TestOAuthCIMD_ASMetadataAdvertisesSupport(t *testing.T) {
 	t.Parallel()
 
-	_, ti, _, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, _, toolset := newTestCIMDService(t)
 
 	mcpSlug := toolset.McpSlug.String
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/"+mcpSlug, nil)
@@ -458,25 +440,6 @@ func TestOAuthCIMD_ASMetadataAdvertisesSupportWhenFlagOn(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &meta))
 	require.Equal(t, true, meta["client_id_metadata_document_supported"])
 	require.Equal(t, []any{"authorization"}, meta["refresh_token_expiration_types_supported"])
-}
-
-func TestOAuthCIMD_ASMetadataOmitsSupportWhenFlagOff(t *testing.T) {
-	t.Parallel()
-
-	_, ti, _, toolset, _ := newTestCIMDService(t)
-
-	mcpSlug := toolset.McpSlug.String
-	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/"+mcpSlug, nil)
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("mcpSlug", mcpSlug)
-	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
-	w := httptest.NewRecorder()
-	require.NoError(t, ti.service.HandleGetAuthorizationServer(w, req))
-	require.Equal(t, http.StatusOK, w.Code)
-
-	var meta map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &meta))
-	require.NotContains(t, meta, "client_id_metadata_document_supported")
 }
 
 func doCIMDConsentGet(t *testing.T, ti *testInstance, mcpSlug, stateID string) *httptest.ResponseRecorder {
@@ -535,8 +498,7 @@ func lapseCIMDCache(t *testing.T, ctx context.Context, ti *testInstance, client 
 func TestOAuthCIMD_RepeatAuthorizeServesFromCache(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:33418/callback"
@@ -567,8 +529,7 @@ func TestOAuthCIMD_RepeatAuthorizeServesFromCache(t *testing.T) {
 func TestOAuthCIMD_RepeatAuthorizeRefreshesClient(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:33418/callback"
@@ -601,8 +562,7 @@ func TestOAuthCIMD_RepeatAuthorizeRefreshesClient(t *testing.T) {
 func TestOAuthCIMD_LapsedCacheRevalidatesWithETag(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.etag = `"v1"` })
 
 	mcpSlug := toolset.McpSlug.String
@@ -638,8 +598,7 @@ func TestOAuthCIMD_LapsedCacheRevalidatesWithETag(t *testing.T) {
 func TestOAuthCIMD_RevalidationPicksUpRotatedDocument(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.etag = `"v1"` })
 
 	mcpSlug := toolset.McpSlug.String
@@ -672,8 +631,7 @@ func TestOAuthCIMD_RevalidationPicksUpRotatedDocument(t *testing.T) {
 func TestOAuthCIMD_PurgeForcesUnconditionalReread(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.etag = `"v1"` })
 
 	mcpSlug := toolset.McpSlug.String
@@ -710,8 +668,7 @@ func TestOAuthCIMD_PurgeForcesUnconditionalReread(t *testing.T) {
 func TestOAuthCIMD_UpstreamMaxAgeClampedToFloor(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.cacheControl = "public, max-age=120" })
 
 	before := time.Now()
@@ -730,8 +687,7 @@ func TestOAuthCIMD_UpstreamMaxAgeClampedToFloor(t *testing.T) {
 func TestOAuthCIMD_RefreshFailureDoesNotPoisonCache(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:33418/callback"
@@ -758,8 +714,7 @@ func TestOAuthCIMD_RefreshFailureDoesNotPoisonCache(t *testing.T) {
 func TestOAuthCIMD_InvalidDocumentOnRefreshDoesNotPoisonCache(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	mcpSlug := toolset.McpSlug.String
 	redirectURI := "http://127.0.0.1:33418/callback"
@@ -788,8 +743,7 @@ func TestOAuthCIMD_InvalidDocumentOnRefreshDoesNotPoisonCache(t *testing.T) {
 func TestOAuthCIMD_SecretBearingCollisionRejected(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	_, err := usersessions_repo.New(ti.conn).CreateUserSessionClient(ctx, usersessions_repo.CreateUserSessionClientParams{
 		UserSessionIssuerID:   toolset.UserSessionIssuerID.UUID,
@@ -819,8 +773,7 @@ func TestOAuthCIMD_SecretBearingCollisionRejected(t *testing.T) {
 func TestOAuthCIMD_LoopbackQueryInjectionRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback?injected=1", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
@@ -832,8 +785,7 @@ func TestOAuthCIMD_LoopbackQueryInjectionRejected(t *testing.T) {
 func TestOAuthCIMD_LoopbackUserinfoRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://user:pass@127.0.0.1:51423/callback", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
@@ -858,8 +810,7 @@ func TestOAuthDCR_LoopbackPortVarianceRejected(t *testing.T) {
 func TestOAuthCIMD_FetchFailureReturns503(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 
 	missingDocURL := ds.srv.URL + "/missing.json"
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, missingDocURL, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
@@ -876,8 +827,7 @@ func TestOAuthCIMD_FetchFailureReturns503(t *testing.T) {
 func TestOAuthCIMD_ConsentEscapesHostileClientName(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_name"] = `<img src=x onerror=alert(1)> Client` })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
@@ -897,8 +847,7 @@ func TestOAuthCIMD_ConsentEscapesHostileClientName(t *testing.T) {
 func TestOAuthCIMD_ConsentNoLoopbackWarningForSameOriginRedirect(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	redirectURI := ds.srv.URL + "/callback"
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{redirectURI} })
 
@@ -919,8 +868,7 @@ func TestOAuthCIMD_ConsentNoLoopbackWarningForSameOriginRedirect(t *testing.T) {
 func TestOAuthCIMD_LoopbackEncodedPathRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 
 	// The document registers /callback; /%63allback decodes to the same
 	// path but is a different URI byte-for-byte.
@@ -934,8 +882,7 @@ func TestOAuthCIMD_LoopbackEncodedPathRejected(t *testing.T) {
 func TestOAuthCIMD_LoopbackFragmentRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback#frag", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
@@ -949,8 +896,7 @@ func TestOAuthCIMD_LoopbackFragmentRejected(t *testing.T) {
 func TestOAuthCIMD_LoopbackEmptyFragmentRegistrationRejected(t *testing.T) {
 	t.Parallel()
 
-	_, ti, ds, toolset, orgID := newTestCIMDService(t)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{"http://127.0.0.1:33418/callback#"} })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(pkceVerifier(t)))

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -93,7 +93,8 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 		return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "client_id is required")
 	}
 	// lookupClientOnly: any CIMD row was persisted at authorize time, and
-	// mid-flow token legs must keep working even if the CIMD flag flips off.
+	// mid-flow token legs must keep working even if the issuer's admission
+	// policy changes between legs.
 	clientRow, err := s.resolveUserSessionClient(ctx, logger, endpoint, clientID, lookupClientOnly)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -88,8 +88,7 @@ type oauthAuthorizationServerMetadata struct {
 
 	// ClientIDMetadataDocumentSupported advertises inbound CIMD support
 	// (draft-ietf-oauth-client-id-metadata-document-02 §6). Emitted as true
-	// only when the issuer organization's gram-user-session-cimd flag is
-	// on; omitted otherwise.
+	// unless the issuer's admission mode is `disabled`; omitted otherwise.
 	ClientIDMetadataDocumentSupported *bool `json:"client_id_metadata_document_supported,omitempty"`
 }
 
@@ -425,11 +424,11 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build OAuth server URLs").LogError(ctx, s.logger)
 	}
-	// Advertised only when the rollout flag is on AND the issuer admits at
-	// least some CIMD client. A `disabled` issuer omits the field: claiming
-	// support while admitting nothing would steer spec-compliant clients
-	// into a guaranteed-failure flow instead of letting them fall back to
-	// dynamic client registration, which is still open on this issuer.
+	// Advertised only when the issuer admits at least some CIMD client. A
+	// `disabled` issuer omits the field: claiming support while admitting
+	// nothing would steer spec-compliant clients into a guaranteed-failure
+	// flow instead of letting them fall back to dynamic client registration,
+	// which is still open on this issuer.
 	//
 	// This is advisory, not a control. The response carries cache headers
 	// (writeJSONMetadata), and clients typically cache authorization-server
@@ -443,7 +442,7 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 			attr.SlogCIMDAdmissionMode(endpoint.CIMDAdmissionModeRaw.String),
 		)
 	}
-	if mode != admission.ModeDisabled && s.userSessionCIMDEnabled(ctx, s.logger, endpoint) {
+	if mode != admission.ModeDisabled {
 		cimdSupported = conv.PtrEmpty(true)
 	}
 	return writeJSONMetadata(ctx, w, r, s.logger, oauthAuthorizationServerMetadata{

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/oauthwire"
@@ -35,13 +34,12 @@ const (
 	// lookupClientOnly resolves strictly from the database. Used by the
 	// token and consent handlers: by the time they run, the authorize leg
 	// has already persisted any CIMD row, and mid-flow requests (a code
-	// exchange or refresh) must keep working even if the CIMD flag flips
-	// off between legs.
+	// exchange or refresh) must keep working even if the issuer's admission
+	// policy changes between legs.
 	lookupClientOnly clientIDResolveMode = "lookup_only"
 
 	// resolveClientCIMD additionally treats a URL-shaped client_id as a
-	// Client ID Metadata Document reference when the issuer organization's
-	// gram-user-session-cimd flag is on: the row is read, the document
+	// Client ID Metadata Document reference: the row is read, the document
 	// fetched and validated when that row's cache has lapsed, and the row
 	// lazily upserted. Authorize-time only — the consent GET/POST re-resolve
 	// the client by client_id, so the row must exist before the flow leaves
@@ -55,18 +53,8 @@ const (
 // rather than echoing it to the client.
 var errCIMDFetchFailed = errors.New("cimd document fetch failed")
 
-// errCIMDDisabled marks a URL-shaped client_id rejected because the issuer
-// organization's gram-user-session-cimd flag is off. Handlers must render it
-// exactly like an unknown client (invalid_client, "unknown client_id") so
-// the wire response does not leak per-organization flag state; the dedicated
-// sentinel exists so the flag-off path is loggable and is not conflated
-// with pgx.ErrNoRows from a lookup that actually ran.
-var errCIMDDisabled = errors.New("cimd disabled for organization")
-
 // An admission denial surfaces as *admission.DenialError, which carries its
-// own client-facing Description. Unlike errCIMDDisabled — whose wire
-// response is deliberately generic so it cannot be used to probe
-// per-organization flag state — an admission denial is customer-configured
+// own client-facing Description. An admission denial is customer-configured
 // policy rather than a rollout secret, so being explicit is safe and
 // useful.
 
@@ -80,20 +68,12 @@ var errCIMDDisabled = errors.New("cimd disabled for organization")
 //     client-safe code + description (resolveClientCIMD only)
 //   - errCIMDFetchFailed: document fetch failure; log, render generic
 //     (resolveClientCIMD only)
-//   - errCIMDDisabled: URL-shaped client_id while the flag is off; render
-//     as unknown client (resolveClientCIMD only). Deliberately fails closed
-//     even when a previously-resolved row exists, so disabling the flag is
-//     a real off switch for new authorize flows
 //   - pgx.ErrNoRows: unknown client
 //   - anything else: infrastructure failure
 func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Logger, endpoint *ResolvedMcpEndpoint, clientID string, mode clientIDResolveMode) (*usersessions_repo.UserSessionClient, error) {
 	queries := usersessions_repo.New(s.db)
 
 	if mode == resolveClientCIMD && cimd.IsClientIDURL(clientID) {
-		if !s.userSessionCIMDEnabled(ctx, logger, endpoint) {
-			return nil, errCIMDDisabled
-		}
-
 		// Admission runs before the resolver, so a denied client_id costs a
 		// map lookup — no outbound request, no fetch timeout. It also runs
 		// before the length cap inside the resolver, which is why admission
@@ -208,32 +188,6 @@ func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Log
 		return nil, fmt.Errorf("lookup user session client: %w", err)
 	}
 	return &row, nil
-}
-
-// userSessionCIMDEnabled evaluates the inbound-CIMD rollout flag for the
-// endpoint's organization. distinctID is the organization ID with no groups
-// (matching the flag's PostHog targeting). Successful evaluations are
-// remembered per organization so a flag-provider outage degrades to the
-// last known state instead of failing closed — this runs on unauthenticated
-// endpoints (/authorize and the well-known metadata), where fail-closed
-// would turn a PostHog outage into an OAuth login outage for every
-// CIMD-enabled organization. Fresh evaluations always win, so flag flips
-// propagate immediately; the map holds one bool per organization that
-// touches the OAuth surface, so growth is bounded by tenant count.
-func (s *Service) userSessionCIMDEnabled(ctx context.Context, logger *slog.Logger, endpoint *ResolvedMcpEndpoint) bool {
-	enabled, err := s.features.IsFlagEnabled(ctx, feature.FlagUserSessionCIMD, endpoint.OrganizationID, nil)
-	if err != nil {
-		s.cimdOrgFlagMu.RLock()
-		lastKnown, ok := s.cimdOrgFlagLastKnown[endpoint.OrganizationID]
-		s.cimdOrgFlagMu.RUnlock()
-		logger.WarnContext(ctx, "evaluate user session cimd flag", attr.SlogError(err))
-		return ok && lastKnown
-	}
-
-	s.cimdOrgFlagMu.Lock()
-	s.cimdOrgFlagLastKnown[endpoint.OrganizationID] = enabled
-	s.cimdOrgFlagMu.Unlock()
-	return enabled
 }
 
 // admitCIMDClient enforces the issuer's CIMD admission policy against a

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -14,7 +14,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -110,18 +109,11 @@ type Service struct {
 	serverURL       *url.URL
 	siteURL         *url.URL
 	posthog         *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
-	// features gates flag-controlled behavior on the OAuth surface (inbound
-	// CIMD, the consent tool picker). Wired from the environment-aware
+	// features resolves flag-controlled behavior (the managed assistant's
+	// Platform MCP toolset variant). Wired from the environment-aware
 	// provider: the posthog client in production, the CSV-backed in-memory
 	// provider in local development, feature.InMemory in tests.
 	features feature.Provider
-	// cimdOrgFlagLastKnown remembers the last successful per-organization
-	// evaluation of FlagUserSessionCIMD so a flag-provider outage degrades
-	// to the last known state instead of failing closed on the
-	// unauthenticated OAuth surface. Guarded by cimdOrgFlagMu; holds one bool
-	// per organization that touches the surface.
-	cimdOrgFlagMu        sync.RWMutex
-	cimdOrgFlagLastKnown map[string]bool
 	// cimdResolver fetches + validates Client ID Metadata Documents for
 	// URL-shaped client_ids and owns the cimd.fetch.* telemetry.
 	cimdResolver *cimd.Resolver
@@ -349,8 +341,6 @@ func NewService(
 		siteURL:              siteURL,
 		posthog:              posthog,
 		features:             features,
-		cimdOrgFlagMu:        sync.RWMutex{},
-		cimdOrgFlagLastKnown: map[string]bool{},
 		cimdResolver:         cimd.NewResolver(guardianPolicy, meterProvider, logger),
 		cimdAdmissionMetrics: admission.NewMetrics(meterProvider, logger),
 		toolProxy: gateway.NewToolProxy(

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -101,7 +101,8 @@ type testInstance struct {
 	audit               *audit.Logger
 	tunnelRoutes        route.Store
 	// features is the injectable flag provider wired into the service; tests
-	// enable flag-gated behavior (e.g. inbound CIMD) with SetFlag.
+	// enable flag-gated behavior (e.g. the Platform MCP assistant toolset
+	// variant) with SetFlagVariant.
 	features *feature.InMemory
 }
 

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -237,6 +237,16 @@ UPDATE user_session_issuers
 SET deleted_at = clock_timestamp()
 WHERE id = @id AND project_id = @project_id AND deleted IS FALSE;
 
+-- name: SetUserSessionIssuerCIMDAdmissionMode :exec
+-- Test-only fixture: writes an issuer's CIMD admission mode as a single-column
+-- update. The production UpdateUserSessionIssuer query COALESCEs every param,
+-- where a Valid-but-empty pgtype.Text silently clobbers the stored value;
+-- keeping that contract out of per-package test helpers is the point of this
+-- narrow query.
+UPDATE user_session_issuers
+SET client_id_metadata_admission_mode = @client_id_metadata_admission_mode
+WHERE id = @id AND project_id = @project_id AND deleted IS FALSE;
+
 -- name: InsertPluginAssignmentFixture :exec
 -- Test-only fixture: writes a plugin_assignments row with an EXPLICIT
 -- organization_id so tests can seed a cross-tenant/stale assignment that the

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1477,6 +1477,28 @@ func (q *Queries) SetProjectSlugFixture(ctx context.Context, arg SetProjectSlugF
 	return err
 }
 
+const setUserSessionIssuerCIMDAdmissionMode = `-- name: SetUserSessionIssuerCIMDAdmissionMode :exec
+UPDATE user_session_issuers
+SET client_id_metadata_admission_mode = $1
+WHERE id = $2 AND project_id = $3 AND deleted IS FALSE
+`
+
+type SetUserSessionIssuerCIMDAdmissionModeParams struct {
+	ClientIDMetadataAdmissionMode pgtype.Text
+	ID                            uuid.UUID
+	ProjectID                     uuid.UUID
+}
+
+// Test-only fixture: writes an issuer's CIMD admission mode as a single-column
+// update. The production UpdateUserSessionIssuer query COALESCEs every param,
+// where a Valid-but-empty pgtype.Text silently clobbers the stored value;
+// keeping that contract out of per-package test helpers is the point of this
+// narrow query.
+func (q *Queries) SetUserSessionIssuerCIMDAdmissionMode(ctx context.Context, arg SetUserSessionIssuerCIMDAdmissionModeParams) error {
+	_, err := q.db.Exec(ctx, setUserSessionIssuerCIMDAdmissionMode, arg.ClientIDMetadataAdmissionMode, arg.ID, arg.ProjectID)
+	return err
+}
+
 const setWorkosLastEventIDFixture = `-- name: SetWorkosLastEventIDFixture :exec
 UPDATE organization_metadata
 SET workos_last_event_id = $1

--- a/server/internal/usersessions/cimd/admission/mode.go
+++ b/server/internal/usersessions/cimd/admission/mode.go
@@ -69,9 +69,9 @@ func (m Mode) Enforces() bool {
 // every spec-valid document), so nothing regresses, while every decision
 // ModePresets would have made is recorded. The exit condition is:
 //
-//  1. Wait for the AIS-212 flag flip, which is what first exposes CIMD to
-//     the whole customer base and therefore produces the only meaningful
-//     sample.
+//  1. CIMD is exposed to the whole customer base (the gram-user-session-cimd
+//     rollout flag reached 100% and was then removed, AIS-210), so
+//     cimd.admission.decisions carries a meaningful sample.
 //  2. Watch cimd.admission.decisions for outcome denied_not_listed with
 //     mode reporting. Each one names a client the catalog is missing; add a
 //     catalog entry, or have the operator add a custom URL.

--- a/server/internal/usersessions/clienthandlers.go
+++ b/server/internal/usersessions/clienthandlers.go
@@ -16,13 +16,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/oauthwire"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -226,16 +226,30 @@ func (s *Service) RefreshUserSessionClientCIMD(ctx context.Context, payload *gen
 		return nil, oops.E(oops.CodeBadRequest, nil, "client was registered via DCR and has no metadata document to refresh").LogError(ctx, logger)
 	}
 
-	// Same flag that gates CIMD resolution on /authorize, evaluated the same
-	// way (per organization, no groups). An org whose flag was turned off
-	// after CIMD rows were created can still see those rows; it cannot make
-	// Gram fetch documents for them.
-	enabled, err := s.features.IsFlagEnabled(ctx, feature.FlagUserSessionCIMD, authCtx.ActiveOrganizationID, nil)
+	// The issuer-level off switch applies to this fetch surface like it does
+	// to /authorize: a `disabled` issuer must not have Gram fetch documents
+	// on its behalf, refresh included. Only `disabled` blocks here — a
+	// presets catalog miss stays refreshable, mirroring the /token asymmetry
+	// where de-listing a client stops new authorize flows without breaking
+	// its existing rows. An unrecognized stored mode fails closed.
+	issuer, err := queries.GetUserSessionIssuerByID(ctx, repo.GetUserSessionIssuerByIDParams{
+		ID:        row.UserSessionIssuerID,
+		ProjectID: *authCtx.ProjectID,
+	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "evaluate user session cimd flag").LogError(ctx, logger)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
+		}
+		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, logger)
 	}
-	if !enabled {
-		return nil, oops.E(oops.CodeForbidden, nil, "CIMD support is not enabled for this organization").LogError(ctx, logger)
+	mode, recognized := admission.ResolveMode(issuer.ClientIDMetadataAdmissionMode.String, issuer.ClientIDMetadataAdmissionMode.Valid)
+	if !recognized {
+		logger.ErrorContext(ctx, "unrecognized cimd admission mode stored on issuer, failing closed",
+			attr.SlogCIMDAdmissionMode(issuer.ClientIDMetadataAdmissionMode.String),
+		)
+	}
+	if mode == admission.ModeDisabled {
+		return nil, oops.E(oops.CodeForbidden, nil, "CIMD is disabled for this issuer").LogError(ctx, logger)
 	}
 
 	// fetched_at advances on every successful read (a 304 revalidation

--- a/server/internal/usersessions/impl.go
+++ b/server/internal/usersessions/impl.go
@@ -33,7 +33,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
@@ -70,13 +69,6 @@ type Service struct {
 	// attribute is tenant-driven at whatever rate the caller chooses.
 	cimdResolver *cimd.Resolver
 
-	// features gates RefreshUserSessionClientCIMD on FlagUserSessionCIMD,
-	// matching the gate the /authorize resolve path applies. Evaluated per
-	// organization (distinctID = org ID, no groups). Unlike the OAuth surface
-	// there is no last-known fallback: this endpoint is authenticated, so a
-	// flag-provider outage can fail the request instead of failing open.
-	features feature.Provider
-
 	// revoker cascades a user-session revoke into the subject's upstream
 	// grants. A revoked session whose provider tokens keep working is only
 	// half a revocation, so the two are driven together.
@@ -111,7 +103,7 @@ var (
 // signer + serverURL drive mintUserSession; pass an empty serverURL to
 // disable that handler (it will 503 on call — used in tests that don't
 // need the surface).
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, db *pgxpool.Pool, sessionManager *sessions.Manager, chatSessionsManager TokenRevoker, authzEngine *authz.Engine, auditLogger *audit.Logger, guardianPolicy *guardian.Policy, enc *encryption.Client, signer *Signer, serverURL string, verifyStore ratelimit.Store, features feature.Provider) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, db *pgxpool.Pool, sessionManager *sessions.Manager, chatSessionsManager TokenRevoker, authzEngine *authz.Engine, auditLogger *audit.Logger, guardianPolicy *guardian.Policy, enc *encryption.Client, signer *Signer, serverURL string, verifyStore ratelimit.Store) *Service {
 	logger = logger.With(attr.SlogComponent("usersessions"))
 
 	return &Service{
@@ -125,7 +117,6 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 		signer:       signer,
 		serverURL:    serverURL,
 		cimdResolver: cimd.NewResolver(guardianPolicy, meterProvider, logger),
-		features:     features,
 		revoker:      remotesessions.NewUpstreamRevoker(logger, tracerProvider, meterProvider, db, enc, guardianPolicy),
 		verifyLimiter: ratelimit.New(verifyStore, "cimd-url-verify",
 			ratelimit.PerMinute(verifyRatePerMin).WithBurst(verifyRateBurst),

--- a/server/internal/usersessions/refreshusersessionclientcimd_test.go
+++ b/server/internal/usersessions/refreshusersessionclientcimd_test.go
@@ -22,9 +22,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -153,11 +155,10 @@ func startCIMDDocServer(t *testing.T) *cimdDocServer {
 }
 
 // newRefreshTestSetup builds a doc server plus a service whose guardian
-// policy trusts the doc server's TLS certificate, creates an issuer, seeds a
-// CIMD client row resolved from the doc server carrying a stored ETag, and
-// enables FlagUserSessionCIMD for the caller's organization. The stored ETag
-// is what makes the no-If-None-Match assertions meaningful: an ordinary
-// revalidation of this row WOULD be conditional.
+// policy trusts the doc server's TLS certificate, creates an issuer, and
+// seeds a CIMD client row resolved from the doc server carrying a stored
+// ETag. The stored ETag is what makes the no-If-None-Match assertions
+// meaningful: an ordinary revalidation of this row WOULD be conditional.
 func newRefreshTestSetup(t *testing.T, issuerSlug string) (context.Context, *testInstance, *cimdDocServer, repo.UserSessionClient) {
 	t.Helper()
 
@@ -185,20 +186,7 @@ func newRefreshTestSetup(t *testing.T, issuerSlug string) (context.Context, *tes
 	require.NoError(t, err)
 	require.True(t, row.ClientIDMetadataEtag.Valid)
 
-	enableCIMDFlag(t, ctx, ti)
-
 	return ctx, ti, ds, row
-}
-
-// enableCIMDFlag turns FlagUserSessionCIMD on for the caller's organization,
-// matching how the flag is targeted in PostHog (distinctID = org ID).
-func enableCIMDFlag(t *testing.T, ctx context.Context, ti *testInstance) {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, authCtx.ActiveOrganizationID, true)
 }
 
 // backdateFetchedAt ages a client row's last successful read past the refresh
@@ -406,16 +394,14 @@ func TestRefreshUserSessionClientCIMD_DCRClientRejected(t *testing.T) {
 	client, err := seedUserSessionClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), "refresh-dcr-client")
 	require.NoError(t, err)
 
-	enableCIMDFlag(t, ctx, ti)
-
 	_, err = ti.service.RefreshUserSessionClientCIMD(ctx, refreshPayload(client.ID.String()))
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }
 
-// The endpoint carries the same organization flag gate as the /authorize
-// resolve path: an org whose flag is off cannot make Gram fetch documents,
-// and the rejection costs no upstream request.
-func TestRefreshUserSessionClientCIMD_FlagDisabled(t *testing.T) {
+// The issuer-level off switch applies to refresh like it does to /authorize:
+// an issuer whose admission mode is `disabled` cannot have Gram fetch
+// documents on its behalf, and the rejection costs no upstream request.
+func TestRefreshUserSessionClientCIMD_AdmissionDisabled(t *testing.T) {
 	t.Parallel()
 
 	ds := startCIMDDocServer(t)
@@ -425,11 +411,19 @@ func TestRefreshUserSessionClientCIMD_FlagDisabled(t *testing.T) {
 		SessionToken:         nil,
 		ApikeyToken:          nil,
 		ProjectSlugInput:     nil,
-		Slug:                 "refresh-flagoff-issuer",
+		Slug:                 "refresh-disabled-issuer",
 		AuthnChallengeMode:   "chain",
 		SessionDurationHours: 24,
 	})
 	require.NoError(t, err)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NoError(t, testrepo.New(ti.conn).SetUserSessionIssuerCIMDAdmissionMode(ctx, testrepo.SetUserSessionIssuerCIMDAdmissionModeParams{
+		ClientIDMetadataAdmissionMode: conv.ToPGText(string(admission.ModeDisabled)),
+		ID:                            uuid.MustParse(issuer.ID),
+		ProjectID:                     *authCtx.ProjectID,
+	}))
 
 	client, err := seedCimdUserSessionClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), ds.clientID)
 	require.NoError(t, err)
@@ -437,7 +431,7 @@ func TestRefreshUserSessionClientCIMD_FlagDisabled(t *testing.T) {
 
 	_, err = ti.service.RefreshUserSessionClientCIMD(ctx, refreshPayload(client.ID.String()))
 	requireOopsCode(t, err, oops.CodeForbidden)
-	require.Equal(t, int64(0), ds.requests.Load())
+	require.Equal(t, int64(0), ds.requests.Load(), "a rejected refresh must cost no upstream request")
 }
 
 func TestRefreshUserSessionClientCIMD_NotFound(t *testing.T) {

--- a/server/internal/usersessions/setup_test.go
+++ b/server/internal/usersessions/setup_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
@@ -63,9 +62,6 @@ type testInstance struct {
 	sessionManager      *sessions.Manager
 	chatSessionsManager *chatsessions.Manager
 	redis               *redis.Client
-	// features is the injectable flag provider wired into the service; tests
-	// flip FlagUserSessionCIMD on it per organization.
-	features *feature.InMemory
 }
 
 func newTestService(t *testing.T) (context.Context, *testInstance) {
@@ -111,8 +107,6 @@ func newTestServiceWithRevoker(t *testing.T, revoker usersessions.TokenRevoker, 
 		tokenRevoker = revoker
 	}
 
-	features := &feature.InMemory{}
-
 	svc := usersessions.NewService(
 		logger,
 		tracerProvider,
@@ -127,7 +121,6 @@ func newTestServiceWithRevoker(t *testing.T, revoker usersessions.TokenRevoker, 
 		usersessions.NewSigner("test-jwt-secret"),
 		"http://0.0.0.0",
 		ratelimit.NewRedisStore(redisClient),
-		features,
 	)
 
 	return ctx, &testInstance{
@@ -136,7 +129,6 @@ func newTestServiceWithRevoker(t *testing.T, revoker usersessions.TokenRevoker, 
 		sessionManager:      sessionManager,
 		chatSessionsManager: chatSessionsManager,
 		redis:               redisClient,
-		features:            features,
 	}
 }
 

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -101,9 +101,6 @@ type testInstance struct {
 	shadowMCPClient *shadowmcp.Client
 	cacheAdapter    cache.Cache
 	serverURL       *url.URL
-	// features is the injectable flag provider wired into the wrapped mcp
-	// service; tests enable flag-gated behavior with SetFlag.
-	features *feature.InMemory
 }
 
 func newTestService(t *testing.T) (context.Context, *testInstance) {
@@ -159,8 +156,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()))
-	features := &feature.InMemory{}
-	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, features, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
+	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, &feature.InMemory{}, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
@@ -182,7 +178,6 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		shadowMCPClient: shadowMCPClient,
 		cacheAdapter:    cacheAdapter,
 		serverURL:       serverURL,
-		features:        features,
 	}
 }
 

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 )
 
 // runWellKnown invokes the supplied xmcp well-known handler with the chi
@@ -472,11 +472,11 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_IssuerGatedRemoteBackend_
 	require.Equal(t, []any{expectedResource}, authServers)
 }
 
-// TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOn verifies the
-// /x/mcp well-known variant advertises client_id_metadata_document_supported
-// when the issuer organization's gram-user-session-cimd flag is on — the
-// shared mcp.ServeGetAuthorizationServer emits it for both route families.
-func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOn(t *testing.T) {
+// TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDAdvertised verifies
+// the /x/mcp well-known variant advertises
+// client_id_metadata_document_supported — the shared
+// mcp.ServeGetAuthorizationServer emits it for both route families.
+func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDAdvertised(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -484,7 +484,6 @@ func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOn(t *testing.T)
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	ti.features.SetFlag(feature.FlagUserSessionCIMD, authCtx.ActiveOrganizationID, true)
 	slug, _, _ := seedIssuerGatedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp", "public")
 
 	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
@@ -496,9 +495,10 @@ func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOn(t *testing.T)
 	require.Equal(t, true, metadata["client_id_metadata_document_supported"])
 }
 
-// TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOff pins the
-// omit-when-disabled behavior on the /x/mcp variant.
-func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOff(t *testing.T) {
+// TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDDisabledOmitted pins
+// the omit-when-disabled behavior on the /x/mcp variant: an issuer whose
+// admission mode is `disabled` must not advertise CIMD support.
+func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDDisabledOmitted(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -506,7 +506,14 @@ func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOff(t *testing.T
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	slug, _, _ := seedIssuerGatedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp", "public")
+	slug, _, issuerID := seedIssuerGatedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp", "public")
+
+	err := testrepo.New(ti.conn).SetUserSessionIssuerCIMDAdmissionMode(ctx, testrepo.SetUserSessionIssuerCIMDAdmissionModeParams{
+		ClientIDMetadataAdmissionMode: conv.ToPGText(string(admission.ModeDisabled)),
+		ID:                            issuerID,
+		ProjectID:                     *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
 
 	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
 	require.NoError(t, err)


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-210/chore-remove-gram-user-session-cimd-feature-flag

The flag reached 100% customer rollout (AIS-212), so inbound CIMD is now always on and gated solely by the per-issuer admission mode. This removes both `IsFlagEnabled` call sites, the `errCIMDDisabled` sentinel and its authorize branch, the per-organization last-known-state fallback that existed only to survive PostHog outages on the unauthenticated OAuth surface, the `FlagUserSessionCIMD` constant, and the now-unused `features` dependency on `usersessions.Service`. The well-known metadata advertises `client_id_metadata_document_supported` based only on the admission mode.

`RefreshUserSessionClientCIMD` previously reused the flag as its gate, so it now checks the issuer's admission mode instead: a `disabled` issuer cannot make Gram fetch documents through refresh either. Only `disabled` blocks there; a presets catalog miss stays refreshable, matching the `/token` asymmetry where de-listing a client stops new authorize flows without breaking existing rows.

Flag-off tests with exact admission-mode equivalents were deleted. Two carried unique coverage and were converted instead: the resolve-then-disable ordering (a cached client row must not bypass a later policy flip) and the `/x/mcp` route family's well-known omission. A new shared `testrepo` fixture query sets an issuer's admission mode as a single-column update so test packages stop copying the COALESCE-preserving `UpdateUserSessionIssuer` block.

**Deploy note:** the PostHog flag must be deleted in dev and prod only after this change is fully deployed and a revert is off the table. A missing flag evaluates false on pre-removal code, which would turn CIMD off globally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `gram-user-session-cimd` feature flag; inbound CIMD is always on and controlled only by the issuer’s admission mode. This makes behavior explicit, removes flag dependencies, and aligns with AIS-210 after full rollout (AIS-212).

- Delete the flag constant, all `IsFlagEnabled` call sites, `errCIMDDisabled`, and the last-known-state fallback on unauthenticated OAuth endpoints. Drop the now-unused `features` dependency from `usersessions.Service` and its constructor; update `server/cmd/gram/start.go` to stop passing it.
- `/mcp/*/authorize`: URL-shaped `client_id` resolution is admission-gated; denials happen pre-fetch and render as unknown client where applicable.
- `/token`: mid-flow legs keep working even if the issuer’s admission policy changes between legs.
- `RefreshUserSessionClientCIMD`: checks the issuer’s admission mode; `disabled` returns 403. Presets catalog misses remain refreshable; unrecognized modes fail closed.
- Well-known metadata: emit `client_id_metadata_document_supported` unless the issuer’s mode is `disabled`.
- Tests: remove flag-based cases; add coverage for resolve-then-disable ordering and well-known omission. Add `testrepo.SetUserSessionIssuerCIMDAdmissionMode` for single-column updates.

**Rollout/Migration**
- After full deploy and once rollback is off the table, delete the PostHog flag in dev and prod. On older code, a missing flag evaluates false and would disable CIMD globally.
- If you construct `usersessions.NewService`, remove the `features` argument.

<sup>Written for commit 008a35d0603aadfedec49e08ee5ec13c3242bd41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

