### PR TITLE
feat(platform-mcp): add direct remote registration

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -387,6 +387,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		platformmcp.NewRemoteMCPReadinessProber(config.Logger, config.DB, config.Encryption, config.GuardianPolicy, config.RemoteChallengeManager),
 	).WithTelemetry(telemetry)
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
+		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -196,6 +196,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		platformmcp.NewRemoteMCPReadinessProber(config.Logger, config.DB, config.Encryption, config.GuardianPolicy, config.RemoteChallengeManager),
 	).WithTelemetry(telemetry)
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
+		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -102,6 +102,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"find_mcp",
 		"get_mcp",
 		"register_catalog_mcp",
+		"register_remote_mcp",
 		"search_mcp_catalog",
 		"inspect_mcp_candidate",
 		"send_platform_mcp_feedback",

--- a/server/internal/platformmcp/direct_remote.go
+++ b/server/internal/platformmcp/direct_remote.go
@@ -1,0 +1,441 @@
+//nolint:wrapcheck // Callers map bounded inspection outcomes to MCP tool results.
+package platformmcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+)
+
+const (
+	directRemoteURLMaxBytes       = 2048
+	directRemoteProbeDeadline     = 10 * time.Second
+	directRemoteProbeMaxRedirects = 3
+	directRemoteProbeMaxBytes     = 256 << 10
+	directRemoteProbeMaxRequests  = 8
+	directRemoteOAuthServerLimit  = 2
+	directRemoteToolNameLimit     = 50
+	directRemoteProviderKey       = "direct-remote-url-v1"
+	directRemoteSourceKind        = "remote_url"
+)
+
+var (
+	ErrDirectRemoteRejected    = errors.New("direct remote MCP URL rejected")
+	ErrDirectRemoteUnavailable = errors.New("direct remote MCP inspection unavailable")
+)
+
+// DirectRemoteInspection is the bounded, non-secret projection of a direct
+// user-supplied remote MCP. It deliberately contains no response headers,
+// response body, OAuth metadata, credentials, or schemas.
+type DirectRemoteInspection struct {
+	CanonicalURL           string   `json:"canonical_url"`
+	Transport              string   `json:"transport"`
+	ToolNames              []string `json:"tool_names"`
+	ToolCount              int      `json:"tool_count"`
+	Authentication         string   `json:"authentication"`
+	OAuthDiscovery         string   `json:"oauth_discovery"`
+	Trust                  string   `json:"trust"`
+	RequiresDashboardSetup bool     `json:"requires_dashboard_setup"`
+}
+
+// DirectRemoteInspector is the boundary shared by candidate inspection and
+// registration. Registration must call it again; an earlier tool result is
+// never admission evidence.
+type DirectRemoteInspector interface {
+	Inspect(ctx context.Context, rawURL string) (DirectRemoteInspection, error)
+}
+
+// GuardianDirectRemoteInspector canonicalizes, validates, and probes one
+// direct remote MCP using Guardian before every network hop. It supports only
+// Streamable HTTP's JSON response form; standalone SSE is intentionally not a
+// D1 admission path.
+type GuardianDirectRemoteInspector struct {
+	policy *guardian.Policy
+}
+
+func NewGuardianDirectRemoteInspector(policy *guardian.Policy) *GuardianDirectRemoteInspector {
+	return &GuardianDirectRemoteInspector{policy: policy}
+}
+
+func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL string) (DirectRemoteInspection, error) {
+	if s == nil || s.policy == nil {
+		return DirectRemoteInspection{}, ErrDirectRemoteUnavailable
+	}
+	canonicalURL, err := canonicalDirectRemoteURL(rawURL)
+	if err != nil {
+		return DirectRemoteInspection{}, err
+	}
+	if _, err := s.policy.ValidateHTTPSURL(ctx, canonicalURL); err != nil {
+		return DirectRemoteInspection{}, fmt.Errorf("validate direct remote URL: %w", ErrDirectRemoteRejected)
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, directRemoteProbeDeadline)
+	defer cancel()
+	budget := &directRemoteResponseBudget{remaining: directRemoteProbeMaxBytes, requestsRemaining: directRemoteProbeMaxRequests}
+	client := s.policy.Client()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > directRemoteProbeMaxRedirects || budget.consumeRequest() != nil {
+			return fmt.Errorf("%w: too many redirects", ErrDirectRemoteRejected)
+		}
+		next, err := canonicalDirectRemoteURL(req.URL.String())
+		if err != nil {
+			return err
+		}
+		validated, err := s.policy.ValidateHTTPSURL(req.Context(), next)
+		if err != nil {
+			return fmt.Errorf("%w: unsafe redirect", ErrDirectRemoteRejected)
+		}
+		req.URL = validated
+		// This probe never sends credentials. Explicitly clearing Authorization
+		// keeps that invariant if a client implementation changes later.
+		req.Header.Del("Authorization")
+		return nil
+	}
+
+	initialize, finalURL, sessionID, status, err := directRemoteRequest(probeCtx, client, canonicalURL, "initialize", map[string]any{
+		"protocolVersion": "2025-06-18",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]string{"name": "gram-platform-mcp", "version": "1"},
+	}, "", budget)
+	if err != nil {
+		return DirectRemoteInspection{}, err
+	}
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return directRemoteInspection(finalURL, nil, "authentication_required", directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget), true), nil
+	}
+	if status < http.StatusOK || status >= http.StatusMultipleChoices || initialize.Result == nil {
+		return DirectRemoteInspection{}, ErrDirectRemoteRejected
+	}
+	if sessionID != "" {
+		finalURL, status, err = directRemoteNotification(probeCtx, client, finalURL, "notifications/initialized", map[string]any{}, sessionID, budget)
+		if err != nil || status < http.StatusOK || status >= http.StatusMultipleChoices {
+			return DirectRemoteInspection{}, ErrDirectRemoteRejected
+		}
+	}
+
+	tools, finalURL, _, status, err := directRemoteRequest(probeCtx, client, finalURL, "tools/list", map[string]any{}, sessionID, budget)
+	if err != nil {
+		return DirectRemoteInspection{}, err
+	}
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return directRemoteInspection(finalURL, nil, "authentication_required", directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget), true), nil
+	}
+	if status < http.StatusOK || status >= http.StatusMultipleChoices || tools.Result == nil {
+		return DirectRemoteInspection{}, ErrDirectRemoteRejected
+	}
+
+	var toolList struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(tools.Result, &toolList); err != nil {
+		return DirectRemoteInspection{}, ErrDirectRemoteRejected
+	}
+	names := make([]string, 0, min(len(toolList.Tools), directRemoteToolNameLimit))
+	for _, tool := range toolList.Tools {
+		if name := strings.TrimSpace(tool.Name); name != "" {
+			names = append(names, name)
+			if len(names) == directRemoteToolNameLimit {
+				break
+			}
+		}
+	}
+	return directRemoteInspection(finalURL, names, "anonymous", "not_advertised", false), nil
+}
+
+type directRemoteResponseBudget struct {
+	remaining         int
+	requestsRemaining int
+}
+
+func (b *directRemoteResponseBudget) consumeRequest() error {
+	if b == nil || b.remaining <= 0 || b.requestsRemaining <= 0 {
+		return ErrDirectRemoteRejected
+	}
+	b.requestsRemaining--
+	return nil
+}
+
+type directRemoteRPCResponse struct {
+	Result json.RawMessage `json:"result"`
+}
+
+func directRemoteRequest(ctx context.Context, client *http.Client, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (directRemoteRPCResponse, string, string, int, error) {
+	if err := budget.consumeRequest(); err != nil {
+		return directRemoteRPCResponse{}, "", "", 0, err
+	}
+	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+	if err != nil {
+		return directRemoteRPCResponse{}, "", "", 0, fmt.Errorf("marshal MCP probe: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return directRemoteRPCResponse{}, "", "", 0, fmt.Errorf("build direct MCP probe: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		if errors.Is(err, ErrDirectRemoteRejected) || errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
+			return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+			return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteUnavailable
+		}
+		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteUnavailable
+	}
+	defer func() { _ = resp.Body.Close() }()
+	finalURL, err := canonicalDirectRemoteURL(resp.Request.URL.String())
+	if err != nil {
+		return directRemoteRPCResponse{}, "", "", 0, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return directRemoteRPCResponse{}, finalURL, "", resp.StatusCode, nil
+	}
+	if mediaType := strings.ToLower(strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])); mediaType != "application/json" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+	}
+	if budget == nil || budget.remaining <= 0 {
+		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+	}
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, int64(budget.remaining+1)))
+	if err != nil || len(payload) > budget.remaining {
+		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+	}
+	budget.remaining -= len(payload)
+	var result directRemoteRPCResponse
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+	}
+	return result, finalURL, resp.Header.Get("Mcp-Session-Id"), resp.StatusCode, nil
+}
+
+func directRemoteNotification(ctx context.Context, client *http.Client, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (string, int, error) {
+	if err := budget.consumeRequest(); err != nil {
+		return "", 0, err
+	}
+	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
+	if err != nil {
+		return "", 0, fmt.Errorf("marshal MCP probe notification: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return "", 0, fmt.Errorf("build direct MCP probe notification: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	resp, err := client.Do(req)
+	if err != nil {
+		if errors.Is(err, ErrDirectRemoteRejected) || errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
+			return "", 0, ErrDirectRemoteRejected
+		}
+		return "", 0, ErrDirectRemoteUnavailable
+	}
+	defer func() { _ = resp.Body.Close() }()
+	finalURL, err := canonicalDirectRemoteURL(resp.Request.URL.String())
+	if err != nil {
+		return "", 0, err
+	}
+	if budget == nil || budget.remaining <= 0 {
+		return "", 0, ErrDirectRemoteRejected
+	}
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, int64(budget.remaining+1)))
+	if err != nil || len(payload) > budget.remaining {
+		return "", 0, ErrDirectRemoteRejected
+	}
+	budget.remaining -= len(payload)
+	return finalURL, resp.StatusCode, nil
+}
+
+// directRemoteOAuthDiscovery returns only the safe discovery category. Metadata
+// URLs are derived from the canonical resource or a discovered issuer, rechecked
+// with Guardian before egress, and charged to the inspection response budget.
+func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, client *http.Client, resourceURL string, budget *directRemoteResponseBudget) string {
+	for _, metadataURL := range directRemoteProtectedResourceMetadataURLs(resourceURL) {
+		metadata, status, err := directRemoteGetJSON(ctx, policy, client, metadataURL, budget)
+		if err != nil || status != http.StatusOK {
+			continue
+		}
+		servers, ok := metadata["authorization_servers"].([]any)
+		if !ok || len(servers) == 0 {
+			continue
+		}
+		for index, server := range servers {
+			if index == directRemoteOAuthServerLimit {
+				break
+			}
+			issuer, ok := server.(string)
+			if !ok || issuer == "" {
+				continue
+			}
+			authorizationMetadataURL := directRemoteAuthorizationServerMetadataURL(issuer)
+			if authorizationMetadataURL == "" {
+				continue
+			}
+			authorizationMetadata, status, err := directRemoteGetJSON(ctx, policy, client, authorizationMetadataURL, budget)
+			if err != nil || status != http.StatusOK {
+				continue
+			}
+			if endpoint, _ := authorizationMetadata["registration_endpoint"].(string); endpoint != "" {
+				return "available_dcr"
+			}
+			return "available"
+		}
+	}
+	return "incomplete"
+}
+
+func directRemoteProtectedResourceMetadataURLs(resourceURL string) []string {
+	parsed, err := url.Parse(resourceURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return nil
+	}
+	origin := "https://" + parsed.Host
+	path := strings.TrimSuffix(parsed.EscapedPath(), "/")
+	if path == "" {
+		return []string{origin + "/.well-known/oauth-protected-resource"}
+	}
+	return []string{origin + "/.well-known/oauth-protected-resource" + path, origin + "/.well-known/oauth-protected-resource"}
+}
+
+func directRemoteAuthorizationServerMetadataURL(issuer string) string {
+	parsed, err := url.Parse(issuer)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return ""
+	}
+	path := strings.TrimSuffix(parsed.EscapedPath(), "/")
+	return "https://" + parsed.Host + "/.well-known/oauth-authorization-server" + path
+}
+
+func directRemoteGetJSON(ctx context.Context, policy *guardian.Policy, client *http.Client, rawURL string, budget *directRemoteResponseBudget) (map[string]any, int, error) {
+	if policy == nil || client == nil || budget == nil || budget.remaining <= 0 {
+		return nil, 0, ErrDirectRemoteUnavailable
+	}
+	canonicalURL, err := canonicalDirectRemoteURL(rawURL)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := policy.ValidateHTTPSURL(ctx, canonicalURL); err != nil {
+		return nil, 0, ErrDirectRemoteRejected
+	}
+	if err := budget.consumeRequest(); err != nil {
+		return nil, 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, canonicalURL, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, nil
+	}
+	if mediaType := strings.ToLower(strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])); mediaType != "application/json" {
+		return nil, resp.StatusCode, ErrDirectRemoteRejected
+	}
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, int64(budget.remaining+1)))
+	if err != nil || len(payload) > budget.remaining {
+		return nil, resp.StatusCode, ErrDirectRemoteRejected
+	}
+	budget.remaining -= len(payload)
+	var value map[string]any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, resp.StatusCode, ErrDirectRemoteRejected
+	}
+	return value, resp.StatusCode, nil
+}
+
+func directRemoteInspection(canonicalURL string, toolNames []string, authentication, oauthDiscovery string, requiresDashboardSetup bool) DirectRemoteInspection {
+	return DirectRemoteInspection{
+		CanonicalURL:           canonicalURL,
+		Transport:              "streamable-http",
+		ToolNames:              append([]string(nil), toolNames...),
+		ToolCount:              len(toolNames),
+		Authentication:         authentication,
+		OAuthDiscovery:         oauthDiscovery,
+		Trust:                  "user_supplied_unreviewed",
+		RequiresDashboardSetup: requiresDashboardSetup,
+	}
+}
+
+// canonicalDirectRemoteURL is intentionally pure so persistence can repeat the
+// cheap shape/canonical-equality guard without DNS or egress while holding its
+// project locks. Guardian validation remains mandatory before probing/persisting.
+func canonicalDirectRemoteURL(rawURL string) (string, error) {
+	if len(rawURL) > directRemoteURLMaxBytes || containsURLControlOrTemplate(rawURL) {
+		return "", ErrDirectRemoteRejected
+	}
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" || len(rawURL) > directRemoteURLMaxBytes {
+		return "", ErrDirectRemoteRejected
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || !parsed.IsAbs() || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" || containsURLControlOrTemplate(parsed.Path) || containsURLControlOrTemplate(parsed.RawPath) {
+		return "", ErrDirectRemoteRejected
+	}
+	port := parsed.Port()
+	if port != "" && port != "443" {
+		return "", ErrDirectRemoteRejected
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if ip := net.ParseIP(host); ip == nil && strings.HasSuffix(host, ".") {
+		return "", ErrDirectRemoteRejected
+	}
+	parsed.Scheme = "https"
+	parsed.Host = host
+	if strings.Contains(host, ":") {
+		parsed.Host = "[" + host + "]"
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	if parsed.Path == "" {
+		parsed.Path = "/"
+	}
+	// A default port has no canonical wire representation. Reject malformed
+	// ports above, then normalize an explicitly supplied :443 away.
+	if port == "443" {
+		parsed.Host = strings.TrimSuffix(parsed.Host, ":"+strconv.Itoa(443))
+	}
+	canonical := parsed.String()
+	if len(canonical) > directRemoteURLMaxBytes {
+		return "", ErrDirectRemoteRejected
+	}
+	return canonical, nil
+}
+
+func containsURLControlOrTemplate(value string) bool {
+	for _, r := range value {
+		if unicode.IsControl(r) || r == '{' || r == '}' {
+			return true
+		}
+	}
+	return false
+}
+
+func validDirectRemoteRegistrationURL(rawURL string) bool {
+	canonical, err := canonicalDirectRemoteURL(rawURL)
+	return err == nil && canonical == rawURL
+}

--- a/server/internal/platformmcp/direct_remote.go
+++ b/server/internal/platformmcp/direct_remote.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -26,6 +25,7 @@ const (
 	directRemoteProbeMaxBytes     = 256 << 10
 	directRemoteProbeMaxRequests  = 8
 	directRemoteOAuthServerLimit  = 2
+	directRemoteSessionIDMaxBytes = 512
 	directRemoteToolNameLimit     = 50
 	directRemoteProviderKey       = "direct-remote-url-v1"
 	directRemoteSourceKind        = "remote_url"
@@ -186,8 +186,11 @@ func directRemoteRequest(ctx context.Context, client *http.Client, rawURL, metho
 		return directRemoteRPCResponse{}, "", "", 0, fmt.Errorf("build direct MCP probe: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
 	if sessionID != "" {
+		if len(sessionID) > directRemoteSessionIDMaxBytes {
+			return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+		}
 		req.Header.Set("Mcp-Session-Id", sessionID)
 	}
 	resp, err := client.Do(req)
@@ -223,7 +226,11 @@ func directRemoteRequest(ctx context.Context, client *http.Client, rawURL, metho
 	if err := json.Unmarshal(payload, &result); err != nil {
 		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
 	}
-	return result, finalURL, resp.Header.Get("Mcp-Session-Id"), resp.StatusCode, nil
+	sessionID = resp.Header.Get("Mcp-Session-Id")
+	if len(sessionID) > directRemoteSessionIDMaxBytes {
+		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+	}
+	return result, finalURL, sessionID, resp.StatusCode, nil
 }
 
 func directRemoteNotification(ctx context.Context, client *http.Client, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (string, int, error) {
@@ -238,8 +245,11 @@ func directRemoteNotification(ctx context.Context, client *http.Client, rawURL, 
 	if err != nil {
 		return "", 0, fmt.Errorf("build direct MCP probe notification: %w", err)
 	}
+	if len(sessionID) > directRemoteSessionIDMaxBytes {
+		return "", 0, ErrDirectRemoteRejected
+	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
 	req.Header.Set("Mcp-Session-Id", sessionID)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -268,6 +278,7 @@ func directRemoteNotification(ctx context.Context, client *http.Client, rawURL, 
 // URLs are derived from the canonical resource or a discovered issuer, rechecked
 // with Guardian before egress, and charged to the inspection response budget.
 func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, client *http.Client, resourceURL string, budget *directRemoteResponseBudget) string {
+	available := false
 	for _, metadataURL := range directRemoteProtectedResourceMetadataURLs(resourceURL) {
 		metadata, status, err := directRemoteGetJSON(ctx, policy, client, metadataURL, budget)
 		if err != nil || status != http.StatusOK {
@@ -296,8 +307,11 @@ func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, cl
 			if endpoint, _ := authorizationMetadata["registration_endpoint"].(string); endpoint != "" {
 				return "available_dcr"
 			}
-			return "available"
+			available = true
 		}
+	}
+	if available {
+		return "available"
 	}
 	return "incomplete"
 }
@@ -413,11 +427,6 @@ func canonicalDirectRemoteURL(rawURL string) (string, error) {
 	parsed.Fragment = ""
 	if parsed.Path == "" {
 		parsed.Path = "/"
-	}
-	// A default port has no canonical wire representation. Reject malformed
-	// ports above, then normalize an explicitly supplied :443 away.
-	if port == "443" {
-		parsed.Host = strings.TrimSuffix(parsed.Host, ":"+strconv.Itoa(443))
 	}
 	canonical := parsed.String()
 	if len(canonical) > directRemoteURLMaxBytes {

--- a/server/internal/platformmcp/direct_remote.go
+++ b/server/internal/platformmcp/direct_remote.go
@@ -11,11 +11,13 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
 
 const (
@@ -173,67 +175,75 @@ type directRemoteRPCResponse struct {
 	Result json.RawMessage `json:"result"`
 }
 
-func directRemoteRequest(ctx context.Context, client *http.Client, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (directRemoteRPCResponse, string, string, int, error) {
+type directRemoteHTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func emptyDirectRemoteRPCResponse() directRemoteRPCResponse {
+	return directRemoteRPCResponse{Result: nil}
+}
+
+func directRemoteRequest(ctx context.Context, client directRemoteHTTPClient, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (directRemoteRPCResponse, string, string, int, error) {
 	if err := budget.consumeRequest(); err != nil {
-		return directRemoteRPCResponse{}, "", "", 0, err
+		return emptyDirectRemoteRPCResponse(), "", "", 0, err
 	}
 	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
 	if err != nil {
-		return directRemoteRPCResponse{}, "", "", 0, fmt.Errorf("marshal MCP probe: %w", err)
+		return emptyDirectRemoteRPCResponse(), "", "", 0, fmt.Errorf("marshal MCP probe: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
 	if err != nil {
-		return directRemoteRPCResponse{}, "", "", 0, fmt.Errorf("build direct MCP probe: %w", err)
+		return emptyDirectRemoteRPCResponse(), "", "", 0, fmt.Errorf("build direct MCP probe: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	if sessionID != "" {
 		if len(sessionID) > directRemoteSessionIDMaxBytes {
-			return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+			return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
 		}
 		req.Header.Set("Mcp-Session-Id", sessionID)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
 		if errors.Is(err, ErrDirectRemoteRejected) || errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
-			return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+			return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
 		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
-			return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteUnavailable
+			return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteUnavailable
 		}
-		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteUnavailable
+		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteUnavailable
 	}
 	defer func() { _ = resp.Body.Close() }()
 	finalURL, err := canonicalDirectRemoteURL(resp.Request.URL.String())
 	if err != nil {
-		return directRemoteRPCResponse{}, "", "", 0, err
+		return emptyDirectRemoteRPCResponse(), "", "", 0, err
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return directRemoteRPCResponse{}, finalURL, "", resp.StatusCode, nil
+		return emptyDirectRemoteRPCResponse(), finalURL, "", resp.StatusCode, nil
 	}
 	if mediaType := strings.ToLower(strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])); mediaType != "application/json" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
 	}
 	if budget == nil || budget.remaining <= 0 {
-		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
 	}
 	payload, err := io.ReadAll(io.LimitReader(resp.Body, int64(budget.remaining+1)))
 	if err != nil || len(payload) > budget.remaining {
-		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
 	}
 	budget.remaining -= len(payload)
 	var result directRemoteRPCResponse
 	if err := json.Unmarshal(payload, &result); err != nil {
-		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
 	}
 	sessionID = resp.Header.Get("Mcp-Session-Id")
 	if len(sessionID) > directRemoteSessionIDMaxBytes {
-		return directRemoteRPCResponse{}, "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
 	}
 	return result, finalURL, sessionID, resp.StatusCode, nil
 }
 
-func directRemoteNotification(ctx context.Context, client *http.Client, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (string, int, error) {
+func directRemoteNotification(ctx context.Context, client directRemoteHTTPClient, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (string, int, error) {
 	if err := budget.consumeRequest(); err != nil {
 		return "", 0, err
 	}
@@ -277,7 +287,7 @@ func directRemoteNotification(ctx context.Context, client *http.Client, rawURL, 
 // directRemoteOAuthDiscovery returns only the safe discovery category. Metadata
 // URLs are derived from the canonical resource or a discovered issuer, rechecked
 // with Guardian before egress, and charged to the inspection response budget.
-func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, client *http.Client, resourceURL string, budget *directRemoteResponseBudget) string {
+func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, client directRemoteHTTPClient, resourceURL string, budget *directRemoteResponseBudget) string {
 	available := false
 	for _, metadataURL := range directRemoteProtectedResourceMetadataURLs(resourceURL) {
 		metadata, status, err := directRemoteGetJSON(ctx, policy, client, metadataURL, budget)
@@ -296,18 +306,17 @@ func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, cl
 			if !ok || issuer == "" {
 				continue
 			}
-			authorizationMetadataURL := directRemoteAuthorizationServerMetadataURL(issuer)
-			if authorizationMetadataURL == "" {
-				continue
+			for _, authorizationMetadataURL := range directRemoteAuthorizationServerMetadataURLs(issuer) {
+				authorizationMetadata, status, err := directRemoteGetJSON(ctx, policy, client, authorizationMetadataURL, budget)
+				if err != nil || status != http.StatusOK {
+					continue
+				}
+				if endpoint, _ := authorizationMetadata["registration_endpoint"].(string); endpoint != "" {
+					return "available_dcr"
+				}
+				available = true
+				break
 			}
-			authorizationMetadata, status, err := directRemoteGetJSON(ctx, policy, client, authorizationMetadataURL, budget)
-			if err != nil || status != http.StatusOK {
-				continue
-			}
-			if endpoint, _ := authorizationMetadata["registration_endpoint"].(string); endpoint != "" {
-				return "available_dcr"
-			}
-			available = true
 		}
 	}
 	if available {
@@ -329,16 +338,24 @@ func directRemoteProtectedResourceMetadataURLs(resourceURL string) []string {
 	return []string{origin + "/.well-known/oauth-protected-resource" + path, origin + "/.well-known/oauth-protected-resource"}
 }
 
-func directRemoteAuthorizationServerMetadataURL(issuer string) string {
+// directRemoteAuthorizationServerMetadataURLs reuses the production issuer
+// discovery candidates. Query parameters identify the MCP endpoint and never
+// flow into metadata URLs.
+func directRemoteAuthorizationServerMetadataURLs(issuer string) []string {
 	parsed, err := url.Parse(issuer)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return ""
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.Fragment != "" {
+		return nil
 	}
-	path := strings.TrimSuffix(parsed.EscapedPath(), "/")
-	return "https://" + parsed.Host + "/.well-known/oauth-authorization-server" + path
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	candidates, err := remotesessions.IssuerMetadataProbeCandidates(parsed.String())
+	if err != nil {
+		return nil
+	}
+	return candidates
 }
 
-func directRemoteGetJSON(ctx context.Context, policy *guardian.Policy, client *http.Client, rawURL string, budget *directRemoteResponseBudget) (map[string]any, int, error) {
+func directRemoteGetJSON(ctx context.Context, policy *guardian.Policy, client directRemoteHTTPClient, rawURL string, budget *directRemoteResponseBudget) (map[string]any, int, error) {
 	if policy == nil || client == nil || budget == nil || budget.remaining <= 0 {
 		return nil, 0, ErrDirectRemoteUnavailable
 	}
@@ -405,7 +422,7 @@ func canonicalDirectRemoteURL(rawURL string) (string, error) {
 		return "", ErrDirectRemoteRejected
 	}
 	parsed, err := url.Parse(rawURL)
-	if err != nil || !parsed.IsAbs() || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" || containsURLControlOrTemplate(parsed.Path) || containsURLControlOrTemplate(parsed.RawPath) {
+	if err != nil || !parsed.IsAbs() || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" || parsed.User != nil || parsed.Fragment != "" || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" || containsURLControlOrTemplate(parsed.Path) || containsURLControlOrTemplate(parsed.RawPath) || !safeDirectRemoteQuery(parsed) {
 		return "", ErrDirectRemoteRejected
 	}
 	port := parsed.Port()
@@ -422,8 +439,6 @@ func canonicalDirectRemoteURL(rawURL string) (string, error) {
 		parsed.Host = "[" + host + "]"
 	}
 	parsed.User = nil
-	parsed.RawQuery = ""
-	parsed.ForceQuery = false
 	parsed.Fragment = ""
 	if parsed.Path == "" {
 		parsed.Path = "/"
@@ -433,6 +448,38 @@ func canonicalDirectRemoteURL(rawURL string) (string, error) {
 		return "", ErrDirectRemoteRejected
 	}
 	return canonical, nil
+}
+
+func safeDirectRemoteQuery(parsed *url.URL) bool {
+	if parsed == nil || parsed.ForceQuery || containsURLControlOrTemplate(parsed.RawQuery) {
+		return false
+	}
+	values, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return false
+	}
+	for key, entries := range values {
+		if containsURLControlOrTemplate(key) || directRemoteQueryCredentialKey(key) {
+			return false
+		}
+		if slices.ContainsFunc(entries, containsURLControlOrTemplate) {
+			return false
+		}
+	}
+	return true
+}
+
+func directRemoteQueryCredentialKey(key string) bool {
+	normalized := strings.NewReplacer("-", "_", ".", "_", " ", "_").Replace(strings.ToLower(strings.TrimSpace(key)))
+	if strings.HasPrefix(normalized, "x_amz_") || strings.HasPrefix(normalized, "x_goog_") {
+		return true
+	}
+	switch normalized {
+	case "access_token", "api_key", "apikey", "authorization", "credential", "key", "password", "secret", "signature", "sig", "token", "client_secret":
+		return true
+	default:
+		return false
+	}
 }
 
 func containsURLControlOrTemplate(value string) bool {

--- a/server/internal/platformmcp/direct_remote_test.go
+++ b/server/internal/platformmcp/direct_remote_test.go
@@ -24,6 +24,15 @@ func TestCanonicalDirectRemoteURL(t *testing.T) {
 	require.Equal(t, "https://example.test/", canonical)
 }
 
+func TestCanonicalDirectRemoteURLPreservesSafeQuery(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := canonicalDirectRemoteURL("HTTPS://Example.TEST:443/mcp?tenant=example&region=us")
+
+	require.NoError(t, err)
+	require.Equal(t, "https://example.test/mcp?tenant=example&region=us", canonical)
+}
+
 func TestCanonicalDirectRemoteURLRejectsUnsafeShapes(t *testing.T) {
 	t.Parallel()
 
@@ -31,6 +40,7 @@ func TestCanonicalDirectRemoteURLRejectsUnsafeShapes(t *testing.T) {
 		"http://example.test/mcp",
 		"https://user:password@example.test/mcp",
 		"https://example.test/mcp?token=value",
+		"https://example.test/mcp?X-Amz-Signature=value",
 		"https://example.test/mcp#fragment",
 		"https://example.test:8443/mcp",
 		"https://example.test/{tenant}/mcp",
@@ -115,6 +125,25 @@ func TestDirectRemoteOAuthDiscoveryScansForDCR(t *testing.T) {
 	require.Len(t, requests, 3)
 }
 
+func TestDirectRemoteOAuthDiscoveryUsesOIDCCompatibleCandidate(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		switch request.URL.String() {
+		case "https://remote.example.test/.well-known/oauth-protected-resource/mcp":
+			return directRemoteTestResponse(request, http.StatusOK, `{"authorization_servers":["https://issuer.example.test/path"]}`)
+		case "https://issuer.example.test/.well-known/oauth-authorization-server/path":
+			return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
+		case "https://issuer.example.test/.well-known/openid-configuration/path":
+			return directRemoteTestResponse(request, http.StatusOK, `{"registration_endpoint":"https://issuer.example.test/register"}`)
+		default:
+			return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
+		}
+	})
+
+	require.Equal(t, "available_dcr", directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8}))
+}
+
 func TestDirectRemoteOAuthDiscoveryReportsAvailableWithoutDCR(t *testing.T) {
 	t.Parallel()
 
@@ -157,6 +186,7 @@ func TestValidDirectRemoteRegistrationURLRequiresCanonicalForm(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, validDirectRemoteRegistrationURL("https://example.test/mcp"))
+	require.True(t, validDirectRemoteRegistrationURL("https://example.test/mcp?tenant=example"))
 	require.False(t, validDirectRemoteRegistrationURL("https://Example.test/mcp"))
 	require.False(t, validDirectRemoteRegistrationURL("https://example.test:443/mcp"))
 }

--- a/server/internal/platformmcp/direct_remote_test.go
+++ b/server/internal/platformmcp/direct_remote_test.go
@@ -1,9 +1,18 @@
 package platformmcp
 
 import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/dns"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestCanonicalDirectRemoteURL(t *testing.T) {
@@ -32,10 +41,144 @@ func TestCanonicalDirectRemoteURLRejectsUnsafeShapes(t *testing.T) {
 	}
 }
 
+func TestDirectRemoteRequestAcceptsJSONAndSSE(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		require.Equal(t, "application/json, text/event-stream", request.Header.Get("Accept"))
+		return directRemoteTestResponse(request, http.StatusOK, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	})
+
+	_, _, _, status, err := directRemoteRequest(t.Context(), client, "https://remote.example.test/mcp", "initialize", map[string]any{}, "", &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 1})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+}
+
+func TestDirectRemoteNotificationAcceptsJSONAndSSE(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		require.Equal(t, "application/json, text/event-stream", request.Header.Get("Accept"))
+		require.Equal(t, "session-id", request.Header.Get("Mcp-Session-Id"))
+		return directRemoteTestResponse(request, http.StatusAccepted, "")
+	})
+
+	_, status, err := directRemoteNotification(t.Context(), client, "https://remote.example.test/mcp", "notifications/initialized", map[string]any{}, "session-id", &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 1})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, status)
+}
+
+func TestDirectRemoteRequestRejectsOversizedSessionID(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		response := directRemoteTestResponse(request, http.StatusOK, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+		response.Header.Set("Mcp-Session-Id", strings.Repeat("x", directRemoteSessionIDMaxBytes+1))
+		return response
+	})
+
+	_, _, _, _, err := directRemoteRequest(t.Context(), client, "https://remote.example.test/mcp", "initialize", map[string]any{}, "", &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 1})
+
+	require.ErrorIs(t, err, ErrDirectRemoteRejected)
+}
+
+func TestDirectRemoteRequestRejectsOversizedOutboundSessionID(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := directRemoteRequest(context.Background(), http.DefaultClient, "https://remote.example.test/mcp", "tools/list", map[string]any{}, strings.Repeat("x", directRemoteSessionIDMaxBytes+1), &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 1})
+
+	require.ErrorIs(t, err, ErrDirectRemoteRejected)
+}
+
+func TestDirectRemoteOAuthDiscoveryScansForDCR(t *testing.T) {
+	t.Parallel()
+
+	requests := make([]string, 0, 3)
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		requests = append(requests, request.URL.String())
+		switch request.URL.String() {
+		case "https://remote.example.test/.well-known/oauth-protected-resource/mcp":
+			return directRemoteTestResponse(request, http.StatusOK, `{"authorization_servers":["https://first.example.test","https://second.example.test"]}`)
+		case "https://first.example.test/.well-known/oauth-authorization-server":
+			return directRemoteTestResponse(request, http.StatusOK, `{}`)
+		case "https://second.example.test/.well-known/oauth-authorization-server":
+			return directRemoteTestResponse(request, http.StatusOK, `{"registration_endpoint":"https://second.example.test/register"}`)
+		default:
+			return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
+		}
+	})
+	result := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
+
+	require.Equal(t, "available_dcr", result)
+	require.Len(t, requests, 3)
+}
+
+func TestDirectRemoteOAuthDiscoveryReportsAvailableWithoutDCR(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		switch request.URL.String() {
+		case "https://remote.example.test/.well-known/oauth-protected-resource/mcp":
+			return directRemoteTestResponse(request, http.StatusOK, `{"authorization_servers":["https://first.example.test","https://second.example.test"]}`)
+		case "https://first.example.test/.well-known/oauth-authorization-server", "https://second.example.test/.well-known/oauth-authorization-server":
+			return directRemoteTestResponse(request, http.StatusOK, `{}`)
+		default:
+			return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
+		}
+	})
+
+	require.Equal(t, "available", directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8}))
+}
+
+func TestDirectRemoteOAuthDiscoveryReportsIncompleteWithoutAuthorizationMetadata(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
+	})
+
+	require.Equal(t, "incomplete", directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8}))
+}
+
+func directRemoteTestPolicy(t *testing.T) *guardian.Policy {
+	t.Helper()
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{}, guardian.WithResolver(dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(context.Context, string, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("8.8.8.8")}, nil
+		},
+	})))
+	require.NoError(t, err)
+	return policy
+}
+
 func TestValidDirectRemoteRegistrationURLRequiresCanonicalForm(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, validDirectRemoteRegistrationURL("https://example.test/mcp"))
 	require.False(t, validDirectRemoteRegistrationURL("https://Example.test/mcp"))
 	require.False(t, validDirectRemoteRegistrationURL("https://example.test:443/mcp"))
