### PR TITLE
feat: lists all suppressions

### DIFF
--- a/.changeset/suppressed-listing-all-reasons.md
+++ b/.changeset/suppressed-listing-all-reasons.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+The suppressed risk results listing (`risk.listDismissedResults`) now covers every suppressed finding — rule exclusions included, previously absent — and accepts an optional `reasons` filter (`rule` | `manual` | `automated`). Legacy pre-convergence rule rows derive their reason from the exclusion id instead of reading as manual.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -38735,7 +38735,7 @@ paths:
         type: query
   /rpc/risk.listDismissedResults:
     get:
-      description: List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.
+      description: List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.
       operationId: listDismissedRiskResults
       parameters:
         - allowEmptyValue: true
@@ -38755,6 +38755,19 @@ paths:
             maximum: 200
             minimum: 1
             type: integer
+        - allowEmptyValue: true
+          description: Only return results suppressed for these reasons. Omitted or empty means all reasons.
+          in: query
+          name: reasons
+          schema:
+            description: Only return results suppressed for these reasons. Omitted or empty means all reasons.
+            items:
+              enum:
+                - rule
+                - manual
+                - automated
+              type: string
+            type: array
         - allowEmptyValue: true
           description: API Key header
           in: header

--- a/client/dashboard/src/sdk/src/funcs/riskResultsListDismissed.ts
+++ b/client/dashboard/src/sdk/src/funcs/riskResultsListDismissed.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * listDismissedRiskResults risk
  *
  * @remarks
