### PR TITLE
chore: derive platform admin feature toggles from the SDK enum

### DIFF
--- a/client/dashboard/src/pages/platform-admin/Features.tsx
+++ b/client/dashboard/src/pages/platform-admin/Features.tsx
@@ -6,6 +6,7 @@ import {
 import {
   invalidateAllProductFeatures,
   useProductFeatures,
+  type ProductFeaturesQueryData,
 } from "@gram/client/react-query/productFeatures.js";
 
 import { Badge } from "@/components/ui/Badge";
@@ -65,69 +66,127 @@ export default function PlatformAdminFeatures(): JSX.Element {
   );
 }
 
-const PRODUCT_FEATURES: {
-  featureName: FeatureName;
-  label: string;
-  description: string;
-  enabledKey:
-    | "authzChallengeLoggingEnabled"
-    | "customerManagedEncryptionKeysEnabled"
-    | "customModelKeysEnabled"
-    | "platformMcpEnabled"
-    | "remoteSessionAutoRefreshEnabled"
-    | "ssoEnabled"
-    | "scimEnabled";
-}[] = [
-  {
-    featureName: FeatureName.AuthzChallengeLogging,
+// Every product feature the SDK exposes gets an entry: either a toggle
+// rendered here, or an explicit note of where else it is administered.
+// Keying the record by FeatureName turns a backend feature added without a
+// decision on this page into a type error instead of a missing toggle.
+type ProductFeatureEntry =
+  | {
+      kind: "toggle";
+      label: string;
+      description: string;
+      enabledKey: keyof ProductFeaturesQueryData;
+    }
+  | { kind: "managed-elsewhere"; where: string };
+
+const PRODUCT_FEATURES: Record<FeatureName, ProductFeatureEntry> = {
+  [FeatureName.AiPlatformPushIntegrations]: {
+    kind: "toggle",
+    label: "AI Platform Push Integrations",
+    description:
+      "Allows this organization to provision push integrations for AI platforms.",
+    enabledKey: "aiPlatformPushIntegrationsEnabled",
+  },
+  [FeatureName.AuthzChallengeLogging]: {
+    kind: "toggle",
     label: "Authz Challenge Logging",
     description:
       'Log every authorization decision (allow/deny) to ClickHouse. Powers auditing of "why did X have access to Y?"',
     enabledKey: "authzChallengeLoggingEnabled",
   },
-  {
-    featureName: FeatureName.CustomerManagedEncryptionKeys,
+  [FeatureName.CustomerManagedEncryptionKeys]: {
+    kind: "toggle",
     label: "Customer-Managed Encryption Keys",
     description:
       "Unlocks encryption key management for an organization, enabling external service credential, external encryption key, and asymmetric signing functionality.",
     enabledKey: "customerManagedEncryptionKeysEnabled",
   },
-  {
-    featureName: FeatureName.CustomModelKeys,
+  [FeatureName.CustomModelKeys]: {
+    kind: "toggle",
     label: "Custom Model Provider Keys",
     description:
       "Allows projects in this organization to store OpenRouter API keys for model completions.",
     enabledKey: "customModelKeysEnabled",
   },
-
-  {
-    featureName: FeatureName.PlatformMcp,
+  [FeatureName.PlatformMcp]: {
+    kind: "toggle",
     label: "Platform MCP access",
     description:
       "Allows this organization to authenticate to and use Platform MCP, including manual setup. Disabling it denies runtime access without removing existing setup records.",
     enabledKey: "platformMcpEnabled",
   },
-
-  {
-    featureName: FeatureName.RemoteSessionAutoRefresh,
+  [FeatureName.RemoteSessionAutoRefresh]: {
+    kind: "toggle",
     label: "Automatic Remote Session Refresh",
     description:
       "Shows the Auto refresh opt-in on remote-session consent screens.",
     enabledKey: "remoteSessionAutoRefreshEnabled",
   },
-  {
-    featureName: FeatureName.Sso,
+  [FeatureName.Sso]: {
+    kind: "toggle",
     label: "SSO",
     description: "Enables WorkOS portal link creation for managing SSO.",
     enabledKey: "ssoEnabled",
   },
-  {
-    featureName: FeatureName.Scim,
+  [FeatureName.Scim]: {
+    kind: "toggle",
     label: "SCIM",
     description: "Enables WorkOS portal link creation for managing SCIM.",
     enabledKey: "scimEnabled",
   },
-];
+
+  // Self-serve org settings own these; a second switch here would compete
+  // with the control the organization already sees.
+  [FeatureName.Logs]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → Logs",
+  },
+  [FeatureName.ToolIoLogs]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → Logs",
+  },
+  [FeatureName.SessionCapture]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → Logs",
+  },
+  [FeatureName.HooksBrowserLogin]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → Logs",
+  },
+  [FeatureName.HooksFailOpen]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → Logs",
+  },
+  [FeatureName.SkillCaptureMetadataOnly]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → Skills content upload",
+  },
+  [FeatureName.ConsentToolFiltering]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → consent tool filtering",
+  },
+  // The enforced variant is one arm of a three-state policy
+  // (disabled / user-controlled / enforced) written through
+  // features.setRemoteSessionAutoRefreshPolicy; flipping it on its own here
+  // would desync it from the sibling entitlement.
+  [FeatureName.RemoteSessionAutoRefreshEnforced]: {
+    kind: "managed-elsewhere",
+    where: "Organization settings → remote session refresh policy",
+  },
+  // Skills is generally available and the server refuses to disable it, so a
+  // switch would be a lie in one direction.
+  [FeatureName.Skills]: {
+    kind: "managed-elsewhere",
+    where: "always on — enabled with the organization's entitlements",
+  },
+};
+
+const TOGGLEABLE_FEATURES = Object.values(FeatureName)
+  .flatMap((featureName) => {
+    const entry = PRODUCT_FEATURES[featureName];
+    return entry.kind === "toggle" ? [{ featureName, ...entry }] : [];
+  })
+  .sort((a, b) => a.label.localeCompare(b.label));
 
 function ProductFeaturesSection({
   organizationId,
@@ -145,7 +204,7 @@ function ProductFeaturesSection({
     organizationId,
   });
   const platformMcp = useFeatureFlag(FEATURE_FLAGS.platformMcp);
-  const visibleFeatures = PRODUCT_FEATURES.filter(
+  const visibleFeatures = TOGGLEABLE_FEATURES.filter(
     (feature) =>
       feature.featureName !== FeatureName.PlatformMcp ||
       platformMcp.status === "enabled",


### PR DESCRIPTION
## Summary

The Platform Admin → Features page listed product feature toggles as a hand-written array, so a feature added on the backend simply never appeared there — nothing forced a decision. Ten of the seventeen features the SDK exposes were unrepresented.

`PRODUCT_FEATURES` is now a `Record<FeatureName, ProductFeatureEntry>` keyed by the SDK's generated `FeatureName` constant, where each entry is either:

- `{ kind: "toggle", label, description, enabledKey }` — a switch rendered on this page, or
- `{ kind: "managed-elsewhere", where }` — an explicit note that another surface owns it.

Adding a feature to the Goa design enum now regenerates `FeatureName` and makes this file a type error until someone decides which of the two it is.

I used a `Record` rather than `switch` + `assertNever` because `assertNever` in `@/lib/utils` is typed `(value: unknown): never` and therefore enforces nothing at compile time. The `Record` fails at the definition site instead, with no runtime code:

```
error TS2741: Property 'skills' is missing in type '{...}'
  but required in type 'Record<FeatureName, ProductFeatureEntry>'
```

Also:

- `enabledKey` is typed `keyof ProductFeaturesQueryData` instead of a hardcoded seven-way string union, so it tracks the response shape too.
- Rows are sorted by label rather than by hand-ordering.
- `ai_platform_push_integrations` gains a toggle. It had no control anywhere in the dashboard, so Platform Admin is the honest home for it rather than a `managed-elsewhere` entry pointing at nothing.

Existing behaviour is otherwise unchanged, including the PostHog gate that hides the Platform MCP row.

## Follow-ups this does not fix

@walker-tx — flagging one for you, since it neighbours #5529.

**`client/admin` holds a second, hand-written copy of the same list.** `client/admin/src/pages/organization/Features.tsx` defines its own `PRODUCT_FEATURES` array against a hand-written `AdminOrganizationFeatureName` union in `client/admin/src/lib/gramAdminApi`, rather than a generated enum. The two pages agree today because #5529 aligned them by hand, but nothing keeps them aligned — the guard added here binds only the dashboard. Worth giving the admin app the same treatment, which likely means generating (or deriving) `AdminOrganizationFeatureName` rather than maintaining it.

**Go and the Goa design can drift below the SDK.** `productfeatures.FeatureSessionPortability` exists in `server/internal/productfeatures/features.go` but is absent from the `Enum(...)` in `server/design/productfeatures/design.go`, so it never reaches the SDK at all — no TypeScript guard can see it. Closing that gap needs a server-side check that the design enum covers every declared `Feature`.

## Testing

- `aube run -F dashboard type-check`
- `aube run -F dashboard vitest run src/pages/platform-admin/Features.test.tsx` (7 passed)
- Verified the guard bites by deleting one key and confirming the TS2741 above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the Platform Admin → Features list from the SDK-generated `FeatureName` enum to prevent silent omissions. Previously a hand-written array allowed backend features to be missed; now type-checking fails until each feature is marked as a toggle or as managed elsewhere.

- `PRODUCT_FEATURES` is a `Record<FeatureName, ProductFeatureEntry>` with entries of kind `toggle` (label, description, `enabledKey`) or `managed-elsewhere` (where).
- Adds a toggle for AI Platform Push Integrations.
- Types `enabledKey` as `keyof ProductFeaturesQueryData`; sorts rows by label.
- Behavior otherwise unchanged; Platform MCP visibility remains PostHog-gated.

<sup>Written for commit 8670f6e06fa1ca6c819a5813708be9e25c24498d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