+}
+
+type directRemoteTestRoundTripper func(*http.Request) (*http.Response, error)
+
+func (roundTrip directRemoteTestRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func directRemoteTestClient(t *testing.T, response func(*http.Request) *http.Response) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: directRemoteTestRoundTripper(func(request *http.Request) (*http.Response, error) {
+		return response(request), nil
+	})}
+}
+
+func directRemoteTestResponse(request *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}
 }

--- a/server/internal/platformmcp/direct_remote_test.go
+++ b/server/internal/platformmcp/direct_remote_test.go
@@ -1,0 +1,41 @@
+package platformmcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalDirectRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := canonicalDirectRemoteURL(" HTTPS://Example.TEST:443 ")
+
+	require.NoError(t, err)
+	require.Equal(t, "https://example.test/", canonical)
+}
+
+func TestCanonicalDirectRemoteURLRejectsUnsafeShapes(t *testing.T) {
+	t.Parallel()
+
+	for _, rawURL := range []string{
+		"http://example.test/mcp",
+		"https://user:password@example.test/mcp",
+		"https://example.test/mcp?token=value",
+		"https://example.test/mcp#fragment",
+		"https://example.test:8443/mcp",
+		"https://example.test/{tenant}/mcp",
+		"https://example.test/mcp\nX-Header: value",
+	} {
+		_, err := canonicalDirectRemoteURL(rawURL)
+		require.ErrorIs(t, err, ErrDirectRemoteRejected, rawURL)
+	}
+}
+
+func TestValidDirectRemoteRegistrationURLRequiresCanonicalForm(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, validDirectRemoteRegistrationURL("https://example.test/mcp"))
+	require.False(t, validDirectRemoteRegistrationURL("https://Example.test/mcp"))
+	require.False(t, validDirectRemoteRegistrationURL("https://example.test:443/mcp"))
+}

