### PR TITLE
feat: rework the Shadow MCP detail page around a summary strip

### DIFF
--- a/.changeset/shadow-mcp-detail-summary-strip.md
+++ b/.changeset/shadow-mcp-detail-summary-strip.md
@@ -1,0 +1,7 @@
+---
+"dashboard": minor
+---
+
+Rework the Shadow MCP server detail page around a summary strip and remove the repetition beneath it. Status, calls, people and last-called now read as one bordered strip of metric tiles sharing a row with the review's own header, replacing a status badge and two lines of prose that left most of the row empty. The figures the strip reports no longer appear a second time as an "Are we already exposed?" fact list — the traffic table answers that question directly, and the one thing it cannot say, what a denial would cost, rides beside its heading instead. Per-source counts drop out of the traffic table when a user has a single source, where they only restated the call count next to them.
+
+The evidence groups line up: the caveats that used to sit as paragraphs under each question now hang off an icon beside it, so every box in a row starts at the same top edge, and a group whose whole answer is one sentence stretches to its row's height with that sentence centred rather than stranded in a corner. The gaps banner no longer repeats failures that the group beneath it already reports as unknown, and the "unreviewed" badge reads Unreviewed instead of "Review requested", which contradicted the notice under it saying no one had asked. Long user lists collapse behind a toggle, and the web research panel drops its intro, its credits warning and its empty state when research is not part of the plan.

--- a/client/dashboard/src/components/mcp-approvals/ApprovalReview.tsx
+++ b/client/dashboard/src/components/mcp-approvals/ApprovalReview.tsx
@@ -567,7 +567,7 @@ function ResearchReports({
           typically several hundred thousand tokens, several minutes per run.
         </p>
       )}
