### PR TITLE
fix: ignore null directory attributes

### DIFF
--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -157,6 +157,7 @@ func TestGetPlugins_DeliversDirectoryAttributeAssignments(t *testing.T) {
 	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-1", email, []byte(`{"department":"Engineering"}`))
 	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-2", email, []byte(`{"manager.email":"lead@example.com"}`))
 	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-3", email, []byte(`{"department":"Engineering"}`))
+	seedDirectoryUserWithAttributes(t, ctx, ti.conn, ti.orgID, "user-directory-attributes-null", email, []byte(`{"department":null}`))
 	audiences, err := plugins.ResolveDirectoryAudiencePrincipalsByEmails(ctx, ti.conn, ti.orgID, []string{email})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{

--- a/server/internal/plugins/list_directory_audiences_test.go
+++ b/server/internal/plugins/list_directory_audiences_test.go
@@ -64,7 +64,7 @@ func TestPluginsService_ListAudiences(t *testing.T) {
 		UserID:                conv.ToPGTextEmpty(""),
 		WorkosDirectoryUserID: directoryUserTwoWorkOSID,
 		Email:                 conv.ToPGText(" MEMBER@example.com "),
-		Attributes:            []byte(`{"department":"engineering"}`),
+		Attributes:            []byte(`{"department":"engineering","unused":null}`),
 		WorkosCreatedAt:       conv.ToPGTimestamptz(now),
 		WorkosUpdatedAt:       conv.ToPGTimestamptz(now),
 		WorkosLastEventID:     conv.ToPGTextEmpty(""),

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -279,12 +279,13 @@ SELECT DISTINCT
   attribute.key::text AS attribute_key,
   attribute.value::text AS attribute_value
 FROM directory_users AS du
-CROSS JOIN LATERAL jsonb_each_text(du.attributes) AS attribute(key, value)
+CROSS JOIN LATERAL jsonb_each_text(CASE jsonb_typeof(du.attributes) WHEN 'object' THEN du.attributes ELSE '{}'::jsonb END) AS attribute(key, value)
 WHERE du.organization_id = @organization_id
   AND du.deleted IS FALSE
   AND du.workos_deleted IS FALSE
   AND du.email IS NOT NULL
   AND LOWER(du.email) = ANY(@emails::text[])
+  AND attribute.value IS NOT NULL
 ORDER BY email, attribute.key, attribute.value;
 
 -- name: DirectoryAttributeValueExists :one
@@ -333,9 +334,10 @@ SELECT
   attribute.value::text AS attribute_value,
   COUNT(DISTINCT NULLIF(LOWER(TRIM(du.email)), ''))::bigint AS member_count
 FROM directory_users AS du
-CROSS JOIN LATERAL jsonb_each_text(du.attributes) AS attribute(key, value)
+CROSS JOIN LATERAL jsonb_each_text(CASE jsonb_typeof(du.attributes) WHEN 'object' THEN du.attributes ELSE '{}'::jsonb END) AS attribute(key, value)
 WHERE du.organization_id = @organization_id
   AND du.deleted IS FALSE
   AND du.workos_deleted IS FALSE
+  AND attribute.value IS NOT NULL
 GROUP BY attribute.key, attribute.value
 ORDER BY attribute.key, attribute.value;

--- a/server/internal/thirdparty/workos/repo/queries.sql.go
+++ b/server/internal/thirdparty/workos/repo/queries.sql.go
@@ -431,10 +431,11 @@ SELECT
   attribute.value::text AS attribute_value,
   COUNT(DISTINCT NULLIF(LOWER(TRIM(du.email)), ''))::bigint AS member_count
 FROM directory_users AS du
-CROSS JOIN LATERAL jsonb_each_text(du.attributes) AS attribute(key, value)
+CROSS JOIN LATERAL jsonb_each_text(CASE jsonb_typeof(du.attributes) WHEN 'object' THEN du.attributes ELSE '{}'::jsonb END) AS attribute(key, value)
 WHERE du.organization_id = $1
   AND du.deleted IS FALSE
   AND du.workos_deleted IS FALSE
+  AND attribute.value IS NOT NULL
 GROUP BY attribute.key, attribute.value
 ORDER BY attribute.key, attribute.value
 `
@@ -569,12 +570,13 @@ SELECT DISTINCT
   attribute.key::text AS attribute_key,
   attribute.value::text AS attribute_value
 FROM directory_users AS du
-CROSS JOIN LATERAL jsonb_each_text(du.attributes) AS attribute(key, value)
+CROSS JOIN LATERAL jsonb_each_text(CASE jsonb_typeof(du.attributes) WHEN 'object' THEN du.attributes ELSE '{}'::jsonb END) AS attribute(key, value)
 WHERE du.organization_id = $1
   AND du.deleted IS FALSE
   AND du.workos_deleted IS FALSE
   AND du.email IS NOT NULL
   AND LOWER(du.email) = ANY($2::text[])
+  AND attribute.value IS NOT NULL
 ORDER BY email, attribute.key, attribute.value
 `
 


### PR DESCRIPTION
## Why?

A directory profile can include null-valued attributes. Resolving plugin audiences treated those values as strings and caused agent polling to fail.

## What?

Ignore null and non-object directory attributes while resolving agent and dashboard audiences. Add regression coverage for both paths.

## Notes

Focused agent and plugin tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore null and non-object directory attributes when resolving plugin audiences to prevent agent polling failures. Previously, null values were coerced to strings; now only non-null values from object attributes are considered.

- SQL hardening: wrap `du.attributes` with `CASE jsonb_typeof(...)` to treat non-objects as `{}` and add `attribute.value IS NOT NULL` in both audience resolution and member count queries.
- Tests: add null-attribute cases for agent and plugin paths; no API changes or migrations.

<sup>Written for commit 43fd53cbdac4f6eb0c8e3d38de6a6a329105af52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

