### PR TITLE
feat: implement empty resources/templates/list for hosted MCP servers

### DIFF
--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1330,6 +1330,8 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 		return handlePromptsGet(ctx, s.logger, s.db, payload, req)
 	case "resources/list":
 		return handleResourcesList(ctx, s.logger, s.db, payload, req, &s.toolsetCache, s.platformExtras)
+	case "resources/templates/list":
+		return handleResourcesTemplatesList(ctx, s.logger, req)
 	case "resources/read":
 		return handleResourcesRead(ctx, s.logger, s.db, payload, req, s.toolProxy, s.env, s.billingTracker, s.billingRepository, s.telemLogger, s.platformExtras)
 	default:

--- a/server/internal/mcp/rpc_resources_templates_list.go
+++ b/server/internal/mcp/rpc_resources_templates_list.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+type resourcesTemplatesListResult struct {
+	ResourceTemplates []*resourceTemplateListEntry `json:"resourceTemplates"`
+}
+
+type resourceTemplateListEntry struct {
+	URITemplate string         `json:"uriTemplate"`
+	Name        string         `json:"name"`
+	Description *string        `json:"description,omitempty"`
+	MimeType    *string        `json:"mimeType,omitempty"`
+	Meta        map[string]any `json:"_meta,omitempty"`
+}
+
+// handleResourcesTemplatesList answers resources/templates/list with an empty
+// list. Hosted servers advertise the resources capability and serve concrete
+// resources via resources/list, but they do not expose URI templates.
+func handleResourcesTemplatesList(ctx context.Context, logger *slog.Logger, req *rawRequest) (json.RawMessage, error) {
+	result := &result[resourcesTemplatesListResult]{
+		ID: req.ID,
+		Result: resourcesTemplatesListResult{
+			ResourceTemplates: make([]*resourceTemplateListEntry, 0),
+		},
+		serverIdentity: serverInfoHostedToolset,
+	}
+
+	bs, err := json.Marshal(result)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize resources/templates/list response").LogError(ctx, logger)
+	}
+
+	return bs, nil
+}

--- a/server/internal/mcp/rpc_resources_templates_list_test.go
+++ b/server/internal/mcp/rpc_resources_templates_list_test.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestHandleResourcesTemplatesList_ReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	bs, err := handleResourcesTemplatesList(ctx, logger, &rawRequest{
+		JSONRPC: "2.0",
+		ID:      mcpjsonrpc.NumberID(7),
+		Method:  "resources/templates/list",
+		Params:  nil,
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(bs, &decoded))
+	require.JSONEq(t, `7`, string(decoded["id"]))
+	require.JSONEq(t, `"2.0"`, string(decoded["jsonrpc"]))
+	require.JSONEq(t, `{
+		"resourceTemplates": [],
+		"resultType": "complete",
+		"_meta": {
+			"io.modelcontextprotocol/serverInfo": {
+				"name": "Gram",
+				"version": "0.0.0"
+			}
+		}
+	}`, string(decoded["result"]))
+}

--- a/server/internal/mcp/servepublic_resources_templates_list_test.go
+++ b/server/internal/mcp/servepublic_resources_templates_list_test.go
@@ -1,0 +1,49 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+func TestServePublic_ResourcesTemplatesList_ReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "res-tmpl-list-"+uuid.NewString()[:8])
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "resources/templates/list",
+	})
+	require.NoError(t, err)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, body, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response), "response body: %s", w.Body.String())
+	require.Nil(t, response["error"], "resources/templates/list must not return method-not-found")
+	require.Equal(t, "2.0", response["jsonrpc"])
+	require.InDelta(t, 4, response["id"], 0)
+
+	result, ok := response["result"].(map[string]any)
+	require.True(t, ok, "result should be a map: %v", response)
+
+	templates, ok := result["resourceTemplates"].([]any)
+	require.True(t, ok, "resourceTemplates should be an array: %v", result)
+	require.Empty(t, templates)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hosted Gram MCP servers advertise the `resources` capability but did not handle `resources/templates/list`, so clients that call that method (including AWS AgentCore) got JSON-RPC method-not-found.

This adds a handler that returns an empty `resourceTemplates` list. Hosted servers still only serve concrete resources via `resources/list`; URI templates are not exposed yet.

Fixes AIS-583.

## Changes

- Dispatch `resources/templates/list` in the hosted MCP `handleRequest` switch (the method was already in the request-layer allowlist).
- Return a spec-shaped empty `resourceTemplates` array with the same result envelope as other hosted RPCs.

## Test plan

- Unit test: handler serializes `resourceTemplates: []` plus the standard result `_meta` / `resultType`.
- Integration test: `ServePublic` on a public hosted MCP answers `resources/templates/list` with HTTP 200 and no JSON-RPC error.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-583](https://linear.app/speakeasy/issue/AIS-583/feat-implement-resourcestemplateslist-for-hosted-gram-mcp-servers)

<div><a href="https://cursor.com/agents/bc-9271301f-8904-4cba-afb7-d05f0500ee19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9271301f-8904-4cba-afb7-d05f0500ee19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a `resources/templates/list` handler for hosted Gram MCP servers to prevent JSON-RPC method-not-found. Previously, hosted servers advertised resources but failed this call; now they return an empty `resourceTemplates` array using the standard result envelope. Addresses AIS-583.

- Dispatches `resources/templates/list` in hosted MCP `handleRequest` to a new handler that returns `resourceTemplates: []` plus `_meta` and `resultType`.
- Adds unit and ServePublic integration tests (HTTP 200, no JSON-RPC error).
- No migration required; hosted servers still only expose concrete resources via `resources/list`.

<sup>Written for commit 9a7356d2e0c87d1654c2caa94e26e48122cb4e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

