### PR TITLE
feat: expose suppressed_* fields on risk results

### DIFF
--- a/.changeset/suppressed-risk-result-fields.md
+++ b/.changeset/suppressed-risk-result-fields.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Risk results now carry converged suppression fields: `suppressed_at`, `suppressed_reason` (`rule` | `manual` | `automated`), `suppressed_detail`, and `exclusion_id`. The dismissed-findings listing populates them for every row; `false_positive_at` remains as a deprecated mirror of `suppressed_at` while clients migrate.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -72993,9 +72993,13 @@ components:
           type: integer
           description: End byte position within the message content.
           format: int64
+        exclusion_id:
+          type: string
+          description: The exclusion rule that suppressed this result. Only set when suppressed_reason is 'rule'.
+          format: uuid
         false_positive_at:
           type: string
-          description: When this result was manually marked as a false positive. Null when not dismissed.
+          description: 'Deprecated: mirror of suppressed_at, kept while clients migrate to the suppressed_* fields. Null when not suppressed.'
           format: date-time
         id:
           type: string
@@ -73030,6 +73034,20 @@ components:
           type: integer
           description: Start byte position within the message content.
           format: int64
+        suppressed_at:
+          type: string
+          description: When this result was suppressed (hidden from open-finding listings). Null when not suppressed.
+          format: date-time
+        suppressed_detail:
+          type: string
+          description: 'Free-form suppression context: the user-supplied dismissal reason for manual suppressions, the catalog reason for automated ones. Null when absent.'
+        suppressed_reason:
+          type: string
+          description: 'Why the result is suppressed: ''rule'' (an exclusion rule, see exclusion_id), ''manual'' (dismissed by a user), or ''automated'' (the automated false-positive sweep). Null when not suppressed.'
+          enum:
+            - rule
+            - manual
+            - automated
         tags:
           type: array
           items:

--- a/client/dashboard/src/sdk/src/models/components/riskresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/riskresult.ts
@@ -5,9 +5,23 @@
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
 import { safeParse } from "../../lib/schemas.js";
+import { ClosedEnum } from "../../types/enums.js";
 import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 import { RiskSpan, RiskSpan$inboundSchema } from "./riskspan.js";
+
+/**
+ * Why the result is suppressed: 'rule' (an exclusion rule, see exclusion_id), 'manual' (dismissed by a user), or 'automated' (the automated false-positive sweep). Null when not suppressed.
+ */
+export const SuppressedReason = {
+  Rule: "rule",
+  Manual: "manual",
+  Automated: "automated",
+} as const;
+/**
+ * Why the result is suppressed: 'rule' (an exclusion rule, see exclusion_id), 'manual' (dismissed by a user), or 'automated' (the automated false-positive sweep). Null when not suppressed.
+ */
+export type SuppressedReason = ClosedEnum<typeof SuppressedReason>;
 
 export type RiskResult = {
   /**
@@ -47,7 +61,11 @@ export type RiskResult = {
    */
   endPos?: number | undefined;
   /**
-   * When this result was manually marked as a false positive. Null when not dismissed.
+   * The exclusion rule that suppressed this result. Only set when suppressed_reason is 'rule'.
+   */
+  exclusionId?: string | undefined;
+  /**
+   * Deprecated: mirror of suppressed_at, kept while clients migrate to the suppressed_* fields. Null when not suppressed.
    */
   falsePositiveAt?: Date | undefined;
   /**
@@ -87,6 +105,18 @@ export type RiskResult = {
    */
   startPos?: number | undefined;
   /**
+   * When this result was suppressed (hidden from open-finding listings). Null when not suppressed.
+   */
+  suppressedAt?: Date | undefined;
+  /**
+   * Free-form suppression context: the user-supplied dismissal reason for manual suppressions, the catalog reason for automated ones. Null when absent.
+   */
+  suppressedDetail?: string | undefined;
+  /**
+   * Why the result is suppressed: 'rule' (an exclusion rule, see exclusion_id), 'manual' (dismissed by a user), or 'automated' (the automated false-positive sweep). Null when not suppressed.
+   */
+  suppressedReason?: SuppressedReason | undefined;
+  /**
    * Tags from the detection rule.
    */
   tags?: Array<string> | undefined;
@@ -95,6 +125,11 @@ export type RiskResult = {
    */
   userId?: string | undefined;
 };
+
+/** @internal */
+export const SuppressedReason$inboundSchema: z.ZodMiniEnum<
+  typeof SuppressedReason
+> = z.enum(SuppressedReason);
 
 /** @internal */
 export const RiskResult$inboundSchema: z.ZodMiniType<RiskResult, unknown> = z
@@ -112,6 +147,7 @@ export const RiskResult$inboundSchema: z.ZodMiniType<RiskResult, unknown> = z
       ),
       description: z.optional(z.string()),
       end_pos: z.optional(z.int()),
