### PR TITLE
fix: carry the vouched agent email in a header, not the getPlugins URL

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -4980,21 +4980,20 @@ paths:
       operationId: getAgentPlugins
       parameters:
         - allowEmptyValue: true
-          description: Email address of the enrolled user. Authoritative when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
-          example: dev@acme.corp
-          in: query
-          name: email
-          required: true
-          schema:
-            description: Email address of the enrolled user. Authoritative when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
-            example: dev@acme.corp
-            type: string
-        - allowEmptyValue: true
           description: API Key header
           in: header
           name: Gram-Key
           schema:
             description: API Key header
+            type: string
+        - allowEmptyValue: true
+          description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+          example: dev@acme.corp
+          in: header
+          name: Gram-User-Email
+          schema:
+            description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+            example: dev@acme.corp
             type: string
         - allowEmptyValue: true
           description: Hardware serial number of the machine the agent runs on, when it can be read. Lets device coverage attest this specific machine rather than its assigned user.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -4987,12 +4987,12 @@ paths:
             description: API Key header
             type: string
         - allowEmptyValue: true
-          description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+          description: Email address of the enrolled user, sent in the Gram-User-Email header. Required when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
           example: dev@acme.corp
           in: header
           name: Gram-User-Email
           schema:
-            description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+            description: Email address of the enrolled user, sent in the Gram-User-Email header. Required when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
             example: dev@acme.corp
             type: string
         - allowEmptyValue: true

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -4980,6 +4980,15 @@ paths:
       operationId: getAgentPlugins
       parameters:
         - allowEmptyValue: true
+          description: 'Deprecated: the vouched email as the `?email=` query parameter, sent by agents predating the Gram-User-Email header. Used only when the header is absent.'
+          example: dev@acme.corp
+          in: query
+          name: email
+          schema:
+            description: 'Deprecated: the vouched email as the `?email=` query parameter, sent by agents predating the Gram-User-Email header. Used only when the header is absent.'
+            example: dev@acme.corp
+            type: string
+        - allowEmptyValue: true
           description: API Key header
           in: header
           name: Gram-Key

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -4755,6 +4755,7 @@ examples:
         header:
           Gram-Device-Serial: "C02XK1ABCDEF"
           Gram-Device-Hostname: "dev-macbook-pro"
+          Gram-User-Email: "dev@acme.corp"
       responses:
         "200":
           application/json: {"etag": "<value>", "marketplaces": [], "plugins": []}

--- a/client/dashboard/src/sdk/src/funcs/agentGetPlugins.ts
+++ b/client/dashboard/src/sdk/src/funcs/agentGetPlugins.ts
@@ -4,7 +4,7 @@
 
 import * as z from "zod/v4-mini";
 import { GramCore } from "../core.js";
-import { encodeFormQuery, encodeSimple } from "../lib/encodings.js";
+import { encodeSimple } from "../lib/encodings.js";
 import { matchStatusCode } from "../lib/http.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
@@ -46,7 +46,7 @@ import { Result } from "../types/fp.js";
  */
 export function agentGetPlugins(
   client: GramCore,
-  request: GetAgentPluginsRequest,
+  request?: GetAgentPluginsRequest | undefined,
   security?: GetAgentPluginsSecurity | undefined,
   options?: RequestOptions,
 ): APIPromise<
