### PR TITLE
chore: share the LGTM stack and cap per-worktree infra memory

### DIFF
--- a/.agents/skills/grafana-lgtm/SKILL.md
+++ b/.agents/skills/grafana-lgtm/SKILL.md
@@ -1,47 +1,63 @@
 ---
 name: grafana-lgtm
-description: Use when inspecting OpenTelemetry traces or metrics that gram-server, gram-worker or pystreams emitted during local development — confirming an endpoint is instrumented, finding the slow or failing span after hitting a local route, proving a request propagated from server into a Temporal activity, or checking a local counter/histogram. Also use when a local trace search comes back empty, a metric looks missing from Prometheus, or results look like they came from the wrong worktree. Triggers — "check the trace", "did that get instrumented", "why is this slow locally", "what did the worker do", TraceQL, Tempo, Grafana, LGTM, spanmetrics, `mise run open:grafana`, GRAFANA_PORT / TEMPO_HTTP_PORT / PROMETHEUS_PORT, and any local trace or metric lookup that returns 404 or an empty result.
+description: Use when inspecting OpenTelemetry traces or metrics that gram-server, gram-worker or pystreams emitted during local development — confirming an endpoint is instrumented, finding the slow or failing span after hitting a local route, proving a request propagated from server into a Temporal activity, or checking a local counter/histogram. Also use when a local trace search comes back empty, a metric looks missing from Prometheus, or results look like they came from the wrong worktree (every worktree now shares one LGTM, so unfiltered queries return everyone's data). Triggers — "check the trace", "did that get instrumented", "why is this slow locally", "what did the worker do", TraceQL, Tempo, Grafana, LGTM, spanmetrics, `mise run open:grafana`, GRAFANA_PORT / TEMPO_HTTP_PORT / PROMETHEUS_PORT, and any local trace or metric lookup that returns 404 or an empty result.
 ---
 
 # Local traces and metrics
 
-One `lgtm` compose service (`grafana/otel-lgtm`) runs Grafana, Tempo and Prometheus together. Query it over HTTP with `curl` — the UI is for humans, the APIs are for you.
+One `lgtm` container (`grafana/otel-lgtm`) runs Grafana, Tempo and Prometheus together. Query it over HTTP with `curl` — the UI is for humans, the APIs are for you.
 
 ```
-gram-server / gram-worker → OTLP gRPC :$OTLP_GRPC_PORT → otel-collector → lgtm:4317
-                                                                          ├→ Tempo      (traces)
-                                                                          └→ Prometheus (metrics)
+every worktree's gram-server / gram-worker
+  → OTLP gRPC localhost:4317 → gram-shared-lgtm-1 ├→ Tempo      (traces)
+                                                  └→ Prometheus (metrics)
 ```
 
-`mise run infra:start` brings it up. Logs and profiles are not wired into it — application logs go to stdout, so reach for `pitchfork logs` instead.
+**It is shared across every worktree**, declared in `compose.shared.yml` under the fixed project `gram-shared` — not in the per-worktree `compose.yml`. One copy serves the whole machine, so its ports are the same everywhere and are never remapped. `mise run infra:start` asserts it (idempotently) from whichever worktree runs first.
 
-## Resolve ports first
+Logs and profiles are not wired into it — application logs go to stdout, so reach for `pitchfork logs` instead.
 
-Several worktrees run their own stack at once, and agents have come one command away from reporting another worktree's data as this one's. Ports are remapped per worktree, and a shell started before a `mise.toml` change carries stale values, so `echo $TEMPO_HTTP_PORT` can print nothing. `mise env` is the authority:
+## Filter by worktree, always
+
+**Every worktree's signals land in the same Tempo and the same Prometheus.** An unfiltered query returns every worktree's data mixed together, and two worktrees on the same commit produce identical span and series names — so an unfiltered result that looks like yours may not be. This is the single most likely way to report the wrong answer here.
+
+What separates them is the `worktree` resource attribute, set from `OTEL_RESOURCE_ATTRIBUTES` in `mise.local.toml` (written by `git:workinit`; the main working tree uses `worktree=main` from `mise.toml`). Get your own value, then filter every query with it:
 
 ```bash
-eval "$(mise env)"
+eval "$(mise env)"                       # authority; a stale shell may have none of these
 TEMPO="http://localhost:$TEMPO_HTTP_PORT"
 PROM="http://localhost:$PROMETHEUS_PORT"
+WT="${OTEL_RESOURCE_ATTRIBUTES#worktree=}"   # e.g. gram-infra-ab12
+```
+
+In TraceQL that is a `resource.worktree` matcher; in PromQL a `worktree` label:
+
+```bash
+curl -s --get "$TEMPO/api/search" \
+  --data-urlencode "q={resource.worktree=\"$WT\"}" \
+  --data-urlencode "start=$S" --data-urlencode "end=$E"
 ```
 
 Grafana UI: `mise run open:grafana`, or `http://localhost:$GRAFANA_PORT` (anonymous admin, no login).
 
-Those ports identify your stack, and `docker ps --filter "publish=$PROMETHEUS_PORT"` names the container behind one (`gram-infra-<slug>-lgtm-1`) when you need to be certain. Daemon state is a separate question — `pitchfork list` tells you whether an emitter is _currently_ running, which explains stale data, but signals nothing about whose data is in Tempo. Traces already ingested stay queryable long after the process that produced them stops, and a stopped daemon prints as `available`, which reads like "fine" at a glance.
+Ports no longer identify a stack — they are the same for everyone, and the container behind them is always `gram-shared-lgtm-1`. Daemon state is a separate question — `pitchfork list` tells you whether an emitter is _currently_ running, which explains stale data, but signals nothing about whose data is in Tempo. Traces already ingested stay queryable long after the process that produced them stops, and a stopped daemon prints as `available`, which reads like "fine" at a glance.
+
+If a search returns nothing, check that you are filtering on a worktree that actually reported (see the table) before assuming the code is uninstrumented.
 
 ## Quick reference
 
 Several of these take a time window; define it once — `S=$(( $(date +%s) - 3600 )); E=$(( $(date +%s) + 60 ))`.
 
-| Goal                         | Command                                                                                                                                                                 |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Which services are reporting | `curl -s --get "$TEMPO/api/v2/search/tag/resource.service.name/values" --data-urlencode "start=$S" --data-urlencode "end=$E"`                                           |
-| Which spans/routes exist     | `curl -s --get "$TEMPO/api/v2/search/tag/name/values" --data-urlencode 'q={resource.service.name="gram-server"}' --data-urlencode "start=$S" --data-urlencode "end=$E"` |
-| Search traces                | `curl -s --get "$TEMPO/api/search" --data-urlencode 'q={…}' --data-urlencode "start=$S" --data-urlencode "end=$E"`                                                      |
-| One trace, all spans         | `curl -s "$TEMPO/api/v2/traces/<traceID>"`                                                                                                                              |
-| Metric names                 | `curl -s "$PROM/api/v1/label/__name__/values"`                                                                                                                          |
-| Labels on a metric           | `curl -s --get "$PROM/api/v1/series" --data-urlencode 'match[]=<metric>'`                                                                                               |
-| Run PromQL                   | `curl -s --get "$PROM/api/v1/query" --data-urlencode 'query=…'`                                                                                                         |
+| Goal                          | Command                                                                                                                                                                 |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Which worktrees are reporting | `curl -s --get "$TEMPO/api/v2/search/tag/resource.worktree/values" --data-urlencode "start=$S" --data-urlencode "end=$E"`                                               |
+| Which services are reporting  | `curl -s --get "$TEMPO/api/v2/search/tag/resource.service.name/values" --data-urlencode "start=$S" --data-urlencode "end=$E"`                                           |
+| Which spans/routes exist      | `curl -s --get "$TEMPO/api/v2/search/tag/name/values" --data-urlencode 'q={resource.service.name="gram-server"}' --data-urlencode "start=$S" --data-urlencode "end=$E"` |
+| Search traces                 | `curl -s --get "$TEMPO/api/search" --data-urlencode 'q={…}' --data-urlencode "start=$S" --data-urlencode "end=$E"`                                                      |
+| One trace, all spans          | `curl -s "$TEMPO/api/v2/traces/<traceID>"`                                                                                                                              |
+| Metric names                  | `curl -s "$PROM/api/v1/label/__name__/values"`                                                                                                                          |
+| Labels on a metric            | `curl -s --get "$PROM/api/v1/series" --data-urlencode 'match[]=<metric>'`                                                                                               |
+| Run PromQL                    | `curl -s --get "$PROM/api/v1/query" --data-urlencode 'query=…'`                                                                                                         |
 
 ## Traces — Tempo
 

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -56,6 +56,13 @@ suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 compose_project="gram-infra-${suffix}"
 mise set --file mise.local.toml "COMPOSE_PROJECT_NAME=${compose_project}"
 
+# The LGTM stack is shared across every worktree (compose.shared.yml), so all of
+# their traces and metrics land in one Tempo/Prometheus. Tagging each worktree's
+# telemetry with its compose project is what keeps those signals apart — without
+# it, two worktrees on the same commit emit identical Prometheus series. The
+# OTel SDK reads this env var directly, so nothing in the Go code has to know.
+mise set --file mise.local.toml "OTEL_RESOURCE_ATTRIBUTES=worktree=${compose_project}"
+
 remap=$(mise run zero:remap-ports --format flat --file -)
 for line in $remap; do
   key="${line%%=*}"

--- a/.mise-tasks/git/worksync.sh
+++ b/.mise-tasks/git/worksync.sh
@@ -88,6 +88,40 @@ if grep -E '^PRESIDIO_ANALYZER_URL[[:space:]]*=' mise.local.toml \
   echo "✅ Reset auto-generated PRESIDIO_PORT / PRESIDIO_ANALYZER_URL to the shared defaults."
 fi
 
+# The LGTM observability stack moved to the shared stack for the same reason,
+# and needs the same treatment: a pre-existing worktree still carries the
+# auto-generated remaps for Grafana/Tempo/Loki/Prometheus and the OTLP
+# receivers, which now point at ports nothing is listening on. Same proof as
+# above — `zero:remap-ports` is the only thing that writes the
+# `{{env.OTLP_GRPC_PORT}}` template into OTEL_EXPORTER_OTLP_ENDPOINT, and it
+# emitted the whole group in one pass, so the marker attests the group is
+# generated and the group is reset together.
+if grep -E '^OTEL_EXPORTER_OTLP_ENDPOINT[[:space:]]*=' mise.local.toml \
+     | grep -qF '{{env.OTLP_GRPC_PORT}}'; then
+  for key in OTEL_EXPORTER_OTLP_ENDPOINT OTLP_GRPC_PORT OTLP_HTTP_PORT \
+             GRAFANA_PORT TEMPO_HTTP_PORT LOKI_HTTP_PORT PROMETHEUS_PORT; do
+    if grep -qE "^${key}[[:space:]]*=" mise.local.toml; then
+      mise unset --file mise.local.toml "$key"
+    fi
+  done
+  echo "✅ Reset auto-generated LGTM ports to the shared defaults."
+fi
+
+# With one LGTM serving every worktree, a worktree that does not tag its
+# telemetry is indistinguishable from every other worktree on the same commit.
+# `git:workinit` writes this for new worktrees; add it here for the ones created
+# before the stack was shared. Only ever filled in when absent, so a
+# hand-customised value survives.
+if ! grep -qE '^OTEL_RESOURCE_ATTRIBUTES[[:space:]]*=' mise.local.toml; then
+  worktree_project=$(mise set --file mise.local.toml 2>/dev/null \
+    | awk '$1 == "COMPOSE_PROJECT_NAME" { print $2 }')
+  if [ -n "$worktree_project" ]; then
+    mise set --file mise.local.toml \
+      "OTEL_RESOURCE_ATTRIBUTES=worktree=${worktree_project}"
+    echo "✅ Tagged this worktree's telemetry as worktree=${worktree_project}."
+  fi
+fi
+
 if [ "${usage_no_migrate:-false}" = "true" ]; then
   echo
   echo "ℹ️  Skipping database migrations (--no-migrate)."

--- a/.mise-tasks/zero/remap-ports.mts
+++ b/.mise-tasks/zero/remap-ports.mts
@@ -38,7 +38,19 @@ import { checkPort } from "get-port-please";
  * skips any env var that depends on it (e.g. PRESIDIO_ANALYZER_URL), so those
  * keep their mise.toml defaults too.
  */
-const SHARED_PORT_ENV_VARS = new Set(["PRESIDIO_PORT"]);
+const SHARED_PORT_ENV_VARS = new Set([
+  "PRESIDIO_PORT",
+  // The LGTM stack is shared too, so every worktree must reach Grafana, Tempo,
+  // Loki, Prometheus and the OTLP receivers on the same default host port.
+  // OTEL_EXPORTER_OTLP_ENDPOINT is derived from OTLP_GRPC_PORT and is skipped
+  // along with it, so it keeps its mise.toml default as well.
+  "GRAFANA_PORT",
+  "TEMPO_HTTP_PORT",
+  "LOKI_HTTP_PORT",
+  "PROMETHEUS_PORT",
+  "OTLP_GRPC_PORT",
+  "OTLP_HTTP_PORT",
+]);
 
 /**
  * Range to draw worktree ports from. Deliberately BELOW the ephemeral range

--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -118,9 +118,18 @@ async function pokeDockerService(
   serviceName: string,
   displayName: string,
   url: string,
+  /**
+   * Services in compose.shared.yml run once for the whole machine under a fixed
+   * project, so they are invisible to a plain `docker compose ps` scoped to this
+   * worktree's COMPOSE_PROJECT_NAME — which would report them as down.
+   */
+  shared = false,
 ) {
+  const composeArgs = shared
+    ? ["-f", "compose.shared.yml", "-p", "gram-shared"]
+    : [];
   let result =
-    await $`docker compose ps ${serviceName} --format json`.nothrow();
+    await $`docker compose ${composeArgs} ps ${serviceName} --format json`.nothrow();
   if (!result.ok) {
     return row(displayName, false, url);
   }
@@ -162,7 +171,12 @@ await pokeDockerService(
 );
 
 const grafanaPort = process.env["GRAFANA_PORT"] ?? "13000";
-await pokeDockerService("lgtm", "Grafana", `http://localhost:${grafanaPort}`);
+await pokeDockerService(
+  "lgtm",
+  "Grafana",
+  `http://localhost:${grafanaPort}`,
+  true,
+);
 
 const clickhouseHTTPPort = process.env["CLICKHOUSE_HTTP_PORT"] ?? "8123";
 await pokeDockerService(

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -6,10 +6,15 @@
 # a FIXED project name instead of the per-worktree `COMPOSE_PROJECT_NAME` used
 # by compose.yml.
 #
-# (LGTM/OTel-collector are intentionally NOT shared: their signals
-# would collide across worktrees — same-commit worktrees emit identical
-# Prometheus series and intermixed traces — so they stay per-worktree in
-# compose.yml.)
+# The LGTM observability stack lives here for the same reason. It used to be
+# per-worktree, on the grounds that same-commit worktrees emit identical
+# Prometheus series and intermixed traces. That is true only while the signals
+# are indistinguishable — so instead of paying ~560 MB per worktree for a second
+# copy (the single most expensive container in the stack, and the main reason
+# several concurrent worktrees exhausted host memory), every worktree now tags
+# its telemetry with OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME.
+# `git:workinit` writes that; `mise.toml` holds the main tree's default. Filter
+# by the `worktree` label in Grafana to get one worktree's signals back.
 #
 # Always manage this file with an explicit fixed project so a worktree's
 # COMPOSE_PROJECT_NAME cannot fork it into a second copy:
@@ -47,3 +52,35 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  # Tempo only makes a trace searchable once it has idled the trace out and cut
+  # a block — seconds to a minute. Lookup by trace ID is immediate.
+  lgtm:
+    image: grafana/otel-lgtm:0.30.1@sha256:bb182ac3174a20923fa58f00d1790fa71eb06cc0150078c0b0e8feb9e6611492
+    restart: unless-stopped
+    ports:
+      - "13000:3000" # Grafana UI
+      - "13200:3200" # Tempo HTTP API
+      - "13100:3100" # Loki HTTP API
+      - "9099:9090" # Prometheus UI/API
+      - "4317:4317" # OTLP gRPC receiver
+      - "4318:4318" # OTLP HTTP receiver
+    volumes:
+      # Runs as root, so wipe this from inside the container rather than sudo:
+      # docker compose -f compose.shared.yml -p gram-shared exec lgtm \
+      #   sh -c 'rm -rf /data/*'
+      #
+      # A named volume, not ./local/lgtm: this stack is started by whichever
+      # worktree happens to run infra:start first, so a relative bind mount
+      # would put the data wherever that tree is — letting which worktree
+      # booted the machine silently decide where everyone's telemetry lives.
+      - lgtm_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+volumes:
+  lgtm_data:
+    driver: local

--- a/compose.yml
+++ b/compose.yml
@@ -1,8 +1,9 @@
 # Per-worktree infra. `git:workinit` sets a unique COMPOSE_PROJECT_NAME (and
 # `zero:remap-ports` remaps the host ports) so each worktree gets its own stack
-# — postgres, clickhouse, temporal, observability, etc. — without colliding.
-# The one exception is the stateless Presidio analyzer, which is shared across
-# all worktrees; see compose.shared.yml.
+# — postgres, clickhouse, temporal, etc. — without colliding.
+# Services that hold no per-worktree state live in compose.shared.yml instead
+# and run as a single copy for the whole machine: the Presidio analyzer and the
+# LGTM observability stack.
 name: ${COMPOSE_PROJECT_NAME:-gram}
 
 services:
@@ -95,28 +96,6 @@ services:
       timeout: 30s
       retries: 5
 
-  # Tempo only makes a trace searchable once it has idled the trace out and cut
-  # a block — seconds to a minute. Lookup by trace ID is immediate.
-  lgtm:
-    image: grafana/otel-lgtm:0.30.1@sha256:bb182ac3174a20923fa58f00d1790fa71eb06cc0150078c0b0e8feb9e6611492
-    restart: unless-stopped
-    ports:
-      - "${GRAFANA_PORT}:3000" # Grafana UI
-      - "${TEMPO_HTTP_PORT}:3200" # Tempo HTTP API
-      - "${LOKI_HTTP_PORT}:3100" # Loki HTTP API
-      - "${PROMETHEUS_PORT}:9090" # Prometheus UI/API
-      - "${OTLP_GRPC_PORT}:4317" # OTLP gRPC receiver
-      - "${OTLP_HTTP_PORT}:4318" # OTLP HTTP receiver
-    volumes:
-      # Runs as root, so wipe this from inside the container rather than sudo:
-      # docker compose exec lgtm sh -c 'rm -rf /data/*'
-      - ./local/lgtm:/data
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 12
-
   litellm:
     profiles: [litellm]
     image: ghcr.io/berriai/litellm:v1.94.0@sha256:65d84a2282137b4dc73bbe184650a7c807177c533e4223b3bfbc87963fe3fabe
@@ -160,6 +139,14 @@ services:
   pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:573.0.0-emulators@sha256:1b083a6a9647024a98d4f38c2b51906a0f61ca36adcba11672b8933544962efe
     restart: unless-stopped
+    environment:
+      # The emulator is a JVM app (cloud-pubsub-emulator-all.jar) launched with
+      # no -Xmx, so its default max heap is 1/4 of container-visible RAM -- the
+      # whole Docker VM, several GB. An emulator serving one developer never
+      # needs that, and the unbounded ceiling is what makes N worktrees
+      # dangerous. `gcloud beta emulators pubsub start` has no pass-through flag
+      # for JVM options, so set the cap through the JVM's own env var.
+      JAVA_TOOL_OPTIONS: -Xmx128m
     ports:
       - "${PUBSUB_EMULATOR_PORT}:8085"
     command:

--- a/local/clickhouse/config.d/limits.xml
+++ b/local/clickhouse/config.d/limits.xml
@@ -3,13 +3,22 @@
 <clickhouse>
     <!-- Hard total server memory cap (bytes). Set explicitly rather than relying on the
          auto ratio (90% of visible RAM) or a compose cgroup limit: cgroup limits are not
-         enforced in every environment, in which case ClickHouse sees the whole host's RAM. -->
-    <max_server_memory_usage>2147483648</max_server_memory_usage> <!-- 2 GiB -->
+         enforced in every environment, in which case ClickHouse sees the whole host's RAM.
+
+         Sized for N concurrent worktrees, not one: each worktree runs its own ClickHouse, so
+         this budget is multiplied by however many stacks are up. 512 MiB is ample for the
+         local dataset (dev seed plus whatever a test run writes) and keeps six worktrees
+         under 3 GiB of ClickHouse headroom instead of 12 GiB. -->
+    <max_server_memory_usage>1073741824</max_server_memory_usage> <!-- 1 GiB -->
 
     <!-- Reduce cache sizes relative to available RAM -->
     <cache_size_to_ram_max_ratio>0.20</cache_size_to_ram_max_ratio>
 
-    <!-- Reduce background thread pools so ClickHouse doesn't spawn too many workers -->
+    <!-- Reduce background thread pools so ClickHouse doesn't spawn too many workers.
+         Do not lower this further without also lowering
+         number_of_free_entries_in_pool_to_execute_mutation (default 20): startup fails with
+         BAD_ARGUMENTS unless background_pool_size * background_merges_mutations_concurrency_ratio
+         is at least that value. -->
     <background_pool_size>20</background_pool_size>
     <background_schedule_pool_size>2</background_schedule_pool_size>
 </clickhouse>

--- a/mise.toml
+++ b/mise.toml
@@ -228,6 +228,16 @@ OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
 ## Change these to 0 to disable OpenTelemetry traces and metrics to be emitted.
 GRAM_ENABLE_OTEL_TRACES = 1
 GRAM_ENABLE_OTEL_METRICS = 1
+## Tags every span, metric and log this worktree emits with the worktree it came
+## from, so the single shared LGTM stack (compose.shared.yml) can host all of
+## them at once without their signals being indistinguishable. `git:workinit`
+## overwrites this in mise.local.toml with the worktree's COMPOSE_PROJECT_NAME;
+## the value here is what the main working tree uses. Filter on it in Grafana
+## with `worktree="gram-infra-abcd"`.
+##
+## Read by the OTel SDK itself (resource.Default picks up the env detector), so
+## nothing in the Go setup needs to know about it.
+OTEL_RESOURCE_ATTRIBUTES = "worktree=main"
 
 ################################
 ## Local development settings ##


### PR DESCRIPTION
## Problem

Running several worktrees at once exhausts host memory. Each worktree runs a full infra stack at ~1.34 GB, and two of its services had no effective ceiling:

| Service | Per stack | ×6 stacks |
| --- | --- | --- |
| `lgtm` | 560 MB | **3.4 GB** |
| `clickhouse` | 283 MB | 1.7 GB |
| `pubsub-emulator` | 271 MB | 1.6 GB |
| `gram-temporal` | 181 MB | 1.1 GB |
| `gram-db` + `gram-cache` | 45 MB | 270 MB |

On top of that, `mise run test:server` spawns ~1.5 GB of testcontainers. That spike landing on 8 GB of *idle* stacks is what tips a machine over.

## Changes

**`lgtm` moves to `compose.shared.yml`** — one copy for the whole machine, alongside Presidio.

It was per-worktree on the grounds that same-commit worktrees emit identical Prometheus series and intermixed traces. That holds only while the signals are indistinguishable, so each worktree now tags its telemetry with `OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME` (`git:workinit` writes it; `mise.toml` carries the main tree's default). The OTel SDK reads that env var itself, so no Go changes. Filter with `{resource.worktree="…"}` in TraceQL or a `worktree` label in PromQL.

Consequences handled: the six LGTM ports join `PRESIDIO_PORT` in `remap-ports`' shared set so they are never remapped; `worksync` resets the remaps a pre-existing worktree already wrote and backfills its tag; `zero:summary` looks in the `gram-shared` project or it reports Grafana as down; the data dir becomes a named volume, since a relative bind mount would let whichever worktree booted first decide where everyone's telemetry lives.

**`pubsub-emulator` heap capped.** It is a JVM app started with no `-Xmx`, so its max heap defaulted to a quarter of container-visible RAM — the whole Docker VM. `gcloud beta emulators pubsub start` has no pass-through flag for JVM options, so the cap goes through `JAVA_TOOL_OPTIONS`.

**ClickHouse `max_server_memory_usage` 2 GiB → 1 GiB.** It was sized for one stack; six worktrees meant 12 GiB of permission to allocate.

## Results

Measured before/after on real containers:

| | before | after |
| --- | --- | --- |
| `lgtm` | 489 MB × N | **489 MB × 1** |
| `clickhouse` | 175–406 MB | **88 MB** |
| `pubsub-emulator` | 270 MB | **143 MB** |

Six worktrees: **~8.0 GB → ~3.4 GB**.

## Verification

- Shared LGTM healthy on fixed ports — Grafana `database: ok`, Prometheus ready, OTLP 4317 accepting.
- **Isolation proven end to end**: sent one span each tagged `worktree=a` / `worktree=b` to the shared collector; Tempo returned exactly one trace per `{resource.worktree="…"}` query, and `resource.worktree` enumerated both.
- Full `mise run infra:start` on a tree: stack came up with no `lgtm` in its project and reused the shared one rather than recreating it.
- `zero:summary` reports Grafana RUNNING while that tree's own services are stopped — the case the `shared` flag fixes.

Two failures caught while testing, both now recorded in code comments:

- `--jvm-flag` is **not** a real flag for the pubsub emulator; it crash-loops with `unrecognized arguments`. Hence `JAVA_TOOL_OPTIONS`.
- ClickHouse derives `background_pool_size` from the memory cap, so 512 MiB shrank the pool until `background_pool_size × concurrency_ratio` fell below `number_of_free_entries_in_pool_to_execute_mutation` and startup failed with `BAD_ARGUMENTS`. 1 GiB is the floor that boots. A `background_pool_size` override in `limits.xml` turned out to be a no-op (reported 20, enforced 8), so it is left at its original value with the constraint documented.

## Migration

`compose.yml` and `.mise-tasks/` are git-tracked, so a worktree picks this up only once its branch contains the commit. Until then its `infra:start` re-declares `lgtm` and recreates the container; the run after that removes it as an orphan. Existing ClickHouse and pubsub containers also keep their old settings until recreated. Running `mise run git:worksync` in a worktree resets its LGTM port remaps and adds its `worktree` tag.

The `grafana-lgtm` skill is rewritten around tag filtering — its previous advice, that ports identify your stack, is now the opposite of true.

Worth knowing when reviewing: `local/lgtm/` data directories are orphaned by the move (~250 MB per worktree) and can be deleted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the LGTM observability stack across all worktrees and cap infra memory to prevent host OOMs. Before: each worktree ran its own LGTM and some services had no effective ceiling. Now: one shared LGTM on fixed ports plus tighter ClickHouse and Pub/Sub emulator limits; queries must filter by worktree.

- LGTM is now in `compose.shared.yml` (project `gram-shared`) with fixed ports: 13000 (Grafana), 13200 (Tempo), 13100 (Loki), 9099 (Prometheus), 4317/4318 (OTLP). Data moves to a named volume (`lgtm_data`). `remap-ports` marks these ports shared (no remap), and `zero:summary` checks the shared project.
- Each worktree tags telemetry via `OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME` (`mise.toml` default; `git:workinit` writes per-worktree). `grafana-lgtm` docs now require filtering by `worktree` in TraceQL/PromQL to avoid mixed results.
- `worksync` resets old LGTM port envs and backfills the `OTEL_RESOURCE_ATTRIBUTES` tag for existing worktrees.
- Pub/Sub emulator heap is capped with `JAVA_TOOL_OPTIONS=-Xmx128m`.
- ClickHouse `max_server_memory_usage` is reduced to 1 GiB (floor that still boots).
- Measured memory: `lgtm` 489 MB × N → 489 MB × 1; ClickHouse 175–406 MB → 88 MB; Pub/Sub 270 MB → 143 MB. Six worktrees: ~8.0 GB → ~3.4 GB.

- Migration
  - Run `mise run git:worksync` in each existing worktree to reset LGTM port remaps and add the `worktree` tag.
  - Recreate ClickHouse and Pub/Sub emulator to pick up new limits.
  - Delete orphaned per-worktree `local/lgtm/` directories if present.
  - Update queries and dashboards to include `worktree=<your value>`; ports no longer identify a stack.

<sup>Written for commit 5f2f02aefd34e23030377706e6a9d311ab4833e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