+      exclusion_id: z.optional(z.string()),
       false_positive_at: z.optional(
         z.pipe(z.iso.datetime({ offset: true }), z.transform(v => new Date(v))),
       ),
@@ -124,6 +160,11 @@ export const RiskResult$inboundSchema: z.ZodMiniType<RiskResult, unknown> = z
       source: z.string(),
       spans: z.optional(z.array(RiskSpan$inboundSchema)),
       start_pos: z.optional(z.int()),
+      suppressed_at: z.optional(
+        z.pipe(z.iso.datetime({ offset: true }), z.transform(v => new Date(v))),
+      ),
+      suppressed_detail: z.optional(z.string()),
+      suppressed_reason: z.optional(SuppressedReason$inboundSchema),
       tags: z.optional(z.array(z.string())),
       user_id: z.optional(z.string()),
     }),
@@ -136,12 +177,16 @@ export const RiskResult$inboundSchema: z.ZodMiniType<RiskResult, unknown> = z
         "chat_title": "chatTitle",
         "created_at": "createdAt",
         "end_pos": "endPos",
+        "exclusion_id": "exclusionId",
         "false_positive_at": "falsePositiveAt",
         "match_redacted": "matchRedacted",
         "policy_id": "policyId",
         "policy_version": "policyVersion",
         "rule_id": "ruleId",
         "start_pos": "startPos",
+        "suppressed_at": "suppressedAt",
+        "suppressed_detail": "suppressedDetail",
+        "suppressed_reason": "suppressedReason",
         "user_id": "userId",
       });
     }),

