### PR TITLE
chore: require demo seed updates for feature changes

### DIFF
--- a/.agents/skills/gram-demo-seed/SKILL.md
+++ b/.agents/skills/gram-demo-seed/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gram-demo-seed
-description: Use when editing or extending the demo org seed or the local dev seed — server/internal/demoseed/{postgres,clickhouse}.sql, demoseed.Spec, RunLocalFixtures, demo.ensure_demo_org(), gram demo-seed, mise run seed, mise run seed:demo, seed/demo/ docs, TestDemoSeedSafety, the demo-seed-safety CI job, org_gram_demo_workspace, dec0de00 uuids — or when that CI check fails with "touched another tenant's rows", "reseed is not cleaning up or not idempotent", "still contains the demo identifier", or a demo seed pre/postflight exception.
+description: Use when adding a new feature or changing an existing one that surfaces data in the dashboard — the demo org (app.getgram.ai/explore-demo) must show it — and when editing or extending the demo org seed or the local dev seed — server/internal/demoseed/{postgres,clickhouse}.sql, demoseed.Spec, RunLocalFixtures, demo.ensure_demo_org(), gram demo-seed, mise run seed, mise run seed:demo, seed/demo/ docs, TestDemoSeedSafety, the demo-seed-safety CI job, org_gram_demo_workspace, dec0de00 uuids — or when that CI check fails with "touched another tenant's rows", "reseed is not cleaning up or not idempotent", "still contains the demo identifier", or a demo seed pre/postflight exception.
 ---
 
 # Extending the demo org seed
@@ -14,6 +14,19 @@ demo-scoped data and reinserts it fresh**, so the seed must stay idempotent and
 perfectly scoped. `TestDemoSeedSafety` (its own required CI check,
 `demo-seed-safety`) enforces that mechanically — this skill explains the system
 and what the test will reject.
+
+## When the seed must change
+
+The demo org (`app.getgram.ai/explore-demo`) is how customers explore Gram before
+their own org is set up, and the same seed provisions every developer's local
+org. So a feature that ships without seed data shows an empty page to both.
+
+**Any new feature, or change to an existing one, that introduces or reshapes
+data a page renders must land with the matching seed change in the same
+PR.** Rule of thumb: if the change adds a table, a column a page reads, a new
+entity kind, or a new telemetry dimension, the seed needs a row for it. Then
+verify the affected pages per `seed/demo/verify.md` and update
+`seed/demo/PAGES.md`.
 
 ## Quick reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ Use `pr-demo-gif` when a user-visible change needs a shareable PR screenshot, GI
 
 `.mcp.json` registers the `assistants-dev` MCP server (`server/cmd/dev-mcp`), which drives the local management API without the dashboard UI. It logs into the local stack on its own (dev-idp auto-approves), so no setup is needed beyond a running dev stack. Use its tools — assistant CRUD, `run_turn` (send a message and wait for the assistant's reply), `load_chat`, and trigger CRUD — to exercise assistant runtime changes end to end. `whoami` lists the available project slugs.
 
+### Demo org and seed data
+
+We maintain a demo org (`app.getgram.ai/explore-demo`) that customers use to explore the product before their own org is set up. It is reseeded daily from a SQL seed stored in this repo, and the same seed provisions each developer's local org.
+
+When you add a feature or change an existing one, update the demo seed in the same change so the new data shows up in both the demo org and local dev. Activate the `gram-demo-seed` skill (`.agents/skills/gram-demo-seed/SKILL.md`) for the rules and the workflow.
+
 ### Database Migrations
 
 Migration rules live in the `postgresql` skill (`.agents/skills/postgresql/SKILL.md`, "Database migrations" section). Activate that skill any time you touch `server/migrations/`, `atlas.sum`, or `server/database/schema.sql`.


### PR DESCRIPTION
Mirrors the demo-org guidance we added to the RFC template into the agent-facing docs, so an agent building a feature learns the rule at feature time rather than only when it is already editing seed files.

## Changes

- `.agents/skills/gram-demo-seed/SKILL.md`
  - Frontmatter `description` now also triggers on feature work ("adding a new feature or changing an existing one that surfaces data in the dashboard"), not just on edits to the seed files. Harnesses match on the description, so this is what makes the skill surface during ordinary feature development.
  - New "When the seed must change" section: why the seed matters (customer-facing demo org + every developer's local org come from the same script), the rule (seed change lands in the same PR), and a rule of thumb — new table, new column a page reads, new entity kind, or new telemetry dimension all need a seeded row — followed by the existing verify / PAGES.md steps.
- `CLAUDE.md` — new "Demo org and seed data" section pointing at the skill, matching how the Database Migrations section points at the `postgresql` skill. Keeps the rule always in context without duplicating the seed's details.

Docs only; no code or seed changes. `hk fix` reports both files correctly formatted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires demo seed updates to ship with feature changes that surface data in the dashboard. Previously the guidance appeared only when editing seed files; now the `gram-demo-seed` skill activates during feature work so the demo org and local dev both show new data.

- **What changed**
  - Expands `description` in `.agents/skills/gram-demo-seed/SKILL.md` so the harness surfaces the skill during feature development.
  - Adds a "When the seed must change" section with the rule, a rule of thumb, and verify/PAGES steps.
  - Adds "Demo org and seed data" to `CLAUDE.md`, pointing to the `gram-demo-seed` skill.
  - Docs only; no code or seed changes.

- **Required action**
  - When a page reads new/changed data (new table, page-read column, entity kind, or telemetry dimension), include matching seed row(s) and update `seed/demo/PAGES.md` in the same PR; run the checks in `seed/demo/verify.md`.

<sup>Written for commit 6c6cd2043f5da1434959d86c5d4ca1fa6821d822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

