### PR TITLE
fix: align admin organization feature controls

### DIFF
--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -11,6 +11,7 @@ import {
 } from "@tanstack/react-query";
 import {
   getOrganization,
+  getOrganizationChatAnalysisSettings,
   getOrganizationFeatures,
   getOrganizationStats,
   getInferenceKeys,
@@ -24,6 +25,7 @@ import {
   omitUnset,
   type AdminInferenceKey,
   type AdminOrganization,
+  type AdminOrganizationChatAnalysisSettings,
   type AdminOrganizationFeatures,
   type AdminProjectDetail,
   type AdminPaygBillingSummary,
@@ -99,6 +101,21 @@ export function organizationFeaturesQuery(
   return queryOptions({
     queryKey: ["gram-admin-organization-features", organizationID] as const,
     queryFn: () => getOrganizationFeatures(organizationID),
+  });
+}
+
+export function organizationChatAnalysisSettingsQuery(
+  organizationID: string,
+): AdminQuery<
+  AdminOrganizationChatAnalysisSettings,
+  readonly ["gram-admin-organization-chat-analysis-settings", string]
+> {
+  return queryOptions({
+    queryKey: [
+      "gram-admin-organization-chat-analysis-settings",
+      organizationID,
+    ] as const,
+    queryFn: () => getOrganizationChatAnalysisSettings(organizationID),
   });
 }
 

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -496,18 +496,23 @@ export type AdminInferenceKey = {
 };
 
 export type AdminOrganizationFeatures = {
-  consent_tool_filtering_enabled: boolean;
-  hooks_browser_login_enabled: boolean;
-  hooks_fail_open_enabled: boolean;
+  authz_challenge_logging_enabled: boolean;
+  customer_managed_encryption_keys_enabled: boolean;
+  custom_model_keys_enabled: boolean;
   platform_mcp_enabled: boolean;
-  remote_session_auto_refresh_policy:
-    | "disabled"
-    | "user_controlled"
-    | "enforced";
-  session_capture_enabled: boolean;
-  skill_capture_metadata_only: boolean;
-  skills_enabled: boolean;
+  remote_session_auto_refresh_enabled: boolean;
+  sso_enabled: boolean;
+  scim_enabled: boolean;
 };
+
+export type AdminOrganizationFeatureName =
+  | "authz_challenge_logging"
+  | "customer_managed_encryption_keys"
+  | "custom_model_keys"
+  | "platform_mcp"
+  | "remote_session_auto_refresh"
+  | "sso"
+  | "scim";
 
 export function getOrganizationFeatures(
   organizationID: string,
@@ -515,6 +520,25 @@ export function getOrganizationFeatures(
   const qs = toSearchParams({ organization_id: organizationID });
   return gramAdminFetch<AdminOrganizationFeatures>(
     `/admin/organization.features?${qs}`,
+  );
+}
+
+export function setOrganizationFeature(input: {
+  organizationID: string;
+  featureName: AdminOrganizationFeatureName;
+  enabled: boolean;
+}): Promise<AdminOrganizationFeatures> {
+  return gramAdminMutation<AdminOrganizationFeatures>(
+    "/admin/organization.features",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organization_id: input.organizationID,
+        feature_name: input.featureName,
+        enabled: input.enabled,
+      }),
+    },
   );
 }
 

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -542,6 +542,64 @@ export function setOrganizationFeature(input: {
   );
 }
 
+export type AdminChatAnalysisJudge = "work_units" | "business_memory";
+
+export type AdminOrganizationChatAnalysisSettings = {
+  organization_id: string;
+  work_units_enabled: boolean;
+  work_units_daily_cap: number;
+  business_memory_enabled: boolean;
+  business_memory_daily_cap: number;
+  is_default: boolean;
+};
+
+export function getOrganizationChatAnalysisSettings(
+  organizationID: string,
+): Promise<AdminOrganizationChatAnalysisSettings> {
+  const qs = toSearchParams({ organization_id: organizationID });
+  return gramAdminFetch<AdminOrganizationChatAnalysisSettings>(
+    `/admin/organization.chatAnalysisSettings?${qs}`,
+  );
+}
+
+export type AdminChatAnalysisTriggerResult = {
+  projects_signaled: number;
+};
+
+export function triggerOrganizationChatAnalysis(
+  organizationID: string,
+): Promise<AdminChatAnalysisTriggerResult> {
+  return gramAdminMutation<AdminChatAnalysisTriggerResult>(
+    "/admin/organization.chatAnalysisTrigger",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ organization_id: organizationID }),
+    },
+  );
+}
+
+export function setOrganizationChatAnalysisSetting(input: {
+  organizationID: string;
+  judge: AdminChatAnalysisJudge;
+  enabled: boolean;
+  dailyCap: number;
+}): Promise<AdminOrganizationChatAnalysisSettings> {
+  return gramAdminMutation<AdminOrganizationChatAnalysisSettings>(
+    "/admin/organization.chatAnalysisSettings",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organization_id: input.organizationID,
+        judge: input.judge,
+        enabled: input.enabled,
+        daily_cap: input.dailyCap,
+      }),
+    },
+  );
+}
+
 export function getInferenceKeys(
   organizationID: string,
 ): Promise<AdminInferenceKey[]> {

--- a/client/admin/src/pages/organization/Features.test.tsx
+++ b/client/admin/src/pages/organization/Features.test.tsx
@@ -1,14 +1,16 @@
 import { QueryClient } from "@tanstack/react-query";
-import { cleanup, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { organizationFeaturesQuery } from "@/lib/adminQueries";
+import type { AdminOrganizationFeatures } from "@/lib/gramAdminApi";
 import { Features } from "@/pages/organization/Features";
 import { anOrganization } from "@/test/fixtures";
 import { renderWithApp } from "@/test/harness";
 
 const mocks = vi.hoisted(() => ({
   getOrganizationFeatures: vi.fn(),
+  setOrganizationFeature: vi.fn(),
 }));
 
 vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
@@ -16,58 +18,101 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
   return {
     ...actual,
     getOrganizationFeatures: mocks.getOrganizationFeatures,
+    setOrganizationFeature: mocks.setOrganizationFeature,
   };
 });
 
 const ORG = anOrganization();
+const FEATURES: AdminOrganizationFeatures = {
+  authz_challenge_logging_enabled: true,
+  customer_managed_encryption_keys_enabled: false,
+  custom_model_keys_enabled: true,
+  platform_mcp_enabled: true,
+  remote_session_auto_refresh_enabled: false,
+  sso_enabled: true,
+  scim_enabled: false,
+};
 
 beforeEach(() => {
   for (const mock of Object.values(mocks)) mock.mockReset();
-  mocks.getOrganizationFeatures.mockResolvedValue({
-    consent_tool_filtering_enabled: true,
-    hooks_browser_login_enabled: false,
-    hooks_fail_open_enabled: true,
-    platform_mcp_enabled: true,
-    remote_session_auto_refresh_policy: "enforced",
-    session_capture_enabled: true,
-    skill_capture_metadata_only: false,
-    skills_enabled: true,
-  });
+  mocks.getOrganizationFeatures.mockResolvedValue(FEATURES);
+  mocks.setOrganizationFeature.mockImplementation(
+    ({ featureName, enabled }: { featureName: string; enabled: boolean }) =>
+      Promise.resolve({
+        ...FEATURES,
+        [`${featureName}_enabled`]: enabled,
+      }),
+  );
 });
 
 afterEach(cleanup);
 
-async function renderFeatures(): Promise<void> {
-  await renderWithApp(<Features org={ORG} />);
+async function renderFeatures(queryClient?: QueryClient): Promise<void> {
+  await renderWithApp(<Features org={ORG} />, { queryClient });
 }
 
 describe("Features", () => {
-  it("renders the curated organization feature states", async () => {
+  it("matches the dashboard platform-admin product feature list", async () => {
     await renderFeatures();
 
-    expect(await screen.findByText("Consent tool filtering")).toBeTruthy();
-    expect(screen.getByText("Platform MCP")).toBeTruthy();
-    expect(screen.getAllByText("Enabled")).toHaveLength(5);
-    expect(screen.getAllByText("Disabled")).toHaveLength(2);
-    expect(screen.getByText("Enforced")).toBeTruthy();
+    for (const label of [
+      "Authz Challenge Logging",
+      "Customer-Managed Encryption Keys",
+      "Custom Model Provider Keys",
+      "Platform MCP access",
+      "Automatic Remote Session Refresh",
+      "SSO",
+      "SCIM",
+    ]) {
+      expect(await screen.findByText(label)).toBeTruthy();
+    }
+    expect(screen.queryByText("Consent tool filtering")).toBeNull();
     expect(mocks.getOrganizationFeatures).toHaveBeenCalledWith(ORG.id);
+  });
+
+  it("updates an organization feature from its switch", async () => {
+    await renderFeatures();
+
+    const control = await screen.findByRole("switch", {
+      name: "Toggle Customer-Managed Encryption Keys",
+    });
+    expect(control.getAttribute("data-state")).toBe("unchecked");
+    fireEvent.click(control);
+
+    await waitFor(() => {
+      expect(mocks.setOrganizationFeature).toHaveBeenCalledWith({
+        organizationID: ORG.id,
+        featureName: "customer_managed_encryption_keys",
+        enabled: true,
+      });
+    });
+    expect(control.getAttribute("data-state")).toBe("checked");
+  });
+
+  it("restores the previous state and reports a mutation failure", async () => {
+    mocks.setOrganizationFeature.mockRejectedValue(new Error("write failed"));
+    await renderFeatures();
+
+    const control = await screen.findByRole("switch", {
+      name: "Toggle SCIM",
+    });
+    fireEvent.click(control);
+
+    expect(await screen.findByText("write failed")).toBeTruthy();
+    expect(control.getAttribute("data-state")).toBe("unchecked");
   });
 
   it("shows a loading state while the query is pending", async () => {
     mocks.getOrganizationFeatures.mockImplementation(
       () => new Promise(() => {}),
     );
-
     await renderFeatures();
-
     expect(screen.getByText("Loading...")).toBeTruthy();
   });
 
   it("shows a load failure message when the query fails", async () => {
     mocks.getOrganizationFeatures.mockRejectedValue(new Error("boom"));
-
     await renderFeatures();
-
     expect(await screen.findByText("Unable to load features")).toBeTruthy();
   });
 
@@ -75,8 +120,8 @@ describe("Features", () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    await renderWithApp(<Features org={ORG} />, { queryClient });
-    expect(await screen.findByText("Consent tool filtering")).toBeTruthy();
+    await renderFeatures(queryClient);
+    expect(await screen.findByText("Authz Challenge Logging")).toBeTruthy();
 
     mocks.getOrganizationFeatures.mockRejectedValue(new Error("boom"));
     await queryClient.invalidateQueries(organizationFeaturesQuery(ORG.id));
@@ -86,6 +131,6 @@ describe("Features", () => {
         "Unable to refresh features; showing the last loaded state.",
       ),
     ).toBeTruthy();
-    expect(screen.getByText("Consent tool filtering")).toBeTruthy();
+    expect(screen.getByText("Authz Challenge Logging")).toBeTruthy();
   });
 });

--- a/client/admin/src/pages/organization/Features.test.tsx
+++ b/client/admin/src/pages/organization/Features.test.tsx
@@ -3,7 +3,10 @@ import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { organizationFeaturesQuery } from "@/lib/adminQueries";
-import type { AdminOrganizationFeatures } from "@/lib/gramAdminApi";
+import type {
+  AdminOrganizationChatAnalysisSettings,
+  AdminOrganizationFeatures,
+} from "@/lib/gramAdminApi";
 import { Features } from "@/pages/organization/Features";
 import { anOrganization } from "@/test/fixtures";
 import { renderWithApp } from "@/test/harness";
@@ -11,6 +14,9 @@ import { renderWithApp } from "@/test/harness";
 const mocks = vi.hoisted(() => ({
   getOrganizationFeatures: vi.fn(),
   setOrganizationFeature: vi.fn(),
+  getOrganizationChatAnalysisSettings: vi.fn(),
+  setOrganizationChatAnalysisSetting: vi.fn(),
+  triggerOrganizationChatAnalysis: vi.fn(),
 }));
 
 vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
@@ -19,6 +25,11 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     ...actual,
     getOrganizationFeatures: mocks.getOrganizationFeatures,
     setOrganizationFeature: mocks.setOrganizationFeature,
+    getOrganizationChatAnalysisSettings:
+      mocks.getOrganizationChatAnalysisSettings,
+    setOrganizationChatAnalysisSetting:
+      mocks.setOrganizationChatAnalysisSetting,
+    triggerOrganizationChatAnalysis: mocks.triggerOrganizationChatAnalysis,
   };
 });
 
@@ -32,6 +43,14 @@ const FEATURES: AdminOrganizationFeatures = {
   sso_enabled: true,
   scim_enabled: false,
 };
+const CHAT_ANALYSIS: AdminOrganizationChatAnalysisSettings = {
+  organization_id: ORG.id,
+  work_units_enabled: true,
+  work_units_daily_cap: 25,
+  business_memory_enabled: false,
+  business_memory_daily_cap: 0,
+  is_default: false,
+};
 
 beforeEach(() => {
   for (const mock of Object.values(mocks)) mock.mockReset();
@@ -43,6 +62,11 @@ beforeEach(() => {
         [`${featureName}_enabled`]: enabled,
       }),
   );
+  mocks.getOrganizationChatAnalysisSettings.mockResolvedValue(CHAT_ANALYSIS);
+  mocks.setOrganizationChatAnalysisSetting.mockResolvedValue(CHAT_ANALYSIS);
+  mocks.triggerOrganizationChatAnalysis.mockResolvedValue({
+    projects_signaled: 2,
+  });
 });
 
 afterEach(cleanup);
