### PR TITLE
chore: reduce Pub/Sub emulator reconciliation logs

### DIFF
--- a/infra/gram_infra/pubsub/broker.py
+++ b/infra/gram_infra/pubsub/broker.py
@@ -411,7 +411,7 @@ class EmulatedPubSubBroker(PubSubBroker):
             self._publisher.create_topic(request=request)
             self._logger.info("topic created", topic=topic_path)
         except AlreadyExists:
-            self._logger.info("topic already exists", topic=topic_path)
+            self._logger.debug("topic already exists", topic=topic_path)
         self._reconciled_topics.add(topic_id)
 
     def _reconcile_subscription(self, sub_id: str, topic_id: str, options) -> None:
@@ -479,7 +479,7 @@ class EmulatedPubSubBroker(PubSubBroker):
             self._subscriber.create_subscription(request=request)
             self._logger.info("subscription created", subscription=sub_path)
         except AlreadyExists:
-            self._logger.info("subscription already exists", subscription=sub_path)
+            self._logger.debug("subscription already exists", subscription=sub_path)
         self._reconciled_subscriptions.add(sub_id)
 
 

--- a/infra/pkg/gcp/pubsub_local.go
+++ b/infra/pkg/gcp/pubsub_local.go
@@ -90,7 +90,7 @@ func (e *EmulatedPubSubBroker) reconcileTopic(ctx context.Context, topicName str
 	_, err := e.client.TopicAdminClient.CreateTopic(ctx, topic)
 	switch {
 	case status.Code(err) == codes.AlreadyExists:
-		e.logger.InfoContext(ctx, "topic already exists", attr.SlogGCPTopicQualifiedName(qname))
+		e.logger.DebugContext(ctx, "topic already exists", attr.SlogGCPTopicQualifiedName(qname))
 	case err != nil:
 		return fmt.Errorf("create topic %q: %w", qname, err)
 	default:
@@ -206,7 +206,7 @@ func (e *EmulatedPubSubBroker) reconcileSubscriptions(ctx context.Context, subNa
 	_, err := e.client.SubscriptionAdminClient.CreateSubscription(ctx, sub)
 	switch {
 	case status.Code(err) == codes.AlreadyExists:
-		e.logger.InfoContext(ctx, "subscription already exists", attr.SlogGCPSubscriptionQualifiedName(qname))
+		e.logger.DebugContext(ctx, "subscription already exists", attr.SlogGCPSubscriptionQualifiedName(qname))
 	case err != nil:
 		return fmt.Errorf("create subscription %q: %w", qname, err)
 	default:


### PR DESCRIPTION
## Summary

- Demote expected `AlreadyExists` reconciliation messages from info to debug in the Go and Python Pub/Sub emulator brokers.
- Keep successful topic and subscription creation messages at info level.

## Validation

- `mise exec -- go test ./infra/pkg/gcp`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Pub/Sub emulator reconciliation log noise by demoting AlreadyExists messages from info to debug in both Go and Python brokers. Topic and subscription creation remains info; no functional changes.

- Changes are limited to AlreadyExists handlers in infra/gram_infra/pubsub/broker.py and infra/pkg/gcp/pubsub_local.go.
- Info-level logs will no longer show these messages; enable debug to see them.
- No config or API changes; no migration required.

<sup>Written for commit d7ee5627ba5190812862e7922a99da5ab36d7568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

