### PR TITLE
feat: add superadmin RBAC setup

### DIFF
--- a/.changeset/setup-legacy-rbac.md
+++ b/.changeset/setup-legacy-rbac.md
@@ -1,0 +1,6 @@
+---
+"admin": patch
+"server": minor
+---
+
+Add a superadmin action that seeds the built-in RBAC roles and core grants for legacy organizations.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -75229,6 +75229,15 @@ components:
           type: string
           description: The user_session_issuer id to link, or null to unlink.
           format: uuid
+    SetupRBACRequestBody:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Organization ID.
+          minLength: 1
+      required:
+        - id
     ShadowMCPInventoryApprovalRequest:
       type: object
       properties:

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -19,6 +19,7 @@ import {
   MIN_TRIAL_REARM_DAYS,
   rearmTrial,
   resumeStripeSubscription,
+  setupOrganizationRBAC,
   toSearchParams,
   type AdminOrganization,
 } from "@/lib/gramAdminApi";
@@ -313,6 +314,24 @@ describe("the organization write endpoints", () => {
 
     expect(requestOf(fetch)).toEqual({
       path: "/admin/organization.enable",
+      method: "POST",
+      contentType: "application/json",
+      body: { id: ORG.id },
+    });
+  });
+
+  it("posts the id to the RBAC setup path", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(
+      setupOrganizationRBAC({ id: ORG.id }),
+    ).resolves.toBeUndefined();
+
+    expect(requestOf(fetch)).toEqual({
+      path: "/admin/organization.setupRBAC",
       method: "POST",
       contentType: "application/json",
       body: { id: ORG.id },

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -375,6 +375,16 @@ export function enableOrganization(
   });
 }
 
+export function setupOrganizationRBAC(
+  body: OrganizationRequest,
+): Promise<void> {
+  return gramAdminSend("/admin/organization.setupRBAC", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 // The server's own bounds, mirrored so a value it would reject never leaves the
 // browser. See MinTrialExtensionDays and MaxTrialExtensionDays in
 // server/internal/constants/trials.go: zero moves nothing but updated_at, a

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   listOrganizationProjects: vi.fn(),
   listOrganizations: vi.fn(),
   getOrganizationStats: vi.fn(),
+  setupOrganizationRBAC: vi.fn(),
   updateOrganization: vi.fn(),
 }));
 
@@ -35,6 +36,7 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     listOrganizationProjects: mocks.listOrganizationProjects,
     listOrganizations: mocks.listOrganizations,
     getOrganizationStats: mocks.getOrganizationStats,
+    setupOrganizationRBAC: mocks.setupOrganizationRBAC,
     updateOrganization: mocks.updateOrganization,
   };
 });
@@ -146,6 +148,8 @@ beforeEach(() => {
   mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
   mocks.listOrganizations.mockReset();
   mocks.getOrganizationStats.mockReset();
+  mocks.setupOrganizationRBAC.mockReset();
+  mocks.setupOrganizationRBAC.mockResolvedValue(undefined);
   mocks.updateOrganization.mockReset();
 });
 
@@ -651,7 +655,47 @@ describe("Overview", () => {
       "Updated",
     ]);
     expect(labelsIn("Plan")).toEqual(["Account type", "Trial"]);
-    expect(labelsIn("Access")).toEqual(["Whitelisted", "Disabled at"]);
+    expect(labelsIn("Access")).toEqual(["Whitelisted", "Disabled at", "RBAC"]);
+  });
+
+  it("marks RBAC setup as a legacy-only repair", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Setup RBAC" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Legacy organizations only. New organizations should have RBAC configured automatically.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("sets up RBAC after confirming the legacy repair", async () => {
+    await renderRouteTree(routeTree, {
+      initialPath: `/organizations/${ORG.slug}`,
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Setup RBAC" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByRole("heading").textContent).toBe(
+      `Setup RBAC for ${ORG.name}?`,
+    );
+    expect(
+      within(dialog).getByText(/Use this only for legacy organizations/),
+    ).toBeTruthy();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Setup RBAC" }));
+    await waitFor(() => {
+      expect(mocks.setupOrganizationRBAC).toHaveBeenCalledWith({ id: ORG.id });
+    });
+    await waitFor(() => {
+      expect(liveRegion().textContent).toContain(
+        `RBAC set up for ${ORG.name}.`,
+      );
+    });
   });
 
   it("nests the group headings under the record's own heading", async () => {

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -5,6 +5,7 @@ import { useParams } from "@tanstack/react-router";
 import { useConfirmDialog } from "@/components/ConfirmDialog";
 import { CopyValue } from "@/components/CopyValue";
 import { Trial } from "@/components/Trial";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -22,6 +23,7 @@ import {
 } from "@/lib/adminQueries";
 import {
   errorMessage,
+  setupOrganizationRBAC,
   updateOrganization,
   type AdminOrganization,
 } from "@/lib/gramAdminApi";
@@ -95,6 +97,7 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
   // `DialogTrigger`, so Radix's own restore drops focus on `document.body`.
   const accountTypeControl = useRef<HTMLButtonElement>(null);
   const whitelistedControl = useRef<HTMLButtonElement>(null);
+  const setupRBACControl = useRef<HTMLButtonElement>(null);
   const openedFrom = useRef<HTMLButtonElement | null>(null);
 
   const mut = useMutation({
@@ -109,6 +112,10 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
     // A failed write replaces nothing it cancelled, so the totals have to be
     // asked for again. The record needs nothing: it was never repainted.
     onError: () => invalidateOrganizationStats(qc),
+  });
+
+  const setupRBACMutation = useMutation({
+    mutationFn: () => setupOrganizationRBAC({ id: org.id }),
   });
 
   // The confirmed path cannot restore focus itself: it disables the control it
@@ -126,6 +133,13 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
     // A control that has left the page is not somewhere to put the keyboard.
     if (openedFrom.current?.isConnected) openedFrom.current.focus();
   }, [mut.status, mut.isPending, mut.variables]);
