### PR TITLE
fix: bill all PAYG inference spend

### DIFF
--- a/.changeset/bill-all-payg-inference.md
+++ b/.changeset/bill-all-payg-inference.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Bill both customer-facing and platform-initiated inference spend for PAYG organizations.

--- a/.changeset/bill-all-payg-inference.md
+++ b/.changeset/bill-all-payg-inference.md
@@ -1,4 +1,5 @@
 ---
+"admin": patch
 "server": minor
 "dashboard": patch
 ---

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -69813,7 +69813,7 @@ components:
           description: Exact estimated current-cycle total in USD through recorded_through
         other_inference_spend_usd:
           type: string
-          description: Exact durable Other inference spend in USD through recorded_through
+          description: Exact durable customer-billable OpenRouter inference spend in USD through recorded_through
         period_end:
           type: string
           description: End of the live paid Stripe service period (exclusive)

--- a/client/admin/src/pages/organization/Billing.test.tsx
+++ b/client/admin/src/pages/organization/Billing.test.tsx
@@ -112,6 +112,8 @@ describe("Billing", () => {
     expect(await screen.findByText("1,234,567")).toBeTruthy();
     expect(screen.getByText("$0.00000035 per token")).toBeTruthy();
     expect(screen.getByText("$2.53209845")).toBeTruthy();
+    expect(screen.getByText("Inference spend")).toBeTruthy();
+    expect(screen.getByText("$2.10")).toBeTruthy();
     expect(screen.getByText("No payment failure reported")).toBeTruthy();
     expect(screen.getByText("Other inference")).toBeTruthy();
     expect(screen.getByText("Security and internal inference")).toBeTruthy();

--- a/client/admin/src/pages/organization/Billing.tsx
+++ b/client/admin/src/pages/organization/Billing.tsx
@@ -142,7 +142,7 @@ function BillingSummary({
         {formatExactUsd(summary.tum_unit_price_usd) ?? "—"} per token
       </Row>
       <Row label="TUM cost">{formatExactUsd(summary.tum_cost_usd) ?? "—"}</Row>
-      <Row label="Other inference spend">
+      <Row label="Inference spend">
         {formatExactUsd(summary.other_inference_spend_usd) ?? "—"}
       </Row>
       {recordedThrough && (

--- a/client/dashboard/src/components/billing/inference-cap-meter.test.tsx
+++ b/client/dashboard/src/components/billing/inference-cap-meter.test.tsx
@@ -106,9 +106,8 @@ describe("InferenceCapMeter", () => {
     });
   });
 
-  // The meter under the invoice estimate is the only place a customer can tell
-  // the invoiced cap from the one Gram funds, so the note has to be exact about
-  // which of the two figures above it belongs to.
+  // The meter under the invoice estimate explains that each independently
+  // capped inference category contributes to the cycle's billable spend.
   describe("the billing note", () => {
     // The threshold note comes first because it is the part that has changed;
     // the billing note is the standing fact about where the spend lands.
@@ -125,14 +124,11 @@ describe("InferenceCapMeter", () => {
       );
     });
 
-    // The platform-funded cap spends money too, but none of it is invoiced —
-    // so its note must never claim a line on the bill or a place in the
-    // estimate printed directly above it.
     it.each<[string, number]>([
       ["with a cap set", 200],
       ["with no cap set", 0],
     ])(
-      "never claims the platform-funded cap is invoiced, %s",
+      "includes platform-initiated inference in PAYG billing, %s",
       (_label, monthlyCredits) => {
         const { container } = render(
           <InferenceCapMeter
@@ -142,11 +138,9 @@ describe("InferenceCapMeter", () => {
         );
 
         const note = lastLine(container);
-        expect(note).toMatch(/it never reaches your invoice/);
-        expect(note).toMatch(/isn't part of the estimate above/);
-        expect(note).not.toMatch(
-          /billed to this organization as its own line/i,
-        );
+        expect(note).toMatch(/included in the inference spend/i);
+        expect(note).toMatch(/invoice/i);
+        expect(note).not.toMatch(/estimate above/i);
       },
     );
 

--- a/client/dashboard/src/components/billing/inference-caps.test.ts
+++ b/client/dashboard/src/components/billing/inference-caps.test.ts
@@ -78,16 +78,15 @@ describe("cap copy", () => {
     );
   });
 
-  // Only one of the two caps is money the customer is invoiced for. Saying so
-  // is the whole job of this half of the note.
-  it("claims a place on the invoice for the billed cap only", () => {
-    expect(inferenceCapInvoiceNote("chat")).toMatch(
-      /billed to this organization as its own line/,
-    );
-    expect(inferenceCapInvoiceNote("internal")).toMatch(
-      /never reaches your invoice/,
-    );
-  });
+  it.each<InferenceSpendCap["keyType"]>(["internal", "chat"])(
+    "includes the %s key in PAYG billing",
+    (keyType) => {
+      expect(inferenceCapInvoiceNote(keyType)).toMatch(
+        /included in the inference spend.*invoice/i,
+      );
+      expect(inferenceCapInvoiceNote(keyType)).not.toMatch(/estimate above/i);
+    },
+  );
 
   // The uncapped meter renders the invoice half on its own, so it has to read
   // as a whole sentence rather than as a fragment of the note it comes from.
@@ -170,7 +169,7 @@ describe("isInferenceCapReached", () => {
 describe("sortInferenceCaps", () => {
   // A refetch that returns the rows in a different order must not reorder the
   // controls under an admin who is typing into one of them.
-  it("puts the invoiced cap first whichever order the list arrives in", () => {
+  it("keeps the product order whichever order the list arrives in", () => {
     const internal = cap({ keyType: "internal" });
     const chat = cap({ keyType: "chat" });
 

--- a/client/dashboard/src/components/billing/inference-caps.ts
+++ b/client/dashboard/src/components/billing/inference-caps.ts
@@ -50,9 +50,10 @@ const CAP_COPY: Record<InferenceSpendCapKeyType, CapCopy> = {
     slug: "security",
     paused:
       "The automated analysis Gram runs over this organization's traffic, including security scanning, is paused for the rest of the month. Raise the cap to start it again.",
-    capReset: "This monthly cap resets on the first of the month.",
+    capReset:
+      "This monthly cap resets on the first of the month, so it doesn't line up with the organization's billing cycle and isn't an invoice estimate.",
     invoice:
-      "Gram funds this inference, so it never reaches your invoice and isn't part of the estimate above.",
+      "This inference is included in the inference spend on this organization's invoice.",
   },
   chat: {
     name: "Other inference",
@@ -60,17 +61,18 @@ const CAP_COPY: Record<InferenceSpendCapKeyType, CapCopy> = {
     paused:
       "Assistants and the other AI-powered dashboard experiences are paused for the rest of the month. Raise the cap to start them again.",
     capReset:
-      "This monthly cap resets on the first of the month, so it doesn't line up with the billing cycle above and isn't the figure in the estimate.",
+      "This monthly cap resets on the first of the month, so it doesn't line up with the organization's billing cycle and isn't an invoice estimate.",
     invoice:
-      "This inference is billed to this organization as its own line on the invoice.",
+      "This inference is included in the inference spend on this organization's invoice.",
   },
 };
 
 /**
  * The display order the caps are always rendered in.
  *
- * Invoiced inference first: it is the one an organization is paying for, so it
- * leads wherever both appear — the section, the usage meters, and the banners.
+ * Customer-facing inference first, followed by the platform-initiated inference.
+ * Both are billable on PAYG, but keeping this product order stable prevents a
+ * refetch from moving controls while an administrator is using them.
  */
 const CAP_ORDER: readonly InferenceSpendCapKeyType[] = ["chat", "internal"];
 
@@ -135,8 +137,7 @@ export function inferenceCapBillingNote(
  * The invoice half alone, for a key with no cap set.
  *
  * The cap-reset sentence would contradict the "No cap is set" line it renders
- * directly under, but where the spend lands is still worth saying — it is the
- * only thing that tells the invoiced key from the one Gram funds.
+ * directly under, but where the spend lands is still worth saying.
  */
 export function inferenceCapInvoiceNote(
   keyType: InferenceSpendCapKeyType,

--- a/client/dashboard/src/components/billing/payg-usage-section.test.tsx
+++ b/client/dashboard/src/components/billing/payg-usage-section.test.tsx
@@ -163,13 +163,13 @@ describe("PaygUsageSection", () => {
     ).toBeTruthy();
   });
 
-  // The estimate's inference line is the invoiced half of the Gram-managed
-  // inference. The analysis Gram funds is not a line here and not in the total.
-  it("names the invoiced inference as its own line", () => {
+  it("names all billable Gram-managed inference", () => {
     render(<PaygUsageSection />);
 
-    expect(screen.getByText("Other inference spend")).toBeTruthy();
-    expect(screen.getByText(/Billed to you as its own line/)).toBeTruthy();
+    expect(screen.getByText("Inference spend")).toBeTruthy();
+    expect(
+      screen.getByText(/customer-facing and platform-initiated inference/),
+    ).toBeTruthy();
   });
 
   // The cutoff is the whole point of that figure: today's usage is not in it.
@@ -296,6 +296,7 @@ describe("PaygUsageSection", () => {
 
     expect(estimatedTotal()).toBeNull();
     expect(screen.queryByText(/72 hours/)).toBeNull();
+    expect(screen.queryByText(/estimate above/i)).toBeNull();
   });
 
   describe("inference cap meters", () => {
@@ -333,27 +334,22 @@ describe("PaygUsageSection", () => {
     // The caps run on the calendar month while the invoice runs on the Stripe
     // cycle; the two windows overlap without matching, so the copy has to say
     // which one these figures belong to.
-    it("says the invoiced cap's month doesn't line up with the cycle", () => {
+    it("says both caps' month doesn't line up with the cycle", () => {
       render(<PaygUsageSection />);
 
       expect(
-        screen.getByText(/doesn't line up with the billing cycle above/),
-      ).toBeTruthy();
-      expect(
-        screen.getByText(/billed to this organization as its own line/i),
-      ).toBeTruthy();
+        screen.getAllByText(
+          /doesn't line up with the organization's billing cycle/,
+        ),
+      ).toHaveLength(2);
     });
 
-    // The distinction the section exists to make: one of these caps is money
-    // the customer is invoiced for, and the other never reaches their bill.
-    it("says the platform-funded cap is not in the invoice estimate", () => {
+    it("says both inference categories are billed on the invoice", () => {
       render(<PaygUsageSection />);
 
       expect(
-        screen.getByText(
-          /Gram funds this inference, so it never reaches your invoice/,
-        ),
-      ).toBeTruthy();
+        screen.getAllByText(/included in the inference spend.*invoice/i),
+      ).toHaveLength(2);
     });
 
     // The estimate's inference figure and the meters' figures come from
@@ -377,6 +373,7 @@ describe("PaygUsageSection", () => {
 
       expect(meters()).toHaveLength(2);
       expect(estimatedTotal()).toBeNull();
+      expect(screen.queryByText(/estimate above/i)).toBeNull();
     });
 
     it.each<[number, number]>([
@@ -427,11 +424,9 @@ describe("PaygUsageSection", () => {
       expect(screen.getByText(/\$10\.00 spent this month/)).toBeTruthy();
     });
 
-    // Uncapped spend is still spend, and one of these keys is invoiced while
-    // the other never is — so the note that tells them apart has to survive the
-    // no-cap branch too. Only that part of it: the rest is about the cap's
-    // month resetting, which would contradict the "No cap is set." beside it.
-    it("keeps the invoice note on an uncapped meter, without the cap-reset copy", () => {
+    // Uncapped spend is still billable. Keep that note while omitting the
+    // cap-reset sentence that would contradict the "No cap is set." line.
+    it("keeps the invoice note on uncapped meters, without the cap-reset copy", () => {
       inferenceCapsQuery([
         cap({ keyType: "chat", creditsUsed: 10, monthlyCredits: 0 }),
         cap({ keyType: "internal", creditsUsed: 20, monthlyCredits: 0 }),
@@ -441,13 +436,8 @@ describe("PaygUsageSection", () => {
 
       expect(meters()).toHaveLength(0);
       expect(
-        screen.getByText(/billed to this organization as its own line/i),
-      ).toBeTruthy();
-      expect(
-        screen.getByText(
-          /Gram funds this inference, so it never reaches your invoice/,
-        ),
-      ).toBeTruthy();
+        screen.getAllByText(/included in the inference spend.*invoice/i),
+      ).toHaveLength(2);
       expect(screen.queryByText(/resets on the first of the month/)).toBeNull();
       expect(
         screen.queryByText(/doesn't line up with the billing cycle above/),

--- a/client/dashboard/src/components/billing/payg-usage-section.tsx
+++ b/client/dashboard/src/components/billing/payg-usage-section.tsx
@@ -101,7 +101,7 @@ function BillingCycleFigures({
   const tokens = formatTokenCount(summary.tumTokens);
   const unitPrice = formatExactUsd(summary.tumUnitPriceUsd);
   const tumCost = formatExactUsd(summary.tumCostUsd);
-  const otherInferenceSpend = formatExactUsd(summary.otherInferenceSpendUsd);
+  const inferenceSpend = formatExactUsd(summary.otherInferenceSpendUsd);
   const estimatedTotal = formatExactUsd(summary.estimatedTotalUsd);
   const recordedThrough = formatRecordedThrough(summary.recordedThrough);
 
@@ -118,14 +118,14 @@ function BillingCycleFigures({
           value={tokens ?? MISSING_FIGURE}
           description={tumCostDescription(unitPrice, tumCost)}
         />
-        {/* The invoiced half of the Gram-managed inference. The analysis
-            Gram runs for its own features is funded by Gram, so it is not a
-            line here and is not in the total below. */}
+        {/* All Gram-managed inference is customer-billable on PAYG. The
+            estimate combines both key types through the latest completed UTC
+            day. */}
         <MetricCard
           size="sm"
           tone="information"
-          label="Other inference spend"
-          value={otherInferenceSpend ?? MISSING_FIGURE}
+          label="Inference spend"
+          value={inferenceSpend ?? MISSING_FIGURE}
           description={inferenceSpendDescription(recordedThrough)}
         />
         <MetricCard
@@ -163,9 +163,9 @@ function tumCostDescription(
 // would make the estimate look stale to the customer who just used it.
 function inferenceSpendDescription(recordedThrough: string | null): string {
   if (recordedThrough === null) {
-    return "Billed to you as its own line. No completed day has been recorded in this cycle yet.";
+    return "Includes customer-facing and platform-initiated inference. No completed day has been recorded in this cycle yet.";
   }
-  return `Billed to you as its own line. Completed days through ${recordedThrough}; today isn't counted yet.`;
+  return `Includes customer-facing and platform-initiated inference. Completed days through ${recordedThrough}; today isn't counted yet.`;
 }
 
 // The total inherits that cutoff, so it names it too — an estimate that
@@ -179,11 +179,10 @@ function estimatedTotalDescription(recordedThrough: string | null): string {
  * This calendar month's spend against every inference cap this organization
  * has, one meter each.
  *
- * Deliberately not part of the estimate above: the caps run on the calendar
+ * Deliberately separate from the invoice estimate: the caps run on the calendar
  * month while the invoice runs on the Stripe cycle, so the two windows overlap
- * without matching. Each meter carries its own billing note, which is also
- * where the invoiced inference is told apart from the analysis Gram funds and
- * never puts on an invoice.
+ * without matching. Each meter carries its own billing note explaining that
+ * its spend is customer-billable.
  */
 function InferenceCapMeters(): JSX.Element | null {
   const { data, isError } = useGetInferenceSpendCaps(undefined, undefined, {

--- a/client/dashboard/src/pages/billing/Billing.test.tsx
+++ b/client/dashboard/src/pages/billing/Billing.test.tsx
@@ -258,7 +258,7 @@ describe("Billing", () => {
           featureBullets: ["Enterprise feature set"],
           includedBullets: [
             "Other inference billed at provider cost",
-            "Security inference funded by Speakeasy",
+            "Security inference billed at provider cost",
           ],
           tumPricePerMillionUsd: "0.35",
         },

--- a/client/dashboard/src/pages/billing/Billing.test.tsx
+++ b/client/dashboard/src/pages/billing/Billing.test.tsx
@@ -258,7 +258,7 @@ describe("Billing", () => {
           featureBullets: ["Enterprise feature set"],
           includedBullets: [
             "Other inference billed at provider cost",
-            "Security inference billed at provider cost",
+            "Platform-initiated inference billed at provider cost",
           ],
           tumPricePerMillionUsd: "0.35",
         },

--- a/client/dashboard/src/sdk/src/models/components/paygbillingsummary.ts
+++ b/client/dashboard/src/sdk/src/models/components/paygbillingsummary.ts
@@ -15,7 +15,7 @@ export type PaygBillingSummary = {
    */
   estimatedTotalUsd: string;
   /**
-   * Exact durable Other inference spend in USD through recorded_through
+   * Exact durable customer-billable OpenRouter inference spend in USD through recorded_through
    */
   otherInferenceSpendUsd: string;
   /**

--- a/server/design/usage/design.go
+++ b/server/design/usage/design.go
@@ -169,7 +169,7 @@ var PaygBillingSummary = Type("PaygBillingSummary", func() {
 	Attribute("tum_tokens", Int64, "Tokens under management in the live paid service period")
 	Attribute("tum_unit_price_usd", String, "Exact flat USD price per token under management")
 	Attribute("tum_cost_usd", String, "Exact estimated tokens-under-management cost in USD")
-	Attribute("other_inference_spend_usd", String, "Exact durable Other inference spend in USD through recorded_through")
+	Attribute("other_inference_spend_usd", String, "Exact durable customer-billable OpenRouter inference spend in USD through recorded_through")
 	Attribute("recorded_through", String, "Most recent completed durable UTC spend day included in the estimate", func() {
 		Format(FormatDate)
 	})

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -70975,7 +70975,7 @@ components:
                     description: Exact estimated current-cycle total in USD through recorded_through
                 other_inference_spend_usd:
                     type: string
-                    description: Exact durable Other inference spend in USD through recorded_through
+                    description: Exact durable customer-billable OpenRouter inference spend in USD through recorded_through
                 period_end:
                     type: string
                     description: End of the live paid Stripe service period (exclusive)

--- a/server/gen/http/usage/client/types.go
+++ b/server/gen/http/usage/client/types.go
@@ -188,7 +188,8 @@ type GetPaygBillingSummaryResponseBody struct {
 	TumUnitPriceUsd *string `form:"tum_unit_price_usd,omitempty" json:"tum_unit_price_usd,omitempty" xml:"tum_unit_price_usd,omitempty"`
 	// Exact estimated tokens-under-management cost in USD
 	TumCostUsd *string `form:"tum_cost_usd,omitempty" json:"tum_cost_usd,omitempty" xml:"tum_cost_usd,omitempty"`
-	// Exact durable Other inference spend in USD through recorded_through
+	// Exact durable customer-billable OpenRouter inference spend in USD through
+	// recorded_through
 	OtherInferenceSpendUsd *string `form:"other_inference_spend_usd,omitempty" json:"other_inference_spend_usd,omitempty" xml:"other_inference_spend_usd,omitempty"`
 	// Most recent completed durable UTC spend day included in the estimate
 	RecordedThrough *string `form:"recorded_through,omitempty" json:"recorded_through,omitempty" xml:"recorded_through,omitempty"`

--- a/server/gen/http/usage/server/types.go
+++ b/server/gen/http/usage/server/types.go
@@ -192,7 +192,8 @@ type GetPaygBillingSummaryResponseBody struct {
 	TumUnitPriceUsd string `form:"tum_unit_price_usd" json:"tum_unit_price_usd" xml:"tum_unit_price_usd"`
 	// Exact estimated tokens-under-management cost in USD
 	TumCostUsd string `form:"tum_cost_usd" json:"tum_cost_usd" xml:"tum_cost_usd"`
-	// Exact durable Other inference spend in USD through recorded_through
+	// Exact durable customer-billable OpenRouter inference spend in USD through
+	// recorded_through
 	OtherInferenceSpendUsd string `form:"other_inference_spend_usd" json:"other_inference_spend_usd" xml:"other_inference_spend_usd"`
 	// Most recent completed durable UTC spend day included in the estimate
 	RecordedThrough *string `form:"recorded_through,omitempty" json:"recorded_through,omitempty" xml:"recorded_through,omitempty"`

--- a/server/gen/usage/service.go
+++ b/server/gen/usage/service.go
@@ -184,7 +184,8 @@ type PaygBillingSummary struct {
 	TumUnitPriceUsd string
 	// Exact estimated tokens-under-management cost in USD
 	TumCostUsd string
-	// Exact durable Other inference spend in USD through recorded_through
+	// Exact durable customer-billable OpenRouter inference spend in USD through
+	// recorded_through
 	OtherInferenceSpendUsd string
 	// Most recent completed durable UTC spend day included in the estimate
 	RecordedThrough *string

--- a/server/internal/background/activities/openrouter_daily_spend.go
+++ b/server/internal/background/activities/openrouter_daily_spend.go
@@ -30,10 +30,11 @@ type CollectOpenRouterDailySpendArgs struct {
 	EndDay time.Time
 }
 
-// CollectOpenRouterDailySpendResult identifies organizations whose chat spend
-// is fresh and gap-free for every known invoice source day.
+// CollectOpenRouterDailySpendResult identifies organizations whose billable
+// key spend is fresh and gap-free for every known invoice source day.
 type CollectOpenRouterDailySpendResult struct {
-	ReadyOrganizationIDs []string
+	ReadyOrganizationIDs         []string
+	BillableKeyPolicyFingerprint string
 }
 
 // CollectOpenRouterDailySpend stores billing-grade daily spend for every live
@@ -81,10 +82,16 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 	}
 
 	var failures []error
-	readyOrganizations := make(map[string]struct{})
+	billableTargets := make(map[string]int)
+	readyBillableTargets := make(map[string]int)
+	for _, target := range targets {
+		if openrouter.KeyType(target.KeyType).IsBillable() {
+			billableTargets[target.OrganizationID]++
+		}
+	}
 	for i, target := range targets {
 		keyType := openrouter.KeyType(target.KeyType)
-		isChat := keyType == openrouter.KeyTypeChat
+		isBillable := keyType.IsBillable()
 		if err := keyType.Validate(); err != nil {
 			failures = append(failures, fmt.Errorf("collect spend for organization %s: %w", target.OrganizationID, err))
 			c.recordHeartbeat(ctx, i+1, len(targets))
@@ -96,8 +103,9 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 		if createdDay.After(targetStart) {
 			targetStart = createdDay
 		}
-		if isChat {
+		if isBillable {
 			recoveryStart, err := queries.GetOpenRouterDailySpendRecoveryStartDay(ctx, repo.GetOpenRouterDailySpendRecoveryStartDayParams{
+				TargetKeyType:        target.KeyType,
 				TargetOrganizationID: pgtype.Text{String: target.OrganizationID, Valid: true},
 				TargetEarliestDay:    pgtype.Date{Time: createdDay, InfinityModifier: pgtype.Finite, Valid: true},
 				TargetEndDay:         pgtype.Date{Time: endDay, InfinityModifier: pgtype.Finite, Valid: true},
@@ -112,8 +120,8 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 			}
 		}
 		if !targetStart.Before(endDay) {
-			if isChat {
-				readyOrganizations[target.OrganizationID] = struct{}{}
+			if isBillable {
+				readyBillableTargets[target.OrganizationID]++
 			}
 			c.recordHeartbeat(ctx, i+1, len(targets))
 			continue
@@ -151,7 +159,7 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 			c.recordHeartbeat(ctx, i+1, len(targets))
 			continue
 		}
-		if isChat {
+		if isBillable {
 			missing, err := queries.CountOpenRouterInvoiceSpendGaps(ctx, repo.CountOpenRouterInvoiceSpendGapsParams{
 				TargetKeyType:        target.KeyType,
 				TargetOrganizationID: pgtype.Text{String: target.OrganizationID, Valid: true},
@@ -163,19 +171,21 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 			} else if missing > 0 {
 				failures = append(failures, fmt.Errorf("organization %s has %d unresolved invoice spend gaps", target.OrganizationID, missing))
 			} else {
-				readyOrganizations[target.OrganizationID] = struct{}{}
+				readyBillableTargets[target.OrganizationID]++
 			}
 		}
 		c.recordHeartbeat(ctx, i+1, len(targets))
 	}
 
 	result := CollectOpenRouterDailySpendResult{
-		ReadyOrganizationIDs: make([]string, 0, len(readyOrganizations)),
+		ReadyOrganizationIDs:         make([]string, 0, len(billableTargets)),
+		BillableKeyPolicyFingerprint: openrouter.BillableKeyPolicyFingerprint(),
 	}
 	for _, target := range targets {
-		if _, ready := readyOrganizations[target.OrganizationID]; ready {
+		required, seen := billableTargets[target.OrganizationID]
+		if seen && readyBillableTargets[target.OrganizationID] == required {
 			result.ReadyOrganizationIDs = append(result.ReadyOrganizationIDs, target.OrganizationID)
-			delete(readyOrganizations, target.OrganizationID)
+			delete(billableTargets, target.OrganizationID)
 		}
 	}
 

--- a/server/internal/background/activities/openrouter_daily_spend.go
+++ b/server/internal/background/activities/openrouter_daily_spend.go
@@ -90,7 +90,8 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 		}
 	}
 	for i, target := range targets {
-		keyType := openrouter.KeyType(target.KeyType)
+		keyType := openrouter.KeyType(target.KeyType).OrDefault()
+		canonicalKeyType := string(keyType)
 		isBillable := keyType.IsBillable()
 		if err := keyType.Validate(); err != nil {
 			failures = append(failures, fmt.Errorf("collect spend for organization %s: %w", target.OrganizationID, err))
@@ -105,7 +106,7 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 		}
 		if isBillable {
 			recoveryStart, err := queries.GetOpenRouterDailySpendRecoveryStartDay(ctx, repo.GetOpenRouterDailySpendRecoveryStartDayParams{
-				TargetKeyType:        target.KeyType,
+				TargetKeyType:        canonicalKeyType,
 				TargetOrganizationID: pgtype.Text{String: target.OrganizationID, Valid: true},
 				TargetEarliestDay:    pgtype.Date{Time: createdDay, InfinityModifier: pgtype.Finite, Valid: true},
 				TargetEndDay:         pgtype.Date{Time: endDay, InfinityModifier: pgtype.Finite, Valid: true},
@@ -131,11 +132,11 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 		// A slow management API must not hold a database connection or locks.
 		result, err := c.spendClient.GetDailySpend(ctx, target.KeyHash, targetStart, endDay)
 		if err != nil {
-			wrapped := fmt.Errorf("collect spend for organization %s key type %s: %w", target.OrganizationID, target.KeyType, err)
+			wrapped := fmt.Errorf("collect spend for organization %s key type %s: %w", target.OrganizationID, canonicalKeyType, err)
 			failures = append(failures, wrapped)
 			c.logger.ErrorContext(ctx, "collect openrouter daily spend",
 				attr.SlogOrganizationID(target.OrganizationID),
-				attr.SlogOpenRouterKeyType(target.KeyType),
+				attr.SlogOpenRouterKeyType(canonicalKeyType),
 				attr.SlogError(err),
 			)
 			c.recordHeartbeat(ctx, i+1, len(targets))
@@ -144,16 +145,16 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 
 		spendByDay, err := validateDailySpendResult(result, targetStart, endDay)
 		if err != nil {
-			failures = append(failures, fmt.Errorf("validate spend for organization %s key type %s: %w", target.OrganizationID, target.KeyType, err))
+			failures = append(failures, fmt.Errorf("validate spend for organization %s key type %s: %w", target.OrganizationID, canonicalKeyType, err))
 			c.recordHeartbeat(ctx, i+1, len(targets))
 			continue
 		}
 
-		if err := c.storeTargetDays(ctx, target.OrganizationID, target.KeyType, targetStart, endDay, spendByDay); err != nil {
-			failures = append(failures, fmt.Errorf("store spend for organization %s key type %s: %w", target.OrganizationID, target.KeyType, err))
+		if err := c.storeTargetDays(ctx, target.OrganizationID, canonicalKeyType, targetStart, endDay, spendByDay); err != nil {
+			failures = append(failures, fmt.Errorf("store spend for organization %s key type %s: %w", target.OrganizationID, canonicalKeyType, err))
 			c.logger.ErrorContext(ctx, "store openrouter daily spend",
 				attr.SlogOrganizationID(target.OrganizationID),
-				attr.SlogOpenRouterKeyType(target.KeyType),
+				attr.SlogOpenRouterKeyType(canonicalKeyType),
 				attr.SlogError(err),
 			)
 			c.recordHeartbeat(ctx, i+1, len(targets))
@@ -161,7 +162,7 @@ func (c *CollectOpenRouterDailySpend) DoWithResult(ctx context.Context, args Col
 		}
 		if isBillable {
 			missing, err := queries.CountOpenRouterInvoiceSpendGaps(ctx, repo.CountOpenRouterInvoiceSpendGapsParams{
-				TargetKeyType:        target.KeyType,
+				TargetKeyType:        canonicalKeyType,
 				TargetOrganizationID: pgtype.Text{String: target.OrganizationID, Valid: true},
 				TargetEarliestDay:    pgtype.Date{Time: createdDay, InfinityModifier: pgtype.Finite, Valid: true},
 				TargetEndDay:         pgtype.Date{Time: endDay, InfinityModifier: pgtype.Finite, Valid: true},

--- a/server/internal/background/activities/openrouter_daily_spend_test.go
+++ b/server/internal/background/activities/openrouter_daily_spend_test.go
@@ -216,6 +216,35 @@ func TestCollectOpenRouterDailySpend_InternalFailureBlocksInvoiceReadiness(t *te
 	client.AssertExpectations(t)
 }
 
+func TestCollectOpenRouterDailySpend_NormalizesDefaultKeyType(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	conn, orgID := setupOpenRouterDailySpendTest(t, "openrouter_daily_spend_default_key_type")
+	keyHash := createOpenRouterSpendTarget(t, conn, orgID, openrouter.KeyType(""), 'i')
+	startDay := utcDay(0)
+	endDay := utcDay(1)
+
+	client := &mockOpenRouterSpendClient{}
+	client.On("GetDailySpend", mock.Anything, keyHash, startDay, endDay).
+		Return(openrouter.DailySpendResult{
+			Days:   []openrouter.DailySpendDay{{Day: startDay, SpendUSD: "1.25"}},
+			Source: openrouter.DailySpendSourceAnalytics,
+		}, nil).Once()
+
+	result, err := activities.NewCollectOpenRouterDailySpend(testenv.NewLogger(t), conn, client).
+		DoWithResult(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: startDay, EndDay: endDay})
+	require.NoError(t, err)
+	require.Equal(t, []string{orgID}, result.ReadyOrganizationIDs)
+	rows, err := backgroundrepo.New(conn).ListOpenRouterDailySpend(ctx, backgroundrepo.ListOpenRouterDailySpendParams{
+		OrganizationID: orgID,
+		KeyType:        string(openrouter.KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "1.250000", numericString(t, rows[0].SpendUsd))
+	client.AssertExpectations(t)
+}
+
 func TestCollectOpenRouterDailySpend_RejectsUnrepresentableSpend(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/activities/openrouter_daily_spend_test.go
+++ b/server/internal/background/activities/openrouter_daily_spend_test.go
@@ -194,6 +194,28 @@ func TestCollectOpenRouterDailySpend_ContinuesAfterUpstreamFailure(t *testing.T)
 	client.AssertExpectations(t)
 }
 
+func TestCollectOpenRouterDailySpend_InternalFailureBlocksInvoiceReadiness(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	conn, orgID := setupOpenRouterDailySpendTest(t, "openrouter_daily_spend_internal_failure")
+	chatHash := createOpenRouterSpendTarget(t, conn, orgID, openrouter.KeyTypeChat, 'g')
+	internalHash := createOpenRouterSpendTarget(t, conn, orgID, openrouter.KeyTypeInternal, 'h')
+	startDay := utcDay(0)
+	endDay := utcDay(1)
+
+	client := &mockOpenRouterSpendClient{}
+	client.On("GetDailySpend", mock.Anything, chatHash, startDay, endDay).
+		Return(openrouter.DailySpendResult{Days: nil, Source: openrouter.DailySpendSourceActivity}, nil).Once()
+	client.On("GetDailySpend", mock.Anything, internalHash, startDay, endDay).
+		Return(openrouter.DailySpendResult{}, errors.New("management API unavailable")).Once()
+
+	act := activities.NewCollectOpenRouterDailySpend(testenv.NewLogger(t), conn, client)
+	result, err := act.DoWithResult(ctx, activities.CollectOpenRouterDailySpendArgs{StartDay: startDay, EndDay: endDay})
+	require.NoError(t, err)
+	require.Empty(t, result.ReadyOrganizationIDs)
+	client.AssertExpectations(t)
+}
+
 func TestCollectOpenRouterDailySpend_RejectsUnrepresentableSpend(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -183,7 +183,7 @@ WHERE invoice.organization_id = @target_organization_id
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || @target_key_type::text
           AND allocation.seq = 1
       )
     )
@@ -194,7 +194,7 @@ WHERE invoice.organization_id = @target_organization_id
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || @target_key_type::text
           AND allocation.seq = 2
       )
     )
@@ -224,7 +224,7 @@ WHERE invoice.organization_id = @target_organization_id
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || @target_key_type::text
           AND allocation.seq = 1
       )
     )
@@ -235,7 +235,7 @@ WHERE invoice.organization_id = @target_organization_id
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || @target_key_type::text
           AND allocation.seq = 2
       )
     )
@@ -269,13 +269,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
+      CROSS JOIN unnest(@billable_key_types::text[]) AS billable(key_type)
       WHERE invoice.service_period_end + interval '48 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 1
         )
     )
@@ -286,13 +287,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
+      CROSS JOIN unnest(@billable_key_types::text[]) AS billable(key_type)
       WHERE invoice.service_period_end + interval '72 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 2
         )
     )
@@ -336,13 +338,14 @@ WHERE invoice.organization_id = @organization_id
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
+      CROSS JOIN unnest(@billable_key_types::text[]) AS billable(key_type)
       WHERE invoice.service_period_end + interval '48 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 1
         )
     )
@@ -353,13 +356,14 @@ WHERE invoice.organization_id = @organization_id
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
+      CROSS JOIN unnest(@billable_key_types::text[]) AS billable(key_type)
       WHERE invoice.service_period_end + interval '72 hours' <= @now
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 2
         )
     )
@@ -402,6 +406,7 @@ WHERE organization_id = @organization_id
 -- name: ListOpenRouterInvoiceSourceDays :many
 SELECT
     generated.source_timestamp::date AS source_day
+  , billable.key_type::text AS key_type
   , COALESCE(spend.spend_usd, 0::numeric) AS spend_usd
   , frozen.source_snapshot_usd AS frozen_snapshot_usd
 FROM stripe_invoices invoice
@@ -410,34 +415,36 @@ CROSS JOIN LATERAL generate_series(
   invoice.service_period_end - interval '1 day',
   interval '1 day'
 ) AS generated(source_timestamp)
+CROSS JOIN unnest(@billable_key_types::text[]) AS billable(key_type)
 LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = invoice.organization_id
- AND spend.key_type = 'chat'
+ AND spend.key_type = billable.key_type
  AND spend.day = generated.source_timestamp::date
 -- Surface a snapshot an earlier pass already froze; the caller must not reseed
--- that day from spend backfilled since.
+-- that key-day from spend backfilled since.
 LEFT JOIN stripe_invoice_allocations frozen
   ON frozen.organization_id = invoice.organization_id
  AND frozen.source_kind = 'openrouter_daily_spend'
- AND frozen.source_key = generated.source_timestamp::date::text || ':chat'
+ AND frozen.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
  AND frozen.seq = 1
 WHERE invoice.organization_id = @organization_id
   AND invoice.stripe_invoice_id = @stripe_invoice_id
   AND invoice.service_period_end + interval '48 hours' <= @now
-ORDER BY source_day;
+ORDER BY generated.source_timestamp::date, billable.key_type;
 
 -- name: ListOpenRouterInvoiceBaselines :many
 SELECT
     allocation.source_key
   , allocation.source_day
+  , split_part(allocation.source_key, ':', 2)::text AS key_type
   , allocation.source_snapshot_usd
   , (CASE
-      WHEN chat_key.created_at IS NULL
-        OR allocation.source_day < (chat_key.created_at AT TIME ZONE 'UTC')::date
+      WHEN inference_key.created_at IS NULL
+        OR allocation.source_day < (inference_key.created_at AT TIME ZONE 'UTC')::date
         THEN 0::numeric
-	  WHEN chat_key.deleted_at IS NOT NULL
-	    AND allocation.source_day >= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
-	    THEN COALESCE(spend.spend_usd, 0::numeric)
+      WHEN inference_key.deleted_at IS NOT NULL
+        AND allocation.source_day >= (inference_key.deleted_at AT TIME ZONE 'UTC')::date
+        THEN COALESCE(spend.spend_usd, 0::numeric)
       ELSE spend.spend_usd
     END)::numeric(14, 6) AS final_spend_usd
   , carry.amount_usd AS existing_carry_amount_usd
@@ -446,16 +453,16 @@ FROM stripe_invoice_allocations allocation
 JOIN stripe_invoices invoice
   ON invoice.organization_id = allocation.organization_id
  AND invoice.stripe_invoice_id = allocation.original_invoice_id
-LEFT JOIN openrouter_api_keys chat_key
-  ON chat_key.organization_id = allocation.organization_id
- AND chat_key.key_type = 'chat'
+LEFT JOIN openrouter_api_keys inference_key
+  ON inference_key.organization_id = allocation.organization_id
+ AND inference_key.key_type = split_part(allocation.source_key, ':', 2)
 LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
- AND spend.key_type = 'chat'
+ AND spend.key_type = split_part(allocation.source_key, ':', 2)
  AND spend.day = allocation.source_day
  AND (
-   chat_key.deleted_at IS NULL
-   OR spend.day <= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
+   inference_key.deleted_at IS NULL
+   OR spend.day <= (inference_key.deleted_at AT TIME ZONE 'UTC')::date
  )
 LEFT JOIN stripe_invoice_allocations carry
   ON carry.organization_id = allocation.organization_id
@@ -466,8 +473,9 @@ WHERE allocation.organization_id = @organization_id
   AND invoice.stripe_invoice_id = @stripe_invoice_id
   AND invoice.service_period_end + interval '72 hours' <= @now
   AND allocation.source_kind = 'openrouter_daily_spend'
+  AND split_part(allocation.source_key, ':', 2) = ANY(@billable_key_types::text[])
   AND allocation.seq = 1
-ORDER BY allocation.source_day;
+ORDER BY allocation.source_day, split_part(allocation.source_key, ':', 2);
 
 -- name: CreateOpenRouterInvoiceAllocation :execrows
 INSERT INTO stripe_invoice_allocations (

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -393,7 +393,7 @@ WHERE invoice.organization_id = $2
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || $1::text
           AND allocation.seq = 1
       )
     )
@@ -404,7 +404,7 @@ WHERE invoice.organization_id = $2
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || $1::text
           AND allocation.seq = 2
       )
     )
@@ -1060,7 +1060,7 @@ WHERE invoice.organization_id = $1
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || $4::text
           AND allocation.seq = 1
       )
     )
@@ -1071,7 +1071,7 @@ WHERE invoice.organization_id = $1
         FROM stripe_invoice_allocations allocation
         WHERE allocation.organization_id = invoice.organization_id
           AND allocation.source_kind = 'openrouter_daily_spend'
-          AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+          AND allocation.source_key = generated.source_timestamp::date::text || ':' || $4::text
           AND allocation.seq = 2
       )
     )
@@ -1082,12 +1082,18 @@ type GetOpenRouterDailySpendRecoveryStartDayParams struct {
 	TargetOrganizationID pgtype.Text
 	TargetEarliestDay    pgtype.Date
 	TargetEndDay         pgtype.Date
+	TargetKeyType        string
 }
 
 // Expand collection to the oldest unresolved invoice day. This heals outages
 // beyond the normal overlap instead of permanently detecting the same gap.
 func (q *Queries) GetOpenRouterDailySpendRecoveryStartDay(ctx context.Context, arg GetOpenRouterDailySpendRecoveryStartDayParams) (pgtype.Date, error) {
-	row := q.db.QueryRow(ctx, getOpenRouterDailySpendRecoveryStartDay, arg.TargetOrganizationID, arg.TargetEarliestDay, arg.TargetEndDay)
+	row := q.db.QueryRow(ctx, getOpenRouterDailySpendRecoveryStartDay,
+		arg.TargetOrganizationID,
+		arg.TargetEarliestDay,
+		arg.TargetEndDay,
+		arg.TargetKeyType,
+	)
 	var recovery_start_day pgtype.Date
 	err := row.Scan(&recovery_start_day)
 	return recovery_start_day, err
@@ -1468,14 +1474,15 @@ const listOpenRouterInvoiceBaselines = `-- name: ListOpenRouterInvoiceBaselines 
 SELECT
     allocation.source_key
   , allocation.source_day
+  , split_part(allocation.source_key, ':', 2)::text AS key_type
   , allocation.source_snapshot_usd
   , (CASE
-      WHEN chat_key.created_at IS NULL
-        OR allocation.source_day < (chat_key.created_at AT TIME ZONE 'UTC')::date
+      WHEN inference_key.created_at IS NULL
+        OR allocation.source_day < (inference_key.created_at AT TIME ZONE 'UTC')::date
         THEN 0::numeric
-	  WHEN chat_key.deleted_at IS NOT NULL
-	    AND allocation.source_day >= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
-	    THEN COALESCE(spend.spend_usd, 0::numeric)
+      WHEN inference_key.deleted_at IS NOT NULL
+        AND allocation.source_day >= (inference_key.deleted_at AT TIME ZONE 'UTC')::date
+        THEN COALESCE(spend.spend_usd, 0::numeric)
       ELSE spend.spend_usd
     END)::numeric(14, 6) AS final_spend_usd
   , carry.amount_usd AS existing_carry_amount_usd
@@ -1484,16 +1491,16 @@ FROM stripe_invoice_allocations allocation
 JOIN stripe_invoices invoice
   ON invoice.organization_id = allocation.organization_id
  AND invoice.stripe_invoice_id = allocation.original_invoice_id
-LEFT JOIN openrouter_api_keys chat_key
-  ON chat_key.organization_id = allocation.organization_id
- AND chat_key.key_type = 'chat'
+LEFT JOIN openrouter_api_keys inference_key
+  ON inference_key.organization_id = allocation.organization_id
+ AND inference_key.key_type = split_part(allocation.source_key, ':', 2)
 LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = allocation.organization_id
- AND spend.key_type = 'chat'
+ AND spend.key_type = split_part(allocation.source_key, ':', 2)
  AND spend.day = allocation.source_day
  AND (
-   chat_key.deleted_at IS NULL
-   OR spend.day <= (chat_key.deleted_at AT TIME ZONE 'UTC')::date
+   inference_key.deleted_at IS NULL
+   OR spend.day <= (inference_key.deleted_at AT TIME ZONE 'UTC')::date
  )
 LEFT JOIN stripe_invoice_allocations carry
   ON carry.organization_id = allocation.organization_id
@@ -1504,19 +1511,22 @@ WHERE allocation.organization_id = $1
   AND invoice.stripe_invoice_id = $2
   AND invoice.service_period_end + interval '72 hours' <= $3
   AND allocation.source_kind = 'openrouter_daily_spend'
+  AND split_part(allocation.source_key, ':', 2) = ANY($4::text[])
   AND allocation.seq = 1
-ORDER BY allocation.source_day
+ORDER BY allocation.source_day, split_part(allocation.source_key, ':', 2)
 `
 
 type ListOpenRouterInvoiceBaselinesParams struct {
-	OrganizationID  pgtype.Text
-	StripeInvoiceID string
-	Now             pgtype.Timestamptz
+	OrganizationID   pgtype.Text
+	StripeInvoiceID  string
+	Now              pgtype.Timestamptz
+	BillableKeyTypes []string
 }
 
 type ListOpenRouterInvoiceBaselinesRow struct {
 	SourceKey              string
 	SourceDay              pgtype.Date
+	KeyType                string
 	SourceSnapshotUsd      pgtype.Numeric
 	FinalSpendUsd          pgtype.Numeric
 	ExistingCarryAmountUsd pgtype.Numeric
@@ -1524,7 +1534,12 @@ type ListOpenRouterInvoiceBaselinesRow struct {
 }
 
 func (q *Queries) ListOpenRouterInvoiceBaselines(ctx context.Context, arg ListOpenRouterInvoiceBaselinesParams) ([]ListOpenRouterInvoiceBaselinesRow, error) {
-	rows, err := q.db.Query(ctx, listOpenRouterInvoiceBaselines, arg.OrganizationID, arg.StripeInvoiceID, arg.Now)
+	rows, err := q.db.Query(ctx, listOpenRouterInvoiceBaselines,
+		arg.OrganizationID,
+		arg.StripeInvoiceID,
+		arg.Now,
+		arg.BillableKeyTypes,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1535,6 +1550,7 @@ func (q *Queries) ListOpenRouterInvoiceBaselines(ctx context.Context, arg ListOp
 		if err := rows.Scan(
 			&i.SourceKey,
 			&i.SourceDay,
+			&i.KeyType,
 			&i.SourceSnapshotUsd,
 			&i.FinalSpendUsd,
 			&i.ExistingCarryAmountUsd,
@@ -1553,6 +1569,7 @@ func (q *Queries) ListOpenRouterInvoiceBaselines(ctx context.Context, arg ListOp
 const listOpenRouterInvoiceSourceDays = `-- name: ListOpenRouterInvoiceSourceDays :many
 SELECT
     generated.source_timestamp::date AS source_day
+  , billable.key_type::text AS key_type
   , COALESCE(spend.spend_usd, 0::numeric) AS spend_usd
   , frozen.source_snapshot_usd AS frozen_snapshot_usd
 FROM stripe_invoices invoice
@@ -1561,37 +1578,45 @@ CROSS JOIN LATERAL generate_series(
   invoice.service_period_end - interval '1 day',
   interval '1 day'
 ) AS generated(source_timestamp)
+CROSS JOIN unnest($1::text[]) AS billable(key_type)
 LEFT JOIN openrouter_spend_daily spend
   ON spend.organization_id = invoice.organization_id
- AND spend.key_type = 'chat'
+ AND spend.key_type = billable.key_type
  AND spend.day = generated.source_timestamp::date
 LEFT JOIN stripe_invoice_allocations frozen
   ON frozen.organization_id = invoice.organization_id
  AND frozen.source_kind = 'openrouter_daily_spend'
- AND frozen.source_key = generated.source_timestamp::date::text || ':chat'
+ AND frozen.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
  AND frozen.seq = 1
-WHERE invoice.organization_id = $1
-  AND invoice.stripe_invoice_id = $2
-  AND invoice.service_period_end + interval '48 hours' <= $3
-ORDER BY source_day
+WHERE invoice.organization_id = $2
+  AND invoice.stripe_invoice_id = $3
+  AND invoice.service_period_end + interval '48 hours' <= $4
+ORDER BY generated.source_timestamp::date, billable.key_type
 `
 
 type ListOpenRouterInvoiceSourceDaysParams struct {
-	OrganizationID  pgtype.Text
-	StripeInvoiceID string
-	Now             pgtype.Timestamptz
+	BillableKeyTypes []string
+	OrganizationID   pgtype.Text
+	StripeInvoiceID  string
+	Now              pgtype.Timestamptz
 }
 
 type ListOpenRouterInvoiceSourceDaysRow struct {
 	SourceDay         pgtype.Date
+	KeyType           string
 	SpendUsd          pgtype.Numeric
 	FrozenSnapshotUsd pgtype.Numeric
 }
 
 // Surface a snapshot an earlier pass already froze; the caller must not reseed
-// that day from spend backfilled since.
+// that key-day from spend backfilled since.
 func (q *Queries) ListOpenRouterInvoiceSourceDays(ctx context.Context, arg ListOpenRouterInvoiceSourceDaysParams) ([]ListOpenRouterInvoiceSourceDaysRow, error) {
-	rows, err := q.db.Query(ctx, listOpenRouterInvoiceSourceDays, arg.OrganizationID, arg.StripeInvoiceID, arg.Now)
+	rows, err := q.db.Query(ctx, listOpenRouterInvoiceSourceDays,
+		arg.BillableKeyTypes,
+		arg.OrganizationID,
+		arg.StripeInvoiceID,
+		arg.Now,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1599,7 +1624,12 @@ func (q *Queries) ListOpenRouterInvoiceSourceDays(ctx context.Context, arg ListO
 	var items []ListOpenRouterInvoiceSourceDaysRow
 	for rows.Next() {
 		var i ListOpenRouterInvoiceSourceDaysRow
-		if err := rows.Scan(&i.SourceDay, &i.SpendUsd, &i.FrozenSnapshotUsd); err != nil {
+		if err := rows.Scan(
+			&i.SourceDay,
+			&i.KeyType,
+			&i.SpendUsd,
+			&i.FrozenSnapshotUsd,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -1695,13 +1725,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
-      WHERE invoice.service_period_end + interval '48 hours' <= $1
+      CROSS JOIN unnest($1::text[]) AS billable(key_type)
+      WHERE invoice.service_period_end + interval '48 hours' <= $2
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 1
         )
     )
@@ -1712,13 +1743,14 @@ WHERE invoice.organization_id IS NOT NULL
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
-      WHERE invoice.service_period_end + interval '72 hours' <= $1
+      CROSS JOIN unnest($1::text[]) AS billable(key_type)
+      WHERE invoice.service_period_end + interval '72 hours' <= $2
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 2
         )
     )
@@ -1743,11 +1775,16 @@ WHERE invoice.organization_id IS NOT NULL
 ORDER BY organization_id
 `
 
+type ListStripeInvoiceBillingOrganizationsParams struct {
+	BillableKeyTypes []string
+	Now              pgtype.Timestamptz
+}
+
 // Organizations remain candidates for as long as a required immutable
 // snapshot, a delivery, or a destination assignment is missing. There is no
 // age cutoff: an outage must delay billing rather than erase it.
-func (q *Queries) ListStripeInvoiceBillingOrganizations(ctx context.Context, now pgtype.Timestamptz) ([]string, error) {
-	rows, err := q.db.Query(ctx, listStripeInvoiceBillingOrganizations, now)
+func (q *Queries) ListStripeInvoiceBillingOrganizations(ctx context.Context, arg ListStripeInvoiceBillingOrganizationsParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, listStripeInvoiceBillingOrganizations, arg.BillableKeyTypes, arg.Now)
 	if err != nil {
 		return nil, err
 	}
@@ -1786,13 +1823,14 @@ WHERE invoice.organization_id = $1
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
-      WHERE invoice.service_period_end + interval '48 hours' <= $2
+      CROSS JOIN unnest($2::text[]) AS billable(key_type)
+      WHERE invoice.service_period_end + interval '48 hours' <= $3
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 1
         )
     )
@@ -1803,13 +1841,14 @@ WHERE invoice.organization_id = $1
         invoice.service_period_end - interval '1 day',
         interval '1 day'
       ) AS generated(source_timestamp)
-      WHERE invoice.service_period_end + interval '72 hours' <= $2
+      CROSS JOIN unnest($2::text[]) AS billable(key_type)
+      WHERE invoice.service_period_end + interval '72 hours' <= $3
         AND NOT EXISTS (
           SELECT 1
           FROM stripe_invoice_allocations allocation
           WHERE allocation.organization_id = invoice.organization_id
             AND allocation.source_kind = 'openrouter_daily_spend'
-            AND allocation.source_key = generated.source_timestamp::date::text || ':chat'
+            AND allocation.source_key = generated.source_timestamp::date::text || ':' || billable.key_type
             AND allocation.seq = 2
         )
     )
@@ -1839,8 +1878,9 @@ ORDER BY service_period_start
 `
 
 type ListStripeInvoicesForOpenRouterBillingParams struct {
-	OrganizationID pgtype.Text
-	Now            pgtype.Timestamptz
+	OrganizationID   pgtype.Text
+	BillableKeyTypes []string
+	Now              pgtype.Timestamptz
 }
 
 type ListStripeInvoicesForOpenRouterBillingRow struct {
@@ -1855,7 +1895,7 @@ type ListStripeInvoicesForOpenRouterBillingRow struct {
 }
 
 func (q *Queries) ListStripeInvoicesForOpenRouterBilling(ctx context.Context, arg ListStripeInvoicesForOpenRouterBillingParams) ([]ListStripeInvoicesForOpenRouterBillingRow, error) {
-	rows, err := q.db.Query(ctx, listStripeInvoicesForOpenRouterBilling, arg.OrganizationID, arg.Now)
+	rows, err := q.db.Query(ctx, listStripeInvoicesForOpenRouterBilling, arg.OrganizationID, arg.BillableKeyTypes, arg.Now)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgerrcode"
@@ -710,7 +711,14 @@ func allocationPeriodAndDescription(claim repo.ClaimNextStripeInvoiceAllocationR
 
 func allocationDescription(claim repo.ClaimNextStripeInvoiceAllocationRow) string {
 	if claim.SourceKind == stripeAllocationSourceOpenRouter && claim.SourceDay.Valid {
-		return "OpenRouter inference usage for " + claim.SourceDay.Time.UTC().Format(time.DateOnly)
+		label := "OpenRouter inference"
+		switch {
+		case strings.HasSuffix(claim.SourceKey, ":"+string(openrouter.KeyTypeChat)):
+			label = "Other inference"
+		case strings.HasSuffix(claim.SourceKey, ":"+string(openrouter.KeyTypeInternal)):
+			label = "Security inference"
+		}
+		return label + " usage for " + claim.SourceDay.Time.UTC().Format(time.DateOnly)
 	}
 	if claim.SourceKind == stripeAllocationSourceTUM && claim.SourcePeriodStart.Valid && claim.SourcePeriodEnd.Valid {
 		return fmt.Sprintf("TUM usage adjustment for %s to %s",

--- a/server/internal/background/activities/settle_stripe_invoice_allocations.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 )
 
@@ -37,9 +38,10 @@ const (
 type SettleStripeInvoiceAllocationsArgs struct {
 	Now time.Time
 	// RestrictOpenRouterToReadyOrganizations is explicit so an empty list from
-	// Temporal means "freeze no chat spend", never "freeze every org".
+	// Temporal means "freeze no billable key spend", never "freeze every org".
 	RestrictOpenRouterToReadyOrganizations bool
 	OpenRouterReadyOrganizationIDs         []string
+	OpenRouterBillableKeyPolicyFingerprint string
 }
 
 // SettleStripeInvoiceAllocations freezes OpenRouter charges, attaches TUM
@@ -77,7 +79,10 @@ func (s *SettleStripeInvoiceAllocations) Do(ctx context.Context, args SettleStri
 	}
 
 	queries := repo.New(s.db)
-	organizations, err := queries.ListStripeInvoiceBillingOrganizations(ctx, timestamptz(now))
+	organizations, err := queries.ListStripeInvoiceBillingOrganizations(ctx, repo.ListStripeInvoiceBillingOrganizationsParams{
+		BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+		Now:              timestamptz(now),
+	})
 	if err != nil {
 		return fmt.Errorf("list Stripe invoice billing organizations: %w", err)
 	}
@@ -90,7 +95,8 @@ func (s *SettleStripeInvoiceAllocations) Do(ctx context.Context, args SettleStri
 	for _, organizationID := range organizations {
 		_, openRouterReady := ready[organizationID]
 		if err := s.settleOrganization(ctx, queries, organizationID, now,
-			!args.RestrictOpenRouterToReadyOrganizations || openRouterReady); err != nil {
+			!args.RestrictOpenRouterToReadyOrganizations ||
+				(openRouterReady && args.OpenRouterBillableKeyPolicyFingerprint == openrouter.BillableKeyPolicyFingerprint())); err != nil {
 			s.logger.ErrorContext(ctx, "settle Stripe invoice allocations",
 				attr.SlogOrganizationID(organizationID),
 				attr.SlogError(err),
@@ -111,8 +117,9 @@ func (s *SettleStripeInvoiceAllocations) settleOrganization(
 ) error {
 	organizationIDParam := pgtype.Text{String: organizationID, Valid: true}
 	invoices, err := queries.ListStripeInvoicesForOpenRouterBilling(ctx, repo.ListStripeInvoicesForOpenRouterBillingParams{
-		OrganizationID: organizationIDParam,
-		Now:            timestamptz(now),
+		OrganizationID:   organizationIDParam,
+		BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+		Now:              timestamptz(now),
 	})
 	if err != nil {
 		return fmt.Errorf("list invoices: %w", err)
@@ -165,17 +172,18 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 	cycleEnd := invoice.ServicePeriodEnd.Time.UTC()
 	if invoice.ServicePeriodEnd.Valid && !now.Before(cycleEnd.Add(openRouterInvoiceFreezeDelay)) {
 		days, err := queries.ListOpenRouterInvoiceSourceDays(ctx, repo.ListOpenRouterInvoiceSourceDaysParams{
-			OrganizationID:  organizationID,
-			StripeInvoiceID: invoice.StripeInvoiceID,
-			Now:             timestamptz(now),
+			OrganizationID:   organizationID,
+			StripeInvoiceID:  invoice.StripeInvoiceID,
+			BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+			Now:              timestamptz(now),
 		})
 		if err != nil {
 			return fmt.Errorf("list source days for invoice %s: %w", invoice.StripeInvoiceID, err)
 		}
 
 		missedFreeze := !now.Before(cycleEnd.Add(openRouterInvoiceObservationDelay))
-		frozenSnapshots := make([]pgtype.Numeric, 0, len(days))
-		previousCumulativeCents := int64(0)
+		frozenTotals := make(map[string]*big.Rat, len(openrouter.BillableKeyTypes()))
+		previousCumulativeCents := make(map[string]int64, len(openrouter.BillableKeyTypes()))
 		for _, day := range days {
 			// A day frozen by an earlier pass is immovable, so the chain
 			// continues from the snapshot on record. Reseeding it from spend that
@@ -188,13 +196,21 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 			case missedFreeze:
 				snapshot = numericFromCents(0)
 			}
-			frozenSnapshots = append(frozenSnapshots, snapshot)
-			cumulativeCents, err := roundNumericsToCents(frozenSnapshots)
+			total, err := addNumericToTotal(frozenTotals[day.KeyType], snapshot)
 			if err != nil {
 				return fmt.Errorf("round baseline for %s: %w", day.SourceDay.Time.Format(time.DateOnly), err)
 			}
-			cents := cumulativeCents - previousCumulativeCents
-			previousCumulativeCents = cumulativeCents
+			frozenTotals[day.KeyType] = total
+			cumulativeCents, err := roundRatToCents(total)
+			if err != nil {
+				return fmt.Errorf("round baseline for %s: %w", day.SourceDay.Time.Format(time.DateOnly), err)
+			}
+			cents := cumulativeCents - previousCumulativeCents[day.KeyType]
+			previousCumulativeCents[day.KeyType] = cumulativeCents
+
+			if day.FrozenSnapshotUsd.Valid {
+				continue
+			}
 
 			destination := pgtype.Text{String: "", Valid: false}
 			if cents != 0 && invoice.InvoiceState == "draft" {
@@ -203,6 +219,7 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 			if _, err := queries.CreateOpenRouterInvoiceAllocation(ctx, openRouterAllocationParams(
 				organizationID,
 				day.SourceDay,
+				day.KeyType,
 				1,
 				snapshot,
 				cents,
@@ -220,70 +237,90 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 	}
 
 	baselines, err := queries.ListOpenRouterInvoiceBaselines(ctx, repo.ListOpenRouterInvoiceBaselinesParams{
-		OrganizationID:  organizationID,
-		StripeInvoiceID: invoice.StripeInvoiceID,
-		Now:             timestamptz(now),
+		OrganizationID:   organizationID,
+		StripeInvoiceID:  invoice.StripeInvoiceID,
+		BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+		Now:              timestamptz(now),
 	})
 	if err != nil {
 		return fmt.Errorf("list final source snapshots for invoice %s: %w", invoice.StripeInvoiceID, err)
 	}
 	// A final row is either durable spend or an authoritative pre-key zero. Do
-	// not allocate past the first unresolved day: later cents depend on every
-	// earlier exact snapshot.
-	readyCount := 0
+	// not allocate a key past its first unresolved day: later cents in that
+	// key's rounding chain depend on every earlier exact snapshot. Other keys
+	// have independent chains and can continue reconciling.
+	readyBaselines := make([]repo.ListOpenRouterInvoiceBaselinesRow, 0, len(baselines))
+	unresolvedKeyTypes := make(map[string]struct{}, len(openrouter.BillableKeyTypes()))
 	for _, baseline := range baselines {
-		if !baseline.FinalSpendUsd.Valid {
-			break
+		if _, unresolved := unresolvedKeyTypes[baseline.KeyType]; unresolved {
+			continue
 		}
-		readyCount++
+		if !baseline.FinalSpendUsd.Valid {
+			unresolvedKeyTypes[baseline.KeyType] = struct{}{}
+			continue
+		}
+		readyBaselines = append(readyBaselines, baseline)
 	}
-	baselines = baselines[:readyCount]
+	baselines = readyBaselines
 
-	frozenSnapshots := make([]pgtype.Numeric, 0, len(baselines))
-	finalSnapshots := make([]pgtype.Numeric, 0, len(baselines))
-	previousCumulativeDeltaCents := int64(0)
+	frozenTotals := make(map[string]*big.Rat, len(openrouter.BillableKeyTypes()))
+	finalTotals := make(map[string]*big.Rat, len(openrouter.BillableKeyTypes()))
+	previousCumulativeDeltaCents := make(map[string]int64, len(openrouter.BillableKeyTypes()))
 	idealCarryCents := make([]int64, len(baselines))
-	existingCarryCents := int64(0)
-	missingCarryCount := 0
+	existingCarryCents := make(map[string]int64, len(openrouter.BillableKeyTypes()))
+	missingCarryCount := make(map[string]int, len(openrouter.BillableKeyTypes()))
 	for i, baseline := range baselines {
-		frozenSnapshots = append(frozenSnapshots, baseline.SourceSnapshotUsd)
-		finalSnapshots = append(finalSnapshots, baseline.FinalSpendUsd)
-		frozenCents, err := roundNumericsToCents(frozenSnapshots)
+		keyType := baseline.KeyType
+		frozenTotal, err := addNumericToTotal(frozenTotals[keyType], baseline.SourceSnapshotUsd)
 		if err != nil {
 			return fmt.Errorf("round frozen snapshot for %s: %w", baseline.SourceKey, err)
 		}
-		finalCents, err := roundNumericsToCents(finalSnapshots)
+		frozenTotals[keyType] = frozenTotal
+		finalTotal, err := addNumericToTotal(finalTotals[keyType], baseline.FinalSpendUsd)
+		if err != nil {
+			return fmt.Errorf("round final snapshot for %s: %w", baseline.SourceKey, err)
+		}
+		finalTotals[keyType] = finalTotal
+		frozenCents, err := roundRatToCents(frozenTotal)
+		if err != nil {
+			return fmt.Errorf("round frozen snapshot for %s: %w", baseline.SourceKey, err)
+		}
+		finalCents, err := roundRatToCents(finalTotal)
 		if err != nil {
 			return fmt.Errorf("round final snapshot for %s: %w", baseline.SourceKey, err)
 		}
 		cumulativeDeltaCents := finalCents - frozenCents
-		idealCarryCents[i] = cumulativeDeltaCents - previousCumulativeDeltaCents
-		previousCumulativeDeltaCents = cumulativeDeltaCents
+		idealCarryCents[i] = cumulativeDeltaCents - previousCumulativeDeltaCents[keyType]
+		previousCumulativeDeltaCents[keyType] = cumulativeDeltaCents
 		if baseline.ExistingCarryAmountUsd.Valid {
 			cents, err := roundNumericToCents(baseline.ExistingCarryAmountUsd)
 			if err != nil {
 				return fmt.Errorf("read existing carry for %s: %w", baseline.SourceKey, err)
 			}
-			existingCarryCents += cents
+			existingCarryCents[keyType] += cents
 		} else {
-			missingCarryCount++
+			missingCarryCount[keyType]++
 		}
 	}
 
 	// Existing carries are immutable. If an older run stored a later sibling
-	// before a missing middle day arrived, put the aggregate reconciliation on
-	// the last missing row so all seq=2 rows still sum to the rounded cycle delta.
-	remainingCarryCents := previousCumulativeDeltaCents - existingCarryCents
+	// before a missing middle day arrived, put each key's aggregate reconciliation
+	// on its last missing row so its seq=2 rows sum to that key's rounded delta.
+	remainingCarryCents := make(map[string]int64, len(openrouter.BillableKeyTypes()))
+	for _, keyType := range openrouter.BillableKeyTypeStrings() {
+		remainingCarryCents[keyType] = previousCumulativeDeltaCents[keyType] - existingCarryCents[keyType]
+	}
 	for i, baseline := range baselines {
 		if baseline.ExistingCarryAmountUsd.Valid {
 			continue
 		}
+		keyType := baseline.KeyType
 		deltaCents := idealCarryCents[i]
-		missingCarryCount--
-		if missingCarryCount == 0 {
-			deltaCents = remainingCarryCents
+		missingCarryCount[keyType]--
+		if missingCarryCount[keyType] == 0 {
+			deltaCents = remainingCarryCents[keyType]
 		}
-		remainingCarryCents -= deltaCents
+		remainingCarryCents[keyType] -= deltaCents
 		destination := pgtype.Text{String: "", Valid: false}
 		if deltaCents < 0 {
 			destination = pgtype.Text{String: invoice.StripeInvoiceID, Valid: true}
@@ -291,6 +328,7 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 		if _, err := queries.CreateOpenRouterInvoiceAllocation(ctx, openRouterAllocationParams(
 			organizationID,
 			baseline.SourceDay,
+			baseline.KeyType,
 			2,
 			baseline.FinalSpendUsd,
 			deltaCents,
@@ -315,7 +353,9 @@ func (s *SettleStripeInvoiceAllocations) freezeInvoice(
 // reaches that one still raises. Both keys derive from the same (organization,
 // source day, seq) tuple, so the violation means the row this run wanted is
 // already stored, and no UPDATE in this package rewrites a stored allocation's
-// amount_usd or source_snapshot_usd. The loser has nothing left to do.
+// amount_usd or source_snapshot_usd. Both identities include the key type, so
+// different billable keys on the same UTC day cannot collide. The loser has
+// nothing left to do.
 //
 // Any other violation, the arbiter's included, is a fault this activity has
 // never reasoned about and still has to surface.
@@ -329,6 +369,7 @@ func allocationAlreadyClaimed(err error) bool {
 func openRouterAllocationParams(
 	organizationID pgtype.Text,
 	day pgtype.Date,
+	keyType string,
 	seq int32,
 	snapshot pgtype.Numeric,
 	cents int64,
@@ -345,14 +386,14 @@ func openRouterAllocationParams(
 	dayText := day.Time.UTC().Format(time.DateOnly)
 	return repo.CreateOpenRouterInvoiceAllocationParams{
 		OrganizationID:       organizationID,
-		SourceKey:            dayText + ":chat",
+		SourceKey:            dayText + ":" + keyType,
 		Seq:                  seq,
 		SourceDay:            day,
 		SourceSnapshotUsd:    snapshot,
 		AmountUsd:            numericFromCents(cents),
 		OriginalInvoiceID:    pgtype.Text{String: originalInvoiceID, Valid: true},
 		DestinationInvoiceID: destinationInvoiceID,
-		IdempotencyKey:       fmt.Sprintf("openrouter:%s:%s:%d", organizationID.String, dayText, seq),
+		IdempotencyKey:       fmt.Sprintf("openrouter:%s:%s:%s:%d", organizationID.String, dayText, keyType, seq),
 		DeliveryState:        deliveryState,
 		ConfirmedAt:          confirmedAt,
 	}
@@ -669,7 +710,7 @@ func allocationPeriodAndDescription(claim repo.ClaimNextStripeInvoiceAllocationR
 
 func allocationDescription(claim repo.ClaimNextStripeInvoiceAllocationRow) string {
 	if claim.SourceKind == stripeAllocationSourceOpenRouter && claim.SourceDay.Valid {
-		return "OpenRouter chat usage for " + claim.SourceDay.Time.UTC().Format(time.DateOnly)
+		return "OpenRouter inference usage for " + claim.SourceDay.Time.UTC().Format(time.DateOnly)
 	}
 	if claim.SourceKind == stripeAllocationSourceTUM && claim.SourcePeriodStart.Valid && claim.SourcePeriodEnd.Valid {
 		return fmt.Sprintf("TUM usage adjustment for %s to %s",
@@ -680,27 +721,32 @@ func allocationDescription(claim repo.ClaimNextStripeInvoiceAllocationRow) strin
 }
 
 func roundNumericToCents(value pgtype.Numeric) (int64, error) {
-	return roundNumericsToCents([]pgtype.Numeric{value})
+	total, err := addNumericToTotal(nil, value)
+	if err != nil {
+		return 0, err
+	}
+	return roundRatToCents(total)
 }
 
-func roundNumericsToCents(values []pgtype.Numeric) (int64, error) {
-	total := new(big.Rat)
-	for _, value := range values {
-		if !value.Valid || value.NaN || value.InfinityModifier != pgtype.Finite || value.Int == nil {
-			return 0, errors.New("amount is not a finite numeric")
-		}
-
-		term := new(big.Rat).SetInt(value.Int)
-		if value.Exp >= 0 {
-			factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(value.Exp)), nil)
-			term.Mul(term, new(big.Rat).SetInt(factor))
-		} else {
-			divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(-int64(value.Exp)), nil)
-			term.Quo(term, new(big.Rat).SetInt(divisor))
-		}
-		total.Add(total, term)
+func addNumericToTotal(total *big.Rat, value pgtype.Numeric) (*big.Rat, error) {
+	if !value.Valid || value.NaN || value.InfinityModifier != pgtype.Finite || value.Int == nil {
+		return nil, errors.New("amount is not a finite numeric")
 	}
+	if total == nil {
+		total = new(big.Rat)
+	}
+	term := new(big.Rat).SetInt(value.Int)
+	if value.Exp >= 0 {
+		factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(value.Exp)), nil)
+		term.Mul(term, new(big.Rat).SetInt(factor))
+	} else {
+		divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(-int64(value.Exp)), nil)
+		term.Quo(term, new(big.Rat).SetInt(divisor))
+	}
+	return total.Add(total, term), nil
+}
 
+func roundRatToCents(total *big.Rat) (int64, error) {
 	scaled := new(big.Rat).Mul(total, big.NewRat(100, 1))
 	absNumerator := new(big.Int).Abs(new(big.Int).Set(scaled.Num()))
 	quotient, remainder := new(big.Int).QuoRem(absNumerator, scaled.Denom(), new(big.Int))

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -334,6 +334,10 @@ func TestSettleStripeInvoiceAllocations_BillsEveryCanonicalKeyTypeExactlyOnce(t 
 	require.Equal(t, start.Format(time.DateOnly)+":internal", rows[1].SourceKey)
 	require.NotEqual(t, rows[0].IdempotencyKey, rows[1].IdempotencyKey)
 	require.ElementsMatch(t, []int64{100, 200}, []int64{stripe.itemInputs[0].AmountCents, stripe.itemInputs[1].AmountCents})
+	require.ElementsMatch(t, []string{
+		"Other inference usage for 2026-01-10",
+		"Security inference usage for 2026-01-10",
+	}, []string{stripe.itemInputs[0].Description, stripe.itemInputs[1].Description})
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(time.Hour)}))
 	require.Len(t, listAllAllocationFixtures(t, db, organizationID), 2)

--- a/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
+++ b/server/internal/background/activities/settle_stripe_invoice_allocations_test.go
@@ -19,7 +19,7 @@ import (
 	backgroundrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
-	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
@@ -176,11 +176,16 @@ func addStripeInvoice(t *testing.T, db *pgxpool.Pool, stripe *allocationStripeMo
 
 func putDailySpend(t *testing.T, db *pgxpool.Pool, organizationID string, day time.Time, amount string) {
 	t.Helper()
+	putDailySpendForKey(t, db, organizationID, openrouter.KeyTypeChat, day, amount)
+}
+
+func putDailySpendForKey(t *testing.T, db *pgxpool.Pool, organizationID string, keyType openrouter.KeyType, day time.Time, amount string) {
+	t.Helper()
 	var spend pgtype.Numeric
 	require.NoError(t, spend.Scan(amount))
 	require.NoError(t, backgroundrepo.New(db).UpsertOpenRouterDailySpend(t.Context(), backgroundrepo.UpsertOpenRouterDailySpendParams{
 		TargetOrganizationID: organizationID,
-		TargetKeyType:        "chat",
+		TargetKeyType:        string(keyType),
 		TargetDay:            pgtype.Date{Time: day.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
 		TargetSpendUsd:       spend,
 	}))
@@ -188,15 +193,23 @@ func putDailySpend(t *testing.T, db *pgxpool.Pool, organizationID string, day ti
 
 func createChatKeyAt(t *testing.T, db *pgxpool.Pool, organizationID string, createdAt time.Time) {
 	t.Helper()
-	_, err := openrouterrepo.New(db).CreateOpenRouterAPIKey(t.Context(), openrouterrepo.CreateOpenRouterAPIKeyParams{
-		OrganizationID: organizationID,
-		KeyType:        "chat",
-		KeyEncrypted:   pgtype.Text{},
-		KeyHash:        strings.Repeat("a", 64),
-		MonthlyCredits: 0,
-	})
-	require.NoError(t, err)
-	setChatKeyCreatedAt(t, db, organizationID, createdAt)
+	createInferenceKeyAt(t, db, organizationID, openrouter.KeyTypeChat, createdAt)
+}
+
+func createInferenceKeyAt(t *testing.T, db *pgxpool.Pool, organizationID string, keyType openrouter.KeyType, createdAt time.Time) {
+	t.Helper()
+	hashRune := 'a'
+	if keyType == openrouter.KeyTypeInternal {
+		hashRune = 'b'
+	}
+	createOpenRouterSpendTarget(t, db, organizationID, keyType, hashRune)
+	require.NoError(t, backgroundrepo.New(db).SetOpenRouterAPIKeyCreatedAtFixture(
+		t.Context(), backgroundrepo.SetOpenRouterAPIKeyCreatedAtFixtureParams{
+			CreatedAt:      pgtype.Timestamptz{Time: createdAt.UTC(), InfinityModifier: pgtype.Finite, Valid: true},
+			OrganizationID: organizationID,
+			KeyType:        string(keyType),
+		},
+	))
 }
 
 func setChatKeyCreatedAt(t *testing.T, db *pgxpool.Pool, organizationID string, createdAt time.Time) {
@@ -246,7 +259,7 @@ func addOpenRouterCarryFixture(
 			AmountUsd:            amountNumeric,
 			OriginalInvoiceID:    pgtype.Text{String: invoiceID, Valid: true},
 			DestinationInvoiceID: pgtype.Text{String: invoiceID, Valid: true},
-			IdempotencyKey:       "openrouter:" + organizationID + ":" + day.UTC().Format(time.DateOnly) + ":2",
+			IdempotencyKey:       "openrouter:" + organizationID + ":" + day.UTC().Format(time.DateOnly) + ":chat:2",
 			DeliveryState:        "confirmed",
 			ConfirmedAt:          pgtype.Timestamptz{Time: now, InfinityModifier: pgtype.Finite, Valid: true},
 		},
@@ -254,12 +267,31 @@ func addOpenRouterCarryFixture(
 	require.NoError(t, err)
 }
 
-func listAllocationFixtures(t *testing.T, db *pgxpool.Pool, organizationID string) []backgroundrepo.ListStripeInvoiceAllocationsFixtureRow {
+func listAllAllocationFixtures(t *testing.T, db *pgxpool.Pool, organizationID string) []backgroundrepo.ListStripeInvoiceAllocationsFixtureRow {
 	t.Helper()
 	rows, err := backgroundrepo.New(db).ListStripeInvoiceAllocationsFixture(
 		t.Context(), pgtype.Text{String: organizationID, Valid: true})
 	require.NoError(t, err)
 	return rows
+}
+
+func listAllocationFixturesForKeyType(t *testing.T, db *pgxpool.Pool, organizationID string, keyType openrouter.KeyType) []backgroundrepo.ListStripeInvoiceAllocationsFixtureRow {
+	t.Helper()
+	rows := listAllAllocationFixtures(t, db, organizationID)
+	filtered := make([]backgroundrepo.ListStripeInvoiceAllocationsFixtureRow, 0, len(rows))
+	for _, row := range rows {
+		if row.SourceKind != "openrouter_daily_spend" || strings.HasSuffix(row.SourceKey, ":"+string(keyType)) {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+// Existing allocation tests predate per-key billing and intentionally assert
+// only the chat rounding chain. Multi-key edge tests use the all/key helpers.
+func listChatAllocationFixtures(t *testing.T, db *pgxpool.Pool, organizationID string) []backgroundrepo.ListStripeInvoiceAllocationsFixtureRow {
+	t.Helper()
+	return listAllocationFixturesForKeyType(t, db, organizationID, openrouter.KeyTypeChat)
 }
 
 func addTUMCarry(t *testing.T, db *pgxpool.Pool, organizationID string, start, end time.Time, cents int64, key string) {
@@ -284,6 +316,78 @@ func addTUMCarry(t *testing.T, db *pgxpool.Pool, organizationID string, start, e
 	}))
 }
 
+func TestSettleStripeInvoiceAllocations_BillsEveryCanonicalKeyTypeExactlyOnce(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_billable_key_types")
+	start := time.Date(2026, time.January, 10, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	createInferenceKeyAt(t, db, organizationID, openrouter.KeyTypeInternal, start.Add(-time.Hour))
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpendForKey(t, db, organizationID, openrouter.KeyTypeChat, start, "1.000000")
+	putDailySpendForKey(t, db, organizationID, openrouter.KeyTypeInternal, start, "2.000000")
+	now := end.Add(48 * time.Hour)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
+	rows := listAllAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 2)
+	require.Equal(t, start.Format(time.DateOnly)+":chat", rows[0].SourceKey)
+	require.Equal(t, start.Format(time.DateOnly)+":internal", rows[1].SourceKey)
+	require.NotEqual(t, rows[0].IdempotencyKey, rows[1].IdempotencyKey)
+	require.ElementsMatch(t, []int64{100, 200}, []int64{stripe.itemInputs[0].AmountCents, stripe.itemInputs[1].AmountCents})
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(time.Hour)}))
+	require.Len(t, listAllAllocationFixtures(t, db, organizationID), 2)
+	require.Len(t, stripe.itemInputs, 2)
+
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+	stripe.invoices["in_original"].Status = "open"
+	stripe.invoices["in_original"].FinalizedAt = end.Add(time.Hour)
+	putDailySpendForKey(t, db, organizationID, openrouter.KeyTypeChat, start, "1.500000")
+	putDailySpendForKey(t, db, organizationID, openrouter.KeyTypeInternal, start, "2.500000")
+	reconcileAt := end.Add(72 * time.Hour)
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: reconcileAt}))
+	rows = listAllAllocationFixtures(t, db, organizationID)
+	require.Len(t, rows, 4)
+	for _, keyType := range openrouter.BillableKeyTypeStrings() {
+		sourceKey := start.Format(time.DateOnly) + ":" + keyType
+		count := 0
+		for _, row := range rows {
+			if row.SourceKey == sourceKey {
+				count++
+			}
+		}
+		require.Equal(t, 2, count, "each billable key has one baseline and one carry")
+	}
+	require.Len(t, stripe.itemInputs, 4)
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: reconcileAt.Add(time.Hour)}))
+	require.Len(t, listAllAllocationFixtures(t, db, organizationID), 4)
+	require.Len(t, stripe.itemInputs, 4)
+}
+
+func TestSettleStripeInvoiceAllocations_RequiresMatchingBillablePolicyForReadyOrganizations(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_policy_version")
+	start := time.Date(2026, time.January, 10, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "draft", 0)
+	putDailySpend(t, db, organizationID, start, "1.000000")
+
+	args := activities.SettleStripeInvoiceAllocationsArgs{
+		Now:                                    end.Add(48 * time.Hour),
+		RestrictOpenRouterToReadyOrganizations: true,
+		OpenRouterReadyOrganizationIDs:         []string{organizationID},
+		OpenRouterBillableKeyPolicyFingerprint: "internal\x00chat",
+	}
+	require.NoError(t, activity.Do(t.Context(), args))
+	require.Empty(t, listAllAllocationFixtures(t, db, organizationID))
+
+	args.OpenRouterBillableKeyPolicyFingerprint = openrouter.BillableKeyPolicyFingerprint()
+	require.NoError(t, activity.Do(t.Context(), args))
+	require.Len(t, listAllAllocationFixtures(t, db, organizationID), len(openrouter.BillableKeyTypes()))
+	require.Len(t, stripe.itemInputs, 1)
+}
+
 func TestSettleStripeInvoiceAllocations_BoundariesAndHalfAwayFromZero(t *testing.T) {
 	t.Parallel()
 	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_boundaries")
@@ -295,12 +399,12 @@ func TestSettleStripeInvoiceAllocations_BoundariesAndHalfAwayFromZero(t *testing
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
 		Now: end.Add(48*time.Hour - time.Nanosecond),
 	}))
-	require.Empty(t, listAllocationFixtures(t, db, organizationID))
+	require.Empty(t, listChatAllocationFixtures(t, db, organizationID))
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
 		Now: end.Add(48 * time.Hour),
 	}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 1)
 	require.Equal(t, "1.005000", numericString(t, rows[0].SourceSnapshotUsd))
 	require.Equal(t, "1.010000", numericString(t, rows[0].AmountUsd))
@@ -314,7 +418,7 @@ func TestSettleStripeInvoiceAllocations_BoundariesAndHalfAwayFromZero(t *testing
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
 		Now: end.Add(72 * time.Hour),
 	}))
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 2)
 	require.Equal(t, int32(2), rows[1].Seq)
 	require.Equal(t, "1.014999", numericString(t, rows[1].SourceSnapshotUsd))
@@ -334,7 +438,7 @@ func TestSettleStripeInvoiceAllocations_MissedWindowRecoversAfter96Hours(t *test
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
 		Now: end.Add(120 * time.Hour),
 	}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 2)
 	require.Equal(t, int32(1), rows[0].Seq)
 	require.Equal(t, "0", numericString(t, rows[0].SourceSnapshotUsd))
@@ -367,7 +471,7 @@ func TestSettleStripeInvoiceAllocations_AssignsEarliestDraftWithinTenant(t *test
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{
 		Now: end.Add(52 * time.Hour),
 	}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 1)
 	require.Equal(t, "0.020000", numericString(t, rows[0].AmountUsd))
 	require.Equal(t, "in_earlier", rows[0].DestinationInvoiceID.String)
@@ -391,7 +495,7 @@ func TestSettleStripeInvoiceAllocations_NegativeCarryCreditsPaidPortion(t *testi
 	state.AmountRemaining = 40
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(76 * time.Hour)}))
 
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 2)
 	require.Equal(t, "-1.010000", numericString(t, rows[1].AmountUsd))
 	require.Equal(t, "in_original", rows[1].DestinationInvoiceID.String)
@@ -447,7 +551,7 @@ func TestSettleStripeInvoiceAllocations_ReconcilesAfter24Hours(t *testing.T) {
 	firstAttempt := end.Add(48 * time.Hour)
 	require.Error(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt}))
 
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 1)
 	stripe.foundItem = &stripeclient.InvoiceItem{
 		ID:          "ii_reconciled",
@@ -456,7 +560,7 @@ func TestSettleStripeInvoiceAllocations_ReconcilesAfter24Hours(t *testing.T) {
 		AmountCents: 125,
 	}
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25 * time.Hour)}))
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Equal(t, "confirmed", rows[0].DeliveryState)
 	require.Equal(t, "ii_reconciled", rows[0].StripeInvoiceItemID.String)
 	require.True(t, rows[0].ReconciledAt.Valid)
@@ -497,7 +601,7 @@ func TestSettleStripeInvoiceAllocations_MissingBaselineBecomesPositiveCarry(t *t
 	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(52 * time.Hour)}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 1)
 	require.Equal(t, "0", numericString(t, rows[0].SourceSnapshotUsd))
 	require.Equal(t, "0", numericString(t, rows[0].AmountUsd))
@@ -505,7 +609,7 @@ func TestSettleStripeInvoiceAllocations_MissingBaselineBecomesPositiveCarry(t *t
 
 	putDailySpend(t, db, organizationID, start, "0.015000")
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(76 * time.Hour)}))
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 2)
 	require.Equal(t, "0.020000", numericString(t, rows[1].AmountUsd))
 	require.Equal(t, "in_future", rows[1].DestinationInvoiceID.String)
@@ -521,14 +625,14 @@ func TestSettleStripeInvoiceAllocations_MissingFinalSourceRemainsRecoverable(t *
 	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(76 * time.Hour)}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 1, "missing durable spend must not be finalized as a zero carry")
 	require.Equal(t, int32(1), rows[0].Seq)
 	require.Equal(t, "0", numericString(t, rows[0].SourceSnapshotUsd))
 
 	putDailySpend(t, db, organizationID, start, "0.015000")
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(77 * time.Hour)}))
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 2)
 	require.Equal(t, int32(2), rows[1].Seq)
 	require.Equal(t, "0.020000", numericString(t, rows[1].AmountUsd))
@@ -549,7 +653,7 @@ func TestSettleStripeInvoiceAllocations_PreKeyDaysFinalizeAsDurableZero(t *testi
 	now := end.Add(76 * time.Hour)
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 6)
 	require.Equal(t, int32(2), rows[1].Seq)
 	require.Equal(t, "0", numericString(t, rows[1].SourceSnapshotUsd))
@@ -563,11 +667,14 @@ func TestSettleStripeInvoiceAllocations_PreKeyDaysFinalizeAsDurableZero(t *testi
 	require.Len(t, stripe.itemInputs, 1)
 
 	candidates, err := backgroundrepo.New(db).ListStripeInvoiceBillingOrganizations(
-		t.Context(), pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true})
+		t.Context(), backgroundrepo.ListStripeInvoiceBillingOrganizationsParams{
+			BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+			Now:              pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		})
 	require.NoError(t, err)
 	require.Empty(t, candidates, "authoritative pre-key zeroes must finish the invoice candidate")
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(time.Hour)}))
-	require.Len(t, listAllocationFixtures(t, db, organizationID), 6)
+	require.Len(t, listChatAllocationFixtures(t, db, organizationID), 6)
 	require.Len(t, stripe.itemInputs, 1)
 }
 
@@ -580,7 +687,7 @@ func TestSettleStripeInvoiceAllocations_NoKeyDaysFinalizeAsDurableZero(t *testin
 	now := end.Add(76 * time.Hour)
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 4)
 	for _, row := range rows {
 		require.Equal(t, "0", numericString(t, row.SourceSnapshotUsd))
@@ -590,7 +697,10 @@ func TestSettleStripeInvoiceAllocations_NoKeyDaysFinalizeAsDurableZero(t *testin
 	require.Empty(t, stripe.itemInputs)
 
 	candidates, err := backgroundrepo.New(db).ListStripeInvoiceBillingOrganizations(
-		t.Context(), pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true})
+		t.Context(), backgroundrepo.ListStripeInvoiceBillingOrganizationsParams{
+			BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+			Now:              pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		})
 	require.NoError(t, err)
 	require.Empty(t, candidates, "an organization without a chat key cannot have chat spend")
 }
@@ -610,7 +720,7 @@ func TestSettleStripeInvoiceAllocations_PostDeletionDaysFinalizeAsDurableZero(t 
 	now := end.Add(76 * time.Hour)
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 6)
 	require.Equal(t, "0.010000", numericString(t, rows[1].SourceSnapshotUsd))
 	require.Equal(t, "0.020000", numericString(t, rows[3].SourceSnapshotUsd), "deletion-day spend remains billable")
@@ -618,9 +728,42 @@ func TestSettleStripeInvoiceAllocations_PostDeletionDaysFinalizeAsDurableZero(t 
 	require.Equal(t, int32(2), rows[5].Seq)
 
 	candidates, err := backgroundrepo.New(db).ListStripeInvoiceBillingOrganizations(
-		t.Context(), pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true})
+		t.Context(), backgroundrepo.ListStripeInvoiceBillingOrganizationsParams{
+			BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+			Now:              pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		})
 	require.NoError(t, err)
 	require.Empty(t, candidates, "post-deletion zeroes must finish the invoice candidate")
+}
+
+func TestSettleStripeInvoiceAllocations_UnresolvedKeyDoesNotBlockAnotherKeyCarry(t *testing.T) {
+	t.Parallel()
+	db, organizationID, stripe, activity := setupAllocationTest(t, "stripe_alloc_independent_key_readiness")
+	start := time.Date(2026, time.August, 14, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 2)
+	createInferenceKeyAt(t, db, organizationID, openrouter.KeyTypeInternal, start.Add(-time.Hour))
+	addStripeInvoice(t, db, stripe, organizationID, "in_original", start, end, "open", 0)
+	addStripeInvoice(t, db, stripe, organizationID, "in_future", end.AddDate(0, 0, 2), end.AddDate(0, 0, 3), "draft", 0)
+	putDailySpend(t, db, organizationID, start, "0.010000")
+	putDailySpend(t, db, organizationID, start.AddDate(0, 0, 1), "0.020000")
+
+	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(76 * time.Hour)}))
+	rows := listAllAllocationFixtures(t, db, organizationID)
+	chatCarries := 0
+	internalCarries := 0
+	for _, row := range rows {
+		if row.Seq != 2 {
+			continue
+		}
+		if strings.HasSuffix(row.SourceKey, ":chat") {
+			chatCarries++
+		}
+		if strings.HasSuffix(row.SourceKey, ":internal") {
+			internalCarries++
+		}
+	}
+	require.Equal(t, 2, chatCarries, "complete chat chain must reconcile")
+	require.Zero(t, internalCarries, "unresolved internal chain must remain recoverable")
 }
 
 func TestSettleStripeInvoiceAllocations_LateMiddleDayReconcilesExistingLaterCarry(t *testing.T) {
@@ -636,7 +779,7 @@ func TestSettleStripeInvoiceAllocations_LateMiddleDayReconcilesExistingLaterCarr
 	now := end.Add(76 * time.Hour)
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 4)
 	require.Equal(t, start.Format(time.DateOnly)+":chat", rows[1].SourceKey)
 	require.Equal(t, int32(2), rows[1].Seq)
@@ -645,7 +788,7 @@ func TestSettleStripeInvoiceAllocations_LateMiddleDayReconcilesExistingLaterCarr
 
 	putDailySpend(t, db, organizationID, middleDay, "0.004000")
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(time.Hour)}))
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 6)
 	require.Equal(t, middleDay.Format(time.DateOnly)+":chat", rows[3].SourceKey)
 	require.Equal(t, int32(2), rows[3].Seq)
@@ -660,7 +803,7 @@ func TestSettleStripeInvoiceAllocations_LateMiddleDayReconcilesExistingLaterCarr
 	require.Empty(t, stripe.itemInputs)
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now.Add(2 * time.Hour)}))
-	require.Len(t, listAllocationFixtures(t, db, organizationID), 6)
+	require.Len(t, listChatAllocationFixtures(t, db, organizationID), 6)
 }
 
 func TestSettleStripeInvoiceAllocations_RoundsCumulativeCycleTotalsAndDrainsBatch(t *testing.T) {
@@ -675,7 +818,7 @@ func TestSettleStripeInvoiceAllocations_RoundsCumulativeCycleTotalsAndDrainsBatc
 	putDailySpend(t, db, organizationID, secondDay, "0.004000")
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(48 * time.Hour)}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 2)
 	require.Equal(t, "0", numericString(t, rows[0].AmountUsd))
 	require.Equal(t, "0.010000", numericString(t, rows[1].AmountUsd))
@@ -689,7 +832,7 @@ func TestSettleStripeInvoiceAllocations_RoundsCumulativeCycleTotalsAndDrainsBatc
 	state.FinalizedAt = end.Add(time.Hour)
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(72 * time.Hour)}))
 
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 4)
 	require.Equal(t, "0.010000", numericString(t, rows[1].AmountUsd))
 	require.Equal(t, "0.010000", numericString(t, rows[2].AmountUsd))
@@ -719,7 +862,7 @@ func TestSettleStripeInvoiceAllocations_TUMPositiveCarryIgnoresChatReadinessAndB
 		RestrictOpenRouterToReadyOrganizations: true,
 		OpenRouterReadyOrganizationIDs:         []string{},
 	}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 1)
 	require.Equal(t, "in_original", rows[0].OriginalInvoiceID.String)
 	require.Equal(t, "in_future", rows[0].DestinationInvoiceID.String)
@@ -739,7 +882,7 @@ func TestSettleStripeInvoiceAllocations_TUMNegativeCarryCreditsOriginal(t *testi
 	addTUMCarry(t, db, organizationID, start, end, -35, "negative")
 
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: end.Add(24 * time.Hour)}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 1)
 	require.Equal(t, "in_original", rows[0].DestinationInvoiceID.String)
 	require.Equal(t, "confirmed", rows[0].DeliveryState)
@@ -766,12 +909,12 @@ func TestSettleStripeInvoiceAllocations_AmbiguousItemWaitsForVisibilityBeforeClo
 	state.FinalizedAt = end.Add(time.Hour)
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(time.Hour)}))
 	require.Zero(t, stripe.findItems, "eventual visibility cannot be decided inside 24 hours")
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Equal(t, "in_original", rows[0].DestinationInvoiceID.String)
 
 	stripe.foundItem = &stripeclient.InvoiceItem{ID: "ii_visible_later", InvoiceID: "in_original", Currency: "usd", AmountCents: 100}
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25 * time.Hour)}))
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Equal(t, "confirmed", rows[0].DeliveryState)
 	require.Equal(t, "in_original", rows[0].DestinationInvoiceID.String)
 	require.Equal(t, "ii_visible_later", rows[0].StripeInvoiceItemID.String)
@@ -796,14 +939,14 @@ func TestSettleStripeInvoiceAllocations_ProvenAbsentClosedItemRebindsWithRotated
 	state.Status = "open"
 	state.FinalizedAt = end.Add(time.Hour)
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25 * time.Hour)}))
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.False(t, rows[0].DestinationInvoiceID.Valid, "proven-absent closed destination is released")
 	require.True(t, rows[0].ReconciledAt.Valid)
 	require.LessOrEqual(t, len(rows[0].IdempotencyKey), 255)
 
 	require.Error(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(25*time.Hour + 6*time.Minute)}))
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: firstAttempt.Add(51 * time.Hour)}))
-	rows = listAllocationFixtures(t, db, organizationID)
+	rows = listChatAllocationFixtures(t, db, organizationID)
 	require.Equal(t, "in_future", rows[0].DestinationInvoiceID.String)
 	require.Equal(t, "confirmed", rows[0].DeliveryState)
 	require.Len(t, stripe.itemInputs, 3)
@@ -895,7 +1038,7 @@ func TestM3FreezeObservationAndCarrySettlementLifecycle(t *testing.T) {
 	require.Equal(t, int64(100_000), tumCarries[0].DeltaTokens.Int64)
 	require.Equal(t, "0.040000", numericString(t, tumCarries[0].AmountUsd))
 
-	allocations := listAllocationFixtures(t, db, organizationID)
+	allocations := listChatAllocationFixtures(t, db, organizationID)
 	amountsBySource := make(map[string][]string)
 	for _, allocation := range allocations {
 		require.Equal(t, "confirmed", allocation.DeliveryState)
@@ -955,7 +1098,7 @@ func TestSettleStripeInvoiceAllocations_BackfilledSpendKeepsFrozenChain(t *testi
 	putDailySpend(t, db, organizationID, start, "0.006000")
 	require.NoError(t, activity.Do(t.Context(), activities.SettleStripeInvoiceAllocationsArgs{Now: now}))
 
-	rows := listAllocationFixtures(t, db, organizationID)
+	rows := listChatAllocationFixtures(t, db, organizationID)
 	require.Len(t, rows, 2)
 	require.Equal(t, "0.004000", numericString(t, rows[0].SourceSnapshotUsd),
 		"the frozen day keeps the snapshot it was written with, not the backfill")

--- a/server/internal/background/openrouter_daily_spend.go
+++ b/server/internal/background/openrouter_daily_spend.go
@@ -64,6 +64,7 @@ func CollectOpenRouterDailySpendWorkflow(ctx workflow.Context) error {
 		Now:                                    workflow.Now(ctx).UTC(),
 		RestrictOpenRouterToReadyOrganizations: true,
 		OpenRouterReadyOrganizationIDs:         collected.ReadyOrganizationIDs,
+		OpenRouterBillableKeyPolicyFingerprint: collected.BillableKeyPolicyFingerprint,
 	}).Get(ctx, nil)
 	if settlementErr != nil {
 		settlementErr = fmt.Errorf("settle Stripe invoice allocations: %w", settlementErr)

--- a/server/internal/background/openrouter_daily_spend_test.go
+++ b/server/internal/background/openrouter_daily_spend_test.go
@@ -28,7 +28,10 @@ func TestCollectOpenRouterDailySpendWorkflowCollectsLastFourCompletedUTCDays(t *
 	env.RegisterActivityWithOptions(
 		func(_ context.Context, args activities.CollectOpenRouterDailySpendArgs) (activities.CollectOpenRouterDailySpendResult, error) {
 			received = args
-			return activities.CollectOpenRouterDailySpendResult{ReadyOrganizationIDs: []string{"org-ready"}}, nil
+			return activities.CollectOpenRouterDailySpendResult{
+				ReadyOrganizationIDs:         []string{"org-ready"},
+				BillableKeyPolicyFingerprint: "4b4e792daf43040a6f92b112a281187144b92cc902d5b355056f28a0c2ad6894",
+			}, nil
 		},
 		activity.RegisterOptions{Name: "CollectOpenRouterDailySpend"},
 	)
@@ -49,6 +52,7 @@ func TestCollectOpenRouterDailySpendWorkflowCollectsLastFourCompletedUTCDays(t *
 	require.Equal(t, time.Date(2026, time.August, 15, 6, 30, 0, 0, time.UTC), settled.Now)
 	require.True(t, settled.RestrictOpenRouterToReadyOrganizations)
 	require.Equal(t, []string{"org-ready"}, settled.OpenRouterReadyOrganizationIDs)
+	require.Equal(t, "4b4e792daf43040a6f92b112a281187144b92cc902d5b355056f28a0c2ad6894", settled.OpenRouterBillableKeyPolicyFingerprint)
 }
 
 func TestCollectOpenRouterDailySpendWorkflowPropagatesFailureAfterRetries(t *testing.T) {

--- a/server/internal/billing/tier_limits.go
+++ b/server/internal/billing/tier_limits.go
@@ -31,7 +31,7 @@ func NewPaygTierLimits() *gen.TierLimits {
 		},
 		IncludedBullets: []string{
 			"Other inference billed at provider cost",
-			"Security inference funded by Speakeasy",
+			"Security inference billed at provider cost",
 		},
 		AddOnBullets:          []string{},
 		TumPricePerMillionUsd: &price,

--- a/server/internal/billing/tier_limits.go
+++ b/server/internal/billing/tier_limits.go
@@ -31,7 +31,7 @@ func NewPaygTierLimits() *gen.TierLimits {
 		},
 		IncludedBullets: []string{
 			"Other inference billed at provider cost",
-			"Security inference billed at provider cost",
+			"Platform-initiated inference billed at provider cost",
 		},
 		AddOnBullets:          []string{},
 		TumPricePerMillionUsd: &price,

--- a/server/internal/billing/usage_tiers_test.go
+++ b/server/internal/billing/usage_tiers_test.go
@@ -33,7 +33,7 @@ func TestNewPaygTierLimits(t *testing.T) {
 	require.Equal(t, "0.00000035", billing.TUMUnitPriceUSD)
 	require.Equal(t, []string{
 		"Other inference billed at provider cost",
-		"Security inference billed at provider cost",
+		"Platform-initiated inference billed at provider cost",
 	}, want.IncludedBullets)
 	require.Empty(t, want.AddOnBullets)
 	require.Equal(t, []string{

--- a/server/internal/billing/usage_tiers_test.go
+++ b/server/internal/billing/usage_tiers_test.go
@@ -33,7 +33,7 @@ func TestNewPaygTierLimits(t *testing.T) {
 	require.Equal(t, "0.00000035", billing.TUMUnitPriceUSD)
 	require.Equal(t, []string{
 		"Other inference billed at provider cost",
-		"Security inference funded by Speakeasy",
+		"Security inference billed at provider cost",
 	}, want.IncludedBullets)
 	require.Empty(t, want.AddOnBullets)
 	require.Equal(t, []string{

--- a/server/internal/email/loops/payg_activated.lmx
+++ b/server/internal/email/loops/payg_activated.lmx
@@ -13,7 +13,7 @@
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">BILLING · PAY AS YOU GO ACTIVE</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Pay as you go is active.</H1>
-<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is on pay as you go with the full feature set. Tokens under management are metered and billed each cycle. Other inference and security inference are billed at provider cost.</Paragraph>
+<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is on pay as you go with the full feature set. Tokens under management are metered and billed each cycle. Customer-facing and platform-initiated inference are billed at provider cost.</Paragraph>
 <Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">METERED RATE</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">${data.tum_price_per_million_usd} per million tokens under management</Text></Paragraph>

--- a/server/internal/email/loops/payg_activated.lmx
+++ b/server/internal/email/loops/payg_activated.lmx
@@ -13,7 +13,7 @@
 </Columns>
 <Paragraph fontSize="12" lineHeight="140" paddingTop="44" paddingRight="40" paddingBottom="18" paddingLeft="40"><Strong textColor="#757575">BILLING · PAY AS YOU GO ACTIVE</Strong></Paragraph>
 <H1 paddingRight="40" paddingBottom="26" paddingLeft="40">Pay as you go is active.</H1>
-<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is on pay as you go with the full feature set. Tokens under management are metered and billed each cycle. Other inference is billed at provider cost, and security inference is funded by Speakeasy.</Paragraph>
+<Paragraph paddingRight="40" paddingBottom="28" paddingLeft="40">{data.organization_name} is on pay as you go with the full feature set. Tokens under management are metered and billed each cycle. Other inference and security inference are billed at provider cost.</Paragraph>
 <Section blockColor="#FFFFFF" blockBorderWidth="1" blockBorderColor="#DBDBDB" paddingTop="22" paddingRight="24" paddingBottom="20" paddingLeft="24">
   <Paragraph fontSize="12" lineHeight="140"><Strong textColor="#757575">METERED RATE</Strong></Paragraph>
   <Paragraph fontSize="14" lineHeight="155" paddingTop="8"><Text textColor="#121212">${data.tum_price_per_million_usd} per million tokens under management</Text></Paragraph>

--- a/server/internal/thirdparty/openrouter/key_type_test.go
+++ b/server/internal/thirdparty/openrouter/key_type_test.go
@@ -20,6 +20,21 @@ func TestKeyTypeOrDefault(t *testing.T) {
 	require.Equal(t, KeyTypeInternal, KeyTypeInternal.OrDefault())
 }
 
+func TestBillableKeyTypes(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []KeyType{KeyTypeChat, KeyTypeInternal}, BillableKeyTypes())
+	require.Equal(t, []string{"chat", "internal"}, BillableKeyTypeStrings())
+	require.Equal(t, "4b4e792daf43040a6f92b112a281187144b92cc902d5b355056f28a0c2ad6894", BillableKeyPolicyFingerprint())
+	require.True(t, KeyTypeChat.IsBillable())
+	require.True(t, KeyTypeInternal.IsBillable())
+	require.False(t, KeyType("future").IsBillable())
+
+	keyTypes := BillableKeyTypes()
+	keyTypes[0] = "changed"
+	require.Equal(t, KeyTypeChat, BillableKeyTypes()[0], "callers cannot mutate billing policy")
+}
+
 func TestKeyTypeValidate(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -3,6 +3,7 @@ package openrouter
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,6 +76,36 @@ func (s KeyDesiredState) Validate() error {
 // limit refreshes) consume it, so adding a key type here propagates without
 // hunting call sites.
 var AllKeyTypes = []KeyType{KeyTypeChat, KeyTypeInternal}
+
+var billableKeyTypes = []KeyType{KeyTypeChat, KeyTypeInternal}
+
+// BillableKeyTypes returns the platform-managed OpenRouter keys whose spend a
+// PAYG organization owns. Estimate and invoice paths must consume this set.
+func BillableKeyTypes() []KeyType {
+	return slices.Clone(billableKeyTypes)
+}
+
+// BillableKeyTypeStrings returns BillableKeyTypes in the shape SQL queries use.
+func BillableKeyTypeStrings() []string {
+	keyTypes := make([]string, len(billableKeyTypes))
+	for i, keyType := range billableKeyTypes {
+		keyTypes[i] = string(keyType)
+	}
+	return keyTypes
+}
+
+// BillableKeyPolicyFingerprint mechanically identifies the ordered canonical
+// billable key set so collection and settlement can reject rolling-deployment
+// handoffs that used different policies.
+func BillableKeyPolicyFingerprint() string {
+	sum := sha256.Sum256([]byte(strings.Join(BillableKeyTypeStrings(), "\x00")))
+	return fmt.Sprintf("%x", sum)
+}
+
+// IsBillable reports whether PAYG invoices include this key type.
+func (k KeyType) IsBillable() bool {
+	return slices.Contains(billableKeyTypes, k.OrDefault())
+}
 
 const (
 	// upstreamKeyCreateTimeout bounds the POST /v1/keys call made while

--- a/server/internal/usage/payg_billing_summary.go
+++ b/server/internal/usage/payg_billing_summary.go
@@ -10,6 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
@@ -84,12 +85,13 @@ func (s *Service) GetPaygBillingSummaryForOrganization(ctx context.Context, orga
 
 	completedBefore := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	costs, err := s.repo.GetPaygBillingSummaryCosts(ctx, repo.GetPaygBillingSummaryCostsParams{
-		TumTokens:       tumTokens,
-		TumUnitPriceUsd: TUMUnitPriceUSD,
-		OrganizationID:  organizationID,
-		PeriodStart:     finiteTimestamptz(periodStart),
-		PeriodEnd:       finiteTimestamptz(periodEnd),
-		CompletedBefore: finiteTimestamptz(completedBefore),
+		TumTokens:        tumTokens,
+		TumUnitPriceUsd:  TUMUnitPriceUSD,
+		OrganizationID:   organizationID,
+		BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+		PeriodStart:      finiteTimestamptz(periodStart),
+		PeriodEnd:        finiteTimestamptz(periodEnd),
+		CompletedBefore:  finiteTimestamptz(completedBefore),
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "get pay as you go billing summary costs").LogError(ctx, s.logger)

--- a/server/internal/usage/payg_billing_summary_test.go
+++ b/server/internal/usage/payg_billing_summary_test.go
@@ -110,14 +110,19 @@ func materializePaygSummaryKey(t *testing.T, db *pgxpool.Pool, orgID string, key
 		MonthlyCredits: 0,
 	})
 	require.NoError(t, err)
-	_, err = db.Exec(t.Context(), `UPDATE openrouter_api_keys SET created_at = $1 WHERE organization_id = $2 AND key_type = $3`, createdAt, orgID, keyType)
-	require.NoError(t, err)
+	require.NoError(t, repo.New(db).SetOpenRouterAPIKeyCreatedAtFixture(t.Context(), repo.SetOpenRouterAPIKeyCreatedAtFixtureParams{
+		CreatedAt:      pgtype.Timestamptz{Time: createdAt, InfinityModifier: pgtype.Finite, Valid: true},
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+	}))
 }
 
 func setPaygSummaryKeysCreatedAt(t *testing.T, db *pgxpool.Pool, orgID string, createdAt time.Time) {
 	t.Helper()
-	_, err := db.Exec(t.Context(), `UPDATE openrouter_api_keys SET created_at = $1 WHERE organization_id = $2`, createdAt, orgID)
-	require.NoError(t, err)
+	require.NoError(t, repo.New(db).SetOpenRouterAPIKeysCreatedAtFixture(t.Context(), repo.SetOpenRouterAPIKeysCreatedAtFixtureParams{
+		CreatedAt:      pgtype.Timestamptz{Time: createdAt, InfinityModifier: pgtype.Finite, Valid: true},
+		OrganizationID: orgID,
+	}))
 }
 
 func upsertPaygSummarySpend(t *testing.T, db *pgxpool.Pool, orgID string, day time.Time, amount string) {

--- a/server/internal/usage/payg_billing_summary_test.go
+++ b/server/internal/usage/payg_billing_summary_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
@@ -52,6 +55,8 @@ func newPaygBillingSummaryTestInstance(t *testing.T) *paygBillingSummaryTestInst
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	start := today.AddDate(0, 0, -3)
 	end := today.AddDate(0, 1, 0)
+	materializePaygSummaryKey(t, db, orgID, openrouter.KeyTypeChat, 'c', start.Add(-time.Hour))
+	materializePaygSummaryKey(t, db, orgID, openrouter.KeyTypeInternal, 'i', start.Add(-time.Hour))
 	stripe := newCheckoutStripeClient()
 	stripe.subscriptionState = &stripeclient.SubscriptionState{
 		ID:                           "sub_summary",
@@ -95,12 +100,38 @@ func (ti *paygBillingSummaryTestInstance) context(t *testing.T, grants ...authz.
 	return authztest.WithExactGrants(t, ctx, grants...)
 }
 
+func materializePaygSummaryKey(t *testing.T, db *pgxpool.Pool, orgID string, keyType openrouter.KeyType, hashRune rune, createdAt time.Time) {
+	t.Helper()
+	_, err := openrouterrepo.New(db).CreateOpenRouterAPIKey(t.Context(), openrouterrepo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+		KeyEncrypted:   pgtype.Text{},
+		KeyHash:        strings.Repeat(string(hashRune), 64),
+		MonthlyCredits: 0,
+	})
+	require.NoError(t, err)
+	_, err = db.Exec(t.Context(), `UPDATE openrouter_api_keys SET created_at = $1 WHERE organization_id = $2 AND key_type = $3`, createdAt, orgID, keyType)
+	require.NoError(t, err)
+}
+
+func setPaygSummaryKeysCreatedAt(t *testing.T, db *pgxpool.Pool, orgID string, createdAt time.Time) {
+	t.Helper()
+	_, err := db.Exec(t.Context(), `UPDATE openrouter_api_keys SET created_at = $1 WHERE organization_id = $2`, createdAt, orgID)
+	require.NoError(t, err)
+}
+
 func upsertPaygSummarySpend(t *testing.T, db *pgxpool.Pool, orgID string, day time.Time, amount string) {
+	t.Helper()
+	upsertPaygSummarySpendForKey(t, db, orgID, openrouter.KeyTypeChat, day, amount)
+}
+
+func upsertPaygSummarySpendForKey(t *testing.T, db *pgxpool.Pool, orgID string, keyType openrouter.KeyType, day time.Time, amount string) {
 	t.Helper()
 	var spend pgtype.Numeric
 	require.NoError(t, spend.Scan(amount))
 	require.NoError(t, repo.New(db).UpsertOpenRouterDailySpendFixture(t.Context(), repo.UpsertOpenRouterDailySpendFixtureParams{
 		OrganizationID: orgID,
+		KeyType:        string(keyType),
 		Day:            pgtype.Date{Time: day, InfinityModifier: pgtype.Finite, Valid: true},
 		SpendUsd:       spend,
 	}))
@@ -134,6 +165,9 @@ func TestGetPaygBillingSummaryReturnsExactCycleAlignedEstimate(t *testing.T) {
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, ti.start, "1.200000")
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, ti.start.AddDate(0, 0, 1), "2.345678")
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, ti.start.AddDate(0, 0, 2), "0.000001")
+	upsertPaygSummarySpendForKey(t, ti.db, ti.orgID, openrouter.KeyTypeInternal, ti.start, "0.500000")
+	upsertPaygSummarySpendForKey(t, ti.db, ti.orgID, openrouter.KeyTypeInternal, ti.start.AddDate(0, 0, 1), "0.250000")
+	upsertPaygSummarySpendForKey(t, ti.db, ti.orgID, openrouter.KeyType("future"), ti.start, "100.000000")
 
 	ctx := ti.context(t, authz.NewGrant(authz.ScopeOrgRead, ti.orgID))
 	result, err := ti.service.GetPaygBillingSummary(ctx, &gen.GetPaygBillingSummaryPayload{})
@@ -143,11 +177,32 @@ func TestGetPaygBillingSummaryReturnsExactCycleAlignedEstimate(t *testing.T) {
 	assert.Equal(t, int64(1_000_000), result.TumTokens)
 	assert.Equal(t, "0.00000035", result.TumUnitPriceUsd)
 	assert.Equal(t, "0.35000000", result.TumCostUsd)
-	assert.Equal(t, "3.545679", result.OtherInferenceSpendUsd)
+	assert.Equal(t, "4.295678", result.OtherInferenceSpendUsd)
 	if assert.NotNil(t, result.RecordedThrough) {
-		assert.Equal(t, ti.start.AddDate(0, 0, 2).Format(time.DateOnly), *result.RecordedThrough)
+		assert.Equal(t, ti.start.AddDate(0, 0, 1).Format(time.DateOnly), *result.RecordedThrough)
 	}
-	assert.Equal(t, "3.89567900", result.EstimatedTotalUsd)
+	assert.Equal(t, "4.64567800", result.EstimatedTotalUsd)
+}
+
+func TestGetPaygBillingSummaryRequiresSpendForEveryApplicableMaterializedKey(t *testing.T) {
+	t.Parallel()
+
+	ti := newPaygBillingSummaryTestInstance(t)
+	upsertPaygSummarySpend(t, ti.db, ti.orgID, ti.start, "1.000000")
+
+	ctx := ti.context(t, authz.NewGrant(authz.ScopeOrgRead, ti.orgID))
+	result, err := ti.service.GetPaygBillingSummary(ctx, &gen.GetPaygBillingSummaryPayload{})
+	require.NoError(t, err)
+	assert.Nil(t, result.RecordedThrough)
+	assert.Equal(t, "0.000000", result.OtherInferenceSpendUsd)
+
+	upsertPaygSummarySpendForKey(t, ti.db, ti.orgID, openrouter.KeyTypeInternal, ti.start, "0.000000")
+	result, err = ti.service.GetPaygBillingSummary(ctx, &gen.GetPaygBillingSummaryPayload{})
+	require.NoError(t, err)
+	if assert.NotNil(t, result.RecordedThrough) {
+		assert.Equal(t, ti.start.Format(time.DateOnly), *result.RecordedThrough)
+	}
+	assert.Equal(t, "1.000000", result.OtherInferenceSpendUsd)
 }
 
 func TestGetPaygBillingSummaryCostsUsesCompletedDaysWithinPeriod(t *testing.T) {
@@ -157,22 +212,27 @@ func TestGetPaygBillingSummaryCostsUsesCompletedDaysWithinPeriod(t *testing.T) {
 	periodStart := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
 	periodEnd := time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC)
 	completedBefore := time.Date(2026, time.August, 15, 0, 0, 0, 0, time.UTC)
+	setPaygSummaryKeysCreatedAt(t, ti.db, ti.orgID, periodStart.Add(-time.Hour))
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, periodStart.AddDate(0, 0, -1), "99.000000")
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, periodStart, "1.200000")
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, completedBefore.AddDate(0, 0, -1), "2.345678")
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, completedBefore, "88.000000")
 	upsertPaygSummarySpend(t, ti.db, ti.orgID, periodEnd, "77.000000")
+	upsertPaygSummarySpendForKey(t, ti.db, ti.orgID, openrouter.KeyTypeInternal, periodStart, "0.500000")
+	upsertPaygSummarySpendForKey(t, ti.db, ti.orgID, openrouter.KeyTypeInternal, completedBefore.AddDate(0, 0, -1), "0.250000")
+	upsertPaygSummarySpendForKey(t, ti.db, ti.orgID, openrouter.KeyType("future"), periodStart, "100.000000")
 
 	costs, err := repo.New(ti.db).GetPaygBillingSummaryCosts(t.Context(), repo.GetPaygBillingSummaryCostsParams{
-		TumTokens:       0,
-		TumUnitPriceUsd: TUMUnitPriceUSD,
-		OrganizationID:  ti.orgID,
-		PeriodStart:     finiteTimestamptz(periodStart),
-		PeriodEnd:       finiteTimestamptz(periodEnd),
-		CompletedBefore: finiteTimestamptz(completedBefore),
+		TumTokens:        0,
+		TumUnitPriceUsd:  TUMUnitPriceUSD,
+		OrganizationID:   ti.orgID,
+		BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+		PeriodStart:      finiteTimestamptz(periodStart),
+		PeriodEnd:        finiteTimestamptz(periodEnd),
+		CompletedBefore:  finiteTimestamptz(completedBefore),
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "3.545678", costs.OtherInferenceSpendUsd)
+	assert.Equal(t, "4.295678", costs.OtherInferenceSpendUsd)
 	assert.True(t, costs.RecordedThrough.Valid)
 	assert.Equal(t, completedBefore.AddDate(0, 0, -1), costs.RecordedThrough.Time.UTC())
 }

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -15,17 +15,41 @@ WITH inputs AS (
   SELECT
       sqlc.arg(tum_tokens)::bigint AS tum_tokens
     , sqlc.arg(tum_unit_price_usd)::text::numeric(20, 8) AS tum_unit_price_usd
-), completed_spend AS (
-  SELECT
-      COALESCE(SUM(spend_usd), 0)::numeric(30, 6) AS other_inference_spend_usd
-    , MAX(day)::date AS recorded_through
+), applicable_keys AS (
+  SELECT key_type
+  FROM openrouter_api_keys
+  WHERE organization_id = sqlc.arg(organization_id)::text
+    AND key_type = ANY(sqlc.arg(billable_key_types)::text[])
+    AND created_at < LEAST(sqlc.arg(period_end)::timestamptz, sqlc.arg(completed_before)::timestamptz)
+    AND (deleted_at IS NULL OR deleted_at >= sqlc.arg(period_start)::timestamptz)
+), billable_spend AS (
+  SELECT key_type, day, spend_usd
   FROM openrouter_spend_daily
   WHERE organization_id = sqlc.arg(organization_id)::text
-    AND key_type = 'chat'
+    AND key_type = ANY(sqlc.arg(billable_key_types)::text[])
     AND day >= (sqlc.arg(period_start)::timestamptz AT TIME ZONE 'UTC')::date
     AND day < (sqlc.arg(period_end)::timestamptz AT TIME ZONE 'UTC')::date
     AND day < (sqlc.arg(completed_before)::timestamptz AT TIME ZONE 'UTC')::date
+), recorded_spend AS (
+  SELECT CASE
+    WHEN COUNT(*) FILTER (WHERE recorded_through IS NULL) > 0 THEN NULL
+    ELSE MIN(recorded_through)::date
+  END AS recorded_through
+  FROM (
+    SELECT applicable_keys.key_type, MAX(billable_spend.day)::date AS recorded_through
+    FROM applicable_keys
+    LEFT JOIN billable_spend USING (key_type)
+    GROUP BY applicable_keys.key_type
+  ) key_watermarks
+), completed_spend AS (
+  SELECT
+      COALESCE(SUM(spend_usd), 0)::numeric(30, 6) AS other_inference_spend_usd
+    , recorded_spend.recorded_through
+  FROM recorded_spend
+  LEFT JOIN billable_spend ON billable_spend.day <= recorded_spend.recorded_through
+  GROUP BY recorded_spend.recorded_through
 )
+
 SELECT
     inputs.tum_unit_price_usd::text AS tum_unit_price_usd
   , (inputs.tum_tokens::numeric * inputs.tum_unit_price_usd)::numeric(30, 8)::text AS tum_cost_usd
@@ -321,7 +345,7 @@ VALUES (@organization_id, @stripe_customer_id, @stripe_subscription_id);
 -- name: UpsertOpenRouterDailySpendFixture :exec
 -- Test-only fixture for billing-summary reads.
 INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
-VALUES (@organization_id, 'chat', @day, @spend_usd)
+VALUES (@organization_id, @key_type, @day, @spend_usd)
 ON CONFLICT (organization_id, key_type, day) DO UPDATE
 SET spend_usd = EXCLUDED.spend_usd,
     updated_at = clock_timestamp();

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -772,3 +772,16 @@ SELECT *
 FROM stripe_invoices
 WHERE organization_id = @organization_id
 ORDER BY service_period_start, stripe_invoice_id;
+
+-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
+-- Test-only fixture for PAYG estimate completeness windows.
+UPDATE openrouter_api_keys
+SET created_at = @created_at
+WHERE organization_id = @organization_id
+  AND key_type = @key_type;
+
+-- name: SetOpenRouterAPIKeysCreatedAtFixture :exec
+-- Test-only fixture for PAYG estimate completeness windows.
+UPDATE openrouter_api_keys
+SET created_at = @created_at
+WHERE organization_id = @organization_id;

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -1738,6 +1738,42 @@ func (q *Queries) PrepareStripeCheckoutIntent(ctx context.Context, arg PrepareSt
 	return i, err
 }
 
+const setOpenRouterAPIKeyCreatedAtFixture = `-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
+UPDATE openrouter_api_keys
+SET created_at = $1
+WHERE organization_id = $2
+  AND key_type = $3
+`
+
+type SetOpenRouterAPIKeyCreatedAtFixtureParams struct {
+	CreatedAt      pgtype.Timestamptz
+	OrganizationID string
+	KeyType        string
+}
+
+// Test-only fixture for PAYG estimate completeness windows.
+func (q *Queries) SetOpenRouterAPIKeyCreatedAtFixture(ctx context.Context, arg SetOpenRouterAPIKeyCreatedAtFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyCreatedAtFixture, arg.CreatedAt, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
+const setOpenRouterAPIKeysCreatedAtFixture = `-- name: SetOpenRouterAPIKeysCreatedAtFixture :exec
+UPDATE openrouter_api_keys
+SET created_at = $1
+WHERE organization_id = $2
+`
+
+type SetOpenRouterAPIKeysCreatedAtFixtureParams struct {
+	CreatedAt      pgtype.Timestamptz
+	OrganizationID string
+}
+
+// Test-only fixture for PAYG estimate completeness windows.
+func (q *Queries) SetOpenRouterAPIKeysCreatedAtFixture(ctx context.Context, arg SetOpenRouterAPIKeysCreatedAtFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterAPIKeysCreatedAtFixture, arg.CreatedAt, arg.OrganizationID)
+	return err
+}
+
 const setStripeCheckoutSessionFixture = `-- name: SetStripeCheckoutSessionFixture :exec
 UPDATE billing_metadata
 SET stripe_checkout_session_id = $1

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -831,17 +831,41 @@ WITH inputs AS (
   SELECT
       $1::bigint AS tum_tokens
     , $2::text::numeric(20, 8) AS tum_unit_price_usd
+), applicable_keys AS (
+  SELECT key_type
+  FROM openrouter_api_keys
+  WHERE organization_id = $3::text
+    AND key_type = ANY($4::text[])
+    AND created_at < LEAST($5::timestamptz, $6::timestamptz)
+    AND (deleted_at IS NULL OR deleted_at >= $7::timestamptz)
+), billable_spend AS (
+  SELECT key_type, day, spend_usd
+  FROM openrouter_spend_daily
+  WHERE organization_id = $3::text
+    AND key_type = ANY($4::text[])
+    AND day >= ($7::timestamptz AT TIME ZONE 'UTC')::date
+    AND day < ($5::timestamptz AT TIME ZONE 'UTC')::date
+    AND day < ($6::timestamptz AT TIME ZONE 'UTC')::date
+), recorded_spend AS (
+  SELECT CASE
+    WHEN COUNT(*) FILTER (WHERE recorded_through IS NULL) > 0 THEN NULL
+    ELSE MIN(recorded_through)::date
+  END AS recorded_through
+  FROM (
+    SELECT applicable_keys.key_type, MAX(billable_spend.day)::date AS recorded_through
+    FROM applicable_keys
+    LEFT JOIN billable_spend USING (key_type)
+    GROUP BY applicable_keys.key_type
+  ) key_watermarks
 ), completed_spend AS (
   SELECT
       COALESCE(SUM(spend_usd), 0)::numeric(30, 6) AS other_inference_spend_usd
-    , MAX(day)::date AS recorded_through
-  FROM openrouter_spend_daily
-  WHERE organization_id = $3::text
-    AND key_type = 'chat'
-    AND day >= ($4::timestamptz AT TIME ZONE 'UTC')::date
-    AND day < ($5::timestamptz AT TIME ZONE 'UTC')::date
-    AND day < ($6::timestamptz AT TIME ZONE 'UTC')::date
+    , recorded_spend.recorded_through
+  FROM recorded_spend
+  LEFT JOIN billable_spend ON billable_spend.day <= recorded_spend.recorded_through
+  GROUP BY recorded_spend.recorded_through
 )
+
 SELECT
     inputs.tum_unit_price_usd::text AS tum_unit_price_usd
   , (inputs.tum_tokens::numeric * inputs.tum_unit_price_usd)::numeric(30, 8)::text AS tum_cost_usd
@@ -853,12 +877,13 @@ CROSS JOIN completed_spend
 `
 
 type GetPaygBillingSummaryCostsParams struct {
-	TumTokens       int64
-	TumUnitPriceUsd string
-	OrganizationID  string
-	PeriodStart     pgtype.Timestamptz
-	PeriodEnd       pgtype.Timestamptz
-	CompletedBefore pgtype.Timestamptz
+	TumTokens        int64
+	TumUnitPriceUsd  string
+	OrganizationID   string
+	BillableKeyTypes []string
+	PeriodEnd        pgtype.Timestamptz
+	CompletedBefore  pgtype.Timestamptz
+	PeriodStart      pgtype.Timestamptz
 }
 
 type GetPaygBillingSummaryCostsRow struct {
@@ -874,9 +899,10 @@ func (q *Queries) GetPaygBillingSummaryCosts(ctx context.Context, arg GetPaygBil
 		arg.TumTokens,
 		arg.TumUnitPriceUsd,
 		arg.OrganizationID,
-		arg.PeriodStart,
+		arg.BillableKeyTypes,
 		arg.PeriodEnd,
 		arg.CompletedBefore,
+		arg.PeriodStart,
 	)
 	var i GetPaygBillingSummaryCostsRow
 	err := row.Scan(
@@ -1978,7 +2004,7 @@ func (q *Queries) UpsertBillingMetadata(ctx context.Context, arg UpsertBillingMe
 
 const upsertOpenRouterDailySpendFixture = `-- name: UpsertOpenRouterDailySpendFixture :exec
 INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
-VALUES ($1, 'chat', $2, $3)
+VALUES ($1, $2, $3, $4)
 ON CONFLICT (organization_id, key_type, day) DO UPDATE
 SET spend_usd = EXCLUDED.spend_usd,
     updated_at = clock_timestamp()
@@ -1986,13 +2012,19 @@ SET spend_usd = EXCLUDED.spend_usd,
 
 type UpsertOpenRouterDailySpendFixtureParams struct {
 	OrganizationID string
+	KeyType        string
 	Day            pgtype.Date
 	SpendUsd       pgtype.Numeric
 }
 
 // Test-only fixture for billing-summary reads.
 func (q *Queries) UpsertOpenRouterDailySpendFixture(ctx context.Context, arg UpsertOpenRouterDailySpendFixtureParams) error {
-	_, err := q.db.Exec(ctx, upsertOpenRouterDailySpendFixture, arg.OrganizationID, arg.Day, arg.SpendUsd)
+	_, err := q.db.Exec(ctx, upsertOpenRouterDailySpendFixture,
+		arg.OrganizationID,
+		arg.KeyType,
+		arg.Day,
+		arg.SpendUsd,
+	)
 	return err
 }
 


### PR DESCRIPTION
## Summary

- treat both customer-facing and platform-initiated OpenRouter keys as billable for PAYG organizations
- align PAYG estimates, collection readiness, invoice allocation, recovery, carry, and reconciliation on one canonical key policy
- keep allocation identities unique by UTC day and key type and update billing copy and regression coverage

Closes [DNO-927](https://linear.app/speakeasy/issue/DNO-927/fix-align-payg-invoices-with-billable-openrouter-key-policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bills all PAYG OpenRouter inference spend so invoices match policy. Previously only chat was invoiced; now both chat and internal are billable, and estimates and Stripe allocations share one canonical billable‑key policy.

- Canonical policy in `server/internal/thirdparty/openrouter`: `BillableKeyTypes()` = ["chat","internal"]; `BillableKeyPolicyFingerprint()` identifies the policy, is propagated and verified during settlement; normalizes default key type. Satisfies DNO-927.
- Collection (`CollectOpenRouterDailySpend`): considers only billable keys; returns the policy fingerprint; org readiness now requires fresh, gap-free data across every billable key, and any key failure blocks readiness.
- Settlement (`SettleStripeInvoiceAllocations`): freezes per-day allocations per billable key; source_key is `YYYY-MM-DD:<keyType>`; verifies the policy fingerprint; restricts freezing to ready orgs; distinguishes inference invoice items by key type.
- Estimates (`GetPaygBillingSummary`): aggregates spend across all in-cycle billable keys; OpenAPI/SDK field `other_inference_spend_usd` now describes “Exact durable customer-billable OpenRouter inference spend”.
- Copy: dashboard/admin labels use “Inference spend”; PAYG tier bullets and the activation email state customer-facing and platform-initiated inference are billed at provider cost.
- Tests: add coverage for readiness gating across keys, per-key allocation and labeling, policy immutability, and copy; update to use SQLc PAYG fixtures. No schema changes or data migration.

<sup>Written for commit dc539016e83f5537e87bdb6df8be20609e1fea9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