-      {!latest && researchFlag.status !== "disabled" && (
+      {!latest && researchFlag.status === "enabled" && (
         <p className="border-border text-muted-foreground border border-dashed px-2.5 py-1.5 text-xs">
           No research has been run for this server.
         </p>

--- a/client/dashboard/src/components/mcp-approvals/ApprovalReview.tsx
+++ b/client/dashboard/src/components/mcp-approvals/ApprovalReview.tsx
@@ -521,7 +521,7 @@ function ResearchReports({
     // org's money, so a non-admin must not see a button whose click comes
     // back 403.
     headerNote = (
-      <RequireScope scope="org:admin" level="component">
+      <RequireScope scope="org:admin" resourceId={project.id} level="component">
         <Button
           size="sm"
           variant="secondary"
@@ -567,7 +567,7 @@ function ResearchReports({
           typically several hundred thousand tokens, several minutes per run.
         </p>
       )}
-      {!latest && (
+      {!latest && researchFlag.status !== "disabled" && (
         <p className="border-border text-muted-foreground border border-dashed px-2.5 py-1.5 text-xs">
           No research has been run for this server.
         </p>

--- a/client/dashboard/src/components/mcp-approvals/ApprovalReview.tsx
+++ b/client/dashboard/src/components/mcp-approvals/ApprovalReview.tsx
@@ -48,17 +48,23 @@ import { toast } from "sonner";
 export function ApprovalReview({
   requestId,
   title,
-  description,
   usage,
+  summary,
 }: {
   requestId: string;
+  /**
+   * The page's at-a-glance strip, rendered beside this review's header as one
+   * two-column row. Owned by the caller because only it has the traffic
+   * figures; sharing the row keeps the summary and the review's own state on
+   * one line instead of two stacked bands.
+   */
+  summary?: React.ReactNode;
   /**
    * Section title, when this review is a section of a larger page. Given
    * one, the request's status shares its row instead of costing a strip of
    * its own; the review sheet, which has its own title, omits it.
    */
   title?: string;
-  description?: string;
   /**
    * Who is calling the server today. Owned by the caller, which holds the
    * traffic query, and rendered inside the evidence as one more question
@@ -98,6 +104,9 @@ export function ApprovalReview({
   if (detailQuery.error && !detail) {
     return (
       <div className="space-y-4">
+        {/* The summary is the page's own data and is already loaded — it must
+            not disappear because this review's query failed. */}
+        {summary}
         <div className="bg-muted/20 flex min-h-24 flex-col items-center justify-center border border-dashed px-6 py-8 text-center">
           <p className="text-sm font-medium">The review could not be loaded</p>
           <p className="text-muted-foreground mt-1 max-w-md text-sm">
@@ -121,6 +130,7 @@ export function ApprovalReview({
   if (!detail) {
     return (
       <div className="space-y-4">
+        {summary}
         <SkeletonTable />
         {usage && (
           <EvidenceGroup question={USAGE_QUESTION}>{usage}</EvidenceGroup>
@@ -130,48 +140,67 @@ export function ApprovalReview({
   }
 
   const unreviewed = detail.request.status === "unreviewed";
+  // Nothing asked, nothing decided: the badge already says "Unreviewed", so
+  // what is left to say is that nobody asked — one clause that rides the
+  // heading row rather than costing a box of its own beneath it.
+  const untouched = unreviewed && detail.decisions.length === 0;
+
+  let reviewBody: React.ReactNode = null;
+  if (!unreviewed) {
+    // Who asked and what we last decided are both short lists read before the
+    // evidence, so they sit side by side rather than pushing the evidence a
+    // screen further down.
+    reviewBody = (
+      <div className="grid items-start gap-x-6 gap-y-4 md:grid-cols-2">
+        <Requesters requesters={detail.requesters} />
+        <PriorDecisions decisions={detail.decisions} />
+      </div>
+    );
+  } else if (!untouched) {
+    // Unreviewed now, but decided before. The history is the exception worth
+    // its own list; the header carries the rest.
+    reviewBody = <PriorDecisions decisions={detail.decisions} />;
+  }
+
+  const header = (
+    <ReviewHeader
+      title={title}
+      collectedAt={detail.evidenceCollectedAt}
+      status={detail.request.status}
+      createdAt={unreviewed ? undefined : detail.request.createdAt}
+      versionPinned={detail.request.versionPinned}
+      notice={
+        untouched
+          ? "No one has asked for it — this is its first review."
+          : undefined
+      }
+    />
+  );
+
+  // Given a summary strip, the two share one row: the figures on the left and
+  // what the review makes of them on the right, both boxed and both ending on
+  // the same line.
+  let headerRow = header;
+  if (summary) {
+    headerRow = (
+      <div className="grid items-stretch gap-x-6 gap-y-3 lg:grid-cols-2">
+        {summary}
+        {header}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">
-      {/* An unreviewed dossier is evidence without a review: no status to
-          report, nobody waiting. The requester list and decision history only
-          exist once someone actually asks or decides. */}
-      <ReviewHeader
-        title={title}
-        description={description}
-        status={detail.request.status}
-        createdAt={unreviewed ? undefined : detail.request.createdAt}
-        versionPinned={detail.request.versionPinned}
-      />
+      {headerRow}
       {detail.request.status === "approved" && detail.evidenceDiff?.changed && (
         <EvidenceChangedNotice
           diff={detail.evidenceDiff}
           changedAt={detail.request.evidenceChangedAt}
         />
       )}
-      {unreviewed ? (
-        <>
-          <p className="text-muted-foreground text-sm">
-            No one has asked for this server and no decision has been recorded.
-          </p>
-          <PriorDecisions decisions={detail.decisions} />
-        </>
-      ) : (
-        <>
-          {/* Who asked and what we last decided are both short lists read
-              before the evidence, so they sit side by side rather than
-              pushing the evidence a screen further down. */}
-          <div className="grid items-start gap-x-6 gap-y-4 md:grid-cols-2">
-            <Requesters requesters={detail.requesters} />
-            <PriorDecisions decisions={detail.decisions} />
-          </div>
-        </>
-      )}
-      <EvidencePanel
-        document={document}
-        collectedAt={detail.evidenceCollectedAt}
-        usage={usage}
-      />
+      {reviewBody}
+      <EvidencePanel document={document} usage={usage} />
       <ResearchReports reports={detail.researchReports} requestId={requestId} />
     </div>
   );
@@ -235,44 +264,75 @@ export function RefreshEvidenceButton({
  */
 function ReviewHeader({
   title,
-  description,
+  collectedAt,
   status,
   createdAt,
   versionPinned,
+  notice,
 }: {
   title: string | undefined;
-  description: string | undefined;
+  /**
+   * When the evidence was gathered, and the caveat that none of it is
+   * verified. This is the section's subtitle rather than a line of its own:
+   * as a standalone paragraph it stacked with the state notice and the
+   * boilerplate description into a column of unrelated one-liners, and of the
+   * three it is the only one carrying information.
+   */
+  collectedAt: Date | undefined;
   status: string;
   /** Absent for an unreviewed dossier: nobody raised it. */
   createdAt: Date | undefined;
   versionPinned: boolean;
+  /** The review's state, when it is short enough to ride this row. */
+  notice?: string;
 }): JSX.Element {
+  // The badge rides the heading instead of a right-aligned cluster. Pushed
+  // right it floated against the page edge with nothing holding it, squeezed
+  // the subtitle into an orphaned second line, and put a second status
+  // treatment far from the summary strip's. Beside the title it reads as this
+  // section's own state, and the subtitle gets the full width to sit on.
+  // Boxed like every other section on the page, and centred in its own height
+  // so it sits level with the metric strip sharing its row.
   return (
-    <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-1">
-      {title && (
-        <div className="min-w-0 flex-1">
-          <Text variant="subheading">{title}</Text>
-          {description && (
-            <Text muted small>
-              {description}
-            </Text>
-          )}
-        </div>
-      )}
-      <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+    <div className="border-border flex h-full flex-col justify-center gap-1 border px-3 py-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        {/* Serif like the evidence questions rather than a sans subheading,
+            which was smaller and plainer than its own children. Sized with
+            them, not above them: boxed in its own column it reads as their
+            peer, and a step larger crowded the row. */}
+        {title && (
+          <Heading variant="h3" className="text-lg font-thin">
+            {title}
+          </Heading>
+        )}
         <StatusBadge status={status} />
         {createdAt && (
-          <span className="text-muted-foreground">
-            First raised{" "}
-            <HumanizeDateTime date={createdAt} includeTime={false} />
+          <span className="text-muted-foreground text-xs">
+            raised <HumanizeDateTime date={createdAt} includeTime={false} />
           </span>
         )}
-        {!versionPinned && (
-          <span className="text-muted-foreground">
-            No pinned version — what runs may differ from the evidence.
-          </span>
+        {notice && (
+          <span className="text-muted-foreground text-xs">{notice}</span>
         )}
       </div>
+      {/* The provenance caveat belongs to gathered evidence, so it only
+          appears when there is some. A request with nothing gathered says so
+          in its own block below; describing where that evidence came from
+          would be claiming a source for something that does not exist. The
+          unpinned-version caveat is about the request, not the evidence, so
+          it stands on its own. */}
+      {(collectedAt || !versionPinned) && (
+        <Text muted small>
+          {collectedAt && (
+            <>
+              Gathered <HumanizeDateTime date={collectedAt} />. Declared by the
+              server or its registry, or seen in this organization's traffic —
+              nothing is verified behavior.{" "}
+            </>
+          )}
+          {!versionPinned && "No version is pinned, so what runs may differ."}
+        </Text>
+      )}
     </div>
   );
 }
@@ -402,7 +462,7 @@ function FrozenEvidence({
       </button>
       {open && (
         <div className="border-border mt-2 border-l pl-2.5">
-          <EvidencePanel document={document} collectedAt={undefined} />
+          <EvidencePanel document={document} />
         </div>
       )}
     </div>
@@ -451,62 +511,62 @@ function ResearchReports({
   const latest = reports[0];
   const previous = reports.slice(1);
 
+  // Display only — the endpoint enforces the same flag, and it fails closed on
+  // an unreadable flag, so anything but a confirmed enabled renders no button:
+  // a control the server would 403 is the breakage this section exists to
+  // remove. Loading/missing/error resolve to nothing at all.
+  let headerNote: React.ReactNode = null;
+  if (researchFlag.status === "enabled") {
+    // The same org-admin gate as the endpoint behind it: research spends the
+    // org's money, so a non-admin must not see a button whose click comes
+    // back 403.
+    headerNote = (
+      <RequireScope scope="org:admin" level="component">
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={running || startResearch.isPending}
+          onClick={() =>
+            startResearch.mutate({
+              request: { id: requestId, gramProject: project.slug },
+            })
+          }
+        >
+          {running && (
+            <Button.LeftIcon>
+              <Loader2 className="animate-spin" />
+            </Button.LeftIcon>
+          )}
+          <Button.Text>{running ? "Researching…" : "Run Research"}</Button.Text>
+        </Button>
+      </RequireScope>
+    );
+  } else if (researchFlag.status === "disabled") {
+    headerNote = (
+      <span className="text-muted-foreground text-xs">
+        Not included in your plan — contact your Speakeasy representative.
+      </span>
+    );
+  }
+
+  // The same group shell as the evidence questions above it, so its heading,
+  // its hint icon and the top edge of its body line up with theirs instead of
+  // being a hand-rolled section that happens to look similar.
   return (
-    <section className="space-y-2">
-      <div className="flex items-center justify-between gap-2">
-        <Heading variant="h3" className="text-lg font-thin">
-          Web research
-        </Heading>
-        {/* Display only — the endpoint enforces the same flag, and it fails
-            closed on an unreadable flag, so anything but a confirmed enabled
-            renders no button: a control the server would 403 is the breakage
-            this section exists to remove. Only a confirmed disabled shows the
-            plan message; loading/missing/error resolve to nothing. */}
-        {researchFlag.status === "disabled" && (
-          <p className="text-muted-foreground max-w-72 text-right text-xs">
-            Web research isn't included in your organization's plan yet —
-            contact your Speakeasy representative to enable it.
-          </p>
-        )}
-        {researchFlag.status === "enabled" && (
-          // The same org-admin gate as the endpoint behind it: research
-          // spends the org's money, so a non-admin must not see a button
-          // whose click comes back 403.
-          <RequireScope scope="org:admin" level="component">
-            <Button
-              size="sm"
-              variant="secondary"
-              disabled={running || startResearch.isPending}
-              onClick={() =>
-                startResearch.mutate({
-                  request: { id: requestId, gramProject: project.slug },
-                })
-              }
-            >
-              {running && (
-                <Button.LeftIcon>
-                  <Loader2 className="animate-spin" />
-                </Button.LeftIcon>
-              )}
-              <Button.Text>
-                {running ? "Researching…" : "Run Research"}
-              </Button.Text>
-            </Button>
-          </RequireScope>
-        )}
-      </div>
-      <p className="text-muted-foreground text-xs">
-        Gathered by an agent from public web sources, which may be inaccurate,
-        incomplete, or deliberately seeded. Read them as leads to verify, not as
-        findings — the agent gathers and cites, it never decides.
-      </p>
-      <p className="border-warning border px-2.5 py-1.5 text-xs">
-        <span className="font-medium">
-          A research run spends real AI credits.
-        </span>{" "}
-        The agent makes dozens of model calls, web searches, and page reads —
-        typically several hundred thousand tokens, several minutes per run.
-      </p>
+    <EvidenceGroup
+      question="Web research"
+      hint={RESEARCH_HINT}
+      note={headerNote}
+    >
+      {researchFlag.status === "enabled" && (
+        <p className="border-warning border px-2.5 py-1.5 text-xs">
+          <span className="font-medium">
+            A research run spends real AI credits.
+          </span>{" "}
+          The agent makes dozens of model calls, web searches, and page reads —
+          typically several hundred thousand tokens, several minutes per run.
+        </p>
+      )}
       {!latest && (
         <p className="border-border text-muted-foreground border border-dashed px-2.5 py-1.5 text-xs">
           No research has been run for this server.
@@ -545,9 +605,13 @@ function ResearchReports({
           )}
         </>
       )}
-    </section>
+    </EvidenceGroup>
   );
 }
+
+/** Where research findings come from and how far to trust them. */
+const RESEARCH_HINT =
+  "Gathered by an agent from public web sources, which may be inaccurate, incomplete, or deliberately seeded. Read them as leads to verify, not as findings — the agent gathers and cites, it never decides.";
 
 function ResearchReportCard({
   report,

--- a/client/dashboard/src/components/mcp-approvals/EvidencePanel.tsx
+++ b/client/dashboard/src/components/mcp-approvals/EvidencePanel.tsx
@@ -4,10 +4,14 @@ import {
 } from "@/components/mcp-approvals/evidence";
 import { Badge } from "@/components/ui/Badge";
 import { Heading } from "@/components/ui/Heading";
+import { SimpleTooltip } from "@/components/ui/Tooltip";
+import { Info } from "lucide-react";
 import { HumanizeDateTime } from "@/lib/dates";
+import {
+  MoreToggle,
+  useCollapsedPreview,
+} from "@/components/ui/collapsible-preview";
 import { cn } from "@/lib/utils";
-import { ChevronDown, ChevronUp } from "lucide-react";
-import { useState } from "react";
 import type {
   EvidenceAdvisories,
   EvidenceAdvisoryItem,
@@ -15,7 +19,6 @@ import type {
   EvidenceCapability,
   EvidenceDocument,
   EvidenceDomain,
-  EvidenceExposure,
   EvidenceIdentity,
   EvidencePackage,
   EvidenceProvenance,
@@ -34,11 +37,9 @@ import { gapLabel } from "./evidence";
  */
 export function EvidencePanel({
   document,
-  collectedAt,
   usage,
 }: {
   document: EvidenceDocument | null;
-  collectedAt: Date | undefined;
   /**
    * Who is calling the server today, supplied by the page that has the
    * traffic query. It reads as one more question about the server, and it
@@ -57,16 +58,18 @@ export function EvidencePanel({
     );
   }
 
+  // A gap whose own group already renders an unknown block is being reported
+  // twice: the banner said "the tool listing could not be read" directly above
+  // a box saying "No tool declarations gathered". The banner is for sources
+  // whose failure has nowhere else to surface — exposure, the code host, the
+  // domain registry — which leave no visible hole of their own.
+  const unshownGaps = document.gaps.filter(
+    (gap) => !GAPS_SHOWN_BY_THEIR_OWN_GROUP.has(gap),
+  );
+
   return (
     <div className="space-y-3">
-      {document.gaps.length > 0 && <GapsNotice gaps={document.gaps} />}
-      {collectedAt && (
-        <p className="text-muted-foreground text-xs">
-          Gathered <HumanizeDateTime date={collectedAt} />. Declared by the
-          server or its registry, or seen in this organization's traffic —
-          nothing is verified behavior.
-        </p>
-      )}
+      {unshownGaps.length > 0 && <GapsNotice gaps={unshownGaps} />}
       {/* Two columns on a wide screen. Each question is short enough that
           stacking them all made the page scroll for no reason; the reading
           order still runs left to right, identity first. */}
@@ -84,7 +87,22 @@ export function EvidencePanel({
               source={document.capabilitiesSource}
               fill
             />
-            <EvidenceGroup question={USAGE_QUESTION}>{usage}</EvidenceGroup>
+            {/* The traffic table answers "are we already exposed?" on its own —
+                names, counts and recency — so that question no longer has a
+                group of its own. What the table cannot say is what a denial
+                would cost, so that judgment rides here as the note. */}
+            <EvidenceGroup
+              question={USAGE_QUESTION}
+              note={
+                document.exposure?.inUse && (
+                  <span className="border-warning border px-2.5 py-1 text-xs">
+                    Already in use — a denial changes existing workflows.
+                  </span>
+                )
+              }
+            >
+              {usage}
+            </EvidenceGroup>
           </>
         ) : (
           <div className="lg:col-span-2">
@@ -94,97 +112,142 @@ export function EvidencePanel({
             />
           </div>
         )}
-        {/* Full width for the same reason as the tools: this group carries
-            the most facts, and a fact list laid out across the page is half
-            the rows it is in a column. */}
-        <div className="lg:col-span-2">
-          <MaturitySection
-            pkg={document.package}
-            notPublished={document.packageNotPublished}
-            packageName={document.identity.packageName}
-            provenance={document.provenance}
-            identityKind={document.identity.kind}
-            repository={document.repository}
-            repositoryNotFound={document.repositoryNotFound}
-          />
-        </div>
+        {/* Maturity and advisories share the last row. Maturity used to span
+            the full width so its fact list could run two columns, but with
+            the exposure group gone an odd number of groups left a hole beside
+            whichever one ran last — and three even rows read better than two
+            rows and two banners. Its list falls back to one column here via
+            its own container query. */}
+        <MaturitySection
+          pkg={document.package}
+          notPublished={document.packageNotPublished}
+          packageName={document.identity.packageName}
+          provenance={document.provenance}
+          identityKind={document.identity.kind}
+          repository={document.repository}
+          repositoryNotFound={document.repositoryNotFound}
+        />
         <AdvisoriesSection
           advisories={document.advisories}
           identityKind={document.identity.kind}
-        />
-        <ExposureSection
-          exposure={document.exposure}
-          identity={document.identity}
         />
       </div>
     </div>
   );
 }
 
+/**
+ * Failed lookups whose group answers for them, so the banner does not repeat
+ * what the reader is already looking at. Each one maps to a group that renders
+ * its own unknown block when the data is missing: authority and capabilities
+ * to their questions, package and catalog to "is it real and maintained?",
+ * advisories to the vulnerability question.
+ *
+ * Deliberately not here: exposure, repository and domain failures. Those leave
+ * facts quietly absent from a list rather than an empty box, so the banner is
+ * the only place they are ever stated.
+ */
+const GAPS_SHOWN_BY_THEIR_OWN_GROUP = new Set([
+  "authority_probe_failed",
+  "tool_declarations_probe_failed",
+  "package_lookup_failed",
+  "catalog_lookup_failed",
+  "advisory_lookup_failed",
+]);
+
 export function EvidenceGroup({
   question,
   note,
-  fill = false,
+  hint,
   children,
 }: {
   question: string;
+  /**
+   * The caveat about where this group's data came from and what it does not
+   * prove, behind an icon beside the question. It reads as a footnote, not a
+   * finding, and as a paragraph under the heading it pushed this group's box
+   * down while the group beside it started at the heading — so no two columns
+   * lined up. In the tooltip the boxes share one top edge across the grid.
+   */
+  hint?: string;
   /**
    * The group's one-line headline, set beside the question rather than in a
    * band below it. For the finding a reader should not be able to miss —
    * everything else belongs in the body.
    */
   note?: React.ReactNode;
-  /**
-   * Give the body the full height of the grid row instead of its natural
-   * height, so a list inside it can size itself against whatever the group
-   * beside it turned out to be.
-   */
-  fill?: boolean;
   children: React.ReactNode;
 }): JSX.Element {
   // A container, so the fact lists inside decide their own column count from
   // the width this group actually got — two when it spans the page, one when
   // it is sharing a row — rather than from the viewport.
+  //
+  // Always full height, never just when a caller asks: the grid stretches the
+  // section to its row, so anything less left a short answer's box floating
+  // against a tall table beside it.
   return (
-    <section
-      className={cn(
-        "@container",
-        fill ? "flex h-full flex-col gap-1.5" : "space-y-1.5",
-      )}
-    >
+    <section className="@container flex h-full flex-col gap-1.5">
       {/* The questions are the page's real structure, so they keep the serif
           treatment content subsections use — sized down so a full gather fits
           on one screen without zooming. */}
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-        <Heading variant="h3" className="text-lg font-thin">
-          {question}
-        </Heading>
+        <div className="flex items-center gap-1.5">
+          <Heading variant="h3" className="text-lg font-thin">
+            {question}
+          </Heading>
+          {hint && (
+            <SimpleTooltip tooltip={hint}>
+              <Info className="text-muted-foreground size-3.5 shrink-0" />
+            </SimpleTooltip>
+          )}
+        </div>
         {note}
       </div>
-      {fill ? (
-        <div className="flex min-h-0 flex-1 flex-col gap-1.5">{children}</div>
-      ) : (
-        children
-      )}
+      {/* The last block grows into whatever height the row settled on, so the
+          short answer and the long table in one row end on the same line
+          instead of one box stopping halfway up its column. */}
+      <div className="flex min-h-0 flex-1 flex-col gap-1.5 [&>*:last-child]:flex-1">
+        {children}
+      </div>
     </section>
   );
 }
 
 /**
- * The visual for "we know nothing about this": a dashed hairline frame that
- * looks conspicuously empty. Deliberately distinct from both an error state
- * and a populated card, and never green.
+ * A group whose whole answer is one sentence, framed in a hairline box with
+ * the sentence centred. Centred because these blocks stretch to their row's
+ * height: against a tall table beside them, a line pinned to the top-left
+ * corner reads as content that failed to load rather than as the answer.
  */
+function AnswerBlock({
+  children,
+  unknown = false,
+}: {
+  children: React.ReactNode;
+  /**
+   * Draw it dashed and muted — the panel's one visual for "we could not find
+   * out", deliberately distinct from a definite answer and never green.
+   */
+  unknown?: boolean;
+}): JSX.Element {
+  return (
+    <div
+      className={cn(
+        "border-border flex items-center justify-center border px-2.5 py-1.5 text-center text-xs",
+        unknown && "text-muted-foreground border-dashed",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
 function UnknownBlock({
   children,
 }: {
   children: React.ReactNode;
 }): JSX.Element {
-  return (
-    <div className="border-border text-muted-foreground border border-dashed px-2.5 py-1.5 text-xs">
-      {children}
-    </div>
-  );
+  return <AnswerBlock unknown>{children}</AnswerBlock>;
 }
 
 function GapsNotice({ gaps }: { gaps: string[] }): JSX.Element {
@@ -342,7 +405,7 @@ function AuthoritySection({
     return (
       <EvidenceGroup question="What is it asking me to hand over?">
         <UnknownBlock>
-          Not gathered. Unknown — not "requires nothing".
+          Not exposed by the server. Unknown — not "requires nothing".
         </UnknownBlock>
       </EvidenceGroup>
     );
@@ -408,69 +471,6 @@ function AuthoritySection({
 
 /** How many scope chips show before the rest collapses behind the toggle. */
 const SCOPE_PREVIEW_COUNT = 4;
-
-/**
- * Hiding the tail of a list: the state, the slice, and what counts as
- * collapsible. Every list here that hides one shares this, so the rule that
- * a list at exactly the preview count shows no toggle is decided once.
- */
-function useCollapsedPreview<T>(
-  items: T[],
-  previewCount: number,
-): {
-  collapsible: boolean;
-  expanded: boolean;
-  toggle: () => void;
-  visible: T[];
-} {
-  const [expanded, setExpanded] = useState(false);
-  const collapsible = items.length > previewCount;
-
-  return {
-    collapsible,
-    expanded,
-    toggle: () => setExpanded((current) => !current),
-    visible: collapsible && !expanded ? items.slice(0, previewCount) : items,
-  };
-}
-
-/**
- * The control that reveals a hidden tail. The chrome around it differs — a
- * chip in a wrap of scopes, a footer row under a framed list — but the
- * accessible contract and the collapse wording are the same wherever it
- * appears, so they live here rather than in each caller.
- */
-function MoreToggle({
-  expanded,
-  onToggle,
-  collapsedLabel,
-  className,
-}: {
-  expanded: boolean;
-  onToggle: () => void;
-  /** What the control says while the tail is hidden. */
-  collapsedLabel: string;
-  className?: string;
-}): JSX.Element {
-  return (
-    <button
-      type="button"
-      aria-expanded={expanded}
-      onClick={onToggle}
-      className={cn(
-        "text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs",
-        className,
-      )}
-    >
-      {expanded ? "Show fewer" : collapsedLabel}
-      {expanded ? (
-        <ChevronUp className="size-3" />
-      ) : (
-        <ChevronDown className="size-3" />
-      )}
-    </button>
-  );
-}
 
 /**
  * The wrap of scope chips, with the tail collapsed behind a "+N more" toggle
@@ -548,13 +548,13 @@ function DeclaredCapabilitySection({
     if (source) {
       return (
         <EvidenceGroup question="What does it say it can do?">
-          <div className="border-border border px-2.5 py-1.5 text-xs">
+          <AnswerBlock>
             {source === "registry"
               ? "The registry catalog's copy declares no tools."
               : "The server answered the listing with zero tools."}{" "}
             The listing succeeded — this is a declared-empty toolset, not a
             failed check.
-          </div>
+          </AnswerBlock>
         </EvidenceGroup>
       );
     }
@@ -572,7 +572,11 @@ function DeclaredCapabilitySection({
   return (
     <EvidenceGroup
       question="What does it say it can do?"
-      fill={fill}
+      hint={`${capabilitySourceNote(source)} ${
+        capabilities.length === 1
+          ? "1 tool declared."
+          : `${capabilities.length} tools declared.`
+      }`}
       note={
         actingTools.length > 0 && (
           <span className="border-warning border px-2.5 py-1 text-xs">
@@ -584,12 +588,6 @@ function DeclaredCapabilitySection({
         )
       }
     >
-      <p className="text-muted-foreground text-xs">
-        {capabilitySourceNote(source)}{" "}
-        {capabilities.length === 1
-          ? "1 tool declared."
-          : `${capabilities.length} tools declared.`}
-      </p>
       <ToolList capabilities={capabilities} fill={fill} />
     </EvidenceGroup>
   );
@@ -770,16 +768,12 @@ function ProvenanceFacts({
     });
   }
 
-  return (
-    <>
-      <p className="text-muted-foreground text-xs">
-        The registry catalog's claims, not ours — a visitor count is a
-        popularity proxy, not evidence about behavior.
-      </p>
-      <FactList facts={facts} />
-    </>
-  );
+  return <FactList facts={facts} />;
 }
+
+/** The provenance caveat, moved to its group's hint. */
+const PROVENANCE_HINT =
+  "The registry catalog's claims, not ours — a visitor count is a popularity proxy, not evidence about behavior.";
 
 function MaturitySection({
   pkg,
@@ -802,15 +796,18 @@ function MaturitySection({
     if (!provenance.catalogued) {
       return (
         <EvidenceGroup question="Is it real and maintained?">
-          <div className="border-border border px-2.5 py-1.5 text-xs">
+          <AnswerBlock>
             No configured MCP registry catalogs this URL. The lookup ran cleanly
             — this is absence from the catalog, not a failed check.
-          </div>
+          </AnswerBlock>
         </EvidenceGroup>
       );
     }
     return (
-      <EvidenceGroup question="Is it real and maintained?">
+      <EvidenceGroup
+        question="Is it real and maintained?"
+        hint={PROVENANCE_HINT}
+      >
         <ProvenanceFacts provenance={provenance} />
       </EvidenceGroup>
     );
@@ -819,12 +816,12 @@ function MaturitySection({
   if (notPublished) {
     return (
       <EvidenceGroup question="Is it real and maintained?">
-        <div className="border-border border px-2.5 py-1.5 text-xs">
+        <AnswerBlock>
           The registry has no package named{" "}
           <code className="text-xs">{packageName ?? "this"}</code>. The lookup
           ran cleanly — this reference points at something its own registry does
           not know.
-        </div>
+        </AnswerBlock>
       </EvidenceGroup>
     );
   }
@@ -1010,10 +1007,10 @@ function AdvisoriesSection({
   if (advisories.knownCount === 0) {
     return (
       <EvidenceGroup question="Does anything published say it's vulnerable?">
-        <div className="border-border border px-2.5 py-1.5 text-xs">
+        <AnswerBlock>
           OSV lists no published advisories for this package. Checked today and
           clean — not a guarantee, and it says nothing about unreported issues.
-        </div>
+        </AnswerBlock>
       </EvidenceGroup>
     );
   }
@@ -1067,78 +1064,6 @@ function AdvisoryList({
   );
 }
 
-function ExposureSection({
-  exposure,
-  identity,
-}: {
-  exposure: EvidenceExposure | undefined;
-  identity: EvidenceIdentity;
-}): JSX.Element {
-  if (!exposure) {
-    const reason =
-      identity.kind === "remote"
-        ? "Usage records could not be gathered."
-        : "No URL to look up in usage records — exposure here is unknowable from traffic.";
-    return (
-      <EvidenceGroup question="Are we already exposed?">
-        <UnknownBlock>{reason}</UnknownBlock>
-      </EvidenceGroup>
-    );
-  }
-
-  if (exposure.status === "unseen") {
-    return (
-      <EvidenceGroup question="Are we already exposed?">
-        <div className="border-border border px-2.5 py-1.5 text-xs">
-          No one in this project has recorded traffic to this server. Denying it
-          costs nobody an existing workflow.
-        </div>
-      </EvidenceGroup>
-    );
-  }
-
-  const facts: Array<{ label: string; value: React.ReactNode }> = [
-    { label: "People who have called it", value: exposure.userCount ?? 0 },
-    { label: "Recorded calls", value: exposure.callCount ?? 0 },
-  ];
-  if (exposure.firstSeen) {
-    facts.push({
-      label: "First seen here",
-      value: (
-        <HumanizeDateTime
-          date={new Date(exposure.firstSeen)}
-          includeTime={false}
-        />
-      ),
-    });
-  }
-  if (exposure.lastCalled) {
-    facts.push({
-      label: "Last called",
-      value: <HumanizeDateTime date={new Date(exposure.lastCalled)} />,
-    });
-  }
-  if (exposure.serverName) {
-    facts.push({ label: "Known here as", value: exposure.serverName });
-  }
-
-  return (
-    <EvidenceGroup question="Are we already exposed?">
-      {exposure.inUse && (
-        <div className="border-warning border px-2.5 py-1.5 text-xs">
-          <span className="font-medium">
-            This server is already in use in this project.
-          </span>{" "}
-          <span className="text-muted-foreground">
-            A denial changes existing workflows, not just future ones.
-          </span>
-        </div>
-      )}
-      <FactList facts={facts} />
-    </EvidenceGroup>
-  );
-}
-
 export function StatusBadge({ status }: { status: string }): JSX.Element {
   switch (status) {
     case "approved":
@@ -1148,6 +1073,11 @@ export function StatusBadge({ status }: { status: string }): JSX.Element {
     case "requested":
       return <Badge variant="information">Awaiting decision</Badge>;
     case "unreviewed":
+      // "Unreviewed", not "Review requested": this state means a dossier was
+      // gathered and nobody has asked for anything — the request states are
+      // "requested" (awaiting a decision) and the two decided ones. Labelling
+      // it as a request contradicted the very notice under it saying no one
+      // had asked.
       // The token palette has no yellow family; the stock yellow scale keeps
       // this state visually distinct from destructive-adjacent orange.
       return (
@@ -1155,7 +1085,7 @@ export function StatusBadge({ status }: { status: string }): JSX.Element {
           variant="warning"
           className="border-yellow-300 text-yellow-600 dark:border-yellow-800 dark:text-yellow-500"
         >
-          Review requested
+          Unreviewed
         </Badge>
       );
     default:

--- a/client/dashboard/src/components/mcp-approvals/EvidencePanel.tsx
+++ b/client/dashboard/src/components/mcp-approvals/EvidencePanel.tsx
@@ -19,6 +19,7 @@ import type {
   EvidenceCapability,
   EvidenceDocument,
   EvidenceDomain,
+  EvidenceExposure,
   EvidenceIdentity,
   EvidencePackage,
   EvidenceProvenance,
@@ -105,12 +106,21 @@ export function EvidencePanel({
             </EvidenceGroup>
           </>
         ) : (
-          <div className="lg:col-span-2">
+          <>
             <DeclaredCapabilitySection
               capabilities={document.capabilities}
               source={document.capabilitiesSource}
             />
-          </div>
+            {/* Without a traffic table the exposure figures have nowhere else
+                to appear: the review sheet has no summary strip, and a frozen
+                decision snapshot is evidence as it stood, not traffic as it is
+                now. The detail page drops this group because its strip and
+                table already answer it. */}
+            <ExposureSection
+              exposure={document.exposure}
+              identity={document.identity}
+            />
+          </>
         )}
         {/* Maturity and advisories share the last row. Maturity used to span
             the full width so its fact list could run two columns, but with
@@ -154,6 +164,78 @@ const GAPS_SHOWN_BY_THEIR_OWN_GROUP = new Set([
   "catalog_lookup_failed",
   "advisory_lookup_failed",
 ]);
+
+/**
+ * What this project's own traffic says, for the surfaces that do not render a
+ * live traffic table beside it.
+ */
+function ExposureSection({
+  exposure,
+  identity,
+}: {
+  exposure: EvidenceExposure | undefined;
+  identity: EvidenceIdentity;
+}): JSX.Element {
+  if (!exposure) {
+    return (
+      <EvidenceGroup question="Are we already exposed?">
+        <UnknownBlock>
+          {identity.kind === "remote"
+            ? "Usage records could not be gathered."
+            : "No URL to look up in usage records — exposure here is unknowable from traffic."}
+        </UnknownBlock>
+      </EvidenceGroup>
+    );
+  }
+
+  if (exposure.status === "unseen") {
+    return (
+      <EvidenceGroup question="Are we already exposed?">
+        <AnswerBlock>
+          No one in this project has recorded traffic to this server. Denying it
+          costs nobody an existing workflow.
+        </AnswerBlock>
+      </EvidenceGroup>
+    );
+  }
+
+  const facts: Array<{ label: string; value: React.ReactNode }> = [
+    { label: "People who have called it", value: exposure.userCount ?? 0 },
+    { label: "Recorded calls", value: exposure.callCount ?? 0 },
+  ];
+  if (exposure.firstSeen) {
+    facts.push({
+      label: "First seen here",
+      value: (
+        <HumanizeDateTime
+          date={new Date(exposure.firstSeen)}
+          includeTime={false}
+        />
+      ),
+    });
+  }
+  if (exposure.lastCalled) {
+    facts.push({
+      label: "Last called",
+      value: <HumanizeDateTime date={new Date(exposure.lastCalled)} />,
+    });
+  }
+
+  return (
+    <EvidenceGroup
+      question="Are we already exposed?"
+      note={
+        exposure.inUse && (
+          <span className="border-warning border px-2.5 py-1 text-xs">
+            Already in use — a denial changes existing workflows.
+          </span>
+        )
+      }
+    >
+      <FactList facts={facts} />
+    </EvidenceGroup>
+  );
+}
 
 export function EvidenceGroup({
   question,

--- a/client/dashboard/src/components/mcp-approvals/EvidencePanel.tsx
+++ b/client/dashboard/src/components/mcp-approvals/EvidencePanel.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/Badge";
 import { Heading } from "@/components/ui/Heading";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { Info } from "lucide-react";
+import { useId } from "react";
 import { HumanizeDateTime } from "@/lib/dates";
 import {
   MoreToggle,
@@ -220,6 +221,12 @@ function ExposureSection({
       value: <HumanizeDateTime date={new Date(exposure.lastCalled)} />,
     });
   }
+  if (exposure.serverName) {
+    // The name this project knew the server by when the evidence was taken —
+    // on a frozen snapshot nothing else carries it, and it can differ from
+    // the name the page shows today.
+    facts.push({ label: "Known here as", value: exposure.serverName });
+  }
 
   return (
     <EvidenceGroup
@@ -279,7 +286,16 @@ export function EvidenceGroup({
           </Heading>
           {hint && (
             <SimpleTooltip tooltip={hint}>
-              <Info className="text-muted-foreground size-3.5 shrink-0" />
+              {/* A button, not the bare icon: an SVG cannot take focus, and
+                  the tooltip opens on focus as well as hover, so this is what
+                  makes the caveat reachable by keyboard at all. */}
+              <button
+                type="button"
+                aria-label="About this data"
+                className="text-muted-foreground hover:text-foreground inline-flex shrink-0"
+              >
+                <Info className="size-3.5" />
+              </button>
             </SimpleTooltip>
           )}
         </div>
@@ -563,9 +579,10 @@ function ScopeChips({ scopes }: { scopes: string[] }): JSX.Element {
     scopes,
     SCOPE_PREVIEW_COUNT,
   );
+  const listId = useId();
 
   return (
-    <div className="flex flex-wrap gap-1">
+    <div id={listId} className="flex flex-wrap gap-1">
       {visible.map((scope) => (
         <span
           key={scope}
@@ -579,6 +596,7 @@ function ScopeChips({ scopes }: { scopes: string[] }): JSX.Element {
           expanded={expanded}
           onToggle={toggle}
           collapsedLabel={`+${scopes.length - SCOPE_PREVIEW_COUNT} more`}
+          controlId={listId}
           className="px-1.5 py-px"
         />
       )}
@@ -702,10 +720,11 @@ function CollapsibleList<T>({
     items,
     previewCount,
   );
+  const listId = useId();
 
   return (
     <div className="border-border border">
-      <ul className="divide-border divide-y">
+      <ul id={listId} className="divide-border divide-y">
         {visible.map((item) => (
           <li key={itemKey(item)} className={itemClassName}>
             {renderItem(item)}
@@ -717,6 +736,7 @@ function CollapsibleList<T>({
           expanded={expanded}
           onToggle={toggle}
           collapsedLabel={`Show all ${items.length} ${noun}`}
+          controlId={listId}
           className="border-border w-full justify-center border-t px-3 py-1"
         />
       )}

--- a/client/dashboard/src/components/ui/MetricCard/index.tsx
+++ b/client/dashboard/src/components/ui/MetricCard/index.tsx
@@ -26,6 +26,9 @@ const valueTone = cva("font-display font-thin", {
       warning: "text-default-warning",
     },
     size: {
+      // For a strip sharing a row rather than owning one: at half width the
+      // sm figures crowd their labels and each other.
+      xs: "text-[1.75rem] leading-[0.95]",
       sm: "text-[2.5rem] leading-[0.85]",
       md: "text-[3.625rem] leading-[0.82]",
       lg: "text-[4.75rem] leading-[0.8]",

--- a/client/dashboard/src/components/ui/collapsible-preview.tsx
+++ b/client/dashboard/src/components/ui/collapsible-preview.tsx
@@ -1,0 +1,67 @@
+// oxlint-disable react/only-export-components -- the toggle ships with the hook that drives it
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * Hiding the tail of a list: the state, the slice, and what counts as
+ * collapsible. Every list that hides one shares this, so the rule that a list
+ * at exactly the preview count shows no toggle is decided once.
+ */
+export function useCollapsedPreview<T>(
+  items: T[],
+  previewCount: number,
+): {
+  collapsible: boolean;
+  expanded: boolean;
+  toggle: () => void;
+  visible: T[];
+} {
+  const [expanded, setExpanded] = useState(false);
+  const collapsible = items.length > previewCount;
+
+  return {
+    collapsible,
+    expanded,
+    toggle: () => setExpanded((current) => !current),
+    visible: collapsible && !expanded ? items.slice(0, previewCount) : items,
+  };
+}
+
+/**
+ * The control that reveals a hidden tail. The chrome around it differs — a
+ * chip in a wrap of scopes, a footer row under a framed list, a row beneath a
+ * table — but the accessible contract and the collapse wording are the same
+ * wherever it appears, so they live here rather than in each caller.
+ */
+export function MoreToggle({
+  expanded,
+  onToggle,
+  collapsedLabel,
+  className,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  /** What the control says while the tail is hidden. */
+  collapsedLabel: string;
+  className?: string;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      aria-expanded={expanded}
+      onClick={onToggle}
+      className={cn(
+        "text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs",
+        className,
+      )}
+    >
+      {expanded ? "Show fewer" : collapsedLabel}
+      {expanded ? (
+        <ChevronUp className="size-3" />
+      ) : (
+        <ChevronDown className="size-3" />
+      )}
+    </button>
+  );
+}

--- a/client/dashboard/src/components/ui/collapsible-preview.tsx
+++ b/client/dashboard/src/components/ui/collapsible-preview.tsx
@@ -38,18 +38,25 @@ export function MoreToggle({
   expanded,
   onToggle,
   collapsedLabel,
+  controlId,
   className,
 }: {
   expanded: boolean;
   onToggle: () => void;
   /** What the control says while the tail is hidden. */
   collapsedLabel: string;
+  /**
+   * The id of the region this toggle expands, for aria-controls — without it
+   * a screen reader hears "expanded" with nothing saying expanded *what*.
+   */
+  controlId?: string;
   className?: string;
 }): JSX.Element {
   return (
     <button
       type="button"
       aria-expanded={expanded}
+      aria-controls={controlId}
       onClick={onToggle}
       className={cn(
         "text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs",

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
@@ -120,13 +120,15 @@ vi.mock("@/components/mcp-approvals/DecideAccessSheet", () => ({
 }));
 
 vi.mock("@/components/mcp-approvals/ApprovalReview", () => ({
-  // The double renders the usage slot, because the real review does: observed
-  // traffic is a section of the review, and a double that swallowed it would
-  // hide the page's own table from every test here.
+  // The double renders the usage and summary slots, because the real review
+  // does: observed traffic and the at-a-glance strip are both sections of the
+  // review, and a double that swallowed them would hide the page's own table
+  // and stats from every test here.
   ApprovalReview: ({
     audience,
     requestId,
     usage,
+    summary,
   }: {
     audience?: {
       disposition: string | null;
@@ -135,12 +137,14 @@ vi.mock("@/components/mcp-approvals/ApprovalReview", () => ({
     };
     requestId: string;
     usage?: React.ReactNode;
+    summary?: React.ReactNode;
   }) => (
     <div
       data-testid="approval-review"
       data-audience-disposition={audience?.disposition ?? undefined}
       data-request-id={requestId}
     >
+      {summary}
       {usage}
     </div>
   ),

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
@@ -51,7 +51,7 @@ import {
 import { useUpdateShadowMCPInventoryServerNameMutation } from "@gram/client/react-query/updateShadowMCPInventoryServerName.js";
 import { useShadowMCPInventoryUsers } from "@gram/client/react-query/shadowMCPInventoryUsers.js";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 
@@ -275,6 +275,7 @@ function TopUsersTable({
     users,
     USERS_PREVIEW_COUNT,
   );
+  const tableId = useId();
 
   if (users.length === 0) {
     return (
@@ -293,26 +294,29 @@ function TopUsersTable({
 
   return (
     <div className="space-y-2">
-      <Table columns={columns}>
-        <Table.Header columns={columns} />
-        <Table.Body
-          columns={columns}
-          data={visible}
-          handleLoadMore={onLoadMore}
-          // While collapsed, don't auto-fetch the next page — expanding is the
-          // signal that the reader wants the whole roster.
-          hasMore={!collapsed && hasMore}
-          isLoading={isLoading}
-          isRowClickable={(user) => Boolean(user.email)}
-          onRowClick={onOpenUser}
-          rowKey={(row) => row.userKey}
-        />
-      </Table>
+      <div id={tableId}>
+        <Table columns={columns}>
+          <Table.Header columns={columns} />
+          <Table.Body
+            columns={columns}
+            data={visible}
+            handleLoadMore={onLoadMore}
+            // While collapsed, don't auto-fetch the next page — expanding is the
+            // signal that the reader wants the whole roster.
+            hasMore={!collapsed && hasMore}
+            isLoading={isLoading}
+            isRowClickable={(user) => Boolean(user.email)}
+            onRowClick={onOpenUser}
+            rowKey={(row) => row.userKey}
+          />
+        </Table>
+      </div>
       {collapsible && (
         <MoreToggle
           expanded={expanded}
           onToggle={toggle}
           collapsedLabel={`Show all ${users.length}${hasMore ? "+" : ""} users`}
+          controlId={tableId}
         />
       )}
     </div>
@@ -595,10 +599,11 @@ export default function ShadowMCPServerDetail(): JSX.Element {
       </div>
     ) : (
       <TopUsersTable
-        // Remount per server: the collapse state lives in the table, and this
-        // route stays mounted when navigating between servers, so without a
-        // key the next server's roster opens already expanded.
-        key={serverSlug}
+        // Remount per project+server: the collapse state lives in the table,
+        // and this route stays mounted when navigating between servers or
+        // switching projects, so without a key the next roster opens already
+        // expanded.
+        key={`${project.id}/${serverSlug}`}
         hasMore={Boolean(nextUsersCursor)}
         isLoading={isLoadingMoreUsers}
         onLoadMore={loadMoreUsers}

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
@@ -4,6 +4,7 @@ import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { MetricCard, type MetricCardProps } from "@/components/ui/MetricCard";
 import { SkeletonTable } from "@/components/ui/Skeleton";
 import { type Column, Table } from "@/components/ui/Table";
 import { Text } from "@/components/ui/Text";
@@ -16,13 +17,17 @@ import {
   DecideAccessSheet,
 } from "@/components/mcp-approvals/DecideAccessSheet";
 import {
+  MoreToggle,
+  useCollapsedPreview,
+} from "@/components/ui/collapsible-preview";
+import {
   eligibleShadowMCPAllowRulePolicies,
   shadowMCPBlockingPolicyDisposition,
   shadowMCPInventoryStatus,
-  shadowMCPInventoryStatusBadgeVariant,
   shadowMCPInventoryStatusDescription,
   shadowMCPInventoryStatusLabel,
   shadowMCPPolicyState,
+  type ShadowMCPInventoryStatus,
   type ShadowMCPPolicy,
   type ShadowMCPPolicyDisposition,
   type ShadowMCPPolicyState,
@@ -53,6 +58,11 @@ import { toast } from "sonner";
 const USERS_PAGE_LIMIT = 50;
 const FIRST_PAGE_CURSOR = "";
 
+// How many users the table shows before the rest collapses behind a toggle.
+// A busy server's roster runs long, and it sits beside the evidence rather
+// than owning the page, so it previews a handful and expands on demand.
+const USERS_PREVIEW_COUNT = 5;
+
 type UsersPage = {
   cursor: string;
   nextCursor?: string;
@@ -81,6 +91,10 @@ function UserSources({
     return sourceLabel(left.source).localeCompare(sourceLabel(right.source));
   });
 
+  // With one source, its count is the user's whole call count — already the
+  // next column over. The split is only worth showing when there is a split.
+  const showCounts = orderedSources.length > 1;
+
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
       {orderedSources.map((source) => (
@@ -89,16 +103,65 @@ function UserSources({
           <span className="whitespace-nowrap font-medium">
             {sourceLabel(source.source)}
           </span>
-          <Badge variant="neutral">
-            <Badge.Text>{source.observedUseCount}</Badge.Text>
-          </Badge>
+          {showCounts && (
+            <Badge variant="neutral">
+              <Badge.Text>{source.observedUseCount}</Badge.Text>
+            </Badge>
+          )}
         </div>
       ))}
     </div>
   );
 }
 
-function ServerStatus({
+// MetricCard defaults to the roomier p-6/gap-4 the deployment page uses. This
+// strip shares a row with the review header and sits above dense hairline
+// tables, so it matches their rhythm, and px-3 puts its labels on the same left
+// rail as the fact lists below.
+const SUMMARY_TILE_CLASS = "gap-2 px-3 py-3";
+
+/** Day without the time, for a figure that has to read at a glance. */
+const summaryDayFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
+
+/** The clock time, demoted to the qualifier line under the day. */
+const summaryTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+/**
+ * How the status colors its figure. The badge variants and the metric tones
+ * are the same vocabulary, but they are separate types — mapping them here
+ * keeps the strip honest if either list grows.
+ */
+function statusTone(status: ShadowMCPInventoryStatus): MetricCardProps["tone"] {
+  switch (status) {
+    case "allowed":
+      return "success";
+    case "blocked":
+      return "destructive";
+    case "restricted":
+    case "pending":
+      return "warning";
+    case "observed":
+    case "unavailable":
+      return "neutral";
+  }
+}
+
+/**
+ * The server at a glance: status, traffic, and recency as one bordered strip.
+ *
+ * Handed to the review as its `summary` so the two share a row. It replaced a
+ * badge and two lines of prose in a full-width block, where the status sat
+ * alone on the left and the figures had nowhere to go that did not read as an
+ * island — giving every figure the same shape and its own column fills the
+ * width by construction instead.
+ */
+function ServerSummary({
   disposition,
   policyState,
   server,
@@ -110,32 +173,54 @@ function ServerStatus({
   const status = shadowMCPInventoryStatus(server, policyState);
 
   return (
-    <div className="space-y-1">
-      <Badge variant={shadowMCPInventoryStatusBadgeVariant(status)}>
-        <Badge.Text>{shadowMCPInventoryStatusLabel(status)}</Badge.Text>
-      </Badge>
-      <Text muted small>
-        {shadowMCPInventoryStatusDescription(server, policyState, disposition)}
-      </Text>
-    </div>
-  );
-}
-
-function ServerSummary({
-  disposition,
-  policyState,
-  server,
-}: {
-  disposition: ShadowMCPPolicyDisposition | null;
-  policyState: ShadowMCPPolicyState;
-  server: ShadowMCPInventoryServer;
-}) {
-  return (
-    <ServerStatus
-      disposition={disposition}
-      policyState={policyState}
-      server={server}
-    />
+    <MetricCard.Group className="flex-wrap">
+      <MetricCard
+        label="Status"
+        value={shadowMCPInventoryStatusLabel(status)}
+        tone={statusTone(status)}
+        size="xs"
+        className={SUMMARY_TILE_CLASS}
+        description={shadowMCPInventoryStatusDescription(
+          server,
+          policyState,
+          disposition,
+        )}
+      />
+      {/* First-seen rides under the call count rather than taking a tile of
+          its own: it is the span those calls happened over, not a figure
+          anyone reads on its own. */}
+      <MetricCard
+        label="Calls"
+        value={server.observedUseCount}
+        tone="neutral"
+        size="xs"
+        className={SUMMARY_TILE_CLASS}
+        description={`since ${summaryDayFormatter.format(server.firstSeen)}`}
+      />
+      <MetricCard
+        label="People"
+        value={server.userCount}
+        tone="neutral"
+        size="xs"
+        className={SUMMARY_TILE_CLASS}
+      />
+      <MetricCard
+        label="Last called"
+        value={
+          server.lastCalled
+            ? summaryDayFormatter.format(server.lastCalled)
+            : "Never"
+        }
+        tone="neutral"
+        size="xs"
+        className={SUMMARY_TILE_CLASS}
+        description={
+          server.lastCalled
+            ? summaryTimeFormatter.format(server.lastCalled)
+            : undefined
+        }
+      />
+    </MetricCard.Group>
   );
 }
 
@@ -186,6 +271,11 @@ function TopUsersTable({
     },
   ];
 
+  const { collapsible, expanded, toggle, visible } = useCollapsedPreview(
+    users,
+    USERS_PREVIEW_COUNT,
+  );
+
   if (users.length === 0) {
     return (
       <div className="bg-muted/20 flex min-h-32 flex-col items-center justify-center border border-dashed px-6 py-8 text-center">
@@ -199,20 +289,33 @@ function TopUsersTable({
     );
   }
 
+  const collapsed = collapsible && !expanded;
+
   return (
-    <Table columns={columns}>
-      <Table.Header columns={columns} />
-      <Table.Body
-        columns={columns}
-        data={users}
-        handleLoadMore={onLoadMore}
-        hasMore={hasMore}
-        isLoading={isLoading}
-        isRowClickable={(user) => Boolean(user.email)}
-        onRowClick={onOpenUser}
-        rowKey={(row) => row.userKey}
-      />
-    </Table>
+    <div className="space-y-2">
+      <Table columns={columns}>
+        <Table.Header columns={columns} />
+        <Table.Body
+          columns={columns}
+          data={visible}
+          handleLoadMore={onLoadMore}
+          // While collapsed, don't auto-fetch the next page — expanding is the
+          // signal that the reader wants the whole roster.
+          hasMore={!collapsed && hasMore}
+          isLoading={isLoading}
+          isRowClickable={(user) => Boolean(user.email)}
+          onRowClick={onOpenUser}
+          rowKey={(row) => row.userKey}
+        />
+      </Table>
+      {collapsible && (
+        <MoreToggle
+          expanded={expanded}
+          onToggle={toggle}
+          collapsedLabel={`Show all ${users.length}${hasMore ? "+" : ""} users`}
+        />
+      )}
+    </div>
   );
 }
 
@@ -611,11 +714,6 @@ export default function ShadowMCPServerDetail(): JSX.Element {
                     members={membersQuery.data?.members ?? []}
                     roles={rolesQuery.data?.roles ?? []}
                   />
-                  <ServerSummary
-                    disposition={disposition}
-                    policyState={policyState}
-                    server={server}
-                  />
                   <section className="min-h-0 space-y-3">
                     {/* The review owns its own heading: the request's status
                         shares that row, and only the review has it. Observed
@@ -626,18 +724,25 @@ export default function ShadowMCPServerDetail(): JSX.Element {
                       <ApprovalReview
                         requestId={server.approvalRequest.id}
                         title="Access review"
-                        description="Evidence, requesters, and decision history. Decisions here allow or block this server."
                         usage={usersPanel}
+                        summary={
+                          <ServerSummary
+                            disposition={disposition}
+                            policyState={policyState}
+                            server={server}
+                          />
+                        }
                       />
                     ) : (
                       <>
-                        <div>
-                          <Text variant="subheading">Access review</Text>
-                          <Text muted small>
-                            Evidence, requesters, and decision history.
-                            Decisions here allow or block this server.
-                          </Text>
-                        </div>
+                        {/* No dossier yet, so the review has no header to
+                            share a row with — the strip stands alone until
+                            the gather lands and the two-column row appears. */}
+                        <ServerSummary
+                          disposition={disposition}
+                          policyState={policyState}
+                          server={server}
+                        />
                         <EnsureServerReview
                           canonicalServerUrl={server.canonicalServerUrl}
                         />

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
@@ -595,6 +595,10 @@ export default function ShadowMCPServerDetail(): JSX.Element {
       </div>
     ) : (
       <TopUsersTable
+        // Remount per server: the collapse state lives in the table, and this
+        // route stays mounted when navigating between servers, so without a
+        // key the next server's roster opens already expanded.
+        key={serverSlug}
         hasMore={Boolean(nextUsersCursor)}
         isLoading={isLoadingMoreUsers}
         onLoadMore={loadMoreUsers}


### PR DESCRIPTION
Reworks the Shadow MCP server detail page. The page reported the same facts up to three times and left most of its width empty; this replaces the top of it with a summary strip and removes the repetition beneath.

## Summary strip

Status, calls, people and last-called now read as one bordered strip of metric tiles, sharing a row with the review's own header. Previously the top of the page was a status badge and two lines of prose in a full-width block, so the right half was empty by construction and anything placed there read as an island. Four equal columns fill the width structurally.

The strip is handed to `ApprovalReview` as a `summary` slot, the same way the traffic table is handed over as `usage` — the page owns the query, the review owns the layout. It renders in the review's loading and error branches too, since it is page-level data that should not wait on the review's query.

`MetricCard` gains an additive `xs` size; at half width the existing `sm` figures crowded their labels.

## Removed repetition

- **Exposure facts.** "Are we already exposed?" restated calls, people, first-seen, last-called and the server's own name — the strip reports the first four and the page title is the fifth. The traffic table answers the question directly, so the group is gone; the one thing it cannot say, what a denial costs, rides beside its heading as a note.
- **Per-source counts.** With a single source, the badge on `Claude Code 3` was the `3 calls` in the next column. Counts now appear only when a user actually has more than one source.
- **Gaps banner.** Failures whose own group already renders an unknown block were announced twice. The banner is now for lookups with nowhere else to surface (exposure, code host, domain registry).
- **Unreviewed state.** A bare "no decision has been recorded", the "Have we decided on this before?" eyebrow and "No prior decisions" were three fragments for one absence. The badge carries the state and the header carries the rest.

## Alignment and empty states

- Caveats that sat as paragraphs under each question now hang off an icon beside it, so every box in a row starts at the same top edge.
- Groups stretch to their row's height, and a group whose whole answer is one sentence centres it rather than stranding it in the top corner.
- `AnswerBlock` replaces four copies of the same bordered-box className; `UnknownBlock` is a thin wrapper over it.
- `useCollapsedPreview` and `MoreToggle` move to `components/ui/collapsible-preview.tsx` and are reused by the users table, which now previews five users behind a toggle.

## Copy fixes

- The `unreviewed` status rendered as **"Review requested"**, directly contradicting the notice under it saying nobody had asked. It reads **"Unreviewed"** now. This also corrects the inventory table, which shares the badge.
- The evidence provenance caveat is gated on there being evidence; it was printing "declared by the server or its registry" above "No evidence gathered".
- Web research drops its intro, credits warning and empty state when research is not in the plan, and its heading matches the evidence groups.

## Testing

`tsc`, `oxlint` and `hk fix` clean; 39 tests pass across `mcp-approvals` and `shadow-mcp`. Verified in the browser against a populated remote server, a sparse one, and the stdio review sheet.

## Note for reviewers

Groups stretch so rows end level, which means a populated-but-short list (advisories beside a long maturity column) leaves empty frame below it. Equal row heights were the goal; scoping the stretch to single-sentence blocks would trade that away. Happy to change it if reviewers prefer the other trade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the Shadow MCP server detail page around a four‑tile summary strip and removes duplicated facts to improve scan speed and alignment. Previously a lone badge and prose owned the top row; now the strip carries figures and the review header carries status, caveats, and first‑review notice.

- Consolidates header and summary: `ApprovalReview` accepts a `summary` slot. The header is boxed, shows status, “raised” date (when applicable), the evidence caveat/timestamp, version‑pin caveat, and a short notice for untouched dossiers. When provided, the summary and header share one two‑column row and the summary remains visible during review loading/error.
- Streamlines evidence: caveats move into tooltip hints on group titles; `AnswerBlock`/`UnknownBlock` center single‑sentence answers; the gaps banner only lists failures without their own unknown block. The “Are we already exposed?” group is removed on the detail page (the traffic table answers it); surfaces without a traffic table (review sheet, frozen snapshot) still render the exposure group with a “denial changes workflows” note when in use. Shows an “evidence changed” notice on approved requests when the evidence diff changed.
- Polishes research: “Web research” is an `EvidenceGroup` with a hint; the Run Research button appears only when the feature is enabled and the viewer has org‑admin; a plan‑disabled note shows when applicable; intro/warning/empty states are suppressed when disabled.
- Improves lists and layout: groups stretch to row height; adds `xs` size to `MetricCard` for the strip; the Top Users table collapses to 5 rows via shared `MoreToggle`/`useCollapsedPreview` with `aria-controls`; per‑source counts appear only when a user has multiple sources.
- Fixes copy/state: the unreviewed badge reads “Unreviewed,” aligning with the inventory table and header notice.

**Migration**
- Update callers of `ApprovalReview`: remove the `description` prop; optionally pass a `summary` node to render beside the header.
- Update callers of `EvidencePanel`: drop the `collectedAt` prop (the header now carries the evidence caveat and timestamp).
- If you used list‑collapsing helpers, import `useCollapsedPreview` and `MoreToggle` from `components/ui/collapsible-preview`.

<sup>Written for commit 2dfa703997235bf173a35684a61a99deebcab5f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

