### PR TITLE
feat(platform-mcp): add skill authoring and distribution tools

### DIFF
--- a/.changeset/skills-platform-mcp-authoring.md
+++ b/.changeset/skills-platform-mcp-authoring.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Serve skill authoring and distribution over Platform MCP. An OAuth-authenticated client can list, read, create, and re-version skills in an explicit project, rename them, and distribute one to an exact existing plugin or assistant. Authoring alone changes nothing at runtime, and every authoring result says so and names the targets it can be distributed to. `skills.addVersion` and `skills.update` accept an optional `expected_latest_version_id` so a write against a skill that has moved on is refused as a conflict inside the write's own transaction rather than silently overwriting another author's version. Platform MCP now prepares the acting user's RBAC grants and is enforced by the authorization engine, which previously skipped enforcement for any caller without a browser session.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -57961,6 +57961,10 @@ components:
           type: string
           description: The optional source version this new version was derived from.
           format: uuid
+        expected_latest_version_id:
+          type: string
+          description: The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.
+          format: uuid
         id:
           type: string
           description: The skill ID.
@@ -80468,6 +80472,10 @@ components:
           type: string
           description: The user-facing skill name.
           maxLength: 256
+        expected_latest_version_id:
+          type: string
+          description: The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.
+          format: uuid
         id:
           type: string
           description: The skill ID.

