### PR TITLE
chore: exclude local directory from hk checks

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -2,6 +2,8 @@ amends "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Config.
 
 import "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Builtins.pkl"
 import "pkl:json"
+// Runtime data and local service configuration are outside source checks.
+exclude = List("local")
 
 // Source the oxfmt step's exclude list from `.oxfmtrc.json` so the two stay in sync.
 // Strip the leading `/` that .oxfmtrc.json uses for repo-root anchoring; hk globs are root-relative.


### PR DESCRIPTION
## Summary

- exclude the `local/` directory from hk source checks
- avoid checking runtime data and per-worktree service configuration

## Verification

- `mise exec -- hk validate`
- pre-commit `pkleval` and `pklfmt` checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `local/` from `hk` source checks so `hk validate` no longer traverses runtime data and per-worktree service config. Previously `hk validate` scanned `local/`; now it skips it, reducing noise without changing other `hk` steps or pre-commit checks.

- Review: run `mise exec -- hk validate` and confirm changes under `local/` are ignored.
- Migration: none; pre-commit checks (`pkleval`, `pklfmt`) are unchanged.

<sup>Written for commit fff858b7f96677a31e19add8472d3b3b510eda60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