--- a/server/design/shared/risk.go
+++ b/server/design/shared/risk.go
@@ -286,8 +286,18 @@ var RiskResult = Type("RiskResult", func() {
 	Attribute("created_at", String, "When this result was created.", func() {
 		Format(FormatDateTime)
 	})
-	Attribute("false_positive_at", String, "When this result was manually marked as a false positive. Null when not dismissed.", func() {
+	Attribute("false_positive_at", String, "Deprecated: mirror of suppressed_at, kept while clients migrate to the suppressed_* fields. Null when not suppressed.", func() {
 		Format(FormatDateTime)
+	})
+	Attribute("suppressed_at", String, "When this result was suppressed (hidden from open-finding listings). Null when not suppressed.", func() {
+		Format(FormatDateTime)
+	})
+	Attribute("suppressed_reason", String, "Why the result is suppressed: 'rule' (an exclusion rule, see exclusion_id), 'manual' (dismissed by a user), or 'automated' (the automated false-positive sweep). Null when not suppressed.", func() {
+		Enum("rule", "manual", "automated")
+	})
+	Attribute("suppressed_detail", String, "Free-form suppression context: the user-supplied dismissal reason for manual suppressions, the catalog reason for automated ones. Null when absent.")
+	Attribute("exclusion_id", String, "The exclusion rule that suppressed this result. Only set when suppressed_reason is 'rule'.", func() {
+		Format(FormatUUID)
 	})
 
 	Required("id", "policy_id", "policy_version", "source", "created_at")

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -74155,9 +74155,13 @@ components:
                     type: integer
                     description: End byte position within the message content.
                     format: int64
+                exclusion_id:
+                    type: string
+                    description: The exclusion rule that suppressed this result. Only set when suppressed_reason is 'rule'.
+                    format: uuid
                 false_positive_at:
                     type: string
-                    description: When this result was manually marked as a false positive. Null when not dismissed.
+                    description: 'Deprecated: mirror of suppressed_at, kept while clients migrate to the suppressed_* fields. Null when not suppressed.'
                     format: date-time
                 id:
                     type: string
@@ -74192,6 +74196,20 @@ components:
                     type: integer
                     description: Start byte position within the message content.
                     format: int64
+                suppressed_at:
+                    type: string
+                    description: When this result was suppressed (hidden from open-finding listings). Null when not suppressed.
+                    format: date-time
+                suppressed_detail:
+                    type: string
+                    description: 'Free-form suppression context: the user-supplied dismissal reason for manual suppressions, the catalog reason for automated ones. Null when absent.'
+                suppressed_reason:
+                    type: string
+                    description: 'Why the result is suppressed: ''rule'' (an exclusion rule, see exclusion_id), ''manual'' (dismissed by a user), or ''automated'' (the automated false-positive sweep). Null when not suppressed.'
+                    enum:
+                        - rule
+                        - manual
+                        - automated
                 tags:
                     type: array
                     items:

--- a/server/gen/http/risk/client/encode_decode.go
+++ b/server/gen/http/risk/client/encode_decode.go
@@ -11605,6 +11605,10 @@ func unmarshalRiskResultResponseBodyToTypesRiskResult(v *RiskResultResponseBody)
 		MatchRedacted:     v.MatchRedacted,
 		CreatedAt:         *v.CreatedAt,
 		FalsePositiveAt:   v.FalsePositiveAt,
+		SuppressedAt:      v.SuppressedAt,
+		SuppressedReason:  v.SuppressedReason,
+		SuppressedDetail:  v.SuppressedDetail,
+		ExclusionID:       v.ExclusionID,
 	}
 	if v.Tags != nil {
 		res.Tags = make([]string, len(v.Tags))

--- a/server/gen/http/risk/client/types.go
+++ b/server/gen/http/risk/client/types.go
@@ -10322,9 +10322,22 @@ type RiskResultResponseBody struct {
 	MatchRedacted *string `form:"match_redacted,omitempty" json:"match_redacted,omitempty" xml:"match_redacted,omitempty"`
 	// When this result was created.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
-	// When this result was manually marked as a false positive. Null when not
-	// dismissed.
+	// Deprecated: mirror of suppressed_at, kept while clients migrate to the
+	// suppressed_* fields. Null when not suppressed.
 	FalsePositiveAt *string `form:"false_positive_at,omitempty" json:"false_positive_at,omitempty" xml:"false_positive_at,omitempty"`
+	// When this result was suppressed (hidden from open-finding listings). Null
+	// when not suppressed.
+	SuppressedAt *string `form:"suppressed_at,omitempty" json:"suppressed_at,omitempty" xml:"suppressed_at,omitempty"`
+	// Why the result is suppressed: 'rule' (an exclusion rule, see exclusion_id),
+	// 'manual' (dismissed by a user), or 'automated' (the automated false-positive
+	// sweep). Null when not suppressed.
+	SuppressedReason *string `form:"suppressed_reason,omitempty" json:"suppressed_reason,omitempty" xml:"suppressed_reason,omitempty"`
+	// Free-form suppression context: the user-supplied dismissal reason for manual
+	// suppressions, the catalog reason for automated ones. Null when absent.
+	SuppressedDetail *string `form:"suppressed_detail,omitempty" json:"suppressed_detail,omitempty" xml:"suppressed_detail,omitempty"`
+	// The exclusion rule that suppressed this result. Only set when
+	// suppressed_reason is 'rule'.
+	ExclusionID *string `form:"exclusion_id,omitempty" json:"exclusion_id,omitempty" xml:"exclusion_id,omitempty"`
 }
 
 // RiskSpanResponseBody is used to define fields on response body types.
@@ -32278,6 +32291,17 @@ func ValidateRiskResultResponseBody(body *RiskResultResponseBody) (err error) {
 	}
 	if body.FalsePositiveAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.false_positive_at", *body.FalsePositiveAt, goa.FormatDateTime))
+	}
+	if body.SuppressedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.suppressed_at", *body.SuppressedAt, goa.FormatDateTime))
+	}
+	if body.SuppressedReason != nil {
+		if !(*body.SuppressedReason == "rule" || *body.SuppressedReason == "manual" || *body.SuppressedReason == "automated") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.suppressed_reason", *body.SuppressedReason, []any{"rule", "manual", "automated"}))
+		}
+	}
+	if body.ExclusionID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.exclusion_id", *body.ExclusionID, goa.FormatUUID))
 	}
 	return
 }

