### PR TITLE
fix: admit Codex CLI per-server CIMD client_ids with a codex catalog pattern

### DIFF
--- a/server/internal/usersessions/cimd/admission/catalog.go
+++ b/server/internal/usersessions/cimd/admission/catalog.go
@@ -139,18 +139,24 @@ var catalog = []Preset{
 		Enabled:     true,
 	},
 
-	// Verified 2026-07. OpenAI mints a document per connector, so the
-	// namespace is unbounded and only a pattern can admit it — see
-	// pattern.go. Two named entries follow so an operator reading the
-	// catalog sees "ChatGPT" and "Codex CLI" rather than just a glob, but
-	// note they differ: Codex sits inside the wildcard's namespace and is
-	// therefore DisplayOnly, while the constant ChatGPT document has no
-	// segment where the wildcard expects one and so is a rule of its own.
+	// Verified 2026-07, re-verified 2026-08-19 (all four entries fetched
+	// live). OpenAI mints CIMD documents per connector and per Codex target
+	// server, so those namespaces are unbounded and only patterns can admit
+	// them — see pattern.go.
 	//
-	// Note both of OpenAI's documents omit token_endpoint_auth_method
-	// entirely; the validator treats that as "none" rather than rejecting,
-	// which is what makes these entries live rather than decorative.
+	// chatgpt.com is a TEMPLATE endpoint: any id in a wildcard position
+	// returns HTTP 200 with a valid self-referential document, so a
+	// successful fetch proves nothing about an id being real. The patterns
+	// stay safe because the id is never reflected into consent-visible
+	// metadata — client_name, client_uri, and logo_uri are constant per
+	// product — and the per-id redirect_uris are loopback-only, so minting
+	// a document at a chosen id gains an attacker nothing over presenting
+	// the vendor's real client_id.
 	{
+		// One document per ChatGPT connector, {id} derived from the MCP
+		// server origin (per OpenAI's Apps SDK docs and comments in the
+		// Codex CLI source: SHAKE-256 over the origin) — deterministic per
+		// server, unbounded across servers.
 		VendorKey:   "openai",
 		DisplayName: "ChatGPT (connectors)",
 		URL:         "https://chatgpt.com/oauth/*/client.json",
@@ -158,18 +164,43 @@ var catalog = []Preset{
 		Enabled:     true,
 	},
 	{
+		// The connector platform's stable shared document. NOT DisplayOnly:
+		// the connector wildcard requires exactly one path segment between
+		// /oauth/ and /client.json, and this URL has none, so nothing else
+		// admits it. It is a rule in its own right.
 		VendorKey:   "openai",
 		DisplayName: "ChatGPT",
 		URL:         "https://chatgpt.com/oauth/client.json",
-		// NOT DisplayOnly. The connector wildcard requires exactly one path
-		// segment between /oauth/ and /client.json, and this URL has none,
-		// so nothing else admits it. It is a rule in its own right.
 		DisplayOnly: false,
 		Enabled:     true,
 	},
 	{
+		// Codex CLI ≥0.148.0 (first stable release 2026-08-18, openai/codex
+		// PR #38089; earlier versions used dynamic client registration and
+		// never presented a CIMD client_id) mints one document per MCP
+		// server: {id} is the base64url-no-pad encoding of the first 9
+		// bytes of SHA-256 of the full server URL, computed client-side.
+		// Deterministic per server URL, not per install — every install
+		// pointed at the same server presents the same client_id — but the
+		// server URL space is unbounded, so only a pattern can admit it.
 		VendorKey:   "openai",
 		DisplayName: "Codex CLI",
+		URL:         "https://chatgpt.com/oauth/codex/*/client.json",
+		DisplayOnly: false,
+		Enabled:     true,
+	},
+	{
+		// The stable shared Codex document. No released Codex version has
+		// ever presented it — the 2026-07 entry was assembled from OpenAI's
+		// docs, not observed traffic — but OpenAI's docs as of 2026-08
+		// state Codex will switch to it, once client support ships, for
+		// authorization servers that advertise
+		// authorization_response_iss_parameter_supported (RFC 9207).
+		// DisplayOnly because the connector wildcard (one segment, here
+		// "codex") already admits it; when Codex flips to this document no
+		// catalog change is needed.
+		VendorKey:   "openai",
+		DisplayName: "Codex CLI (stable document)",
 		URL:         "https://chatgpt.com/oauth/codex/client.json",
 		DisplayOnly: true,
 		Enabled:     true,

--- a/server/internal/usersessions/cimd/admission/pattern_test.go
+++ b/server/internal/usersessions/cimd/admission/pattern_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const chatGPTPattern = "https://chatgpt.com/oauth/*/client.json"
+const (
+	chatGPTPattern = "https://chatgpt.com/oauth/*/client.json"
+	codexPattern   = "https://chatgpt.com/oauth/codex/*/client.json"
+)
 
 func TestPresetIsPattern(t *testing.T) {
 	t.Parallel()
@@ -220,6 +223,55 @@ func TestCatalogAdmits_ChatGPTConnectorNamespace(t *testing.T) {
 
 	require.False(t, catalogAdmits("https://chatgpt.com.evil.example.com/oauth/x/client.json"))
 	require.False(t, catalogAdmits("https://chatgpt.com/oauth/x/y/client.json"))
+}
+
+// TestCatalogAdmits_CodexPerServerNamespace exercises the Codex CLI pattern
+// against the client_id shape Codex ≥0.148.0 presents: {id} is a 12-char
+// base64url-no-pad digest of the MCP server URL, so real ids draw only on
+// A-Z, a-z, 0-9, "-", and "_" — an alphabet containing no "/", which is
+// what makes single-segment matching sound for this namespace.
+func TestCatalogAdmits_CodexPerServerNamespace(t *testing.T) {
+	t.Parallel()
+
+	// The first two are real ids observed in production denials (AIS-582);
+	// between them they cover the "-" alphabet character, and the third
+	// covers "_".
+	admitted := []string{
+		"https://chatgpt.com/oauth/codex/WoV6218LroET/client.json",
+		"https://chatgpt.com/oauth/codex/Lv2-Pvw8pHkH/client.json",
+		"https://chatgpt.com/oauth/codex/p9jr1GJD7_bK/client.json",
+	}
+	for _, clientID := range admitted {
+		require.Truef(t, matchesPattern(codexPattern, clientID), "%q should match", clientID)
+		require.Truef(t, catalogAdmits(clientID), "%q should be admitted by the catalog", clientID)
+	}
+
+	rejected := []string{
+		"https://chatgpt.com/oauth/codex/client.json",                    // zero segments for the *
+		"https://chatgpt.com/oauth/codex/a/b/client.json",                // two segments for one *
+		"https://chatgpt.com/oauth/codex//client.json",                   // empty segment
+		"https://chatgpt.com/oauth/other/abc123/client.json",             // literal segment differs
+		"https://chatgpt.com/oauth/codex/x/client.json?probe=1",          // query is part of the compare
+		"https://chatgpt.com.evil.example.com/oauth/codex/x/client.json", // suffix-extended host
+	}
+	for _, clientID := range rejected {
+		require.Falsef(t, matchesPattern(codexPattern, clientID), "%q must NOT match", clientID)
+	}
+	// The deeper shape must miss the whole catalog, not just this pattern.
+	require.False(t, catalogAdmits("https://chatgpt.com/oauth/codex/a/b/client.json"))
+}
+
+// TestCatalog_CodexStableDocumentAttribution pins which rule covers the
+// DisplayOnly stable Codex document: the one-segment connector wildcard,
+// not the Codex per-server pattern, which requires a segment between
+// "codex" and "client.json". A catalog edit that shifts this coverage
+// should fail here rather than move the invariant silently.
+func TestCatalog_CodexStableDocumentAttribution(t *testing.T) {
+	t.Parallel()
+
+	const stableDocument = "https://chatgpt.com/oauth/codex/client.json"
+	require.True(t, matchesPattern(chatGPTPattern, stableDocument))
+	require.False(t, matchesPattern(codexPattern, stableDocument))
 }
 
 // TestCatalogAdmits_ExactEntriesUnaffectedByPatterns: adding wildcards must


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-582/codex-cli-now-presents-per-install-cimd-client-id-urls-that-the

Codex CLI 0.148.0 and later ([openai/codex#38089](https://github.com/openai/codex/pull/38089), first stable release 2026-08-18) presents one CIMD client_id per MCP server, of the shape `https://chatgpt.com/oauth/codex/{id}/client.json`, where `{id}` is the base64url encoding of the first 9 bytes of SHA-256 of the full server URL. The existing one-segment ChatGPT connectors wildcard correctly rejects the two-segment shape, so these clients were recorded as `denied_not_listed` in reporting mode and would hard-fail once admission enforces presets.

This change adds an enabled catalog pattern `https://chatgpt.com/oauth/codex/*/client.json`, verified live 2026-08-19 against both production denials (HTTP 200, self-referential `client_id`, `token_endpoint_auth_method` of `none`, loopback-only `redirect_uris`, and the `{id}` is not reflected into any consent-visible metadata).

It also reconciles the OpenAI vendor block comments with the corrected history: no released Codex version ever presented the constant `https://chatgpt.com/oauth/codex/client.json` (the 2026-07 entry was assembled from OpenAI documentation, not observed traffic). That row stays `DisplayOnly`, renamed to "Codex CLI (stable document)", since OpenAI documents it as the future shape for authorization servers advertising RFC 9207 issuer identification, and the connectors wildcard already admits it. The comments also record that chatgpt.com mints valid self-referential documents for arbitrary ids, so admission trust rests on the origin and pattern rather than document existence.

New tests cover the Codex namespace matching and pin that the connectors wildcard, not the codex pattern, is what covers the `DisplayOnly` row.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admits Codex CLI per-server CIMD client_ids by adding a Codex namespace pattern. Previously, the one‑segment ChatGPT connectors wildcard rejected `https://chatgpt.com/oauth/codex/{id}/client.json`, recording `denied_not_listed` and risking hard failures when presets are enforced.

- Catalog: adds enabled `https://chatgpt.com/oauth/codex/*/client.json`; keeps `https://chatgpt.com/oauth/client.json` as its own rule; renames the documented but unused `https://chatgpt.com/oauth/codex/client.json` to "Codex CLI (stable document)" as DisplayOnly; updates comments (template endpoint behavior, RFC 9207 context).
- Tests: cover Codex per‑server namespace matching and pin that the ChatGPT connectors wildcard, not the Codex pattern, covers the stable Codex document.
- Safety: pattern is single‑segment; chatgpt.com returns self‑referential docs for arbitrary ids, but ids are not reflected into consent‑visible metadata and redirect_uris are loopback‑only.

**Rollout**
- No migrations. Merge before enabling CIMD preset enforcement to prevent Codex CLI failures.
- Addresses Linear AIS-582 (Codex CLI per‑install/per‑server client_id URLs were not admitted).

<sup>Written for commit 3a0e6c361fe71589c5d1153f16d379928c58956b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