--- a/server/internal/platformmcp/gate.go
+++ b/server/internal/platformmcp/gate.go
@@ -99,10 +99,19 @@ func NewCatalogRegistrationGate(platform Gate) *CatalogRegistrationGate {
 }
 
 func (g *CatalogRegistrationGate) Enabled(ctx context.Context, organizationID, projectSlug string) (bool, error) {
-	if g == nil || g.platform == nil || organizationID == "" || projectSlug == "" {
+	if projectSlug == "" {
 		return false, ErrUnavailable
 	}
+	return g.EnabledOrganization(ctx, organizationID)
+}
 
+// EnabledOrganization checks the same rollout and durable entitlement as a
+// mutation without accepting a project selector. Read-only direct inspection
+// needs this gate before it can perform user-directed egress.
+func (g *CatalogRegistrationGate) EnabledOrganization(ctx context.Context, organizationID string) (bool, error) {
+	if g == nil || g.platform == nil || organizationID == "" {
+		return false, ErrUnavailable
+	}
 	enabled, err := g.platform.Enabled(ctx, organizationID)
 	if err != nil {
 		return false, fmt.Errorf("check platform mcp gate: %w", err)

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -62,26 +62,16 @@ func (b OperationBudget) Allow(ctx context.Context, principal Principal) error {
 	if !b.valid() || principal.OrganizationID == "" {
 		return ErrOperationBudgetUnavailable
 	}
-	// A surface acting under assistant identity holds no OAuth connection, so
-	// there is no connection bucket to charge and the organization bucket meters
-	// it alone. Refusing the operation instead would deny every connection-less
-	// caller, and keying the connection bucket on the empty string would pool
-	// every such caller across every organization into one bucket.
-	if principal.HasConnection() {
-		// HasConnection is an OR, so a principal claiming a connection through its
-		// generation alone lands here rather than being metered as connection-less.
-		// It has no key to charge, and charging the empty string would pool every
-		// such caller into one bucket, so the budget is unavailable to it.
-		if principal.ConnectionID == "" {
-			return ErrOperationBudgetUnavailable
-		}
-		connection, err := b.Connection.Allow(ctx, principal.ConnectionID)
-		if err != nil {
-			return fmt.Errorf("limit platform mcp connection operation: %w: %w", ErrOperationBudgetUnavailable, err)
-		}
-		if !connection.Allowed {
-			return ErrOperationRateLimited
-		}
+	actorKey, err := operationBudgetActorKey(principal)
+	if err != nil {
+		return err
+	}
+	connection, err := b.Connection.Allow(ctx, actorKey)
+	if err != nil {
+		return fmt.Errorf("limit platform mcp actor operation: %w: %w", ErrOperationBudgetUnavailable, err)
+	}
+	if !connection.Allowed {
+		return ErrOperationRateLimited
 	}
 	organization, err := b.Organization.Allow(ctx, principal.OrganizationID)
 	if err != nil {
@@ -91,6 +81,24 @@ func (b OperationBudget) Allow(ctx context.Context, principal Principal) error {
 		return ErrOperationRateLimited
 	}
 	return nil
+}
+
+// operationBudgetActorKey is the actor bucket for remote egress and mutations.
+// External Platform MCP calls are isolated by their OAuth connection. A managed
+// assistant has no connection, so it is isolated by its fixed client identity
+// and the real user that authorized the action; it never pools all assistants
+// into one empty-key bucket.
+func operationBudgetActorKey(principal Principal) (string, error) {
+	if principal.HasConnection() {
+		if principal.ConnectionID == "" {
+			return "", ErrOperationBudgetUnavailable
+		}
+		return principal.ConnectionID, nil
+	}
+	if principal.surface() != SurfaceProjectAssistant || principal.ClientID == "" || principal.UserID == "" {
+		return "", ErrOperationBudgetUnavailable
+	}
+	return "assistant:" + principal.ClientID + ":" + principal.UserID, nil
 }
 
 // OperationBudgets groups the independently metered public Platform MCP

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -47,29 +47,28 @@ func TestOperationBudgetDistinguishesLimiterFailureFromThrottle(t *testing.T) {
 	require.NotErrorIs(t, err, ErrOperationRateLimited)
 }
 
-func TestOperationBudgetMetersAConnectionlessPrincipalOnTheOrganizationAlone(t *testing.T) {
+func TestOperationBudgetMetersAConnectionlessAssistantByUser(t *testing.T) {
 	t.Parallel()
 
 	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
 	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
-	err := (OperationBudget{Connection: connection, Organization: organization}).Allow(t.Context(), Principal{ConnectionID: "", OrganizationID: "organization"})
+	err := (OperationBudget{Connection: connection, Organization: organization}).Allow(t.Context(), Principal{UserID: "user", OrganizationID: "organization", ClientID: AssistantClientID, Surface: SurfaceProjectAssistant})
 
 	require.NoError(t, err)
-	require.Empty(t, connection.keys)
+	require.Equal(t, []string{"assistant:" + AssistantClientID + ":user"}, connection.keys)
 	require.Equal(t, []string{"organization"}, organization.keys)
 }
 
-func TestOperationBudgetThrottlesAConnectionlessPrincipalOnTheOrganization(t *testing.T) {
+func TestOperationBudgetThrottlesAConnectionlessAssistantBeforeOrganization(t *testing.T) {
 	t.Parallel()
 
-	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}
-	err := (OperationBudget{
-		Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
-		Organization: organization,
-	}).Allow(t.Context(), Principal{ConnectionID: "", OrganizationID: "organization"})
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	err := (OperationBudget{Connection: connection, Organization: organization}).Allow(t.Context(), Principal{UserID: "user", OrganizationID: "organization", ClientID: AssistantClientID, Surface: SurfaceProjectAssistant})
 
 	require.ErrorIs(t, err, ErrOperationRateLimited)
-	require.Equal(t, []string{"organization"}, organization.keys)
+	require.Equal(t, []string{"assistant:" + AssistantClientID + ":user"}, connection.keys)
+	require.Empty(t, organization.keys)
 }
 
 func TestOperationBudgetRejectsAConnectionClaimedByGenerationAlone(t *testing.T) {
@@ -90,7 +89,7 @@ func TestOperationBudgetStillRequiresAnOrganization(t *testing.T) {
 	err := (OperationBudget{
 		Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
 		Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
-	}).Allow(t.Context(), Principal{ConnectionID: "", OrganizationID: ""})
+	}).Allow(t.Context(), Principal{UserID: "user", ClientID: AssistantClientID, Surface: SurfaceProjectAssistant, OrganizationID: ""})
 
 	require.ErrorIs(t, err, ErrOperationBudgetUnavailable)
 }

--- a/server/internal/platformmcp/registration.go
+++ b/server/internal/platformmcp/registration.go
@@ -38,7 +38,6 @@ const (
 	registrationStatusPending    = "pending"
 	registrationStatusRegistered = "registered"
 	receiptLifetime              = 24 * time.Hour
-	platformMCPIssuerLifetime    = 14 * 24 * time.Hour
 	maxMCPEndpointSlugLength     = 128
 )
 
@@ -500,7 +499,7 @@ func (s *RegistrationStore) CompleteRegistration(ctx context.Context, principal 
 	if s == nil || s.db == nil {
 		return OperationReceipt{}, ErrUnavailable
 	}
-	if err := validateCatalogRegistrationRequest(principal, project, request); err != nil || receipt.ID == uuid.Nil || !receipt.RegistrationID.Valid || !validRegistrationRemoteURL(configuration.remoteURL) {
+	if err := validateCatalogRegistrationRequest(principal, project, request); err != nil || receipt.ID == uuid.Nil || !receipt.RegistrationID.Valid || !validRegistrationRemoteURL(configuration.remoteURL) || (request.SourceKind == directRemoteSourceKind && !validDirectRemoteRegistrationURL(configuration.remoteURL)) {
 		return OperationReceipt{}, ErrRegistrationInvalid
 	}
 	connectionID, generation, err := principalConnection(principal)
@@ -707,10 +706,6 @@ func (s *RegistrationStore) createPrivateRegistrationComponents(ctx context.Cont
 	if err != nil {
 		return platformrepo.PlatformMcpCatalogRegistration{}, fmt.Errorf("generate platform mcp remote source id: %w", err)
 	}
-	serverID, err := uuid.NewV7()
-	if err != nil {
-		return platformrepo.PlatformMcpCatalogRegistration{}, fmt.Errorf("generate platform mcp server id: %w", err)
-	}
 	suffix, err := newRegistrationComponentSuffix()
 	if err != nil {
 		return platformrepo.PlatformMcpCatalogRegistration{}, err
@@ -720,7 +715,6 @@ func (s *RegistrationStore) createPrivateRegistrationComponents(ctx context.Cont
 		return platformrepo.PlatformMcpCatalogRegistration{}, fmt.Errorf("load platform mcp component organization: %w", err)
 	}
 	remoteSlug := "platform-mcp-remote-" + suffix
-	serverSlug := "platform-mcp-" + suffix
 	displayName := configuration.displayName
 	if displayName == "" {
 		displayName = "MCP Catalogue server"
@@ -767,13 +761,18 @@ func (s *RegistrationStore) createPrivateRegistrationComponents(ctx context.Cont
 		Slug:               "platform-mcp-issuer-" + suffix,
 		AuthnChallengeMode: "interactive",
 		SessionDuration: pgtype.Interval{
-			Microseconds: platformMCPIssuerLifetime.Microseconds(),
+			Microseconds: 14 * 24 * time.Hour.Microseconds(),
 			Valid:        true,
 		},
 	})
 	if err != nil {
 		return platformrepo.PlatformMcpCatalogRegistration{}, fmt.Errorf("create platform mcp session issuer: %w", err)
 	}
+	serverID, err := uuid.NewV7()
+	if err != nil {
+		return platformrepo.PlatformMcpCatalogRegistration{}, fmt.Errorf("generate platform mcp server id: %w", err)
+	}
+	serverSlug := "platform-mcp-" + suffix
 	server, err := mcpserversrepo.New(tx).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
 		ID:                  serverID,
 		ProjectID:           project.ID,

--- a/server/internal/platformmcp/registration_service.go
+++ b/server/internal/platformmcp/registration_service.go
@@ -16,6 +16,7 @@ var ErrRegistrationUnavailable = errors.New("platform mcp catalog registration u
 
 type CatalogRegistrationGateChecker interface {
 	Enabled(ctx context.Context, organizationID, projectSlug string) (bool, error)
+	EnabledOrganization(ctx context.Context, organizationID string) (bool, error)
 }
 
 type RegistrationPersistence interface {
@@ -74,6 +75,7 @@ type RegistrationService struct {
 	readiness                  *ReadinessService
 	dashboardURL               *url.URL
 	identityProviderAttachment CatalogIdentityProviderAttachment
+	directRemoteInspector      DirectRemoteInspector
 	budgets                    OperationBudgets
 	telemetry                  LifecycleTelemetry
 }
@@ -122,6 +124,15 @@ func (s *RegistrationService) WithReadiness(readiness *ReadinessService) *Regist
 func (s *RegistrationService) WithIdentityProviderAttachment(attachment CatalogIdentityProviderAttachment) *RegistrationService {
 	if s != nil {
 		s.identityProviderAttachment = attachment
+	}
+	return s
+}
+
+// WithDirectRemoteInspector enables direct user-supplied remote MCP admission.
+// The inspector is server-composed because it owns Guardian-backed egress.
+func (s *RegistrationService) WithDirectRemoteInspector(inspector DirectRemoteInspector) *RegistrationService {
+	if s != nil {
+		s.directRemoteInspector = inspector
 	}
 	return s
 }
@@ -188,6 +199,13 @@ func (s *RegistrationService) DashboardSetupURL(ctx context.Context, principal P
 	}
 	if persisted.ProviderKey != catalog.ProviderKey || persisted.CatalogRef != catalog.CatalogRef {
 		return "", ErrCatalogRejected
+	}
+	return s.dashboardSettingsURL(ctx, principal, project, registrationID)
+}
+
+func (s *RegistrationService) dashboardSettingsURL(ctx context.Context, principal Principal, project ResolvedProject, registrationID uuid.UUID) (string, error) {
+	if s == nil || s.store == nil || s.dashboardURL == nil || registrationID == uuid.Nil {
+		return "", ErrRegistrationUnavailable
 	}
 	setup, err := s.store.ResolveRegistrationDashboardSetup(ctx, principal, project, registrationID)
 	if err != nil {
@@ -333,6 +351,100 @@ func (s *RegistrationService) IssueSetupHandoffForRegistration(ctx context.Conte
 		ProviderKey:    candidate.ProviderKey,
 		CatalogRef:     candidate.CatalogRef,
 	})
+}
+
+type RegisterRemoteMCPInput struct {
+	ProjectSlug    string
+	RemoteURL      string
+	DisplayName    string
+	IdempotencyKey string
+}
+
+type RegisterRemoteMCPResult struct {
+	Project           ResolvedProject
+	RemoteURL         string
+	Receipt           OperationReceipt
+	Registration      string
+	NextAction        string
+	DashboardSetupURL string
+}
+
+// RegisterRemoteMCP re-inspects the exact URL before persistence. An inspection
+// result from an earlier MCP call is deliberately not trusted as admission
+// evidence, and no caller can supply credentials or headers.
+func (s *RegistrationService) RegisterRemoteMCP(ctx context.Context, principal Principal, input RegisterRemoteMCPInput) (RegisterRemoteMCPResult, error) {
+	if s == nil || s.gate == nil || s.store == nil || s.directRemoteInspector == nil || !s.budgets.Registration.valid() || input.ProjectSlug == "" || input.RemoteURL == "" || input.IdempotencyKey == "" {
+		return RegisterRemoteMCPResult{}, ErrRegistrationUnavailable
+	}
+	if err := s.budgets.Registration.Allow(ctx, principal); err != nil {
+		return RegisterRemoteMCPResult{}, err
+	}
+	enabled, err := s.gate.Enabled(ctx, principal.OrganizationID, input.ProjectSlug)
+	if err != nil {
+		return RegisterRemoteMCPResult{}, fmt.Errorf("check direct remote registration gate: %w", err)
+	}
+	if !enabled {
+		return RegisterRemoteMCPResult{}, ErrRegistrationUnavailable
+	}
+	inspection, err := s.directRemoteInspector.Inspect(ctx, input.RemoteURL)
+	if err != nil {
+		return RegisterRemoteMCPResult{}, err
+	}
+	if inspection.CanonicalURL == "" || inspection.Transport != "streamable-http" || inspection.Trust != "user_supplied_unreviewed" {
+		return RegisterRemoteMCPResult{}, ErrDirectRemoteRejected
+	}
+	project, err := s.store.ResolveProject(ctx, principal.OrganizationID, input.ProjectSlug)
+	if err != nil {
+		return RegisterRemoteMCPResult{}, fmt.Errorf("resolve direct remote registration project: %w", err)
+	}
+	if err := s.requireEligibleTarget(ctx, principal.OrganizationID, project); err != nil {
+		return RegisterRemoteMCPResult{}, err
+	}
+	displayName := strings.TrimSpace(input.DisplayName)
+	if displayName == "" {
+		displayName = inspection.CanonicalURL
+	}
+	request := CatalogRegistrationRequest{
+		ProjectSlug:      project.Slug,
+		SourceKind:       directRemoteSourceKind,
+		CatalogProvider:  directRemoteProviderKey,
+		CatalogReference: inspection.CanonicalURL,
+		IdempotencyKey:   input.IdempotencyKey,
+		InputHash:        catalogRegistrationInputHash(project.Slug, directRemoteSourceKind, directRemoteProviderKey, inspection.CanonicalURL),
+	}
+	receipt, err := s.store.BeginReceipt(ctx, principal, project, request, s.now())
+	if err != nil {
+		return RegisterRemoteMCPResult{}, fmt.Errorf("begin direct remote registration receipt: %w", err)
+	}
+	if !receipt.Replayed || receipt.Status == receiptStatusPending {
+		receipt, err = s.store.ConvergeRegistration(ctx, principal, project, request, receipt)
+		if err != nil {
+			return RegisterRemoteMCPResult{}, fmt.Errorf("converge direct remote registration: %w", err)
+		}
+	}
+	if receipt.ResultCode == receiptResultActiveCap {
+		return RegisterRemoteMCPResult{}, ErrRegistrationCap
+	}
+	if !receipt.RegistrationID.Valid {
+		return RegisterRemoteMCPResult{}, ErrRegistrationUnavailable
+	}
+	if receipt.Status == receiptStatusPending {
+		receipt, err = s.store.CompleteRegistration(ctx, principal, project, request, receipt, resolvedCatalogConfiguration{remoteURL: inspection.CanonicalURL, displayName: displayName})
+		if err != nil {
+			return RegisterRemoteMCPResult{}, fmt.Errorf("complete direct remote registration: %w", err)
+		}
+	}
+	setupURL := ""
+	nextAction := "ready"
+	if inspection.RequiresDashboardSetup {
+		setupURL, err = s.dashboardSettingsURL(ctx, principal, project, receipt.RegistrationID.UUID)
+		if err != nil {
+			return RegisterRemoteMCPResult{}, fmt.Errorf("resolve direct remote dashboard setup: %w", err)
+		}
+		nextAction = "secure_dashboard_setup_required"
+	}
+	s.telemetry.Record(ctx, LifecycleEvent{Operation: "direct_remote_registration", Phase: "complete", Outcome: "succeeded", State: ""})
+	return RegisterRemoteMCPResult{Project: project, RemoteURL: inspection.CanonicalURL, Receipt: receipt, Registration: receipt.RegistrationID.UUID.String(), NextAction: nextAction, DashboardSetupURL: setupURL}, nil
 }
 
 func (s *RegistrationService) RegisterCatalogMCP(ctx context.Context, principal Principal, input RegisterCatalogMCPInput) (RegisterCatalogMCPResult, error) {

--- a/server/internal/platformmcp/registration_service.go
+++ b/server/internal/platformmcp/registration_service.go
@@ -14,6 +14,8 @@ import (
 
 var ErrRegistrationUnavailable = errors.New("platform mcp catalog registration unavailable")
 
+const directRemoteDisplayNameMaxBytes = 256
+
 type CatalogRegistrationGateChecker interface {
 	Enabled(ctx context.Context, organizationID, projectSlug string) (bool, error)
 	EnabledOrganization(ctx context.Context, organizationID string) (bool, error)
@@ -393,6 +395,10 @@ func (s *RegistrationService) RegisterRemoteMCP(ctx context.Context, principal P
 	if inspection.CanonicalURL == "" || inspection.Transport != "streamable-http" || inspection.Trust != "user_supplied_unreviewed" {
 		return RegisterRemoteMCPResult{}, ErrDirectRemoteRejected
 	}
+	displayName := strings.TrimSpace(input.DisplayName)
+	if len(displayName) > directRemoteDisplayNameMaxBytes || strings.ContainsAny(displayName, "\r\n") {
+		return RegisterRemoteMCPResult{}, ErrRegistrationInvalid
+	}
 	project, err := s.store.ResolveProject(ctx, principal.OrganizationID, input.ProjectSlug)
 	if err != nil {
 		return RegisterRemoteMCPResult{}, fmt.Errorf("resolve direct remote registration project: %w", err)
@@ -400,7 +406,6 @@ func (s *RegistrationService) RegisterRemoteMCP(ctx context.Context, principal P
 	if err := s.requireEligibleTarget(ctx, principal.OrganizationID, project); err != nil {
 		return RegisterRemoteMCPResult{}, err
 	}
-	displayName := strings.TrimSpace(input.DisplayName)
 	if displayName == "" {
 		displayName = inspection.CanonicalURL
 	}

--- a/server/internal/platformmcp/registration_service_test.go
+++ b/server/internal/platformmcp/registration_service_test.go
@@ -63,6 +63,61 @@ func TestRegistrationServiceRegistersReviewedCandidateWithServerComputedHash(t *
 	require.Equal(t, 1, store.completeCalls)
 }
 
+type testDirectRemoteInspector struct {
+	inspection DirectRemoteInspection
+	err        error
+	calls      int
+	rawURL     string
+}
+
+func (i *testDirectRemoteInspector) Inspect(_ context.Context, rawURL string) (DirectRemoteInspection, error) {
+	i.calls++
+	i.rawURL = rawURL
+	return i.inspection, i.err
+}
+
+func TestRegistrationServiceRegistersDirectRemoteWithFreshInspection(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Name: "Project", Slug: "project"}
+	registrationID := uuid.New()
+	store := &recordingRegistrationStore{
+		project:   project,
+		begin:     OperationReceipt{ID: uuid.New()},
+		converged: OperationReceipt{ID: uuid.New(), RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, Status: receiptStatusPending},
+		completed: OperationReceipt{ID: uuid.New(), RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, Status: receiptStatusSucceeded},
+	}
+	inspector := &testDirectRemoteInspector{inspection: DirectRemoteInspection{CanonicalURL: "https://remote.example.test/mcp", Transport: "streamable-http", Trust: "user_supplied_unreviewed"}}
+	service := newRegistrationService(testCatalog{}, &testRegistrationGate{enabled: true}, store).WithDirectRemoteInspector(inspector)
+
+	result, err := service.RegisterRemoteMCP(t.Context(), registrationServicePrincipal(), RegisterRemoteMCPInput{ProjectSlug: project.Slug, RemoteURL: "https://REMOTE.example.test/mcp", DisplayName: "External MCP", IdempotencyKey: "request-key"})
+
+	require.NoError(t, err)
+	require.Equal(t, "https://REMOTE.example.test/mcp", inspector.rawURL)
+	require.Equal(t, 1, inspector.calls)
+	require.Equal(t, directRemoteSourceKind, store.request.SourceKind)
+	require.Equal(t, directRemoteProviderKey, store.request.CatalogProvider)
+	require.Equal(t, "https://remote.example.test/mcp", store.request.CatalogReference)
+	require.Equal(t, "External MCP", store.configuration.displayName)
+	require.Equal(t, "https://remote.example.test/mcp", store.configuration.remoteURL)
+	require.Equal(t, registrationID.String(), result.Registration)
+}
+
+func TestRegistrationServiceRejectsDirectRemoteBeforePersistence(t *testing.T) {
+	t.Parallel()
+
+	store := &recordingRegistrationStore{project: ResolvedProject{ID: uuid.New(), Slug: "project"}}
+	inspector := &testDirectRemoteInspector{err: ErrDirectRemoteRejected}
+	service := newRegistrationService(testCatalog{}, &testRegistrationGate{enabled: true}, store).WithDirectRemoteInspector(inspector)
+
+	_, err := service.RegisterRemoteMCP(t.Context(), registrationServicePrincipal(), RegisterRemoteMCPInput{ProjectSlug: "project", RemoteURL: "https://unsafe.example.test/mcp", IdempotencyKey: "request-key"})
+
+	require.ErrorIs(t, err, ErrDirectRemoteRejected)
+	require.Equal(t, 1, inspector.calls)
+	require.Zero(t, store.resolveCalls)
+	require.Zero(t, store.beginCalls)
+}
+
 func TestRegistrationServiceRejectsSecretConfigurationBeforePersistence(t *testing.T) {
 	t.Parallel()
 
@@ -429,6 +484,13 @@ func (g *testRegistrationGate) Enabled(_ context.Context, organizationID, projec
 	g.calls++
 	g.organizationID = organizationID
 	g.projectSlug = projectSlug
+	return g.enabled, g.err
+}
+
+func (g *testRegistrationGate) EnabledOrganization(_ context.Context, organizationID string) (bool, error) {
+	g.calls++
+	g.organizationID = organizationID
+	g.projectSlug = ""
 	return g.enabled, g.err
 }
 

--- a/server/internal/platformmcp/registration_service_test.go
+++ b/server/internal/platformmcp/registration_service_test.go
@@ -103,6 +103,40 @@ func TestRegistrationServiceRegistersDirectRemoteWithFreshInspection(t *testing.
 	require.Equal(t, registrationID.String(), result.Registration)
 }
 
+func TestRegistrationServiceRejectsOversizedDirectRemoteDisplayNameBeforePersistence(t *testing.T) {
+	t.Parallel()
+
+	store := &recordingRegistrationStore{project: ResolvedProject{ID: uuid.New(), Slug: "project"}}
+	inspector := &testDirectRemoteInspector{inspection: DirectRemoteInspection{CanonicalURL: "https://remote.example.test/mcp", Transport: "streamable-http", Trust: "user_supplied_unreviewed"}}
+	service := newRegistrationService(testCatalog{}, &testRegistrationGate{enabled: true}, store).WithDirectRemoteInspector(inspector)
+
+	_, err := service.RegisterRemoteMCP(t.Context(), registrationServicePrincipal(), RegisterRemoteMCPInput{
+		ProjectSlug: "project", RemoteURL: "https://remote.example.test/mcp", DisplayName: string(make([]byte, directRemoteDisplayNameMaxBytes+1)), IdempotencyKey: "request-key",
+	})
+
+	require.ErrorIs(t, err, ErrRegistrationInvalid)
+	require.Equal(t, 1, inspector.calls)
+	require.Zero(t, store.resolveCalls)
+	require.Zero(t, store.beginCalls)
+}
+
+func TestRegistrationServiceRejectsDirectRemoteDisplayNameWithNewlineBeforePersistence(t *testing.T) {
+	t.Parallel()
+
+	store := &recordingRegistrationStore{project: ResolvedProject{ID: uuid.New(), Slug: "project"}}
+	inspector := &testDirectRemoteInspector{inspection: DirectRemoteInspection{CanonicalURL: "https://remote.example.test/mcp", Transport: "streamable-http", Trust: "user_supplied_unreviewed"}}
+	service := newRegistrationService(testCatalog{}, &testRegistrationGate{enabled: true}, store).WithDirectRemoteInspector(inspector)
+
+	_, err := service.RegisterRemoteMCP(t.Context(), registrationServicePrincipal(), RegisterRemoteMCPInput{
+		ProjectSlug: "project", RemoteURL: "https://remote.example.test/mcp", DisplayName: "External\r\nMCP", IdempotencyKey: "request-key",
+	})
+
+	require.ErrorIs(t, err, ErrRegistrationInvalid)
+	require.Equal(t, 1, inspector.calls)
+	require.Zero(t, store.resolveCalls)
+	require.Zero(t, store.beginCalls)
+}
+
 func TestRegistrationServiceRejectsDirectRemoteBeforePersistence(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/skills_test.go
+++ b/server/internal/platformmcp/skills_test.go
@@ -147,6 +147,10 @@ func (s stubSkillsGate) Enabled(_ context.Context, _, _ string) (bool, error) {
 	return s.enabled, s.err
 }
 
+func (s stubSkillsGate) EnabledOrganization(_ context.Context, _ string) (bool, error) {
+	return s.enabled, s.err
+}
+
 func testTargets() []SkillTarget {
 	return []SkillTarget{
 		{Kind: SkillTargetPlugin, ID: testDefaultPluginID, Name: "Default", Slug: "default", IsDefault: true},

--- a/server/internal/platformmcp/tool_catalog.go
+++ b/server/internal/platformmcp/tool_catalog.go
@@ -24,7 +24,7 @@ type SearchCatalogOutput struct {
 type InspectCatalogCandidateInput struct {
 	ProviderKey string `json:"provider_key,omitempty" jsonschema:"reviewed provider key returned by search_mcp_catalog; provide with catalog_ref, or provide remote_url instead"`
 	CatalogRef  string `json:"catalog_ref,omitempty" jsonschema:"canonical catalog reference returned by search_mcp_catalog; provide with provider_key, or provide remote_url instead"`
-	RemoteURL   string `json:"remote_url,omitempty" jsonschema:"user-supplied HTTPS Streamable HTTP MCP URL; mutually exclusive with provider_key and catalog_ref; credentials, query parameters, and fragments are not supported"`
+	RemoteURL   string `json:"remote_url,omitempty" jsonschema:"user-supplied HTTPS Streamable HTTP MCP URL; mutually exclusive with provider_key and catalog_ref; safe endpoint query parameters are supported, but credentials, credential-like query parameters, and fragments are not"`
 }
 
 // CandidateInspection is the safe common projection for reviewed and direct

--- a/server/internal/platformmcp/tool_catalog.go
+++ b/server/internal/platformmcp/tool_catalog.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -21,8 +22,29 @@ type SearchCatalogOutput struct {
 }
 
 type InspectCatalogCandidateInput struct {
-	ProviderKey string `json:"provider_key" jsonschema:"reviewed provider key returned by search_mcp_catalog"`
-	CatalogRef  string `json:"catalog_ref" jsonschema:"canonical catalog reference returned by search_mcp_catalog"`
+	ProviderKey string `json:"provider_key,omitempty" jsonschema:"reviewed provider key returned by search_mcp_catalog; provide with catalog_ref, or provide remote_url instead"`
+	CatalogRef  string `json:"catalog_ref,omitempty" jsonschema:"canonical catalog reference returned by search_mcp_catalog; provide with provider_key, or provide remote_url instead"`
+	RemoteURL   string `json:"remote_url,omitempty" jsonschema:"user-supplied HTTPS Streamable HTTP MCP URL; mutually exclusive with provider_key and catalog_ref; credentials, query parameters, and fragments are not supported"`
+}
+
+// CandidateInspection is the safe common projection for reviewed and direct
+// candidate paths. Direct remote URLs are always marked unreviewed and never
+// enter the reviewed catalogue.
+type CandidateInspection struct {
+	ProviderKey            string                      `json:"provider_key,omitempty"`
+	CatalogRef             string                      `json:"catalog_ref,omitempty"`
+	CanonicalURL           string                      `json:"canonical_url,omitempty"`
+	Name                   string                      `json:"name,omitempty"`
+	Description            string                      `json:"description,omitempty"`
+	Version                string                      `json:"version,omitempty"`
+	Transport              string                      `json:"transport"`
+	ToolNames              []string                    `json:"tool_names"`
+	ToolCount              int                         `json:"tool_count"`
+	Configuration          []CatalogConfigurationField `json:"configuration,omitempty"`
+	RequiresDashboardSetup bool                        `json:"requires_dashboard_setup"`
+	Trust                  string                      `json:"trust"`
+	Authentication         string                      `json:"authentication,omitempty"`
+	OAuthDiscovery         string                      `json:"oauth_discovery,omitempty"`
 }
 
 func registerCatalogTools(reg *Registrar, catalog Catalog, budget OperationBudget, cursorCodec *catalogCursorCodec, onboarding *OnboardingService) {
@@ -42,10 +64,7 @@ func registerCatalogTools(reg *Registrar, catalog Catalog, budget OperationBudge
 			}
 			return nil, SearchCatalogOutput{}, err
 		}
-		if catalog == nil {
-			return nil, SearchCatalogOutput{}, ErrCatalogUnavailable
-		}
-		if cursorCodec == nil {
+		if catalog == nil || cursorCodec == nil {
 			return nil, SearchCatalogOutput{}, ErrCatalogUnavailable
 		}
 		position := 0
@@ -80,53 +99,68 @@ func registerCatalogTools(reg *Registrar, catalog Catalog, budget OperationBudge
 		}
 		output := SearchCatalogOutput{Candidates: page}
 		if nextPosition > 0 {
-			output.NextCursor, err = cursorCodec.Encode(catalogCursor{
-				OrganizationID: principal.OrganizationID,
-				Generation:     principalCursorBinding(principal),
-				Query:          normalizeCatalogQuery(input.Query),
-				ProviderKey:    providerKey,
-				Position:       nextPosition,
-			})
+			output.NextCursor, err = cursorCodec.Encode(catalogCursor{OrganizationID: principal.OrganizationID, Generation: principalCursorBinding(principal), Query: normalizeCatalogQuery(input.Query), ProviderKey: providerKey, Position: nextPosition})
 			if err != nil {
 				return nil, SearchCatalogOutput{}, fmt.Errorf("encode platform mcp catalog cursor: %w", err)
 			}
 		}
 		return nil, output, nil
 	})
+}
 
+func registerCandidateInspectionTool(reg *Registrar, catalog Catalog, directRemote DirectRemoteInspector, gate CatalogRegistrationGateChecker, budget OperationBudget) {
 	addTool(reg, &mcp.Tool{
 		Name:        "inspect_mcp_candidate",
 		Title:       "Inspect MCP Candidate",
-		Description: "Inspect one reviewed catalog MCP candidate by its provider key and canonical catalog reference.",
+		Description: "Inspect one reviewed catalog MCP candidate or one user-supplied HTTPS Streamable HTTP MCP URL. Inspection does not register or distribute an MCP.",
 		Annotations: readOnlyAnnotations(),
-	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input InspectCatalogCandidateInput) (*mcp.CallToolResult, CatalogDetails, error) {
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input InspectCatalogCandidateInput) (*mcp.CallToolResult, CandidateInspection, error) {
 		principal, err := principalFromToolContext(ctx)
 		if err != nil {
-			return nil, CatalogDetails{}, err
+			return nil, CandidateInspection{}, err
 		}
 		if err := budget.Allow(ctx, principal); err != nil {
 			if result, ok := operationBudgetToolResult(err); ok {
-				return result, CatalogDetails{}, nil
+				return result, CandidateInspection{}, nil
 			}
-			return nil, CatalogDetails{}, err
+			return nil, CandidateInspection{}, err
 		}
-		if input.ProviderKey == "" || input.CatalogRef == "" {
-			return nil, CatalogDetails{}, ErrCatalogRejected
+		remoteURL := strings.TrimSpace(input.RemoteURL)
+		catalogSelection := input.ProviderKey != "" || input.CatalogRef != ""
+		if (remoteURL == "" && (!catalogSelection || input.ProviderKey == "" || input.CatalogRef == "")) || (remoteURL != "" && catalogSelection) {
+			return nil, CandidateInspection{}, ErrCatalogRejected
+		}
+		if remoteURL != "" {
+			if directRemote == nil || gate == nil {
+				return nil, CandidateInspection{}, ErrDirectRemoteUnavailable
+			}
+			enabled, err := gate.EnabledOrganization(ctx, principal.OrganizationID)
+			if err != nil {
+				return nil, CandidateInspection{}, fmt.Errorf("check direct remote inspection gate: %w", err)
+			}
+			if !enabled {
+				return nil, CandidateInspection{}, ErrDirectRemoteUnavailable
+			}
+			inspection, err := directRemote.Inspect(ctx, remoteURL)
+			if err != nil {
+				return nil, CandidateInspection{}, err
+			}
+			return nil, CandidateInspection{CanonicalURL: inspection.CanonicalURL, Transport: inspection.Transport, ToolNames: inspection.ToolNames, ToolCount: inspection.ToolCount, RequiresDashboardSetup: inspection.RequiresDashboardSetup, Trust: inspection.Trust, Authentication: inspection.Authentication, OAuthDiscovery: inspection.OAuthDiscovery}, nil
 		}
 		if catalog == nil {
-			return nil, CatalogDetails{}, ErrCatalogUnavailable
+			return nil, CandidateInspection{}, ErrCatalogUnavailable
 		}
 		details, err := catalog.Inspect(ctx, input.ProviderKey, input.CatalogRef)
 		if errors.Is(err, ErrCatalogRejected) {
-			return nil, CatalogDetails{}, ErrCatalogRejected
+			return nil, CandidateInspection{}, ErrCatalogRejected
 		}
 		if err != nil {
 			if result, ok := operationBudgetToolResult(ErrCatalogUnavailable); ok {
-				return result, CatalogDetails{}, nil
+				return result, CandidateInspection{}, nil
 			}
-			return nil, CatalogDetails{}, ErrCatalogUnavailable
+			return nil, CandidateInspection{}, ErrCatalogUnavailable
 		}
-		return nil, details, nil
+		return nil, CandidateInspection{ProviderKey: details.ProviderKey, CatalogRef: details.CatalogRef, Name: details.Name, Description: details.Description, Version: details.Version, Transport: details.Transport, ToolNames: details.ToolNames, ToolCount: details.ToolCount, Configuration: details.Configuration, RequiresDashboardSetup: details.RequiresDashboardSetup, Trust: "reviewed_catalog"}, nil
 	})
 }
 

--- a/server/internal/platformmcp/tool_catalog.go
+++ b/server/internal/platformmcp/tool_catalog.go
@@ -45,6 +45,7 @@ type CandidateInspection struct {
 	Trust                  string                      `json:"trust"`
 	Authentication         string                      `json:"authentication,omitempty"`
 	OAuthDiscovery         string                      `json:"oauth_discovery,omitempty"`
+	SetupIntent            string                      `json:"setup_intent,omitempty"`
 }
 
 func registerCatalogTools(reg *Registrar, catalog Catalog, budget OperationBudget, cursorCodec *catalogCursorCodec, onboarding *OnboardingService) {
@@ -132,18 +133,18 @@ func registerCandidateInspectionTool(reg *Registrar, catalog Catalog, directRemo
 		}
 		if remoteURL != "" {
 			if directRemote == nil || gate == nil {
-				return nil, CandidateInspection{}, ErrDirectRemoteUnavailable
+				return directRemoteInspectionUnavailableToolResult()
 			}
 			enabled, err := gate.EnabledOrganization(ctx, principal.OrganizationID)
-			if err != nil {
-				return nil, CandidateInspection{}, fmt.Errorf("check direct remote inspection gate: %w", err)
-			}
-			if !enabled {
-				return nil, CandidateInspection{}, ErrDirectRemoteUnavailable
+			if err != nil || !enabled {
+				return directRemoteInspectionUnavailableToolResult()
 			}
 			inspection, err := directRemote.Inspect(ctx, remoteURL)
 			if err != nil {
-				return nil, CandidateInspection{}, err
+				if result, ok := operationBudgetToolResult(err); ok {
+					return result, CandidateInspection{}, nil
+				}
+				return directRemoteInspectionUnavailableToolResult()
 			}
 			return nil, CandidateInspection{CanonicalURL: inspection.CanonicalURL, Transport: inspection.Transport, ToolNames: inspection.ToolNames, ToolCount: inspection.ToolCount, RequiresDashboardSetup: inspection.RequiresDashboardSetup, Trust: inspection.Trust, Authentication: inspection.Authentication, OAuthDiscovery: inspection.OAuthDiscovery}, nil
 		}
@@ -160,8 +161,15 @@ func registerCandidateInspectionTool(reg *Registrar, catalog Catalog, directRemo
 			}
 			return nil, CandidateInspection{}, ErrCatalogUnavailable
 		}
-		return nil, CandidateInspection{ProviderKey: details.ProviderKey, CatalogRef: details.CatalogRef, Name: details.Name, Description: details.Description, Version: details.Version, Transport: details.Transport, ToolNames: details.ToolNames, ToolCount: details.ToolCount, Configuration: details.Configuration, RequiresDashboardSetup: details.RequiresDashboardSetup, Trust: "reviewed_catalog"}, nil
+		return nil, CandidateInspection{ProviderKey: details.ProviderKey, CatalogRef: details.CatalogRef, Name: details.Name, Description: details.Description, Version: details.Version, Transport: details.Transport, ToolNames: details.ToolNames, ToolCount: details.ToolCount, Configuration: details.Configuration, RequiresDashboardSetup: details.RequiresDashboardSetup, Trust: "reviewed_catalog", SetupIntent: details.SetupIntent}, nil
 	})
+}
+
+func directRemoteInspectionUnavailableToolResult() (*mcp.CallToolResult, CandidateInspection, error) {
+	if result, ok := operationBudgetToolResult(ErrDirectRemoteUnavailable); ok {
+		return result, CandidateInspection{}, nil
+	}
+	return nil, CandidateInspection{}, ErrDirectRemoteUnavailable
 }
 
 func catalogSearchPage(candidates []CatalogCandidate, position int) ([]CatalogCandidate, int, error) {

--- a/server/internal/platformmcp/tool_catalog_test.go
+++ b/server/internal/platformmcp/tool_catalog_test.go
@@ -1,0 +1,73 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCandidateInspectionIncludesCatalogSetupIntent(t *testing.T) {
+	t.Parallel()
+
+	server := newTestMCPServer()
+	registrar := newRegistrar(server)
+	catalog := testCatalog{details: CatalogDetails{
+		CatalogCandidate: CatalogCandidate{
+			ProviderKey: "provider",
+			CatalogRef:  "reviewed/mcp",
+			SetupIntent: "dashboard_source_settings",
+		},
+		Transport: "streamable-http",
+	}}
+	registerCandidateInspectionTool(registrar, catalog, nil, &testRegistrationGate{enabled: true}, allowBudget())
+
+	result, err := catalogInspectionDescriptor(t, registrar).Invoke(
+		ContextWithPrincipal(t.Context(), registrationServicePrincipal()),
+		json.RawMessage(`{"provider_key":"provider","catalog_ref":"reviewed/mcp"}`),
+	)
+
+	require.NoError(t, err)
+	inspection, ok := result.(CandidateInspection)
+	require.True(t, ok)
+	require.Equal(t, "dashboard_source_settings", inspection.SetupIntent)
+}
+
+func TestCandidateInspectionReturnsSafeDirectRemoteErrors(t *testing.T) {
+	t.Parallel()
+
+	server := newTestMCPServer()
+	registrar := newRegistrar(server)
+	registerCandidateInspectionTool(
+		registrar,
+		nil,
+		&testDirectRemoteInspector{err: fmtDirectRemoteInspectionError()},
+		&testRegistrationGate{enabled: true},
+		allowBudget(),
+	)
+
+	_, err := catalogInspectionDescriptor(t, registrar).Invoke(
+		ContextWithPrincipal(t.Context(), registrationServicePrincipal()),
+		json.RawMessage(`{"remote_url":"https://remote.example.test/mcp"}`),
+	)
+
+	var refusal *ToolRefusalError
+	require.ErrorAs(t, err, &refusal)
+	require.JSONEq(t, `{"code":"feature_unavailable","reason":"remote_inspection_unavailable","message":"The remote MCP could not be inspected safely right now. Retry after a short delay."}`, refusal.Payload)
+}
+
+func fmtDirectRemoteInspectionError() error {
+	return errors.New("unsafe network detail that must not reach the caller")
+}
+
+func catalogInspectionDescriptor(t *testing.T, registrar *Registrar) Descriptor {
+	t.Helper()
+	for _, descriptor := range registrar.Descriptors() {
+		if descriptor.Name == "inspect_mcp_candidate" {
+			return descriptor
+		}
+	}
+	require.FailNow(t, "inspect_mcp_candidate descriptor was not registered")
+	return Descriptor{}
+}

--- a/server/internal/platformmcp/tool_registration.go
+++ b/server/internal/platformmcp/tool_registration.go
@@ -28,6 +28,23 @@ type RegisterCatalogMCPToolOutput struct {
 	SecretFieldsPending []CatalogConfigurationField `json:"secret_fields_pending,omitempty"`
 }
 
+type RegisterRemoteMCPToolInput struct {
+	ProjectSlug    string `json:"project_slug" jsonschema:"explicit AICP project slug that will own the user-supplied MCP"`
+	RemoteURL      string `json:"remote_url" jsonschema:"HTTPS Streamable HTTP MCP URL; query parameters, fragments, userinfo, headers, and credentials are not accepted"`
+	DisplayName    string `json:"display_name,omitempty" jsonschema:"optional project-local display name for the MCP"`
+	IdempotencyKey string `json:"idempotency_key" jsonschema:"caller-generated idempotency key; reuse only to retry the same project and canonical remote URL"`
+}
+
+type RegisterRemoteMCPToolOutput struct {
+	ProjectSlug       string `json:"project_slug"`
+	CanonicalURL      string `json:"canonical_url"`
+	ReceiptID         string `json:"receipt_id"`
+	RegistrationID    string `json:"registration_id"`
+	Replayed          bool   `json:"replayed"`
+	NextAction        string `json:"next_action"`
+	DashboardSetupURL string `json:"dashboard_setup_url,omitempty"`
+}
+
 func registerCatalogRegistrationTool(reg *Registrar, registrations *RegistrationService) {
 	addTool(reg, &mcp.Tool{
 		Name:        "register_catalog_mcp",
@@ -75,6 +92,35 @@ func registerCatalogRegistrationTool(reg *Registrar, registrations *Registration
 			NextAction:          nextAction,
 			DashboardSetupURL:   dashboardSetupURL,
 			SecretFieldsPending: append([]CatalogConfigurationField(nil), result.SecretFieldsPending...),
+		}, nil
+	})
+}
+
+func registerRemoteRegistrationTool(reg *Registrar, registrations *RegistrationService) {
+	addTool(reg, &mcp.Tool{
+		Name:        "register_remote_mcp",
+		Title:       "Register Remote MCP",
+		Description: "Register one user-supplied Streamable HTTP MCP URL in an explicit AICP project. The URL is revalidated and re-inspected before private registration. Registration does not distribute the MCP or publish a plugin package.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input RegisterRemoteMCPToolInput) (*mcp.CallToolResult, RegisterRemoteMCPToolOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, RegisterRemoteMCPToolOutput{}, err
+		}
+		result, err := registrations.RegisterRemoteMCP(ctx, principal, RegisterRemoteMCPInput(input))
+		if err != nil {
+			if budgetResult, ok := operationBudgetToolResult(err); ok {
+				return budgetResult, RegisterRemoteMCPToolOutput{}, nil
+			}
+			return nil, RegisterRemoteMCPToolOutput{}, err
+		}
+		return nil, RegisterRemoteMCPToolOutput{
+			ProjectSlug:       result.Project.Slug,
+			CanonicalURL:      result.RemoteURL,
+			ReceiptID:         result.Receipt.ID.String(),
+			RegistrationID:    result.Registration,
+			Replayed:          result.Receipt.Replayed,
+			NextAction:        result.NextAction,
+			DashboardSetupURL: result.DashboardSetupURL,
 		}, nil
 	})
 }

--- a/server/internal/platformmcp/tool_registration.go
+++ b/server/internal/platformmcp/tool_registration.go
@@ -30,7 +30,7 @@ type RegisterCatalogMCPToolOutput struct {
 
 type RegisterRemoteMCPToolInput struct {
 	ProjectSlug    string `json:"project_slug" jsonschema:"explicit AICP project slug that will own the user-supplied MCP"`
-	RemoteURL      string `json:"remote_url" jsonschema:"HTTPS Streamable HTTP MCP URL; query parameters, fragments, userinfo, headers, and credentials are not accepted"`
+	RemoteURL      string `json:"remote_url" jsonschema:"HTTPS Streamable HTTP MCP URL; safe endpoint query parameters are supported, but fragments, userinfo, headers, credentials, and credential-like query parameters are not accepted"`
 	DisplayName    string `json:"display_name,omitempty" jsonschema:"optional project-local display name for the MCP; maximum 256 bytes"`
 	IdempotencyKey string `json:"idempotency_key" jsonschema:"caller-generated idempotency key; reuse only to retry the same project and canonical remote URL"`
 }

--- a/server/internal/platformmcp/tool_registration.go
+++ b/server/internal/platformmcp/tool_registration.go
@@ -31,7 +31,7 @@ type RegisterCatalogMCPToolOutput struct {
 type RegisterRemoteMCPToolInput struct {
 	ProjectSlug    string `json:"project_slug" jsonschema:"explicit AICP project slug that will own the user-supplied MCP"`
 	RemoteURL      string `json:"remote_url" jsonschema:"HTTPS Streamable HTTP MCP URL; query parameters, fragments, userinfo, headers, and credentials are not accepted"`
-	DisplayName    string `json:"display_name,omitempty" jsonschema:"optional project-local display name for the MCP"`
+	DisplayName    string `json:"display_name,omitempty" jsonschema:"optional project-local display name for the MCP; maximum 256 bytes"`
 	IdempotencyKey string `json:"idempotency_key" jsonschema:"caller-generated idempotency key; reuse only to retry the same project and canonical remote URL"`
 }
 

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -156,17 +156,29 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 		registerSearchDocsTool(reg, NewMemoryDocsIndex(setupResources, time.Now), registrations.budgets.Docs)
 	}
 	registerReadDocTool(reg)
-	if catalog == nil || registrations == nil || !registrations.budgets.Catalog.valid() {
+	if registrations == nil || !registrations.budgets.Catalog.valid() {
 		registerUnavailableCatalogTools(reg)
-	} else if cursorCodec, err := newCatalogCursorCodec(cursorKeyMaterial); err != nil {
-		registerUnavailableCatalogTools(reg)
+		registerUnavailableCandidateInspectionTool(reg)
 	} else {
-		registerCatalogTools(reg, catalog, registrations.budgets.Catalog, cursorCodec, onboarding)
+		registerCandidateInspectionTool(reg, catalog, registrations.directRemoteInspector, registrations.gate, registrations.budgets.Catalog)
+		if catalog == nil {
+			registerUnavailableCatalogTools(reg)
+		} else if cursorCodec, err := newCatalogCursorCodec(cursorKeyMaterial); err != nil {
+			registerUnavailableCatalogTools(reg)
+		} else {
+			registerCatalogTools(reg, catalog, registrations.budgets.Catalog, cursorCodec, onboarding)
+		}
 	}
 	if registrations == nil || registrations.store == nil || !registrations.budgets.Registration.valid() {
 		registerUnavailableCatalogRegistrationTool(reg)
+		registerUnavailableRemoteRegistrationTool(reg)
 	} else {
 		registerCatalogRegistrationTool(reg, registrations)
+		if registrations.directRemoteInspector == nil {
+			registerUnavailableRemoteRegistrationTool(reg)
+		} else {
+			registerRemoteRegistrationTool(reg, registrations)
+		}
 	}
 	if registrations == nil || registrations.store == nil || !registrations.budgets.Handoff.valid() {
 		registerUnavailableSetupHandoffTool(reg)
@@ -216,7 +228,6 @@ func registerUnavailableCatalogTools(reg *Registrar) {
 		description string
 	}{
 		{"search_mcp_catalog", "Search MCP Catalog", "Search reviewed catalog MCP candidates. Catalog access is not enabled in the current rollout."},
-		{"inspect_mcp_candidate", "Inspect MCP Candidate", "Inspect one reviewed catalog MCP candidate. Catalog access is not enabled in the current rollout."},
 	} {
 		addTool(reg, &mcp.Tool{
 			Name:        tool.name,
@@ -227,12 +238,29 @@ func registerUnavailableCatalogTools(reg *Registrar) {
 	}
 }
 
+func registerUnavailableCandidateInspectionTool(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "inspect_mcp_candidate",
+		Title:       "Inspect MCP Candidate",
+		Description: "Inspect one reviewed catalog MCP candidate or user-supplied HTTPS MCP URL. Candidate inspection is not available in the current rollout.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeNone}, unavailableTool("candidate_inspection"))
+}
+
 func registerUnavailableCatalogRegistrationTool(reg *Registrar) {
 	addTool(reg, &mcp.Tool{
 		Name:        "register_catalog_mcp",
 		Title:       "Register Catalog MCP",
 		Description: "Register an approved catalog MCP in a project. Registration is not available in the current preview.",
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("catalog_registration"))
+}
+
+func registerUnavailableRemoteRegistrationTool(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "register_remote_mcp",
+		Title:       "Register Remote MCP",
+		Description: "Register a user-supplied HTTPS MCP in a project. Direct remote registration is not available in the current preview.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("direct_remote_registration"))
 }
 
 func registerUnavailableSetupHandoffTool(reg *Registrar) {
@@ -291,6 +319,10 @@ func operationBudgetToolResult(err error) (*mcp.CallToolResult, bool) {
 		result = operationBudgetResult{Code: "rate_limited", Message: "This Platform MCP operation is temporarily rate limited. Retry after a short delay."}
 	case errors.Is(err, ErrCatalogUnavailable):
 		result = operationBudgetResult{Code: unavailableCode, Reason: "catalog_unavailable", Message: "The reviewed MCP Catalogue is temporarily unavailable. Retry the catalogue search after a short delay; other Platform MCP tools may remain available."}
+	case errors.Is(err, ErrDirectRemoteRejected):
+		result = operationBudgetResult{Code: "invalid_request", Reason: "remote_url_rejected", Message: "The remote MCP URL is unsafe, unsupported, or did not complete the required Streamable HTTP inspection. Use an HTTPS URL without credentials, query parameters, or fragments."}
+	case errors.Is(err, ErrDirectRemoteUnavailable):
+		result = operationBudgetResult{Code: unavailableCode, Reason: "remote_inspection_unavailable", Message: "The remote MCP could not be inspected safely right now. Retry after a short delay."}
 	case errors.Is(err, ErrOperationBudgetUnavailable), errors.Is(err, ErrRegistrationUnavailable):
 		result = operationBudgetResult{Code: unavailableCode, Message: "This Platform MCP operation is temporarily unavailable."}
 	case errors.Is(err, ErrRegistrationCap):

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -847,7 +847,7 @@ func (e *discoveryError) UserMessage() string {
 // deviations from the spec callers should be aware of. The supplied
 // guardian.Policy gates the outbound dial.
 //
-// It probes the well-known locations returned by issuerProbeCandidates in
+// It probes the well-known locations returned by IssuerMetadataProbeCandidates in
 // order, returning the first that yields a usable document — one carrying both
 // an authorization_endpoint and a token_endpoint. A 200 that parses but lacks
 // those endpoints is almost always a SPA/gateway catch-all answering our
@@ -911,7 +911,7 @@ func DiscoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 }
 
 func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuerURL string) (rfc8414Document, []string, error) {
-	candidates, err := issuerProbeCandidates(issuerURL)
+	candidates, err := IssuerMetadataProbeCandidates(issuerURL)
 	if err != nil {
 		return rfc8414Document{}, nil, &discoveryError{
 			WellKnownURL: "",
@@ -1035,7 +1035,7 @@ func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKn
 	return doc, nil
 }
 
-// issuerProbeCandidates returns the ordered list of well-known metadata URLs to
+// IssuerMetadataProbeCandidates returns the ordered list of well-known metadata URLs to
 // probe for an issuer. The first candidate is the canonical RFC 8414 location;
 // the rest broaden coverage to OpenID Connect Discovery and to non-compliant
 // upstreams that only serve metadata at the origin root.
@@ -1047,7 +1047,7 @@ func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKn
 // path component we additionally fall back to the origin-style locations, since
 // some gateways and SPA catch-alls serve metadata at the root regardless of the
 // issuer path. Duplicate URLs (e.g. when the issuer has no path) are collapsed.
-func issuerProbeCandidates(issuerURL string) ([]string, error) {
+func IssuerMetadataProbeCandidates(issuerURL string) ([]string, error) {
 	u, err := url.Parse(issuerURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse issuer url: %w", err)


### PR DESCRIPTION
## Why

Platform MCP needs a bounded way to add a user-supplied remote MCP that is not part of the reviewed catalogue, while preserving the platform's existing private registration and dashboard setup model.

## What changed

- add `inspect_mcp_candidate` support for a direct HTTPS Streamable HTTP URL and add `register_remote_mcp` for private project registration
- canonicalize and Guardian-validate direct URLs; bound redirects, request count, response bytes, tool names, and OAuth metadata discovery
- require a fresh inspection before materialization; retain no caller-supplied headers, credentials, or OAuth material
- persist direct sources as `remote_url` / `direct-remote-url-v1` through the existing receipt, ownership, audit, and private component workflow
- admit the tools to both Platform MCP and Project Assistant, with actor-specific operation budgets and the existing organization rollout/entitlement gate
- direct authenticated/setup-required MCPs to the existing dashboard Authentication settings route

## Validation

- `hk fix`
- `mise exec -- go test -c -o /tmp/platformmcp.test ./server/internal/platformmcp`
- `mise exec -- go test -c -o /tmp/remotemcp.test ./server/internal/remotemcp`
- `mise exec -- go test ./server/cmd/gram -run '^$' -count=1`
- `git diff --check`
- independent review; fixed bounded OAuth fan-out, redirect classification, same-gate egress, and standard Streamable HTTP initialization sequencing

Focused runtime tests remain blocked locally because the sandbox cannot access the Colima Docker socket required by package TestMain/Testcontainers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direct inspection and private registration for user‑supplied HTTPS Streamable HTTP MCPs, and unifies candidate inspection across reviewed and direct sources. This enables per‑project remote MCPs without changing catalog distribution and preserves dashboard setup.

- Direct inspection: canonicalizes HTTPS URLs while preserving safe endpoint query parameters; rejects userinfo, fragments, non‑443 ports, control/templating chars, and credential‑like query keys (for example access_token, x‑amz‑*, x‑goog‑*). Validates each hop with Guardian and probes within strict limits (10s, ≤3 redirects/≤8 requests/≤256 KiB). Follows Streamable HTTP initialize → initialized notification → tools/list (≤50 names), treats 401/403 as auth‑required, sends Accept: application/json,text/event‑stream, enforces JSON on success, caps Mcp‑Session‑Id (≤512 bytes), and classifies OAuth discovery as available_dcr/available/incomplete; anonymous success reports not_advertised. Standalone SSE is not an admission path.
- Candidate inspection: `inspect_mcp_candidate` accepts reviewed `provider_key`+`catalog_ref` or a `remote_url`, returning a unified shape (transport, tool names/count, trust, authentication, OAuth discovery, requires‑dashboard‑setup, reviewed `setup_intent`). Read‑only direct inspection is gated by `EnabledOrganization`. Unsafe/unavailable cases return `invalid_request/remote_url_rejected` or `feature_unavailable/remote_inspection_unavailable` without leaking network details.
- Registration: adds `register_remote_mcp`. It re‑inspects the exact URL, validates display name (≤256 bytes, no newlines), requires canonical URL equality at persistence, and stores as `remote_url`/`direct-remote-url-v1` via the existing private workflow. Returns `NextAction=ready` or `secure_dashboard_setup_required` with a same‑origin dashboard settings URL.
- Budgets: charges an actor bucket first — by connection ID, or for managed assistants without a connection, by `client_id+user_id` — before the organization bucket. Tool errors map to `invalid_request/remote_url_rejected` and `feature_unavailable/remote_inspection_unavailable`.
- Gate and wiring: exposes `EnabledOrganization` for read‑only direct inspection; composes the inspector via `.WithDirectRemoteInspector(...)` using a Guardian‑backed implementation; registers unavailable variants when budgets, the catalog, or the inspector are disabled. `inspect_mcp_candidate` is registered independently from catalog search availability.
- Linear AGE‑3166: delivers `register_remote_mcp` and unified candidate inspection without changing distribution semantics; direct URLs never evolve the shared catalog.

<sup>Written for commit 14ca2d9040d446a4f064d032b33af47a5a54fcaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