+
+  const setupRestoreWanted = useRef(false);
+  useEffect(() => {
+    if (setupRBACMutation.isPending || !setupRestoreWanted.current) return;
+    setupRestoreWanted.current = false;
+    if (setupRBACControl.current?.isConnected) setupRBACControl.current.focus();
+  }, [setupRBACMutation.status, setupRBACMutation.isPending]);
 
   const commit = async (
     change: FactChange,
@@ -153,6 +167,30 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
       onSuccess: () => announce(`${org.name} updated. ${describe}.`),
       onError: (error) => {
         const text = `Could not update ${org.name}: ${errorMessage(error)}`;
+        announce(text);
+        showFailure(text);
+      },
+    });
+  };
+
+  const setupRBAC = async (): Promise<void> => {
+    const confirmed = await confirm({
+      title: `Setup RBAC for ${org.name}?`,
+      description:
+        "This seeds the core roles and grants. Use this only for legacy organizations; new organizations should have RBAC configured automatically.",
+      confirmLabel: "Setup RBAC",
+    });
+    if (!confirmed) {
+      setupRBACControl.current?.focus();
+      return;
+    }
+
+    showFailure(null);
+    setupRestoreWanted.current = true;
+    setupRBACMutation.mutate(undefined, {
+      onSuccess: () => announce(`RBAC set up for ${org.name}.`),
+      onError: (error) => {
+        const text = `Could not set up RBAC for ${org.name}: ${errorMessage(error)}`;
         announce(text);
         showFailure(text);
       },
@@ -260,6 +298,23 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
           >
             {fmtDateShort(org.disabled_at)}
           </span>
+        </Row>
+        <Row label="RBAC">
+          <div className="flex flex-col items-start gap-1.5">
+            <Button
+              ref={setupRBACControl}
+              variant="outline"
+              size="xs"
+              disabled={setupRBACMutation.isPending}
+              onClick={() => void setupRBAC()}
+            >
+              {setupRBACMutation.isPending ? "Setting up…" : "Setup RBAC"}
+            </Button>
+            <p className="text-muted-foreground max-w-xl text-xs">
+              Legacy organizations only. New organizations should have RBAC
+              configured automatically.
+            </p>
+          </div>
         </Row>
       </Group>
 

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -411,6 +411,28 @@ var _ = Service("admin", func() {
 		Meta("openapi:operationId", "adminEnableOrganization")
 	})
 
+	Method("setupRBAC", func() {
+		Description("Seeds the built-in roles and their core grants for a legacy organization. Idempotent: roles that already hold grants are left unchanged. New organizations receive this setup automatically.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("id")
+
+			Meta("openapi:typename", "SetupRBACRequestBody")
+
+			Attribute("id", String, "Organization ID.", func() {
+				MinLength(1)
+			})
+		})
+
+		HTTP(func() {
+			POST("/admin/organization.setupRBAC")
+			Response(StatusNoContent)
+		})
+
+		Meta("openapi:operationId", "adminSetupRBAC")
+	})
+
 	Method("getOrganization", func() {
 		Description("Returns full admin details for a single organization by id or slug.")
 

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	BulkUpdateAccountTypeEndpoint    goa.Endpoint
 	DisableOrganizationEndpoint      goa.Endpoint
 	EnableOrganizationEndpoint       goa.Endpoint
+	SetupRBACEndpoint                goa.Endpoint
 	GetOrganizationEndpoint          goa.Endpoint
 	ListOrganizationMembersEndpoint  goa.Endpoint
 	ListOrganizationProjectsEndpoint goa.Endpoint
@@ -39,7 +40,7 @@ type Client struct {
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, setupRBAC, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
@@ -49,6 +50,7 @@ func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpda
 		BulkUpdateAccountTypeEndpoint:    bulkUpdateAccountType,
 		DisableOrganizationEndpoint:      disableOrganization,
 		EnableOrganizationEndpoint:       enableOrganization,
+		SetupRBACEndpoint:                setupRBAC,
 		GetOrganizationEndpoint:          getOrganization,
 		ListOrganizationMembersEndpoint:  listOrganizationMembers,
 		ListOrganizationProjectsEndpoint: listOrganizationProjects,
@@ -239,6 +241,24 @@ func (c *Client) EnableOrganization(ctx context.Context, p *EnableOrganizationPa
 		return
 	}
 	return ires.(*AdminOrganization), nil
+}
+
+// SetupRBAC calls the "setupRBAC" endpoint of the "admin" service.
+// SetupRBAC may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) SetupRBAC(ctx context.Context, p *SetupRBACPayload) (err error) {
+	_, err = c.SetupRBACEndpoint(ctx, p)
+	return
 }
 
 // GetOrganization calls the "getOrganization" endpoint of the "admin" service.

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -24,6 +24,7 @@ type Endpoints struct {
 	BulkUpdateAccountType    goa.Endpoint
 	DisableOrganization      goa.Endpoint
 	EnableOrganization       goa.Endpoint
+	SetupRBAC                goa.Endpoint
 	GetOrganization          goa.Endpoint
 	ListOrganizationMembers  goa.Endpoint
 	ListOrganizationProjects goa.Endpoint
@@ -52,6 +53,7 @@ func NewEndpoints(s Service) *Endpoints {
 		BulkUpdateAccountType:    NewBulkUpdateAccountTypeEndpoint(s, a.APIKeyAuth),
 		DisableOrganization:      NewDisableOrganizationEndpoint(s, a.APIKeyAuth),
 		EnableOrganization:       NewEnableOrganizationEndpoint(s, a.APIKeyAuth),
+		SetupRBAC:                NewSetupRBACEndpoint(s, a.APIKeyAuth),
 		GetOrganization:          NewGetOrganizationEndpoint(s, a.APIKeyAuth),
 		ListOrganizationMembers:  NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
 		ListOrganizationProjects: NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
@@ -78,6 +80,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.BulkUpdateAccountType = m(e.BulkUpdateAccountType)
 	e.DisableOrganization = m(e.DisableOrganization)
 	e.EnableOrganization = m(e.EnableOrganization)
+	e.SetupRBAC = m(e.SetupRBAC)
 	e.GetOrganization = m(e.GetOrganization)
 	e.ListOrganizationMembers = m(e.ListOrganizationMembers)
 	e.ListOrganizationProjects = m(e.ListOrganizationProjects)
@@ -232,6 +235,29 @@ func NewEnableOrganizationEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFu
 			return nil, err
 		}
 		return s.EnableOrganization(ctx, p)
+	}
+}
+
+// NewSetupRBACEndpoint returns an endpoint function that calls the method
+// "setupRBAC" of service "admin".
+func NewSetupRBACEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*SetupRBACPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return nil, s.SetupRBAC(ctx, p)
 	}
 }
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -39,6 +39,10 @@ type Service interface {
 	// Re-enables a disabled organization by clearing disabled_at. Idempotent: an
 	// organization that is already active is unaffected.
 	EnableOrganization(context.Context, *EnableOrganizationPayload) (res *AdminOrganization, err error)
+	// Seeds the built-in roles and their core grants for a legacy organization.
+	// Idempotent: roles that already hold grants are left unchanged. New
+	// organizations receive this setup automatically.
+	SetupRBAC(context.Context, *SetupRBACPayload) (err error)
 	// Returns full admin details for a single organization by id or slug.
 	GetOrganization(context.Context, *GetOrganizationPayload) (res *AdminOrganization, err error)
 	// Lists members of an organization (admin view, no auth scoping).
@@ -101,7 +105,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [21]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription"}
+var MethodNames = [22]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "setupRBAC", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription"}
 
 // AdminBulkUpdateAccountTypeResult is the result type of the admin service
 // bulkUpdateAccountType method.
@@ -509,6 +513,13 @@ type RearmTrialPayload struct {
 type ResumeStripeSubscriptionPayload struct {
 	AdminSessionToken *string
 	OrganizationID    string
+}
+
+// SetupRBACPayload is the payload type of the admin service setupRBAC method.
+type SetupRBACPayload struct {
+	AdminSessionToken *string
+	// Organization ID.
+	ID string
 }
 
 // UpdateOrganizationPayload is the payload type of the admin service

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -272,6 +272,37 @@ func BuildEnableOrganizationPayload(adminEnableOrganizationBody string, adminEna
 	return v, nil
 }
 
+// BuildSetupRBACPayload builds the payload for the admin setupRBAC endpoint
+// from CLI flags.
+func BuildSetupRBACPayload(adminSetupRBACBody string, adminSetupRBACAdminSessionToken string) (*admin.SetupRBACPayload, error) {
+	var err error
+	var body SetupRBACRequestBody
+	{
+		err = json.Unmarshal([]byte(adminSetupRBACBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"aa\"\n   }'")
+		}
+		if utf8.RuneCountInString(body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", body.ID, utf8.RuneCountInString(body.ID), 1, true))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminSetupRBACAdminSessionToken != "" {
+			adminSessionToken = &adminSetupRBACAdminSessionToken
+		}
+	}
+	v := &admin.SetupRBACPayload{
+		ID: body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}
+
 // BuildGetOrganizationPayload builds the payload for the admin getOrganization
 // endpoint from CLI flags.
 func BuildGetOrganizationPayload(adminGetOrganizationIDOrSlug string, adminGetOrganizationAdminSessionToken string) (*admin.GetOrganizationPayload, error) {

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -47,6 +47,10 @@ type Client struct {
 	// enableOrganization endpoint.
 	EnableOrganizationDoer goahttp.Doer
 
+	// SetupRBAC Doer is the HTTP client used to make requests to the setupRBAC
+	// endpoint.
+	SetupRBACDoer goahttp.Doer
+
 	// GetOrganization Doer is the HTTP client used to make requests to the
 	// getOrganization endpoint.
 	GetOrganizationDoer goahttp.Doer
@@ -127,6 +131,7 @@ func NewClient(
 		BulkUpdateAccountTypeDoer:    doer,
 		DisableOrganizationDoer:      doer,
 		EnableOrganizationDoer:       doer,
+		SetupRBACDoer:                doer,
 		GetOrganizationDoer:          doer,
 		ListOrganizationMembersDoer:  doer,
 		ListOrganizationProjectsDoer: doer,
@@ -335,6 +340,30 @@ func (c *Client) EnableOrganization() goa.Endpoint {
 		resp, err := c.EnableOrganizationDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "enableOrganization", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// SetupRBAC returns an endpoint that makes HTTP requests to the admin service
+// setupRBAC server.
+func (c *Client) SetupRBAC() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeSetupRBACRequest(c.encoder)
+		decodeResponse = DecodeSetupRBACResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildSetupRBACRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.SetupRBACDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "setupRBAC", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -1925,6 +1925,227 @@ func DecodeEnableOrganizationResponse(decoder func(*http.Response) goahttp.Decod
 	}
 }
 
+// BuildSetupRBACRequest instantiates a HTTP request object with method and
+// path set to call the "admin" service "setupRBAC" endpoint
+func (c *Client) BuildSetupRBACRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: SetupRBACAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "setupRBAC", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeSetupRBACRequest returns an encoder for requests sent to the admin
+// setupRBAC server.
+func EncodeSetupRBACRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.SetupRBACPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "setupRBAC", "*admin.SetupRBACPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewSetupRBACRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "setupRBAC", err)
+		}
+		return nil
+	}
+}
+
+// DecodeSetupRBACResponse returns a decoder for responses returned by the
+// admin setupRBAC endpoint. restoreBody controls whether the response body
+// should be restored after having been read.
+// DecodeSetupRBACResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeSetupRBACResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusNoContent:
+			return nil, nil
+		case http.StatusUnauthorized:
+			var (
+				body SetupRBACUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body SetupRBACForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body SetupRBACBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body SetupRBACNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body SetupRBACConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body SetupRBACUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body SetupRBACInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body SetupRBACInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+				}
+				err = ValidateSetupRBACInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+				}
+				return nil, NewSetupRBACInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body SetupRBACUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+				}
+				err = ValidateSetupRBACUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+				}
+				return nil, NewSetupRBACUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "setupRBAC", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body SetupRBACGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "setupRBAC", err)
+			}
+			err = ValidateSetupRBACGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "setupRBAC", err)
+			}
+			return nil, NewSetupRBACGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "setupRBAC", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // BuildGetOrganizationRequest instantiates a HTTP request object with method
 // and path set to call the "admin" service "getOrganization" endpoint
 func (c *Client) BuildGetOrganizationRequest(ctx context.Context, v any) (*http.Request, error) {

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -47,6 +47,11 @@ func EnableOrganizationAdminPath() string {
 	return "/admin/organization.enable"
 }
 
+// SetupRBACAdminPath returns the URL path to the admin service setupRBAC HTTP endpoint.
+func SetupRBACAdminPath() string {
+	return "/admin/organization.setupRBAC"
+}
+
 // GetOrganizationAdminPath returns the URL path to the admin service getOrganization HTTP endpoint.
 func GetOrganizationAdminPath() string {
 	return "/admin/organization.get"

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -46,6 +46,13 @@ type EnableOrganizationRequestBody struct {
 	ID string `form:"id" json:"id" xml:"id"`
 }
 
+// SetupRBACRequestBody is the type of the "admin" service "setupRBAC" endpoint
+// HTTP request body.
+type SetupRBACRequestBody struct {
+	// Organization ID.
+	ID string `form:"id" json:"id" xml:"id"`
+}
+
 // ExtendTrialRequestBody is the type of the "admin" service "extendTrial"
 // endpoint HTTP request body.
 type ExtendTrialRequestBody struct {
@@ -1904,6 +1911,186 @@ type EnableOrganizationUnexpectedResponseBody struct {
 // service "enableOrganization" endpoint HTTP response body for the
 // "gateway_error" error.
 type EnableOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACUnauthorizedResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "unauthorized" error.
+type SetupRBACUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACForbiddenResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "forbidden" error.
+type SetupRBACForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACBadRequestResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "bad_request" error.
+type SetupRBACBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACNotFoundResponseBody is the type of the "admin" service "setupRBAC"
+// endpoint HTTP response body for the "not_found" error.
+type SetupRBACNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACConflictResponseBody is the type of the "admin" service "setupRBAC"
+// endpoint HTTP response body for the "conflict" error.
+type SetupRBACConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACUnsupportedMediaResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "unsupported_media" error.
+type SetupRBACUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACInvalidResponseBody is the type of the "admin" service "setupRBAC"
+// endpoint HTTP response body for the "invalid" error.
+type SetupRBACInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACInvariantViolationResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "invariant_violation" error.
+type SetupRBACInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACUnexpectedResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "unexpected" error.
+type SetupRBACUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SetupRBACGatewayErrorResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "gateway_error" error.
+type SetupRBACGatewayErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -4454,6 +4641,15 @@ func NewEnableOrganizationRequestBody(p *admin.EnableOrganizationPayload) *Enabl
 	return body
 }
 
+// NewSetupRBACRequestBody builds the HTTP request body from the payload of the
+// "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACRequestBody(p *admin.SetupRBACPayload) *SetupRBACRequestBody {
+	body := &SetupRBACRequestBody{
+		ID: p.ID,
+	}
+	return body
+}
+
 // NewExtendTrialRequestBody builds the HTTP request body from the payload of
 // the "extendTrial" endpoint of the "admin" service.
 func NewExtendTrialRequestBody(p *admin.ExtendTrialPayload) *ExtendTrialRequestBody {
@@ -5802,6 +5998,155 @@ func NewEnableOrganizationUnexpected(body *EnableOrganizationUnexpectedResponseB
 // NewEnableOrganizationGatewayError builds a admin service enableOrganization
 // endpoint gateway_error error.
 func NewEnableOrganizationGatewayError(body *EnableOrganizationGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACUnauthorized builds a admin service setupRBAC endpoint
+// unauthorized error.
+func NewSetupRBACUnauthorized(body *SetupRBACUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACForbidden builds a admin service setupRBAC endpoint forbidden
+// error.
+func NewSetupRBACForbidden(body *SetupRBACForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACBadRequest builds a admin service setupRBAC endpoint bad_request
+// error.
+func NewSetupRBACBadRequest(body *SetupRBACBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACNotFound builds a admin service setupRBAC endpoint not_found
+// error.
+func NewSetupRBACNotFound(body *SetupRBACNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACConflict builds a admin service setupRBAC endpoint conflict
+// error.
+func NewSetupRBACConflict(body *SetupRBACConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACUnsupportedMedia builds a admin service setupRBAC endpoint
+// unsupported_media error.
+func NewSetupRBACUnsupportedMedia(body *SetupRBACUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACInvalid builds a admin service setupRBAC endpoint invalid error.
+func NewSetupRBACInvalid(body *SetupRBACInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACInvariantViolation builds a admin service setupRBAC endpoint
+// invariant_violation error.
+func NewSetupRBACInvariantViolation(body *SetupRBACInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACUnexpected builds a admin service setupRBAC endpoint unexpected
+// error.
+func NewSetupRBACUnexpected(body *SetupRBACUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSetupRBACGatewayError builds a admin service setupRBAC endpoint
+// gateway_error error.
+func NewSetupRBACGatewayError(body *SetupRBACGatewayErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -10580,6 +10925,246 @@ func ValidateEnableOrganizationUnexpectedResponseBody(body *EnableOrganizationUn
 // ValidateEnableOrganizationGatewayErrorResponseBody runs the validations
 // defined on enableOrganization_gateway_error_response_body
 func ValidateEnableOrganizationGatewayErrorResponseBody(body *EnableOrganizationGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACUnauthorizedResponseBody runs the validations defined on
+// setupRBAC_unauthorized_response_body
+func ValidateSetupRBACUnauthorizedResponseBody(body *SetupRBACUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACForbiddenResponseBody runs the validations defined on
+// setupRBAC_forbidden_response_body
+func ValidateSetupRBACForbiddenResponseBody(body *SetupRBACForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACBadRequestResponseBody runs the validations defined on
+// setupRBAC_bad_request_response_body
+func ValidateSetupRBACBadRequestResponseBody(body *SetupRBACBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACNotFoundResponseBody runs the validations defined on
+// setupRBAC_not_found_response_body
+func ValidateSetupRBACNotFoundResponseBody(body *SetupRBACNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACConflictResponseBody runs the validations defined on
+// setupRBAC_conflict_response_body
+func ValidateSetupRBACConflictResponseBody(body *SetupRBACConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACUnsupportedMediaResponseBody runs the validations defined
+// on setupRBAC_unsupported_media_response_body
+func ValidateSetupRBACUnsupportedMediaResponseBody(body *SetupRBACUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACInvalidResponseBody runs the validations defined on
+// setupRBAC_invalid_response_body
+func ValidateSetupRBACInvalidResponseBody(body *SetupRBACInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACInvariantViolationResponseBody runs the validations defined
+// on setupRBAC_invariant_violation_response_body
+func ValidateSetupRBACInvariantViolationResponseBody(body *SetupRBACInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACUnexpectedResponseBody runs the validations defined on
+// setupRBAC_unexpected_response_body
+func ValidateSetupRBACUnexpectedResponseBody(body *SetupRBACUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSetupRBACGatewayErrorResponseBody runs the validations defined on
+// setupRBAC_gateway_error_response_body
+func ValidateSetupRBACGatewayErrorResponseBody(body *SetupRBACGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -1691,6 +1691,216 @@ func EncodeEnableOrganizationError(encoder func(context.Context, http.ResponseWr
 	}
 }
 
+// EncodeSetupRBACResponse returns an encoder for responses returned by the
+// admin setupRBAC endpoint.
+func EncodeSetupRBACResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		w.WriteHeader(http.StatusNoContent)
+		return nil
+	}
+}
+
+// DecodeSetupRBACRequest returns a decoder for requests sent to the admin
+// setupRBAC endpoint.
+func DecodeSetupRBACRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.SetupRBACPayload, error) {
+	return func(r *http.Request) (*admin.SetupRBACPayload, error) {
+		var payload *admin.SetupRBACPayload
+		var (
+			body SetupRBACRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateSetupRBACRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewSetupRBACPayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeSetupRBACError returns an encoder for errors returned by the setupRBAC
+// admin endpoint.
+func EncodeSetupRBACError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSetupRBACGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // EncodeGetOrganizationResponse returns an encoder for responses returned by
 // the admin getOrganization endpoint.
 func EncodeGetOrganizationResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -47,6 +47,11 @@ func EnableOrganizationAdminPath() string {
 	return "/admin/organization.enable"
 }
 
+// SetupRBACAdminPath returns the URL path to the admin service setupRBAC HTTP endpoint.
+func SetupRBACAdminPath() string {
+	return "/admin/organization.setupRBAC"
+}
+
 // GetOrganizationAdminPath returns the URL path to the admin service getOrganization HTTP endpoint.
 func GetOrganizationAdminPath() string {
 	return "/admin/organization.get"

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	BulkUpdateAccountType    http.Handler
 	DisableOrganization      http.Handler
 	EnableOrganization       http.Handler
+	SetupRBAC                http.Handler
 	GetOrganization          http.Handler
 	ListOrganizationMembers  http.Handler
 	ListOrganizationProjects http.Handler
@@ -77,6 +78,7 @@ func New(
 			{"BulkUpdateAccountType", "POST", "/admin/organizations.bulkUpdateAccountType"},
 			{"DisableOrganization", "POST", "/admin/organization.disable"},
 			{"EnableOrganization", "POST", "/admin/organization.enable"},
+			{"SetupRBAC", "POST", "/admin/organization.setupRBAC"},
 			{"GetOrganization", "GET", "/admin/organization.get"},
 			{"ListOrganizationMembers", "GET", "/admin/organization.members"},
 			{"ListOrganizationProjects", "GET", "/admin/organization.projects"},
@@ -99,6 +101,7 @@ func New(
 		BulkUpdateAccountType:    NewBulkUpdateAccountTypeHandler(e.BulkUpdateAccountType, mux, decoder, encoder, errhandler, formatter),
 		DisableOrganization:      NewDisableOrganizationHandler(e.DisableOrganization, mux, decoder, encoder, errhandler, formatter),
 		EnableOrganization:       NewEnableOrganizationHandler(e.EnableOrganization, mux, decoder, encoder, errhandler, formatter),
+		SetupRBAC:                NewSetupRBACHandler(e.SetupRBAC, mux, decoder, encoder, errhandler, formatter),
 		GetOrganization:          NewGetOrganizationHandler(e.GetOrganization, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizationMembers:  NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizationProjects: NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
@@ -128,6 +131,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.BulkUpdateAccountType = m(s.BulkUpdateAccountType)
 	s.DisableOrganization = m(s.DisableOrganization)
 	s.EnableOrganization = m(s.EnableOrganization)
+	s.SetupRBAC = m(s.SetupRBAC)
 	s.GetOrganization = m(s.GetOrganization)
 	s.ListOrganizationMembers = m(s.ListOrganizationMembers)
 	s.ListOrganizationProjects = m(s.ListOrganizationProjects)
@@ -156,6 +160,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountBulkUpdateAccountTypeHandler(mux, h.BulkUpdateAccountType)
 	MountDisableOrganizationHandler(mux, h.DisableOrganization)
 	MountEnableOrganizationHandler(mux, h.EnableOrganization)
+	MountSetupRBACHandler(mux, h.SetupRBAC)
 	MountGetOrganizationHandler(mux, h.GetOrganization)
 	MountListOrganizationMembersHandler(mux, h.ListOrganizationMembers)
 	MountListOrganizationProjectsHandler(mux, h.ListOrganizationProjects)
@@ -577,6 +582,59 @@ func NewEnableOrganizationHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "enableOrganization")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountSetupRBACHandler configures the mux to serve the "admin" service
+// "setupRBAC" endpoint.
+func MountSetupRBACHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/organization.setupRBAC", f)
+}
+
+// NewSetupRBACHandler creates a HTTP handler which loads the HTTP request and
+// calls the "admin" service "setupRBAC" endpoint.
+func NewSetupRBACHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeSetupRBACRequest(mux, decoder)
+		encodeResponse = EncodeSetupRBACResponse(encoder)
+		encodeError    = EncodeSetupRBACError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "setupRBAC")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -48,6 +48,13 @@ type EnableOrganizationRequestBody struct {
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 }
 
+// SetupRBACRequestBody is the type of the "admin" service "setupRBAC" endpoint
+// HTTP request body.
+type SetupRBACRequestBody struct {
+	// Organization ID.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+}
+
 // ExtendTrialRequestBody is the type of the "admin" service "extendTrial"
 // endpoint HTTP request body.
 type ExtendTrialRequestBody struct {
@@ -1910,6 +1917,186 @@ type EnableOrganizationUnexpectedResponseBody struct {
 // service "enableOrganization" endpoint HTTP response body for the
 // "gateway_error" error.
 type EnableOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACUnauthorizedResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "unauthorized" error.
+type SetupRBACUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACForbiddenResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "forbidden" error.
+type SetupRBACForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACBadRequestResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "bad_request" error.
+type SetupRBACBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACNotFoundResponseBody is the type of the "admin" service "setupRBAC"
+// endpoint HTTP response body for the "not_found" error.
+type SetupRBACNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACConflictResponseBody is the type of the "admin" service "setupRBAC"
+// endpoint HTTP response body for the "conflict" error.
+type SetupRBACConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACUnsupportedMediaResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "unsupported_media" error.
+type SetupRBACUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACInvalidResponseBody is the type of the "admin" service "setupRBAC"
+// endpoint HTTP response body for the "invalid" error.
+type SetupRBACInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACInvariantViolationResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "invariant_violation" error.
+type SetupRBACInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACUnexpectedResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "unexpected" error.
+type SetupRBACUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SetupRBACGatewayErrorResponseBody is the type of the "admin" service
+// "setupRBAC" endpoint HTTP response body for the "gateway_error" error.
+type SetupRBACGatewayErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -5903,6 +6090,146 @@ func NewEnableOrganizationGatewayErrorResponseBody(res *goa.ServiceError) *Enabl
 	return body
 }
 
+// NewSetupRBACUnauthorizedResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACUnauthorizedResponseBody(res *goa.ServiceError) *SetupRBACUnauthorizedResponseBody {
+	body := &SetupRBACUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACForbiddenResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACForbiddenResponseBody(res *goa.ServiceError) *SetupRBACForbiddenResponseBody {
+	body := &SetupRBACForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACBadRequestResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACBadRequestResponseBody(res *goa.ServiceError) *SetupRBACBadRequestResponseBody {
+	body := &SetupRBACBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACNotFoundResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACNotFoundResponseBody(res *goa.ServiceError) *SetupRBACNotFoundResponseBody {
+	body := &SetupRBACNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACConflictResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACConflictResponseBody(res *goa.ServiceError) *SetupRBACConflictResponseBody {
+	body := &SetupRBACConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACUnsupportedMediaResponseBody builds the HTTP response body from
+// the result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACUnsupportedMediaResponseBody(res *goa.ServiceError) *SetupRBACUnsupportedMediaResponseBody {
+	body := &SetupRBACUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACInvalidResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACInvalidResponseBody(res *goa.ServiceError) *SetupRBACInvalidResponseBody {
+	body := &SetupRBACInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACInvariantViolationResponseBody builds the HTTP response body
+// from the result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACInvariantViolationResponseBody(res *goa.ServiceError) *SetupRBACInvariantViolationResponseBody {
+	body := &SetupRBACInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACUnexpectedResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACUnexpectedResponseBody(res *goa.ServiceError) *SetupRBACUnexpectedResponseBody {
+	body := &SetupRBACUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSetupRBACGatewayErrorResponseBody builds the HTTP response body from the
+// result of the "setupRBAC" endpoint of the "admin" service.
+func NewSetupRBACGatewayErrorResponseBody(res *goa.ServiceError) *SetupRBACGatewayErrorResponseBody {
+	body := &SetupRBACGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewGetOrganizationUnauthorizedResponseBody builds the HTTP response body
 // from the result of the "getOrganization" endpoint of the "admin" service.
 func NewGetOrganizationUnauthorizedResponseBody(res *goa.ServiceError) *GetOrganizationUnauthorizedResponseBody {
@@ -7889,6 +8216,16 @@ func NewEnableOrganizationPayload(body *EnableOrganizationRequestBody, adminSess
 	return v
 }
 
+// NewSetupRBACPayload builds a admin service setupRBAC endpoint payload.
+func NewSetupRBACPayload(body *SetupRBACRequestBody, adminSessionToken *string) *admin.SetupRBACPayload {
+	v := &admin.SetupRBACPayload{
+		ID: *body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
 // NewGetOrganizationPayload builds a admin service getOrganization endpoint
 // payload.
 func NewGetOrganizationPayload(idOrSlug string, adminSessionToken *string) *admin.GetOrganizationPayload {
@@ -8092,6 +8429,20 @@ func ValidateDisableOrganizationRequestBody(body *DisableOrganizationRequestBody
 // ValidateEnableOrganizationRequestBody runs the validations defined on
 // EnableOrganizationRequestBody
 func ValidateEnableOrganizationRequestBody(body *EnableOrganizationRequestBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.ID != nil {
+		if utf8.RuneCountInString(*body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
+		}
+	}
+	return
+}
+
+// ValidateSetupRBACRequestBody runs the validations defined on
+// SetupRBACRequestBody
+func ValidateSetupRBACRequestBody(body *SetupRBACRequestBody) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -100,7 +100,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|list-shadow-mcp-inventory-servers-for-user|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription)",
+		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|setup-rbac|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration|get-session-meta|report-session-moved|create-session-handoff)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-image-from-url|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -349,6 +349,10 @@ func ParseEndpoint(
 		adminEnableOrganizationFlags                 = flag.NewFlagSet("enable-organization", flag.ExitOnError)
 		adminEnableOrganizationBodyFlag              = adminEnableOrganizationFlags.String("body", "REQUIRED", "")
 		adminEnableOrganizationAdminSessionTokenFlag = adminEnableOrganizationFlags.String("admin-session-token", "", "")
+
+		adminSetupRBACFlags                 = flag.NewFlagSet("setup-rbac", flag.ExitOnError)
+		adminSetupRBACBodyFlag              = adminSetupRBACFlags.String("body", "REQUIRED", "")
+		adminSetupRBACAdminSessionTokenFlag = adminSetupRBACFlags.String("admin-session-token", "", "")
 
 		adminGetOrganizationFlags                 = flag.NewFlagSet("get-organization", flag.ExitOnError)
 		adminGetOrganizationIDOrSlugFlag          = adminGetOrganizationFlags.String("id-or-slug", "REQUIRED", "")
@@ -3573,6 +3577,7 @@ func ParseEndpoint(
 	adminBulkUpdateAccountTypeFlags.Usage = adminBulkUpdateAccountTypeUsage
 	adminDisableOrganizationFlags.Usage = adminDisableOrganizationUsage
 	adminEnableOrganizationFlags.Usage = adminEnableOrganizationUsage
+	adminSetupRBACFlags.Usage = adminSetupRBACUsage
 	adminGetOrganizationFlags.Usage = adminGetOrganizationUsage
 	adminListOrganizationMembersFlags.Usage = adminListOrganizationMembersUsage
 	adminListOrganizationProjectsFlags.Usage = adminListOrganizationProjectsUsage
@@ -4559,6 +4564,9 @@ func ParseEndpoint(
 
 			case "enable-organization":
 				epf = adminEnableOrganizationFlags
+
+			case "setup-rbac":
+				epf = adminSetupRBACFlags
 
 			case "get-organization":
 				epf = adminGetOrganizationFlags
@@ -6659,6 +6667,9 @@ func ParseEndpoint(
 			case "enable-organization":
 				endpoint = c.EnableOrganization()
 				data, err = adminc.BuildEnableOrganizationPayload(*adminEnableOrganizationBodyFlag, *adminEnableOrganizationAdminSessionTokenFlag)
+			case "setup-rbac":
+				endpoint = c.SetupRBAC()
+				data, err = adminc.BuildSetupRBACPayload(*adminSetupRBACBodyFlag, *adminSetupRBACAdminSessionTokenFlag)
 			case "get-organization":
 				endpoint = c.GetOrganization()
 				data, err = adminc.BuildGetOrganizationPayload(*adminGetOrganizationIDOrSlugFlag, *adminGetOrganizationAdminSessionTokenFlag)
@@ -9196,6 +9207,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    bulk-update-account-type: Sets one account type on many organizations in a single statement. An ID that matches no organization is reported back rather than failing the batch, so a stale ID costs the operator that row and not the whole call.`)
 	fmt.Fprintln(os.Stderr, `    disable-organization: Disables an organization, recording the moment of the action in disabled_at. Idempotent: disabling an already-disabled organization keeps the original timestamp.`)
 	fmt.Fprintln(os.Stderr, `    enable-organization: Re-enables a disabled organization by clearing disabled_at. Idempotent: an organization that is already active is unaffected.`)
+	fmt.Fprintln(os.Stderr, `    setup-rbac: Seeds the built-in roles and their core grants for a legacy organization. Idempotent: roles that already hold grants are left unchanged. New organizations receive this setup automatically.`)
 	fmt.Fprintln(os.Stderr, `    get-organization: Returns full admin details for a single organization by id or slug.`)
 	fmt.Fprintln(os.Stderr, `    list-organization-members: Lists members of an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organization-projects: Lists projects belonging to an organization (admin view, no auth scoping).`)
@@ -9377,6 +9389,26 @@ func adminEnableOrganizationUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin enable-organization --body '{\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminSetupRBACUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin setup-rbac", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Seeds the built-in roles and their core grants for a legacy organization. Idempotent: roles that already hold grants are left unchanged. New organizations receive this setup automatically.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin setup-rbac --body '{\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
 }
 
 func adminGetOrganizationUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1050,6 +1050,78 @@ paths:
                                 $ref: '#/components/schemas/Error'
             security:
                 - admin_auth_header_Authorization: []
+    /admin/organization.setupRBAC:
+        post:
+            tags:
+                - admin
+            summary: setupRBAC admin
+            description: 'Seeds the built-in roles and their core grants for a legacy organization. Idempotent: roles that already hold grants are left unchanged. New organizations receive this setup automatically.'
+            operationId: adminSetupRBAC
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SetupRBACRequestBody'
+            responses:
+                "204":
+                    description: No Content response.
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/organization.stripeSubscription:
         get:
             tags:
@@ -76390,6 +76462,15 @@ components:
                     type: string
                     description: The user_session_issuer id to link, or null to unlink.
                     format: uuid
+        SetupRBACRequestBody:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Organization ID.
+                    minLength: 1
+            required:
+                - id
         ShadowMCPInventoryApprovalRequest:
             type: object
             properties:

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -787,6 +787,25 @@ func (s *Service) EnableOrganization(ctx context.Context, payload *gen.EnableOrg
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enable")
 }
 
+func (s *Service) SetupRBAC(ctx context.Context, payload *gen.SetupRBACPayload) error {
+	_, err := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{
+		ID:        payload.ID,
+		AllowSlug: false,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return oops.C(oops.CodeNotFound)
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "find organization for RBAC setup").LogError(ctx, s.logger)
+	}
+
+	if err := authz.SeedSystemRoleGrants(ctx, s.db, payload.ID); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "set up organization RBAC").LogError(ctx, s.logger.With(attr.SlogOrganizationID(payload.ID)))
+	}
+
+	return nil
+}
+
 func (s *Service) ExtendTrial(ctx context.Context, payload *gen.ExtendTrialPayload) (*gen.AdminOrganization, error) {
 	// The design bounds this too, but that validation is generated into the
 	// request decoder and only runs at the HTTP boundary. Repeating it here is

--- a/server/internal/admin/setuprbac_test.go
+++ b/server/internal/admin/setuprbac_test.go
@@ -1,0 +1,43 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestSetupRBAC_SeedsSystemRolesAndGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	const organizationID = "org_legacy_rbac"
+	seedOrg(t, ctx, conn, orgFixture{id: organizationID, name: "Legacy Org", slug: "legacy-org", whitelisted: true})
+
+	err := svc.SetupRBAC(ctx, &gen.SetupRBACPayload{ID: organizationID})
+	require.NoError(t, err)
+
+	for _, roleSlug := range []string{authz.SystemRoleAdmin, authz.SystemRoleMember} {
+		role, err := accessrepo.New(conn).GetGlobalRoleBySlug(ctx, roleSlug)
+		require.NoError(t, err)
+
+		grants, err := authz.GrantsForRole(ctx, svc.logger, conn, organizationID, "role:global:"+role.ID.String())
+		require.NoError(t, err)
+		require.NotEmpty(t, grants)
+	}
+
+	require.NoError(t, svc.SetupRBAC(ctx, &gen.SetupRBACPayload{ID: organizationID}))
+}
+
+func TestSetupRBAC_UnknownOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, _ := newTestAdminService(t)
+	err := svc.SetupRBAC(ctx, &gen.SetupRBACPayload{ID: "org_missing"})
+
+	requireOopsCode(t, err, oops.CodeNotFound)
+}


### PR DESCRIPTION
## Why?

Legacy organizations created before automatic RBAC provisioning can be missing the built-in roles and core grants, with no supported repair action in the superadmin dashboard.

## What?

- Add a superadmin `Setup RBAC` control to the organization overview, with confirmation and explicit legacy-only guidance.
- Add an idempotent admin endpoint that seeds the canonical system roles and grants and rejects unknown organizations.
- Regenerate the API contracts and cover the server, client request, and UI interaction.

## Notes

New organizations continue to receive RBAC setup automatically. Existing grants are preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a superadmin action to seed built-in RBAC roles and core grants for legacy organizations. Previously there was no repair path; now superadmins can trigger an idempotent setup that preserves existing grants and rejects unknown organizations.

- New admin endpoint: POST /admin/organization.setupRBAC with JSON body { id }. Requires Authorization, returns 204, and surfaces standard errors; verifies the org exists and calls authz seeding idempotently.
- Admin UI: Organization Overview adds an “RBAC” row with a “Setup RBAC” button, legacy-only guidance, confirmation dialog, pending state, and live-region announcements.
- Client: Adds setupOrganizationRBAC() in the admin API; updates tests to assert request shape. Regenerates API contracts and codegen (including `server/gen/http/openapi3.yaml`) and adds a CLI command: admin setup-rbac.
- Server: Implements SetupRBAC in `server/internal/admin` and adds tests to seed roles/grants and handle unknown orgs.

- No schema changes. The action is safe to re-run. New organizations continue to be provisioned automatically.

<sup>Written for commit f62aa377c305d9c8f50c7d75194ea470b9a9148f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

