### PR TITLE
feat: add reusable error logging helper

### DIFF
--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -186,6 +186,16 @@ func NoLogDefer(cb func() error) {
 	_ = cb()
 }
 
+func LogError(ctx context.Context, logger *slog.Logger, err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+
+	logger.ErrorContext(ctx, msg, attr.SlogError(err))
+
+	return err
+}
+
 type pgxLogger struct {
 	logger *slog.Logger
 }

--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -186,6 +186,8 @@ func NoLogDefer(cb func() error) {
 	_ = cb()
 }
 
+// LogError logs a non-nil error with context and returns it unchanged, making
+// it convenient to use in tail return statements.
 func LogError(ctx context.Context, logger *slog.Logger, err error, msg string) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
## Summary

- add `o11y.LogError` for context-aware logging of non-nil errors
- attach the canonical structured error attribute and return the original error

## Verification

- `mise run test:server ./internal/o11y/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `o11y.LogError` to log non-nil errors with context via `logger.ErrorContext` and `attr.SlogError(err)`, and returns the same error. Skips logging when `err` is nil and includes doc comments to guide usage; no behavior change for nil errors.

<sup>Written for commit b08b59a972ddaedaede98229335133b9058e7fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