- * List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.
+ * List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.
  */
 export function riskResultsListDismissed(
   client: GramCore,
@@ -113,6 +113,7 @@ async function $do(
   const query = encodeFormQuery({
     "cursor": payload?.cursor,
     "limit": payload?.limit,
+    "reasons": payload?.reasons,
   });
 
   const headers = new Headers(compactMap({

--- a/client/dashboard/src/sdk/src/models/operations/listdismissedriskresults.ts
+++ b/client/dashboard/src/sdk/src/models/operations/listdismissedriskresults.ts
@@ -4,6 +4,7 @@
 
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
+import { ClosedEnum } from "../../types/enums.js";
 
 export type ListDismissedRiskResultsSecurityOption1 = {
   apikeyHeaderGramKey: string;
@@ -20,6 +21,13 @@ export type ListDismissedRiskResultsSecurity = {
   option2?: ListDismissedRiskResultsSecurityOption2 | undefined;
 };
 
+export const Reasons = {
+  Rule: "rule",
+  Manual: "manual",
+  Automated: "automated",
+} as const;
+export type Reasons = ClosedEnum<typeof Reasons>;
+
 export type ListDismissedRiskResultsRequest = {
   /**
    * Cursor to fetch the next page of results.
@@ -29,6 +37,10 @@ export type ListDismissedRiskResultsRequest = {
    * Maximum number of results to return per page.
    */
   limit?: number | undefined;
+  /**
+   * Only return results suppressed for these reasons. Omitted or empty means all reasons.
+   */
+  reasons?: Array<Reasons> | undefined;
   /**
    * API Key header
    */
@@ -151,9 +163,15 @@ export function listDismissedRiskResultsSecurityToJSON(
 }
 
 /** @internal */
+export const Reasons$outboundSchema: z.ZodMiniEnum<typeof Reasons> = z.enum(
+  Reasons,
+);
+
+/** @internal */
 export type ListDismissedRiskResultsRequest$Outbound = {
   cursor?: string | undefined;
   limit?: number | undefined;
+  reasons?: Array<string> | undefined;
   "Gram-Key"?: string | undefined;
   "Gram-Session"?: string | undefined;
   "Gram-Project"?: string | undefined;
@@ -167,6 +185,7 @@ export const ListDismissedRiskResultsRequest$outboundSchema: z.ZodMiniType<
   z.object({
     cursor: z.optional(z.string()),
     limit: z.optional(z.int()),
+    reasons: z.optional(z.array(Reasons$outboundSchema)),
     gramKey: z.optional(z.string()),
     gramSession: z.optional(z.string()),
     gramProject: z.optional(z.string()),

--- a/client/dashboard/src/sdk/src/react-query/riskListDismissedResults.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/riskListDismissedResults.core.ts
@@ -15,6 +15,7 @@ import { ListRiskResultsResult } from "../models/components/listriskresultsresul
 import {
   ListDismissedRiskResultsRequest,
   ListDismissedRiskResultsSecurity,
+  Reasons,
 } from "../models/operations/listdismissedriskresults.js";
 import { unwrapAsync } from "../types/fp.js";
 export type RiskListDismissedResultsQueryData = ListRiskResultsResult;
@@ -51,6 +52,7 @@ export function buildRiskListDismissedResultsQuery(
     queryKey: queryKeyRiskListDismissedResults({
       cursor: request?.cursor,
       limit: request?.limit,
+      reasons: request?.reasons,
       gramKey: request?.gramKey,
       gramSession: request?.gramSession,
       gramProject: request?.gramProject,
@@ -83,6 +85,7 @@ export function queryKeyRiskListDismissedResults(
   parameters: {
     cursor?: string | undefined;
     limit?: number | undefined;
+    reasons?: Array<Reasons> | undefined;
     gramKey?: string | undefined;
     gramSession?: string | undefined;
     gramProject?: string | undefined;

--- a/client/dashboard/src/sdk/src/react-query/riskListDismissedResults.ts
+++ b/client/dashboard/src/sdk/src/react-query/riskListDismissedResults.ts
@@ -24,6 +24,7 @@ import { ServiceError } from "../models/errors/serviceerror.js";
 import {
   ListDismissedRiskResultsRequest,
   ListDismissedRiskResultsSecurity,
+  Reasons,
 } from "../models/operations/listdismissedriskresults.js";
 import { useGramContext } from "./_context.js";
 import {
@@ -59,7 +60,7 @@ export type RiskListDismissedResultsQueryError =
  * listDismissedRiskResults risk
  *
  * @remarks
- * List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.
+ * List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.
  */
 export function useRiskListDismissedResults(
   request?: ListDismissedRiskResultsRequest | undefined,
@@ -88,7 +89,7 @@ export function useRiskListDismissedResults(
  * listDismissedRiskResults risk
  *
  * @remarks
- * List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.
+ * List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.
  */
 export function useRiskListDismissedResultsSuspense(
   request?: ListDismissedRiskResultsRequest | undefined,
@@ -119,6 +120,7 @@ export function setRiskListDismissedResultsData(
     parameters: {
       cursor?: string | undefined;
       limit?: number | undefined;
+      reasons?: Array<Reasons> | undefined;
       gramKey?: string | undefined;
       gramSession?: string | undefined;
       gramProject?: string | undefined;
@@ -137,6 +139,7 @@ export function invalidateRiskListDismissedResults(
     [parameters: {
       cursor?: string | undefined;
       limit?: number | undefined;
+      reasons?: Array<Reasons> | undefined;
       gramKey?: string | undefined;
       gramSession?: string | undefined;
       gramProject?: string | undefined;

--- a/client/dashboard/src/sdk/src/sdk/results.ts
+++ b/client/dashboard/src/sdk/src/sdk/results.ts
@@ -49,7 +49,7 @@ export class Results extends ClientSDK {
    * listDismissedRiskResults risk
    *
    * @remarks
-   * List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.
+   * List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.
    */
   async listDismissed(
     request?: ListDismissedRiskResultsRequest | undefined,

--- a/server/design/risk/design.go
+++ b/server/design/risk/design.go
@@ -513,7 +513,7 @@ var _ = Service("risk", func() {
 	})
 
 	Method("listDismissedRiskResults", func() {
-		Description("List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.")
+		Description("List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.")
 
 		Payload(func() {
 			security.ByKeyPayload()
@@ -524,6 +524,9 @@ var _ = Service("risk", func() {
 				Minimum(1)
 				Maximum(200)
 			})
+			Attribute("reasons", ArrayOf(String, func() {
+				Enum("rule", "manual", "automated")
+			}), "Only return results suppressed for these reasons. Omitted or empty means all reasons.")
 		})
 
 		Result(ListRiskResultsResult)
@@ -535,6 +538,7 @@ var _ = Service("risk", func() {
 			security.ProjectHeader()
 			Param("cursor")
 			Param("limit")
+			Param("reasons")
 			Response(StatusOK)
 		})
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -2410,6 +2410,7 @@ func ParseEndpoint(
 		riskListDismissedRiskResultsFlags                = flag.NewFlagSet("list-dismissed-risk-results", flag.ExitOnError)
 		riskListDismissedRiskResultsCursorFlag           = riskListDismissedRiskResultsFlags.String("cursor", "", "")
 		riskListDismissedRiskResultsLimitFlag            = riskListDismissedRiskResultsFlags.String("limit", "", "")
+		riskListDismissedRiskResultsReasonsFlag          = riskListDismissedRiskResultsFlags.String("reasons", "", "")
 		riskListDismissedRiskResultsApikeyTokenFlag      = riskListDismissedRiskResultsFlags.String("apikey-token", "", "")
 		riskListDismissedRiskResultsSessionTokenFlag     = riskListDismissedRiskResultsFlags.String("session-token", "", "")
 		riskListDismissedRiskResultsProjectSlugInputFlag = riskListDismissedRiskResultsFlags.String("project-slug-input", "", "")
@@ -8002,7 +8003,7 @@ func ParseEndpoint(
 				data, err = riskc.BuildUnmarkRiskResultsFalsePositivePayload(*riskUnmarkRiskResultsFalsePositiveBodyFlag, *riskUnmarkRiskResultsFalsePositiveApikeyTokenFlag, *riskUnmarkRiskResultsFalsePositiveSessionTokenFlag, *riskUnmarkRiskResultsFalsePositiveProjectSlugInputFlag)
 			case "list-dismissed-risk-results":
 				endpoint = c.ListDismissedRiskResults()
-				data, err = riskc.BuildListDismissedRiskResultsPayload(*riskListDismissedRiskResultsCursorFlag, *riskListDismissedRiskResultsLimitFlag, *riskListDismissedRiskResultsApikeyTokenFlag, *riskListDismissedRiskResultsSessionTokenFlag, *riskListDismissedRiskResultsProjectSlugInputFlag)
+				data, err = riskc.BuildListDismissedRiskResultsPayload(*riskListDismissedRiskResultsCursorFlag, *riskListDismissedRiskResultsLimitFlag, *riskListDismissedRiskResultsReasonsFlag, *riskListDismissedRiskResultsApikeyTokenFlag, *riskListDismissedRiskResultsSessionTokenFlag, *riskListDismissedRiskResultsProjectSlugInputFlag)
 			case "get-risk-overview":
 				endpoint = c.GetRiskOverview()
 				data, err = riskc.BuildGetRiskOverviewPayload(*riskGetRiskOverviewFromFlag, *riskGetRiskOverviewToFlag, *riskGetRiskOverviewApikeyTokenFlag, *riskGetRiskOverviewSessionTokenFlag, *riskGetRiskOverviewProjectSlugInputFlag)
@@ -18328,7 +18329,7 @@ func riskUsage() {
 	fmt.Fprintln(os.Stderr, `    list-risk-results-by-chat: List risk results grouped by chat session for the current project.`)
 	fmt.Fprintln(os.Stderr, `    mark-risk-results-false-positive: Mark one or more risk results as manually-reviewed false positives. Distinct from exclusions: this suppresses the specific results picked, not future findings matching a rule.`)
 	fmt.Fprintln(os.Stderr, `    unmark-risk-results-false-positive: Undo a false-positive dismissal for one or more risk results.`)
-	fmt.Fprintln(os.Stderr, `    list-dismissed-risk-results: List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.`)
+	fmt.Fprintln(os.Stderr, `    list-dismissed-risk-results: List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.`)
 	fmt.Fprintln(os.Stderr, `    get-risk-overview: Get risk overview metrics and trend data for the current project.`)
 	fmt.Fprintln(os.Stderr, `    list-risk-categories: Return the canonical risk category definitions: metadata (label/description/icon) plus the classification (source / rule_id list / rule_id prefix) used to bucket findings. Dashboards and CLIs should call this instead of maintaining their own copy of the mapping.`)
 	fmt.Fprintln(os.Stderr, `    compile-expr: Compile a single CEL expression (a detection predicate or a policy scope predicate) without evaluating it, so the editor can validate as the author types. Returns ok=true when it compiles, otherwise ok=false with the compiler error message. An empty expression is valid (ok=true).`)
@@ -18704,6 +18705,7 @@ func riskListDismissedRiskResultsUsage() {
 	fmt.Fprintf(os.Stderr, "%s [flags] risk list-dismissed-risk-results", os.Args[0])
 	fmt.Fprint(os.Stderr, " -cursor STRING")
 	fmt.Fprint(os.Stderr, " -limit INT")
+	fmt.Fprint(os.Stderr, " -reasons JSON")
 	fmt.Fprint(os.Stderr, " -apikey-token STRING")
 	fmt.Fprint(os.Stderr, " -session-token STRING")
 	fmt.Fprint(os.Stderr, " -project-slug-input STRING")
@@ -18711,18 +18713,19 @@ func riskListDismissedRiskResultsUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.`)
+	fmt.Fprintln(os.Stderr, `List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -cursor STRING: `)
 	fmt.Fprintln(os.Stderr, `    -limit INT: `)
+	fmt.Fprintln(os.Stderr, `    -reasons JSON: `)
 	fmt.Fprintln(os.Stderr, `    -apikey-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -session-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -project-slug-input STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "risk list-dismissed-risk-results --cursor \"abc123\" --limit 2 --apikey-token \"abc123\" --session-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "risk list-dismissed-risk-results --cursor \"abc123\" --limit 2 --reasons '[\n      \"manual\"\n   ]' --apikey-token \"abc123\" --session-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func riskGetRiskOverviewUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -40076,7 +40076,7 @@ paths:
                 type: query
     /rpc/risk.listDismissedResults:
         get:
-            description: List risk results manually marked as false positive for the current project (the Dismissed tab). Kept separate from listRiskResults, which never returns dismissed results.
+            description: List suppressed risk results for the current project — findings hidden by an exclusion rule, a manual dismissal, or the automated false-positive sweep. Kept separate from listRiskResults, which never returns suppressed results.
             operationId: listDismissedRiskResults
             parameters:
                 - allowEmptyValue: true
@@ -40096,6 +40096,19 @@ paths:
                     maximum: 200
                     minimum: 1
                     type: integer
+                - allowEmptyValue: true
+                  description: Only return results suppressed for these reasons. Omitted or empty means all reasons.
+                  in: query
+                  name: reasons
+                  schema:
+                    description: Only return results suppressed for these reasons. Omitted or empty means all reasons.
+                    items:
+                        enum:
+                            - rule
+                            - manual
+                            - automated
+                        type: string
+                    type: array
                 - allowEmptyValue: true
                   description: API Key header
                   in: header

--- a/server/gen/http/risk/client/cli.go
+++ b/server/gen/http/risk/client/cli.go
@@ -1013,7 +1013,7 @@ func BuildUnmarkRiskResultsFalsePositivePayload(riskUnmarkRiskResultsFalsePositi
 
 // BuildListDismissedRiskResultsPayload builds the payload for the risk
 // listDismissedRiskResults endpoint from CLI flags.
-func BuildListDismissedRiskResultsPayload(riskListDismissedRiskResultsCursor string, riskListDismissedRiskResultsLimit string, riskListDismissedRiskResultsApikeyToken string, riskListDismissedRiskResultsSessionToken string, riskListDismissedRiskResultsProjectSlugInput string) (*risk.ListDismissedRiskResultsPayload, error) {
+func BuildListDismissedRiskResultsPayload(riskListDismissedRiskResultsCursor string, riskListDismissedRiskResultsLimit string, riskListDismissedRiskResultsReasons string, riskListDismissedRiskResultsApikeyToken string, riskListDismissedRiskResultsSessionToken string, riskListDismissedRiskResultsProjectSlugInput string) (*risk.ListDismissedRiskResultsPayload, error) {
 	var err error
 	var cursor *string
 	{
@@ -1042,6 +1042,23 @@ func BuildListDismissedRiskResultsPayload(riskListDismissedRiskResultsCursor str
 			}
 		}
 	}
+	var reasons []string
+	{
+		if riskListDismissedRiskResultsReasons != "" {
+			err = json.Unmarshal([]byte(riskListDismissedRiskResultsReasons), &reasons)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for reasons, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"manual\"\n   ]'")
+			}
+			for _, e := range reasons {
+				if !(e == "rule" || e == "manual" || e == "automated") {
+					err = goa.MergeErrors(err, goa.InvalidEnumValueError("reasons[*]", e, []any{"rule", "manual", "automated"}))
+				}
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 	var apikeyToken *string
 	{
 		if riskListDismissedRiskResultsApikeyToken != "" {
@@ -1063,6 +1080,7 @@ func BuildListDismissedRiskResultsPayload(riskListDismissedRiskResultsCursor str
 	v := &risk.ListDismissedRiskResultsPayload{}
 	v.Cursor = cursor
 	v.Limit = limit
+	v.Reasons = reasons
 	v.ApikeyToken = apikeyToken
 	v.SessionToken = sessionToken
 	v.ProjectSlugInput = projectSlugInput

--- a/server/gen/http/risk/client/encode_decode.go
+++ b/server/gen/http/risk/client/encode_decode.go
@@ -2998,6 +2998,9 @@ func EncodeListDismissedRiskResultsRequest(encoder func(*http.Request) goahttp.E
 		if p.Limit != nil {
 			values.Add("limit", fmt.Sprintf("%v", *p.Limit))
 		}
+		for _, value := range p.Reasons {
+			values.Add("reasons", value)
+		}
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}

--- a/server/gen/http/risk/server/encode_decode.go
+++ b/server/gen/http/risk/server/encode_decode.go
@@ -3008,6 +3008,7 @@ func DecodeListDismissedRiskResultsRequest(mux goahttp.Muxer, decoder func(*http
 		var (
 			cursor           *string
 			limit            *int
+			reasons          []string
 			apikeyToken      *string
 			sessionToken     *string
 			projectSlugInput *string
@@ -3039,6 +3040,12 @@ func DecodeListDismissedRiskResultsRequest(mux goahttp.Muxer, decoder func(*http
 				err = goa.MergeErrors(err, goa.InvalidRangeError("limit", *limit, 200, false))
 			}
 		}
+		reasons = qp["reasons"]
+		for _, e := range reasons {
+			if !(e == "rule" || e == "manual" || e == "automated") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("reasons[*]", e, []any{"rule", "manual", "automated"}))
+			}
+		}
 		apikeyTokenRaw := r.Header.Get("Gram-Key")
 		if apikeyTokenRaw != "" {
 			apikeyToken = &apikeyTokenRaw
@@ -3054,7 +3061,7 @@ func DecodeListDismissedRiskResultsRequest(mux goahttp.Muxer, decoder func(*http
 		if err != nil {
 			return payload, err
 		}
-		payload = NewListDismissedRiskResultsPayload(cursor, limit, apikeyToken, sessionToken, projectSlugInput)
+		payload = NewListDismissedRiskResultsPayload(cursor, limit, reasons, apikeyToken, sessionToken, projectSlugInput)
 		if payload.ApikeyToken != nil {
 			if strings.Contains(*payload.ApikeyToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -19025,10 +19025,11 @@ func NewUnmarkRiskResultsFalsePositivePayload(body *UnmarkRiskResultsFalsePositi
 
 // NewListDismissedRiskResultsPayload builds a risk service
 // listDismissedRiskResults endpoint payload.
-func NewListDismissedRiskResultsPayload(cursor *string, limit *int, apikeyToken *string, sessionToken *string, projectSlugInput *string) *risk.ListDismissedRiskResultsPayload {
+func NewListDismissedRiskResultsPayload(cursor *string, limit *int, reasons []string, apikeyToken *string, sessionToken *string, projectSlugInput *string) *risk.ListDismissedRiskResultsPayload {
 	v := &risk.ListDismissedRiskResultsPayload{}
 	v.Cursor = cursor
 	v.Limit = limit
+	v.Reasons = reasons
 	v.ApikeyToken = apikeyToken
 	v.SessionToken = sessionToken
 	v.ProjectSlugInput = projectSlugInput

--- a/server/gen/risk/service.go
+++ b/server/gen/risk/service.go
@@ -52,9 +52,9 @@ type Service interface {
 	MarkRiskResultsFalsePositive(context.Context, *MarkRiskResultsFalsePositivePayload) (err error)
 	// Undo a false-positive dismissal for one or more risk results.
 	UnmarkRiskResultsFalsePositive(context.Context, *UnmarkRiskResultsFalsePositivePayload) (err error)
-	// List risk results manually marked as false positive for the current project
-	// (the Dismissed tab). Kept separate from listRiskResults, which never returns
-	// dismissed results.
+	// List suppressed risk results for the current project — findings hidden by an
+	// exclusion rule, a manual dismissal, or the automated false-positive sweep.
+	// Kept separate from listRiskResults, which never returns suppressed results.
 	ListDismissedRiskResults(context.Context, *ListDismissedRiskResultsPayload) (res *ListRiskResultsResult, err error)
 	// Get risk overview metrics and trend data for the current project.
 	GetRiskOverview(context.Context, *GetRiskOverviewPayload) (res *RiskOverviewResult, err error)
@@ -652,6 +652,9 @@ type ListDismissedRiskResultsPayload struct {
 	Cursor *string
 	// Maximum number of results to return per page.
 	Limit *int
+	// Only return results suppressed for these reasons. Omitted or empty means all
+	// reasons.
+	Reasons []string
 }
 
 // ListRiskCategoriesPayload is the payload type of the risk service

--- a/server/internal/risk/chrepo/dismissed.go
+++ b/server/internal/risk/chrepo/dismissed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -16,9 +17,12 @@ import (
 type ListDismissedRiskFindingsParams struct {
 	OrganizationID string
 	ProjectID      string
-	CursorTime     *time.Time
-	CursorID       uuid.NullUUID
-	Limit          uint64
+	// Reasons narrows the listing to rows whose derived suppression reason
+	// (suppressedReasonExpr) is in the set. Empty means all reasons.
+	Reasons    []string
+	CursorTime *time.Time
+	CursorID   uuid.NullUUID
+	Limit      uint64
 }
 
 // DismissedRiskFindingRow is one row of the Dismissed listing: the Risk Events
@@ -43,18 +47,24 @@ type DismissedRiskFindingRow struct {
 	ExclusionID      *uuid.UUID
 }
 
-// dismissedStateCond selects the findings the Dismissed tab lists: user and
-// automated dismissals. Rule-suppressed findings are deliberately absent —
-// the tab shows what a person dismissed and can restore, and rule suppression
-// is managed from the exclusions surface instead.
-//
-// The second disjunct is the safety margin for rows the suppression backfill
-// did not reach: a pre-convergence dismissal carries only false_positive_at
-// and no excluded_reason at all. Both disjuncts guarantee suppressedAtExpr
-// resolves non-null — excluded_reason is only ever written alongside
-// excluded_at — which is what makes it usable as a total sort and cursor key.
-const dismissedStateCond = "(excluded_reason IN ('" + ExcludedReasonManual + "', '" + ExcludedReasonAutomated + "')" +
-	" OR (excluded_reason = '' AND false_positive_at IS NOT NULL))"
+// dismissedStateCond selects the findings the suppressed listing serves:
+// every finding whose latest copy is suppressed, whatever the mechanism — an
+// exclusion rule, a manual dismissal, the automated sweep, or a legacy
+// pre-convergence row carrying only false_positive_at. Either disjunct
+// guarantees suppressedAtExpr resolves non-null, which is what makes it
+// usable as a total sort and cursor key.
+const dismissedStateCond = "(excluded_at IS NOT NULL OR false_positive_at IS NOT NULL)"
+
+// suppressedReasonExpr derives the effective suppression reason for filtering
+// and display. Rows written since the suppression convergence carry
+// excluded_reason directly. Legacy rows don't: an ingest- or reconcile-time
+// rule exclusion from before the convergence has excluded_at and exclusion_id
+// but no reason, and a pre-convergence dismissal has only false_positive_at —
+// so exclusion_id decides between rule and manual for them. Keep in lockstep
+// with the Go-side mapping in ListDismissedRiskResults.
+const suppressedReasonExpr = "multiIf(excluded_reason != '', excluded_reason," +
+	" exclusion_id IS NOT NULL, '" + ExcludedReasonRule + "'," +
+	" '" + ExcludedReasonManual + "')"
 
 // suppressedAtExpr is the effective suppression time: the converged
 // excluded_at, or the legacy false_positive_at for a row that predates the
@@ -87,10 +97,24 @@ func dismissedRiskFindingsLatest(p ListDismissedRiskFindingsParams, innerColumns
 		OrderBy("inserted_at DESC").
 		Suffix("LIMIT 1 BY id")
 
-	return sq.Select(outerColumns...).
+	sb := sq.Select(outerColumns...).
 		FromSelect(latest, "latest").
 		Where("dead_letter_reason = ''").
 		Where(dismissedStateCond)
+	if len(p.Reasons) > 0 {
+		sb = sb.Where(squirrel.Expr(suppressedReasonExpr+" IN ("+
+			strings.TrimSuffix(strings.Repeat("?,", len(p.Reasons)), ",")+")", toAnySlice(p.Reasons)...))
+	}
+	return sb
+}
+
+// toAnySlice widens a string slice for squirrel's variadic Expr args.
+func toAnySlice(values []string) []any {
+	out := make([]any, len(values))
+	for i, v := range values {
+		out[i] = v
+	}
+	return out
 }
 
 // ListDismissedRiskFindings returns one page of dismissed findings, newest

--- a/server/internal/risk/false_positive.go
+++ b/server/internal/risk/false_positive.go
@@ -296,6 +296,7 @@ func (s *Service) ListDismissedRiskResults(ctx context.Context, payload *gen.Lis
 	params := chrepo.ListDismissedRiskFindingsParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      projectID.String(),
+		Reasons:        payload.Reasons,
 		CursorTime:     nil,
 		CursorID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		// resolvePageSize bounds pageSize to [1, 200], so the conversion
@@ -336,12 +337,18 @@ func (s *Service) ListDismissedRiskResults(ctx context.Context, payload *gen.Lis
 		// FalsePositiveAt is the deprecated mirror of SuppressedAt, kept
 		// populated while clients migrate to the suppressed_* fields.
 		result.FalsePositiveAt = &suppressedAt
-		// A legacy row the suppression backfill never reached carries no
-		// excluded_reason; it can only have come from a dismissal, so it maps
-		// to manual — keeping the API enum closed until the TTL retires them.
+		// Legacy pre-convergence rows carry no excluded_reason, so derive it
+		// the way chrepo's suppressedReasonExpr does (keep the two in
+		// lockstep): an exclusion id marks a rule suppression, anything else
+		// can only have come from a dismissal and maps to manual — keeping
+		// the API enum closed until the TTL retires such rows.
 		reason := row.SuppressedReason
 		if reason == "" {
-			reason = chrepo.ExcludedReasonManual
+			if row.ExclusionID != nil {
+				reason = chrepo.ExcludedReasonRule
+			} else {
+				reason = chrepo.ExcludedReasonManual
+			}
 		}
 		result.SuppressedReason = &reason
 		result.SuppressedDetail = conv.PtrEmpty(row.SuppressedDetail)

--- a/server/internal/risk/false_positive_test.go
+++ b/server/internal/risk/false_positive_test.go
@@ -328,11 +328,12 @@ func TestMarkRiskResultsFalsePositive_ContentPartAnchoredFindingIsListable(t *te
 }
 
 // TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction drives the
-// ClickHouse-backed Dismissed tab end to end: suppression-time ordering, cursor
-// pagination, the total count, the store-side redaction the tab now inherits
-// from the Risk Events listing, and the predicate's edges — automated sweep
-// rows and legacy false-positive-only rows are listed, while rule suppression,
-// open findings, dead-letter sentinels and other tenants are not.
+// ClickHouse-backed suppressed listing end to end: suppression-time ordering,
+// cursor pagination, the total count, the store-side redaction it inherits
+// from the Risk Events listing, the reasons filter, and the predicate's edges
+// — rule-suppressed, manual, automated-sweep and legacy false-positive-only
+// rows are all listed, while open findings, dead-letter sentinels and other
+// tenants are not.
 func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)

--- a/server/internal/risk/false_positive_test.go
+++ b/server/internal/risk/false_positive_test.go
@@ -388,8 +388,8 @@ func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.
 	legacy := finding("secret.aws_secret_key", "wJal********************EY", base.Add(3*time.Hour))
 	legacy.FalsePositiveAt = &legacyAt
 
-	// Not listed: rule suppression belongs to the exclusions surface, an open
-	// finding was never dismissed, and a dead-letter sentinel is not a finding.
+	// Rule-suppressed findings are part of the suppressed listing too — the
+	// newest suppression in this fixture set.
 	ruleAt := base.Add(10 * time.Hour)
 	exclusionID := uuid.Must(uuid.NewV7())
 	ruleSuppressed := finding("secret.db_password", "hunt****ter", base.Add(4*time.Hour))
@@ -397,6 +397,8 @@ func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.
 	ruleSuppressed.ExclusionID = &exclusionID
 	ruleSuppressed.ExcludedReason = chrepo.ExcludedReasonRule
 
+	// Not listed: an open finding was never suppressed, and a dead-letter
+	// sentinel is not a finding.
 	open := finding("secret.stripe_api_key", "sk_l**********ve", base.Add(5*time.Hour))
 
 	deadLetter := finding("", "", base.Add(6*time.Hour))
@@ -423,18 +425,30 @@ func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.
 		return out
 	}
 
-	pageSize := 2
-	page1, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: &pageSize})
+	pageSize := 3
+	page1, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: &pageSize, Reasons: nil})
 	require.NoError(t, err)
-	require.Equal(t, int64(4), page1.TotalCount)
-	require.Len(t, page1.Results, 2)
-	require.Equal(t, manual.ID.String(), page1.Results[0].ID, "newest suppression first")
-	require.Contains(t, []string{tiedA.ID.String(), tiedB.ID.String()}, page1.Results[1].ID)
+	require.Equal(t, int64(5), page1.TotalCount)
+	require.Len(t, page1.Results, 3)
+	require.Equal(t, ruleSuppressed.ID.String(), page1.Results[0].ID, "newest suppression first — the rule-suppressed row")
+	require.Equal(t, manual.ID.String(), page1.Results[1].ID)
+	require.Contains(t, []string{tiedA.ID.String(), tiedB.ID.String()}, page1.Results[2].ID)
 	require.NotNil(t, page1.NextCursor)
 
-	// Store-side redaction: the Dismissed tab serves match_redacted like the
-	// Risk Events listing, never the raw match.
-	first := page1.Results[0]
+	// The rule-suppressed row carries its provenance: reason rule, the
+	// exclusion id, no detail.
+	ruleRow := page1.Results[0]
+	require.NotNil(t, ruleRow.SuppressedReason)
+	require.Equal(t, chrepo.ExcludedReasonRule, *ruleRow.SuppressedReason)
+	require.NotNil(t, ruleRow.ExclusionID)
+	require.Equal(t, exclusionID.String(), *ruleRow.ExclusionID)
+	require.Nil(t, ruleRow.SuppressedDetail)
+	require.NotNil(t, ruleRow.SuppressedAt)
+	require.Equal(t, ruleAt.Format(time.RFC3339), *ruleRow.SuppressedAt)
+
+	// Store-side redaction: the suppressed listing serves match_redacted like
+	// the Risk Events listing, never the raw match.
+	first := page1.Results[1]
 	require.Nil(t, first.Match)
 	require.Nil(t, first.Spans)
 	require.NotNil(t, first.MatchRedacted)
@@ -459,12 +473,12 @@ func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.
 	require.NotNil(t, first.UserID)
 	require.Equal(t, "alice@example.com", *first.UserID)
 
-	page2, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: &pageSize, Cursor: page1.NextCursor})
+	page2, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: &pageSize, Cursor: page1.NextCursor, Reasons: nil})
 	require.NoError(t, err)
 	require.Len(t, page2.Results, 2)
 	require.Equal(t, legacy.ID.String(), page2.Results[1].ID, "the legacy false-positive-only row is the fallback disjunct's job")
 	require.Nil(t, page2.NextCursor)
-	require.Equal(t, int64(4), page2.TotalCount)
+	require.Equal(t, int64(5), page2.TotalCount)
 	require.NotNil(t, page2.Results[1].FalsePositiveAt)
 	require.Equal(t, legacyAt.Format(time.RFC3339), *page2.Results[1].FalsePositiveAt)
 	// A legacy row carries no excluded_reason; the API maps it to manual so
@@ -493,9 +507,79 @@ func TestListDismissedRiskResults_ClickHousePageOrderingAndRedaction(t *testing.
 	// skip. Which of the two lands on which page is ClickHouse's UUID ordering
 	// to decide; the cursor only has to agree with it.
 	require.ElementsMatch(t,
-		[]string{manual.ID.String(), tiedA.ID.String(), tiedB.ID.String(), legacy.ID.String()},
+		[]string{ruleSuppressed.ID.String(), manual.ID.String(), tiedA.ID.String(), tiedB.ID.String(), legacy.ID.String()},
 		append(ids(page1), ids(page2)...),
 	)
+
+	// The reasons filter narrows on the derived reason, and its counts follow.
+	ruleOnly, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: nil, Cursor: nil, Reasons: []string{chrepo.ExcludedReasonRule}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), ruleOnly.TotalCount)
+	require.Len(t, ruleOnly.Results, 1)
+	require.Equal(t, ruleSuppressed.ID.String(), ruleOnly.Results[0].ID)
+
+	// The legacy false-positive-only row derives manual, so it joins the
+	// manual dismissals under the filter.
+	manualOnly, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: nil, Cursor: nil, Reasons: []string{chrepo.ExcludedReasonManual}})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), manualOnly.TotalCount)
+	require.ElementsMatch(t,
+		[]string{manual.ID.String(), tiedB.ID.String(), legacy.ID.String()},
+		ids(manualOnly),
+	)
+}
+
+// TestListDismissedRiskResults_ClickHouseLegacyRuleRowDerivesRule pins the
+// derived reason on pre-convergence rule exclusions: a row annotated at ingest
+// or reconcile time before the suppression convergence carries excluded_at and
+// exclusion_id but no excluded_reason, and both the listing's reason field and
+// the reasons filter must classify it as rule, not manual.
+func TestListDismissedRiskResults_ClickHouseLegacyRuleRowDerivesRule(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Legacy Rule Row")})
+	require.NoError(t, err)
+
+	base := time.Now().UTC().AddDate(0, 0, -7).Truncate(time.Hour)
+	chatID, msgID := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+
+	excludedAt := base.Add(time.Hour)
+	exclusionID := uuid.Must(uuid.NewV7())
+	legacyRule := chListFinding(t, projectID, orgID, chatID, msgID, policy.ID, base, base, "gitleaks", "secret.github_pat", "alice@example.com", "AKIA**************LE", "", "")
+	legacyRule.ExcludedAt = &excludedAt
+	legacyRule.ExclusionID = &exclusionID
+	// Deliberately no ExcludedReason: this is the pre-convergence shape.
+
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{legacyRule}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	listed, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: nil, Cursor: nil, Reasons: nil})
+	require.NoError(t, err)
+	require.Len(t, listed.Results, 1)
+	row := listed.Results[0]
+	require.NotNil(t, row.SuppressedReason)
+	require.Equal(t, chrepo.ExcludedReasonRule, *row.SuppressedReason)
+	require.NotNil(t, row.ExclusionID)
+	require.Equal(t, exclusionID.String(), *row.ExclusionID)
+
+	// The SQL-side derived reason agrees with the Go-side mapping.
+	ruleOnly, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: nil, Cursor: nil, Reasons: []string{chrepo.ExcludedReasonRule}})
+	require.NoError(t, err)
+	require.Len(t, ruleOnly.Results, 1)
+
+	manualOnly, err := ti.service.ListDismissedRiskResults(ctx, &gen.ListDismissedRiskResultsPayload{Limit: nil, Cursor: nil, Reasons: []string{chrepo.ExcludedReasonManual}})
+	require.NoError(t, err)
+	require.Empty(t, manualOnly.Results)
+	require.Zero(t, manualOnly.TotalCount)
 }
 
 // TestListDismissedRiskResults_ClickHouseResolvesLatestCopy pins the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lists all suppressed risk results, not just manual dismissals, so the endpoint now returns findings hidden by rule exclusions, manual dismissals, and the automated sweep. Previously it returned only manual false positives; counts may increase without a filter, with pagination and ordering unchanged.

- API: `GET /rpc/risk.listDismissedResults` adds an optional `reasons[]=rule|manual|automated` query param (omitted/empty means all). Legacy rows derive their reason: if `exclusion_id` is set, reason is `rule`; if only `false_positive_at` is present, reason is `manual`.
- SDK/CLI: Dashboard SDK adds optional `reasons` to `Results.listDismissed` and React Query keys; the risk CLI adds `-reasons` (JSON array). No changes required for existing callers.
- Migration: If you relied on “Dismissed” == manual, call the endpoint with `reasons=['manual']` to keep the old behavior.

<sup>Written for commit 56b66f046205b4d96af34b4fe9179778a0f3c479. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