@@ -68,6 +92,140 @@ describe("Features", () => {
     }
     expect(screen.queryByText("Consent tool filtering")).toBeNull();
     expect(mocks.getOrganizationFeatures).toHaveBeenCalledWith(ORG.id);
+  });
+
+  it("shows chat analysis controls beneath product features", async () => {
+    await renderFeatures();
+
+    expect(await screen.findByText("Chat analysis")).toBeTruthy();
+    expect(screen.getByText("Work Delivered Chat Analysis")).toBeTruthy();
+    expect(screen.getByText("Business Memory Extraction")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Caps are evaluations per UTC day; a cap of 0 disables the pipeline.",
+      ),
+    ).toBeTruthy();
+    const runNow = screen.getByRole("button", { name: "Run now" });
+    expect(runNow.previousElementSibling?.textContent).toBe("Disable");
+  });
+
+  it("triggers chat analysis from the enabled row", async () => {
+    await renderFeatures();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Run now" }));
+
+    await waitFor(() => {
+      expect(mocks.triggerOrganizationChatAnalysis).toHaveBeenCalledWith(
+        ORG.id,
+      );
+    });
+    expect(await screen.findByText("Triggered 2 projects.")).toBeTruthy();
+  });
+
+  it("enables a disabled zero-cap judge with the default cap", async () => {
+    mocks.setOrganizationChatAnalysisSetting.mockResolvedValue({
+      ...CHAT_ANALYSIS,
+      business_memory_enabled: true,
+      business_memory_daily_cap: 100,
+    });
+    await renderFeatures();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Enable" }));
+
+    await waitFor(() => {
+      expect(mocks.setOrganizationChatAnalysisSetting).toHaveBeenCalledWith({
+        organizationID: ORG.id,
+        judge: "business_memory",
+        enabled: true,
+        dailyCap: 100,
+      });
+    });
+    expect(
+      (
+        screen.getByLabelText(
+          "Business memory daily extraction cap",
+        ) as HTMLInputElement
+      ).value,
+    ).toBe("100");
+  });
+
+  it("saves an integer cap and replaces settings from the response", async () => {
+    mocks.setOrganizationChatAnalysisSetting.mockResolvedValue({
+      ...CHAT_ANALYSIS,
+      work_units_daily_cap: 48,
+      business_memory_daily_cap: 7,
+    });
+    await renderFeatures();
+
+    const input = await screen.findByLabelText(
+      "Work delivered daily evaluation cap",
+    );
+    const otherInput = screen.getByLabelText(
+      "Business memory daily extraction cap",
+    );
+    fireEvent.change(otherInput, { target: { value: "12" } });
+    fireEvent.change(input, { target: { value: "48" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save cap" }));
+
+    await waitFor(() => {
+      expect(mocks.setOrganizationChatAnalysisSetting).toHaveBeenCalledWith({
+        organizationID: ORG.id,
+        judge: "work_units",
+        enabled: true,
+        dailyCap: 48,
+      });
+    });
+    expect((otherInput as HTMLInputElement).value).toBe("12");
+  });
+
+  it("disables an enabled judge with its stored cap", async () => {
+    mocks.setOrganizationChatAnalysisSetting.mockResolvedValue({
+      ...CHAT_ANALYSIS,
+      work_units_enabled: false,
+    });
+    await renderFeatures();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(mocks.setOrganizationChatAnalysisSetting).toHaveBeenCalledWith({
+        organizationID: ORG.id,
+        judge: "work_units",
+        enabled: false,
+        dailyCap: 25,
+      });
+    });
+  });
+
+  it("rejects non-integer and out-of-range caps", async () => {
+    await renderFeatures();
+    const input = await screen.findByLabelText(
+      "Work delivered daily evaluation cap",
+    );
+
+    for (const value of ["", "1.5", "10001", "-1"]) {
+      fireEvent.change(input, { target: { value } });
+      expect(
+        screen.getByText("Cap must be a whole number from 0 to 10,000."),
+      ).toBeTruthy();
+      expect(
+        (screen.getByRole("button", { name: "Disable" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
+    }
+    expect(mocks.setOrganizationChatAnalysisSetting).not.toHaveBeenCalled();
+  });
+
+  it("reports a chat analysis mutation failure on its row", async () => {
+    mocks.setOrganizationChatAnalysisSetting.mockRejectedValue(
+      new Error("chat write failed"),
+    );
+    await renderFeatures();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Disable" }));
+
+    expect(await screen.findByText("chat write failed")).toBeTruthy();
+    expect(screen.getByText("Enabled")).toBeTruthy();
   });
 
   it("updates an organization feature from its switch", async () => {

--- a/client/admin/src/pages/organization/Features.tsx
+++ b/client/admin/src/pages/organization/Features.tsx
@@ -1,62 +1,76 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import type { JSX, ReactNode } from "react";
+import type { JSX } from "react";
 
+import { Switch } from "@/components/ui/switch";
 import {
   organizationFeaturesQuery,
   organizationQuery,
 } from "@/lib/adminQueries";
-import type {
-  AdminOrganization,
-  AdminOrganizationFeatures,
+import {
+  errorMessage,
+  setOrganizationFeature,
+  type AdminOrganization,
+  type AdminOrganizationFeatureName,
+  type AdminOrganizationFeatures,
 } from "@/lib/gramAdminApi";
 
-function Group({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}): JSX.Element {
-  return (
-    <section className="mt-5 first:mt-0">
-      <h5 className="text-muted-foreground mb-1 text-xs font-medium">
-        {title}
-      </h5>
-      {children}
-    </section>
-  );
-}
-
-function Row({
-  label,
-  value,
-}: {
+type FeatureDefinition = {
+  featureName: AdminOrganizationFeatureName;
+  enabledKey: keyof AdminOrganizationFeatures;
   label: string;
-  value: boolean | string;
-}): JSX.Element {
-  return (
-    <div className="grid grid-cols-[20rem_1fr] items-baseline gap-3 py-1">
-      <span className="text-muted-foreground text-sm">{label}</span>
-      <span className="text-sm">
-        {typeof value === "boolean" ? (value ? "Enabled" : "Disabled") : value}
-      </span>
-    </div>
-  );
-}
+  description: string;
+};
 
-function remoteSessionAutoRefreshPolicyLabel(
-  policy: AdminOrganizationFeatures["remote_session_auto_refresh_policy"],
-): string {
-  switch (policy) {
-    case "disabled":
-      return "Disabled";
-    case "user_controlled":
-      return "User controlled";
-    case "enforced":
-      return "Enforced";
-  }
-}
+const PRODUCT_FEATURES: FeatureDefinition[] = [
+  {
+    featureName: "authz_challenge_logging",
+    enabledKey: "authz_challenge_logging_enabled",
+    label: "Authz Challenge Logging",
+    description:
+      'Log every authorization decision (allow/deny) to ClickHouse. Powers auditing of "why did X have access to Y?"',
+  },
+  {
+    featureName: "customer_managed_encryption_keys",
+    enabledKey: "customer_managed_encryption_keys_enabled",
+    label: "Customer-Managed Encryption Keys",
+    description:
+      "Unlocks encryption key management for an organization, enabling external service credential, external encryption key, and asymmetric signing functionality.",
+  },
+  {
+    featureName: "custom_model_keys",
+    enabledKey: "custom_model_keys_enabled",
+    label: "Custom Model Provider Keys",
+    description:
+      "Allows projects in this organization to store OpenRouter API keys for model completions.",
+  },
+  {
+    featureName: "platform_mcp",
+    enabledKey: "platform_mcp_enabled",
+    label: "Platform MCP access",
+    description:
+      "Allows this organization to authenticate to and use Platform MCP, including manual setup. Disabling it denies runtime access without removing existing setup records.",
+  },
+  {
+    featureName: "remote_session_auto_refresh",
+    enabledKey: "remote_session_auto_refresh_enabled",
+    label: "Automatic Remote Session Refresh",
+    description:
+      "Shows the Auto refresh opt-in on remote-session consent screens.",
+  },
+  {
+    featureName: "sso",
+    enabledKey: "sso_enabled",
+    label: "SSO",
+    description: "Enables WorkOS portal link creation for managing SSO.",
+  },
+  {
+    featureName: "scim",
+    enabledKey: "scim_enabled",
+    label: "SCIM",
+    description: "Enables WorkOS portal link creation for managing SCIM.",
+  },
+];
 
 export function FeaturesRoute(): JSX.Element | null {
   const { idOrSlug } = useParams({ from: "/organizations/$idOrSlug" });
@@ -66,15 +80,71 @@ export function FeaturesRoute(): JSX.Element | null {
 }
 
 export function Features({ org }: { org: AdminOrganization }): JSX.Element {
+  const queryClient = useQueryClient();
+  const query = organizationFeaturesQuery(org.id);
   const { data, isPending, isError } = useQuery({
-    ...organizationFeaturesQuery(org.id),
+    ...query,
     enabled: !!org.id,
+  });
+  const mutation = useMutation({
+    mutationFn: ({
+      featureName,
+      enabled,
+    }: {
+      featureName: AdminOrganizationFeatureName;
+      enabled: boolean;
+    }) =>
+      setOrganizationFeature({
+        organizationID: org.id,
+        featureName,
+        enabled,
+      }),
+    onMutate: async ({ featureName, enabled }) => {
+      await queryClient.cancelQueries({ queryKey: query.queryKey });
+      const previous = queryClient.getQueryData<AdminOrganizationFeatures>(
+        query.queryKey,
+      );
+      const definition = PRODUCT_FEATURES.find(
+        (feature) => feature.featureName === featureName,
+      );
+      if (previous && definition) {
+        queryClient.setQueryData<AdminOrganizationFeatures>(query.queryKey, {
+          ...previous,
+          [definition.enabledKey]: enabled,
+        });
+      }
+      return {
+        enabledKey: definition?.enabledKey,
+        previousEnabled: definition
+          ? previous?.[definition.enabledKey]
+          : undefined,
+      };
+    },
+    onError: async (_error, _variables, context) => {
+      const enabledKey = context?.enabledKey;
+      const previousEnabled = context?.previousEnabled;
+      if (enabledKey && previousEnabled !== undefined) {
+        queryClient.setQueryData<AdminOrganizationFeatures>(
+          query.queryKey,
+          (current) =>
+            current
+              ? {
+                  ...current,
+                  [enabledKey]: previousEnabled,
+                }
+              : current,
+        );
+      }
+      await queryClient.invalidateQueries({ queryKey: query.queryKey });
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(query.queryKey, updated);
+    },
   });
 
   if (isPending) {
     return <span className="text-muted-foreground text-sm">Loading...</span>;
   }
-
   if (!data) {
     return (
       <span className="text-muted-foreground text-sm">
@@ -90,42 +160,51 @@ export function Features({ org }: { org: AdminOrganization }): JSX.Element {
           Unable to refresh features; showing the last loaded state.
         </p>
       )}
-      <FeaturesView features={data} />
+      <section className="border-border overflow-hidden rounded-md border">
+        <div className="border-border bg-muted/20 border-b px-4 py-3">
+          <h5 className="text-sm font-medium">Product features</h5>
+          <p className="text-muted-foreground text-sm">
+            Org-level entitlements. Changes apply immediately to every member of
+            the organization.
+          </p>
+        </div>
+        <div className="divide-border divide-y">
+          {PRODUCT_FEATURES.map((feature) => {
+            const rowError =
+              mutation.isError &&
+              mutation.variables.featureName === feature.featureName
+                ? errorMessage(mutation.error)
+                : undefined;
+            return (
+              <div
+                className="grid grid-cols-[1fr_auto] items-center gap-4 px-4 py-3"
+                key={feature.featureName}
+              >
+                <div>
+                  <p className="text-sm font-medium">{feature.label}</p>
+                  <p className="text-muted-foreground text-sm">
+                    {feature.description}
+                  </p>
+                  {rowError && (
+                    <p className="text-destructive mt-1 text-sm">{rowError}</p>
+                  )}
+                </div>
+                <Switch
+                  checked={data[feature.enabledKey]}
+                  disabled={mutation.isPending}
+                  onCheckedChange={(enabled) =>
+                    mutation.mutate({
+                      featureName: feature.featureName,
+                      enabled,
+                    })
+                  }
+                  aria-label={`Toggle ${feature.label}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </section>
     </>
-  );
-}
-
-function FeaturesView({
-  features,
-}: {
-  features: AdminOrganizationFeatures;
-}): JSX.Element {
-  return (
-    <div className="border-border bg-muted/10 rounded-md border p-4">
-      <Group title="Feature flags">
-        <Row
-          label="Consent tool filtering"
-          value={features.consent_tool_filtering_enabled}
-        />
-        <Row
-          label="Hooks browser login"
-          value={features.hooks_browser_login_enabled}
-        />
-        <Row label="Hooks fail open" value={features.hooks_fail_open_enabled} />
-        <Row label="Platform MCP" value={features.platform_mcp_enabled} />
-        <Row
-          label="Remote session auto refresh policy"
-          value={remoteSessionAutoRefreshPolicyLabel(
-            features.remote_session_auto_refresh_policy,
-          )}
-        />
-        <Row label="Session capture" value={features.session_capture_enabled} />
-        <Row
-          label="Skill capture metadata only"
-          value={features.skill_capture_metadata_only}
-        />
-        <Row label="Skills" value={features.skills_enabled} />
-      </Group>
-    </div>
   );
 }

--- a/client/admin/src/pages/organization/Features.tsx
+++ b/client/admin/src/pages/organization/Features.tsx
@@ -1,16 +1,24 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import type { JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
+  organizationChatAnalysisSettingsQuery,
   organizationFeaturesQuery,
   organizationQuery,
 } from "@/lib/adminQueries";
 import {
   errorMessage,
+  setOrganizationChatAnalysisSetting,
   setOrganizationFeature,
+  triggerOrganizationChatAnalysis,
+  type AdminChatAnalysisJudge,
   type AdminOrganization,
+  type AdminOrganizationChatAnalysisSettings,
   type AdminOrganizationFeatureName,
   type AdminOrganizationFeatures,
 } from "@/lib/gramAdminApi";
@@ -80,6 +88,15 @@ export function FeaturesRoute(): JSX.Element | null {
 }
 
 export function Features({ org }: { org: AdminOrganization }): JSX.Element {
+  return (
+    <div className="space-y-6">
+      <ProductFeatures org={org} />
+      <ChatAnalysis org={org} />
+    </div>
+  );
+}
+
+function ProductFeatures({ org }: { org: AdminOrganization }): JSX.Element {
   const queryClient = useQueryClient();
   const query = organizationFeaturesQuery(org.id);
   const { data, isPending, isError } = useQuery({
@@ -154,7 +171,7 @@ export function Features({ org }: { org: AdminOrganization }): JSX.Element {
   }
 
   return (
-    <>
+    <div>
       {isError && (
         <p className="text-muted-foreground mb-3 text-sm">
           Unable to refresh features; showing the last loaded state.
@@ -205,6 +222,259 @@ export function Features({ org }: { org: AdminOrganization }): JSX.Element {
           })}
         </div>
       </section>
-    </>
+    </div>
+  );
+}
+
+type ChatAnalysisDefinition = {
+  judge: AdminChatAnalysisJudge;
+  enabledKey: "work_units_enabled" | "business_memory_enabled";
+  capKey: "work_units_daily_cap" | "business_memory_daily_cap";
+  label: string;
+  description: string;
+  capLabel: string;
+};
+
+const CHAT_ANALYSIS_CONTROLS: ChatAnalysisDefinition[] = [
+  {
+    judge: "work_units",
+    enabledKey: "work_units_enabled",
+    capKey: "work_units_daily_cap",
+    label: "Work Delivered Chat Analysis",
+    description:
+      "Evaluates work delivered in the organization's quiet chat sessions.",
+    capLabel: "Work delivered daily evaluation cap",
+  },
+  {
+    judge: "business_memory",
+    enabledKey: "business_memory_enabled",
+    capKey: "business_memory_daily_cap",
+    label: "Business Memory Extraction",
+    description:
+      "Extracts reusable glossary entries, procedures, and prior results from quiet chat sessions.",
+    capLabel: "Business memory daily extraction cap",
+  },
+];
+
+function validDailyCap(value: string): number | undefined {
+  if (value.trim() === "") return undefined;
+  const cap = Number(value);
+  return Number.isInteger(cap) && cap >= 0 && cap <= 10_000 ? cap : undefined;
+}
+
+function ChatAnalysis({ org }: { org: AdminOrganization }): JSX.Element {
+  const queryClient = useQueryClient();
+  const query = organizationChatAnalysisSettingsQuery(org.id);
+  const { data, isPending, isError } = useQuery({
+    ...query,
+    enabled: !!org.id,
+  });
+  const [caps, setCaps] = useState<Record<AdminChatAnalysisJudge, string>>({
+    work_units: "",
+    business_memory: "",
+  });
+  const [dirtyCaps, setDirtyCaps] = useState<
+    Record<AdminChatAnalysisJudge, boolean>
+  >({
+    work_units: false,
+    business_memory: false,
+  });
+
+  useEffect(() => {
+    if (!data) return;
+    setCaps((current) => ({
+      work_units: dirtyCaps.work_units
+        ? current.work_units
+        : String(data.work_units_daily_cap),
+      business_memory: dirtyCaps.business_memory
+        ? current.business_memory
+        : String(data.business_memory_daily_cap),
+    }));
+  }, [data, dirtyCaps.work_units, dirtyCaps.business_memory]);
+
+  const mutation = useMutation({
+    mutationFn: ({
+      judge,
+      enabled,
+      dailyCap,
+    }: {
+      judge: AdminChatAnalysisJudge;
+      enabled: boolean;
+      dailyCap: number;
+    }) =>
+      setOrganizationChatAnalysisSetting({
+        organizationID: org.id,
+        judge,
+        enabled,
+        dailyCap,
+      }),
+    onSuccess: (updated, variables) => {
+      queryClient.setQueryData<AdminOrganizationChatAnalysisSettings>(
+        query.queryKey,
+        updated,
+      );
+      setDirtyCaps((current) => ({
+        ...current,
+        [variables.judge]: false,
+      }));
+    },
+  });
+  const trigger = useMutation({
+    mutationFn: (judge: AdminChatAnalysisJudge) =>
+      triggerOrganizationChatAnalysis(org.id).then((result) => ({
+        ...result,
+        judge,
+      })),
+  });
+
+  if (isPending) {
+    return (
+      <span className="text-muted-foreground text-sm">
+        Loading chat analysis...
+      </span>
+    );
+  }
+  if (!data) {
+    return (
+      <span className="text-muted-foreground text-sm">
+        Unable to load chat analysis settings
+      </span>
+    );
+  }
+
+  return (
+    <div>
+      {isError && (
+        <p className="text-muted-foreground mb-3 text-sm">
+          Unable to refresh chat analysis settings; showing the last loaded
+          state.
+        </p>
+      )}
+      <section className="border-border overflow-hidden rounded-md border">
+        <div className="border-border bg-muted/20 border-b px-4 py-3">
+          <h5 className="text-sm font-medium">Chat analysis</h5>
+          <p className="text-muted-foreground text-sm">
+            Caps are evaluations per UTC day; a cap of 0 disables the pipeline.
+          </p>
+        </div>
+        <div className="divide-border divide-y">
+          {CHAT_ANALYSIS_CONTROLS.map((control) => {
+            const enabled = data[control.enabledKey];
+            const cap = validDailyCap(caps[control.judge]);
+            const capDirty = cap !== undefined && cap !== data[control.capKey];
+            const actionLabel = !enabled
+              ? "Enable"
+              : capDirty
+                ? "Save cap"
+                : "Disable";
+            const rowError =
+              mutation.isError && mutation.variables.judge === control.judge
+                ? errorMessage(mutation.error)
+                : undefined;
+            const triggerError =
+              trigger.isError && trigger.variables === control.judge
+                ? errorMessage(trigger.error)
+                : undefined;
+            const triggerResult =
+              trigger.isSuccess && trigger.data.judge === control.judge
+                ? trigger.data
+                : undefined;
+            return (
+              <div className="px-4 py-3" key={control.judge}>
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium">{control.label}</p>
+                      <Badge variant="outline">
+                        {enabled ? "Enabled" : "Disabled"}
+                      </Badge>
+                    </div>
+                    <p className="text-muted-foreground text-sm">
+                      {control.description}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Input
+                      className="w-28"
+                      type="number"
+                      min={0}
+                      max={10_000}
+                      step={1}
+                      aria-label={control.capLabel}
+                      value={caps[control.judge]}
+                      disabled={mutation.isPending}
+                      onChange={(event) => {
+                        setCaps((current) => ({
+                          ...current,
+                          [control.judge]: event.target.value,
+                        }));
+                        setDirtyCaps((current) => ({
+                          ...current,
+                          [control.judge]: true,
+                        }));
+                      }}
+                    />
+                    <Button
+                      size="sm"
+                      variant={enabled && !capDirty ? "destructive" : "default"}
+                      disabled={mutation.isPending || cap === undefined}
+                      onClick={() => {
+                        if (cap === undefined) return;
+                        const dailyCap = !enabled && cap === 0 ? 100 : cap;
+                        if (dailyCap !== cap) {
+                          setCaps((current) => ({
+                            ...current,
+                            [control.judge]: String(dailyCap),
+                          }));
+                        }
+                        mutation.mutate({
+                          judge: control.judge,
+                          enabled: !enabled || capDirty,
+                          dailyCap,
+                        });
+                      }}
+                    >
+                      {actionLabel}
+                    </Button>
+                    {enabled && !capDirty && data[control.capKey] > 0 && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        disabled={trigger.isPending}
+                        onClick={() => trigger.mutate(control.judge)}
+                      >
+                        {trigger.isPending &&
+                        trigger.variables === control.judge
+                          ? "Running…"
+                          : "Run now"}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                {cap === undefined && (
+                  <p className="text-destructive mt-1 text-sm">
+                    Cap must be a whole number from 0 to 10,000.
+                  </p>
+                )}
+                {rowError && (
+                  <p className="text-destructive mt-1 text-sm">{rowError}</p>
+                )}
+                {triggerError && (
+                  <p className="text-destructive mt-1 text-sm">
+                    {triggerError}
+                  </p>
+                )}
+                {triggerResult && (
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    Triggered {triggerResult.projects_signaled} project
+                    {triggerResult.projects_signaled === 1 ? "" : "s"}.
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -26,6 +26,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/admin"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/background"
+	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
 	"github.com/speakeasy-api/gram/server/internal/control"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
@@ -83,6 +85,32 @@ func newAdminCommand() *cli.Command {
 			Usage:    "The current server environment", // local, dev, prod
 			Required: true,
 			EnvVars:  []string{"GRAM_ENVIRONMENT"},
+		},
+		&cli.StringFlag{
+			Name:    "temporal-address",
+			Usage:   "Address of the Temporal server",
+			EnvVars: []string{"TEMPORAL_ADDRESS"},
+		},
+		&cli.StringFlag{
+			Name:    "temporal-namespace",
+			Usage:   "Namespace of the Temporal server",
+			EnvVars: []string{"TEMPORAL_NAMESPACE"},
+		},
+		&cli.StringFlag{
+			Name:    "temporal-task-queue",
+			Usage:   "Task queue of the Temporal server",
+			EnvVars: []string{"TEMPORAL_TASK_QUEUE"},
+			Value:   "main",
+		},
+		&cli.StringFlag{
+			Name:    "temporal-client-cert",
+			Usage:   "Client cert of the Temporal server",
+			EnvVars: []string{"TEMPORAL_CLIENT_CERT"},
+		},
+		&cli.StringFlag{
+			Name:    "temporal-client-key",
+			Usage:   "Client key of the Temporal server",
+			EnvVars: []string{"TEMPORAL_CLIENT_KEY"},
 		},
 		&cli.StringFlag{
 			Name:     "ssl-key-file",
@@ -292,6 +320,24 @@ func newAdminCommand() *cli.Command {
 			meterProvider := otel.GetMeterProvider()
 			slog.SetDefault(logger)
 
+			temporalEnv, temporalShutdown, err := newTemporalClient(logger, meterProvider, temporalClientOptions{
+				address:      c.String("temporal-address"),
+				namespace:    c.String("temporal-namespace"),
+				taskQueue:    c.String("temporal-task-queue"),
+				certPEMBlock: []byte(c.String("temporal-client-cert")),
+				keyPEMBlock:  []byte(c.String("temporal-client-key")),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create temporal client: %w", err)
+			}
+			chatAnalysisSignaler := analysis.Signaler(admin.ChatAnalysisTriggerUnavailable{})
+			temporalHealth := []*o11y.NamedResource[client.Client]{}
+			if temporalEnv != nil {
+				shutdownFuncs = append(shutdownFuncs, temporalShutdown)
+				chatAnalysisSignaler = &background.TemporalChatAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger}
+				temporalHealth = append(temporalHealth, &o11y.NamedResource[client.Client]{Name: "default", Resource: temporalEnv.Client()})
+			}
+
 			db, err := newDBClient(ctx, logger, meterProvider, c.String("database-url"), dbClientOptions{
 				enableUnsafeLogging: c.Bool("unsafe-db-log"),
 			})
@@ -383,7 +429,7 @@ func newAdminCommand() *cli.Command {
 			trialNotifier := trialemails.NewService(db, loopsWorkflowClient, logger, c.String("site-url"))
 
 			billingOperations := usage.NewBillingOperations(logger, db, stripeClient, billingTelemetry, audit.NewLogger())
-			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminOpenRouter, trialNotifier, productFeatures, billingOperations))
+			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, adminWorkOSClient, adminOpenRouter, trialNotifier, productFeatures, chatAnalysisSignaler, billingOperations))
 
 			srv := &http.Server{
 				Addr:              c.String("address"),
@@ -448,7 +494,7 @@ func newAdminCommand() *cli.Command {
 					[]*o11y.NamedResource[*o11y.HTTPEndpoint]{{Name: "api", Resource: healthzEndpoint}},
 					[]*o11y.NamedResource[*pgxpool.Pool]{{Name: "default", Resource: db}},
 					[]*o11y.NamedResource[*redis.Client]{{Name: "default", Resource: redisClient}},
-					[]*o11y.NamedResource[client.Client]{},
+					temporalHealth,
 				))
 				if err != nil {
 					return fmt.Errorf("failed to start control server: %w", err)

--- a/server/internal/admin/chatanalysis_handler.go
+++ b/server/internal/admin/chatanalysis_handler.go
@@ -1,0 +1,147 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/businessmemory"
+	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
+	"github.com/speakeasy-api/gram/server/internal/chatanalysis"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+type setAdminChatAnalysisSettingsRequest struct {
+	OrganizationID string `json:"organization_id"`
+	Judge          string `json:"judge"`
+	Enabled        *bool  `json:"enabled"`
+	DailyCap       *int   `json:"daily_cap"`
+}
+
+type triggerAdminChatAnalysisRequest struct {
+	OrganizationID string `json:"organization_id"`
+}
+
+type triggerAdminChatAnalysisResponse struct {
+	ProjectsSignaled int `json:"projects_signaled"`
+}
+
+var adminChatAnalysisJudges = map[string]struct{}{
+	analysis.WorkUnitsJudgeName: {},
+	businessmemory.JudgeName:    {},
+}
+
+func (s *Service) writeAdminChatAnalysisSettings(w http.ResponseWriter, ctx context.Context, organizationID string) error {
+	settings, err := chatanalysis.LoadSettings(ctx, s.db, organizationID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "load chat analysis settings").LogError(ctx, s.logger)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(settings); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "encode chat analysis settings").LogError(ctx, s.logger)
+	}
+	return nil
+}
+
+func (s *Service) handleGetChatAnalysisSettings(w http.ResponseWriter, r *http.Request) error {
+	ctx, err := s.authorizeAdminRequest(r)
+	if err != nil {
+		return err
+	}
+	organizationID, err := s.canonicalAdminOrganizationForRequest(ctx, r.URL.Query().Get("organization_id"))
+	if err != nil {
+		return err
+	}
+	return s.writeAdminChatAnalysisSettings(w, ctx, organizationID)
+}
+
+func (s *Service) handleTriggerChatAnalysis(w http.ResponseWriter, r *http.Request) error {
+	ctx, err := s.authorizeAdminRequest(r)
+	if err != nil {
+		return err
+	}
+
+	var body triggerAdminChatAnalysisRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		return oops.E(oops.CodeBadRequest, err, "decode chat analysis trigger request")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return oops.E(oops.CodeBadRequest, err, "decode chat analysis trigger request")
+	}
+
+	organizationID, err := s.canonicalAdminOrganizationForRequest(ctx, body.OrganizationID)
+	if err != nil {
+		return err
+	}
+	projectsSignaled, err := chatanalysis.TriggerOrganization(ctx, s.db, s.chatAnalysisSignaler, organizationID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "trigger chat analysis").LogError(ctx, s.logger)
+	}
+
+	_, operatorEmail := adminActor(ctx)
+	s.logger.InfoContext(ctx, "triggered chat analysis",
+		attr.SlogOrganizationID(organizationID),
+		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
+	)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(triggerAdminChatAnalysisResponse{ProjectsSignaled: projectsSignaled}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "encode chat analysis trigger response").LogError(ctx, s.logger)
+	}
+	return nil
+}
+
+func (s *Service) handleSetChatAnalysisSettings(w http.ResponseWriter, r *http.Request) error {
+	ctx, err := s.authorizeAdminRequest(r)
+	if err != nil {
+		return err
+	}
+
+	var body setAdminChatAnalysisSettingsRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		return oops.E(oops.CodeBadRequest, err, "decode chat analysis settings request")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return oops.E(oops.CodeBadRequest, err, "decode chat analysis settings request")
+	}
+	if body.Enabled == nil || body.DailyCap == nil {
+		return oops.C(oops.CodeBadRequest)
+	}
+	if _, ok := adminChatAnalysisJudges[body.Judge]; !ok {
+		return oops.C(oops.CodeBadRequest)
+	}
+	if *body.DailyCap < 0 || *body.DailyCap > chatanalysis.MaxDailyCap {
+		return oops.C(oops.CodeBadRequest)
+	}
+
+	organizationID, err := s.canonicalAdminOrganizationForRequest(ctx, body.OrganizationID)
+	if err != nil {
+		return err
+	}
+	actor, operatorEmail := adminActor(ctx)
+	settings, err := chatanalysis.UpsertSettings(
+		ctx, s.db, s.audit, organizationID, body.Judge, *body.Enabled, *body.DailyCap,
+		actor, conv.PtrEmpty(audit.SpeakeasyTeamActorLabel),
+	)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "update chat analysis settings").LogError(ctx, s.logger)
+	}
+
+	s.logger.InfoContext(ctx, "updated chat analysis settings",
+		attr.SlogOrganizationID(organizationID),
+		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
+	)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(settings); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "encode chat analysis settings").LogError(ctx, s.logger)
+	}
+	return nil
+}

--- a/server/internal/admin/chatanalysis_handler_test.go
+++ b/server/internal/admin/chatanalysis_handler_test.go
@@ -1,0 +1,196 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/chatanalysis"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+type recordingAdminChatAnalysisSignaler struct {
+	projectIDs []uuid.UUID
+}
+
+func (s *recordingAdminChatAnalysisSignaler) Signal(_ context.Context, projectID uuid.UUID) error {
+	s.projectIDs = append(s.projectIDs, projectID)
+	return nil
+}
+
+func TestChatAnalysisSettingsRequiresAdminSession(t *testing.T) {
+	t.Parallel()
+	svc := newTestSessionService(t, newTestOIDCClient(t, userinfoOK("sub-chat-analysis-auth", "operator@example.com")))
+	mux := goahttp.NewMuxer()
+	Attach(mux, svc)
+
+	for _, test := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/admin/organization.chatAnalysisSettings"},
+		{method: http.MethodPost, path: "/admin/organization.chatAnalysisSettings"},
+		{method: http.MethodPost, path: "/admin/organization.chatAnalysisTrigger"},
+	} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(test.method, test.path, nil))
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+}
+
+func TestChatAnalysisSettingsDefaultsUpdatesAndAudits(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn := newTestAdminService(t)
+	const (
+		orgID         = "org_admin_chat_analysis"
+		operatorEmail = "operator@example.com"
+	)
+	now := time.Now().UTC()
+	require.NoError(t, testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID: orgID, Name: "Admin Chat Analysis Org", Slug: "admin-chat-analysis", GramAccountType: "enterprise",
+		FreeTrialStartedAt: conv.ToPGTimestamptz(now), FreeTrialEndsAt: conv.ToPGTimestamptz(now.Add(14 * 24 * time.Hour)),
+	}))
+
+	mux := goahttp.NewMuxer()
+	Attach(mux, svc)
+	handler := SessionMiddleware(mux)
+	sessionID := makeAdminFeatureSession(t, ctx, svc, operatorEmail)
+
+	get := httptest.NewRequest(http.MethodGet, "/admin/organization.chatAnalysisSettings?organization_id="+orgID, nil)
+	get.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+	getResult := httptest.NewRecorder()
+	handler.ServeHTTP(getResult, get)
+	require.Equal(t, http.StatusOK, getResult.Code)
+	var defaults chatanalysis.Settings
+	require.NoError(t, json.Unmarshal(getResult.Body.Bytes(), &defaults))
+	require.Equal(t, chatanalysis.Settings{OrganizationID: orgID, IsDefault: true}, defaults)
+
+	body := []byte(`{"organization_id":"` + orgID + `","judge":"work_units","enabled":true,"daily_cap":321}`)
+	post := httptest.NewRequest(http.MethodPost, "/admin/organization.chatAnalysisSettings", bytes.NewReader(body))
+	post.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+	postResult := httptest.NewRecorder()
+	handler.ServeHTTP(postResult, post)
+	require.Equal(t, http.StatusOK, postResult.Code)
+	var updated chatanalysis.Settings
+	require.NoError(t, json.Unmarshal(postResult.Body.Bytes(), &updated))
+	require.Equal(t, chatanalysis.Settings{
+		OrganizationID: orgID, WorkUnitsEnabled: true, WorkUnitsDailyCap: 321, IsDefault: false,
+	}, updated)
+
+	// false and zero are valid required values, not missing fields. This also
+	// exercises the second and only other allowlisted judge.
+	body = []byte(`{"organization_id":"` + orgID + `","judge":"business_memory","enabled":false,"daily_cap":0}`)
+	post = httptest.NewRequest(http.MethodPost, "/admin/organization.chatAnalysisSettings", bytes.NewReader(body))
+	post.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+	postResult = httptest.NewRecorder()
+	handler.ServeHTTP(postResult, post)
+	require.Equal(t, http.StatusOK, postResult.Code)
+	require.NoError(t, json.Unmarshal(postResult.Body.Bytes(), &updated))
+	require.Equal(t, chatanalysis.Settings{
+		OrganizationID: orgID, WorkUnitsEnabled: true, WorkUnitsDailyCap: 321, IsDefault: false,
+	}, updated)
+
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionChatAnalysisSettingsUpsert)
+	require.NoError(t, err)
+	require.Equal(t, "sub-admin", entry.ActorID)
+	require.NotNil(t, entry.ActorDisplayName)
+	require.Equal(t, audit.SpeakeasyTeamActorLabel, *entry.ActorDisplayName)
+	for name, field := range map[string]string{
+		"actor display name": *entry.ActorDisplayName,
+		"actor slug":         entry.ActorSlug,
+		"actor id":           entry.ActorID,
+		"before snapshot":    string(entry.BeforeSnapshot),
+		"after snapshot":     string(entry.AfterSnapshot),
+		"metadata":           string(entry.Metadata),
+	} {
+		require.NotContains(t, field, operatorEmail, "operator email leaked through %s", name)
+	}
+}
+
+func TestTriggerChatAnalysisSignalsOrganizationProjects(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn := newTestAdminService(t)
+	const orgID = "org_admin_chat_analysis_trigger"
+	now := time.Now().UTC()
+	require.NoError(t, testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID: orgID, Name: "Admin Chat Analysis Trigger Org", Slug: "admin-chat-analysis-trigger", GramAccountType: "enterprise",
+		FreeTrialStartedAt: conv.ToPGTimestamptz(now), FreeTrialEndsAt: conv.ToPGTimestamptz(now.Add(14 * 24 * time.Hour)),
+	}))
+	first, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name: "trigger-first", Slug: "trigger-first", OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+	second, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name: "trigger-second", Slug: "trigger-second", OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	signaler := &recordingAdminChatAnalysisSignaler{}
+	svc.chatAnalysisSignaler = signaler
+	mux := goahttp.NewMuxer()
+	Attach(mux, svc)
+	handler := SessionMiddleware(mux)
+	sessionID := makeAdminFeatureSession(t, ctx, svc, "operator@example.com")
+	body := []byte(`{"organization_id":"` + orgID + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/admin/organization.chatAnalysisTrigger", bytes.NewReader(body))
+	req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var response triggerAdminChatAnalysisResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Equal(t, triggerAdminChatAnalysisResponse{ProjectsSignaled: 2}, response)
+	require.ElementsMatch(t, []uuid.UUID{first.ID, second.ID}, signaler.projectIDs)
+}
+
+func TestSetChatAnalysisSettingsRejectsInvalidBodies(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn := newTestAdminService(t)
+	const orgID = "org_admin_chat_analysis_reject"
+	now := time.Now().UTC()
+	require.NoError(t, testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID: orgID, Name: "Admin Chat Analysis Reject Org", Slug: "admin-chat-analysis-reject", GramAccountType: "enterprise",
+		FreeTrialStartedAt: conv.ToPGTimestamptz(now), FreeTrialEndsAt: conv.ToPGTimestamptz(now.Add(14 * 24 * time.Hour)),
+	}))
+	mux := goahttp.NewMuxer()
+	Attach(mux, svc)
+	handler := SessionMiddleware(mux)
+	sessionID := makeAdminFeatureSession(t, ctx, svc, "operator@example.com")
+
+	for name, body := range map[string]string{
+		"missing enabled": `{"organization_id":"` + orgID + `","judge":"work_units","daily_cap":1}`,
+		"missing cap":     `{"organization_id":"` + orgID + `","judge":"work_units","enabled":false}`,
+		"unknown judge":   `{"organization_id":"` + orgID + `","judge":"other","enabled":true,"daily_cap":1}`,
+		"negative cap":    `{"organization_id":"` + orgID + `","judge":"business_memory","enabled":true,"daily_cap":-1}`,
+		"oversized cap":   `{"organization_id":"` + orgID + `","judge":"work_units","enabled":true,"daily_cap":10001}`,
+		"unknown field":   `{"organization_id":"` + orgID + `","judge":"work_units","enabled":true,"daily_cap":1,"run_now":true}`,
+		"trailing JSON":   `{"organization_id":"` + orgID + `","judge":"work_units","enabled":true,"daily_cap":1}{}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, "/admin/organization.chatAnalysisSettings", bytes.NewBufferString(body))
+			req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+
+	stored, err := chatanalysis.LoadSettings(ctx, conn, orgID)
+	require.NoError(t, err)
+	require.Equal(t, chatanalysis.Settings{OrganizationID: orgID, IsDefault: true}, stored)
+}

--- a/server/internal/admin/features_handler.go
+++ b/server/internal/admin/features_handler.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"goa.design/goa/v3/security"
-
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"goa.design/goa/v3/security"
 )
 
 // adminOrganizationFeaturesResponse is the response body of GET /admin/organization.features.
@@ -35,14 +34,14 @@ type setAdminOrganizationFeatureRequest struct {
 	Enabled        *bool  `json:"enabled"`
 }
 
-var adminOrganizationFeatures = map[productfeatures.Feature]struct{}{
-	productfeatures.FeatureAuthzChallengeLogging:         {},
-	productfeatures.FeatureCustomerManagedEncryptionKeys: {},
-	productfeatures.FeatureCustomModelKeys:               {},
-	productfeatures.FeaturePlatformMCP:                   {},
-	productfeatures.FeatureRemoteSessionAutoRefresh:      {},
-	productfeatures.FeatureSSO:                           {},
-	productfeatures.FeatureSCIM:                          {},
+var adminOrganizationFeatures = map[string]productfeatures.Feature{
+	string(productfeatures.FeatureAuthzChallengeLogging):         productfeatures.FeatureAuthzChallengeLogging,
+	string(productfeatures.FeatureCustomerManagedEncryptionKeys): productfeatures.FeatureCustomerManagedEncryptionKeys,
+	string(productfeatures.FeatureCustomModelKeys):               productfeatures.FeatureCustomModelKeys,
+	string(productfeatures.FeaturePlatformMCP):                   productfeatures.FeaturePlatformMCP,
+	string(productfeatures.FeatureRemoteSessionAutoRefresh):      productfeatures.FeatureRemoteSessionAutoRefresh,
+	string(productfeatures.FeatureSSO):                           productfeatures.FeatureSSO,
+	string(productfeatures.FeatureSCIM):                          productfeatures.FeatureSCIM,
 }
 
 func (s *Service) authorizeAdminRequest(r *http.Request) (context.Context, error) {
@@ -130,8 +129,8 @@ func (s *Service) handleSetOrganizationFeature(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return err
 	}
-	feature := productfeatures.Feature(body.FeatureName)
-	if _, ok := adminOrganizationFeatures[feature]; !ok || body.Enabled == nil {
+	feature, ok := adminOrganizationFeatures[body.FeatureName]
+	if !ok || body.Enabled == nil {
 		return oops.C(oops.CodeBadRequest)
 	}
 

--- a/server/internal/admin/features_handler.go
+++ b/server/internal/admin/features_handler.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,23 +14,38 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 )
 
-// adminOrganizationFeatures is the response body of GET /admin/organization.features.
+// adminOrganizationFeaturesResponse is the response body of GET /admin/organization.features.
 //
 // Like sessionInfo, this endpoint is deliberately not a Goa method so the
 // standalone admin UI contract stays out of the shared OpenAPI document and the
 // generated public SDKs.
-type adminOrganizationFeatures struct {
-	ConsentToolFilteringEnabled    bool   `json:"consent_tool_filtering_enabled"`
-	HooksBrowserLoginEnabled       bool   `json:"hooks_browser_login_enabled"`
-	HooksFailOpenEnabled           bool   `json:"hooks_fail_open_enabled"`
-	PlatformMcpEnabled             bool   `json:"platform_mcp_enabled"`
-	RemoteSessionAutoRefreshPolicy string `json:"remote_session_auto_refresh_policy"`
-	SessionCaptureEnabled          bool   `json:"session_capture_enabled"`
-	SkillCaptureMetadataOnly       bool   `json:"skill_capture_metadata_only"`
-	SkillsEnabled                  bool   `json:"skills_enabled"`
+type adminOrganizationFeaturesResponse struct {
+	AuthzChallengeLoggingEnabled         bool `json:"authz_challenge_logging_enabled"`
+	CustomerManagedEncryptionKeysEnabled bool `json:"customer_managed_encryption_keys_enabled"`
+	CustomModelKeysEnabled               bool `json:"custom_model_keys_enabled"`
+	PlatformMcpEnabled                   bool `json:"platform_mcp_enabled"`
+	RemoteSessionAutoRefreshEnabled      bool `json:"remote_session_auto_refresh_enabled"`
+	SsoEnabled                           bool `json:"sso_enabled"`
+	ScimEnabled                          bool `json:"scim_enabled"`
 }
 
-func (s *Service) handleGetOrganizationFeatures(w http.ResponseWriter, r *http.Request) error {
+type setAdminOrganizationFeatureRequest struct {
+	OrganizationID string `json:"organization_id"`
+	FeatureName    string `json:"feature_name"`
+	Enabled        *bool  `json:"enabled"`
+}
+
+var adminOrganizationFeatures = map[productfeatures.Feature]struct{}{
+	productfeatures.FeatureAuthzChallengeLogging:         {},
+	productfeatures.FeatureCustomerManagedEncryptionKeys: {},
+	productfeatures.FeatureCustomModelKeys:               {},
+	productfeatures.FeaturePlatformMCP:                   {},
+	productfeatures.FeatureRemoteSessionAutoRefresh:      {},
+	productfeatures.FeatureSSO:                           {},
+	productfeatures.FeatureSCIM:                          {},
+}
+
+func (s *Service) authorizeAdminRequest(r *http.Request) (context.Context, error) {
 	scheme := security.APIKeyScheme{
 		Name:           constants.AdminAuthSecurityScheme,
 		Scopes:         []string{},
@@ -38,19 +54,19 @@ func (s *Service) handleGetOrganizationFeatures(w http.ResponseWriter, r *http.R
 
 	ctx, err := s.verifier.Authorize(r.Context(), "", &scheme)
 	if err != nil {
-		return fmt.Errorf("admin auth: %w", err)
+		return nil, fmt.Errorf("admin auth: %w", err)
 	}
+	return ctx, nil
+}
 
-	organizationID := r.URL.Query().Get("organization_id")
+func (s *Service) canonicalAdminOrganizationForRequest(ctx context.Context, organizationID string) (string, error) {
 	if organizationID == "" {
-		return oops.C(oops.CodeBadRequest)
+		return "", oops.C(oops.CodeBadRequest)
 	}
+	return s.canonicalAdminOrganizationID(ctx, organizationID)
+}
 
-	organizationID, err = s.canonicalAdminOrganizationID(ctx, organizationID)
-	if err != nil {
-		return err
-	}
-
+func (s *Service) readAdminOrganizationFeatures(ctx context.Context, organizationID string) adminOrganizationFeaturesResponse {
 	readFeature := func(feature productfeatures.Feature) bool {
 		enabled, err := s.productFeatures.IsFeatureEnabled(ctx, organizationID, feature)
 		if err != nil {
@@ -66,26 +82,64 @@ func (s *Service) handleGetOrganizationFeatures(w http.ResponseWriter, r *http.R
 		return enabled
 	}
 
-	remoteSessionAutoRefreshPolicy := "disabled"
-	if readFeature(productfeatures.FeatureRemoteSessionAutoRefreshEnforced) {
-		remoteSessionAutoRefreshPolicy = "enforced"
-	} else if readFeature(productfeatures.FeatureRemoteSessionAutoRefresh) {
-		remoteSessionAutoRefreshPolicy = "user_controlled"
+	return adminOrganizationFeaturesResponse{
+		AuthzChallengeLoggingEnabled:         readFeature(productfeatures.FeatureAuthzChallengeLogging),
+		CustomerManagedEncryptionKeysEnabled: readFeature(productfeatures.FeatureCustomerManagedEncryptionKeys),
+		CustomModelKeysEnabled:               readFeature(productfeatures.FeatureCustomModelKeys),
+		PlatformMcpEnabled:                   readFeature(productfeatures.FeaturePlatformMCP),
+		RemoteSessionAutoRefreshEnabled:      readFeature(productfeatures.FeatureRemoteSessionAutoRefresh),
+		SsoEnabled:                           readFeature(productfeatures.FeatureSSO),
+		ScimEnabled:                          readFeature(productfeatures.FeatureSCIM),
 	}
+}
 
+func (s *Service) writeAdminOrganizationFeatures(w http.ResponseWriter, ctx context.Context, organizationID string) error {
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(adminOrganizationFeatures{
-		ConsentToolFilteringEnabled:    readFeature(productfeatures.FeatureConsentToolFiltering),
-		HooksBrowserLoginEnabled:       readFeature(productfeatures.FeatureHooksBrowserLogin),
-		HooksFailOpenEnabled:           readFeature(productfeatures.FeatureHooksFailOpen),
-		PlatformMcpEnabled:             readFeature(productfeatures.FeaturePlatformMCP),
-		RemoteSessionAutoRefreshPolicy: remoteSessionAutoRefreshPolicy,
-		SessionCaptureEnabled:          readFeature(productfeatures.FeatureSessionCapture),
-		SkillCaptureMetadataOnly:       readFeature(productfeatures.FeatureSkillCaptureMetadataOnly),
-		SkillsEnabled:                  true,
-	}); err != nil {
+	if err := json.NewEncoder(w).Encode(s.readAdminOrganizationFeatures(ctx, organizationID)); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "encode organization features").LogError(ctx, s.logger)
 	}
-
 	return nil
+}
+
+func (s *Service) handleGetOrganizationFeatures(w http.ResponseWriter, r *http.Request) error {
+	ctx, err := s.authorizeAdminRequest(r)
+	if err != nil {
+		return err
+	}
+	organizationID, err := s.canonicalAdminOrganizationForRequest(ctx, r.URL.Query().Get("organization_id"))
+	if err != nil {
+		return err
+	}
+	return s.writeAdminOrganizationFeatures(w, ctx, organizationID)
+}
+
+func (s *Service) handleSetOrganizationFeature(w http.ResponseWriter, r *http.Request) error {
+	ctx, err := s.authorizeAdminRequest(r)
+	if err != nil {
+		return err
+	}
+
+	var body setAdminOrganizationFeatureRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		return oops.E(oops.CodeBadRequest, err, "decode organization feature request")
+	}
+
+	organizationID, err := s.canonicalAdminOrganizationForRequest(ctx, body.OrganizationID)
+	if err != nil {
+		return err
+	}
+	feature := productfeatures.Feature(body.FeatureName)
+	if _, ok := adminOrganizationFeatures[feature]; !ok || body.Enabled == nil {
+		return oops.C(oops.CodeBadRequest)
+	}
+
+	if err := s.productFeatures.SetFeatureEnabled(ctx, organizationID, feature, *body.Enabled); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "set organization feature").LogError(ctx, s.logger,
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogProductFeatureName(string(feature)),
+		)
+	}
+	return s.writeAdminOrganizationFeatures(w, ctx, organizationID)
 }

--- a/server/internal/admin/features_handler.go
+++ b/server/internal/admin/features_handler.go
@@ -3,7 +3,9 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -124,18 +126,27 @@ func (s *Service) handleSetOrganizationFeature(w http.ResponseWriter, r *http.Re
 	if err := decoder.Decode(&body); err != nil {
 		return oops.E(oops.CodeBadRequest, err, "decode organization feature request")
 	}
-
-	organizationID, err := s.canonicalAdminOrganizationForRequest(ctx, body.OrganizationID)
-	if err != nil {
-		return err
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return oops.E(oops.CodeBadRequest, err, "decode organization feature request")
 	}
+
 	feature, ok := adminOrganizationFeatures[body.FeatureName]
 	if !ok || body.Enabled == nil {
 		return oops.C(oops.CodeBadRequest)
 	}
+	organizationID, err := s.canonicalAdminOrganizationForRequest(ctx, body.OrganizationID)
+	if err != nil {
+		return err
+	}
 
-	if err := s.productFeatures.SetFeatureEnabled(ctx, organizationID, feature, *body.Enabled); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "set organization feature").LogError(ctx, s.logger,
+	var setErr error
+	if feature == productfeatures.FeatureRemoteSessionAutoRefresh {
+		setErr = s.productFeatures.SetRemoteSessionAutoRefreshEnabled(ctx, organizationID, *body.Enabled)
+	} else {
+		setErr = s.productFeatures.SetFeatureEnabled(ctx, organizationID, feature, *body.Enabled)
+	}
+	if setErr != nil {
+		return oops.E(oops.CodeUnexpected, setErr, "set organization feature").LogError(ctx, s.logger,
 			attr.SlogOrganizationID(organizationID),
 			attr.SlogProductFeatureName(string(feature)),
 		)

--- a/server/internal/admin/features_handler_test.go
+++ b/server/internal/admin/features_handler_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -14,124 +15,118 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
-	productfeaturesrepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
 
-func TestAttach_MountsOrganizationFeaturesRoute(t *testing.T) {
+func TestAttach_MountsOrganizationFeaturesRoutes(t *testing.T) {
 	t.Parallel()
 
 	svc := newTestSessionService(t, newTestOIDCClient(t, userinfoOK("sub-mounted-features", "operator@example.com")))
 	svc.tracer = testenv.NewTracerProvider(t).Tracer("admin_test")
-
 	mux := goahttp.NewMuxer()
 	Attach(mux, svc)
 
-	rec := httptest.NewRecorder()
-	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/organization.features", nil))
-
-	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(method, "/admin/organization.features", nil))
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
 }
 
-func TestHandleGetOrganizationFeatures_ReturnsCuratedFlags(t *testing.T) {
+func TestOrganizationFeatures_MatchesPlatformAdminAndUpdatesCuratedFlags(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn := newTestAdminService(t)
-
 	orgID := "org_admin_features"
 	now := time.Now().UTC()
-	err := testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+	require.NoError(t, testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
 		ID:                 orgID,
 		Name:               "Admin Features Org",
 		Slug:               "admin-features-org",
 		GramAccountType:    "enterprise",
 		FreeTrialStartedAt: conv.ToPGTimestamptz(now),
 		FreeTrialEndsAt:    conv.ToPGTimestamptz(now.Add(14 * 24 * time.Hour)),
-	})
-	require.NoError(t, err)
+	}))
 
 	mux := goahttp.NewMuxer()
 	Attach(mux, svc)
 	handler := SessionMiddleware(mux)
 	sessionID := makeAdminFeatureSession(t, ctx, svc, "operator@example.com")
+
+	result := getAdminOrganizationFeatures(t, handler, sessionID, orgID)
+	require.Equal(t, adminOrganizationFeaturesResponse{}, result)
+
+	for feature := range adminOrganizationFeatures {
+		body, err := json.Marshal(setAdminOrganizationFeatureRequest{
+			OrganizationID: orgID,
+			FeatureName:    string(feature),
+			Enabled:        ptrTo(true),
+		})
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/admin/organization.features", bytes.NewReader(body))
+		req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	result = getAdminOrganizationFeatures(t, handler, sessionID, orgID)
+	require.True(t, result.AuthzChallengeLoggingEnabled)
+	require.True(t, result.CustomerManagedEncryptionKeysEnabled)
+	require.True(t, result.CustomModelKeysEnabled)
+	require.True(t, result.PlatformMcpEnabled)
+	require.True(t, result.RemoteSessionAutoRefreshEnabled)
+	require.True(t, result.SsoEnabled)
+	require.True(t, result.ScimEnabled)
+}
+
+func TestSetOrganizationFeature_RejectsFeatureOutsidePlatformAdminList(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	orgID := "org_admin_feature_allowlist"
+	now := time.Now().UTC()
+	require.NoError(t, testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID: orgID, Name: "Admin Features Org", Slug: "admin-features-allowlist", GramAccountType: "enterprise",
+		FreeTrialStartedAt: conv.ToPGTimestamptz(now), FreeTrialEndsAt: conv.ToPGTimestamptz(now.Add(14 * 24 * time.Hour)),
+	}))
+
+	mux := goahttp.NewMuxer()
+	Attach(mux, svc)
+	handler := SessionMiddleware(mux)
+	sessionID := makeAdminFeatureSession(t, ctx, svc, "operator@example.com")
+	body := []byte(`{"organization_id":"` + orgID + `","feature_name":"hooks_fail_open","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/admin/organization.features", bytes.NewReader(body))
+	req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	enabled, err := svc.productFeatures.IsFeatureEnabled(ctx, orgID, productfeatures.FeatureHooksFailOpen)
+	require.NoError(t, err)
+	require.False(t, enabled)
+}
+
+func getAdminOrganizationFeatures(t *testing.T, handler http.Handler, sessionID, orgID string) adminOrganizationFeaturesResponse {
+	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/admin/organization.features?organization_id="+orgID, nil)
 	req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	var result adminOrganizationFeatures
+	var result adminOrganizationFeaturesResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
-	require.False(t, result.ConsentToolFilteringEnabled)
-	require.False(t, result.HooksBrowserLoginEnabled)
-	require.False(t, result.HooksFailOpenEnabled)
-	require.False(t, result.PlatformMcpEnabled)
-	require.Equal(t, "disabled", result.RemoteSessionAutoRefreshPolicy)
-	require.False(t, result.SessionCaptureEnabled)
-	require.False(t, result.SkillCaptureMetadataOnly)
-	require.True(t, result.SkillsEnabled)
-
-	queries := productfeaturesrepo.New(conn)
-	for _, feature := range []productfeatures.Feature{
-		productfeatures.FeatureConsentToolFiltering,
-		productfeatures.FeatureHooksBrowserLogin,
-		productfeatures.FeatureHooksFailOpen,
-		productfeatures.FeaturePlatformMCP,
-		productfeatures.FeatureRemoteSessionAutoRefresh,
-		productfeatures.FeatureSessionCapture,
-		productfeatures.FeatureSkillCaptureMetadataOnly,
-	} {
-		_, err = queries.EnableFeature(ctx, productfeaturesrepo.EnableFeatureParams{
-			OrganizationID: orgID,
-			FeatureName:    string(feature),
-		})
-		require.NoError(t, err)
-		svc.productFeatures.UpdateFeatureCache(ctx, orgID, feature, true)
-	}
-
-	req = httptest.NewRequest(http.MethodGet, "/admin/organization.features?organization_id="+orgID, nil)
-	req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
-	rec = httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
-	require.True(t, result.ConsentToolFilteringEnabled)
-	require.True(t, result.HooksBrowserLoginEnabled)
-	require.True(t, result.HooksFailOpenEnabled)
-	require.True(t, result.PlatformMcpEnabled)
-	require.Equal(t, "user_controlled", result.RemoteSessionAutoRefreshPolicy)
-	require.True(t, result.SessionCaptureEnabled)
-	require.True(t, result.SkillCaptureMetadataOnly)
-	require.True(t, result.SkillsEnabled)
-
-	_, err = queries.EnableFeature(ctx, productfeaturesrepo.EnableFeatureParams{
-		OrganizationID: orgID,
-		FeatureName:    string(productfeatures.FeatureRemoteSessionAutoRefreshEnforced),
-	})
-	require.NoError(t, err)
-	svc.productFeatures.UpdateFeatureCache(ctx, orgID, productfeatures.FeatureRemoteSessionAutoRefreshEnforced, true)
-
-	req = httptest.NewRequest(http.MethodGet, "/admin/organization.features?organization_id="+orgID, nil)
-	req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
-	rec = httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
-	require.Equal(t, "enforced", result.RemoteSessionAutoRefreshPolicy)
+	return result
 }
 
 func makeAdminFeatureSession(t *testing.T, ctx context.Context, svc *Service, email string) string {
 	t.Helper()
 
 	sessionID, err := svc.sessions.Store(ctx, StoreParams{
-		Email:        email,
-		Name:         "Test Operator",
-		OIDCSubject:  "sub-admin",
-		HD:           testAdminHD,
-		AccessToken:  "access-token",
-		RefreshToken: "refresh-token",
-		ExpiresAt:    time.Now().Add(time.Hour),
+		Email: email, Name: "Test Operator", OIDCSubject: "sub-admin", HD: testAdminHD,
+		AccessToken: "access-token", RefreshToken: "refresh-token", ExpiresAt: time.Now().Add(time.Hour),
 	})
 	require.NoError(t, err)
 	return sessionID

--- a/server/internal/admin/features_handler_test.go
+++ b/server/internal/admin/features_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
@@ -58,20 +59,9 @@ func TestOrganizationFeatures_MatchesPlatformAdminAndUpdatesCuratedFlags(t *test
 	require.Equal(t, adminOrganizationFeaturesResponse{}, result)
 
 	for _, feature := range adminOrganizationFeatures {
-		body, err := json.Marshal(setAdminOrganizationFeatureRequest{
-			OrganizationID: orgID,
-			FeatureName:    string(feature),
-			Enabled:        ptrTo(true),
-		})
-		require.NoError(t, err)
-		req := httptest.NewRequest(http.MethodPost, "/admin/organization.features", bytes.NewReader(body))
-		req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-		require.Equal(t, http.StatusOK, rec.Code)
+		result = setAdminOrganizationFeature(t, handler, sessionID, orgID, feature, true)
 	}
 
-	result = getAdminOrganizationFeatures(t, handler, sessionID, orgID)
 	require.True(t, result.AuthzChallengeLoggingEnabled)
 	require.True(t, result.CustomerManagedEncryptionKeysEnabled)
 	require.True(t, result.CustomModelKeysEnabled)
@@ -79,6 +69,23 @@ func TestOrganizationFeatures_MatchesPlatformAdminAndUpdatesCuratedFlags(t *test
 	require.True(t, result.RemoteSessionAutoRefreshEnabled)
 	require.True(t, result.SsoEnabled)
 	require.True(t, result.ScimEnabled)
+
+	// The binary standalone-admin control must also clear the legacy enforced
+	// state so the displayed value and runtime policy cannot disagree.
+	_, err := featurerepo.New(conn).EnableFeature(ctx, featurerepo.EnableFeatureParams{
+		OrganizationID: orgID, FeatureName: string(productfeatures.FeatureRemoteSessionAutoRefreshEnforced),
+	})
+	require.NoError(t, err)
+	svc.productFeatures.UpdateFeatureCache(ctx, orgID, productfeatures.FeatureRemoteSessionAutoRefreshEnforced, true)
+
+	for _, feature := range adminOrganizationFeatures {
+		result = setAdminOrganizationFeature(t, handler, sessionID, orgID, feature, false)
+	}
+	require.Equal(t, adminOrganizationFeaturesResponse{}, result)
+
+	enforced, err := svc.productFeatures.IsFeatureEnabled(ctx, orgID, productfeatures.FeatureRemoteSessionAutoRefreshEnforced)
+	require.NoError(t, err)
+	require.False(t, enforced)
 }
 
 func TestSetOrganizationFeature_RejectsFeatureOutsidePlatformAdminList(t *testing.T) {
@@ -106,6 +113,30 @@ func TestSetOrganizationFeature_RejectsFeatureOutsidePlatformAdminList(t *testin
 	enabled, err := svc.productFeatures.IsFeatureEnabled(ctx, orgID, productfeatures.FeatureHooksFailOpen)
 	require.NoError(t, err)
 	require.False(t, enabled)
+}
+
+func setAdminOrganizationFeature(
+	t *testing.T,
+	handler http.Handler,
+	sessionID string,
+	orgID string,
+	feature productfeatures.Feature,
+	enabled bool,
+) adminOrganizationFeaturesResponse {
+	t.Helper()
+	body, err := json.Marshal(setAdminOrganizationFeatureRequest{
+		OrganizationID: orgID, FeatureName: string(feature), Enabled: &enabled,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/admin/organization.features", bytes.NewReader(body))
+	req.AddCookie(&http.Cookie{Name: constants.AdminSessionCookie, Value: sessionID})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var result adminOrganizationFeaturesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+	return result
 }
 
 func getAdminOrganizationFeatures(t *testing.T, handler http.Handler, sessionID, orgID string) adminOrganizationFeaturesResponse {

--- a/server/internal/admin/features_handler_test.go
+++ b/server/internal/admin/features_handler_test.go
@@ -57,7 +57,7 @@ func TestOrganizationFeatures_MatchesPlatformAdminAndUpdatesCuratedFlags(t *test
 	result := getAdminOrganizationFeatures(t, handler, sessionID, orgID)
 	require.Equal(t, adminOrganizationFeaturesResponse{}, result)
 
-	for feature := range adminOrganizationFeatures {
+	for _, feature := range adminOrganizationFeatures {
 		body, err := json.Marshal(setAdminOrganizationFeatureRequest{
 			OrganizationID: orgID,
 			FeatureName:    string(feature),

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background/activities/keybillinglock"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -62,9 +63,10 @@ type Service struct {
 	// CreateOrganization reports rather than working around.
 	workos orgprovision.WorkOSOrganizationCreator
 
-	openRouter      TrialKeyReviver
-	openRouterUsage OpenRouterUsageReader
-	productFeatures *productfeatures.Client
+	openRouter           TrialKeyReviver
+	openRouterUsage      OpenRouterUsageReader
+	productFeatures      *productfeatures.Client
+	chatAnalysisSignaler analysis.Signaler
 
 	audit *audit.Logger
 
@@ -98,6 +100,14 @@ type AdminOpenRouter interface {
 
 // ErrOpenRouterUnavailable reports a deployment that cannot reach OpenRouter.
 var ErrOpenRouterUnavailable = errors.New("no usable OpenRouter configuration")
+
+var ErrChatAnalysisTriggerUnavailable = errors.New("chat analysis triggering is not configured")
+
+type ChatAnalysisTriggerUnavailable struct{}
+
+func (ChatAnalysisTriggerUnavailable) Signal(context.Context, uuid.UUID) error {
+	return ErrChatAnalysisTriggerUnavailable
+}
 
 const keyBillingLockWaitTimeout = 5 * time.Second
 
@@ -135,6 +145,7 @@ func NewService(
 	openRouter AdminOpenRouter,
 	trialNotifier trialemails.Notifier,
 	productFeatures *productfeatures.Client,
+	chatAnalysisSignaler analysis.Signaler,
 	billing BillingOperations,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("admin"))
@@ -154,18 +165,19 @@ func NewService(
 	)
 
 	return &Service{
-		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/admin"),
-		logger:          logger,
-		db:              db,
-		oidc:            oidcClient,
-		sessions:        sessionStore,
-		verifier:        NewVerifier(logger, sessionStore, oidcClient, adminCache),
-		allowedOrigins:  allowedOrigins,
-		workos:          workosClient,
-		openRouter:      openRouter,
-		openRouterUsage: openRouter,
-		productFeatures: productFeatures,
-		audit:           audit.NewLogger(),
+		tracer:               tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/admin"),
+		logger:               logger,
+		db:                   db,
+		oidc:                 oidcClient,
+		sessions:             sessionStore,
+		verifier:             NewVerifier(logger, sessionStore, oidcClient, adminCache),
+		allowedOrigins:       allowedOrigins,
+		workos:               workosClient,
+		openRouter:           openRouter,
+		openRouterUsage:      openRouter,
+		productFeatures:      productFeatures,
+		chatAnalysisSignaler: chatAnalysisSignaler,
+		audit:                audit.NewLogger(),
 		loginStates: cache.NewTypedObjectCache[LoginState](
 			logger.With(attr.SlogCacheNamespace("admin_login_state")),
 			adminCache,
@@ -202,6 +214,21 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		http.MethodPost,
 		"/admin/organization.features",
 		oops.ErrHandle(service.logger, service.handleSetOrganizationFeature).ServeHTTP,
+	)
+	mux.Handle(
+		http.MethodGet,
+		"/admin/organization.chatAnalysisSettings",
+		oops.ErrHandle(service.logger, service.handleGetChatAnalysisSettings).ServeHTTP,
+	)
+	mux.Handle(
+		http.MethodPost,
+		"/admin/organization.chatAnalysisSettings",
+		oops.ErrHandle(service.logger, service.handleSetChatAnalysisSettings).ServeHTTP,
+	)
+	mux.Handle(
+		http.MethodPost,
+		"/admin/organization.chatAnalysisTrigger",
+		oops.ErrHandle(service.logger, service.handleTriggerChatAnalysis).ServeHTTP,
 	)
 }
 

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -198,6 +198,11 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		"/admin/organization.features",
 		oops.ErrHandle(service.logger, service.handleGetOrganizationFeatures).ServeHTTP,
 	)
+	mux.Handle(
+		http.MethodPost,
+		"/admin/organization.features",
+		oops.ErrHandle(service.logger, service.handleSetOrganizationFeature).ServeHTTP,
+	)
 }
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {

--- a/server/internal/chatanalysis/impl.go
+++ b/server/internal/chatanalysis/impl.go
@@ -7,7 +7,6 @@ package chatanalysis
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5"
@@ -27,15 +26,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
 	"github.com/speakeasy-api/gram/server/internal/chat/analysis/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
-	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
-
-const maxDailyCap = 10000
 
 type Service struct {
 	tracer   trace.Tracer
@@ -129,69 +124,18 @@ func (s *Service) upsertJudgeSettings(ctx context.Context, organizationID string
 	if err != nil {
 		return nil, err
 	}
-	if dailyCap < 0 || dailyCap > maxDailyCap {
-		return nil, oops.E(oops.CodeInvalid, nil, "daily cap must be between 0 and %d", maxDailyCap)
+	if dailyCap < 0 || dailyCap > MaxDailyCap {
+		return nil, oops.E(oops.CodeInvalid, nil, "daily cap must be between 0 and %d", MaxDailyCap)
 	}
 
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin chat analysis settings upsert").LogError(ctx, logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
-
-	queries := repo.New(dbtx)
-	// The reservation transaction counts spend under this organization lock, so
-	// holding it here keeps a budget change from landing mid-count.
-	if err := queries.LockOrganizationChatAnalysisBudget(ctx, organizationID); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "lock chat analysis settings").LogError(ctx, logger)
-	}
-
-	var beforeSnapshot *audit.ChatAnalysisSettingsSnapshot
-	before, err := queries.GetChatAnalysisSettingForOrganizationJudge(ctx, repo.GetChatAnalysisSettingForOrganizationJudgeParams{
-		OrganizationID: organizationID,
-		Judge:          judge,
-	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "get existing chat analysis settings").LogError(ctx, logger)
-	default:
-		snapshot := buildSnapshot(before)
-		beforeSnapshot = &snapshot
-	}
-
-	row, err := queries.UpsertChatAnalysisSettingForOrganizationJudge(ctx, repo.UpsertChatAnalysisSettingForOrganizationJudgeParams{
-		OrganizationID: organizationID,
-		Judge:          judge,
-		Enabled:        enabled,
-		DailyCap:       conv.SafeInt32(dailyCap),
-	})
+	view, err := UpsertSettings(
+		ctx, s.db, s.audit, organizationID, judge, enabled, dailyCap,
+		urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID), authCtx.Email,
+	)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "upsert chat analysis settings").LogError(ctx, logger)
 	}
-	afterSnapshot := buildSnapshot(row)
-
-	if err := s.audit.LogChatAnalysisSettingsUpsert(ctx, dbtx, audit.LogChatAnalysisSettingsUpsertEvent{
-		OrganizationID:                     organizationID,
-		Actor:                              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName:                   authCtx.Email,
-		ActorSlug:                          nil,
-		ChatAnalysisSettingsURN:            urn.NewChatAnalysisSettings(organizationID),
-		ChatAnalysisSettingsSnapshotBefore: beforeSnapshot,
-		ChatAnalysisSettingsSnapshotAfter:  &afterSnapshot,
-	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log chat analysis settings upsert").LogError(ctx, logger)
-	}
-
-	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit chat analysis settings upsert").LogError(ctx, logger)
-	}
-
-	view, err := loadSettingsView(ctx, repo.New(s.db), organizationID)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "reload chat analysis settings").LogError(ctx, logger)
-	}
-	return view, nil
+	return settingsView(view), nil
 }
 
 // TriggerAnalysis wakes the chat analysis coordinator of every live project in
@@ -205,88 +149,26 @@ func (s *Service) TriggerAnalysis(ctx context.Context, payload *gen.TriggerAnaly
 		return nil, err
 	}
 
-	projectIDs, err := repo.New(s.db).ListChatAnalysisProjectsForOrganization(ctx, payload.OrganizationID)
+	projectsSignaled, err := TriggerOrganization(ctx, s.db, s.signaler, payload.OrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list organization projects").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "trigger chat analysis").LogError(ctx, logger)
 	}
 
-	// Continue through failures so one bad project doesn't starve the rest of
-	// the organization of its signal.
-	var signalErrs []error
-	for _, projectID := range projectIDs {
-		if err := s.signaler.Signal(ctx, projectID); err != nil {
-			logger.ErrorContext(ctx, "failed to signal chat analysis coordinator", attr.SlogProjectID(projectID.String()), attr.SlogError(err))
-			signalErrs = append(signalErrs, err)
-		}
-	}
-	if len(signalErrs) > 0 {
-		return nil, oops.E(
-			oops.CodeUnexpected,
-			errors.Join(signalErrs...),
-			"failed to signal chat analysis coordinator for %d of %d projects", len(signalErrs), len(projectIDs),
-		).LogError(ctx, logger)
-	}
-
-	return &gen.TriggerAnalysisResult{ProjectsSignaled: len(projectIDs)}, nil
-}
-
-// defaultView is what an organization with no stored row gets: everything off.
-// The pipeline has no default enablement — a judge with no settings row spends
-// nothing — so the defaults mirror that rather than suggesting a budget.
-func defaultView(organizationID string) *gen.ChatAnalysisSettings {
-	return &gen.ChatAnalysisSettings{
-		OrganizationID:         organizationID,
-		WorkUnitsEnabled:       false,
-		WorkUnitsDailyCap:      0,
-		BusinessMemoryEnabled:  false,
-		BusinessMemoryDailyCap: 0,
-		IsDefault:              true,
-	}
+	return &gen.TriggerAnalysisResult{ProjectsSignaled: projectsSignaled}, nil
 }
 
 func loadSettingsView(ctx context.Context, queries *repo.Queries, organizationID string) (*gen.ChatAnalysisSettings, error) {
-	view := defaultView(organizationID)
-	settings := []struct {
-		judge string
-		apply func(repo.ChatAnalysisSetting)
-	}{
-		{
-			judge: analysis.WorkUnitsJudgeName,
-			apply: func(row repo.ChatAnalysisSetting) {
-				view.WorkUnitsEnabled = row.Enabled
-				view.WorkUnitsDailyCap = int(row.DailyCap)
-			},
-		},
-		{
-			judge: businessmemory.JudgeName,
-			apply: func(row repo.ChatAnalysisSetting) {
-				view.BusinessMemoryEnabled = row.Enabled
-				view.BusinessMemoryDailyCap = int(row.DailyCap)
-			},
-		},
+	view, err := loadSettings(ctx, queries, organizationID)
+	if err != nil {
+		return nil, err
 	}
-	for _, setting := range settings {
-		row, err := queries.GetChatAnalysisSettingForOrganizationJudge(ctx, repo.GetChatAnalysisSettingForOrganizationJudgeParams{
-			OrganizationID: organizationID,
-			Judge:          setting.judge,
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-			continue
-		case err != nil:
-			return nil, fmt.Errorf("get %s chat analysis setting: %w", setting.judge, err)
-		default:
-			view.IsDefault = false
-			setting.apply(row)
-		}
-	}
-	return view, nil
+	return settingsView(view), nil
 }
 
-func buildSnapshot(row repo.ChatAnalysisSetting) audit.ChatAnalysisSettingsSnapshot {
-	return audit.ChatAnalysisSettingsSnapshot{
-		Judge:    row.Judge,
-		Enabled:  row.Enabled,
-		DailyCap: row.DailyCap,
+func settingsView(view Settings) *gen.ChatAnalysisSettings {
+	return &gen.ChatAnalysisSettings{
+		OrganizationID: view.OrganizationID, WorkUnitsEnabled: view.WorkUnitsEnabled,
+		WorkUnitsDailyCap: view.WorkUnitsDailyCap, BusinessMemoryEnabled: view.BusinessMemoryEnabled,
+		BusinessMemoryDailyCap: view.BusinessMemoryDailyCap, IsDefault: view.IsDefault,
 	}
 }

--- a/server/internal/chatanalysis/settings_persistence.go
+++ b/server/internal/chatanalysis/settings_persistence.go
@@ -1,0 +1,142 @@
+package chatanalysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/businessmemory"
+	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
+	"github.com/speakeasy-api/gram/server/internal/chat/analysis/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const MaxDailyCap = 10000
+
+// Settings is the complete organization-level chat analysis settings view.
+// Missing rows are represented as disabled with a zero cap.
+type Settings struct {
+	OrganizationID         string `json:"organization_id"`
+	WorkUnitsEnabled       bool   `json:"work_units_enabled"`
+	WorkUnitsDailyCap      int    `json:"work_units_daily_cap"`
+	BusinessMemoryEnabled  bool   `json:"business_memory_enabled"`
+	BusinessMemoryDailyCap int    `json:"business_memory_daily_cap"`
+	IsDefault              bool   `json:"is_default"`
+}
+
+func LoadSettings(ctx context.Context, db *pgxpool.Pool, organizationID string) (Settings, error) {
+	return loadSettings(ctx, repo.New(db), organizationID)
+}
+
+// UpsertSettings preserves the budget-lock, audit/outbox, and reload ordering
+// shared by every administrative chat analysis settings surface.
+func UpsertSettings(
+	ctx context.Context,
+	db *pgxpool.Pool,
+	auditLogger *audit.Logger,
+	organizationID string,
+	judge string,
+	enabled bool,
+	dailyCap int,
+	actor urn.Principal,
+	actorDisplayName *string,
+) (Settings, error) {
+	if dailyCap < 0 || dailyCap > MaxDailyCap {
+		return Settings{}, fmt.Errorf("daily cap must be between 0 and %d", MaxDailyCap)
+	}
+
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return Settings{}, fmt.Errorf("begin chat analysis settings upsert: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	queries := repo.New(tx)
+	if err := queries.LockOrganizationChatAnalysisBudget(ctx, organizationID); err != nil {
+		return Settings{}, fmt.Errorf("lock chat analysis settings: %w", err)
+	}
+
+	var beforeSnapshot *audit.ChatAnalysisSettingsSnapshot
+	before, err := queries.GetChatAnalysisSettingForOrganizationJudge(ctx, repo.GetChatAnalysisSettingForOrganizationJudgeParams{
+		OrganizationID: organizationID, Judge: judge,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+	case err != nil:
+		return Settings{}, fmt.Errorf("get existing chat analysis settings: %w", err)
+	default:
+		snapshot := buildSnapshot(before)
+		beforeSnapshot = &snapshot
+	}
+
+	row, err := queries.UpsertChatAnalysisSettingForOrganizationJudge(ctx, repo.UpsertChatAnalysisSettingForOrganizationJudgeParams{
+		OrganizationID: organizationID, Judge: judge, Enabled: enabled, DailyCap: conv.SafeInt32(dailyCap),
+	})
+	if err != nil {
+		return Settings{}, fmt.Errorf("upsert chat analysis settings: %w", err)
+	}
+	afterSnapshot := buildSnapshot(row)
+	if err := auditLogger.LogChatAnalysisSettingsUpsert(ctx, tx, audit.LogChatAnalysisSettingsUpsertEvent{
+		OrganizationID: organizationID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil,
+		ChatAnalysisSettingsURN:            urn.NewChatAnalysisSettings(organizationID),
+		ChatAnalysisSettingsSnapshotBefore: beforeSnapshot, ChatAnalysisSettingsSnapshotAfter: &afterSnapshot,
+	}); err != nil {
+		return Settings{}, fmt.Errorf("log chat analysis settings upsert: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Settings{}, fmt.Errorf("commit chat analysis settings upsert: %w", err)
+	}
+
+	settings, err := LoadSettings(ctx, db, organizationID)
+	if err != nil {
+		return Settings{}, fmt.Errorf("reload chat analysis settings: %w", err)
+	}
+	return settings, nil
+}
+
+func loadSettings(ctx context.Context, queries *repo.Queries, organizationID string) (Settings, error) {
+	view := Settings{
+		OrganizationID: organizationID, IsDefault: true,
+		WorkUnitsEnabled: false, WorkUnitsDailyCap: 0,
+		BusinessMemoryEnabled: false, BusinessMemoryDailyCap: 0,
+	}
+	settings := []struct {
+		judge string
+		apply func(repo.ChatAnalysisSetting)
+	}{
+		{judge: analysis.WorkUnitsJudgeName, apply: func(row repo.ChatAnalysisSetting) {
+			view.WorkUnitsEnabled = row.Enabled
+			view.WorkUnitsDailyCap = int(row.DailyCap)
+		}},
+		{judge: businessmemory.JudgeName, apply: func(row repo.ChatAnalysisSetting) {
+			view.BusinessMemoryEnabled = row.Enabled
+			view.BusinessMemoryDailyCap = int(row.DailyCap)
+		}},
+	}
+	for _, setting := range settings {
+		row, err := queries.GetChatAnalysisSettingForOrganizationJudge(ctx, repo.GetChatAnalysisSettingForOrganizationJudgeParams{
+			OrganizationID: organizationID, Judge: setting.judge,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			continue
+		case err != nil:
+			return Settings{}, fmt.Errorf("get %s chat analysis setting: %w", setting.judge, err)
+		default:
+			view.IsDefault = false
+			setting.apply(row)
+		}
+	}
+	return view, nil
+}
+
+func buildSnapshot(row repo.ChatAnalysisSetting) audit.ChatAnalysisSettingsSnapshot {
+	return audit.ChatAnalysisSettingsSnapshot{Judge: row.Judge, Enabled: row.Enabled, DailyCap: row.DailyCap}
+}

--- a/server/internal/chatanalysis/setup_test.go
+++ b/server/internal/chatanalysis/setup_test.go
@@ -54,6 +54,7 @@ type testInstance struct {
 type captureSignaler struct {
 	mu       sync.Mutex
 	projects []uuid.UUID
+	errors   map[uuid.UUID]error
 }
 
 var _ analysis.Signaler = (*captureSignaler)(nil)
@@ -62,7 +63,7 @@ func (c *captureSignaler) Signal(_ context.Context, projectID uuid.UUID) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.projects = append(c.projects, projectID)
-	return nil
+	return c.errors[projectID]
 }
 
 func (c *captureSignaler) Signaled() []uuid.UUID {
@@ -89,7 +90,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	ctx = authztest.InitAuthContext(t, ctx, conn, sessionManager)
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 
-	signaler := &captureSignaler{}
+	signaler := &captureSignaler{projects: nil, errors: nil}
 
 	return ctx, &testInstance{
 		service:  chatanalysis.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, audit.NewLogger(), signaler),

--- a/server/internal/chatanalysis/trigger.go
+++ b/server/internal/chatanalysis/trigger.go
@@ -28,7 +28,7 @@ func TriggerOrganization(
 	var signalErrs []error
 	for _, projectID := range projectIDs {
 		if err := signaler.Signal(ctx, projectID); err != nil {
-			signalErrs = append(signalErrs, err)
+			signalErrs = append(signalErrs, fmt.Errorf("signal project %s: %w", projectID, err))
 		}
 	}
 	if len(signalErrs) > 0 {

--- a/server/internal/chatanalysis/trigger.go
+++ b/server/internal/chatanalysis/trigger.go
@@ -1,0 +1,42 @@
+package chatanalysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
+	"github.com/speakeasy-api/gram/server/internal/chat/analysis/repo"
+)
+
+// TriggerOrganization wakes the chat analysis coordinator for every live
+// project in an organization. It continues through individual signal failures
+// so one project cannot prevent the others from being woken.
+func TriggerOrganization(
+	ctx context.Context,
+	db *pgxpool.Pool,
+	signaler analysis.Signaler,
+	organizationID string,
+) (int, error) {
+	projectIDs, err := repo.New(db).ListChatAnalysisProjectsForOrganization(ctx, organizationID)
+	if err != nil {
+		return 0, fmt.Errorf("list organization projects: %w", err)
+	}
+
+	var signalErrs []error
+	for _, projectID := range projectIDs {
+		if err := signaler.Signal(ctx, projectID); err != nil {
+			signalErrs = append(signalErrs, err)
+		}
+	}
+	if len(signalErrs) > 0 {
+		return 0, fmt.Errorf(
+			"signal chat analysis coordinator for %d of %d projects: %w",
+			len(signalErrs), len(projectIDs), errors.Join(signalErrs...),
+		)
+	}
+
+	return len(projectIDs), nil
+}

--- a/server/internal/chatanalysis/trigger_analysis_test.go
+++ b/server/internal/chatanalysis/trigger_analysis_test.go
@@ -1,12 +1,14 @@
 package chatanalysis_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin_chat_analysis"
+	"github.com/speakeasy-api/gram/server/internal/chatanalysis"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
@@ -19,6 +21,27 @@ func TestTriggerAnalysisRequiresPlatformAdmin(t *testing.T) {
 	_, err := ti.service.TriggerAnalysis(ctx, &gen.TriggerAnalysisPayload{OrganizationID: "target-org"})
 	requireOopsCode(t, err, oops.CodeForbidden)
 	require.Empty(t, ti.signaler.Signaled())
+}
+
+func TestTriggerAnalysisReportsFailedProjectAndContinues(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	targetOrganizationID := createTargetOrganization(t, ctx, ti)
+
+	first, err := projectsRepo.New(ti.conn).CreateProject(ctx, projectsRepo.CreateProjectParams{
+		Name: "chat-analysis-failing-first", Slug: "chat-analysis-failing-first", OrganizationID: targetOrganizationID,
+	})
+	require.NoError(t, err)
+	second, err := projectsRepo.New(ti.conn).CreateProject(ctx, projectsRepo.CreateProjectParams{
+		Name: "chat-analysis-successful-second", Slug: "chat-analysis-successful-second", OrganizationID: targetOrganizationID,
+	})
+	require.NoError(t, err)
+	ti.signaler.errors = map[uuid.UUID]error{first.ID: errors.New("signal failed")}
+
+	_, err = chatanalysis.TriggerOrganization(ctx, ti.conn, ti.signaler, targetOrganizationID)
+	require.Error(t, err)
+	require.ErrorContains(t, err, first.ID.String())
+	require.ElementsMatch(t, []uuid.UUID{first.ID, second.ID}, ti.signaler.Signaled())
 }
 
 func TestTriggerAnalysisSignalsOnlyRequestedOrganizationProjects(t *testing.T) {

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -175,11 +175,24 @@ func (c *Client) SetRemoteSessionAutoRefreshEnabled(ctx context.Context, organiz
 	})
 }
 
-// UpdateFeatureCache stores the given enabled state for the feature directly
-// into the cache. Call this after writing the feature flag to the database
-// from a code path that bypasses this client, so the cache stays consistent.
-func (c *Client) UpdateFeatureCache(ctx context.Context, organizationID string, feature Feature, enabled bool) {
-	c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
+// UpdateFeatureCache reloads the durable feature state and refreshes the cache
+// under the same lock used by cache fills and writes. Call this after writing
+// the feature flag from a code path that bypasses this client.
+func (c *Client) UpdateFeatureCache(ctx context.Context, organizationID string, feature Feature, _ bool) {
+	if err := c.withFeatureCacheLock(ctx, organizationID, feature, func(conn *pgxpool.Conn) error {
+		enabled, err := repo.New(conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+			OrganizationID: organizationID, FeatureName: string(feature),
+		})
+		if err != nil {
+			return fmt.Errorf("reload feature cache state: %w", err)
+		}
+		c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
+		return nil
+	}); err != nil {
+		c.logger.WarnContext(ctx, "failed to refresh feature flag cache",
+			attr.SlogError(err), attr.SlogOrganizationID(organizationID), attr.SlogProductFeatureName(string(feature)),
+		)
+	}
 }
 
 func (c *Client) storeFeatureCache(ctx context.Context, organizationID string, feature Feature, enabled bool, message string) {
@@ -217,16 +230,25 @@ func (c *Client) withFeatureCacheLock(ctx context.Context, organizationID string
 }
 
 func (c *Client) withFeatureCacheLocks(ctx context.Context, organizationID string, features []Feature, fn func(*pgxpool.Conn) error) error {
+	conn, release, err := c.acquireFeatureCacheLocks(ctx, organizationID, features)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return fn(conn)
+}
+
+func (c *Client) acquireFeatureCacheLocks(ctx context.Context, organizationID string, features []Feature) (*pgxpool.Conn, func(), error) {
 	conn, err := c.db.Acquire(ctx)
 	if err != nil {
-		return fmt.Errorf("acquire feature cache lock connection: %w", err)
+		return nil, nil, fmt.Errorf("acquire feature cache lock connection: %w", err)
 	}
 
 	queries := repo.New(conn)
 	features = slices.Clone(features)
 	slices.Sort(features)
 	acquired := make([]repo.AcquireFeatureCacheLockParams, 0, len(features))
-	defer func() {
+	release := func() {
 		unlockCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		for i := len(acquired) - 1; i >= 0; i-- {
@@ -243,17 +265,18 @@ func (c *Client) withFeatureCacheLocks(ctx context.Context, organizationID strin
 			}
 		}
 		conn.Release()
-	}()
+	}
 
 	for _, feature := range features {
 		params := repo.AcquireFeatureCacheLockParams{OrganizationID: organizationID, FeatureName: string(feature)}
 		if err := queries.AcquireFeatureCacheLock(ctx, params); err != nil {
-			return fmt.Errorf("acquire feature cache lock: %w", err)
+			release()
+			return nil, nil, fmt.Errorf("acquire feature cache lock: %w", err)
 		}
 		acquired = append(acquired, params)
 	}
 
-	return fn(conn)
+	return conn, release, nil
 }
 
 func provisionSkillsSystemRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, organizationID string) error {

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -130,6 +130,31 @@ func (c *Client) PlatformFeatureCheck(ctx context.Context, organizationID string
 	return enabled
 }
 
+// SetFeatureEnabled writes a generic product-feature flag and refreshes its
+// cache entry. Callers must perform authorization and restrict feature names to
+// flags without specialized write behavior before calling this method.
+func (c *Client) SetFeatureEnabled(ctx context.Context, organizationID string, feature Feature, enabled bool) error {
+	if enabled {
+		if _, err := c.repo.EnableFeature(ctx, repo.EnableFeatureParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		}); err != nil {
+			return fmt.Errorf("enable feature: %w", err)
+		}
+	} else {
+		_, err := c.repo.DeleteFeature(ctx, repo.DeleteFeatureParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		})
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("disable feature: %w", err)
+		}
+	}
+
+	c.UpdateFeatureCache(ctx, organizationID, feature, enabled)
+	return nil
+}
+
 // UpdateFeatureCache stores the given enabled state for the feature directly
 // into the cache. Call this after writing the feature flag to the database
 // from a code path that bypasses this client, so the cache stays consistent.

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -21,6 +23,7 @@ import (
 type Client struct {
 	tracer       trace.Tracer
 	logger       *slog.Logger
+	db           *pgxpool.Pool
 	repo         *repo.Queries
 	featureCache cache.TypedCacheObject[FeatureCache]
 }
@@ -31,6 +34,7 @@ func NewClient(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgx
 	return &Client{
 		tracer:       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/productfeatures"),
 		logger:       logger,
+		db:           db,
 		repo:         repo.New(db),
 		featureCache: cache.NewTypedObjectCache[FeatureCache](logger.With(attr.SlogCacheNamespace("productfeature")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
 	}
@@ -46,44 +50,42 @@ func (c *Client) IsFeatureEnabled(ctx context.Context, organizationID string, fe
 		return cached.Enabled, nil
 	}
 
-	res, err := c.repo.IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
-		OrganizationID: organizationID,
-		FeatureName:    string(feature),
+	var enabled bool
+	err := c.withFeatureCacheLock(ctx, organizationID, feature, func(conn *pgxpool.Conn) error {
+		// A concurrent writer or cache fill may have populated the entry while
+		// this request waited for the lock.
+		if cached, cacheErr := c.featureCache.Get(ctx, FeatureCacheKey(organizationID, feature)); cacheErr == nil {
+			enabled = cached.Enabled
+			return nil
+		}
+
+		res, queryErr := repo.New(conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		})
+		switch {
+		case errors.Is(queryErr, context.Canceled):
+			// Do not cache results if the context was canceled, as this likely
+			// indicates a timeout or shutdown in progress.
+			enabled = false
+			return nil
+		case errors.Is(queryErr, pgx.ErrNoRows):
+			res = false
+		case queryErr != nil:
+			return oops.E(
+				oops.CodeUnexpected, queryErr,
+				"failed to get organization feature flag %q", string(feature),
+			).LogError(ctx, c.logger, attr.SlogOrganizationID(organizationID))
+		}
+
+		enabled = res
+		c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to cache feature flag state")
+		return nil
 	})
-	switch {
-	case errors.Is(err, context.Canceled):
-		// Do not cache results if the context was canceled, as this likely
-		// indicates a timeout or shutdown in progress. Caching in this case
-		// could lead to incorrect feature flag states being stored.
-		return false, nil
-	case errors.Is(err, pgx.ErrNoRows):
-		// If there is no row, the feature is not enabled. Cache this result to
-		// avoid hitting the database repeatedly for missing features.
-		res = false
-	case err != nil:
-		return false, oops.E(
-			oops.CodeUnexpected,
-			err,
-			"failed to get organization feature flag %q",
-			string(feature),
-		).LogError(ctx, c.logger, attr.SlogOrganizationID(organizationID))
+	if err != nil {
+		return false, err
 	}
-
-	cacheEntry := FeatureCache{
-		OrganizationID: organizationID,
-		Feature:        feature,
-		Enabled:        res,
-	}
-
-	if cacheErr := c.featureCache.Store(ctx, cacheEntry); cacheErr != nil {
-		c.logger.WarnContext(ctx, "failed to cache feature flag state",
-			attr.SlogError(cacheErr),
-			attr.SlogOrganizationID(organizationID),
-			attr.SlogProductFeatureName(string(feature)),
-		)
-	}
-
-	return res, nil
+	return enabled, nil
 }
 
 // IsFeatureEnabledUncached reads the durable feature state directly. Security-
@@ -134,43 +136,124 @@ func (c *Client) PlatformFeatureCheck(ctx context.Context, organizationID string
 // cache entry. Callers must perform authorization and restrict feature names to
 // flags without specialized write behavior before calling this method.
 func (c *Client) SetFeatureEnabled(ctx context.Context, organizationID string, feature Feature, enabled bool) error {
-	if enabled {
-		if _, err := c.repo.EnableFeature(ctx, repo.EnableFeatureParams{
-			OrganizationID: organizationID,
-			FeatureName:    string(feature),
-		}); err != nil {
-			return fmt.Errorf("enable feature: %w", err)
+	return c.withFeatureCacheLock(ctx, organizationID, feature, func(conn *pgxpool.Conn) error {
+		if err := setFeatureEnabled(ctx, repo.New(conn), organizationID, feature, enabled); err != nil {
+			return err
 		}
-	} else {
-		_, err := c.repo.DeleteFeature(ctx, repo.DeleteFeatureParams{
-			OrganizationID: organizationID,
-			FeatureName:    string(feature),
-		})
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("disable feature: %w", err)
-		}
-	}
+		c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
+		return nil
+	})
+}
 
-	c.UpdateFeatureCache(ctx, organizationID, feature, enabled)
-	return nil
+// SetRemoteSessionAutoRefreshEnabled maps the standalone admin's binary control
+// to the existing tri-state policy. Either choice clears the enforced state so
+// the displayed value and runtime behavior cannot disagree.
+func (c *Client) SetRemoteSessionAutoRefreshEnabled(ctx context.Context, organizationID string, enabled bool) error {
+	return c.withFeatureCacheLocks(ctx, organizationID, []Feature{
+		FeatureRemoteSessionAutoRefresh, FeatureRemoteSessionAutoRefreshEnforced,
+	}, func(conn *pgxpool.Conn) error {
+		tx, err := conn.Begin(ctx)
+		if err != nil {
+			return fmt.Errorf("begin remote session auto-refresh update: %w", err)
+		}
+		defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+		queries := repo.New(tx)
+		if err := setFeatureEnabled(ctx, queries, organizationID, FeatureRemoteSessionAutoRefreshEnforced, false); err != nil {
+			return err
+		}
+		if err := setFeatureEnabled(ctx, queries, organizationID, FeatureRemoteSessionAutoRefresh, enabled); err != nil {
+			return err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit remote session auto-refresh update: %w", err)
+		}
+
+		c.storeFeatureCache(ctx, organizationID, FeatureRemoteSessionAutoRefreshEnforced, false, "failed to update feature flag cache")
+		c.storeFeatureCache(ctx, organizationID, FeatureRemoteSessionAutoRefresh, enabled, "failed to update feature flag cache")
+		return nil
+	})
 }
 
 // UpdateFeatureCache stores the given enabled state for the feature directly
 // into the cache. Call this after writing the feature flag to the database
 // from a code path that bypasses this client, so the cache stays consistent.
 func (c *Client) UpdateFeatureCache(ctx context.Context, organizationID string, feature Feature, enabled bool) {
+	c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
+}
+
+func (c *Client) storeFeatureCache(ctx context.Context, organizationID string, feature Feature, enabled bool, message string) {
 	cacheEntry := FeatureCache{
 		OrganizationID: organizationID,
 		Feature:        feature,
 		Enabled:        enabled,
 	}
 	if err := c.featureCache.Store(ctx, cacheEntry); err != nil {
-		c.logger.WarnContext(ctx, "failed to update feature flag cache",
+		c.logger.WarnContext(ctx, message,
 			attr.SlogError(err),
 			attr.SlogOrganizationID(organizationID),
 			attr.SlogProductFeatureName(string(feature)),
 		)
 	}
+}
+
+func setFeatureEnabled(ctx context.Context, queries *repo.Queries, organizationID string, feature Feature, enabled bool) error {
+	if enabled {
+		if _, err := queries.EnableFeature(ctx, repo.EnableFeatureParams{OrganizationID: organizationID, FeatureName: string(feature)}); err != nil {
+			return fmt.Errorf("enable feature: %w", err)
+		}
+		return nil
+	}
+
+	_, err := queries.DeleteFeature(ctx, repo.DeleteFeatureParams{OrganizationID: organizationID, FeatureName: string(feature)})
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("disable feature: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) withFeatureCacheLock(ctx context.Context, organizationID string, feature Feature, fn func(*pgxpool.Conn) error) error {
+	return c.withFeatureCacheLocks(ctx, organizationID, []Feature{feature}, fn)
+}
+
+func (c *Client) withFeatureCacheLocks(ctx context.Context, organizationID string, features []Feature, fn func(*pgxpool.Conn) error) error {
+	conn, err := c.db.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire feature cache lock connection: %w", err)
+	}
+
+	queries := repo.New(conn)
+	features = slices.Clone(features)
+	slices.Sort(features)
+	acquired := make([]repo.AcquireFeatureCacheLockParams, 0, len(features))
+	defer func() {
+		unlockCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		for i := len(acquired) - 1; i >= 0; i-- {
+			params := acquired[i]
+			unlocked, unlockErr := queries.ReleaseFeatureCacheLock(unlockCtx, repo.ReleaseFeatureCacheLockParams(params))
+			if unlockErr != nil || !unlocked {
+				c.logger.ErrorContext(unlockCtx, "failed to release feature cache lock",
+					attr.SlogError(unlockErr),
+					attr.SlogOrganizationID(organizationID),
+					attr.SlogProductFeatureName(params.FeatureName),
+				)
+				_ = conn.Hijack().Close(unlockCtx)
+				return
+			}
+		}
+		conn.Release()
+	}()
+
+	for _, feature := range features {
+		params := repo.AcquireFeatureCacheLockParams{OrganizationID: organizationID, FeatureName: string(feature)}
+		if err := queries.AcquireFeatureCacheLock(ctx, params); err != nil {
+			return fmt.Errorf("acquire feature cache lock: %w", err)
+		}
+		acquired = append(acquired, params)
+	}
+
+	return fn(conn)
 }
 
 func provisionSkillsSystemRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, organizationID string) error {

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -20,7 +20,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
-	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -32,14 +31,14 @@ import (
 
 // Service implements organization feature management operations.
 type Service struct {
-	tracer       trace.Tracer
-	logger       *slog.Logger
-	db           *pgxpool.Pool
-	repo         *repo.Queries
-	auth         *auth.Auth
-	authz        *authz.Engine
-	featureCache cache.TypedCacheObject[FeatureCache]
-	audit        *audit.Logger
+	tracer        trace.Tracer
+	logger        *slog.Logger
+	db            *pgxpool.Pool
+	repo          *repo.Queries
+	auth          *auth.Auth
+	authz         *authz.Engine
+	featureClient *Client
+	audit         *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -56,14 +55,14 @@ func NewService(
 	logger = logger.With(attr.SlogComponent("product_features"))
 
 	return &Service{
-		tracer:       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/productfeatures"),
-		logger:       logger,
-		db:           db,
-		repo:         repo.New(db),
-		auth:         auth.New(logger, db, sessions, authzEngine),
-		authz:        authzEngine,
-		featureCache: cache.NewTypedObjectCache[FeatureCache](logger.With(attr.SlogCacheNamespace("productfeature")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
-		audit:        auditLogger,
+		tracer:        tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/productfeatures"),
+		logger:        logger,
+		db:            db,
+		repo:          repo.New(db),
+		auth:          auth.New(logger, db, sessions, authzEngine),
+		authz:         authzEngine,
+		featureClient: NewClient(logger, tracerProvider, db, redisClient),
+		audit:         auditLogger,
 	}
 }
 
@@ -119,7 +118,13 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 		return nil
 	}
 
-	dbtx, err := s.db.Begin(ctx)
+	lockConn, releaseFeatureLock, err := s.featureClient.acquireFeatureCacheLocks(ctx, orgID, []Feature{Feature(payload.FeatureName)})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "lock feature cache state").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
+	}
+	defer releaseFeatureLock()
+
+	dbtx, err := lockConn.Begin(ctx)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "begin feature flag transaction").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
@@ -187,19 +192,7 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 		return oops.E(oops.CodeUnexpected, err, "commit feature flag change").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
 
-	cacheEntry := FeatureCache{
-		OrganizationID: orgID,
-		Feature:        Feature(payload.FeatureName),
-		Enabled:        payload.Enabled,
-	}
-
-	if cacheErr := s.featureCache.Store(ctx, cacheEntry); cacheErr != nil {
-		s.logger.WarnContext(ctx, "failed to cache feature flag state",
-			attr.SlogError(cacheErr),
-			attr.SlogOrganizationID(orgID),
-			attr.SlogProductFeatureName(payload.FeatureName),
-		)
-	}
+	s.featureClient.storeFeatureCache(ctx, orgID, Feature(payload.FeatureName), payload.Enabled, "failed to cache feature flag state")
 
 	return nil
 }
@@ -220,7 +213,15 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 		return oops.C(oops.CodeBadRequest)
 	}
 
-	dbtx, err := s.db.Begin(ctx)
+	lockConn, releaseFeatureLocks, err := s.featureClient.acquireFeatureCacheLocks(ctx, orgID, []Feature{
+		FeatureRemoteSessionAutoRefresh, FeatureRemoteSessionAutoRefreshEnforced,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "lock remote session refresh cache state").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
+	}
+	defer releaseFeatureLocks()
+
+	dbtx, err := lockConn.Begin(ctx)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "begin remote session refresh policy transaction").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
@@ -269,18 +270,7 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 		{feature: FeatureRemoteSessionAutoRefresh, enabled: visible},
 		{feature: FeatureRemoteSessionAutoRefreshEnforced, enabled: enforced},
 	} {
-		cacheEntry := FeatureCache{
-			OrganizationID: orgID,
-			Feature:        state.feature,
-			Enabled:        state.enabled,
-		}
-		if cacheErr := s.featureCache.Store(ctx, cacheEntry); cacheErr != nil {
-			s.logger.WarnContext(ctx, "failed to cache remote session refresh policy",
-				attr.SlogError(cacheErr),
-				attr.SlogOrganizationID(orgID),
-				attr.SlogProductFeatureName(string(state.feature)),
-			)
-		}
+		s.featureClient.storeFeatureCache(ctx, orgID, state.feature, state.enabled, "failed to cache remote session refresh policy")
 	}
 
 	return nil
@@ -292,21 +282,8 @@ func (s *Service) GetProductFeatures(ctx context.Context, payload *gen.GetProduc
 		return nil, err
 	}
 
-	// Helper function to check if a feature is enabled (cache first, then DB)
 	isEnabled := func(feature Feature) bool {
-		cacheKey := FeatureCacheKey(orgID, feature)
-
-		// Try cache first
-		cached, err := s.featureCache.Get(ctx, cacheKey)
-		if err == nil {
-			return cached.Enabled
-		}
-
-		// Fall back to database
-		enabled, err := s.repo.IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
-			OrganizationID: orgID,
-			FeatureName:    string(feature),
-		})
+		enabled, err := s.featureClient.IsFeatureEnabled(ctx, orgID, feature)
 		if err != nil {
 			s.logger.WarnContext(ctx, "failed to check feature flag",
 				attr.SlogError(err),
@@ -314,20 +291,6 @@ func (s *Service) GetProductFeatures(ctx context.Context, payload *gen.GetProduc
 				attr.SlogProductFeatureName(string(feature)),
 			)
 			return false
-		}
-
-		// Cache the result
-		cacheEntry := FeatureCache{
-			OrganizationID: orgID,
-			Feature:        feature,
-			Enabled:        enabled,
-		}
-		if cacheErr := s.featureCache.Store(ctx, cacheEntry); cacheErr != nil {
-			s.logger.WarnContext(ctx, "failed to cache feature flag state",
-				attr.SlogError(cacheErr),
-				attr.SlogOrganizationID(orgID),
-				attr.SlogProductFeatureName(string(feature)),
-			)
 		}
 
 		return enabled

--- a/server/internal/productfeatures/queries.sql
+++ b/server/internal/productfeatures/queries.sql
@@ -4,6 +4,14 @@ FROM organization_metadata
 WHERE id = @organization_id
 FOR UPDATE;
 
+-- name: AcquireFeatureCacheLock :exec
+-- Serialize durable feature updates with cache fills and refreshes so an older
+-- operation cannot overwrite a newer cache value after the database changes.
+SELECT pg_advisory_lock(hashtextextended('product-feature:' || @organization_id::text || ':' || @feature_name::text, 0));
+
+-- name: ReleaseFeatureCacheLock :one
+SELECT pg_advisory_unlock(hashtextextended('product-feature:' || @organization_id::text || ':' || @feature_name::text, 0)) AS unlocked;
+
 -- name: IsFeatureEnabled :one
 SELECT EXISTS (
         SELECT 1

--- a/server/internal/productfeatures/repo/queries.sql.go
+++ b/server/internal/productfeatures/repo/queries.sql.go
@@ -9,6 +9,22 @@ import (
 	"context"
 )
 
+const acquireFeatureCacheLock = `-- name: AcquireFeatureCacheLock :exec
+SELECT pg_advisory_lock(hashtextextended('product-feature:' || $1::text || ':' || $2::text, 0))
+`
+
+type AcquireFeatureCacheLockParams struct {
+	OrganizationID string
+	FeatureName    string
+}
+
+// Serialize durable feature updates with cache fills and refreshes so an older
+// operation cannot overwrite a newer cache value after the database changes.
+func (q *Queries) AcquireFeatureCacheLock(ctx context.Context, arg AcquireFeatureCacheLockParams) error {
+	_, err := q.db.Exec(ctx, acquireFeatureCacheLock, arg.OrganizationID, arg.FeatureName)
+	return err
+}
+
 const deleteFeature = `-- name: DeleteFeature :one
 UPDATE organization_features
 SET deleted_at = clock_timestamp(),
@@ -147,4 +163,20 @@ func (q *Queries) LockOrganizationMetadata(ctx context.Context, organizationID s
 	var id string
 	err := row.Scan(&id)
 	return id, err
+}
+
+const releaseFeatureCacheLock = `-- name: ReleaseFeatureCacheLock :one
+SELECT pg_advisory_unlock(hashtextextended('product-feature:' || $1::text || ':' || $2::text, 0)) AS unlocked
+`
+
+type ReleaseFeatureCacheLockParams struct {
+	OrganizationID string
+	FeatureName    string
+}
+
+func (q *Queries) ReleaseFeatureCacheLock(ctx context.Context, arg ReleaseFeatureCacheLockParams) (bool, error) {
+	row := q.db.QueryRow(ctx, releaseFeatureCacheLock, arg.OrganizationID, arg.FeatureName)
+	var unlocked bool
+	err := row.Scan(&unlocked)
+	return unlocked, err
 }


### PR DESCRIPTION
## Summary

- align the standalone organization Features page with the seven curated Platform Admin product features
- add controls for Work Delivered Chat Analysis and Business Memory Extraction, including enabled state and per-UTC-day caps
- add an authenticated organization-wide **Run now** action backed by Temporal signaling, with graceful errors when Temporal is not configured
- share chat-analysis settings persistence with the dashboard path so budget locking and transactional audit/outbox behavior remain consistent
- keep admin operator identity in internal logs while using the team actor label in customer-visible audit records

## Testing

- `mise run build:server --readonly`
- `mise run lint:server`
- `cd server && go test ./internal/admin -run 'TestOrganizationFeatures|TestChatAnalysisSettings|TestSetChatAnalysisSettings|TestTriggerChatAnalysis' -count=1`
- `cd server && go test ./internal/chatanalysis -count=1`
- `cd server && go test ./cmd/gram -run '^$' -count=1`
- `cd client/admin && CI=true pnpm vitest run src/pages/organization/Features.test.tsx`
- `cd client/admin && CI=true pnpm run type-check`
- manually verified the Features page and organization-wide trigger against the local stack

## Review notes

- **Run now** is organization-wide even though it is rendered beside each enabled pipeline row.
- Product-feature cache fills and writes use a shared PostgreSQL advisory lock so concurrent operations cannot publish stale Redis state.

Linear: AGE-3242
