### PR TITLE
feat: remove beta badge from the Secure nav group

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -207,7 +207,6 @@ export function AppSidebar({
           <ScopeGatedNavGroup
             label="Secure"
             Icon={(p) => <Icon {...p} name="shield" />}
-            stage="beta"
             items={[
               // Watchdog supersedes Risk Overview and Risk Events: exactly one
               // of the two sets shows, mirroring useProjectNavRoutes.


### PR DESCRIPTION
## What

Removes the `beta` badge from the **Secure** group in the project sidebar.

## Why

The badge was kept until Watchdog shipped to all organizations — that milestone landed with the Watchdog UI (#5124), and the team agreed in Slack to drop the group-level beta tag once it went out.

Route-level beta badges elsewhere (Project Assistant, Assistants, Webhooks) are intentionally untouched. The org sidebar's Secure group never carried a badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the beta badge from the Secure group in the project sidebar now that Watchdog is fully rolled out. Previously the Secure group showed a “beta” badge; now it appears without a badge, with no changes to routes, gating, or access.

- Single change: remove stage="beta" from the `ScopeGatedNavGroup` labeled “Secure”.
- Route-level beta badges (Project Assistant, Assistants, Webhooks) are unchanged; the org sidebar never had a Secure badge.

<sup>Written for commit 8c93245a57180f59de3bedb0b9056cd1166a2d81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