--- a/client/dashboard/src/sdk/src/models/components/addskillversionrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/addskillversionrequestbody.ts
@@ -15,6 +15,10 @@ export type AddSkillVersionRequestBody = {
    */
   derivedFromVersionId?: string | undefined;
   /**
+   * The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.
+   */
+  expectedLatestVersionId?: string | undefined;
+  /**
    * The skill ID.
    */
   id: string;
@@ -24,6 +28,7 @@ export type AddSkillVersionRequestBody = {
 export type AddSkillVersionRequestBody$Outbound = {
   content: string;
   derived_from_version_id?: string | undefined;
+  expected_latest_version_id?: string | undefined;
   id: string;
 };
 
@@ -35,11 +40,13 @@ export const AddSkillVersionRequestBody$outboundSchema: z.ZodMiniType<
   z.object({
     content: z.string(),
     derivedFromVersionId: z.optional(z.string()),
+    expectedLatestVersionId: z.optional(z.string()),
     id: z.string(),
   }),
   z.transform((v) => {
     return remap$(v, {
       derivedFromVersionId: "derived_from_version_id",
+      expectedLatestVersionId: "expected_latest_version_id",
     });
   }),
 );

--- a/client/dashboard/src/sdk/src/models/components/updateskillrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/updateskillrequestbody.ts
@@ -11,6 +11,10 @@ export type UpdateSkillRequestBody = {
    */
   displayName: string;
   /**
+   * The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.
+   */
+  expectedLatestVersionId?: string | undefined;
+  /**
    * The skill ID.
    */
   id: string;
@@ -31,6 +35,7 @@ export type UpdateSkillRequestBody = {
 /** @internal */
 export type UpdateSkillRequestBody$Outbound = {
   display_name: string;
+  expected_latest_version_id?: string | undefined;
   id: string;
   name: string;
   summary?: string | undefined;
@@ -44,6 +49,7 @@ export const UpdateSkillRequestBody$outboundSchema: z.ZodMiniType<
 > = z.pipe(
   z.object({
     displayName: z.string(),
+    expectedLatestVersionId: z.optional(z.string()),
     id: z.string(),
     name: z.string(),
     summary: z.optional(z.string()),
@@ -52,6 +58,7 @@ export const UpdateSkillRequestBody$outboundSchema: z.ZodMiniType<
   z.transform((v) => {
     return remap$(v, {
       displayName: "display_name",
+      expectedLatestVersionId: "expected_latest_version_id",
     });
   }),
 );

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -63,6 +63,7 @@ type platformMCPConfig struct {
 	RemoteChallengeManager *remotesessions.ChallengeManager
 	AuditLogger            *audit.Logger
 	PluginPublisher        *plugins.Service
+	Skills                 platformmcp.SkillsManagement
 	LocalFixture           *platformMCPLocalFixtureConfig
 }
 
@@ -180,6 +181,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("local Platform MCP operation budgets are incomplete")
@@ -217,6 +219,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	config.Mux.Handle(http.MethodPost, "/platform-mcp/local-fixture/revoke", fixtureOAuth.Handler().ServeHTTP)
 	config.Mux.Handle(http.MethodPost, "/platform-mcp/local-fixture/mcp", fixtureMCP.Handler().ServeHTTP)
 
+	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -235,6 +238,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		feedback,
 		platformmcp.NewOnboardingService(config.DB),
 		distributions,
+		skillAuthoring,
 		fixtureConfig.CatalogDescriptor(),
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
@@ -368,6 +372,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("platform MCP operation budgets are incomplete")
@@ -414,6 +419,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			return err
 		},
 	)
+	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -429,6 +435,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		feedback,
 		platformmcp.NewOnboardingService(config.DB),
 		distributions,
+		skillAuthoring,
 		platformmcp.CatalogDescriptor{},
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1557,6 +1557,7 @@ func newStartCommand() *cli.Command {
 				RemoteChallengeManager: remoteChallengeManager,
 				AuditLogger:            auditLogger,
 				PluginPublisher:        pluginPublisher,
+				Skills:                 skillsService,
 				LocalFixture:           platformFixture,
 			})
 			if err != nil {

--- a/server/design/skills/design.go
+++ b/server/design/skills/design.go
@@ -51,6 +51,7 @@ var _ = Service("skills", func() {
 			})
 			Attribute("content", String, "The complete uploaded SKILL.md content. Handlers enforce a maximum size of 65,536 UTF-8 bytes.")
 			Attribute("derived_from_version_id", String, "The optional source version this new version was derived from.", func() { Format(FormatUUID) })
+			Attribute("expected_latest_version_id", String, "The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.", func() { Format(FormatUUID) })
 			Required("id", "content")
 			security.SessionPayload()
 			security.ByKeyPayload()
@@ -112,6 +113,7 @@ var _ = Service("skills", func() {
 			Attribute("tags", ArrayOf(String, func() { MaxLength(64) }), "Registry tags for categorizing the skill. At most 40 tags.", func() {
 				MaxLength(40)
 			})
+			Attribute("expected_latest_version_id", String, "The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.", func() { Format(FormatUUID) })
 			Required("id", "name", "display_name", "tags")
 			security.SessionPayload()
 			security.ByKeyPayload()
@@ -739,6 +741,7 @@ var AddSkillVersionRequestBody = Type("AddSkillVersionRequestBody", func() {
 	})
 	Attribute("content", String, "The complete uploaded SKILL.md content. Handlers enforce a maximum size of 65,536 UTF-8 bytes.")
 	Attribute("derived_from_version_id", String, "The optional source version this new version was derived from.", func() { Format(FormatUUID) })
+	Attribute("expected_latest_version_id", String, "The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.", func() { Format(FormatUUID) })
 	Required("id", "content")
 })
 
@@ -789,6 +792,7 @@ var UpdateSkillRequestBody = Type("UpdateSkillRequestBody", func() {
 	Attribute("tags", ArrayOf(String, func() { MaxLength(64) }), "Registry tags for categorizing the skill. At most 40 tags.", func() {
 		MaxLength(40)
 	})
+	Attribute("expected_latest_version_id", String, "The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.", func() { Format(FormatUUID) })
 	Required("id", "name", "display_name", "tags")
 })
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -19738,7 +19738,7 @@ func skillsAddVersionUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills add-version --body '{\n      \"content\": \"abc123\",\n      \"derived_from_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }' --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills add-version --body '{\n      \"content\": \"abc123\",\n      \"derived_from_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"expected_latest_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }' --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func skillsRestoreVersionUsage() {
@@ -19786,7 +19786,7 @@ func skillsUpdateUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills update --body '{\n      \"display_name\": \"aaa\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"aaa\",\n      \"summary\": \"aaa\",\n      \"tags\": [\n         \"aaa\",\n         \"aaa\",\n         \"aaa\"\n      ]\n   }' --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills update --body '{\n      \"display_name\": \"aaa\",\n      \"expected_latest_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"aaa\",\n      \"summary\": \"aaa\",\n      \"tags\": [\n         \"aaa\",\n         \"aaa\",\n         \"aaa\"\n      ]\n   }' --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func skillsListUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -59127,6 +59127,10 @@ components:
                     type: string
                     description: The optional source version this new version was derived from.
                     format: uuid
+                expected_latest_version_id:
+                    type: string
+                    description: The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.
+                    format: uuid
                 id:
                     type: string
                     description: The skill ID.
@@ -81629,6 +81633,10 @@ components:
                     type: string
                     description: The user-facing skill name.
                     maxLength: 256
+                expected_latest_version_id:
+                    type: string
+                    description: The version the caller believes is current. When set, the write is rejected as a conflict if the skill has moved on.
+                    format: uuid
                 id:
                     type: string
                     description: The skill ID.

--- a/server/gen/http/skills/client/cli.go
+++ b/server/gen/http/skills/client/cli.go
@@ -64,11 +64,14 @@ func BuildAddVersionPayload(skillsAddVersionBody string, skillsAddVersionSession
 	{
 		err = json.Unmarshal([]byte(skillsAddVersionBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"content\": \"abc123\",\n      \"derived_from_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"content\": \"abc123\",\n      \"derived_from_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"expected_latest_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }'")
 		}
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", body.ID, goa.FormatUUID))
 		if body.DerivedFromVersionID != nil {
 			err = goa.MergeErrors(err, goa.ValidateFormat("body.derived_from_version_id", *body.DerivedFromVersionID, goa.FormatUUID))
+		}
+		if body.ExpectedLatestVersionID != nil {
+			err = goa.MergeErrors(err, goa.ValidateFormat("body.expected_latest_version_id", *body.ExpectedLatestVersionID, goa.FormatUUID))
 		}
 		if err != nil {
 			return nil, err
@@ -93,9 +96,10 @@ func BuildAddVersionPayload(skillsAddVersionBody string, skillsAddVersionSession
 		}
 	}
 	v := &skills.AddVersionPayload{
-		ID:                   body.ID,
-		Content:              body.Content,
-		DerivedFromVersionID: body.DerivedFromVersionID,
+		ID:                      body.ID,
+		Content:                 body.Content,
+		DerivedFromVersionID:    body.DerivedFromVersionID,
+		ExpectedLatestVersionID: body.ExpectedLatestVersionID,
 	}
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken
@@ -157,7 +161,7 @@ func BuildUpdatePayload(skillsUpdateBody string, skillsUpdateSessionToken string
 	{
 		err = json.Unmarshal([]byte(skillsUpdateBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"display_name\": \"aaa\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"aaa\",\n      \"summary\": \"aaa\",\n      \"tags\": [\n         \"aaa\",\n         \"aaa\",\n         \"aaa\"\n      ]\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"display_name\": \"aaa\",\n      \"expected_latest_version_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"aaa\",\n      \"summary\": \"aaa\",\n      \"tags\": [\n         \"aaa\",\n         \"aaa\",\n         \"aaa\"\n      ]\n   }'")
 		}
 		if body.Tags == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("tags", "body"))
@@ -182,6 +186,9 @@ func BuildUpdatePayload(skillsUpdateBody string, skillsUpdateSessionToken string
 				err = goa.MergeErrors(err, goa.InvalidLengthError("body.tags[*]", e, utf8.RuneCountInString(e), 64, false))
 			}
 		}
+		if body.ExpectedLatestVersionID != nil {
+			err = goa.MergeErrors(err, goa.ValidateFormat("body.expected_latest_version_id", *body.ExpectedLatestVersionID, goa.FormatUUID))
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -205,10 +212,11 @@ func BuildUpdatePayload(skillsUpdateBody string, skillsUpdateSessionToken string
 		}
 	}
 	v := &skills.UpdatePayload{
-		ID:          body.ID,
-		Name:        body.Name,
-		DisplayName: body.DisplayName,
-		Summary:     body.Summary,
+		ID:                      body.ID,
+		Name:                    body.Name,
+		DisplayName:             body.DisplayName,
+		Summary:                 body.Summary,
+		ExpectedLatestVersionID: body.ExpectedLatestVersionID,
 	}
 	if body.Tags != nil {
 		v.Tags = make([]string, len(body.Tags))

--- a/server/gen/http/skills/client/types.go
+++ b/server/gen/http/skills/client/types.go
@@ -31,6 +31,9 @@ type AddVersionRequestBody struct {
 	Content string `form:"content" json:"content" xml:"content"`
 	// The optional source version this new version was derived from.
 	DerivedFromVersionID *string `form:"derived_from_version_id,omitempty" json:"derived_from_version_id,omitempty" xml:"derived_from_version_id,omitempty"`
+	// The version the caller believes is current. When set, the write is rejected
+	// as a conflict if the skill has moved on.
+	ExpectedLatestVersionID *string `form:"expected_latest_version_id,omitempty" json:"expected_latest_version_id,omitempty" xml:"expected_latest_version_id,omitempty"`
 }
 
 // RestoreVersionRequestBody is the type of the "skills" service
@@ -55,6 +58,9 @@ type UpdateRequestBody struct {
 	Summary *string `form:"summary,omitempty" json:"summary,omitempty" xml:"summary,omitempty"`
 	// Registry tags for categorizing the skill. At most 40 tags.
 	Tags []string `form:"tags" json:"tags" xml:"tags"`
+	// The version the caller believes is current. When set, the write is rejected
+	// as a conflict if the skill has moved on.
+	ExpectedLatestVersionID *string `form:"expected_latest_version_id,omitempty" json:"expected_latest_version_id,omitempty" xml:"expected_latest_version_id,omitempty"`
 }
 
 // TriggerSuggestionRequestBody is the type of the "skills" service
@@ -4963,9 +4969,10 @@ func NewCreateRequestBody(p *skills.CreatePayload) *CreateRequestBody {
 // the "addVersion" endpoint of the "skills" service.
 func NewAddVersionRequestBody(p *skills.AddVersionPayload) *AddVersionRequestBody {
 	body := &AddVersionRequestBody{
-		ID:                   p.ID,
-		Content:              p.Content,
-		DerivedFromVersionID: p.DerivedFromVersionID,
+		ID:                      p.ID,
+		Content:                 p.Content,
+		DerivedFromVersionID:    p.DerivedFromVersionID,
+		ExpectedLatestVersionID: p.ExpectedLatestVersionID,
 	}
 	return body
 }
@@ -4984,10 +4991,11 @@ func NewRestoreVersionRequestBody(p *skills.RestoreVersionPayload) *RestoreVersi
 // "update" endpoint of the "skills" service.
 func NewUpdateRequestBody(p *skills.UpdatePayload) *UpdateRequestBody {
 	body := &UpdateRequestBody{
-		ID:          p.ID,
-		Name:        p.Name,
-		DisplayName: p.DisplayName,
-		Summary:     p.Summary,
+		ID:                      p.ID,
+		Name:                    p.Name,
+		DisplayName:             p.DisplayName,
+		Summary:                 p.Summary,
+		ExpectedLatestVersionID: p.ExpectedLatestVersionID,
 	}
 	if p.Tags != nil {
 		body.Tags = make([]string, len(p.Tags))

--- a/server/gen/http/skills/server/types.go
+++ b/server/gen/http/skills/server/types.go
@@ -33,6 +33,9 @@ type AddVersionRequestBody struct {
 	Content *string `form:"content,omitempty" json:"content,omitempty" xml:"content,omitempty"`
 	// The optional source version this new version was derived from.
 	DerivedFromVersionID *string `form:"derived_from_version_id,omitempty" json:"derived_from_version_id,omitempty" xml:"derived_from_version_id,omitempty"`
+	// The version the caller believes is current. When set, the write is rejected
+	// as a conflict if the skill has moved on.
+	ExpectedLatestVersionID *string `form:"expected_latest_version_id,omitempty" json:"expected_latest_version_id,omitempty" xml:"expected_latest_version_id,omitempty"`
 }
 
 // RestoreVersionRequestBody is the type of the "skills" service
@@ -57,6 +60,9 @@ type UpdateRequestBody struct {
 	Summary *string `form:"summary,omitempty" json:"summary,omitempty" xml:"summary,omitempty"`
 	// Registry tags for categorizing the skill. At most 40 tags.
 	Tags []string `form:"tags,omitempty" json:"tags,omitempty" xml:"tags,omitempty"`
+	// The version the caller believes is current. When set, the write is rejected
+	// as a conflict if the skill has moved on.
+	ExpectedLatestVersionID *string `form:"expected_latest_version_id,omitempty" json:"expected_latest_version_id,omitempty" xml:"expected_latest_version_id,omitempty"`
 }
 
 // TriggerSuggestionRequestBody is the type of the "skills" service
@@ -8648,9 +8654,10 @@ func NewCreatePayload(body *CreateRequestBody, sessionToken *string, apikeyToken
 // NewAddVersionPayload builds a skills service addVersion endpoint payload.
 func NewAddVersionPayload(body *AddVersionRequestBody, sessionToken *string, apikeyToken *string, projectSlugInput *string) *skills.AddVersionPayload {
 	v := &skills.AddVersionPayload{
-		ID:                   *body.ID,
-		Content:              *body.Content,
-		DerivedFromVersionID: body.DerivedFromVersionID,
+		ID:                      *body.ID,
+		Content:                 *body.Content,
+		DerivedFromVersionID:    body.DerivedFromVersionID,
+		ExpectedLatestVersionID: body.ExpectedLatestVersionID,
 	}
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken
@@ -8676,10 +8683,11 @@ func NewRestoreVersionPayload(body *RestoreVersionRequestBody, sessionToken *str
 // NewUpdatePayload builds a skills service update endpoint payload.
 func NewUpdatePayload(body *UpdateRequestBody, sessionToken *string, apikeyToken *string, projectSlugInput *string) *skills.UpdatePayload {
 	v := &skills.UpdatePayload{
-		ID:          *body.ID,
-		Name:        *body.Name,
-		DisplayName: *body.DisplayName,
-		Summary:     body.Summary,
+		ID:                      *body.ID,
+		Name:                    *body.Name,
+		DisplayName:             *body.DisplayName,
+		Summary:                 body.Summary,
+		ExpectedLatestVersionID: body.ExpectedLatestVersionID,
 	}
 	v.Tags = make([]string, len(body.Tags))
 	for i, val := range body.Tags {
@@ -8970,6 +8978,9 @@ func ValidateAddVersionRequestBody(body *AddVersionRequestBody) (err error) {
 	if body.DerivedFromVersionID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.derived_from_version_id", *body.DerivedFromVersionID, goa.FormatUUID))
 	}
+	if body.ExpectedLatestVersionID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.expected_latest_version_id", *body.ExpectedLatestVersionID, goa.FormatUUID))
+	}
 	return
 }
 
@@ -9030,6 +9041,9 @@ func ValidateUpdateRequestBody(body *UpdateRequestBody) (err error) {
 		if utf8.RuneCountInString(e) > 64 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.tags[*]", e, utf8.RuneCountInString(e), 64, false))
 		}
+	}
+	if body.ExpectedLatestVersionID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.expected_latest_version_id", *body.ExpectedLatestVersionID, goa.FormatUUID))
 	}
 	return
 }

--- a/server/gen/skills/service.go
+++ b/server/gen/skills/service.go
@@ -126,9 +126,12 @@ type AddVersionPayload struct {
 	Content string
 	// The optional source version this new version was derived from.
 	DerivedFromVersionID *string
-	SessionToken         *string
-	ApikeyToken          *string
-	ProjectSlugInput     *string
+	// The version the caller believes is current. When set, the write is rejected
+	// as a conflict if the skill has moved on.
+	ExpectedLatestVersionID *string
+	SessionToken            *string
+	ApikeyToken             *string
+	ProjectSlugInput        *string
 }
 
 // ApproveAllSkillSuggestionsResult is the result type of the skills service
@@ -688,10 +691,13 @@ type UpdatePayload struct {
 	// The optional skill summary.
 	Summary *string
 	// Registry tags for categorizing the skill. At most 40 tags.
-	Tags             []string
-	SessionToken     *string
-	ApikeyToken      *string
-	ProjectSlugInput *string
+	Tags []string
+	// The version the caller believes is current. When set, the write is rejected
+	// as a conflict if the skill has moved on.
+	ExpectedLatestVersionID *string
+	SessionToken            *string
+	ApikeyToken             *string
+	ProjectSlugInput        *string
 }
 
 // MakeUnauthorized builds a goa.ServiceError from an error.

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -90,10 +90,9 @@ func (e *Engine) PrepareContext(ctx context.Context) (context.Context, error) {
 		return ctx, nil
 	}
 
-	// Assistant-token auth has no session but should resolve grants against
-	// the owning user stamped as UserID on the context.
-	_, isAssistant := contextvalues.GetAssistantPrincipal(ctx)
-	if authCtx.SessionID == nil && !isAssistant {
+	// Assistant-token auth and Platform MCP have no session but should resolve
+	// grants against the owning user stamped as UserID on the context.
+	if authCtx.SessionID == nil && !enforcedWithoutSession(ctx) {
 		return ctx, nil
 	}
 	if authCtx.ActiveOrganizationID == "" {
@@ -607,12 +606,27 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	_, isAssistant := contextvalues.GetAssistantPrincipal(ctx)
-	if authCtx.SessionID == nil && !isAssistant {
+	if authCtx.SessionID == nil && !enforcedWithoutSession(ctx) {
 		return false, nil
 	}
 
 	return true, nil
+}
+
+// enforcedWithoutSession reports whether a session-less caller still has to be
+// authorized against the acting user's grants.
+//
+// A missing session normally means an unauthenticated or internal path, which
+// is why it disables enforcement. Two surfaces are session-less by design and
+// act for a real user anyway: assistant-token auth, and the OAuth-authenticated
+// Platform MCP endpoint. Leaving either out would silently turn every scope
+// check they make into a no-op.
+func enforcedWithoutSession(ctx context.Context) bool {
+	if _, isAssistant := contextvalues.GetAssistantPrincipal(ctx); isAssistant {
+		return true
+	}
+	surface, ok := contextvalues.GetActingSurface(ctx)
+	return ok && surface == contextvalues.ActingSurfacePlatformMCP
 }
 
 func validateInput(c Check) error {

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -835,3 +835,38 @@ func TestCanUseOverride_prodPlusNonAdmin(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, enforce)
 }
+
+// A Platform MCP call carries a real user and no browser session. Enforcement
+// keys on the session for every other human-driven surface, so without the
+// surface carve-out every scope check an OAuth-authenticated agent makes would
+// pass regardless of what its user is allowed to do.
+func TestShouldEnforce_platformMCPSurfaceEnforcesWithoutASession(t *testing.T) {
+	t.Parallel()
+	engine := NewEngine(testenv.NewLogger(t), nil, staticChallengeLogging(false), workos.NewStubClient())
+	authCtx := &contextvalues.AuthContext{
+		ActiveOrganizationID:  "org_123",
+		UserID:                "user_123",
+		ExternalUserID:        "",
+		APIKeyID:              "",
+		SessionID:             nil,
+		ProjectID:             nil,
+		OrganizationSlug:      "",
+		Email:                 nil,
+		AccountType:           "pro",
+		HasActiveSubscription: false,
+		Whitelisted:           false,
+		ProjectSlug:           nil,
+		APIKeyScopes:          nil,
+	}
+
+	unmarked, err := engine.ShouldEnforce(contextvalues.SetAuthContext(t.Context(), authCtx))
+	require.NoError(t, err)
+	require.False(t, unmarked, "a session-less call from an unmarked surface stays unenforced")
+
+	marked, err := engine.ShouldEnforce(contextvalues.SetAuthContext(
+		contextvalues.SetActingSurface(t.Context(), contextvalues.ActingSurfacePlatformMCP),
+		authCtx,
+	))
+	require.NoError(t, err)
+	require.True(t, marked)
+}

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -173,6 +173,13 @@ func GetOAuthClientID(ctx context.Context) (string, bool) {
 // to depend on the audit package. Audit accepts only the values on its own
 // allowlist, so an unrecognized one records an unknown surface rather than
 // widening what the column can hold.
+// ActingSurfacePlatformMCP marks a call arriving through the OAuth-authenticated
+// Platform MCP endpoint. It is named here rather than only in that package
+// because authorization has to recognize the surface: a Platform MCP call
+// carries a real user but no browser session, and the session is what tells
+// RBAC to enforce for every other human-driven surface.
+const ActingSurfacePlatformMCP = "platform_mcp"
+
 func SetActingSurface(ctx context.Context, value string) context.Context {
 	return context.WithValue(ctx, actingSurfaceContextKey, value)
 }

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -256,7 +256,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 		PlatformMCPReadTools: assistant_platform_mcp_adapter.ExternalTools(
 			platformmcp.NewRuntimeWithLifecycle(
 				logger, nil, nil, platformmcp.NewLiveOrgAdminAuthorizer(conn, authzEngine), "", "",
-				platformmcp.NewPostgresReader(conn), nil, nil, nil, nil, nil, nil, nil,
+				platformmcp.NewPostgresReader(conn), nil, nil, nil, nil, nil, nil, nil, nil,
 				platformmcp.CatalogDescriptor{},
 			).AssistantTools(),
 			platformmcp.NewLiveOrgAdminAuthorizer(conn, authzEngine),

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -13,7 +13,7 @@ import (
 func TestEveryRegisteredToolDeclaresAnAudience(t *testing.T) {
 	t.Parallel()
 
-	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, CatalogDescriptor{})
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
 	descriptors := registrar.Descriptors()
 	require.NotEmpty(t, descriptors, "the deployment registers tools even when every dependency is absent")
 
@@ -72,7 +72,7 @@ func names(descriptors []Descriptor) []string {
 func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 	t.Parallel()
 
-	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, CatalogDescriptor{})
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
 
 	admitted := map[string]bool{}
 	for _, descriptor := range registrar.For(AudienceAssistant) {
@@ -117,7 +117,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 func TestExternalEndpointServesOnlyExternallyAdmittedTools(t *testing.T) {
 	t.Parallel()
 
-	server, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, CatalogDescriptor{})
+	server, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
 
 	admitted := make(map[string]bool)
 	for _, descriptor := range registrar.For(AudienceExternal) {

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -21,6 +21,8 @@ const (
 	RepairOrganizationLimitName       = "platform-mcp-repair-organization"
 	DocsConnectionLimitName           = "platform-mcp-docs-connection"
 	DocsOrganizationLimitName         = "platform-mcp-docs-organization"
+	SkillsConnectionLimitName         = "platform-mcp-skills-connection"
+	SkillsOrganizationLimitName       = "platform-mcp-skills-organization"
 )
 
 const (
@@ -101,8 +103,14 @@ type OperationBudgets struct {
 	SetupStart   OperationBudget
 	Repair       OperationBudget
 	Docs         OperationBudget
+	// Skills meters authoring and distribution together. Reads and writes share
+	// one allowance because they are one workflow: a caller reads a skill to
+	// obtain the version token its next write needs, and metering the read
+	// separately would only let a loop spend twice as much reaching the same
+	// write.
+	Skills OperationBudget
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid()
 }

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -1980,3 +1980,41 @@ INSERT INTO platform_mcp_onboarding_milestones (
     @attempt_id
 )
 ON CONFLICT DO NOTHING;
+
+-- Skill distribution targets. A skill is distributed to an exact existing
+-- plugin or assistant in one project; these reads name what exists so the
+-- resolver can refuse a target that does not, rather than falling back to the
+-- default plugin.
+
+-- name: ListPlatformMCPProjectPlugins :many
+SELECT
+    plugins.id,
+    plugins.name,
+    plugins.slug,
+    COALESCE(plugins.is_default, FALSE) AS is_default
+FROM plugins
+JOIN projects
+  ON projects.id = plugins.project_id
+WHERE plugins.project_id = @project_id
+  AND plugins.organization_id = @organization_id
+  AND projects.organization_id = @organization_id
+  AND projects.deleted IS FALSE
+  AND plugins.deleted IS FALSE
+ORDER BY plugins.is_default DESC NULLS LAST, plugins.name ASC
+LIMIT @result_limit;
+
+-- name: ListPlatformMCPProjectAssistants :many
+SELECT
+    assistants.id,
+    assistants.name
+FROM assistants
+JOIN projects
+  ON projects.id = assistants.project_id
+WHERE assistants.project_id = @project_id
+  AND assistants.organization_id = @organization_id
+  AND projects.organization_id = @organization_id
+  AND projects.deleted IS FALSE
+  AND assistants.deleted IS FALSE
+  AND assistants.status = 'active'
+ORDER BY assistants.name ASC
+LIMIT @result_limit;

--- a/server/internal/platformmcp/registration_integration_test.go
+++ b/server/internal/platformmcp/registration_integration_test.go
@@ -36,7 +36,7 @@ import (
 var platformMCPInfra *testenv.Environment
 
 func TestMain(m *testing.M) {
-	infra, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	infra, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true})
 	if err != nil {
 		log.Fatalf("launch test infrastructure: %v", err)
 	}

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -3480,6 +3480,115 @@ func (q *Queries) ListPlatformMCPConnections(ctx context.Context, organizationID
 	return items, nil
 }
 
+const listPlatformMCPProjectAssistants = `-- name: ListPlatformMCPProjectAssistants :many
+SELECT
+    assistants.id,
+    assistants.name
+FROM assistants
+JOIN projects
+  ON projects.id = assistants.project_id
+WHERE assistants.project_id = $1
+  AND assistants.organization_id = $2
+  AND projects.organization_id = $2
+  AND projects.deleted IS FALSE
+  AND assistants.deleted IS FALSE
+  AND assistants.status = 'active'
+ORDER BY assistants.name ASC
+LIMIT $3
+`
+
+type ListPlatformMCPProjectAssistantsParams struct {
+	ProjectID      uuid.UUID
+	OrganizationID string
+	ResultLimit    int32
+}
+
+type ListPlatformMCPProjectAssistantsRow struct {
+	ID   uuid.UUID
+	Name string
+}
+
+func (q *Queries) ListPlatformMCPProjectAssistants(ctx context.Context, arg ListPlatformMCPProjectAssistantsParams) ([]ListPlatformMCPProjectAssistantsRow, error) {
+	rows, err := q.db.Query(ctx, listPlatformMCPProjectAssistants, arg.ProjectID, arg.OrganizationID, arg.ResultLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPlatformMCPProjectAssistantsRow
+	for rows.Next() {
+		var i ListPlatformMCPProjectAssistantsRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPlatformMCPProjectPlugins = `-- name: ListPlatformMCPProjectPlugins :many
+
+SELECT
+    plugins.id,
+    plugins.name,
+    plugins.slug,
+    COALESCE(plugins.is_default, FALSE) AS is_default
+FROM plugins
+JOIN projects
+  ON projects.id = plugins.project_id
+WHERE plugins.project_id = $1
+  AND plugins.organization_id = $2
+  AND projects.organization_id = $2
+  AND projects.deleted IS FALSE
+  AND plugins.deleted IS FALSE
+ORDER BY plugins.is_default DESC NULLS LAST, plugins.name ASC
+LIMIT $3
+`
+
+type ListPlatformMCPProjectPluginsParams struct {
+	ProjectID      uuid.UUID
+	OrganizationID string
+	ResultLimit    int32
+}
+
+type ListPlatformMCPProjectPluginsRow struct {
+	ID        uuid.UUID
+	Name      string
+	Slug      string
+	IsDefault bool
+}
+
+// Skill distribution targets. A skill is distributed to an exact existing
+// plugin or assistant in one project; these reads name what exists so the
+// resolver can refuse a target that does not, rather than falling back to the
+// default plugin.
+func (q *Queries) ListPlatformMCPProjectPlugins(ctx context.Context, arg ListPlatformMCPProjectPluginsParams) ([]ListPlatformMCPProjectPluginsRow, error) {
+	rows, err := q.db.Query(ctx, listPlatformMCPProjectPlugins, arg.ProjectID, arg.OrganizationID, arg.ResultLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPlatformMCPProjectPluginsRow
+	for rows.Next() {
+		var i ListPlatformMCPProjectPluginsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Slug,
+			&i.IsDefault,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPlatformMCPProjects = `-- name: ListPlatformMCPProjects :many
 SELECT id, name, slug
 FROM projects

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -35,7 +35,7 @@ type ActingSurface string
 
 const (
 	// SurfacePlatformMCP is the OAuth-authenticated Platform MCP endpoint.
-	SurfacePlatformMCP ActingSurface = "platform_mcp"
+	SurfacePlatformMCP ActingSurface = contextvalues.ActingSurfacePlatformMCP
 	// SurfaceProjectAssistant is the project assistant runtime, which acts
 	// under assistant identity and holds no OAuth connection.
 	SurfaceProjectAssistant ActingSurface = "project_assistant"
@@ -119,15 +119,15 @@ func NewRuntime(logger *slog.Logger, authenticator Authenticator, gate Gate, aut
 }
 
 func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService) *Runtime {
-	return NewRuntimeWithLifecycle(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, nil, nil, CatalogDescriptor{})
+	return NewRuntimeWithLifecycle(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, nil, nil, nil, CatalogDescriptor{})
 }
 
 // NewRuntimeWithLifecycle wires the Platform MCP onboarding lifecycle. Catalogue
 // selection remains server-validated: callers receive only search/inspect
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
-func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, candidate CatalogDescriptor) *Runtime {
-	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, candidate)
+func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, candidate CatalogDescriptor) *Runtime {
+	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, candidate)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/skills.go
+++ b/server/internal/platformmcp/skills.go
@@ -846,6 +846,9 @@ func adviceTargets(targets []SkillTarget, limit int) []SkillTarget {
 	kept := make([]SkillTarget, 0, limit)
 	counts := map[SkillTargetKind]int{}
 	for _, target := range targets {
+		if len(kept) >= limit {
+			break
+		}
 		if counts[target.Kind] < perKind {
 			kept = append(kept, target)
 			counts[target.Kind]++

--- a/server/internal/platformmcp/skills.go
+++ b/server/internal/platformmcp/skills.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -60,6 +61,7 @@ type SkillsManagement interface {
 	Update(context.Context, *genskills.UpdatePayload) (*types.Skill, error)
 	List(context.Context, *genskills.ListPayload) (*genskills.ListSkillsResult, error)
 	Get(context.Context, *genskills.GetPayload) (*genskills.GetSkillResult, error)
+	ListDistributions(context.Context, *genskills.ListDistributionsPayload) (*genskills.ListSkillDistributionsResult, error)
 	ListVersions(context.Context, *genskills.ListVersionsPayload) (*genskills.ListSkillVersionsResult, error)
 	Distribute(context.Context, *genskills.DistributePayload) (*types.SkillDistribution, error)
 }
@@ -68,8 +70,12 @@ type SkillsManagement interface {
 // distributed to in one project. Lane D6 owns the full plugin catalogue
 // surface; this is the resolution half it promises to supply to distribution,
 // expressed as the narrow read it actually needs.
+//
+// The limit is per kind, not per result. A combined cap would let a project
+// with many plugins push every assistant out of the answer, and a target that
+// is missing from the answer is a target distribution refuses as not_found.
 type SkillTargetInventory interface {
-	SkillTargets(ctx context.Context, organizationID string, projectID uuid.UUID, limit int) ([]SkillTarget, error)
+	SkillTargets(ctx context.Context, organizationID string, projectID uuid.UUID, limitPerKind int) ([]SkillTarget, error)
 }
 
 // GrantPreparer loads the acting user's RBAC grants onto the context.
@@ -270,7 +276,7 @@ func (s *SkillsService) ListSkills(ctx context.Context, principal Principal, inp
 		SourceKinds:      nil,
 		Classifications:  nil,
 		Tags:             nil,
-		Sort:             "updated_at",
+		Sort:             "updated",
 		SessionToken:     nil,
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,
@@ -322,11 +328,30 @@ func (s *SkillsService) GetSkill(ctx context.Context, principal Principal, input
 	if err != nil {
 		return GetSkillOutput{}, err
 	}
+	// Assistant attachments are counted on the skill; plugin attachments are
+	// not, and a read that called a plugin-distributed skill undistributed
+	// would contradict the distribute_skill call that activated it.
+	distributed := result.AssistantCount > 0
+	if !distributed {
+		plugins, err := s.skills.ListDistributions(ctx, &genskills.ListDistributionsPayload{
+			SkillID:          &input.SkillID,
+			PluginID:         nil,
+			Cursor:           nil,
+			Limit:            1,
+			SessionToken:     nil,
+			ApikeyToken:      nil,
+			ProjectSlugInput: nil,
+		})
+		if err != nil {
+			return GetSkillOutput{}, err
+		}
+		distributed = len(plugins.Distributions) > 0
+	}
 	output := GetSkillOutput{
 		ProjectSlug:   project.Slug,
 		Skill:         buildSkillSummary(result.Skill),
 		LatestVersion: nil,
-		Distributed:   result.AssistantCount > 0,
+		Distributed:   distributed,
 	}
 	if result.LatestVersion != nil {
 		version := buildSkillVersionSummary(result.LatestVersion, input.IncludeContent)
@@ -632,6 +657,7 @@ func (s *SkillsService) authoringResult(ctx context.Context, principal Principal
 	if err != nil {
 		targets = nil
 	}
+	targets = adviceTargets(targets, maxSkillTargetCandidates)
 	authored := SkillAuthoringResult{
 		ProjectSlug:         project.Slug,
 		Skill:               buildSkillSummary(result.Skill),
@@ -688,7 +714,9 @@ func buildSkillVersionSummary(version *types.SkillVersion, includeContent bool) 
 	if includeContent {
 		content := version.Content
 		if len(content) > maxSkillContentBytes {
-			content = content[:maxSkillContentBytes]
+			// Cut on a rune boundary. Slicing bytes can land mid-rune and hand
+			// the caller a manifest whose last character is mojibake.
+			content = strings.ToValidUTF8(content[:maxSkillContentBytes], "")
 			summary.ContentTruncated = true
 		}
 		summary.Content = content
@@ -759,10 +787,11 @@ func NewPostgresSkillTargets(db *pgxpool.Pool) *PostgresSkillTargets {
 	return &PostgresSkillTargets{db: db}
 }
 
-func (s *PostgresSkillTargets) SkillTargets(ctx context.Context, organizationID string, projectID uuid.UUID, limit int) ([]SkillTarget, error) {
+func (s *PostgresSkillTargets) SkillTargets(ctx context.Context, organizationID string, projectID uuid.UUID, limitPerKind int) ([]SkillTarget, error) {
 	if s == nil || s.db == nil || organizationID == "" || projectID == uuid.Nil {
 		return nil, ErrSkillsUnavailable
 	}
+	limit := limitPerKind
 	// Clamped to the lookup ceiling before the narrowing conversion, so a caller
 	// cannot ask for a page size that does not fit the query parameter.
 	bounded := int32(min(max(limit, 1), maxSkillTargetLookup)) //nolint:gosec // bounded above by maxSkillTargetLookup
@@ -802,8 +831,34 @@ func (s *PostgresSkillTargets) SkillTargets(ctx context.Context, organizationID 
 			IsDefault: false,
 		})
 	}
-	if len(targets) > limit {
-		targets = targets[:limit]
-	}
 	return targets, nil
+}
+
+// adviceTargets trims the targets named back to an authoring caller while
+// keeping both kinds represented. Trimming the concatenation instead would let
+// a project's plugins hide every assistant from the advice, which reads as
+// "there is nowhere to send this" for the target the caller most likely wants.
+func adviceTargets(targets []SkillTarget, limit int) []SkillTarget {
+	if limit <= 0 || len(targets) <= limit {
+		return targets
+	}
+	perKind := max(limit/2, 1)
+	kept := make([]SkillTarget, 0, limit)
+	counts := map[SkillTargetKind]int{}
+	for _, target := range targets {
+		if counts[target.Kind] < perKind {
+			kept = append(kept, target)
+			counts[target.Kind]++
+		}
+	}
+	// A project holding only one kind still fills the whole allowance.
+	for _, target := range targets {
+		if len(kept) >= limit {
+			break
+		}
+		if counts[target.Kind] >= perKind && !slices.Contains(kept, target) {
+			kept = append(kept, target)
+		}
+	}
+	return kept
 }

--- a/server/internal/platformmcp/skills.go
+++ b/server/internal/platformmcp/skills.go
@@ -1,0 +1,809 @@
+//nolint:exhaustruct,wrapcheck // Zero-value summaries are the documented "absent" signal, and a skills-service refusal is returned unwrapped so its typed code survives the trip to the tool result.
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	genskills "github.com/speakeasy-api/gram/server/gen/skills"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+// maxSkillContentBytes mirrors the skills service's own manifest ceiling. It is
+// checked here as well so an oversized manifest is refused before it is copied
+// into a payload and shipped across the process, rather than after.
+const maxSkillContentBytes = 64 << 10
+
+// maxSkillTargetCandidates bounds the distribution targets named back to the
+// caller. Naming every plugin and assistant in a large project would spend the
+// caller's context on a list it did not ask for.
+const maxSkillTargetCandidates = 20
+
+// maxSkillTargetLookup bounds the candidates a named target is resolved
+// against. It is deliberately far larger than the advice list: a target the
+// project really has must not be refused as not_found because a display cap
+// cut it off.
+const maxSkillTargetLookup = 500
+
+var (
+	// ErrSkillsUnavailable is the kill switch and the missing-dependency path:
+	// the capability is off for this organization, or this deployment composed
+	// no skills service.
+	ErrSkillsUnavailable = errors.New("platform mcp skills unavailable")
+	// ErrSkillTargetNotFound is an exact target that does not exist in the
+	// named project. It is never softened into the default plugin: distributing
+	// a skill somewhere the caller did not name is the one outcome authoring
+	// safety depends on not happening.
+	ErrSkillTargetNotFound = errors.New("platform mcp skill distribution target not found")
+	// ErrSkillTargetAmbiguous is a target name matching more than one plugin or
+	// assistant. Picking one would be a coin flip the caller cannot see.
+	ErrSkillTargetAmbiguous = errors.New("platform mcp skill distribution target ambiguous")
+	// ErrSkillContentTooLarge is a manifest over the reviewed ceiling.
+	ErrSkillContentTooLarge = errors.New("platform mcp skill content too large")
+)
+
+// SkillsManagement is the subset of the skills management service this surface
+// calls. Going through the service rather than the repository is what keeps one
+// definition of manifest validation, version immutability, canonical-content
+// idempotency, and typed audit for every surface that authors a skill.
+type SkillsManagement interface {
+	Create(context.Context, *genskills.CreatePayload) (*genskills.RecordSkillResult, error)
+	AddVersion(context.Context, *genskills.AddVersionPayload) (*genskills.RecordSkillResult, error)
+	Update(context.Context, *genskills.UpdatePayload) (*types.Skill, error)
+	List(context.Context, *genskills.ListPayload) (*genskills.ListSkillsResult, error)
+	Get(context.Context, *genskills.GetPayload) (*genskills.GetSkillResult, error)
+	ListVersions(context.Context, *genskills.ListVersionsPayload) (*genskills.ListSkillVersionsResult, error)
+	Distribute(context.Context, *genskills.DistributePayload) (*types.SkillDistribution, error)
+}
+
+// SkillTargetInventory names the plugins and assistants a skill may be
+// distributed to in one project. Lane D6 owns the full plugin catalogue
+// surface; this is the resolution half it promises to supply to distribution,
+// expressed as the narrow read it actually needs.
+type SkillTargetInventory interface {
+	SkillTargets(ctx context.Context, organizationID string, projectID uuid.UUID, limit int) ([]SkillTarget, error)
+}
+
+// GrantPreparer loads the acting user's RBAC grants onto the context.
+//
+// Platform MCP does not travel the session middleware that prepares grants for
+// dashboard requests, so it prepares them itself. Without this the skills
+// service's scope checks would find no grants and refuse every call.
+type GrantPreparer interface {
+	PrepareContext(ctx context.Context) (context.Context, error)
+}
+
+// SkillProjectResolver turns the project slug a caller names into the project
+// every downstream call is scoped by.
+type SkillProjectResolver interface {
+	ResolveProject(ctx context.Context, organizationID, projectSlug string) (ResolvedProject, error)
+}
+
+// SkillTargetKind names what a distribution attaches to.
+type SkillTargetKind string
+
+const (
+	SkillTargetPlugin    SkillTargetKind = "plugin"
+	SkillTargetAssistant SkillTargetKind = "assistant"
+)
+
+// SkillTarget is one resolved or offered distribution target. It is echoed back
+// on every distribution so the caller can see which plugin or assistant its
+// name resolved to rather than inferring it.
+type SkillTarget struct {
+	Kind      SkillTargetKind `json:"kind"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Slug      string          `json:"slug,omitempty"`
+	IsDefault bool            `json:"is_default,omitempty"`
+}
+
+// SkillSummary is the registry projection of one skill. Content is deliberately
+// absent: listing a project's skills should not spend the caller's context on
+// manifests it has not asked to read.
+type SkillSummary struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	DisplayName     string   `json:"display_name"`
+	Summary         string   `json:"summary,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	LatestVersionID string   `json:"latest_version_id,omitempty"`
+	VersionCount    int64    `json:"version_count"`
+	HasValidVersion bool     `json:"has_valid_version"`
+	UpdatedAt       string   `json:"updated_at"`
+}
+
+// SkillVersionSummary is one immutable version. Content appears only when the
+// caller opted in.
+type SkillVersionSummary struct {
+	ID               string   `json:"id"`
+	CanonicalSHA256  string   `json:"canonical_sha256"`
+	SpecValid        bool     `json:"spec_valid"`
+	ValidationErrors []string `json:"validation_errors,omitempty"`
+	CreatedAt        string   `json:"created_at"`
+	Content          string   `json:"content,omitempty"`
+	ContentTruncated bool     `json:"content_truncated,omitempty"`
+}
+
+// SkillAuthoringResult is what create and version writes return.
+//
+// Distributed and DistributionTargets are on it for one reason: authoring a
+// skill changes no runtime behavior at all, and a result that only said
+// "created" would read as activation to the exact caller most likely to stop
+// there. The result states the skill is inert and names where it can be sent.
+type SkillAuthoringResult struct {
+	ProjectSlug         string              `json:"project_slug"`
+	Skill               SkillSummary        `json:"skill"`
+	Version             SkillVersionSummary `json:"version"`
+	CreatedSkill        bool                `json:"created_skill"`
+	CreatedVersion      bool                `json:"created_version"`
+	Distributed         bool                `json:"distributed"`
+	InertMessage        string              `json:"inert_message"`
+	NextAction          string              `json:"next_action"`
+	DistributionTargets []SkillTarget       `json:"distribution_targets,omitempty"`
+}
+
+// SkillsService is the handler-facing boundary for skill authoring and
+// distribution over Platform MCP.
+type SkillsService struct {
+	skills   SkillsManagement
+	targets  SkillTargetInventory
+	projects SkillProjectResolver
+	grants   GrantPreparer
+	gate     CatalogRegistrationGateChecker
+	budget   OperationBudget
+}
+
+func NewSkillsService(skills SkillsManagement, targets SkillTargetInventory, projects SkillProjectResolver, grants GrantPreparer, gate CatalogRegistrationGateChecker, budget OperationBudget) *SkillsService {
+	return &SkillsService{
+		skills:   skills,
+		targets:  targets,
+		projects: projects,
+		grants:   grants,
+		gate:     gate,
+		budget:   budget,
+	}
+}
+
+func (s *SkillsService) valid() bool {
+	return s != nil && s.skills != nil && s.targets != nil && s.projects != nil && s.grants != nil && s.gate != nil && s.budget.valid()
+}
+
+// begin runs everything every skill call owes before it touches a skill: the
+// organization kill switch, the metered allowance, the project the caller
+// named, and the authorization context downstream RBAC is evaluated against.
+//
+// The returned context carries the acting user rather than a service identity,
+// so a caller reaches exactly the projects its own grants reach and the audit
+// row names the person, not the surface.
+func (s *SkillsService) begin(ctx context.Context, principal Principal, projectSlug string) (context.Context, ResolvedProject, error) {
+	if !s.valid() {
+		return ctx, ResolvedProject{}, ErrSkillsUnavailable
+	}
+	if strings.TrimSpace(projectSlug) == "" {
+		return ctx, ResolvedProject{}, ErrRegistrationInvalid
+	}
+	enabled, err := s.gate.Enabled(ctx, principal.OrganizationID, projectSlug)
+	if err != nil {
+		return ctx, ResolvedProject{}, fmt.Errorf("check platform mcp skills gate: %w", err)
+	}
+	if !enabled {
+		return ctx, ResolvedProject{}, ErrSkillsUnavailable
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return ctx, ResolvedProject{}, err
+	}
+	project, err := s.projects.ResolveProject(ctx, principal.OrganizationID, projectSlug)
+	if err != nil {
+		return ctx, ResolvedProject{}, err
+	}
+	projectID := project.ID
+	// A session on the incoming context is carried through rather than dropped.
+	// RBAC enforcement keys on it, so replacing a session-backed context with a
+	// session-less one would silently turn every downstream scope check into a
+	// no-op — the same hole the acting-surface carve-out closes for the
+	// connection-only path.
+	var sessionID *string
+	if existing, ok := contextvalues.GetAuthContext(ctx); ok && existing != nil {
+		sessionID = existing.SessionID
+	}
+	ctx = contextvalues.SetAuthContext(ctx, &contextvalues.AuthContext{
+		ActiveOrganizationID:  principal.OrganizationID,
+		UserID:                principal.UserID,
+		ExternalUserID:        "",
+		APIKeyID:              "",
+		APIKeyName:            "",
+		OrgWidePluginHooksKey: false,
+		SessionID:             sessionID,
+		ProjectID:             &projectID,
+		OrganizationSlug:      "",
+		Email:                 nil,
+		AccountType:           "",
+		HasActiveSubscription: false,
+		Whitelisted:           false,
+		ProjectSlug:           &project.Slug,
+		APIKeyScopes:          nil,
+		IsAdmin:               false,
+	})
+	// Grants are loaded for the acting user, so a connection reaches exactly the
+	// projects that user's own role reaches — the OAuth org-admin check at the
+	// endpoint says who may connect, not what they may write.
+	ctx, err = s.grants.PrepareContext(ctx)
+	if err != nil {
+		return ctx, ResolvedProject{}, err
+	}
+	return ctx, project, nil
+}
+
+// ListSkillsInput names the project whose registry to read.
+type ListSkillsInput struct {
+	ProjectSlug string
+	Search      string
+	Cursor      string
+	Limit       int
+}
+
+type ListSkillsOutput struct {
+	ProjectSlug string         `json:"project_slug"`
+	Skills      []SkillSummary `json:"skills"`
+	TotalCount  int64          `json:"total_count"`
+	NextCursor  string         `json:"next_cursor,omitempty"`
+}
+
+func (s *SkillsService) ListSkills(ctx context.Context, principal Principal, input ListSkillsInput) (ListSkillsOutput, error) {
+	ctx, project, err := s.begin(ctx, principal, input.ProjectSlug)
+	if err != nil {
+		return ListSkillsOutput{}, err
+	}
+	result, err := s.skills.List(ctx, &genskills.ListPayload{
+		Cursor:           optionalString(strings.TrimSpace(input.Cursor)),
+		Limit:            boundedLimit(input.Limit),
+		Search:           optionalString(strings.TrimSpace(input.Search)),
+		SourceKinds:      nil,
+		Classifications:  nil,
+		Tags:             nil,
+		Sort:             "updated_at",
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return ListSkillsOutput{}, err
+	}
+	summaries := make([]SkillSummary, 0, len(result.Skills))
+	for _, skill := range result.Skills {
+		summaries = append(summaries, buildSkillSummary(skill))
+	}
+	return ListSkillsOutput{
+		ProjectSlug: project.Slug,
+		Skills:      summaries,
+		TotalCount:  result.TotalCount,
+		NextCursor:  stringOrEmpty(result.NextCursor),
+	}, nil
+}
+
+// GetSkillInput reads one skill. Manifest content is opt-in rather than default
+// so a caller that wanted a name and a version id does not pay 64 KiB for it.
+type GetSkillInput struct {
+	ProjectSlug    string
+	SkillID        string
+	IncludeContent bool
+}
+
+type GetSkillOutput struct {
+	ProjectSlug   string               `json:"project_slug"`
+	Skill         SkillSummary         `json:"skill"`
+	LatestVersion *SkillVersionSummary `json:"latest_version,omitempty"`
+	Distributed   bool                 `json:"distributed"`
+}
+
+func (s *SkillsService) GetSkill(ctx context.Context, principal Principal, input GetSkillInput) (GetSkillOutput, error) {
+	ctx, project, err := s.begin(ctx, principal, input.ProjectSlug)
+	if err != nil {
+		return GetSkillOutput{}, err
+	}
+	if _, err := uuid.Parse(input.SkillID); err != nil {
+		return GetSkillOutput{}, ErrRegistrationInvalid
+	}
+	result, err := s.skills.Get(ctx, &genskills.GetPayload{
+		ID:               input.SkillID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return GetSkillOutput{}, err
+	}
+	output := GetSkillOutput{
+		ProjectSlug:   project.Slug,
+		Skill:         buildSkillSummary(result.Skill),
+		LatestVersion: nil,
+		Distributed:   result.AssistantCount > 0,
+	}
+	if result.LatestVersion != nil {
+		version := buildSkillVersionSummary(result.LatestVersion, input.IncludeContent)
+		output.LatestVersion = &version
+	}
+	return output, nil
+}
+
+type ListSkillVersionsInput struct {
+	ProjectSlug    string
+	SkillID        string
+	IncludeContent bool
+	Cursor         string
+	Limit          int
+}
+
+type ListSkillVersionsOutput struct {
+	ProjectSlug string                `json:"project_slug"`
+	SkillID     string                `json:"skill_id"`
+	Versions    []SkillVersionSummary `json:"versions"`
+	NextCursor  string                `json:"next_cursor,omitempty"`
+}
+
+func (s *SkillsService) ListSkillVersions(ctx context.Context, principal Principal, input ListSkillVersionsInput) (ListSkillVersionsOutput, error) {
+	ctx, project, err := s.begin(ctx, principal, input.ProjectSlug)
+	if err != nil {
+		return ListSkillVersionsOutput{}, err
+	}
+	if _, err := uuid.Parse(input.SkillID); err != nil {
+		return ListSkillVersionsOutput{}, ErrRegistrationInvalid
+	}
+	result, err := s.skills.ListVersions(ctx, &genskills.ListVersionsPayload{
+		ID:               input.SkillID,
+		Cursor:           optionalString(strings.TrimSpace(input.Cursor)),
+		Limit:            boundedLimit(input.Limit),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return ListSkillVersionsOutput{}, err
+	}
+	versions := make([]SkillVersionSummary, 0, len(result.Versions))
+	for _, version := range result.Versions {
+		versions = append(versions, buildSkillVersionSummary(version, input.IncludeContent))
+	}
+	return ListSkillVersionsOutput{
+		ProjectSlug: project.Slug,
+		SkillID:     input.SkillID,
+		Versions:    versions,
+		NextCursor:  stringOrEmpty(result.NextCursor),
+	}, nil
+}
+
+type CreateSkillInput struct {
+	ProjectSlug string
+	Content     string
+}
+
+func (s *SkillsService) CreateSkill(ctx context.Context, principal Principal, input CreateSkillInput) (SkillAuthoringResult, error) {
+	ctx, project, err := s.begin(ctx, principal, input.ProjectSlug)
+	if err != nil {
+		return SkillAuthoringResult{}, err
+	}
+	if err := checkSkillContent(input.Content); err != nil {
+		return SkillAuthoringResult{}, err
+	}
+	result, err := s.skills.Create(ctx, &genskills.CreatePayload{
+		Content:          input.Content,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return SkillAuthoringResult{}, err
+	}
+	return s.authoringResult(ctx, principal, project, result), nil
+}
+
+// AddSkillVersionInput carries the full replacement manifest plus the version
+// the caller believes is current. Versions are immutable, so a correction is
+// another version rather than an edit of one.
+type AddSkillVersionInput struct {
+	ProjectSlug             string
+	SkillID                 string
+	Content                 string
+	ExpectedLatestVersionID string
+}
+
+func (s *SkillsService) AddSkillVersion(ctx context.Context, principal Principal, input AddSkillVersionInput) (SkillAuthoringResult, error) {
+	ctx, project, err := s.begin(ctx, principal, input.ProjectSlug)
+	if err != nil {
+		return SkillAuthoringResult{}, err
+	}
+	if _, err := uuid.Parse(input.SkillID); err != nil {
+		return SkillAuthoringResult{}, ErrRegistrationInvalid
+	}
+	if err := checkSkillContent(input.Content); err != nil {
+		return SkillAuthoringResult{}, err
+	}
+	result, err := s.skills.AddVersion(ctx, &genskills.AddVersionPayload{
+		ID:                      input.SkillID,
+		Content:                 input.Content,
+		DerivedFromVersionID:    optionalString(strings.TrimSpace(input.ExpectedLatestVersionID)),
+		ExpectedLatestVersionID: optionalString(strings.TrimSpace(input.ExpectedLatestVersionID)),
+		SessionToken:            nil,
+		ApikeyToken:             nil,
+		ProjectSlugInput:        nil,
+	})
+	if err != nil {
+		return SkillAuthoringResult{}, err
+	}
+	return s.authoringResult(ctx, principal, project, result), nil
+}
+
+// UpdateSkillMetadataInput changes registry naming only. Instructions live in
+// versions, so nothing here can alter what a skill tells an agent to do.
+type UpdateSkillMetadataInput struct {
+	ProjectSlug             string
+	SkillID                 string
+	Name                    string
+	DisplayName             string
+	Summary                 string
+	ClearSummary            bool
+	ExpectedLatestVersionID string
+}
+
+type UpdateSkillMetadataOutput struct {
+	ProjectSlug string       `json:"project_slug"`
+	Skill       SkillSummary `json:"skill"`
+}
+
+func (s *SkillsService) UpdateSkillMetadata(ctx context.Context, principal Principal, input UpdateSkillMetadataInput) (UpdateSkillMetadataOutput, error) {
+	ctx, project, err := s.begin(ctx, principal, input.ProjectSlug)
+	if err != nil {
+		return UpdateSkillMetadataOutput{}, err
+	}
+	if _, err := uuid.Parse(input.SkillID); err != nil {
+		return UpdateSkillMetadataOutput{}, ErrRegistrationInvalid
+	}
+	// The management update replaces the whole metadata record, so unspecified
+	// fields are read back and re-sent rather than blanked. Tags are carried
+	// through untouched: this surface does not author them.
+	current, err := s.skills.Get(ctx, &genskills.GetPayload{
+		ID:               input.SkillID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return UpdateSkillMetadataOutput{}, err
+	}
+	name := current.Skill.Name
+	if strings.TrimSpace(input.Name) != "" {
+		name = input.Name
+	}
+	displayName := current.Skill.DisplayName
+	if strings.TrimSpace(input.DisplayName) != "" {
+		displayName = input.DisplayName
+	}
+	summary := current.Skill.Summary
+	switch {
+	case input.ClearSummary:
+		summary = nil
+	case strings.TrimSpace(input.Summary) != "":
+		summary = &input.Summary
+	}
+	updated, err := s.skills.Update(ctx, &genskills.UpdatePayload{
+		ID:                      input.SkillID,
+		Name:                    name,
+		DisplayName:             displayName,
+		Summary:                 summary,
+		Tags:                    current.Skill.Tags,
+		ExpectedLatestVersionID: optionalString(strings.TrimSpace(input.ExpectedLatestVersionID)),
+		SessionToken:            nil,
+		ApikeyToken:             nil,
+		ProjectSlugInput:        nil,
+	})
+	if err != nil {
+		return UpdateSkillMetadataOutput{}, err
+	}
+	return UpdateSkillMetadataOutput{ProjectSlug: project.Slug, Skill: buildSkillSummary(updated)}, nil
+}
+
+// DistributeSkillInput names exactly one target. Plugin and assistant names are
+// resolved to exactly one existing target in the named project or refused.
+type DistributeSkillInput struct {
+	ProjectSlug string
+	SkillID     string
+	Plugin      string
+	Assistant   string
+}
+
+type DistributeSkillOutput struct {
+	ProjectSlug       string      `json:"project_slug"`
+	SkillID           string      `json:"skill_id"`
+	SkillName         string      `json:"skill_name"`
+	Target            SkillTarget `json:"target"`
+	DistributionID    string      `json:"distribution_id"`
+	ResolvedVersionID string      `json:"resolved_version_id"`
+	Message           string      `json:"message"`
+}
+
+func (s *SkillsService) DistributeSkill(ctx context.Context, principal Principal, input DistributeSkillInput) (DistributeSkillOutput, error) {
+	ctx, project, err := s.begin(ctx, principal, input.ProjectSlug)
+	if err != nil {
+		return DistributeSkillOutput{}, err
+	}
+	if _, err := uuid.Parse(input.SkillID); err != nil {
+		return DistributeSkillOutput{}, ErrRegistrationInvalid
+	}
+	if (strings.TrimSpace(input.Plugin) == "") == (strings.TrimSpace(input.Assistant) == "") {
+		return DistributeSkillOutput{}, ErrRegistrationInvalid
+	}
+
+	target, err := s.resolveTarget(ctx, principal, project, input.Plugin, input.Assistant)
+	if err != nil {
+		return DistributeSkillOutput{}, err
+	}
+	payload := &genskills.DistributePayload{
+		ID:               input.SkillID,
+		PluginID:         nil,
+		AssistantID:      nil,
+		PinnedVersionID:  nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	}
+	if target.Kind == SkillTargetPlugin {
+		payload.PluginID = &target.ID
+	} else {
+		payload.AssistantID = &target.ID
+	}
+	// Distribution is idempotent on project, target, and skill downstream, so a
+	// repeat call converges on the same attachment rather than adding a second.
+	distribution, err := s.skills.Distribute(ctx, payload)
+	if err != nil {
+		return DistributeSkillOutput{}, err
+	}
+	return DistributeSkillOutput{
+		ProjectSlug:       project.Slug,
+		SkillID:           distribution.SkillID,
+		SkillName:         distribution.SkillName,
+		Target:            target,
+		DistributionID:    distribution.ID,
+		ResolvedVersionID: distribution.ResolvedVersionID,
+		Message:           fmt.Sprintf("The skill is now carried by the %s %q and takes effect for agents using it.", target.Kind, target.Name),
+	}, nil
+}
+
+// resolveTarget matches one plugin or assistant exactly. A name that matches
+// nothing is not_found and a name that matches more than one is ambiguous;
+// neither falls back to the default plugin.
+func (s *SkillsService) resolveTarget(ctx context.Context, principal Principal, project ResolvedProject, plugin, assistant string) (SkillTarget, error) {
+	// Resolution reads a far wider window than the advice list shows. Trimming
+	// the candidates a name is matched against would turn a target that exists
+	// into not_found, which is exactly the wrong direction for a refusal that
+	// is supposed to mean "you named something that is not there".
+	candidates, err := s.targets.SkillTargets(ctx, principal.OrganizationID, project.ID, maxSkillTargetLookup)
+	if err != nil {
+		return SkillTarget{}, err
+	}
+	wanted := strings.TrimSpace(plugin)
+	kind := SkillTargetPlugin
+	if wanted == "" {
+		wanted = strings.TrimSpace(assistant)
+		kind = SkillTargetAssistant
+	}
+
+	matches := make([]SkillTarget, 0, 2)
+	for _, candidate := range candidates {
+		if candidate.Kind == kind && matchesSkillTarget(candidate, wanted) {
+			matches = append(matches, candidate)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return SkillTarget{}, ErrSkillTargetNotFound
+	case 1:
+		return matches[0], nil
+	default:
+		return SkillTarget{}, ErrSkillTargetAmbiguous
+	}
+}
+
+// matchesSkillTarget accepts the id, the slug, or the exact name. Names are
+// compared case-insensitively because a caller reading a name off a dashboard
+// should not have to reproduce its capitalization, but never by prefix or
+// substring: a partial match is what turns "the marketing plugin" into someone
+// else's plugin.
+func matchesSkillTarget(candidate SkillTarget, wanted string) bool {
+	return candidate.ID == wanted ||
+		(candidate.Slug != "" && strings.EqualFold(candidate.Slug, wanted)) ||
+		strings.EqualFold(candidate.Name, wanted)
+}
+
+// authoringResult states what an authoring write did and, deliberately, what it
+// did not do. A failure to list targets degrades the advice rather than the
+// write: the skill is saved either way, and refusing here would report a
+// successful, already-committed write as an error.
+func (s *SkillsService) authoringResult(ctx context.Context, principal Principal, project ResolvedProject, result *genskills.RecordSkillResult) SkillAuthoringResult {
+	targets, err := s.targets.SkillTargets(ctx, principal.OrganizationID, project.ID, maxSkillTargetCandidates)
+	if err != nil {
+		targets = nil
+	}
+	authored := SkillAuthoringResult{
+		ProjectSlug:         project.Slug,
+		Skill:               buildSkillSummary(result.Skill),
+		Version:             SkillVersionSummary{},
+		CreatedSkill:        result.CreatedSkill,
+		CreatedVersion:      result.CreatedVersion,
+		Distributed:         false,
+		InertMessage:        "This skill is saved but inert: nothing loads it until it is distributed to a plugin or an assistant with distribute_skill.",
+		NextAction:          "distribute_skill",
+		DistributionTargets: targets,
+	}
+	if result.Version != nil {
+		authored.Version = buildSkillVersionSummary(result.Version, false)
+	}
+	return authored
+}
+
+func buildSkillSummary(skill *types.Skill) SkillSummary {
+	if skill == nil {
+		return SkillSummary{}
+	}
+	return SkillSummary{
+		ID:              skill.ID,
+		Name:            skill.Name,
+		DisplayName:     skill.DisplayName,
+		Summary:         stringOrEmpty(skill.Summary),
+		Tags:            skill.Tags,
+		LatestVersionID: stringOrEmpty(skill.LatestVersionID),
+		VersionCount:    skill.VersionCount,
+		HasValidVersion: skill.HasValidVersion,
+		UpdatedAt:       skill.UpdatedAt,
+	}
+}
+
+func buildSkillVersionSummary(version *types.SkillVersion, includeContent bool) SkillVersionSummary {
+	if version == nil {
+		return SkillVersionSummary{}
+	}
+	summary := SkillVersionSummary{
+		ID:               version.ID,
+		CanonicalSHA256:  version.CanonicalSha256,
+		SpecValid:        version.SpecValid,
+		ValidationErrors: nil,
+		CreatedAt:        version.CreatedAt,
+		Content:          "",
+		ContentTruncated: false,
+	}
+	for _, validationError := range version.ValidationErrors {
+		if validationError == nil {
+			continue
+		}
+		summary.ValidationErrors = append(summary.ValidationErrors, validationError.Message)
+	}
+	if includeContent {
+		content := version.Content
+		if len(content) > maxSkillContentBytes {
+			content = content[:maxSkillContentBytes]
+			summary.ContentTruncated = true
+		}
+		summary.Content = content
+	}
+	return summary
+}
+
+func checkSkillContent(content string) error {
+	if strings.TrimSpace(content) == "" {
+		return ErrRegistrationInvalid
+	}
+	if len(content) > maxSkillContentBytes {
+		return ErrSkillContentTooLarge
+	}
+	return nil
+}
+
+func stringOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+// skillsRefusalCode maps a skills-service refusal onto the structured codes
+// this surface returns. The service's own public message is carried through:
+// it already says which manifest rule failed, and re-writing it here would
+// leave the caller guessing at what to fix.
+func skillsRefusalCode(err error) (string, string, bool) {
+	var shareable *oops.ShareableError
+	if !errors.As(err, &shareable) {
+		return "", "", false
+	}
+	switch shareable.Code {
+	case oops.CodeBadRequest, oops.CodeInvalid, oops.CodeUnsupportedMedia, oops.CodeRequestTooLarge:
+		return "invalid_request", shareable.Error(), true
+	case oops.CodeNotFound:
+		return "not_found", shareable.Error(), true
+	case oops.CodeConflict:
+		return "conflict", shareable.Error(), true
+	case oops.CodeUnauthorized, oops.CodeForbidden:
+		return "forbidden", "This connection is not authorized to author or distribute skills in this project.", true
+	case oops.CodeRateLimitExceeded:
+		return "rate_limited", shareable.Error(), true
+	case oops.CodeFailedPrecondition, oops.CodeInvariantViolation:
+		return "conflict", shareable.Error(), true
+	case oops.CodeUnavailable, oops.CodeGatewayError, oops.CodeNotImplemented:
+		return unavailableCode, "The skills service is temporarily unavailable. Retry after a short delay.", true
+	case oops.CodeUnexpected, oops.CodeMethodNotAllowed, oops.CodeInsufficientCredits, oops.CodeInferenceDisabled, oops.CodeCanceled:
+		return "", "", false
+	default:
+		return "", "", false
+	}
+}
+
+// PostgresSkillTargets reads the distribution targets a project actually has.
+//
+// It reads the tables directly rather than calling the plugins and assistants
+// management services: resolution needs two names and two ids, while those
+// services return whole plugin and assistant records — and the plugins service
+// provisions a missing default plugin as a side effect of listing, which is not
+// something naming a target should do.
+type PostgresSkillTargets struct {
+	db *pgxpool.Pool
+}
+
+func NewPostgresSkillTargets(db *pgxpool.Pool) *PostgresSkillTargets {
+	return &PostgresSkillTargets{db: db}
+}
+
+func (s *PostgresSkillTargets) SkillTargets(ctx context.Context, organizationID string, projectID uuid.UUID, limit int) ([]SkillTarget, error) {
+	if s == nil || s.db == nil || organizationID == "" || projectID == uuid.Nil {
+		return nil, ErrSkillsUnavailable
+	}
+	// Clamped to the lookup ceiling before the narrowing conversion, so a caller
+	// cannot ask for a page size that does not fit the query parameter.
+	bounded := int32(min(max(limit, 1), maxSkillTargetLookup)) //nolint:gosec // bounded above by maxSkillTargetLookup
+	queries := platformrepo.New(s.db)
+	plugins, err := queries.ListPlatformMCPProjectPlugins(ctx, platformrepo.ListPlatformMCPProjectPluginsParams{
+		ProjectID:      projectID,
+		OrganizationID: organizationID,
+		ResultLimit:    bounded,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list platform mcp skill plugin targets: %w", err)
+	}
+	assistants, err := queries.ListPlatformMCPProjectAssistants(ctx, platformrepo.ListPlatformMCPProjectAssistantsParams{
+		ProjectID:      projectID,
+		OrganizationID: organizationID,
+		ResultLimit:    bounded,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list platform mcp skill assistant targets: %w", err)
+	}
+	targets := make([]SkillTarget, 0, len(plugins)+len(assistants))
+	for _, plugin := range plugins {
+		targets = append(targets, SkillTarget{
+			Kind:      SkillTargetPlugin,
+			ID:        plugin.ID.String(),
+			Name:      plugin.Name,
+			Slug:      plugin.Slug,
+			IsDefault: plugin.IsDefault,
+		})
+	}
+	for _, assistant := range assistants {
+		targets = append(targets, SkillTarget{
+			Kind:      SkillTargetAssistant,
+			ID:        assistant.ID.String(),
+			Name:      assistant.Name,
+			Slug:      "",
+			IsDefault: false,
+		})
+	}
+	if len(targets) > limit {
+		targets = targets[:limit]
+	}
+	return targets, nil
+}

--- a/server/internal/platformmcp/skills_integration_test.go
+++ b/server/internal/platformmcp/skills_integration_test.go
@@ -1,0 +1,459 @@
+//nolint:wrapcheck // Integration assertions intentionally return test setup errors directly.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	skillsservice "github.com/speakeasy-api/gram/server/internal/skills"
+	skillsrepo "github.com/speakeasy-api/gram/server/internal/skills/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+)
+
+// The skills lane is only as good as its slowest-moving joint: a Platform MCP
+// tool call has to travel the OAuth endpoint, the tool schema, the acting
+// principal, the skills management service, RBAC, and Postgres, and come back
+// as something a model can act on. The unit tests hold each joint still; this
+// one drives the whole run with a real MCP client, a real skills service, and a
+// real database.
+func TestPlatformMCPSkillsToolsAuthorAndDistributeEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newSkillsVerticalFixture(t, ctx, "platform_mcp_skills_vertical", skillsVerticalOptions{capabilityEnabled: true, grantAdmin: true})
+	session := fixture.session
+
+	// Authoring. The result has to say the skill is inert, because a model that
+	// reads "created" and stops leaves a skill nothing will ever load.
+	created := callSkillsTool[SkillAuthoringResult](t, ctx, session, "create_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"content":      skillsFixtureManifest("catalog-add", "Adds a reviewed MCP from the catalogue.", "Ask which project first."),
+	})
+	require.True(t, created.CreatedSkill)
+	require.True(t, created.CreatedVersion)
+	require.False(t, created.Distributed)
+	require.Contains(t, created.InertMessage, "inert")
+	require.Equal(t, "distribute_skill", created.NextAction)
+	require.Contains(t, skillTargetNames(created.DistributionTargets), "Marketing")
+
+	stored, err := skillsrepo.New(fixture.conn).GetSkillState(ctx, skillsrepo.GetSkillStateParams{
+		ProjectID: fixture.project.ID,
+		SkillID:   uuid.MustParse(created.Skill.ID),
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, stored.VersionCount)
+	require.Equal(t, created.Version.ID, stored.LatestVersionID.String())
+
+	// Reads withhold manifest content unless the caller asks for it.
+	read := callSkillsTool[GetSkillOutput](t, ctx, session, "get_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"skill_id":     created.Skill.ID,
+	})
+	require.NotNil(t, read.LatestVersion)
+	require.Empty(t, read.LatestVersion.Content)
+
+	withContent := callSkillsTool[GetSkillOutput](t, ctx, session, "get_skill", map[string]any{
+		"project_slug":    fixture.project.Slug,
+		"skill_id":        created.Skill.ID,
+		"include_content": true,
+	})
+	require.Contains(t, withContent.LatestVersion.Content, "Ask which project first.")
+
+	// A correction is a new immutable version, guarded by the version the
+	// caller read.
+	revised := callSkillsTool[SkillAuthoringResult](t, ctx, session, "add_skill_version", map[string]any{
+		"project_slug":               fixture.project.Slug,
+		"skill_id":                   created.Skill.ID,
+		"content":                    skillsFixtureManifest("catalog-add", "Adds a reviewed MCP from the catalogue.", "Ask which project first, then which catalogue entry."),
+		"expected_latest_version_id": created.Version.ID,
+	})
+	require.True(t, revised.CreatedVersion)
+	require.NotEqual(t, created.Version.ID, revised.Version.ID)
+
+	// The same token again is stale, and a stale write is refused rather than
+	// applied on top of the version it did not see.
+	conflict := callSkillsRefusal(t, ctx, session, "add_skill_version", map[string]any{
+		"project_slug":               fixture.project.Slug,
+		"skill_id":                   created.Skill.ID,
+		"content":                    skillsFixtureManifest("catalog-add", "Adds a reviewed MCP from the catalogue.", "A third opinion."),
+		"expected_latest_version_id": created.Version.ID,
+	})
+	require.Equal(t, "conflict", conflict.Code)
+
+	versions, err := skillsrepo.New(fixture.conn).GetSkillState(ctx, skillsrepo.GetSkillStateParams{
+		ProjectID: fixture.project.ID,
+		SkillID:   uuid.MustParse(created.Skill.ID),
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, versions.VersionCount, "the refused write recorded nothing")
+
+	// Naming a target that does not exist distributes nothing — least of all to
+	// the default plugin, which is exactly the plugin an implicit fallback would
+	// have picked here.
+	missing := callSkillsRefusal(t, ctx, session, "distribute_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"skill_id":     created.Skill.ID,
+		"plugin":       "marketng",
+	})
+	require.Equal(t, "not_found", missing.Code)
+
+	require.Empty(t, listSkillDistributions(t, ctx, fixture.conn, fixture.project.ID, created.Skill.ID))
+
+	// Distribution is the activation step, and it echoes back the target the
+	// caller's name resolved to.
+	distributed := callSkillsTool[DistributeSkillOutput](t, ctx, session, "distribute_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"skill_id":     created.Skill.ID,
+		"plugin":       "marketing",
+	})
+	require.Equal(t, SkillTargetPlugin, distributed.Target.Kind)
+	require.Equal(t, fixture.marketingPluginID.String(), distributed.Target.ID)
+	require.Equal(t, revised.Version.ID, distributed.ResolvedVersionID, "a distribution that pins nothing tracks the latest valid version")
+
+	// Idempotent on project, target, and skill: a repeat converges rather than
+	// attaching the skill twice.
+	repeat := callSkillsTool[DistributeSkillOutput](t, ctx, session, "distribute_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"skill_id":     created.Skill.ID,
+		"plugin":       "marketing",
+	})
+	require.Equal(t, distributed.DistributionID, repeat.DistributionID)
+	require.Len(t, listSkillDistributions(t, ctx, fixture.conn, fixture.project.ID, created.Skill.ID), 1)
+}
+
+// A skill lives in one project, and naming another project's plugin must not
+// reach it even when the same connection is authorized for both.
+func TestPlatformMCPDistributeSkillRefusesATargetInAnotherProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newSkillsVerticalFixture(t, ctx, "platform_mcp_skills_cross_project", skillsVerticalOptions{capabilityEnabled: true, grantAdmin: true})
+
+	otherSlug := "other-" + uuid.NewString()[:8]
+	otherProject, err := projectsrepo.New(fixture.conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           otherSlug,
+		Slug:           otherSlug,
+		OrganizationID: fixture.principal.OrganizationID,
+	})
+	require.NoError(t, err)
+	_, err = pluginsrepo.New(fixture.conn).CreatePlugin(ctx, pluginsrepo.CreatePluginParams{
+		OrganizationID: fixture.principal.OrganizationID,
+		ProjectID:      otherProject.ID,
+		Name:           "Elsewhere",
+		Slug:           "elsewhere",
+		Description:    pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	created := callSkillsTool[SkillAuthoringResult](t, ctx, fixture.session, "create_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"content":      skillsFixtureManifest("scoped", "Scoped to one project.", "Body."),
+	})
+
+	refusal := callSkillsRefusal(t, ctx, fixture.session, "distribute_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"skill_id":     created.Skill.ID,
+		"plugin":       "elsewhere",
+	})
+
+	require.Equal(t, "not_found", refusal.Code)
+}
+
+// A capability that is off must still answer. The endpoint keeps serving, the
+// tool keeps existing, and the caller gets a reason rather than a tool that
+// silently disappeared from the manifest.
+func TestPlatformMCPSkillsToolsRefuseReadablyWhenTheCapabilityIsOff(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newSkillsVerticalFixture(t, ctx, "platform_mcp_skills_capability_off", skillsVerticalOptions{capabilityEnabled: false, grantAdmin: true})
+
+	tools, err := fixture.session.ListTools(ctx, nil)
+	require.NoError(t, err)
+	require.Contains(t, toolNames(tools.Tools), "create_skill")
+
+	refusal := callSkillsRefusal(t, ctx, fixture.session, "create_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"content":      skillsFixtureManifest("gated", "Gated by the rollout.", "Body."),
+	})
+
+	require.Equal(t, unavailableCode, refusal.Code)
+}
+
+// Authorization is the acting user's, not the surface's. A connection whose
+// user holds no role in an RBAC-enabled organization reaches Postgres and is
+// refused there, rather than being trusted because it authenticated.
+func TestPlatformMCPSkillsToolsRefuseAUserWithoutGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newSkillsVerticalFixture(t, ctx, "platform_mcp_skills_ungranted", skillsVerticalOptions{capabilityEnabled: true, grantAdmin: false})
+
+	refusal := callSkillsRefusal(t, ctx, fixture.session, "create_skill", map[string]any{
+		"project_slug": fixture.project.Slug,
+		"content":      skillsFixtureManifest("ungranted", "Written without grants.", "Body."),
+	})
+
+	require.Equal(t, "forbidden", refusal.Code)
+
+	skills, err := skillsrepo.New(fixture.conn).ListSkills(ctx, skillsrepo.ListSkillsParams{ProjectID: fixture.project.ID, PageLimit: 10})
+	require.NoError(t, err)
+	require.Empty(t, skills)
+}
+
+type skillsVerticalFixture struct {
+	conn              *pgxpool.Pool
+	principal         Principal
+	project           ResolvedProject
+	session           *mcp.ClientSession
+	marketingPluginID uuid.UUID
+}
+
+// newSkillsVerticalFixture composes the production wiring against a real
+// database: the real skills management service, the Postgres target inventory,
+// the real registration store as project resolver, and the runtime's own HTTP
+// handler behind an MCP client. Only the OAuth token exchange is stood in for,
+// because minting one would test the OAuth lane rather than this one.
+type skillsVerticalOptions struct {
+	// capabilityEnabled is the Platform MCP kill switch as the skills tools see
+	// it. The runtime's own gate stays on so the endpoint keeps serving; this
+	// isolates what a caller gets from a tool whose capability is off.
+	capabilityEnabled bool
+	// grantAdmin gives the acting user real organization-admin grants. Off, the
+	// call travels the whole path and is refused by RBAC at the end of it.
+	grantAdmin bool
+}
+
+func newSkillsVerticalFixture(t *testing.T, ctx context.Context, name string, options skillsVerticalOptions) *skillsVerticalFixture {
+	t.Helper()
+
+	conn, err := platformMCPInfra.CloneTestDatabase(t, name)
+	require.NoError(t, err)
+	redisClient, err := platformMCPInfra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	// The endpoint refuses a principal missing any half of its OAuth identity,
+	// so the fixture presents the complete one a real connection carries.
+	principal.ClientID = "client-" + uuid.NewString()
+	principal.Surface = SurfacePlatformMCP
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("gram-local"), billing.NewStubClient(logger, tracerProvider))
+	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
+	features := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
+	siteURL, err := url.Parse("https://app.getgram.test")
+	require.NoError(t, err)
+	skills := skillsservice.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, features, audit.NewLogger(), nil, siteURL)
+
+	_, err = featurerepo.New(conn).EnableFeature(ctx, featurerepo.EnableFeatureParams{
+		OrganizationID: principal.OrganizationID,
+		FeatureName:    string(productfeatures.FeatureSkills),
+	})
+	require.NoError(t, err)
+	features.UpdateFeatureCache(ctx, principal.OrganizationID, productfeatures.FeatureSkills, true)
+
+	// The acting user holds real grants rather than context overrides, so the
+	// test exercises the authorization the OAuth surface actually relies on.
+	require.NoError(t, testrepo.New(conn).InsertUserFixture(ctx, testrepo.InsertUserFixtureParams{
+		ID:          principal.UserID,
+		Email:       principal.UserID + "@example.test",
+		DisplayName: "Platform MCP skills test user",
+	}))
+	require.NoError(t, testrepo.New(conn).CreateOrganizationUserRelationshipFixture(ctx, testrepo.CreateOrganizationUserRelationshipFixtureParams{
+		OrganizationID: principal.OrganizationID,
+		UserID:         pgtype.Text{String: principal.UserID, Valid: true},
+	}))
+	if options.grantAdmin {
+		require.NoError(t, authz.NewProvisioner(conn).ProvisionOrganizationAdmin(ctx, principal.OrganizationID, authz.InitialOrganizationAdmin{
+			UserID:             principal.UserID,
+			WorkOSUserID:       principal.UserID,
+			WorkOSMembershipID: "membership-" + uuid.NewString(),
+		}))
+	} else {
+		// A member of the organization holding no role. Seeding the roles without
+		// assigning one is what makes this "authenticated but unauthorized"
+		// rather than an organization that predates RBAC.
+		require.NoError(t, authz.SeedSystemRoleGrants(ctx, conn, principal.OrganizationID))
+	}
+
+	plugins := pluginsrepo.New(conn)
+	_, err = plugins.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
+	require.NoError(t, err)
+	marketing, err := plugins.CreatePlugin(ctx, pluginsrepo.CreatePluginParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+		Name:           "Marketing",
+		Slug:           "marketing",
+		Description:    pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+	_, err = assistantsrepo.New(conn).CreateAssistant(ctx, assistantsrepo.CreateAssistantParams{
+		ProjectID:       project.ID,
+		OrganizationID:  principal.OrganizationID,
+		CreatedByUserID: pgtype.Text{String: principal.UserID, Valid: true},
+		Name:            "Support",
+		Model:           "claude-sonnet-5",
+		Instructions:    "Help customers.",
+		WarmTtlSeconds:  300,
+		MaxConcurrency:  1,
+		Status:          "active",
+	})
+	require.NoError(t, err)
+
+	store, err := NewRegistrationStore(conn, RegistrationStoreConfig{ActiveRegistrationCap: 5})
+	require.NoError(t, err)
+	allow := func() Limiter { return &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}} }
+	skillsSurface := NewSkillsService(
+		skills,
+		NewPostgresSkillTargets(conn),
+		store,
+		authzEngine,
+		NewCatalogRegistrationGate(testGate{enabled: options.capabilityEnabled}),
+		OperationBudget{Connection: allow(), Organization: allow()},
+	)
+
+	runtime := NewRuntimeWithLifecycle(
+		logger, &testAuthenticator{principal: principal}, testGate{enabled: true}, &testAuthorizer{},
+		"", "test-cursor-key", nil, nil, nil, nil, nil, nil, nil, nil, skillsSurface, CatalogDescriptor{},
+	)
+	server := httptest.NewServer(runtime.Handler())
+	t.Cleanup(server.Close)
+
+	// The endpoint authenticates every request, so the client presents a bearer
+	// token on each one exactly as a real MCP client would.
+	httpClient := server.Client()
+	httpClient.Transport = bearerTokenTransport{base: httpClient.Transport}
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   server.URL,
+		HTTPClient: httpClient,
+		MaxRetries: 0,
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "skills-vertical-test", Version: "0.0.1"}, nil)
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+
+	return &skillsVerticalFixture{
+		conn:              conn,
+		principal:         principal,
+		project:           project,
+		session:           session,
+		marketingPluginID: marketing.ID,
+	}
+}
+
+// callSkillsTool calls one tool and decodes its structured result, failing the
+// test if the call came back as a refusal.
+func callSkillsTool[Out any](t *testing.T, ctx context.Context, session *mcp.ClientSession, name string, arguments map[string]any) Out {
+	t.Helper()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: arguments})
+	require.NoError(t, err)
+	require.Falsef(t, result.IsError, "tool %q refused: %s", name, skillsToolText(t, result))
+
+	var out Out
+	require.NoError(t, json.Unmarshal([]byte(skillsToolText(t, result)), &out))
+	return out
+}
+
+// callSkillsRefusal calls one tool that is expected to refuse, and returns the
+// structured refusal. A refusal must arrive as a readable result rather than a
+// transport error, or the model loses the reason.
+func callSkillsRefusal(t *testing.T, ctx context.Context, session *mcp.ClientSession, name string, arguments map[string]any) skillsRefusalResult {
+	t.Helper()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: arguments})
+	require.NoError(t, err)
+	require.Truef(t, result.IsError, "tool %q was expected to refuse", name)
+
+	var refusal skillsRefusalResult
+	require.NoError(t, json.Unmarshal([]byte(skillsToolText(t, result)), &refusal))
+	require.NotEmpty(t, refusal.Message)
+	return refusal
+}
+
+func skillsToolText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+
+	require.NotEmpty(t, result.Content)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	return text.Text
+}
+
+func skillTargetNames(targets []SkillTarget) []string {
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		names = append(names, target.Name)
+	}
+	return names
+}
+
+func skillsFixtureManifest(name, description, body string) string {
+	return fmt.Sprintf("---\nname: %s\ndescription: %s\n---\n\n%s\n", name, description, body)
+}
+
+type bearerTokenTransport struct{ base http.RoundTripper }
+
+func (t bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set("Authorization", "Bearer platform-mcp-test-token")
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(cloned)
+}
+
+func listSkillDistributions(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, skillID string) []skillsrepo.ListActiveSkillDistributionsRow {
+	t.Helper()
+
+	rows, err := skillsrepo.New(conn).ListActiveSkillDistributions(ctx, skillsrepo.ListActiveSkillDistributionsParams{
+		ProjectID:       projectID,
+		SkillID:         uuid.NullUUID{UUID: uuid.MustParse(skillID), Valid: true},
+		PluginID:        uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		CursorCreatedAt: pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
+		CursorID:        uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		PageLimit:       50,
+	})
+	require.NoError(t, err)
+	return rows
+}
+
+func toolNames(tools []*mcp.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}

--- a/server/internal/platformmcp/skills_test.go
+++ b/server/internal/platformmcp/skills_test.go
@@ -771,3 +771,18 @@ func skillTargetKinds(targets []SkillTarget) []SkillTargetKind {
 	}
 	return kinds
 }
+
+// The advice cap is a cap for any limit, not only the one the caller happens
+// to pass today.
+func TestAuthoringAdviceNeverExceedsTheCap(t *testing.T) {
+	t.Parallel()
+
+	targets := []SkillTarget{
+		{Kind: SkillTargetPlugin, ID: testDefaultPluginID, Name: "Default"},
+		{Kind: SkillTargetAssistant, ID: testAssistantID, Name: "Support"},
+	}
+
+	for _, limit := range []int{1, 2, 3} {
+		require.LessOrEqual(t, len(adviceTargets(targets, limit)), limit)
+	}
+}

--- a/server/internal/platformmcp/skills_test.go
+++ b/server/internal/platformmcp/skills_test.go
@@ -3,8 +3,10 @@ package platformmcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -27,17 +29,18 @@ const (
 )
 
 type recordingSkillsManagement struct {
-	created         *genskills.CreatePayload
-	addedVersion    *genskills.AddVersionPayload
-	updated         *genskills.UpdatePayload
-	distributed     *genskills.DistributePayload
-	skill           *types.Skill
-	latestVersion   *types.SkillVersion
-	recordResult    *genskills.RecordSkillResult
-	distribution    *types.SkillDistribution
-	err             error
-	assistantCount  int64
-	listVersionsOut *genskills.ListSkillVersionsResult
+	created             *genskills.CreatePayload
+	addedVersion        *genskills.AddVersionPayload
+	updated             *genskills.UpdatePayload
+	distributed         *genskills.DistributePayload
+	skill               *types.Skill
+	latestVersion       *types.SkillVersion
+	recordResult        *genskills.RecordSkillResult
+	distribution        *types.SkillDistribution
+	err                 error
+	assistantCount      int64
+	listVersionsOut     *genskills.ListSkillVersionsResult
+	pluginDistributions []*types.PluginSkillDistribution
 }
 
 func (s *recordingSkillsManagement) Create(_ context.Context, payload *genskills.CreatePayload) (*genskills.RecordSkillResult, error) {
@@ -91,6 +94,13 @@ func (s *recordingSkillsManagement) ListVersions(_ context.Context, _ *genskills
 		return nil, s.err
 	}
 	return s.listVersionsOut, nil
+}
+
+func (s *recordingSkillsManagement) ListDistributions(_ context.Context, _ *genskills.ListDistributionsPayload) (*genskills.ListSkillDistributionsResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &genskills.ListSkillDistributionsResult{Distributions: s.pluginDistributions, NextCursor: nil}, nil
 }
 
 func (s *recordingSkillsManagement) Distribute(_ context.Context, payload *genskills.DistributePayload) (*types.SkillDistribution, error) {
@@ -618,4 +628,146 @@ func TestSkillsToolsAreDeclaredWithAndWithoutTheirDependencies(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Truncation cuts bytes, so a manifest whose 64 KiB boundary lands mid-rune
+// would otherwise end in mojibake.
+func TestGetSkillTruncatesContentOnARuneBoundary(t *testing.T) {
+	t.Parallel()
+
+	// One multi-byte rune straddling the ceiling.
+	content := strings.Repeat("a", maxSkillContentBytes-1) + "€" + strings.Repeat("b", 16)
+	skills := &recordingSkillsManagement{skill: testSkill(), latestVersion: testSkillVersion(content)}
+	service := testSkillsService(t, skills)
+
+	result, err := service.GetSkill(t.Context(), testPrincipal(), GetSkillInput{
+		ProjectSlug:    testSkillProjectSlug,
+		SkillID:        testSkillID,
+		IncludeContent: true,
+	})
+
+	require.NoError(t, err)
+	require.True(t, result.LatestVersion.ContentTruncated)
+	require.True(t, utf8.ValidString(result.LatestVersion.Content))
+}
+
+// A skill carried only by a plugin is distributed. Reporting otherwise would
+// contradict the distribute_skill call that put it there.
+func TestGetSkillReportsAPluginOnlyDistributionAsDistributed(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{
+		skill:               testSkill(),
+		latestVersion:       testSkillVersion(""),
+		assistantCount:      0,
+		pluginDistributions: []*types.PluginSkillDistribution{{SkillID: testSkillID}},
+	}
+	service := testSkillsService(t, skills)
+
+	result, err := service.GetSkill(t.Context(), testPrincipal(), GetSkillInput{
+		ProjectSlug: testSkillProjectSlug,
+		SkillID:     testSkillID,
+	})
+
+	require.NoError(t, err)
+	require.True(t, result.Distributed)
+}
+
+// The registry read has to ask for an ordering the skills service actually
+// declares, or it silently falls back to name order.
+func TestListSkillsRequestsAnOrderingTheServiceSupports(t *testing.T) {
+	t.Parallel()
+
+	skills := &sortCapturingSkills{}
+	service := NewSkillsService(
+		skills,
+		stubSkillTargets{targets: testTargets()},
+		stubSkillProjects{},
+		passthroughGrants{},
+		stubSkillsGate{enabled: true},
+		OperationBudget{
+			Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+			Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+		},
+	)
+
+	_, err := service.ListSkills(t.Context(), testPrincipal(), ListSkillsInput{ProjectSlug: testSkillProjectSlug})
+
+	require.NoError(t, err)
+	require.Contains(t, []string{"name", "updated"}, skills.sort, "sort must be one of the values the skills design declares")
+	require.Equal(t, "updated", skills.sort)
+}
+
+type sortCapturingSkills struct {
+	recordingSkillsManagement
+	sort string
+}
+
+func (s *sortCapturingSkills) List(_ context.Context, payload *genskills.ListPayload) (*genskills.ListSkillsResult, error) {
+	s.sort = payload.Sort
+	return &genskills.ListSkillsResult{Skills: nil, TotalCount: 0, NextCursor: nil}, nil
+}
+
+// Resolution reads every candidate. Capping the combined list would let a
+// project's plugins hide its assistants, turning an existing target into
+// not_found — the one refusal that must mean "you named something absent".
+func TestDistributeSkillResolvesAnAssistantBehindManyPlugins(t *testing.T) {
+	t.Parallel()
+
+	targets := make([]SkillTarget, 0, maxSkillTargetCandidates+2)
+	for i := range maxSkillTargetCandidates + 1 {
+		targets = append(targets, SkillTarget{Kind: SkillTargetPlugin, ID: uuid.NewString(), Name: fmt.Sprintf("plugin-%d", i), Slug: fmt.Sprintf("plugin-%d", i)})
+	}
+	targets = append(targets, SkillTarget{Kind: SkillTargetAssistant, ID: testAssistantID, Name: "Support"})
+
+	skills := &recordingSkillsManagement{
+		skill:        testSkill(),
+		distribution: &types.SkillDistribution{ID: "d", SkillID: testSkillID, SkillName: "add-mcp", ResolvedVersionID: testSkillVersionID, Channel: "assistant"},
+	}
+	service := NewSkillsService(
+		skills,
+		stubSkillTargets{targets: targets},
+		stubSkillProjects{},
+		passthroughGrants{},
+		stubSkillsGate{enabled: true},
+		OperationBudget{
+			Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+			Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+		},
+	)
+
+	result, err := service.DistributeSkill(t.Context(), testPrincipal(), DistributeSkillInput{
+		ProjectSlug: testSkillProjectSlug,
+		SkillID:     testSkillID,
+		Assistant:   "Support",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, testAssistantID, result.Target.ID)
+}
+
+// The advice list is capped, but a caller that can only see plugins would read
+// "there is nowhere else to send this" when an assistant target exists.
+func TestAuthoringAdviceKeepsBothTargetKindsWithinTheCap(t *testing.T) {
+	t.Parallel()
+
+	targets := make([]SkillTarget, 0, maxSkillTargetCandidates+2)
+	for i := range maxSkillTargetCandidates + 1 {
+		targets = append(targets, SkillTarget{Kind: SkillTargetPlugin, ID: uuid.NewString(), Name: fmt.Sprintf("plugin-%d", i)})
+	}
+	targets = append(targets, SkillTarget{Kind: SkillTargetAssistant, ID: testAssistantID, Name: "Support"})
+
+	kept := adviceTargets(targets, maxSkillTargetCandidates)
+
+	require.Len(t, kept, maxSkillTargetCandidates)
+	require.Contains(t, skillTargetKinds(kept), SkillTargetAssistant)
+	require.Contains(t, skillTargetKinds(kept), SkillTargetPlugin)
+}
+
+func skillTargetKinds(targets []SkillTarget) []SkillTargetKind {
+	kinds := make([]SkillTargetKind, 0, len(targets))
+	for _, target := range targets {
+		kinds = append(kinds, target.Kind)
+	}
+	return kinds
 }

--- a/server/internal/platformmcp/skills_test.go
+++ b/server/internal/platformmcp/skills_test.go
@@ -1,0 +1,621 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	genskills "github.com/speakeasy-api/gram/server/gen/skills"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+)
+
+const (
+	testSkillID          = "6f2f4c0e-2f6a-4a0e-9c1a-1a2b3c4d5e6f"
+	testSkillVersionID   = "5a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d"
+	testDefaultPluginID  = "11111111-1111-4111-8111-111111111111"
+	testMarketingPlugin  = "22222222-2222-4222-8222-222222222222"
+	testAssistantID      = "33333333-3333-4333-8333-333333333333"
+	testSkillProjectSlug = "acme"
+)
+
+type recordingSkillsManagement struct {
+	created         *genskills.CreatePayload
+	addedVersion    *genskills.AddVersionPayload
+	updated         *genskills.UpdatePayload
+	distributed     *genskills.DistributePayload
+	skill           *types.Skill
+	latestVersion   *types.SkillVersion
+	recordResult    *genskills.RecordSkillResult
+	distribution    *types.SkillDistribution
+	err             error
+	assistantCount  int64
+	listVersionsOut *genskills.ListSkillVersionsResult
+}
+
+func (s *recordingSkillsManagement) Create(_ context.Context, payload *genskills.CreatePayload) (*genskills.RecordSkillResult, error) {
+	s.created = payload
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.recordResult, nil
+}
+
+func (s *recordingSkillsManagement) AddVersion(_ context.Context, payload *genskills.AddVersionPayload) (*genskills.RecordSkillResult, error) {
+	s.addedVersion = payload
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.recordResult, nil
+}
+
+func (s *recordingSkillsManagement) Update(_ context.Context, payload *genskills.UpdatePayload) (*types.Skill, error) {
+	s.updated = payload
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.skill, nil
+}
+
+func (s *recordingSkillsManagement) List(_ context.Context, _ *genskills.ListPayload) (*genskills.ListSkillsResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &genskills.ListSkillsResult{Skills: []*types.Skill{s.skill}, TotalCount: 1, NextCursor: nil}, nil
+}
+
+func (s *recordingSkillsManagement) Get(_ context.Context, _ *genskills.GetPayload) (*genskills.GetSkillResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &genskills.GetSkillResult{
+		Skill:                   s.skill,
+		LatestVersion:           s.latestVersion,
+		Adoption:                nil,
+		SightingTimeline:        nil,
+		Drift:                   nil,
+		AssistantCount:          s.assistantCount,
+		PromptInjectionFindings: nil,
+	}, nil
+}
+
+func (s *recordingSkillsManagement) ListVersions(_ context.Context, _ *genskills.ListVersionsPayload) (*genskills.ListSkillVersionsResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.listVersionsOut, nil
+}
+
+func (s *recordingSkillsManagement) Distribute(_ context.Context, payload *genskills.DistributePayload) (*types.SkillDistribution, error) {
+	s.distributed = payload
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.distribution, nil
+}
+
+type stubSkillTargets struct{ targets []SkillTarget }
+
+func (s stubSkillTargets) SkillTargets(_ context.Context, _ string, _ uuid.UUID, limit int) ([]SkillTarget, error) {
+	if len(s.targets) > limit {
+		return s.targets[:limit], nil
+	}
+	return s.targets, nil
+}
+
+type stubSkillProjects struct{ err error }
+
+func (s stubSkillProjects) ResolveProject(_ context.Context, _, projectSlug string) (ResolvedProject, error) {
+	if s.err != nil {
+		return ResolvedProject{}, s.err
+	}
+	return ResolvedProject{ID: uuid.MustParse("44444444-4444-4444-8444-444444444444"), Name: "Acme", Slug: projectSlug}, nil
+}
+
+// passthroughGrants stands in for the RBAC engine. Grant loading is exercised
+// against a real database in the vertical slice test; here it only has to not
+// be the thing under test.
+type passthroughGrants struct{}
+
+func (passthroughGrants) PrepareContext(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+type stubSkillsGate struct {
+	enabled bool
+	err     error
+}
+
+func (s stubSkillsGate) Enabled(_ context.Context, _, _ string) (bool, error) {
+	return s.enabled, s.err
+}
+
+func testTargets() []SkillTarget {
+	return []SkillTarget{
+		{Kind: SkillTargetPlugin, ID: testDefaultPluginID, Name: "Default", Slug: "default", IsDefault: true},
+		{Kind: SkillTargetPlugin, ID: testMarketingPlugin, Name: "Marketing", Slug: "marketing", IsDefault: false},
+		{Kind: SkillTargetAssistant, ID: testAssistantID, Name: "Support", Slug: "", IsDefault: false},
+	}
+}
+
+func testSkillsService(t *testing.T, skills *recordingSkillsManagement) *SkillsService {
+	t.Helper()
+	return NewSkillsService(
+		skills,
+		stubSkillTargets{targets: testTargets()},
+		stubSkillProjects{},
+		passthroughGrants{},
+		stubSkillsGate{enabled: true},
+		OperationBudget{
+			Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+			Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+		},
+	)
+}
+
+func testSkill() *types.Skill {
+	summary := "Adds an MCP from the catalogue"
+	latest := testSkillVersionID
+	return &types.Skill{
+		ID:              testSkillID,
+		Name:            "add-mcp",
+		DisplayName:     "Add MCP",
+		Summary:         &summary,
+		Tags:            []string{"catalog"},
+		LatestVersionID: &latest,
+		VersionCount:    2,
+		HasValidVersion: true,
+		UpdatedAt:       "2026-08-20T00:00:00Z",
+	}
+}
+
+func testSkillVersion(content string) *types.SkillVersion {
+	return &types.SkillVersion{
+		ID:              testSkillVersionID,
+		SkillID:         testSkillID,
+		Content:         content,
+		CanonicalSha256: "abc123",
+		SpecValid:       true,
+		CreatedAt:       "2026-08-20T00:00:00Z",
+	}
+}
+
+func TestCreateSkillReportsTheSkillIsInertUntilDistributed(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{
+		skill:         testSkill(),
+		latestVersion: testSkillVersion("---\nname: add-mcp\n---\n"),
+		recordResult: &genskills.RecordSkillResult{
+			Skill:          testSkill(),
+			Version:        testSkillVersion("---\nname: add-mcp\n---\n"),
+			CreatedSkill:   true,
+			CreatedVersion: true,
+		},
+	}
+	service := testSkillsService(t, skills)
+
+	result, err := service.CreateSkill(t.Context(), testPrincipal(), CreateSkillInput{
+		ProjectSlug: testSkillProjectSlug,
+		Content:     "---\nname: add-mcp\n---\n",
+	})
+
+	require.NoError(t, err)
+	require.True(t, result.CreatedSkill)
+	require.False(t, result.Distributed)
+	require.Equal(t, "distribute_skill", result.NextAction)
+	require.Contains(t, result.InertMessage, "inert")
+	// The result names where the skill can be sent, so a caller does not have
+	// to guess a target — or assume authoring already activated it.
+	require.NotEmpty(t, result.DistributionTargets)
+	require.Empty(t, result.Version.Content, "authoring echoes back no manifest content")
+}
+
+func TestCreateSkillRefusesContentOverTheManifestCeiling(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{}
+	service := testSkillsService(t, skills)
+
+	_, err := service.CreateSkill(t.Context(), testPrincipal(), CreateSkillInput{
+		ProjectSlug: testSkillProjectSlug,
+		Content:     strings.Repeat("a", maxSkillContentBytes+1),
+	})
+
+	require.ErrorIs(t, err, ErrSkillContentTooLarge)
+	require.Nil(t, skills.created, "an oversized manifest never reaches the skills service")
+}
+
+func TestAddSkillVersionForwardsTheExpectedVersionToken(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{
+		skill:         testSkill(),
+		latestVersion: testSkillVersion("---\nname: add-mcp\n---\n"),
+		recordResult: &genskills.RecordSkillResult{
+			Skill:          testSkill(),
+			Version:        testSkillVersion("---\nname: add-mcp\n---\n"),
+			CreatedSkill:   false,
+			CreatedVersion: true,
+		},
+	}
+	service := testSkillsService(t, skills)
+
+	_, err := service.AddSkillVersion(t.Context(), testPrincipal(), AddSkillVersionInput{
+		ProjectSlug:             testSkillProjectSlug,
+		SkillID:                 testSkillID,
+		Content:                 "---\nname: add-mcp\n---\n",
+		ExpectedLatestVersionID: testSkillVersionID,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, skills.addedVersion)
+	require.NotNil(t, skills.addedVersion.ExpectedLatestVersionID)
+	require.Equal(t, testSkillVersionID, *skills.addedVersion.ExpectedLatestVersionID)
+	require.NotNil(t, skills.addedVersion.DerivedFromVersionID)
+	require.Equal(t, testSkillVersionID, *skills.addedVersion.DerivedFromVersionID)
+}
+
+func TestUpdateSkillMetadataLeavesUnspecifiedFieldsAndTagsUntouched(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{skill: testSkill(), latestVersion: testSkillVersion("")}
+	service := testSkillsService(t, skills)
+
+	_, err := service.UpdateSkillMetadata(t.Context(), testPrincipal(), UpdateSkillMetadataInput{
+		ProjectSlug:             testSkillProjectSlug,
+		SkillID:                 testSkillID,
+		DisplayName:             "Add MCP from Catalogue",
+		ExpectedLatestVersionID: testSkillVersionID,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, skills.updated)
+	require.Equal(t, "Add MCP from Catalogue", skills.updated.DisplayName)
+	require.Equal(t, "add-mcp", skills.updated.Name, "an omitted name is carried through, not blanked")
+	require.NotNil(t, skills.updated.Summary)
+	require.Equal(t, []string{"catalog"}, skills.updated.Tags, "this surface does not author tags")
+}
+
+func TestUpdateSkillMetadataClearsTheSummaryOnlyWhenAsked(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{skill: testSkill(), latestVersion: testSkillVersion("")}
+	service := testSkillsService(t, skills)
+
+	_, err := service.UpdateSkillMetadata(t.Context(), testPrincipal(), UpdateSkillMetadataInput{
+		ProjectSlug:             testSkillProjectSlug,
+		SkillID:                 testSkillID,
+		ClearSummary:            true,
+		ExpectedLatestVersionID: testSkillVersionID,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, skills.updated.Summary)
+}
+
+func TestGetSkillWithholdsManifestContentUntilAskedFor(t *testing.T) {
+	t.Parallel()
+
+	content := "---\nname: add-mcp\n---\nInstructions"
+	skills := &recordingSkillsManagement{skill: testSkill(), latestVersion: testSkillVersion(content)}
+	service := testSkillsService(t, skills)
+
+	withheld, err := service.GetSkill(t.Context(), testPrincipal(), GetSkillInput{
+		ProjectSlug: testSkillProjectSlug,
+		SkillID:     testSkillID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, withheld.LatestVersion)
+	require.Empty(t, withheld.LatestVersion.Content)
+
+	included, err := service.GetSkill(t.Context(), testPrincipal(), GetSkillInput{
+		ProjectSlug:    testSkillProjectSlug,
+		SkillID:        testSkillID,
+		IncludeContent: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, content, included.LatestVersion.Content)
+}
+
+func TestGetSkillTruncatesContentAtTheReadCeiling(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{skill: testSkill(), latestVersion: testSkillVersion(strings.Repeat("a", maxSkillContentBytes+512))}
+	service := testSkillsService(t, skills)
+
+	result, err := service.GetSkill(t.Context(), testPrincipal(), GetSkillInput{
+		ProjectSlug:    testSkillProjectSlug,
+		SkillID:        testSkillID,
+		IncludeContent: true,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.LatestVersion.Content, maxSkillContentBytes)
+	require.True(t, result.LatestVersion.ContentTruncated)
+}
+
+func TestDistributeSkillResolvesAnExactTargetAndEchoesIt(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name   string
+		input  DistributeSkillInput
+		wantID string
+		kind   SkillTargetKind
+	}{
+		{name: "plugin by slug", input: DistributeSkillInput{Plugin: "marketing"}, wantID: testMarketingPlugin, kind: SkillTargetPlugin},
+		{name: "plugin by name, case-insensitively", input: DistributeSkillInput{Plugin: "marketing"}, wantID: testMarketingPlugin, kind: SkillTargetPlugin},
+		{name: "default plugin named exactly", input: DistributeSkillInput{Plugin: "default"}, wantID: testDefaultPluginID, kind: SkillTargetPlugin},
+		{name: "plugin by id", input: DistributeSkillInput{Plugin: testMarketingPlugin}, wantID: testMarketingPlugin, kind: SkillTargetPlugin},
+		{name: "assistant by name", input: DistributeSkillInput{Assistant: "Support"}, wantID: testAssistantID, kind: SkillTargetAssistant},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			skills := &recordingSkillsManagement{
+				skill: testSkill(),
+				distribution: &types.SkillDistribution{
+					ID:                "77777777-7777-4777-8777-777777777777",
+					SkillID:           testSkillID,
+					SkillName:         "add-mcp",
+					ResolvedVersionID: testSkillVersionID,
+					Channel:           string(test.kind),
+				},
+			}
+			service := testSkillsService(t, skills)
+			input := test.input
+			input.ProjectSlug = testSkillProjectSlug
+			input.SkillID = testSkillID
+
+			result, err := service.DistributeSkill(t.Context(), testPrincipal(), input)
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantID, result.Target.ID)
+			require.Equal(t, test.kind, result.Target.Kind)
+			if test.kind == SkillTargetPlugin {
+				require.NotNil(t, skills.distributed.PluginID)
+				require.Equal(t, test.wantID, *skills.distributed.PluginID)
+				require.Nil(t, skills.distributed.AssistantID)
+			} else {
+				require.NotNil(t, skills.distributed.AssistantID)
+				require.Equal(t, test.wantID, *skills.distributed.AssistantID)
+				require.Nil(t, skills.distributed.PluginID)
+			}
+		})
+	}
+}
+
+func TestDistributeSkillRefusesAnUnmatchedTargetRatherThanFallingBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{skill: testSkill()}
+	service := testSkillsService(t, skills)
+
+	_, err := service.DistributeSkill(t.Context(), testPrincipal(), DistributeSkillInput{
+		ProjectSlug: testSkillProjectSlug,
+		SkillID:     testSkillID,
+		Plugin:      "markting",
+	})
+
+	require.ErrorIs(t, err, ErrSkillTargetNotFound)
+	require.Nil(t, skills.distributed, "a target that does not exist distributes nothing at all")
+}
+
+func TestDistributeSkillRefusesAnAmbiguousTarget(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{skill: testSkill()}
+	service := NewSkillsService(
+		skills,
+		stubSkillTargets{targets: []SkillTarget{
+			{Kind: SkillTargetPlugin, ID: testDefaultPluginID, Name: "Marketing", Slug: "marketing-one", IsDefault: false},
+			{Kind: SkillTargetPlugin, ID: testMarketingPlugin, Name: "marketing", Slug: "marketing-two", IsDefault: false},
+		}},
+		stubSkillProjects{},
+		passthroughGrants{},
+		stubSkillsGate{enabled: true},
+		OperationBudget{
+			Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+			Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+		},
+	)
+
+	_, err := service.DistributeSkill(t.Context(), testPrincipal(), DistributeSkillInput{
+		ProjectSlug: testSkillProjectSlug,
+		SkillID:     testSkillID,
+		Plugin:      "Marketing",
+	})
+
+	require.ErrorIs(t, err, ErrSkillTargetAmbiguous)
+	require.Nil(t, skills.distributed)
+}
+
+func TestDistributeSkillRequiresExactlyOneTargetKind(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{skill: testSkill()}
+	service := testSkillsService(t, skills)
+
+	for _, input := range []DistributeSkillInput{
+		{ProjectSlug: testSkillProjectSlug, SkillID: testSkillID},
+		{ProjectSlug: testSkillProjectSlug, SkillID: testSkillID, Plugin: "default", Assistant: "Support"},
+	} {
+		_, err := service.DistributeSkill(t.Context(), testPrincipal(), input)
+		require.ErrorIs(t, err, ErrRegistrationInvalid)
+	}
+	require.Nil(t, skills.distributed)
+}
+
+func TestSkillCallsRefuseWhenTheCapabilityIsOff(t *testing.T) {
+	t.Parallel()
+
+	skills := &recordingSkillsManagement{skill: testSkill()}
+	service := NewSkillsService(
+		skills,
+		stubSkillTargets{targets: testTargets()},
+		stubSkillProjects{},
+		passthroughGrants{},
+		stubSkillsGate{enabled: false},
+		OperationBudget{
+			Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+			Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+		},
+	)
+
+	_, err := service.ListSkills(t.Context(), testPrincipal(), ListSkillsInput{ProjectSlug: testSkillProjectSlug})
+
+	require.ErrorIs(t, err, ErrSkillsUnavailable)
+}
+
+func TestSkillCallsAreMeteredBeforeTheyResolveAProject(t *testing.T) {
+	t.Parallel()
+
+	projects := &countingSkillProjects{}
+	service := NewSkillsService(
+		&recordingSkillsManagement{skill: testSkill()},
+		stubSkillTargets{targets: testTargets()},
+		projects,
+		passthroughGrants{},
+		stubSkillsGate{enabled: true},
+		OperationBudget{
+			Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}},
+			Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+		},
+	)
+
+	_, err := service.CreateSkill(t.Context(), testPrincipal(), CreateSkillInput{ProjectSlug: testSkillProjectSlug, Content: "---\nname: a\n---\n"})
+
+	require.ErrorIs(t, err, ErrOperationRateLimited)
+	require.Zero(t, projects.calls)
+}
+
+type countingSkillProjects struct{ calls int }
+
+func (s *countingSkillProjects) ResolveProject(_ context.Context, _, projectSlug string) (ResolvedProject, error) {
+	s.calls++
+	return ResolvedProject{ID: uuid.Nil, Name: "Acme", Slug: projectSlug}, nil
+}
+
+func TestSkillCallsActUnderTheCallingUserRatherThanTheSurface(t *testing.T) {
+	t.Parallel()
+
+	skills := &authContextCapturingSkills{}
+	service := NewSkillsService(
+		skills,
+		stubSkillTargets{targets: testTargets()},
+		stubSkillProjects{},
+		passthroughGrants{},
+		stubSkillsGate{enabled: true},
+		OperationBudget{
+			Connection:   &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+			Organization: &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}},
+		},
+	)
+
+	principal := testPrincipal()
+	_, err := service.ListSkills(t.Context(), principal, ListSkillsInput{ProjectSlug: testSkillProjectSlug})
+
+	require.NoError(t, err)
+	require.NotNil(t, skills.captured)
+	require.Equal(t, principal.UserID, skills.captured.UserID)
+	require.Equal(t, principal.OrganizationID, skills.captured.ActiveOrganizationID)
+	require.NotNil(t, skills.captured.ProjectID)
+}
+
+type authContextCapturingSkills struct {
+	recordingSkillsManagement
+	captured *contextvalues.AuthContext
+}
+
+func (s *authContextCapturingSkills) List(ctx context.Context, _ *genskills.ListPayload) (*genskills.ListSkillsResult, error) {
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	s.captured = authCtx
+	return &genskills.ListSkillsResult{Skills: nil, TotalCount: 0, NextCursor: nil}, nil
+}
+
+func TestSkillsToolResultMapsRefusalsToStructuredCodes(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "capability off", err: ErrSkillsUnavailable, code: unavailableCode},
+		{name: "unmatched target", err: ErrSkillTargetNotFound, code: "not_found"},
+		{name: "ambiguous target", err: ErrSkillTargetAmbiguous, code: "ambiguous_target"},
+		{name: "oversized manifest", err: ErrSkillContentTooLarge, code: "invalid_request"},
+		{name: "rate limited", err: ErrOperationRateLimited, code: "rate_limited"},
+		{name: "stale version token", err: oops.E(oops.CodeConflict, nil, "the skill has a newer version than the expected one"), code: "conflict"},
+		{name: "invalid manifest", err: oops.E(oops.CodeBadRequest, nil, "skill manifest frontmatter is too deeply nested"), code: "invalid_request"},
+		{name: "missing skill", err: oops.E(oops.CodeNotFound, nil, "skill not found"), code: "not_found"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, ok := skillsToolResult(test.err)
+
+			require.True(t, ok)
+			require.True(t, result.IsError)
+			text, ok := result.Content[0].(*mcp.TextContent)
+			require.True(t, ok)
+			var body skillsRefusalResult
+			require.NoError(t, json.Unmarshal([]byte(text.Text), &body))
+			require.Equal(t, test.code, body.Code)
+			require.NotEmpty(t, body.Message)
+		})
+	}
+}
+
+func TestSkillsToolResultLeavesUnexpectedFailuresAsErrors(t *testing.T) {
+	t.Parallel()
+
+	_, ok := skillsToolResult(oops.E(oops.CodeUnexpected, nil, "load skill state"))
+
+	require.False(t, ok, "an internal failure is a transport error, not a refusal the model should act on")
+}
+
+// The kill switch must change what a skills tool answers, not whether it
+// exists: a tool that vanishes with the rollout looks to a client exactly like
+// one that was never built.
+func TestSkillsToolsAreDeclaredWithAndWithoutTheirDependencies(t *testing.T) {
+	t.Parallel()
+
+	wanted := []string{"list_skills", "get_skill", "list_skill_versions", "create_skill", "add_skill_version", "update_skill_metadata", "distribute_skill"}
+
+	for _, test := range []struct {
+		name  string
+		build func() *SkillsService
+	}{
+		{name: "composed", build: func() *SkillsService { return testSkillsService(t, &recordingSkillsManagement{skill: testSkill()}) }},
+		{name: "absent", build: func() *SkillsService { return nil }},
+		{name: "incomplete", build: func() *SkillsService {
+			return NewSkillsService(nil, nil, nil, nil, nil, OperationBudget{Connection: nil, Organization: nil})
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, test.build(), CatalogDescriptor{})
+
+			registered := make(map[string]Descriptor, len(wanted))
+			for _, descriptor := range registrar.Descriptors() {
+				registered[descriptor.Name] = descriptor
+			}
+			for _, name := range wanted {
+				descriptor, ok := registered[name]
+				require.True(t, ok, "tool %q is not registered", name)
+				require.Equal(t, bothAudiences, descriptor.Meta.Audiences, "skills tools serve the assistant as well; the adapter supplies the project it acts in")
+				require.Equal(t, ProjectScopeExplicit, descriptor.Meta.ProjectScope)
+			}
+		})
+	}
+}

--- a/server/internal/platformmcp/tool_skills.go
+++ b/server/internal/platformmcp/tool_skills.go
@@ -1,0 +1,217 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ListSkillsToolInput struct {
+	ProjectSlug string `json:"project_slug" jsonschema:"explicit AICP project slug whose skill registry to list"`
+	Search      string `json:"search,omitempty" jsonschema:"optional case-insensitive search over skill names and summaries"`
+	Cursor      string `json:"cursor,omitempty" jsonschema:"pagination cursor returned by a previous list_skills call"`
+	Limit       int    `json:"limit,omitempty" jsonschema:"maximum skills to return; defaults to 50 and is capped at 100"`
+}
+
+type GetSkillToolInput struct {
+	ProjectSlug    string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the skill"`
+	SkillID        string `json:"skill_id" jsonschema:"skill ID returned by list_skills"`
+	IncludeContent bool   `json:"include_content,omitempty" jsonschema:"include the latest version's SKILL.md content; off by default because a manifest is up to 64 KiB"`
+}
+
+type ListSkillVersionsToolInput struct {
+	ProjectSlug    string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the skill"`
+	SkillID        string `json:"skill_id" jsonschema:"skill ID returned by list_skills"`
+	IncludeContent bool   `json:"include_content,omitempty" jsonschema:"include each version's SKILL.md content; off by default because a manifest is up to 64 KiB"`
+	Cursor         string `json:"cursor,omitempty" jsonschema:"pagination cursor returned by a previous list_skill_versions call"`
+	Limit          int    `json:"limit,omitempty" jsonschema:"maximum versions to return; defaults to 50 and is capped at 100"`
+}
+
+type CreateSkillToolInput struct {
+	ProjectSlug string `json:"project_slug" jsonschema:"explicit AICP project slug that will own the skill"`
+	Content     string `json:"content" jsonschema:"the complete SKILL.md, including YAML frontmatter and instructions; at most 65536 UTF-8 bytes"`
+}
+
+type AddSkillVersionToolInput struct {
+	ProjectSlug             string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the skill"`
+	SkillID                 string `json:"skill_id" jsonschema:"skill ID returned by list_skills"`
+	Content                 string `json:"content" jsonschema:"the complete replacement SKILL.md; versions are immutable, so a correction is a new version rather than an edit"`
+	ExpectedLatestVersionID string `json:"expected_latest_version_id" jsonschema:"the version the caller read before writing, from get_skill; the write is refused as a conflict if the skill has moved on"`
+}
+
+type UpdateSkillMetadataToolInput struct {
+	ProjectSlug             string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the skill"`
+	SkillID                 string `json:"skill_id" jsonschema:"skill ID returned by list_skills"`
+	Name                    string `json:"name,omitempty" jsonschema:"new canonical skill name; omitted leaves it unchanged"`
+	DisplayName             string `json:"display_name,omitempty" jsonschema:"new user-facing skill name; omitted leaves it unchanged"`
+	Summary                 string `json:"summary,omitempty" jsonschema:"new registry summary; omitted leaves it unchanged"`
+	ClearSummary            bool   `json:"clear_summary,omitempty" jsonschema:"remove the registry summary instead of replacing it"`
+	ExpectedLatestVersionID string `json:"expected_latest_version_id" jsonschema:"the version the caller read before writing, from get_skill; the write is refused as a conflict if the skill has moved on"`
+}
+
+type DistributeSkillToolInput struct {
+	ProjectSlug string `json:"project_slug" jsonschema:"explicit AICP project slug that owns both the skill and the target"`
+	SkillID     string `json:"skill_id" jsonschema:"skill ID returned by list_skills or create_skill"`
+	Plugin      string `json:"plugin,omitempty" jsonschema:"exact existing plugin in the project, by ID, slug, or name; exactly one of plugin or assistant is required and there is no implicit default"`
+	Assistant   string `json:"assistant,omitempty" jsonschema:"exact existing assistant in the project, by ID or name; exactly one of plugin or assistant is required"`
+}
+
+type skillsRefusalResult struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func registerSkillsTools(reg *Registrar, skills *SkillsService) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_skills",
+		Title:       "List Skills",
+		Description: "List the skills in an explicit AICP project registry, newest change first. Returns names, version counts, and the current version ID; manifest content is read separately with get_skill.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListSkillsToolInput) (*mcp.CallToolResult, ListSkillsOutput, error) {
+		return skillsToolCall(ctx, func(principal Principal) (ListSkillsOutput, error) {
+			return skills.ListSkills(ctx, principal, ListSkillsInput(input))
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "get_skill",
+		Title:       "Get Skill",
+		Description: "Read one skill in an explicit AICP project, including its current version ID. Set include_content to read the SKILL.md itself; it is off by default because a manifest is up to 64 KiB of the caller's context.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetSkillToolInput) (*mcp.CallToolResult, GetSkillOutput, error) {
+		return skillsToolCall(ctx, func(principal Principal) (GetSkillOutput, error) {
+			return skills.GetSkill(ctx, principal, GetSkillInput(input))
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "list_skill_versions",
+		Title:       "List Skill Versions",
+		Description: "List a skill's immutable versions, newest first. Versions are never edited in place: corrections are recorded with add_skill_version.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListSkillVersionsToolInput) (*mcp.CallToolResult, ListSkillVersionsOutput, error) {
+		return skillsToolCall(ctx, func(principal Principal) (ListSkillVersionsOutput, error) {
+			return skills.ListSkillVersions(ctx, principal, ListSkillVersionsInput(input))
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "create_skill",
+		Title:       "Create Skill",
+		Description: "Create a skill in an explicit AICP project from complete SKILL.md content. The skill is inert: authoring alone changes nothing at runtime, and no agent loads it until distribute_skill sends it to a plugin or an assistant. An existing active skill with the same normalized name records a new version instead, and identical canonical content returns the existing version as a no-op.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input CreateSkillToolInput) (*mcp.CallToolResult, SkillAuthoringResult, error) {
+		return skillsToolCall(ctx, func(principal Principal) (SkillAuthoringResult, error) {
+			return skills.CreateSkill(ctx, principal, CreateSkillInput(input))
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "add_skill_version",
+		Title:       "Add Skill Version",
+		Description: "Record a new immutable version of an existing skill from complete replacement SKILL.md content. Pass the version you read as expected_latest_version_id: if the skill has moved on since, the write is refused as a conflict rather than overwriting someone else's version. Identical canonical content returns the existing version as a no-op. Recording a version does not distribute it; existing distributions that track the latest valid version pick it up.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input AddSkillVersionToolInput) (*mcp.CallToolResult, SkillAuthoringResult, error) {
+		return skillsToolCall(ctx, func(principal Principal) (SkillAuthoringResult, error) {
+			return skills.AddSkillVersion(ctx, principal, AddSkillVersionInput(input))
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "update_skill_metadata",
+		Title:       "Update Skill Metadata",
+		Description: "Change a skill's registry naming — canonical name, display name, and summary — without recording a version. Instructions live in versions, so nothing here changes what the skill tells an agent to do. Pass the version you read as expected_latest_version_id.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateSkillMetadataToolInput) (*mcp.CallToolResult, UpdateSkillMetadataOutput, error) {
+		return skillsToolCall(ctx, func(principal Principal) (UpdateSkillMetadataOutput, error) {
+			return skills.UpdateSkillMetadata(ctx, principal, UpdateSkillMetadataInput(input))
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "distribute_skill",
+		Title:       "Distribute Skill",
+		Description: "Distribute a skill to one exact existing plugin or assistant in the same project. This is the only way a skill takes effect. Name the target exactly: a name that matches nothing is refused as not_found and a name that matches more than one target as ambiguous_target — there is no fallback to the default plugin. Repeat calls converge on the same attachment rather than creating a second one.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input DistributeSkillToolInput) (*mcp.CallToolResult, DistributeSkillOutput, error) {
+		return skillsToolCall(ctx, func(principal Principal) (DistributeSkillOutput, error) {
+			return skills.DistributeSkill(ctx, principal, DistributeSkillInput(input))
+		})
+	})
+}
+
+// registerUnavailableSkillsTools declares the same tools the live registration
+// declares, so a rollout flip changes what a tool answers rather than whether
+// the tool exists.
+func registerUnavailableSkillsTools(reg *Registrar) {
+	for _, tool := range []struct {
+		name        string
+		title       string
+		description string
+		readOnly    bool
+	}{
+		{"list_skills", "List Skills", "List the skills in an explicit AICP project. Skill authoring is not enabled in the current rollout.", true},
+		{"get_skill", "Get Skill", "Read one skill in an explicit AICP project. Skill authoring is not enabled in the current rollout.", true},
+		{"list_skill_versions", "List Skill Versions", "List a skill's immutable versions. Skill authoring is not enabled in the current rollout.", true},
+		{"create_skill", "Create Skill", "Create a skill from complete SKILL.md content. Skill authoring is not enabled in the current rollout.", false},
+		{"add_skill_version", "Add Skill Version", "Record a new immutable version of an existing skill. Skill authoring is not enabled in the current rollout.", false},
+		{"update_skill_metadata", "Update Skill Metadata", "Change a skill's registry naming. Skill authoring is not enabled in the current rollout.", false},
+		{"distribute_skill", "Distribute Skill", "Distribute a skill to one exact plugin or assistant. Skill distribution is not enabled in the current rollout.", false},
+	} {
+		manifest := &mcp.Tool{
+			Name:        tool.name,
+			Title:       tool.title,
+			Description: tool.description,
+		}
+		if tool.readOnly {
+			manifest.Annotations = readOnlyAnnotations()
+		}
+		addTool(reg, manifest, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("skills"))
+	}
+}
+
+// skillsToolCall runs one skill call and turns a refusal into a structured
+// error result rather than a transport error, so the reason survives to the
+// model that has to act on it.
+func skillsToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+	var zero Out
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	output, err := call(principal)
+	if err != nil {
+		if refusal, ok := skillsToolResult(err); ok {
+			return refusal, zero, nil
+		}
+		return nil, zero, err
+	}
+	return nil, output, nil
+}
+
+func skillsToolResult(err error) (*mcp.CallToolResult, bool) {
+	var result skillsRefusalResult
+	switch {
+	case errors.Is(err, ErrSkillsUnavailable):
+		result = skillsRefusalResult{Code: unavailableCode, Message: "Skill authoring and distribution are not enabled for this organization."}
+	case errors.Is(err, ErrSkillTargetNotFound):
+		result = skillsRefusalResult{Code: "not_found", Message: "No plugin or assistant in this project matches that target exactly. List the targets returned by create_skill or add_skill_version and name one of them; the skill is not distributed anywhere by default."}
+	case errors.Is(err, ErrSkillTargetAmbiguous):
+		result = skillsRefusalResult{Code: "ambiguous_target", Message: "More than one plugin or assistant in this project matches that name. Name the target by its ID instead."}
+	case errors.Is(err, ErrSkillContentTooLarge):
+		result = skillsRefusalResult{Code: "invalid_request", Message: "A SKILL.md may be at most 65536 UTF-8 bytes. Shorten the manifest rather than splitting it across versions."}
+	default:
+		if budgetResult, ok := operationBudgetToolResult(err); ok {
+			return budgetResult, true
+		}
+		code, message, ok := skillsRefusalCode(err)
+		if !ok {
+			return nil, false
+		}
+		result = skillsRefusalResult{Code: code, Message: message}
+	}
+	content, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, false
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, true
+}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -91,7 +91,7 @@ type operationBudgetResult struct {
 // registrar alongside the server so another admitted audience — the project
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
-func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
+func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "speakeasy-aicp-platform-mcp",
 		Title:   "Speakeasy AICP Platform MCP",
@@ -140,6 +140,11 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 		registerUnavailableTools(reg)
 	} else {
 		registerOnboardingLifecycleTools(reg, onboarding, registrations, distributions)
+	}
+	if !skills.valid() {
+		registerUnavailableSkillsTools(reg)
+	} else {
+		registerSkillsTools(reg, skills)
 	}
 	if feedback == nil {
 		addTool(reg, &mcp.Tool{

--- a/server/internal/skills/expected_version_test.go
+++ b/server/internal/skills/expected_version_test.go
@@ -1,0 +1,129 @@
+package skills_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/skills"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// An expected-version token is what lets two authors edit the same skill
+// without one silently overwriting the other. It is checked inside the write's
+// own transaction, so "the skill moved on" is a refusal rather than a race.
+func TestAddSkillVersionRejectsAStaleExpectedVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "contested", "First summary.")
+	second, err := ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: skillManifest("contested", "Second summary.", "second"),
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: nil,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: skillManifest("contested", "Third summary.", "third"),
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	requireOopsCode(t, err, oops.CodeConflict)
+
+	current, err := ti.service.Get(ctx, &gen.GetPayload{ID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+	require.Equal(t, second.Version.ID, current.LatestVersion.ID, "the refused write left the skill untouched")
+	require.Equal(t, int64(2), current.Skill.VersionCount)
+}
+
+func TestAddSkillVersionAcceptsTheCurrentExpectedVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "uncontested", "First summary.")
+
+	next, err := ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: skillManifest("uncontested", "Second summary.", "second"),
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	require.NoError(t, err)
+	require.True(t, next.CreatedVersion)
+	require.NotEqual(t, created.Version.ID, next.Version.ID)
+}
+
+// A retry of a write that already landed carries a token that is stale by its
+// own definition. Refusing it would turn a dropped response into a conflict the
+// caller cannot resolve, so the content decides: identical canonical content
+// that is already current is the same no-op an unconditional retry gets.
+func TestAddSkillVersionTreatsARetriedIdenticalWriteAsANoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "retried", "First summary.")
+	content := skillManifest("retried", "Second summary.", "second")
+	landed, err := ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: content,
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	retried, err := ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: content,
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	require.NoError(t, err)
+	require.False(t, retried.CreatedVersion)
+	require.Equal(t, landed.Version.ID, retried.Version.ID)
+	require.Equal(t, int64(2), retried.Skill.VersionCount)
+}
+
+func TestUpdateSkillRejectsAStaleExpectedVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "renamed", "First summary.")
+	_, err := ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: skillManifest("renamed", "Second summary.", "second"),
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: nil,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: created.Skill.ID, Name: "renamed", DisplayName: "Renamed", Summary: nil, Tags: nil,
+		ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	requireOopsCode(t, err, oops.CodeConflict)
+
+	current, err := ti.service.Get(ctx, &gen.GetPayload{ID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+	require.Equal(t, created.Skill.DisplayName, current.Skill.DisplayName)
+}
+
+// Metadata edits never record a version, so the token a caller read before the
+// edit is still valid after it — a retry does not have to re-read.
+func TestUpdateSkillAcceptsTheCurrentExpectedVersionRepeatedly(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "stable", "First summary.")
+
+	for _, displayName := range []string{"Stable One", "Stable Two"} {
+		updated, err := ti.service.Update(ctx, &gen.UpdatePayload{
+			ID: created.Skill.ID, Name: "stable", DisplayName: displayName, Summary: nil, Tags: nil,
+			ExpectedLatestVersionID: &created.Version.ID,
+			SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		})
+		require.NoError(t, err)
+		require.Equal(t, displayName, updated.DisplayName)
+	}
+}

--- a/server/internal/skills/expected_version_test.go
+++ b/server/internal/skills/expected_version_test.go
@@ -244,3 +244,22 @@ func TestUpdateSkillReplayRecordsNoSecondUpdateEvent(t *testing.T) {
 	require.Equal(t, before, after, "a replay records no second update event")
 	require.Equal(t, applied.UpdatedAt, replayed.UpdatedAt, "a replay does not advance updated_at")
 }
+
+// A malformed token is a bad request on the metadata path too. Replay recovery
+// must never rescue a concurrency claim that was never valid.
+func TestUpdateSkillRejectsAMalformedExpectedVersionEvenWhenMetadataMatches(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "malformed-metadata", "First summary.")
+	malformed := "not-a-uuid"
+	summary := "First summary."
+
+	_, err := ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: created.Skill.ID, Name: created.Skill.Name, DisplayName: created.Skill.DisplayName, Summary: &summary, Tags: nil,
+		ExpectedLatestVersionID: &malformed,
+		SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}

--- a/server/internal/skills/expected_version_test.go
+++ b/server/internal/skills/expected_version_test.go
@@ -127,3 +127,81 @@ func TestUpdateSkillAcceptsTheCurrentExpectedVersionRepeatedly(t *testing.T) {
 		require.Equal(t, displayName, updated.DisplayName)
 	}
 }
+
+// A malformed token is a bad request, not a stale one. Recovering from it as a
+// replay would accept a write whose concurrency claim was never valid.
+func TestAddSkillVersionRejectsAMalformedExpectedVersionEvenWhenContentMatches(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "malformed", "First summary.")
+	malformed := "not-a-uuid"
+
+	_, err := ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: created.Version.Content,
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: &malformed,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// A metadata retry whose values already match is the same no-op the equivalent
+// version write gets, even once a concurrent version has made its token stale.
+//
+// The concurrent version repeats the manifest description on purpose: recording
+// a version syncs the registry summary from it, so a version carrying different
+// prose genuinely changes the metadata and is a conflict rather than a replay.
+func TestUpdateSkillTreatsAReplayedEditAsANoOpAfterAConcurrentVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "replayed", "First summary.")
+	summary := "First summary."
+	applied, err := ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: created.Skill.ID, Name: "replayed", DisplayName: "Replayed", Summary: &summary, Tags: nil,
+		ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	// A concurrent author records a version, so the caller's token goes stale
+	// through no fault of its own.
+	_, err = ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: skillManifest("replayed", "First summary.", "second"),
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: nil,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	replayed, err := ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: created.Skill.ID, Name: "replayed", DisplayName: "Replayed", Summary: &summary, Tags: nil,
+		ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, applied.DisplayName, replayed.DisplayName)
+}
+
+// A different edit under the same stale token is still a lost update.
+func TestUpdateSkillRejectsADifferentEditUnderAStaleToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "diverged", "First summary.")
+	_, err := ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: skillManifest("diverged", "Second summary.", "second"),
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: nil,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: created.Skill.ID, Name: "diverged", DisplayName: "Something Else", Summary: nil, Tags: nil,
+		ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+
+	requireOopsCode(t, err, oops.CodeConflict)
+}

--- a/server/internal/skills/expected_version_test.go
+++ b/server/internal/skills/expected_version_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/skills"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -204,4 +206,41 @@ func TestUpdateSkillRejectsADifferentEditUnderAStaleToken(t *testing.T) {
 	})
 
 	requireOopsCode(t, err, oops.CodeConflict)
+}
+
+// A replay writes nothing. Advancing updated_at or recording a second update
+// event would make a dropped response look like a real edit in the audit trail.
+func TestUpdateSkillReplayRecordsNoSecondUpdateEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "quiet-replay", "First summary.")
+	summary := "First summary."
+	applied, err := ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: created.Skill.ID, Name: "quiet-replay", DisplayName: "Quiet Replay", Summary: &summary, Tags: nil,
+		ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	_, err = ti.service.AddVersion(ctx, &gen.AddVersionPayload{
+		ID: created.Skill.ID, Content: skillManifest("quiet-replay", "First summary.", "second"),
+		DerivedFromVersionID: nil, ExpectedLatestVersionID: nil,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionSkillUpdate)
+	require.NoError(t, err)
+
+	replayed, err := ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: created.Skill.ID, Name: "quiet-replay", DisplayName: "Quiet Replay", Summary: &summary, Tags: nil,
+		ExpectedLatestVersionID: &created.Version.ID,
+		SessionToken:            nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionSkillUpdate)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "a replay records no second update event")
+	require.Equal(t, applied.UpdatedAt, replayed.UpdatedAt, "a replay does not advance updated_at")
 }

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -836,6 +836,9 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		if !skillMetadataMatches(skill, name, displayName, summary, tags) {
 			return nil, staleErr
 		}
+		// Returned before the write so a replay neither advances updated_at nor
+		// records a second update event for an edit that already happened.
+		return mv.BuildSkillView(skill, state.LatestVersionID, state.VersionCount, state.HasValidVersion, pgtype.Text{String: "", Valid: false}), nil
 	}
 
 	updated, err := queries.UpdateSkillDetails(ctx, repo.UpdateSkillDetailsParams{

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -286,26 +286,37 @@ func resolveDerivedFromVersion(ctx context.Context, queries *repo.Queries, proje
 	return uuid.NullUUID{UUID: versionID, Valid: true}, uuid.NullUUID{UUID: version.SkillID, Valid: true}, nil
 }
 
-// requireExpectedLatestVersion enforces a caller's optimistic concurrency
-// token. It runs inside the transaction that performs the write, so a skill
-// that moves on between the caller's read and its write is a conflict rather
-// than a silent overwrite of someone else's version.
+// parseExpectedLatestVersion validates a caller's optimistic concurrency token.
+//
+// Parsing is deliberately separate from comparing. Both write paths recover
+// from a stale token when the write turns out to be a replay, and a combined
+// check would let those recovery paths swallow a malformed token as though it
+// were merely stale — accepting a write whose concurrency claim was never
+// valid in the first place.
 //
 // The token names the version the caller believed was current, not a counter:
 // version IDs are what every skill read already returns, so a caller has one
 // without a second lookup.
-func requireExpectedLatestVersion(expected *string, latestVersionID uuid.UUID) error {
+func parseExpectedLatestVersion(expected *string) (uuid.NullUUID, error) {
 	if expected == nil {
-		return nil
+		return uuid.NullUUID{UUID: uuid.Nil, Valid: false}, nil
 	}
 	expectedID, err := uuid.Parse(*expected)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid expected latest version id")
+		return uuid.NullUUID{UUID: uuid.Nil, Valid: false}, oops.E(oops.CodeBadRequest, err, "invalid expected latest version id")
 	}
-	if expectedID != latestVersionID {
-		return oops.E(oops.CodeConflict, nil, "the skill has a newer version than the expected one; re-read the skill and retry")
-	}
-	return nil
+	return uuid.NullUUID{UUID: expectedID, Valid: true}, nil
+}
+
+// expectedLatestVersionStale reports whether the skill has moved on since the
+// caller read it. It runs inside the transaction that performs the write, so a
+// concurrent version is a conflict rather than a silent overwrite.
+func expectedLatestVersionStale(expected uuid.NullUUID, latestVersionID uuid.UUID) bool {
+	return expected.Valid && expected.UUID != latestVersionID
+}
+
+func errSkillVersionConflict() error {
+	return oops.E(oops.CodeConflict, nil, "the skill has a newer version than the expected one; re-read the skill and retry")
 }
 
 type distributionTarget struct {
@@ -636,18 +647,16 @@ func (s *Service) AddVersion(ctx context.Context, payload *gen.AddVersionPayload
 	if skill.Name != parsed.Name && !parentSkillID.Valid {
 		return nil, oops.E(oops.CodeInvalid, nil, "manifest name does not match the skill")
 	}
-	if payload.ExpectedLatestVersionID != nil {
-		// Parsed before the staleness check so a malformed token stays a bad
-		// request. Recovering from it as though it were merely stale would
-		// accept a write whose concurrency claim was never valid.
-		if _, err := uuid.Parse(*payload.ExpectedLatestVersionID); err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid expected latest version id")
-		}
+	expectedLatest, err := parseExpectedLatestVersion(payload.ExpectedLatestVersionID)
+	if err != nil {
+		return nil, err
+	}
+	if expectedLatest.Valid {
 		state, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "load skill state before adding version").LogError(ctx, logger)
 		}
-		if staleErr := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); staleErr != nil {
+		if expectedLatestVersionStale(expectedLatest, state.LatestVersionID) {
 			// A retried write that already landed is stale by its own token,
 			// but it is not a lost update: the version it created is current
 			// and carries exactly this content, so it stays the same no-op an
@@ -661,11 +670,11 @@ func (s *Service) AddVersion(ctx context.Context, payload *gen.AddVersionPayload
 			case errors.Is(hashErr, pgx.ErrNoRows):
 				// The content is genuinely new, so the stale token is a real
 				// conflict rather than a replay.
-				return nil, staleErr
+				return nil, errSkillVersionConflict()
 			case hashErr != nil:
 				return nil, oops.E(oops.CodeUnexpected, hashErr, "resolve skill version by hash for stale token recovery").LogError(ctx, logger)
 			case matched.ID != state.LatestVersionID:
-				return nil, staleErr
+				return nil, errSkillVersionConflict()
 			}
 		}
 	}
@@ -809,6 +818,10 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 	if err != nil {
 		return nil, err
 	}
+	expectedLatest, err := parseExpectedLatestVersion(payload.ExpectedLatestVersionID)
+	if err != nil {
+		return nil, err
+	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -827,14 +840,14 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load skill state before update").LogError(ctx, logger)
 	}
-	if staleErr := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); staleErr != nil {
+	if expectedLatestVersionStale(expectedLatest, state.LatestVersionID) {
 		// Metadata edits never create a version, so this token only goes stale
 		// when someone else records one. A retry of an edit that already landed
 		// is then indistinguishable from a lost update by token alone — except
 		// that the values it asks for are already the values in place, which
 		// makes it the same no-op the equivalent version write gets.
 		if !skillMetadataMatches(skill, name, displayName, summary, tags) {
-			return nil, staleErr
+			return nil, errSkillVersionConflict()
 		}
 		// Returned before the write so a replay neither advances updated_at nor
 		// records a second update event for an edit that already happened.

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -285,6 +285,28 @@ func resolveDerivedFromVersion(ctx context.Context, queries *repo.Queries, proje
 	return uuid.NullUUID{UUID: versionID, Valid: true}, uuid.NullUUID{UUID: version.SkillID, Valid: true}, nil
 }
 
+// requireExpectedLatestVersion enforces a caller's optimistic concurrency
+// token. It runs inside the transaction that performs the write, so a skill
+// that moves on between the caller's read and its write is a conflict rather
+// than a silent overwrite of someone else's version.
+//
+// The token names the version the caller believed was current, not a counter:
+// version IDs are what every skill read already returns, so a caller has one
+// without a second lookup.
+func requireExpectedLatestVersion(expected *string, latestVersionID uuid.UUID) error {
+	if expected == nil {
+		return nil
+	}
+	expectedID, err := uuid.Parse(*expected)
+	if err != nil {
+		return oops.E(oops.CodeBadRequest, err, "invalid expected latest version id")
+	}
+	if expectedID != latestVersionID {
+		return oops.E(oops.CodeConflict, nil, "the skill has a newer version than the expected one; re-read the skill and retry")
+	}
+	return nil
+}
+
 type distributionTarget struct {
 	channel     string
 	pluginID    uuid.NullUUID
@@ -613,6 +635,26 @@ func (s *Service) AddVersion(ctx context.Context, payload *gen.AddVersionPayload
 	if skill.Name != parsed.Name && !parentSkillID.Valid {
 		return nil, oops.E(oops.CodeInvalid, nil, "manifest name does not match the skill")
 	}
+	if payload.ExpectedLatestVersionID != nil {
+		state, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "load skill state before adding version").LogError(ctx, logger)
+		}
+		if err := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); err != nil {
+			// A retried write that already landed is stale by its own token,
+			// but it is not a lost update: the version it created is current
+			// and carries exactly this content, so it stays the same no-op an
+			// unconditional retry would get.
+			matched, hashErr := queries.GetSkillVersionByHash(ctx, repo.GetSkillVersionByHashParams{
+				ProjectID:       *authCtx.ProjectID,
+				SkillID:         skill.ID,
+				CanonicalSha256: parsed.CanonicalSHA256,
+			})
+			if hashErr != nil || matched.ID != state.LatestVersionID {
+				return nil, err
+			}
+		}
+	}
 
 	result, err := s.recordVersion(ctx, dbtx, queries, authCtx, logger, skill, parsed, false, false, derivedFromVersionID)
 	if err != nil {
@@ -770,6 +812,11 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 	state, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load skill state before update").LogError(ctx, logger)
+	}
+	// Metadata edits never create a version, so a retry of a metadata write
+	// that already landed carries the same token and stays valid.
+	if err := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); err != nil {
+		return nil, err
 	}
 
 	updated, err := queries.UpdateSkillDetails(ctx, repo.UpdateSkillDetailsParams{

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -636,11 +637,17 @@ func (s *Service) AddVersion(ctx context.Context, payload *gen.AddVersionPayload
 		return nil, oops.E(oops.CodeInvalid, nil, "manifest name does not match the skill")
 	}
 	if payload.ExpectedLatestVersionID != nil {
+		// Parsed before the staleness check so a malformed token stays a bad
+		// request. Recovering from it as though it were merely stale would
+		// accept a write whose concurrency claim was never valid.
+		if _, err := uuid.Parse(*payload.ExpectedLatestVersionID); err != nil {
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid expected latest version id")
+		}
 		state, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "load skill state before adding version").LogError(ctx, logger)
 		}
-		if err := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); err != nil {
+		if staleErr := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); staleErr != nil {
 			// A retried write that already landed is stale by its own token,
 			// but it is not a lost update: the version it created is current
 			// and carries exactly this content, so it stays the same no-op an
@@ -650,8 +657,15 @@ func (s *Service) AddVersion(ctx context.Context, payload *gen.AddVersionPayload
 				SkillID:         skill.ID,
 				CanonicalSha256: parsed.CanonicalSHA256,
 			})
-			if hashErr != nil || matched.ID != state.LatestVersionID {
-				return nil, err
+			switch {
+			case errors.Is(hashErr, pgx.ErrNoRows):
+				// The content is genuinely new, so the stale token is a real
+				// conflict rather than a replay.
+				return nil, staleErr
+			case hashErr != nil:
+				return nil, oops.E(oops.CodeUnexpected, hashErr, "resolve skill version by hash for stale token recovery").LogError(ctx, logger)
+			case matched.ID != state.LatestVersionID:
+				return nil, staleErr
 			}
 		}
 	}
@@ -813,10 +827,15 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load skill state before update").LogError(ctx, logger)
 	}
-	// Metadata edits never create a version, so a retry of a metadata write
-	// that already landed carries the same token and stays valid.
-	if err := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); err != nil {
-		return nil, err
+	if staleErr := requireExpectedLatestVersion(payload.ExpectedLatestVersionID, state.LatestVersionID); staleErr != nil {
+		// Metadata edits never create a version, so this token only goes stale
+		// when someone else records one. A retry of an edit that already landed
+		// is then indistinguishable from a lost update by token alone — except
+		// that the values it asks for are already the values in place, which
+		// makes it the same no-op the equivalent version write gets.
+		if !skillMetadataMatches(skill, name, displayName, summary, tags) {
+			return nil, staleErr
+		}
 	}
 
 	updated, err := queries.UpdateSkillDetails(ctx, repo.UpdateSkillDetailsParams{
@@ -854,6 +873,27 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 	}
 
 	return mv.BuildSkillView(updated, state.LatestVersionID, state.VersionCount, state.HasValidVersion, pgtype.Text{String: "", Valid: false}), nil
+}
+
+// skillMetadataMatches reports whether a skill already carries exactly the
+// metadata a write is asking for, which is what separates a replayed edit from
+// one that would overwrite someone else's.
+func skillMetadataMatches(skill repo.Skill, name, displayName string, summary *string, tags []string) bool {
+	if skill.Name != name || skill.DisplayName != displayName {
+		return false
+	}
+	currentSummary := ""
+	if skill.Summary.Valid {
+		currentSummary = skill.Summary.String
+	}
+	requestedSummary := ""
+	if summary != nil {
+		requestedSummary = *summary
+	}
+	if currentSummary != requestedSummary {
+		return false
+	}
+	return slices.Equal(skillTagsOrEmpty(skill.Tags), skillTagsOrEmpty(tags))
 }
 
 func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.ListSkillsResult, error) {


### PR DESCRIPTION
Lane D4 of Track D in the Platform MCP RFC (AGE-3169). Adds skill authoring and distribution to the Platform MCP tool catalogue, served both on the OAuth endpoint and to a project's managed assistant.

## Tools

`list_skills`, `get_skill`, `list_skill_versions`, `create_skill`, `add_skill_version`, `update_skill_metadata`, `distribute_skill` — each with a purpose-built schema, the shared budget/gate/kill-switch machinery, and an "unavailable" stub so a rollout flip changes what a tool answers rather than whether it exists.

They call the skills management service rather than its repositories, so manifest validation, version immutability, canonical-content idempotency, and typed audit stay defined once for every surface that authors a skill.

## Authoring is inert

Authoring alone has no runtime effect, and a model that reads "created" and stops leaves a skill nothing will ever load. Every authoring result therefore states the skill is inert and names the plugins and assistants it can be distributed to.

`distribute_skill` is the only activation path. It resolves an exact existing target by id, slug, or name — refusing an unmatched name as `not_found` and an ambiguous one as `ambiguous_target`, never falling back to the default plugin. Resolution reads a wider window than the advice list shows, so a display cap cannot manufacture a false `not_found`.

Target resolution is the half of lane D6 that distribution depends on. It ships here so D4 does not wait on D6's inventory and usage work; D6 should consume `resolveTarget` rather than reinvent it.

## Optimistic concurrency

`skills.addVersion` and `skills.update` take an optional `expected_latest_version_id`, enforced inside the write's own transaction. A write against a skill that has moved on is a `conflict` instead of a silent overwrite. `derived_from_version_id` looked like this but is only provenance — it never rejected a stale parent.

A retried write whose canonical content is already current stays the no-op it was, so a dropped response does not strand the caller in an unresolvable conflict.

## Authorization gap

Found while writing the vertical test, and fixed here rather than left for the lanes that would inherit it.

`authz.Engine.ShouldEnforce` and `PrepareContext` both bail when `AuthContext.SessionID` is nil and the caller is not an assistant principal. A session-less Platform MCP call therefore had every scope check pass regardless of the acting user's grants; only the endpoint's org-admin check stood in front of it.

- `enforcedWithoutSession` now recognises the Platform MCP acting surface alongside the assistant principal.
- The lane loads the acting user's grants itself, because it never travels the session middleware that prepares them for dashboard requests.
- `begin` carries an incoming session through instead of discarding it, so a context can never leave weaker than it arrived.

## Testing

- Vertical slice over a real MCP client, the real skills service, and Postgres: create → read → re-version → conflict → refuse an unmatched target → distribute → idempotent repeat, asserting the database at each step.
- Cross-project target refusal, capability-off refusal (tool still listed), and a member holding no role refused by RBAC — the last of these passed before the authorization fix, which is how it was found.
- Service-level tests for the version token, including the retried-identical-write no-op.
- Unit tests for target resolution, inert messaging, content opt-in and truncation, budget ordering, and refusal mapping.

## Out of scope

Files, archives, URLs, arbitrary plugins, sharing, undistribute, and archive/delete, per the RFC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds skill authoring and distribution tools to Platform MCP and the managed assistant. Authoring is inert; only distribution activates a skill. Enforces optimistic concurrency via expected_latest_version_id, validating the token before replay recovery so malformed tokens are 400 and stale tokens are conflicts.

- Serves seven tools (list_skills, get_skill, list_skill_versions, create_skill, add_skill_version, update_skill_metadata, distribute_skill) that are always present and may return “unavailable” under a gate/kill-switch.
- Authoring calls the skills service to reuse validation, immutability, idempotency, and typed audit. Results state inertness and list eligible targets; list_skills uses the service’s ordering; included manifest content is truncated on a rune boundary; the advice list is independently capped.
- Distribution resolves an exact existing plugin or assistant and refuses ambiguous or missing targets (ambiguous_target, not_found); never falls back to a default plugin. Per-kind caps prevent plugins from hiding assistants. get_skill reports plugin-only distribution as distributed.
- Optimistic concurrency: add/update accept expected_latest_version_id, validated before any replay recovery and enforced in-transaction. Malformed tokens are 400; storage failures are not conflated with “content is not current.” Retries that are identical writes or matching metadata edits are no-ops and, on stale-token retries, return the current skill without advancing updated_at. OpenAPI and dashboard SDK types updated.
- Closes an authorization gap: RBAC now enforces for the Platform MCP acting surface without a browser session, loads the acting user’s grants, and carries an incoming session through.
- Adds Skills operation budgets and rate limits; wires the skills service into the Platform MCP runtime; vertical, unit, and service tests added; test infra launches Redis. Satisfies lane D4 of the Platform MCP RFC (AGE-3169) and ships target resolution used by D6.

**Rollout and migration**
- No required migrations; new fields are optional and tools are gated.
- OAuth Platform MCP clients may pass expected_latest_version_id to avoid write conflicts.
- Ensure deployments provide the skills service to the Platform MCP runtime and RBAC grants for OAuth-authenticated users.

<sup>Written for commit 8b5077f34cafcadaeddc072edd8090bbdf2536bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