@@ -73,7 +73,7 @@ export function agentGetPlugins(
 
 async function $do(
   client: GramCore,
-  request: GetAgentPluginsRequest,
+  request?: GetAgentPluginsRequest | undefined,
   security?: GetAgentPluginsSecurity | undefined,
   options?: RequestOptions,
 ): Promise<
@@ -95,7 +95,8 @@ async function $do(
 > {
   const parsed = safeParse(
     request,
-    (value) => z.parse(GetAgentPluginsRequest$outboundSchema, value),
+    (value) =>
+      z.parse(z.optional(GetAgentPluginsRequest$outboundSchema), value),
     "Input validation failed",
   );
   if (!parsed.ok) {
@@ -106,26 +107,27 @@ async function $do(
 
   const path = pathToFunc("/rpc/agent.getPlugins")();
 
-  const query = encodeFormQuery({
-    "email": payload.email,
-  });
-
   const headers = new Headers(compactMap({
     Accept: "application/json",
     "Gram-Device-Hostname": encodeSimple(
       "Gram-Device-Hostname",
-      payload["Gram-Device-Hostname"],
+      payload?.["Gram-Device-Hostname"],
       { explode: false, charEncoding: "none" },
     ),
     "Gram-Device-Serial": encodeSimple(
       "Gram-Device-Serial",
-      payload["Gram-Device-Serial"],
+      payload?.["Gram-Device-Serial"],
       { explode: false, charEncoding: "none" },
     ),
-    "Gram-Key": encodeSimple("Gram-Key", payload["Gram-Key"], {
+    "Gram-Key": encodeSimple("Gram-Key", payload?.["Gram-Key"], {
       explode: false,
       charEncoding: "none",
     }),
+    "Gram-User-Email": encodeSimple(
+      "Gram-User-Email",
+      payload?.["Gram-User-Email"],
+      { explode: false, charEncoding: "none" },
+    ),
   }));
 
   const requestSecurity = resolveSecurity(
@@ -159,7 +161,6 @@ async function $do(
     baseURL: options?.serverURL,
     path: path,
     headers: headers,
-    query: query,
     body: body,
     userAgent: client._options.userAgent,
     timeoutMs: options?.timeoutMs || client._options.timeoutMs || -1,

--- a/client/dashboard/src/sdk/src/funcs/agentGetPlugins.ts
+++ b/client/dashboard/src/sdk/src/funcs/agentGetPlugins.ts
@@ -4,7 +4,7 @@
 
 import * as z from "zod/v4-mini";
 import { GramCore } from "../core.js";
-import { encodeSimple } from "../lib/encodings.js";
+import { encodeFormQuery, encodeSimple } from "../lib/encodings.js";
 import { matchStatusCode } from "../lib/http.js";
 import * as M from "../lib/matchers.js";
 import { compactMap } from "../lib/primitives.js";
@@ -107,6 +107,10 @@ async function $do(
 
   const path = pathToFunc("/rpc/agent.getPlugins")();
 
+  const query = encodeFormQuery({
+    "email": payload?.email,
+  });
+
   const headers = new Headers(compactMap({
     Accept: "application/json",
     "Gram-Device-Hostname": encodeSimple(
@@ -161,6 +165,7 @@ async function $do(
     baseURL: options?.serverURL,
     path: path,
     headers: headers,
+    query: query,
     body: body,
     userAgent: client._options.userAgent,
     timeoutMs: options?.timeoutMs || client._options.timeoutMs || -1,

--- a/client/dashboard/src/sdk/src/models/operations/getagentplugins.ts
+++ b/client/dashboard/src/sdk/src/models/operations/getagentplugins.ts
@@ -15,7 +15,7 @@ export type GetAgentPluginsRequest = {
    */
   gramKey?: string | undefined;
   /**
-   * Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+   * Email address of the enrolled user, sent in the Gram-User-Email header. Required when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
    */
   gramUserEmail?: string | undefined;
   /**

--- a/client/dashboard/src/sdk/src/models/operations/getagentplugins.ts
+++ b/client/dashboard/src/sdk/src/models/operations/getagentplugins.ts
@@ -11,6 +11,10 @@ export type GetAgentPluginsSecurity = {
 
 export type GetAgentPluginsRequest = {
   /**
+   * Deprecated: the vouched email as the `?email=` query parameter, sent by agents predating the Gram-User-Email header. Used only when the header is absent.
+   */
+  email?: string | undefined;
+  /**
    * API Key header
    */
   gramKey?: string | undefined;
@@ -58,6 +62,7 @@ export function getAgentPluginsSecurityToJSON(
 
 /** @internal */
 export type GetAgentPluginsRequest$Outbound = {
+  email?: string | undefined;
   "Gram-Key"?: string | undefined;
   "Gram-User-Email"?: string | undefined;
   "Gram-Device-Serial"?: string | undefined;
@@ -70,6 +75,7 @@ export const GetAgentPluginsRequest$outboundSchema: z.ZodMiniType<
   GetAgentPluginsRequest
 > = z.pipe(
   z.object({
+    email: z.optional(z.string()),
     gramKey: z.optional(z.string()),
     gramUserEmail: z.optional(z.string()),
     gramDeviceSerial: z.optional(z.string()),

--- a/client/dashboard/src/sdk/src/models/operations/getagentplugins.ts
+++ b/client/dashboard/src/sdk/src/models/operations/getagentplugins.ts
@@ -11,13 +11,13 @@ export type GetAgentPluginsSecurity = {
 
 export type GetAgentPluginsRequest = {
   /**
-   * Email address of the enrolled user. Authoritative when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
-   */
-  email: string;
-  /**
    * API Key header
    */
   gramKey?: string | undefined;
+  /**
+   * Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+   */
+  gramUserEmail?: string | undefined;
   /**
    * Hardware serial number of the machine the agent runs on, when it can be read. Lets device coverage attest this specific machine rather than its assigned user.
    */
@@ -58,8 +58,8 @@ export function getAgentPluginsSecurityToJSON(
 
 /** @internal */
 export type GetAgentPluginsRequest$Outbound = {
-  email: string;
   "Gram-Key"?: string | undefined;
+  "Gram-User-Email"?: string | undefined;
   "Gram-Device-Serial"?: string | undefined;
   "Gram-Device-Hostname"?: string | undefined;
 };
@@ -70,14 +70,15 @@ export const GetAgentPluginsRequest$outboundSchema: z.ZodMiniType<
   GetAgentPluginsRequest
 > = z.pipe(
   z.object({
-    email: z.string(),
     gramKey: z.optional(z.string()),
+    gramUserEmail: z.optional(z.string()),
     gramDeviceSerial: z.optional(z.string()),
     gramDeviceHostname: z.optional(z.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
       gramKey: "Gram-Key",
+      gramUserEmail: "Gram-User-Email",
       gramDeviceSerial: "Gram-Device-Serial",
       gramDeviceHostname: "Gram-Device-Hostname",
     });

--- a/client/dashboard/src/sdk/src/react-query/agentPlugins.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/agentPlugins.core.ts
@@ -22,7 +22,7 @@ export type AgentPluginsQueryData = GetPluginsResult;
 export function prefetchAgentPlugins(
   queryClient: QueryClient,
   client$: GramCore,
-  request: GetAgentPluginsRequest,
+  request?: GetAgentPluginsRequest | undefined,
   security?: GetAgentPluginsSecurity | undefined,
   options?: RequestOptions,
 ): Promise<void> {
@@ -38,7 +38,7 @@ export function prefetchAgentPlugins(
 
 export function buildAgentPluginsQuery(
   client$: GramCore,
-  request: GetAgentPluginsRequest,
+  request?: GetAgentPluginsRequest | undefined,
   security?: GetAgentPluginsSecurity | undefined,
   options?: RequestOptions,
 ): {
@@ -47,10 +47,10 @@ export function buildAgentPluginsQuery(
 } {
   return {
     queryKey: queryKeyAgentPlugins({
-      email: request.email,
-      gramKey: request.gramKey,
-      gramDeviceSerial: request.gramDeviceSerial,
-      gramDeviceHostname: request.gramDeviceHostname,
+      gramKey: request?.gramKey,
+      gramUserEmail: request?.gramUserEmail,
+      gramDeviceSerial: request?.gramDeviceSerial,
+      gramDeviceHostname: request?.gramDeviceHostname,
     }),
     queryFn: async function agentPluginsQueryFn(
       ctx,
@@ -78,8 +78,8 @@ export function buildAgentPluginsQuery(
 
 export function queryKeyAgentPlugins(
   parameters: {
-    email: string;
     gramKey?: string | undefined;
+    gramUserEmail?: string | undefined;
     gramDeviceSerial?: string | undefined;
     gramDeviceHostname?: string | undefined;
   },

--- a/client/dashboard/src/sdk/src/react-query/agentPlugins.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/agentPlugins.core.ts
@@ -47,6 +47,7 @@ export function buildAgentPluginsQuery(
 } {
   return {
     queryKey: queryKeyAgentPlugins({
+      email: request?.email,
       gramKey: request?.gramKey,
       gramUserEmail: request?.gramUserEmail,
       gramDeviceSerial: request?.gramDeviceSerial,
@@ -78,6 +79,7 @@ export function buildAgentPluginsQuery(
 
 export function queryKeyAgentPlugins(
   parameters: {
+    email?: string | undefined;
     gramKey?: string | undefined;
     gramUserEmail?: string | undefined;
     gramDeviceSerial?: string | undefined;

--- a/client/dashboard/src/sdk/src/react-query/agentPlugins.ts
+++ b/client/dashboard/src/sdk/src/react-query/agentPlugins.ts
@@ -62,7 +62,7 @@ export type AgentPluginsQueryError =
  * Resolve the marketplaces, plugins, and optional organization configuration assigned to the enrolled user. The device agent reconciles these into the AI developer tools it manages. Organization configuration is delivered on this existing poll so agents do not need a second control-plane request.
  */
 export function useAgentPlugins(
-  request: GetAgentPluginsRequest,
+  request?: GetAgentPluginsRequest | undefined,
   security?: GetAgentPluginsSecurity | undefined,
   options?: QueryHookOptions<AgentPluginsQueryData, AgentPluginsQueryError>,
 ): UseQueryResult<AgentPluginsQueryData, AgentPluginsQueryError> {
@@ -85,7 +85,7 @@ export function useAgentPlugins(
  * Resolve the marketplaces, plugins, and optional organization configuration assigned to the enrolled user. The device agent reconciles these into the AI developer tools it manages. Organization configuration is delivered on this existing poll so agents do not need a second control-plane request.
  */
 export function useAgentPluginsSuspense(
-  request: GetAgentPluginsRequest,
+  request?: GetAgentPluginsRequest | undefined,
   security?: GetAgentPluginsSecurity | undefined,
   options?: SuspenseQueryHookOptions<
     AgentPluginsQueryData,
@@ -108,8 +108,8 @@ export function setAgentPluginsData(
   client: QueryClient,
   queryKeyBase: [
     parameters: {
-      email: string;
       gramKey?: string | undefined;
+      gramUserEmail?: string | undefined;
       gramDeviceSerial?: string | undefined;
       gramDeviceHostname?: string | undefined;
     },
@@ -125,8 +125,8 @@ export function invalidateAgentPlugins(
   client: QueryClient,
   queryKeyBase: TupleToPrefixes<
     [parameters: {
-      email: string;
       gramKey?: string | undefined;
+      gramUserEmail?: string | undefined;
       gramDeviceSerial?: string | undefined;
       gramDeviceHostname?: string | undefined;
     }]

--- a/client/dashboard/src/sdk/src/react-query/agentPlugins.ts
+++ b/client/dashboard/src/sdk/src/react-query/agentPlugins.ts
@@ -108,6 +108,7 @@ export function setAgentPluginsData(
   client: QueryClient,
   queryKeyBase: [
     parameters: {
+      email?: string | undefined;
       gramKey?: string | undefined;
       gramUserEmail?: string | undefined;
       gramDeviceSerial?: string | undefined;
@@ -125,6 +126,7 @@ export function invalidateAgentPlugins(
   client: QueryClient,
   queryKeyBase: TupleToPrefixes<
     [parameters: {
+      email?: string | undefined;
       gramKey?: string | undefined;
       gramUserEmail?: string | undefined;
       gramDeviceSerial?: string | undefined;

--- a/client/dashboard/src/sdk/src/sdk/agent.ts
+++ b/client/dashboard/src/sdk/src/sdk/agent.ts
@@ -91,7 +91,7 @@ export class Agent extends ClientSDK {
    * Resolve the marketplaces, plugins, and optional organization configuration assigned to the enrolled user. The device agent reconciles these into the AI developer tools it manages. Organization configuration is delivered on this existing poll so agents do not need a second control-plane request.
    */
   async getPlugins(
-    request: GetAgentPluginsRequest,
+    request?: GetAgentPluginsRequest | undefined,
     security?: GetAgentPluginsSecurity | undefined,
     options?: RequestOptions,
   ): Promise<GetPluginsResult> {

--- a/server/design/agent/design.go
+++ b/server/design/agent/design.go
@@ -22,9 +22,9 @@ var _ = Service("agent", func() {
 		// Authenticated with an API key carrying the `agent_user` scope — the
 		// per-user key minted by token-exchange, so the enrolled user is the key
 		// owner and the org derives from the key. An org `agent` install key also
-		// passes (it implies `agent_user`; see auth.Authorize), so agents still
-		// on the shared org key keep working during the transition. `email` is
-		// retained as an optional param for the legacy vouched-email path.
+		// passes (it implies `agent_user`; see auth.Authorize); on that path the
+		// MDM profile vouches the enrolled user's email via the Gram-User-Email
+		// header (DNO-935).
 		Security(security.ByKey, func() {
 			Scope("agent_user")
 		})
@@ -35,7 +35,7 @@ var _ = Service("agent", func() {
 			// scope): that key's owner is an admin, not the enrolled developer, so
 			// the MDM profile vouches the developer's email here. Ignored for a
 			// per-user key (`agent_user`), whose owner is the enrolled user.
-			Attribute("email", String, "Email address of the enrolled user. Authoritative when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.", func() {
+			Attribute("email", String, "Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.", func() {
 				Example("dev@acme.corp")
 			})
 			// Hardware identity, reported by agents that can read it. Both are
@@ -51,7 +51,6 @@ var _ = Service("agent", func() {
 			Attribute("hostname", String, "Hostname of the machine the agent runs on, when it can be read.", func() {
 				Example("dev-macbook-pro")
 			})
-			Required("email")
 		})
 
 		Result(GetPluginsResult)
@@ -59,13 +58,14 @@ var _ = Service("agent", func() {
 		HTTP(func() {
 			GET("/rpc/agent.getPlugins")
 			security.ByKeyHeader()
-			Param("email")
-			// Carried as headers rather than query params: a serial is a
-			// durable hardware identifier and a hostname frequently embeds a
-			// person's name, and the request logger records URLs but not
-			// headers. `email` remains a query param for compatibility with
-			// deployed agents; the request logging middleware redacts it from
-			// logged URLs.
+			// Carried as headers rather than query params: the email and
+			// hostname identify a person and a serial is a durable hardware
+			// identifier, and the request logger records URLs but not headers
+			// (DNO-935). Legacy agents still append `?email=` to the URL; the
+			// generated decoder only reads declared bindings so the param is
+			// ignored, and the request logging middleware keeps redacting it
+			// from logged URLs.
+			Header("email:Gram-User-Email")
 			Header("serial_number:Gram-Device-Serial")
 			Header("hostname:Gram-Device-Hostname")
 			Response(StatusOK)

--- a/server/design/agent/design.go
+++ b/server/design/agent/design.go
@@ -22,9 +22,8 @@ var _ = Service("agent", func() {
 		// Authenticated with an API key carrying the `agent_user` scope — the
 		// per-user key minted by token-exchange, so the enrolled user is the key
 		// owner and the org derives from the key. An org `agent` install key also
-		// passes (it implies `agent_user`; see auth.Authorize); on that path the
-		// MDM profile vouches the enrolled user's email via the Gram-User-Email
-		// header (DNO-935).
+		// passes (it implies `agent_user`; see auth.Authorize); the MDM profile
+		// then vouches the enrolled user's email via the Gram-User-Email header.
 		Security(security.ByKey, func() {
 			Scope("agent_user")
 		})
@@ -35,7 +34,7 @@ var _ = Service("agent", func() {
 			// scope): that key's owner is an admin, not the enrolled developer, so
 			// the MDM profile vouches the developer's email here. Ignored for a
 			// per-user key (`agent_user`), whose owner is the enrolled user.
-			Attribute("email", String, "Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.", func() {
+			Attribute("email", String, "Email address of the enrolled user, sent in the Gram-User-Email header. Required when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.", func() {
 				Example("dev@acme.corp")
 			})
 			// Hardware identity, reported by agents that can read it. Both are
@@ -58,13 +57,10 @@ var _ = Service("agent", func() {
 		HTTP(func() {
 			GET("/rpc/agent.getPlugins")
 			security.ByKeyHeader()
-			// Carried as headers rather than query params: the email and
-			// hostname identify a person and a serial is a durable hardware
-			// identifier, and the request logger records URLs but not headers
-			// (DNO-935). Legacy agents still append `?email=` to the URL; the
-			// generated decoder only reads declared bindings so the param is
-			// ignored, and the request logging middleware keeps redacting it
-			// from logged URLs.
+			// Headers rather than query params: all three identify a person or
+			// a machine, and the request logger records URLs but not headers.
+			// Legacy agents still append `?email=`; the decoder ignores
+			// undeclared params and the logging middleware redacts it.
 			Header("email:Gram-User-Email")
 			Header("serial_number:Gram-Device-Serial")
 			Header("hostname:Gram-Device-Hostname")

--- a/server/design/agent/design.go
+++ b/server/design/agent/design.go
@@ -37,6 +37,13 @@ var _ = Service("agent", func() {
 			Attribute("email", String, "Email address of the enrolled user, sent in the Gram-User-Email header. Required when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.", func() {
 				Example("dev@acme.corp")
 			})
+			// Deployed org-key agents predate the header and vouch via `?email=`;
+			// an updated server must keep accepting it or their polls 400 until
+			// the device updates — which auto-update settings can defer
+			// indefinitely. Remove once org-key polls no longer carry it.
+			Attribute("legacy_email", String, "Deprecated: the vouched email as the `?email=` query parameter, sent by agents predating the Gram-User-Email header. Used only when the header is absent.", func() {
+				Example("dev@acme.corp")
+			})
 			// Hardware identity, reported by agents that can read it. Both are
 			// optional and MUST stay that way: agents predating the capability
 			// omit them entirely, and Goa rejects a request missing a Required
@@ -59,9 +66,10 @@ var _ = Service("agent", func() {
 			security.ByKeyHeader()
 			// Headers rather than query params: all three identify a person or
 			// a machine, and the request logger records URLs but not headers.
-			// Legacy agents still append `?email=`; the decoder ignores
-			// undeclared params and the logging middleware redacts it.
+			// The deprecated `?email=` fallback stays redacted by the logging
+			// middleware.
 			Header("email:Gram-User-Email")
+			Param("legacy_email:email")
 			Header("serial_number:Gram-Device-Serial")
 			Header("hostname:Gram-Device-Hostname")
 			Response(StatusOK)

--- a/server/gen/agent/service.go
+++ b/server/gen/agent/service.go
@@ -187,10 +187,12 @@ type GetConfigurationPayload struct {
 // GetPluginsPayload is the payload type of the agent service getPlugins method.
 type GetPluginsPayload struct {
 	ApikeyToken *string
-	// Email address of the enrolled user. Authoritative when authenticating with
-	// an org-scoped agent install key (the MDM zero-touch path); ignored for a
-	// per-user key, whose owner is the enrolled user.
-	Email string
+	// Email address of the enrolled user, carried in the Gram-User-Email header.
+	// Authoritative — and required by the handler — when authenticating with an
+	// org-scoped agent install key (the MDM zero-touch path); ignored for a
+	// per-user key, whose owner is the enrolled user. Optional at the transport
+	// level so per-user-key agents need not send it.
+	Email *string
 	// Hardware serial number of the machine the agent runs on, when it can be
 	// read. Lets device coverage attest this specific machine rather than its
 	// assigned user.

--- a/server/gen/agent/service.go
+++ b/server/gen/agent/service.go
@@ -187,11 +187,10 @@ type GetConfigurationPayload struct {
 // GetPluginsPayload is the payload type of the agent service getPlugins method.
 type GetPluginsPayload struct {
 	ApikeyToken *string
-	// Email address of the enrolled user, carried in the Gram-User-Email header.
-	// Authoritative — and required by the handler — when authenticating with an
-	// org-scoped agent install key (the MDM zero-touch path); ignored for a
-	// per-user key, whose owner is the enrolled user. Optional at the transport
-	// level so per-user-key agents need not send it.
+	// Email address of the enrolled user, sent in the Gram-User-Email header.
+	// Required when authenticating with an org-scoped agent install key (the MDM
+	// zero-touch path); ignored for a per-user key, whose owner is the enrolled
+	// user.
 	Email *string
 	// Hardware serial number of the machine the agent runs on, when it can be
 	// read. Lets device coverage attest this specific machine rather than its

--- a/server/gen/agent/service.go
+++ b/server/gen/agent/service.go
@@ -192,6 +192,10 @@ type GetPluginsPayload struct {
 	// zero-touch path); ignored for a per-user key, whose owner is the enrolled
 	// user.
 	Email *string
+	// Deprecated: the vouched email as the `?email=` query parameter, sent by
+	// agents predating the Gram-User-Email header. Used only when the header is
+	// absent.
+	LegacyEmail *string
 	// Hardware serial number of the machine the agent runs on, when it can be
 	// read. Lets device coverage attest this specific machine rather than its
 	// assigned user.

--- a/server/gen/http/agent/client/cli.go
+++ b/server/gen/http/agent/client/cli.go
@@ -18,15 +18,17 @@ import (
 
 // BuildGetPluginsPayload builds the payload for the agent getPlugins endpoint
 // from CLI flags.
-func BuildGetPluginsPayload(agentGetPluginsEmail string, agentGetPluginsApikeyToken string, agentGetPluginsSerialNumber string, agentGetPluginsHostname string) (*agent.GetPluginsPayload, error) {
-	var email string
-	{
-		email = agentGetPluginsEmail
-	}
+func BuildGetPluginsPayload(agentGetPluginsApikeyToken string, agentGetPluginsEmail string, agentGetPluginsSerialNumber string, agentGetPluginsHostname string) (*agent.GetPluginsPayload, error) {
 	var apikeyToken *string
 	{
 		if agentGetPluginsApikeyToken != "" {
 			apikeyToken = &agentGetPluginsApikeyToken
+		}
+	}
+	var email *string
+	{
+		if agentGetPluginsEmail != "" {
+			email = &agentGetPluginsEmail
 		}
 	}
 	var serialNumber *string
@@ -42,8 +44,8 @@ func BuildGetPluginsPayload(agentGetPluginsEmail string, agentGetPluginsApikeyTo
 		}
 	}
 	v := &agent.GetPluginsPayload{}
-	v.Email = email
 	v.ApikeyToken = apikeyToken
+	v.Email = email
 	v.SerialNumber = serialNumber
 	v.Hostname = hostname
 

--- a/server/gen/http/agent/client/cli.go
+++ b/server/gen/http/agent/client/cli.go
@@ -18,7 +18,13 @@ import (
 
 // BuildGetPluginsPayload builds the payload for the agent getPlugins endpoint
 // from CLI flags.
-func BuildGetPluginsPayload(agentGetPluginsApikeyToken string, agentGetPluginsEmail string, agentGetPluginsSerialNumber string, agentGetPluginsHostname string) (*agent.GetPluginsPayload, error) {
+func BuildGetPluginsPayload(agentGetPluginsLegacyEmail string, agentGetPluginsApikeyToken string, agentGetPluginsEmail string, agentGetPluginsSerialNumber string, agentGetPluginsHostname string) (*agent.GetPluginsPayload, error) {
+	var legacyEmail *string
+	{
+		if agentGetPluginsLegacyEmail != "" {
+			legacyEmail = &agentGetPluginsLegacyEmail
+		}
+	}
 	var apikeyToken *string
 	{
 		if agentGetPluginsApikeyToken != "" {
@@ -44,6 +50,7 @@ func BuildGetPluginsPayload(agentGetPluginsApikeyToken string, agentGetPluginsEm
 		}
 	}
 	v := &agent.GetPluginsPayload{}
+	v.LegacyEmail = legacyEmail
 	v.ApikeyToken = apikeyToken
 	v.Email = email
 	v.SerialNumber = serialNumber

--- a/server/gen/http/agent/client/encode_decode.go
+++ b/server/gen/http/agent/client/encode_decode.go
@@ -45,6 +45,10 @@ func EncodeGetPluginsRequest(encoder func(*http.Request) goahttp.Encoder) func(*
 			head := *p.ApikeyToken
 			req.Header.Set("Gram-Key", head)
 		}
+		if p.Email != nil {
+			head := *p.Email
+			req.Header.Set("Gram-User-Email", head)
+		}
 		if p.SerialNumber != nil {
 			head := *p.SerialNumber
 			req.Header.Set("Gram-Device-Serial", head)
@@ -53,9 +57,6 @@ func EncodeGetPluginsRequest(encoder func(*http.Request) goahttp.Encoder) func(*
 			head := *p.Hostname
 			req.Header.Set("Gram-Device-Hostname", head)
 		}
-		values := req.URL.Query()
-		values.Add("email", p.Email)
-		req.URL.RawQuery = values.Encode()
 		return nil
 	}
 }

--- a/server/gen/http/agent/client/encode_decode.go
+++ b/server/gen/http/agent/client/encode_decode.go
@@ -57,6 +57,11 @@ func EncodeGetPluginsRequest(encoder func(*http.Request) goahttp.Encoder) func(*
 			head := *p.Hostname
 			req.Header.Set("Gram-Device-Hostname", head)
 		}
+		values := req.URL.Query()
+		if p.LegacyEmail != nil {
+			values.Add("email", *p.LegacyEmail)
+		}
+		req.URL.RawQuery = values.Encode()
 		return nil
 	}
 }

--- a/server/gen/http/agent/server/encode_decode.go
+++ b/server/gen/http/agent/server/encode_decode.go
@@ -37,11 +37,16 @@ func DecodeGetPluginsRequest(mux goahttp.Muxer, decoder func(*http.Request) goah
 	return func(r *http.Request) (*agent.GetPluginsPayload, error) {
 		var payload *agent.GetPluginsPayload
 		var (
+			legacyEmail  *string
 			apikeyToken  *string
 			email        *string
 			serialNumber *string
 			hostname     *string
 		)
+		legacyEmailRaw := r.URL.Query().Get("email")
+		if legacyEmailRaw != "" {
+			legacyEmail = &legacyEmailRaw
+		}
 		apikeyTokenRaw := r.Header.Get("Gram-Key")
 		if apikeyTokenRaw != "" {
 			apikeyToken = &apikeyTokenRaw
@@ -58,7 +63,7 @@ func DecodeGetPluginsRequest(mux goahttp.Muxer, decoder func(*http.Request) goah
 		if hostnameRaw != "" {
 			hostname = &hostnameRaw
 		}
-		payload = NewGetPluginsPayload(apikeyToken, email, serialNumber, hostname)
+		payload = NewGetPluginsPayload(legacyEmail, apikeyToken, email, serialNumber, hostname)
 		if payload.ApikeyToken != nil {
 			if strings.Contains(*payload.ApikeyToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/agent/server/encode_decode.go
+++ b/server/gen/http/agent/server/encode_decode.go
@@ -37,19 +37,18 @@ func DecodeGetPluginsRequest(mux goahttp.Muxer, decoder func(*http.Request) goah
 	return func(r *http.Request) (*agent.GetPluginsPayload, error) {
 		var payload *agent.GetPluginsPayload
 		var (
-			email        string
 			apikeyToken  *string
+			email        *string
 			serialNumber *string
 			hostname     *string
-			err          error
 		)
-		email = r.URL.Query().Get("email")
-		if email == "" {
-			err = goa.MergeErrors(err, goa.MissingFieldError("email", "query string"))
-		}
 		apikeyTokenRaw := r.Header.Get("Gram-Key")
 		if apikeyTokenRaw != "" {
 			apikeyToken = &apikeyTokenRaw
+		}
+		emailRaw := r.Header.Get("Gram-User-Email")
+		if emailRaw != "" {
+			email = &emailRaw
 		}
 		serialNumberRaw := r.Header.Get("Gram-Device-Serial")
 		if serialNumberRaw != "" {
@@ -59,10 +58,7 @@ func DecodeGetPluginsRequest(mux goahttp.Muxer, decoder func(*http.Request) goah
 		if hostnameRaw != "" {
 			hostname = &hostnameRaw
 		}
-		if err != nil {
-			return payload, err
-		}
-		payload = NewGetPluginsPayload(email, apikeyToken, serialNumber, hostname)
+		payload = NewGetPluginsPayload(apikeyToken, email, serialNumber, hostname)
 		if payload.ApikeyToken != nil {
 			if strings.Contains(*payload.ApikeyToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/agent/server/types.go
+++ b/server/gen/http/agent/server/types.go
@@ -2610,8 +2610,9 @@ func NewCreateSessionHandoffGatewayErrorResponseBody(res *goa.ServiceError) *Cre
 }
 
 // NewGetPluginsPayload builds a agent service getPlugins endpoint payload.
-func NewGetPluginsPayload(apikeyToken *string, email *string, serialNumber *string, hostname *string) *agent.GetPluginsPayload {
+func NewGetPluginsPayload(legacyEmail *string, apikeyToken *string, email *string, serialNumber *string, hostname *string) *agent.GetPluginsPayload {
 	v := &agent.GetPluginsPayload{}
+	v.LegacyEmail = legacyEmail
 	v.ApikeyToken = apikeyToken
 	v.Email = email
 	v.SerialNumber = serialNumber

--- a/server/gen/http/agent/server/types.go
+++ b/server/gen/http/agent/server/types.go
@@ -2610,10 +2610,10 @@ func NewCreateSessionHandoffGatewayErrorResponseBody(res *goa.ServiceError) *Cre
 }
 
 // NewGetPluginsPayload builds a agent service getPlugins endpoint payload.
-func NewGetPluginsPayload(email string, apikeyToken *string, serialNumber *string, hostname *string) *agent.GetPluginsPayload {
+func NewGetPluginsPayload(apikeyToken *string, email *string, serialNumber *string, hostname *string) *agent.GetPluginsPayload {
 	v := &agent.GetPluginsPayload{}
-	v.Email = email
 	v.ApikeyToken = apikeyToken
+	v.Email = email
 	v.SerialNumber = serialNumber
 	v.Hostname = hostname
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -181,7 +181,7 @@ func UsageExamples() string {
 		os.Args[0] + " " + "about openapi" + "\n" +
 		os.Args[0] + " " + "access list-roles --apikey-token \"abc123\" --session-token \"abc123\"" + "\n" +
 		os.Args[0] + " " + "admin login --return-to \"abc123\" --prompt \"abc123\"" + "\n" +
-		os.Args[0] + " " + "agent get-plugins --email \"dev@acme.corp\" --apikey-token \"abc123\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"" + "\n" +
+		os.Args[0] + " " + "agent get-plugins --apikey-token \"abc123\" --email \"dev@acme.corp\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"" + "\n" +
 		""
 }
 
@@ -414,8 +414,8 @@ func ParseEndpoint(
 		agentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
 
 		agentGetPluginsFlags            = flag.NewFlagSet("get-plugins", flag.ExitOnError)
-		agentGetPluginsEmailFlag        = agentGetPluginsFlags.String("email", "REQUIRED", "")
 		agentGetPluginsApikeyTokenFlag  = agentGetPluginsFlags.String("apikey-token", "", "")
+		agentGetPluginsEmailFlag        = agentGetPluginsFlags.String("email", "", "")
 		agentGetPluginsSerialNumberFlag = agentGetPluginsFlags.String("serial-number", "", "")
 		agentGetPluginsHostnameFlag     = agentGetPluginsFlags.String("hostname", "", "")
 
@@ -6691,7 +6691,7 @@ func ParseEndpoint(
 			switch epn {
 			case "get-plugins":
 				endpoint = c.GetPlugins()
-				data, err = agentc.BuildGetPluginsPayload(*agentGetPluginsEmailFlag, *agentGetPluginsApikeyTokenFlag, *agentGetPluginsSerialNumberFlag, *agentGetPluginsHostnameFlag)
+				data, err = agentc.BuildGetPluginsPayload(*agentGetPluginsApikeyTokenFlag, *agentGetPluginsEmailFlag, *agentGetPluginsSerialNumberFlag, *agentGetPluginsHostnameFlag)
 			case "list-synced-users":
 				endpoint = c.ListSyncedUsers()
 				data, err = agentc.BuildListSyncedUsersPayload(*agentListSyncedUsersSessionTokenFlag)
@@ -9660,8 +9660,8 @@ func agentUsage() {
 func agentGetPluginsUsage() {
 	// Header with flags
 	fmt.Fprintf(os.Stderr, "%s [flags] agent get-plugins", os.Args[0])
-	fmt.Fprint(os.Stderr, " -email STRING")
 	fmt.Fprint(os.Stderr, " -apikey-token STRING")
+	fmt.Fprint(os.Stderr, " -email STRING")
 	fmt.Fprint(os.Stderr, " -serial-number STRING")
 	fmt.Fprint(os.Stderr, " -hostname STRING")
 	fmt.Fprintln(os.Stderr)
@@ -9671,14 +9671,14 @@ func agentGetPluginsUsage() {
 	fmt.Fprintln(os.Stderr, `Resolve the marketplaces, plugins, and optional organization configuration assigned to the enrolled user. The device agent reconciles these into the AI developer tools it manages. Organization configuration is delivered on this existing poll so agents do not need a second control-plane request.`)
 
 	// Flags list
-	fmt.Fprintln(os.Stderr, `    -email STRING: `)
 	fmt.Fprintln(os.Stderr, `    -apikey-token STRING: `)
+	fmt.Fprintln(os.Stderr, `    -email STRING: `)
 	fmt.Fprintln(os.Stderr, `    -serial-number STRING: `)
 	fmt.Fprintln(os.Stderr, `    -hostname STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agent get-plugins --email \"dev@acme.corp\" --apikey-token \"abc123\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agent get-plugins --apikey-token \"abc123\" --email \"dev@acme.corp\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"")
 }
 
 func agentListSyncedUsersUsage() {

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -181,7 +181,7 @@ func UsageExamples() string {
 		os.Args[0] + " " + "about openapi" + "\n" +
 		os.Args[0] + " " + "access list-roles --apikey-token \"abc123\" --session-token \"abc123\"" + "\n" +
 		os.Args[0] + " " + "admin login --return-to \"abc123\" --prompt \"abc123\"" + "\n" +
-		os.Args[0] + " " + "agent get-plugins --apikey-token \"abc123\" --email \"dev@acme.corp\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"" + "\n" +
+		os.Args[0] + " " + "agent get-plugins --legacy-email \"dev@acme.corp\" --apikey-token \"abc123\" --email \"dev@acme.corp\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"" + "\n" +
 		""
 }
 
@@ -414,6 +414,7 @@ func ParseEndpoint(
 		agentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
 
 		agentGetPluginsFlags            = flag.NewFlagSet("get-plugins", flag.ExitOnError)
+		agentGetPluginsLegacyEmailFlag  = agentGetPluginsFlags.String("legacy-email", "", "")
 		agentGetPluginsApikeyTokenFlag  = agentGetPluginsFlags.String("apikey-token", "", "")
 		agentGetPluginsEmailFlag        = agentGetPluginsFlags.String("email", "", "")
 		agentGetPluginsSerialNumberFlag = agentGetPluginsFlags.String("serial-number", "", "")
@@ -6691,7 +6692,7 @@ func ParseEndpoint(
 			switch epn {
 			case "get-plugins":
 				endpoint = c.GetPlugins()
-				data, err = agentc.BuildGetPluginsPayload(*agentGetPluginsApikeyTokenFlag, *agentGetPluginsEmailFlag, *agentGetPluginsSerialNumberFlag, *agentGetPluginsHostnameFlag)
+				data, err = agentc.BuildGetPluginsPayload(*agentGetPluginsLegacyEmailFlag, *agentGetPluginsApikeyTokenFlag, *agentGetPluginsEmailFlag, *agentGetPluginsSerialNumberFlag, *agentGetPluginsHostnameFlag)
 			case "list-synced-users":
 				endpoint = c.ListSyncedUsers()
 				data, err = agentc.BuildListSyncedUsersPayload(*agentListSyncedUsersSessionTokenFlag)
@@ -9660,6 +9661,7 @@ func agentUsage() {
 func agentGetPluginsUsage() {
 	// Header with flags
 	fmt.Fprintf(os.Stderr, "%s [flags] agent get-plugins", os.Args[0])
+	fmt.Fprint(os.Stderr, " -legacy-email STRING")
 	fmt.Fprint(os.Stderr, " -apikey-token STRING")
 	fmt.Fprint(os.Stderr, " -email STRING")
 	fmt.Fprint(os.Stderr, " -serial-number STRING")
@@ -9671,6 +9673,7 @@ func agentGetPluginsUsage() {
 	fmt.Fprintln(os.Stderr, `Resolve the marketplaces, plugins, and optional organization configuration assigned to the enrolled user. The device agent reconciles these into the AI developer tools it manages. Organization configuration is delivered on this existing poll so agents do not need a second control-plane request.`)
 
 	// Flags list
+	fmt.Fprintln(os.Stderr, `    -legacy-email STRING: `)
 	fmt.Fprintln(os.Stderr, `    -apikey-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -email STRING: `)
 	fmt.Fprintln(os.Stderr, `    -serial-number STRING: `)
@@ -9678,7 +9681,7 @@ func agentGetPluginsUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agent get-plugins --apikey-token \"abc123\" --email \"dev@acme.corp\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agent get-plugins --legacy-email \"dev@acme.corp\" --apikey-token \"abc123\" --email \"dev@acme.corp\" --serial-number \"C02XK1ABCDEF\" --hostname \"dev-macbook-pro\"")
 }
 
 func agentListSyncedUsersUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -6673,6 +6673,15 @@ paths:
             operationId: getAgentPlugins
             parameters:
                 - allowEmptyValue: true
+                  description: 'Deprecated: the vouched email as the `?email=` query parameter, sent by agents predating the Gram-User-Email header. Used only when the header is absent.'
+                  example: dev@acme.corp
+                  in: query
+                  name: email
+                  schema:
+                    description: 'Deprecated: the vouched email as the `?email=` query parameter, sent by agents predating the Gram-User-Email header. Used only when the header is absent.'
+                    example: dev@acme.corp
+                    type: string
+                - allowEmptyValue: true
                   description: API Key header
                   in: header
                   name: Gram-Key

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -6673,21 +6673,20 @@ paths:
             operationId: getAgentPlugins
             parameters:
                 - allowEmptyValue: true
-                  description: Email address of the enrolled user. Authoritative when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
-                  example: dev@acme.corp
-                  in: query
-                  name: email
-                  required: true
-                  schema:
-                    description: Email address of the enrolled user. Authoritative when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
-                    example: dev@acme.corp
-                    type: string
-                - allowEmptyValue: true
                   description: API Key header
                   in: header
                   name: Gram-Key
                   schema:
                     description: API Key header
+                    type: string
+                - allowEmptyValue: true
+                  description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+                  example: dev@acme.corp
+                  in: header
+                  name: Gram-User-Email
+                  schema:
+                    description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+                    example: dev@acme.corp
                     type: string
                 - allowEmptyValue: true
                   description: Hardware serial number of the machine the agent runs on, when it can be read. Lets device coverage attest this specific machine rather than its assigned user.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -6680,12 +6680,12 @@ paths:
                     description: API Key header
                     type: string
                 - allowEmptyValue: true
-                  description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+                  description: Email address of the enrolled user, sent in the Gram-User-Email header. Required when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
                   example: dev@acme.corp
                   in: header
                   name: Gram-User-Email
                   schema:
-                    description: Email address of the enrolled user, carried in the Gram-User-Email header. Authoritative — and required by the handler — when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user. Optional at the transport level so per-user-key agents need not send it.
+                    description: Email address of the enrolled user, sent in the Gram-User-Email header. Required when authenticating with an org-scoped agent install key (the MDM zero-touch path); ignored for a per-user key, whose owner is the enrolled user.
                     example: dev@acme.corp
                     type: string
                 - allowEmptyValue: true

--- a/server/internal/agent/configuration_test.go
+++ b/server/internal/agent/configuration_test.go
@@ -53,7 +53,7 @@ func TestUpdateConfigurationPersistsAndDeliversOnPluginPoll(t *testing.T) {
 	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, ti.orgID))
 	ctx = withPlatformAdmin(t, ctx)
 
-	beforePoll, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "developer@example.com"})
+	beforePoll, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("developer@example.com")})
 	require.NoError(t, err)
 	require.Nil(t, beforePoll.Configuration)
 
@@ -96,7 +96,7 @@ func TestUpdateConfigurationPersistsAndDeliversOnPluginPoll(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, updated, dashboardView)
 
-	afterPoll, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "developer@example.com"})
+	afterPoll, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("developer@example.com")})
 	require.NoError(t, err)
 	require.NotNil(t, afterPoll.Configuration)
 	require.Equal(t, updated, afterPoll.Configuration)

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -47,7 +47,7 @@ func TestGetPlugins_ObservabilityWithoutAssignments(t *testing.T) {
 
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 1)
@@ -71,7 +71,7 @@ func TestGetPlugins_ScopesToAssignedPrincipals(t *testing.T) {
 	other := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "someone-elses-tool")
 	assignPlugin(t, ctx, ti.conn, other, ti.orgID, "email:someone-else@example.com")
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 1)
@@ -92,7 +92,7 @@ func TestGetPlugins_DeliversEmailAndWildcardAssignments(t *testing.T) {
 	wildcardTool := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "wildcard-tool")
 	assignPlugin(t, ctx, ti.conn, wildcardTool, ti.orgID, "*")
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.ElementsMatch(t,
@@ -117,7 +117,7 @@ func TestGetPlugins_DeliversUserAndRoleAssignments(t *testing.T) {
 	roleURN := assignUserToRole(t, ctx, ti.conn, ti.orgID, mockidp.MockUserID, "engineering")
 	assignPlugin(t, ctx, ti.conn, roleTool, ti.orgID, roleURN)
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 	require.ElementsMatch(t,
 		[]string{wantObservability, "user-tool", "role-tool"},
@@ -126,7 +126,7 @@ func TestGetPlugins_DeliversUserAndRoleAssignments(t *testing.T) {
 
 	// A non-member email resolves to no user, so it gets neither the user- nor
 	// role-scoped plugin — only observability.
-	nonMember, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "stranger@example.com"})
+	nonMember, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("stranger@example.com")})
 	require.NoError(t, err)
 	require.Equal(t, []string{wantObservability}, pluginSlugs(nonMember),
 		"user:/role: assignments are withheld from non-members")
@@ -143,7 +143,7 @@ func TestGetPlugins_DeliversDirectoryGroupAssignmentsToUnlinkedUsers(t *testing.
 	plugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "directory-group-tool")
 	assignPlugin(t, ctx, ti.conn, plugin, ti.orgID, plugins.DirectoryGroupPrincipal(group))
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "unlinked@example.com"})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("unlinked@example.com")})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{wantObservability, "directory-group-tool"}, pluginSlugs(res))
 }
@@ -169,7 +169,7 @@ func TestGetPlugins_DeliversDirectoryAttributeAssignments(t *testing.T) {
 	managerPlugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "manager-tool")
 	assignPlugin(t, ctx, ti.conn, managerPlugin, ti.orgID, plugins.DirectoryAttributePrincipal("manager.email", "lead@example.com"))
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(email)})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{wantObservability, "department-tool", "manager-tool"}, pluginSlugs(res))
 }
@@ -198,7 +198,7 @@ func TestGetPlugins_RefreshesDirectoryGroupMembership(t *testing.T) {
 		assignPlugin(t, ctx, ti.conn, plugin, ti.orgID, plugins.DirectoryGroupPrincipal(assignment.group))
 	}
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(email)})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{wantObservability, "alpha-tool", "beta-tool", "gamma-tool"}, pluginSlugs(res))
 
@@ -207,7 +207,7 @@ func TestGetPlugins_RefreshesDirectoryGroupMembership(t *testing.T) {
 		DirectoryGroupID: alpha,
 	})
 	require.NoError(t, err)
-	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(email)})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{wantObservability, "beta-tool", "gamma-tool"}, pluginSlugs(res))
 
@@ -217,7 +217,7 @@ func TestGetPlugins_RefreshesDirectoryGroupMembership(t *testing.T) {
 		WorkosLastEventID:      conv.ToPGText("event-group-beta-deleted"),
 	})
 	require.NoError(t, err)
-	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(email)})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{wantObservability, "gamma-tool"}, pluginSlugs(res))
 
@@ -227,7 +227,7 @@ func TestGetPlugins_RefreshesDirectoryGroupMembership(t *testing.T) {
 		WorkosLastEventID:     conv.ToPGText("event-user-gamma-deleted"),
 	})
 	require.NoError(t, err)
-	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: email})
+	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(email)})
 	require.NoError(t, err)
 	require.Equal(t, []string{wantObservability}, pluginSlugs(res))
 }
@@ -244,7 +244,7 @@ func TestGetPlugins_DirectoryGroupsAreOrganizationScoped(t *testing.T) {
 	plugin := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "other-org-group-tool")
 	assignPlugin(t, ctx, ti.conn, plugin, ti.orgID, plugins.DirectoryGroupPrincipal(group))
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "directory-user@example.com"})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("directory-user@example.com")})
 	require.NoError(t, err)
 	require.Equal(t, []string{wantObservability}, pluginSlugs(res))
 }
@@ -257,7 +257,7 @@ func TestGetPlugins_UnpublishedProjectExcluded(t *testing.T) {
 	// nothing is installable and the endpoint returns empty.
 	seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "unpublished-tool")
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Empty(t, res.Marketplaces)
@@ -284,7 +284,7 @@ func TestGetPlugins_MultiProjectDistinctByDefault(t *testing.T) {
 	assignPlugin(t, ctx, ti.conn, betaTool, ti.orgID, "*")
 	wantBeta := naming.MarketplaceName(mockidp.MockOrgName, "beta", false) // local-dev-org-beta-speakeasy
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 2, "distinct project-scoped names do not collapse")
@@ -319,7 +319,7 @@ func TestGetPlugins_CollidingNamesPreferDefault(t *testing.T) {
 	betaTool := seedPlugin(t, ctx, ti.conn, ti.orgID, beta, "beta-only-tool")
 	assignPlugin(t, ctx, ti.conn, betaTool, ti.orgID, "*")
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 1, "colliding names collapse to one")
@@ -352,7 +352,7 @@ func TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces(t *testing.T) {
 	betaTool := seedPlugin(t, ctx, ti.conn, ti.orgID, beta, "beta-tool")
 	assignPlugin(t, ctx, ti.conn, betaTool, ti.orgID, "*")
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 2, "distinct names must not collapse")
@@ -383,7 +383,7 @@ func TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden(t *testing.T) {
 	publishMarketplace(t, ctx, ti.conn, beta, "beta-token")
 	wantBeta := naming.MarketplaceName(mockidp.MockOrgName, "beta", false)
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 1, "only the default project surfaces")
@@ -406,7 +406,7 @@ func TestGetPlugins_CrossOrgIsolation(t *testing.T) {
 	// A different org has a published marketplace + a wildcard-assigned plugin.
 	seedSecondOrg(t, ctx, ti.conn)
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 1, "only the caller's org marketplace")
@@ -444,7 +444,7 @@ func TestGetPlugins_IgnoresMismatchedOrgAssignment(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 	require.Equal(t, []string{wantObservability}, pluginSlugs(res),
 		"an assignment row stamped with a different org must not deliver the plugin")
@@ -454,15 +454,19 @@ func TestGetPlugins_InvalidEmail(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)
 
-	// The default context is an org install key, so the vouched email is
-	// authoritative and an empty one is rejected.
-	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: ""})
-	require.Error(t, err, "empty email must be rejected")
+	// The default context is an org install key, so the vouched email
+	// (Gram-User-Email header) is authoritative and a missing or empty one is
+	// rejected.
+	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: nil})
+	require.Error(t, err, "absent email header must be rejected")
+
+	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("")})
+	require.Error(t, err, "empty email header must be rejected")
 }
 
 // TestGetPlugins_PerUserKeyBindsToOwner pins the DNO-383 scope-aware attribution:
 // a per-user `agent_user` key resolves the polling identity from the
-// authenticated key owner, so a vouched `email` param is ignored — a leaked
+// authenticated key owner, so a vouched email header is ignored — a leaked
 // per-user key cannot claim another member's plugins.
 func TestGetPlugins_PerUserKeyBindsToOwner(t *testing.T) {
 	t.Parallel()
@@ -472,7 +476,7 @@ func TestGetPlugins_PerUserKeyBindsToOwner(t *testing.T) {
 
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
 
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "someone-else@example.com"})
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("someone-else@example.com")})
 	require.NoError(t, err, "per-user key ignores the vouched email and uses its owner")
 	require.Len(t, res.Marketplaces, 1)
 }
@@ -486,7 +490,7 @@ func TestGetPlugins_RecordsDeviceSync(t *testing.T) {
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
 
 	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-		Email:        mockidp.MockUserEmail,
+		Email:        new(mockidp.MockUserEmail),
 		SerialNumber: new("C02XK1ABCDEF"),
 		Hostname:     new("dev-macbook-pro"),
 	})
@@ -512,7 +516,7 @@ func TestGetPlugins_DeviceSyncSkippedWithoutSerial(t *testing.T) {
 
 	for _, serial := range []*string{nil, new(""), new("   ")} {
 		_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-			Email:        mockidp.MockUserEmail,
+			Email:        new(mockidp.MockUserEmail),
 			SerialNumber: serial,
 			Hostname:     nil,
 		})
@@ -541,7 +545,7 @@ func TestGetPlugins_DeviceSyncReassignmentBeatsThrottle(t *testing.T) {
 
 	const serial = "C02XK1ABCDEF"
 	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-		Email:        mockidp.MockUserEmail,
+		Email:        new(mockidp.MockUserEmail),
 		SerialNumber: ptr(serial),
 		Hostname:     new("old-name"),
 	})
@@ -554,7 +558,7 @@ func TestGetPlugins_DeviceSyncReassignmentBeatsThrottle(t *testing.T) {
 
 	// Same machine, same user, immediately: the heartbeat throttle holds.
 	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-		Email:        mockidp.MockUserEmail,
+		Email:        new(mockidp.MockUserEmail),
 		SerialNumber: ptr(serial),
 		Hostname:     new("old-name"),
 	})
@@ -567,7 +571,7 @@ func TestGetPlugins_DeviceSyncReassignmentBeatsThrottle(t *testing.T) {
 
 	// A rename inside the same window must land despite the throttle.
 	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-		Email:        mockidp.MockUserEmail,
+		Email:        new(mockidp.MockUserEmail),
 		SerialNumber: ptr(serial),
 		Hostname:     new("new-name"),
 	})
@@ -580,7 +584,7 @@ func TestGetPlugins_DeviceSyncReassignmentBeatsThrottle(t *testing.T) {
 
 	// Dropping the hostname must not blank a known one.
 	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-		Email:        mockidp.MockUserEmail,
+		Email:        new(mockidp.MockUserEmail),
 		SerialNumber: ptr(serial),
 		Hostname:     nil,
 	})
@@ -603,7 +607,7 @@ func TestGetPlugins_DeviceSyncNormalizesSerialCase(t *testing.T) {
 
 	for _, reported := range []string{"C02XK1ABCDEF", "c02xk1abcdef", "  C02xk1AbCdEf  "} {
 		_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-			Email:        mockidp.MockUserEmail,
+			Email:        new(mockidp.MockUserEmail),
 			SerialNumber: new(reported),
 			Hostname:     nil,
 		})
@@ -635,7 +639,7 @@ func TestGetPlugins_DeviceSyncRejectsPlaceholderSerials(t *testing.T) {
 		"N/A",
 	} {
 		_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
-			Email:        mockidp.MockUserEmail,
+			Email:        new(mockidp.MockUserEmail),
 			SerialNumber: new(placeholder),
 			Hostname:     nil,
 		})

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -463,6 +463,33 @@ func TestGetPlugins_InvalidEmail(t *testing.T) {
 	require.Error(t, err, "empty email header must be rejected")
 }
 
+// TestGetPlugins_LegacyEmailParamFallback pins the compatibility contract for
+// deployed org-key agents that predate the Gram-User-Email header: the
+// deprecated ?email= query param still vouches, and the header wins when both
+// are present.
+func TestGetPlugins_LegacyEmailParamFallback(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
+	headerTool := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "header-tool")
+	assignPlugin(t, ctx, ti.conn, headerTool, ti.orgID, "email:header@example.com")
+	legacyTool := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "legacy-tool")
+	assignPlugin(t, ctx, ti.conn, legacyTool, ti.orgID, "email:legacy@example.com")
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{LegacyEmail: new("legacy@example.com")})
+	require.NoError(t, err, "param-only vouching must keep working for deployed agents")
+	require.Contains(t, pluginSlugs(res), "legacy-tool")
+
+	res, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{
+		Email:       new("header@example.com"),
+		LegacyEmail: new("legacy@example.com"),
+	})
+	require.NoError(t, err)
+	require.Contains(t, pluginSlugs(res), "header-tool")
+	require.NotContains(t, pluginSlugs(res), "legacy-tool", "the header must win over the deprecated param")
+}
+
 // TestGetPlugins_PerUserKeyBindsToOwner pins the DNO-383 scope-aware attribution:
 // a per-user `agent_user` key resolves the polling identity from the
 // authenticated key owner, so a vouched email header is ignored — a leaked

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -454,9 +454,8 @@ func TestGetPlugins_InvalidEmail(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)
 
-	// The default context is an org install key, so the vouched email
-	// (Gram-User-Email header) is authoritative and a missing or empty one is
-	// rejected.
+	// The default context is an org install key, so the vouched email is
+	// authoritative and a missing or empty one is rejected.
 	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: nil})
 	require.Error(t, err, "absent email header must be rejected")
 

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -120,14 +120,13 @@ func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.A
 // the key belongs to differs:
 //   - Per-user key (`agent_user`): the key owner IS the enrolled developer
 //     (minted by token-exchange or manual enrollment), so the polling identity
-//     is the authenticated key owner (authCtx.Email) and the vouched email
-//     (Gram-User-Email header) is ignored. Delivery is bound to the
-//     authenticated principal.
+//     is the authenticated key owner (authCtx.Email) and the vouched email is
+//     ignored. Delivery is bound to the authenticated principal.
 //   - Org install key (`agent` scope): the key owner is whoever minted the org
 //     token in the dashboard (an admin), NOT the developer. The polling identity
 //     is the vouched email the MDM profile supplies in the Gram-User-Email
-//     header (DNO-935) — required here. This is the zero-touch MDM path where
-//     the developer never signs in.
+//     header — required here. This is the zero-touch MDM path where the
+//     developer never signs in.
 //
 // SECURITY: a per-user `agent_user` key's polling identity is the authenticated
 // key owner, so it cannot claim another member's user-/role-scoped plugins. An
@@ -193,9 +192,7 @@ func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload
 	var email string
 	if isInstallKey {
 		// Org key: the owner is an admin, not the developer, so we must be vouched
-		// an email — the MDM profile supplies it via the Gram-User-Email header
-		// (DNO-935; formerly the `?email=` query param, which legacy agents still
-		// send and the decoder now ignores).
+		// an email — the MDM profile supplies it via the Gram-User-Email header.
 		email = conv.NormalizeEmail(conv.PtrValOr(payload.Email, ""))
 		if email == "" {
 			return nil, oops.E(oops.CodeBadRequest, nil, "the Gram-User-Email header is required when authenticating with an org-scoped agent install key")

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -200,7 +200,7 @@ func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload
 		}
 		email = conv.NormalizeEmail(vouched)
 		if email == "" {
-			return nil, oops.E(oops.CodeBadRequest, nil, "the Gram-User-Email header is required when authenticating with an org-scoped agent install key")
+			return nil, oops.E(oops.CodeBadRequest, nil, "a vouched email is required when authenticating with an org-scoped agent install key; send it in the Gram-User-Email header")
 		}
 	} else if authCtx.Email != nil {
 		// Per-user key: the owner is the enrolled developer, bound to the token.

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -120,12 +120,14 @@ func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.A
 // the key belongs to differs:
 //   - Per-user key (`agent_user`): the key owner IS the enrolled developer
 //     (minted by token-exchange or manual enrollment), so the polling identity
-//     is the authenticated key owner (authCtx.Email) and the vouched `email`
-//     param is ignored. Delivery is bound to the authenticated principal.
+//     is the authenticated key owner (authCtx.Email) and the vouched email
+//     (Gram-User-Email header) is ignored. Delivery is bound to the
+//     authenticated principal.
 //   - Org install key (`agent` scope): the key owner is whoever minted the org
 //     token in the dashboard (an admin), NOT the developer. The polling identity
-//     is the vouched `email` param the MDM profile supplies — required here.
-//     This is the zero-touch MDM path where the developer never signs in.
+//     is the vouched email the MDM profile supplies in the Gram-User-Email
+//     header (DNO-935) — required here. This is the zero-touch MDM path where
+//     the developer never signs in.
 //
 // SECURITY: a per-user `agent_user` key's polling identity is the authenticated
 // key owner, so it cannot claim another member's user-/role-scoped plugins. An
@@ -191,10 +193,12 @@ func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload
 	var email string
 	if isInstallKey {
 		// Org key: the owner is an admin, not the developer, so we must be vouched
-		// an email — the MDM profile supplies it.
-		email = conv.NormalizeEmail(payload.Email)
+		// an email — the MDM profile supplies it via the Gram-User-Email header
+		// (DNO-935; formerly the `?email=` query param, which legacy agents still
+		// send and the decoder now ignores).
+		email = conv.NormalizeEmail(conv.PtrValOr(payload.Email, ""))
 		if email == "" {
-			return nil, oops.E(oops.CodeBadRequest, nil, "email is required when authenticating with an org-scoped agent install key")
+			return nil, oops.E(oops.CodeBadRequest, nil, "the Gram-User-Email header is required when authenticating with an org-scoped agent install key")
 		}
 	} else if authCtx.Email != nil {
 		// Per-user key: the owner is the enrolled developer, bound to the token.

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -192,8 +192,13 @@ func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload
 	var email string
 	if isInstallKey {
 		// Org key: the owner is an admin, not the developer, so we must be vouched
-		// an email — the MDM profile supplies it via the Gram-User-Email header.
-		email = conv.NormalizeEmail(conv.PtrValOr(payload.Email, ""))
+		// an email — the MDM profile supplies it via the Gram-User-Email header,
+		// or the deprecated `?email=` param on agents predating it.
+		vouched := conv.PtrValOr(payload.Email, "")
+		if vouched == "" {
+			vouched = conv.PtrValOr(payload.LegacyEmail, "")
+		}
+		email = conv.NormalizeEmail(vouched)
 		if email == "" {
 			return nil, oops.E(oops.CodeBadRequest, nil, "the Gram-User-Email header is required when authenticating with an org-scoped agent install key")
 		}

--- a/server/internal/agent/syncedusers_test.go
+++ b/server/internal/agent/syncedusers_test.go
@@ -43,7 +43,7 @@ func TestGetPlugins_RecordsSync(t *testing.T) {
 
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
 
-	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	rows, err := agentrepo.New(ti.conn).ListDeviceAgentSyncs(ctx, ti.orgID)
@@ -53,7 +53,7 @@ func TestGetPlugins_RecordsSync(t *testing.T) {
 	firstSeen := rows[0].LastSeenAt.Time
 
 	// A second poll within the guard window leaves last_seen_at untouched.
-	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new(mockidp.MockUserEmail)})
 	require.NoError(t, err)
 
 	rows, err = agentrepo.New(ti.conn).ListDeviceAgentSyncs(ctx, ti.orgID)
@@ -72,9 +72,9 @@ func TestListSyncedUsers_AllowsOrgAdmin(t *testing.T) {
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
 
 	// Two distinct users poll; the second poll is later, so it sorts first.
-	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "early@acme.corp"})
+	_, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("early@acme.corp")})
 	require.NoError(t, err)
-	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: "later@acme.corp"})
+	_, err = ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("later@acme.corp")})
 	require.NoError(t, err)
 
 	adminCtx := withOrgAdmin(t, ctx)

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -89,9 +89,7 @@ var redactedQueryParams = map[string]bool{
 	"token": true,
 
 	// Email address on auth.login, and on agent.getPlugins polls from legacy
-	// device agents — the agent moved it to the Gram-User-Email header
-	// (DNO-935), but already-deployed agents keep appending `?email=` to the
-	// URL, so it must stay redacted.
+	// agents that still append `?email=` (current agents send a header).
 	"email": true,
 
 	// Chat search terms, which are user-typed free text.

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -88,7 +88,10 @@ var redactedQueryParams = map[string]bool{
 	// Live capability token on public share and signed-asset URLs.
 	"token": true,
 
-	// Email address on auth.login and agent.getPlugins.
+	// Email address on auth.login, and on agent.getPlugins polls from legacy
+	// device agents — the agent moved it to the Gram-User-Email header
+	// (DNO-935), but already-deployed agents keep appending `?email=` to the
+	// URL, so it must stay redacted.
 	"email": true,
 
 	// Chat search terms, which are user-typed free text.


### PR DESCRIPTION
## What

`GET /rpc/agent.getPlugins` carried the enrolled user's email as a `?email=` query parameter. URLs land in every surface that records them — proxy/LB access logs, OTel http attributes, error strings — even though our own request logger redacts the param. This moves the email into a `Gram-User-Email` request header, following the existing `Gram-Device-Serial` / `Gram-Device-Hostname` precedent (headers are never logged). Fixes DNO-935.

## How

- **Design** (`server/design/agent/design.go`): the `email` attribute moves from `Param("email")` to `Header("email:Gram-User-Email")` and is no longer `Required`. A deprecated `legacy_email` attribute keeps binding the `?email=` query param.
- **Handler** (`server/internal/agent/impl.go`): unchanged semantics. A per-user (`agent_user`) key never needed the field — the polling identity is the key owner. The org-install-key (MDM zero-touch) path still requires a vouched email: header preferred, deprecated query param as fallback; missing both still 400s.
- **Why the fallback**: deployed org-key agents predate the header, and devices with auto-update off can stay on those builds indefinitely — dropping the param outright would 400 their polls until each machine updates. Remove `legacy_email` in a follow-up once org-key polls no longer carry it. The `email` entry stays in the logging middleware's `redactedQueryParams` so those URLs keep being scrubbed.
- Regenerated Goa server/client/OpenAPI output and the dashboard TS SDK (mechanical churn; no dashboard call site passes `email`).

## Rollout

Deploy before the device-agent release that sends the header (companion PR in the device-agent repo) — a header-only agent against the current server fails the decoder's `Required("email")` check. The reverse direction is safe in perpetuity: old agents keep vouching via the deprecated param.

## Testing

- `mise run test:server ./internal/agent/... ./internal/middleware/...` — 162 tests pass, including new `TestGetPlugins_InvalidEmail` cases (absent vs. empty header) and `TestGetPlugins_LegacyEmailParamFallback` (param-only vouching works; header wins when both are present).
- `mise run lint:server`, dashboard `type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