--- a/server/gen/http/risk/server/encode_decode.go
+++ b/server/gen/http/risk/server/encode_decode.go
@@ -11275,6 +11275,10 @@ func marshalTypesRiskResultToRiskResultResponseBody(v *types.RiskResult) *RiskRe
 		MatchRedacted:     v.MatchRedacted,
 		CreatedAt:         v.CreatedAt,
 		FalsePositiveAt:   v.FalsePositiveAt,
+		SuppressedAt:      v.SuppressedAt,
+		SuppressedReason:  v.SuppressedReason,
+		SuppressedDetail:  v.SuppressedDetail,
+		ExclusionID:       v.ExclusionID,
 	}
 	if v.Tags != nil {
 		res.Tags = make([]string, len(v.Tags))

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -10298,9 +10298,22 @@ type RiskResultResponseBody struct {
 	MatchRedacted *string `form:"match_redacted,omitempty" json:"match_redacted,omitempty" xml:"match_redacted,omitempty"`
 	// When this result was created.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
-	// When this result was manually marked as a false positive. Null when not
-	// dismissed.
+	// Deprecated: mirror of suppressed_at, kept while clients migrate to the
+	// suppressed_* fields. Null when not suppressed.
 	FalsePositiveAt *string `form:"false_positive_at,omitempty" json:"false_positive_at,omitempty" xml:"false_positive_at,omitempty"`
+	// When this result was suppressed (hidden from open-finding listings). Null
+	// when not suppressed.
+	SuppressedAt *string `form:"suppressed_at,omitempty" json:"suppressed_at,omitempty" xml:"suppressed_at,omitempty"`
+	// Why the result is suppressed: 'rule' (an exclusion rule, see exclusion_id),
+	// 'manual' (dismissed by a user), or 'automated' (the automated false-positive
+	// sweep). Null when not suppressed.
+	SuppressedReason *string `form:"suppressed_reason,omitempty" json:"suppressed_reason,omitempty" xml:"suppressed_reason,omitempty"`
+	// Free-form suppression context: the user-supplied dismissal reason for manual
+	// suppressions, the catalog reason for automated ones. Null when absent.
+	SuppressedDetail *string `form:"suppressed_detail,omitempty" json:"suppressed_detail,omitempty" xml:"suppressed_detail,omitempty"`
+	// The exclusion rule that suppressed this result. Only set when
+	// suppressed_reason is 'rule'.
+	ExclusionID *string `form:"exclusion_id,omitempty" json:"exclusion_id,omitempty" xml:"exclusion_id,omitempty"`
 }
 
 // RiskSpanResponseBody is used to define fields on response body types.

--- a/server/gen/types/risk_result.go
+++ b/server/gen/types/risk_result.go
@@ -58,7 +58,20 @@ type RiskResult struct {
 	MatchRedacted *string
 	// When this result was created.
 	CreatedAt string
-	// When this result was manually marked as a false positive. Null when not
-	// dismissed.
+	// Deprecated: mirror of suppressed_at, kept while clients migrate to the
+	// suppressed_* fields. Null when not suppressed.
 	FalsePositiveAt *string
+	// When this result was suppressed (hidden from open-finding listings). Null
+	// when not suppressed.
+	SuppressedAt *string
+	// Why the result is suppressed: 'rule' (an exclusion rule, see exclusion_id),
+	// 'manual' (dismissed by a user), or 'automated' (the automated false-positive
+	// sweep). Null when not suppressed.
+	SuppressedReason *string
+	// Free-form suppression context: the user-supplied dismissal reason for manual
+	// suppressions, the catalog reason for automated ones. Null when absent.
+	SuppressedDetail *string
+	// The exclusion rule that suppressed this result. Only set when
+	// suppressed_reason is 'rule'.
+	ExclusionID *string
 }

--- a/server/internal/risk/chrepo/dismissed.go
+++ b/server/internal/risk/chrepo/dismissed.go
@@ -32,6 +32,15 @@ type DismissedRiskFindingRow struct {
 	// back to the legacy false_positive_at on rows the suppression backfill
 	// did not reach.
 	SuppressedAt time.Time
+
+	// SuppressedReason is the row's excluded_reason — manual or automated on
+	// this listing (rule rows are gated out), empty on a legacy row carrying
+	// only false_positive_at. SuppressedDetail is the free-form context (user
+	// dismissal note or sweep catalog reason). ExclusionID rides along for
+	// shape parity with the API type; nil on every row this listing serves.
+	SuppressedReason string
+	SuppressedDetail string
+	ExclusionID      *uuid.UUID
 }
 
 // dismissedStateCond selects the findings the Dismissed tab lists: user and
@@ -52,10 +61,11 @@ const dismissedStateCond = "(excluded_reason IN ('" + ExcludedReasonManual + "',
 // backfill.
 const suppressedAtExpr = "coalesce(excluded_at, false_positive_at)"
 
-// dismissedStateColumns are the suppression columns dismissedStateCond and
-// suppressedAtExpr read off each id's latest copy. They ride along in the
-// dedup subquery's projection only; callers never select them.
-var dismissedStateColumns = []string{"dead_letter_reason", "excluded_reason", "excluded_at", "false_positive_at"}
+// dismissedStateColumns are the suppression columns dismissedStateCond,
+// suppressedAtExpr, and the listing's suppression projection read off each
+// id's latest copy. They ride along in the dedup subquery's projection; the
+// list query additionally selects the reason/detail/exclusion columns.
+var dismissedStateColumns = []string{"dead_letter_reason", "excluded_reason", "excluded_at", "false_positive_at", "excluded_detail", "exclusion_id"}
 
 // dismissedRiskFindingsLatest builds the row source both the list and the count
 // read from: every id in the tenant resolved to its most-recently-inserted
@@ -91,7 +101,8 @@ func dismissedRiskFindingsLatest(p ListDismissedRiskFindingsParams, innerColumns
 // suppression time — the pre-dismissal copy has none at all — so a cursor
 // applied first could drop the copy that carries the state this listing reads.
 func (q *Queries) ListDismissedRiskFindings(ctx context.Context, p ListDismissedRiskFindingsParams) ([]DismissedRiskFindingRow, error) {
-	outerColumns := append(slices.Clone(riskFindingListColumns), suppressedAtExpr+" AS suppressed_at")
+	outerColumns := append(slices.Clone(riskFindingListColumns),
+		suppressedAtExpr+" AS suppressed_at", "excluded_reason", "excluded_detail", "exclusion_id")
 	sb := dismissedRiskFindingsLatest(p, riskFindingListColumns, outerColumns...)
 
 	if p.CursorTime != nil && p.CursorID.Valid {
@@ -120,7 +131,7 @@ func (q *Queries) ListDismissedRiskFindings(ctx context.Context, p ListDismissed
 	var out []DismissedRiskFindingRow
 	for rows.Next() {
 		var row DismissedRiskFindingRow
-		if err := rows.Scan(append(row.scanTargets(), &row.SuppressedAt)...); err != nil {
+		if err := rows.Scan(append(row.scanTargets(), &row.SuppressedAt, &row.SuppressedReason, &row.SuppressedDetail, &row.ExclusionID)...); err != nil {
 			return nil, fmt.Errorf("scan dismissed risk findings list row: %w", err)
 		}
 		out = append(out, row)

--- a/server/internal/risk/false_positive.go
+++ b/server/internal/risk/false_positive.go
@@ -331,10 +331,23 @@ func (s *Service) ListDismissedRiskResults(ctx context.Context, payload *gen.Lis
 	var nextCursor *riskResultsCursor
 	for i, row := range rows {
 		result := chListRowToResult(row.RiskFindingListRow, titles, blocks)
-		// The dashboard renders the dismissal timestamp from this field. It
-		// carries the effective suppression time — excluded_at, or the legacy
-		// false_positive_at for a row the suppression backfill did not reach.
-		result.FalsePositiveAt = new(row.SuppressedAt.UTC().Format(time.RFC3339))
+		suppressedAt := row.SuppressedAt.UTC().Format(time.RFC3339)
+		result.SuppressedAt = &suppressedAt
+		// FalsePositiveAt is the deprecated mirror of SuppressedAt, kept
+		// populated while clients migrate to the suppressed_* fields.
+		result.FalsePositiveAt = &suppressedAt
+		// A legacy row the suppression backfill never reached carries no
+		// excluded_reason; it can only have come from a dismissal, so it maps
+		// to manual — keeping the API enum closed until the TTL retires them.
+		reason := row.SuppressedReason
+		if reason == "" {
+			reason = chrepo.ExcludedReasonManual
+		}
+		result.SuppressedReason = &reason
+		result.SuppressedDetail = conv.PtrEmpty(row.SuppressedDetail)
+		if row.ExclusionID != nil {
+			result.ExclusionID = conv.PtrEmpty(row.ExclusionID.String())
+		}
 		results = append(results, result)
 		if i == pageSize {
 			// Cursor from the LAST RETURNED row (not this extra row): the

--- a/server/internal/risk/false_positive_test.go
+++ b/server/internal/risk/false_positive_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -442,6 +443,16 @@ func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.
 	require.NotNil(t, first.FalsePositiveAt)
 	require.Equal(t, manualAt.Format(time.RFC3339), *first.FalsePositiveAt)
 
+	// The suppressed_* fields carry the converged suppression state;
+	// false_positive_at above is their deprecated mirror.
+	require.NotNil(t, first.SuppressedAt)
+	require.Equal(t, *first.FalsePositiveAt, *first.SuppressedAt)
+	require.NotNil(t, first.SuppressedReason)
+	require.Equal(t, chrepo.ExcludedReasonManual, *first.SuppressedReason)
+	require.NotNil(t, first.SuppressedDetail)
+	require.Equal(t, "noise", *first.SuppressedDetail)
+	require.Nil(t, first.ExclusionID, "manual suppression carries no exclusion id")
+
 	// Postgres display enrichment, same as the Risk Events listing.
 	require.NotNil(t, first.ChatTitle)
 	require.Equal(t, "test chat", *first.ChatTitle)
@@ -456,6 +467,27 @@ func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.
 	require.Equal(t, int64(4), page2.TotalCount)
 	require.NotNil(t, page2.Results[1].FalsePositiveAt)
 	require.Equal(t, legacyAt.Format(time.RFC3339), *page2.Results[1].FalsePositiveAt)
+	// A legacy row carries no excluded_reason; the API maps it to manual so
+	// the reason enum stays closed while the TTL retires such rows.
+	require.NotNil(t, page2.Results[1].SuppressedReason)
+	require.Equal(t, chrepo.ExcludedReasonManual, *page2.Results[1].SuppressedReason)
+	require.NotNil(t, page2.Results[1].SuppressedAt)
+	require.Equal(t, legacyAt.Format(time.RFC3339), *page2.Results[1].SuppressedAt)
+	require.Nil(t, page2.Results[1].SuppressedDetail)
+
+	// The automated dismissal keeps its reason and catalog detail wherever the
+	// tied pair landed.
+	var automated *types.RiskResult
+	for _, r := range append(page1.Results, page2.Results...) {
+		if r.ID == tiedA.ID.String() {
+			automated = r
+		}
+	}
+	require.NotNil(t, automated)
+	require.NotNil(t, automated.SuppressedReason)
+	require.Equal(t, chrepo.ExcludedReasonAutomated, *automated.SuppressedReason)
+	require.NotNil(t, automated.SuppressedDetail)
+	require.Equal(t, "known test fixture", *automated.SuppressedDetail)
 
 	// The tied pair is split across the boundary exactly once: no repeat, no
 	// skip. Which of the two lands on which page is ClickHouse's UUID ordering

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -4197,10 +4197,14 @@ func foundRowToResult(
 		// for callers ListRiskResults decides shouldn't see raw match/spans.
 		MatchRedacted: nil,
 		CreatedAt:     createdAt.Time.Format(time.RFC3339),
-		// FalsePositiveAt is populated later by callers (ListDismissedRiskResults)
-		// that have a dismissal timestamp to attach; every other caller leaves it
-		// unset since listRiskResults never returns a dismissed result.
-		FalsePositiveAt: nil,
+		// The PG listings behind this mapper only return open findings, so the
+		// suppression fields (and the deprecated FalsePositiveAt mirror) stay
+		// unset; the suppressed listing populates them from its own rows.
+		FalsePositiveAt:  nil,
+		SuppressedAt:     nil,
+		SuppressedReason: nil,
+		SuppressedDetail: nil,
+		ExclusionID:      nil,
 	}
 }
 

--- a/server/internal/risk/list_ch.go
+++ b/server/internal/risk/list_ch.go
@@ -258,10 +258,14 @@ func chListRowToResult(row chrepo.RiskFindingListRow, titles map[uuid.UUID]strin
 		Tags:              tags,
 		Spans:             nil,
 		MatchRedacted:     conv.PtrEmpty(row.MatchRedacted),
-		// The ClickHouse listing filters false_positive_at IS NULL, so a
-		// served row is never dismissed; only ListDismissedRiskResults
-		// populates this, which it does after calling this mapper.
-		FalsePositiveAt: nil,
+		// The ClickHouse listing only serves open findings, so a served row is
+		// never suppressed; only ListDismissedRiskResults populates the
+		// suppression fields, which it does after calling this mapper.
+		FalsePositiveAt:  nil,
+		SuppressedAt:     nil,
+		SuppressedReason: nil,
+		SuppressedDetail: nil,
+		ExclusionID:      nil,
 		// Message event time, not scan time: the Postgres listing exposes
 		// message_created_at as CreatedAt, and the sort order and cursor both
 		// key on it.


### PR DESCRIPTION
## What

Adds the converged suppression fields to the `RiskResult` API type (follows #5455): `suppressed_at`, `suppressed_reason` (`rule` | `manual` | `automated`), `suppressed_detail`, and `exclusion_id`. They map 1:1 from the ClickHouse `excluded_*` columns; the dismissed-findings listing populates them on every row. `false_positive_at` stays as a deprecated mirror of `suppressed_at` while clients migrate.

Details: legacy pre-convergence rows (no stored reason) map to `manual` to keep the enum closed until the TTL retires them; open-finding listings never serve suppressed rows so their mappers leave the fields null. Goa + SDK regenerated; changeset `server: minor`.

## Testing

Dismissed-listing tests assert the full field set on manual (reason + user detail), automated (catalog detail), and legacy (mapped-to-manual) rows. Full `./internal/risk/...` tree green (548 tests); build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose converged suppression fields on RiskResult and populate them in the dismissed findings API. Previously only false_positive_at indicated manual dismissals; now suppressed_at, suppressed_reason, suppressed_detail, and exclusion_id communicate suppression origin and context, with false_positive_at kept as a deprecated mirror.

- Fields map 1:1 from ClickHouse excluded_* columns. The dismissed-findings listing sets them on every row; open-finding listings leave them null.
- Legacy rows without a stored reason map to suppressed_reason = "manual" to keep the enum closed; exclusion_id is set only when suppressed_reason = "rule".
- OpenAPI and Goa/TypeScript SDKs are regenerated; the dashboard SDK adds a closed enum for suppressed_reason.

**Migration**
- Clients should read suppressed_* fields going forward and treat false_positive_at as deprecated (it mirrors suppressed_at during migration).
- Handle null suppression fields on open results; when suppressed_reason = "rule", read exclusion_id, otherwise expect it to be null.

<sup>Written for commit 6d75cb69f6bfb3bcae820118072cb9d9e686a1dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

