### PR TITLE
fix: refuse device-agent enrollment under impersonation (DNO-938)

### DIFF
--- a/.changeset/device-agent-enrollment-impersonation.md
+++ b/.changeset/device-agent-enrollment-impersonation.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Refuse device-agent manual enrollment under impersonation: cliAuth.authorize now rejects admin org-override sessions, WorkOS user-impersonation sessions, and sessions whose user is not a member of the active organization.
+Refuse device-agent manual enrollment while impersonating an organization or user, or without membership in the active organization.

--- a/.changeset/device-agent-enrollment-impersonation.md
+++ b/.changeset/device-agent-enrollment-impersonation.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Refuse device-agent manual enrollment under impersonation: cliAuth.authorize now rejects admin org-override sessions, WorkOS user-impersonation sessions, and sessions whose user is not a member of the active organization (DNO-938).
+Refuse device-agent manual enrollment under impersonation: cliAuth.authorize now rejects admin org-override sessions, WorkOS user-impersonation sessions, and sessions whose user is not a member of the active organization.

--- a/.changeset/device-agent-enrollment-impersonation.md
+++ b/.changeset/device-agent-enrollment-impersonation.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Refuse device-agent manual enrollment under impersonation: cliAuth.authorize now rejects admin org-override sessions, WorkOS user-impersonation sessions, and sessions whose user is not a member of the active organization (DNO-938).

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -11689,7 +11689,7 @@ paths:
       x-speakeasy-name-override: revoke
   /rpc/cliAuth.authorize:
     post:
-      description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
+      description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.
       operationId: cliAuthAuthorize
       parameters:
         - allowEmptyValue: true

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -11689,7 +11689,7 @@ paths:
       x-speakeasy-name-override: revoke
   /rpc/cliAuth.authorize:
     post:
-      description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.
+      description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
       operationId: cliAuthAuthorize
       parameters:
         - allowEmptyValue: true

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -11689,7 +11689,7 @@ paths:
       x-speakeasy-name-override: revoke
   /rpc/cliAuth.authorize:
     post:
-      description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
+      description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
       operationId: cliAuthAuthorize
       parameters:
         - allowEmptyValue: true

--- a/client/dashboard/src/sdk/src/funcs/cliAuthAuthorize.ts
+++ b/client/dashboard/src/sdk/src/funcs/cliAuthAuthorize.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * authorize cliAuth
  *
  * @remarks
- * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
+ * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.
  */
 export function cliAuthAuthorize(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/funcs/cliAuthAuthorize.ts
+++ b/client/dashboard/src/sdk/src/funcs/cliAuthAuthorize.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * authorize cliAuth
  *
  * @remarks
- * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
+ * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
  */
 export function cliAuthAuthorize(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/funcs/cliAuthAuthorize.ts
+++ b/client/dashboard/src/sdk/src/funcs/cliAuthAuthorize.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * authorize cliAuth
  *
  * @remarks
- * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.
+ * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
  */
 export function cliAuthAuthorize(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/react-query/cliAuthAuthorize.ts
+++ b/client/dashboard/src/sdk/src/react-query/cliAuthAuthorize.ts
@@ -54,7 +54,7 @@ export type CliAuthAuthorizeMutationError =
  * authorize cliAuth
  *
  * @remarks
- * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
+ * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.
  */
 export function useCliAuthAuthorizeMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/react-query/cliAuthAuthorize.ts
+++ b/client/dashboard/src/sdk/src/react-query/cliAuthAuthorize.ts
@@ -54,7 +54,7 @@ export type CliAuthAuthorizeMutationError =
  * authorize cliAuth
  *
  * @remarks
- * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
+ * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
  */
 export function useCliAuthAuthorizeMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/react-query/cliAuthAuthorize.ts
+++ b/client/dashboard/src/sdk/src/react-query/cliAuthAuthorize.ts
@@ -54,7 +54,7 @@ export type CliAuthAuthorizeMutationError =
  * authorize cliAuth
  *
  * @remarks
- * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.
+ * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
  */
 export function useCliAuthAuthorizeMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/sdk/cliauth.ts
+++ b/client/dashboard/src/sdk/src/sdk/cliauth.ts
@@ -19,7 +19,7 @@ export class CliAuth extends ClientSDK {
    * authorize cliAuth
    *
    * @remarks
-   * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
+   * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
    */
   async authorize(
     request: CliAuthAuthorizeRequest,

--- a/client/dashboard/src/sdk/src/sdk/cliauth.ts
+++ b/client/dashboard/src/sdk/src/sdk/cliauth.ts
@@ -19,7 +19,7 @@ export class CliAuth extends ClientSDK {
    * authorize cliAuth
    *
    * @remarks
-   * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.
+   * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
    */
   async authorize(
     request: CliAuthAuthorizeRequest,

--- a/client/dashboard/src/sdk/src/sdk/cliauth.ts
+++ b/client/dashboard/src/sdk/src/sdk/cliauth.ts
@@ -19,7 +19,7 @@ export class CliAuth extends ClientSDK {
    * authorize cliAuth
    *
    * @remarks
-   * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
+   * Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.
    */
   async authorize(
     request: CliAuthAuthorizeRequest,

--- a/server/design/cliauth/design.go
+++ b/server/design/cliauth/design.go
@@ -23,7 +23,7 @@ var _ = Service("cliAuth", func() {
 	shared.DeclareErrorResponses()
 
 	Method("authorize", func() {
-		Description("Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).")
+		Description("Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.")
 
 		Security(security.Session)
 

--- a/server/design/cliauth/design.go
+++ b/server/design/cliauth/design.go
@@ -23,7 +23,7 @@ var _ = Service("cliAuth", func() {
 	shared.DeclareErrorResponses()
 
 	Method("authorize", func() {
-		Description("Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.")
+		Description("Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.")
 
 		Security(security.Session)
 

--- a/server/design/cliauth/design.go
+++ b/server/design/cliauth/design.go
@@ -23,7 +23,7 @@ var _ = Service("cliAuth", func() {
 	shared.DeclareErrorResponses()
 
 	Method("authorize", func() {
-		Description("Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.")
+		Description("Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).")
 
 		Security(security.Session)
 

--- a/server/gen/cli_auth/service.go
+++ b/server/gen/cli_auth/service.go
@@ -23,7 +23,10 @@ type Service interface {
 	// of the authenticated dashboard user. Resolves the target project (given
 	// slug, else the org's default/first project) and records {user, org, project,
 	// scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL.
-	// Requires a member-available session (org:read); NOT org-admin.
+	// Requires a member-available session (org:read); NOT org-admin. Refused (403)
+	// under any form of impersonation — an admin org override, a WorkOS
+	// user-impersonation session, or a session whose user is not an actual member
+	// of the active org (DNO-938).
 	Authorize(context.Context, *AuthorizePayload) (res *AuthorizeResult, err error)
 	// Exchange a one-time code plus its PKCE code_verifier for a freshly minted
 	// per-user [agent,hooks] API key. No session or API-key auth: proving

--- a/server/gen/cli_auth/service.go
+++ b/server/gen/cli_auth/service.go
@@ -26,7 +26,7 @@ type Service interface {
 	// Requires a member-available session (org:read); NOT org-admin. Refused (403)
 	// under any form of impersonation — an admin org override, a WorkOS
 	// user-impersonation session, or a session whose user is not an actual member
-	// of the active org (DNO-938).
+	// of the active org.
 	Authorize(context.Context, *AuthorizePayload) (res *AuthorizeResult, err error)
 	// Exchange a one-time code plus its PKCE code_verifier for a freshly minted
 	// per-user [agent,hooks] API key. No session or API-key auth: proving

--- a/server/gen/cli_auth/service.go
+++ b/server/gen/cli_auth/service.go
@@ -24,9 +24,8 @@ type Service interface {
 	// slug, else the org's default/first project) and records {user, org, project,
 	// scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL.
 	// Requires a member-available session (org:read); NOT org-admin. Refused (403)
-	// under any form of impersonation — an admin org override, a WorkOS
-	// user-impersonation session, or a session whose user is not an actual member
-	// of the active org.
+	// while impersonating an organization or user, or without membership in the
+	// active org.
 	Authorize(context.Context, *AuthorizePayload) (res *AuthorizeResult, err error)
 	// Exchange a one-time code plus its PKCE code_verifier for a freshly minted
 	// per-user [agent,hooks] API key. No session or API-key auth: proving

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11684,7 +11684,7 @@ func cliAuthUsage() {
 	fmt.Fprintln(os.Stderr, `Interactive device-agent enrollment via a PKCE one-time-code exchange. authorize (dashboard session) mints a short-lived code bound to a PKCE challenge; redeem (no auth — the code+verifier pair is the credential) exchanges it once for a per-user [agent,hooks] API key.`)
 	fmt.Fprintf(os.Stderr, "Usage:\n    %s [globalflags] cli-auth COMMAND [flags]\n\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "COMMAND:")
-	fmt.Fprintln(os.Stderr, `    authorize: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.`)
+	fmt.Fprintln(os.Stderr, `    authorize: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).`)
 	fmt.Fprintln(os.Stderr, `    redeem: Exchange a one-time code plus its PKCE code_verifier for a freshly minted per-user [agent,hooks] API key. No session or API-key auth: proving knowledge of the code_verifier that matches the stored challenge IS the credential. The code is single-use — consumed atomically on lookup — so any missing/expired/already-consumed code or PKCE mismatch returns 401. The raw key is returned exactly once and never again.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
@@ -11699,7 +11699,7 @@ func cliAuthAuthorizeUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.`)
+	fmt.Fprintln(os.Stderr, `Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11684,7 +11684,7 @@ func cliAuthUsage() {
 	fmt.Fprintln(os.Stderr, `Interactive device-agent enrollment via a PKCE one-time-code exchange. authorize (dashboard session) mints a short-lived code bound to a PKCE challenge; redeem (no auth — the code+verifier pair is the credential) exchanges it once for a per-user [agent,hooks] API key.`)
 	fmt.Fprintf(os.Stderr, "Usage:\n    %s [globalflags] cli-auth COMMAND [flags]\n\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "COMMAND:")
-	fmt.Fprintln(os.Stderr, `    authorize: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).`)
+	fmt.Fprintln(os.Stderr, `    authorize: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.`)
 	fmt.Fprintln(os.Stderr, `    redeem: Exchange a one-time code plus its PKCE code_verifier for a freshly minted per-user [agent,hooks] API key. No session or API-key auth: proving knowledge of the code_verifier that matches the stored challenge IS the credential. The code is single-use — consumed atomically on lookup — so any missing/expired/already-consumed code or PKCE mismatch returns 401. The raw key is returned exactly once and never again.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
@@ -11699,7 +11699,7 @@ func cliAuthAuthorizeUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).`)
+	fmt.Fprintln(os.Stderr, `Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11684,7 +11684,7 @@ func cliAuthUsage() {
 	fmt.Fprintln(os.Stderr, `Interactive device-agent enrollment via a PKCE one-time-code exchange. authorize (dashboard session) mints a short-lived code bound to a PKCE challenge; redeem (no auth — the code+verifier pair is the credential) exchanges it once for a per-user [agent,hooks] API key.`)
 	fmt.Fprintf(os.Stderr, "Usage:\n    %s [globalflags] cli-auth COMMAND [flags]\n\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "COMMAND:")
-	fmt.Fprintln(os.Stderr, `    authorize: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.`)
+	fmt.Fprintln(os.Stderr, `    authorize: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.`)
 	fmt.Fprintln(os.Stderr, `    redeem: Exchange a one-time code plus its PKCE code_verifier for a freshly minted per-user [agent,hooks] API key. No session or API-key auth: proving knowledge of the code_verifier that matches the stored challenge IS the credential. The code is single-use — consumed atomically on lookup — so any missing/expired/already-consumed code or PKCE mismatch returns 401. The raw key is returned exactly once and never again.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
@@ -11699,7 +11699,7 @@ func cliAuthAuthorizeUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.`)
+	fmt.Fprintln(os.Stderr, `Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -13301,7 +13301,7 @@ paths:
             x-speakeasy-name-override: revoke
     /rpc/cliAuth.authorize:
         post:
-            description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
+            description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
             operationId: cliAuthAuthorize
             parameters:
                 - allowEmptyValue: true

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -13301,7 +13301,7 @@ paths:
             x-speakeasy-name-override: revoke
     /rpc/cliAuth.authorize:
         post:
-            description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org.
+            description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) while impersonating an organization or user, or without membership in the active org.
             operationId: cliAuthAuthorize
             parameters:
                 - allowEmptyValue: true

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -13301,7 +13301,7 @@ paths:
             x-speakeasy-name-override: revoke
     /rpc/cliAuth.authorize:
         post:
-            description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin.
+            description: Mint a short-lived one-time code bound to a PKCE code_challenge, on behalf of the authenticated dashboard user. Resolves the target project (given slug, else the org's default/first project) and records {user, org, project, scopes:[agent,hooks], challenge} against the code with a ~5 minute TTL. Requires a member-available session (org:read); NOT org-admin. Refused (403) under any form of impersonation — an admin org override, a WorkOS user-impersonation session, or a session whose user is not an actual member of the active org (DNO-938).
             operationId: cliAuthAuthorize
             parameters:
                 - allowEmptyValue: true

--- a/server/internal/cliauth/authorize_test.go
+++ b/server/internal/cliauth/authorize_test.go
@@ -44,7 +44,7 @@ func TestAuthorize_MemberSessionSucceeds(t *testing.T) {
 
 // A Speakeasy admin impersonating an org via the dev-tools override — the
 // override targeting the session's active org — is refused enrollment
-// outright, even though impersonation grants every RBAC scope (DNO-938):
+// outright, even though impersonation grants every RBAC scope:
 // enrolling would bind the admin's device to that org's policies and route
 // session transcripts there.
 func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {

--- a/server/internal/cliauth/authorize_test.go
+++ b/server/internal/cliauth/authorize_test.go
@@ -1,0 +1,168 @@
+package cliauth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	mockidp "github.com/speakeasy-api/gram/dev-idp/pkg/testidp"
+	gen "github.com/speakeasy-api/gram/server/gen/cli_auth"
+	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// A plain org member authorizes and the device agent redeems: the full
+// PKCE exchange mints a per-user key carrying the member's identity.
+func TestAuthorize_MemberSessionSucceeds(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	verifier, challenge := pkcePair(t)
+
+	authorized, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ProjectSlug:         nil,
+		SessionToken:        nil,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, authorized.Code)
+	require.Positive(t, authorized.ExpiresIn)
+
+	redeemed, err := ti.service.Redeem(ctx, &gen.RedeemPayload{
+		Code:         authorized.Code,
+		CodeVerifier: verifier,
+	})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(redeemed.AccessToken, "gram_local_"))
+	require.Equal(t, mockidp.MockUserEmail, redeemed.UserEmail)
+	require.NotEmpty(t, redeemed.ProjectSlug)
+}
+
+// A Speakeasy admin impersonating a customer org via the dev-tools override is
+// refused enrollment outright, even though impersonation grants every RBAC
+// scope (DNO-938): enrolling would bind the admin's device to the customer
+// org's policies and route session transcripts there.
+func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.IsAdmin = true
+	ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
+
+	_, challenge := pkcePair(t)
+	_, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ProjectSlug:         nil,
+		SessionToken:        nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorContains(t, err, "impersonating an organization")
+}
+
+// A stray admin-override cookie on a NON-admin member's session must not block
+// enrollment: the override only ever takes effect for Speakeasy admins.
+func TestAuthorize_NonAdminWithOverrideValueSucceeds(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
+
+	_, challenge := pkcePair(t)
+	authorized, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ProjectSlug:         nil,
+		SessionToken:        nil,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, authorized.Code)
+}
+
+// A session minted through WorkOS user impersonation is refused enrollment:
+// the impersonating admin would otherwise walk away with a durable per-user
+// key bearing the impersonated user's identity.
+func TestAuthorize_ImpersonatedUserSessionBlocked(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	ctx = authenticateSession(t, ctx, ti, sessions.Session{
+		SessionID:            uuid.NewString(),
+		UserID:               mockidp.MockUserID,
+		ActiveOrganizationID: mockidp.MockOrgID,
+		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "support-admin@speakeasy.com",
+	})
+
+	_, challenge := pkcePair(t)
+	_, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ProjectSlug:         nil,
+		SessionToken:        nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorContains(t, err, "impersonating a user")
+}
+
+// An admin session parked on an org the admin is not a member of — an
+// impersonation session that outlived its override cookie — is refused by the
+// membership backstop even with no override present on the request.
+func TestAuthorize_AdminSessionOnNonMemberOrgBlocked(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	adminID := seedUser(t, ctx, ti.conn, "test-admin-"+uuid.NewString()[:8], "admin@speakeasy.com", true)
+	customerOrgID := uuid.NewString()
+	seedOrgMetadata(t, ctx, ti.conn, customerOrgID, "Customer Org", "customer-org-"+customerOrgID[:8])
+
+	ctx = authenticateSession(t, ctx, ti, sessions.Session{
+		SessionID:            uuid.NewString(),
+		UserID:               adminID,
+		ActiveOrganizationID: customerOrgID,
+		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "",
+	})
+
+	_, challenge := pkcePair(t)
+	_, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ProjectSlug:         nil,
+		SessionToken:        nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorContains(t, err, "requires membership")
+}
+
+// The shared demo org has no membership rows by design, and any authenticated
+// user may hold a session pointed at it — but a real device must never enroll
+// there: its transcripts would land in an org every prospect can read.
+func TestAuthorize_DemoOrgSessionBlocked(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	seedOrgMetadata(t, ctx, ti.conn, constants.DemoOrganizationID, "Acme Demo Workspace", "acme-demo")
+
+	ctx = authenticateSession(t, ctx, ti, sessions.Session{
+		SessionID:            uuid.NewString(),
+		UserID:               mockidp.MockUserID,
+		ActiveOrganizationID: constants.DemoOrganizationID,
+		WorkOSSessionID:      "",
+		ImpersonatorEmail:    "",
+	})
+
+	_, challenge := pkcePair(t)
+	_, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ProjectSlug:         nil,
+		SessionToken:        nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorContains(t, err, "requires membership")
+}

--- a/server/internal/cliauth/authorize_test.go
+++ b/server/internal/cliauth/authorize_test.go
@@ -42,17 +42,18 @@ func TestAuthorize_MemberSessionSucceeds(t *testing.T) {
 	require.NotEmpty(t, redeemed.ProjectSlug)
 }
 
-// A Speakeasy admin impersonating a customer org via the dev-tools override is
-// refused enrollment outright, even though impersonation grants every RBAC
-// scope (DNO-938): enrolling would bind the admin's device to the customer
-// org's policies and route session transcripts there.
+// A Speakeasy admin impersonating an org via the dev-tools override — the
+// override targeting the session's active org — is refused enrollment
+// outright, even though impersonation grants every RBAC scope (DNO-938):
+// enrolling would bind the admin's device to that org's policies and route
+// session transcripts there.
 func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	authCtx.IsAdmin = true
-	ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
+	ctx = contextvalues.SetAdminOverrideInContext(ctx, mockidp.MockOrgSlug)
 
 	_, challenge := pkcePair(t)
 	_, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
@@ -63,6 +64,29 @@ func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
 	require.ErrorContains(t, err, "impersonating an organization")
+}
+
+// A stale gram_admin_override cookie pointing at some OTHER org must not block
+// an admin enrolling on their own org: the cookie survives switching back, and
+// the refusal only applies when the override targets the active org. The
+// membership backstop still guards genuine parked-impersonation sessions.
+func TestAuthorize_AdminWithStaleOverrideOnOwnOrgSucceeds(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.IsAdmin = true
+	ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
+
+	_, challenge := pkcePair(t)
+	authorized, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ProjectSlug:         nil,
+		SessionToken:        nil,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, authorized.Code)
 }
 
 // A stray admin-override cookie on a NON-admin member's session must not block

--- a/server/internal/cliauth/authorize_test.go
+++ b/server/internal/cliauth/authorize_test.go
@@ -41,14 +41,15 @@ func TestAuthorize_MemberSessionSucceeds(t *testing.T) {
 	require.NotEmpty(t, redeemed.ProjectSlug)
 }
 
-// An admin impersonating the active org via the dev-tools override is refused.
-func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {
+// An admin impersonating the active org via a support session is refused.
+func TestAuthorize_ImpersonatingAdminSupportSessionBlocked(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	authCtx.IsAdmin = true
-	ctx = contextvalues.SetAdminOverrideInContext(ctx, mockidp.MockOrgSlug)
+	authCtx.SupportOrganizationID = authCtx.ActiveOrganizationID
+	ctx = contextvalues.WithValidatedSupportSession(ctx, authCtx)
 
 	_, challenge := pkcePair(t)
 	_, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
@@ -61,15 +62,16 @@ func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {
 	require.ErrorContains(t, err, "impersonating an organization")
 }
 
-// A stale override cookie pointing at another org must not block an admin's
+// A support session opened against another org must not block an admin's
 // own-org enrollment.
-func TestAuthorize_AdminWithStaleOverrideOnOwnOrgSucceeds(t *testing.T) {
+func TestAuthorize_AdminWithSupportSessionElsewhereOnOwnOrgSucceeds(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	authCtx.IsAdmin = true
-	ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
+	authCtx.SupportOrganizationID = "customer-org"
+	ctx = contextvalues.WithValidatedSupportSession(ctx, authCtx)
 
 	_, challenge := pkcePair(t)
 	authorized, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
@@ -82,11 +84,15 @@ func TestAuthorize_AdminWithStaleOverrideOnOwnOrgSucceeds(t *testing.T) {
 	require.NotEmpty(t, authorized.Code)
 }
 
-// The override only takes effect for admins; a non-admin member enrolls fine.
-func TestAuthorize_NonAdminWithOverrideValueSucceeds(t *testing.T) {
+// Support authority only takes effect for admins; a non-admin member with a
+// support org recorded on the session still enrolls fine.
+func TestAuthorize_NonAdminWithSupportOrgSucceeds(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
-	ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.SupportOrganizationID = authCtx.ActiveOrganizationID
+	ctx = contextvalues.WithValidatedSupportSession(ctx, authCtx)
 
 	_, challenge := pkcePair(t)
 	authorized, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
@@ -123,8 +129,11 @@ func TestAuthorize_ImpersonatedUserSessionBlocked(t *testing.T) {
 	require.ErrorContains(t, err, "impersonating a user")
 }
 
-// An admin session on a non-member org is refused even with no override set.
-func TestAuthorize_AdminSessionOnNonMemberOrgBlocked(t *testing.T) {
+// An admin parked on a non-member org without a live support session never
+// reaches the handler: session authentication itself refuses. Pinned here so a
+// relaxation upstream shows up as a cliauth failure — the membership backstop
+// in Authorize is the second line of defense, not the first.
+func TestAuthorize_AdminSessionOnNonMemberOrgRefusedAtAuth(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
 
@@ -132,23 +141,17 @@ func TestAuthorize_AdminSessionOnNonMemberOrgBlocked(t *testing.T) {
 	customerOrgID := uuid.NewString()
 	seedOrgMetadata(t, ctx, ti.conn, customerOrgID, "Customer Org", "customer-org-"+customerOrgID[:8])
 
-	ctx = authenticateSession(t, ctx, ti, sessions.Session{
+	session := sessions.Session{
 		SessionID:            uuid.NewString(),
 		UserID:               adminID,
 		ActiveOrganizationID: customerOrgID,
 		WorkOSSessionID:      "",
 		ImpersonatorEmail:    "",
-	})
+	}
+	require.NoError(t, ti.sessionManager.StoreSession(ctx, session))
 
-	_, challenge := pkcePair(t)
-	_, err := ti.service.Authorize(ctx, &gen.AuthorizePayload{
-		CodeChallenge:       challenge,
-		CodeChallengeMethod: "S256",
-		ProjectSlug:         nil,
-		SessionToken:        nil,
-	})
+	_, err := ti.sessionManager.Authenticate(ctx, session.SessionID)
 	requireOopsCode(t, err, oops.CodeForbidden)
-	require.ErrorContains(t, err, "requires membership")
 }
 
 // The shared demo org has no memberships; devices must never enroll there.

--- a/server/internal/cliauth/authorize_test.go
+++ b/server/internal/cliauth/authorize_test.go
@@ -15,8 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-// A plain org member authorizes and the device agent redeems: the full
-// PKCE exchange mints a per-user key carrying the member's identity.
+// A plain org member completes the full authorize→redeem PKCE exchange.
 func TestAuthorize_MemberSessionSucceeds(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -42,11 +41,7 @@ func TestAuthorize_MemberSessionSucceeds(t *testing.T) {
 	require.NotEmpty(t, redeemed.ProjectSlug)
 }
 
-// A Speakeasy admin impersonating an org via the dev-tools override — the
-// override targeting the session's active org — is refused enrollment
-// outright, even though impersonation grants every RBAC scope:
-// enrolling would bind the admin's device to that org's policies and route
-// session transcripts there.
+// An admin impersonating the active org via the dev-tools override is refused.
 func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -66,10 +61,8 @@ func TestAuthorize_ImpersonatingAdminOrgOverrideBlocked(t *testing.T) {
 	require.ErrorContains(t, err, "impersonating an organization")
 }
 
-// A stale gram_admin_override cookie pointing at some OTHER org must not block
-// an admin enrolling on their own org: the cookie survives switching back, and
-// the refusal only applies when the override targets the active org. The
-// membership backstop still guards genuine parked-impersonation sessions.
+// A stale override cookie pointing at another org must not block an admin's
+// own-org enrollment.
 func TestAuthorize_AdminWithStaleOverrideOnOwnOrgSucceeds(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -89,8 +82,7 @@ func TestAuthorize_AdminWithStaleOverrideOnOwnOrgSucceeds(t *testing.T) {
 	require.NotEmpty(t, authorized.Code)
 }
 
-// A stray admin-override cookie on a NON-admin member's session must not block
-// enrollment: the override only ever takes effect for Speakeasy admins.
+// The override only takes effect for admins; a non-admin member enrolls fine.
 func TestAuthorize_NonAdminWithOverrideValueSucceeds(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -107,9 +99,7 @@ func TestAuthorize_NonAdminWithOverrideValueSucceeds(t *testing.T) {
 	require.NotEmpty(t, authorized.Code)
 }
 
-// A session minted through WorkOS user impersonation is refused enrollment:
-// the impersonating admin would otherwise walk away with a durable per-user
-// key bearing the impersonated user's identity.
+// A WorkOS user-impersonation session is refused.
 func TestAuthorize_ImpersonatedUserSessionBlocked(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -133,9 +123,7 @@ func TestAuthorize_ImpersonatedUserSessionBlocked(t *testing.T) {
 	require.ErrorContains(t, err, "impersonating a user")
 }
 
-// An admin session parked on an org the admin is not a member of — an
-// impersonation session that outlived its override cookie — is refused by the
-// membership backstop even with no override present on the request.
+// An admin session on a non-member org is refused even with no override set.
 func TestAuthorize_AdminSessionOnNonMemberOrgBlocked(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -163,9 +151,7 @@ func TestAuthorize_AdminSessionOnNonMemberOrgBlocked(t *testing.T) {
 	require.ErrorContains(t, err, "requires membership")
 }
 
-// The shared demo org has no membership rows by design, and any authenticated
-// user may hold a session pointed at it — but a real device must never enroll
-// there: its transcripts would land in an org every prospect can read.
+// The shared demo org has no memberships; devices must never enroll there.
 func TestAuthorize_DemoOrgSessionBlocked(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)

--- a/server/internal/cliauth/impl.go
+++ b/server/internal/cliauth/impl.go
@@ -153,10 +153,11 @@ func (s *Service) Authorize(ctx context.Context, payload *gen.AuthorizePayload) 
 	// device to the impersonated org's policies and transcript reporting.
 	// RBAC cannot gate this — impersonating admins hold every scope.
 
-	// Admin org-override impersonation. Only refused when the override
-	// targets the active org: the cookie outlives impersonation, and the
-	// membership check below still catches parked sessions.
-	if override, impersonating := contextvalues.GetAdminOverrideFromContext(ctx); impersonating && authCtx.IsAdmin && override == authCtx.OrganizationSlug {
+	// Platform-admin support session (the same predicate chat uses to protect
+	// transcripts). It is already scoped to the active org, so a support
+	// session opened against a different org does not block an admin from
+	// enrolling into their own.
+	if contextvalues.IsSupportSession(ctx) {
 		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating an organization").LogError(ctx, s.logger)
 	}
 
@@ -173,9 +174,12 @@ func (s *Service) Authorize(ctx context.Context, payload *gen.AuthorizePayload) 
 		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating a user").LogError(ctx, s.logger)
 	}
 
-	// Backstop: the user must be a real member of the active org (the demo
-	// org has no memberships). Resolved via GetUserInfo so lookup failures
-	// surface as unexpected errors, not a misleading 403.
+	// Backstop: the user must be a real member of the active org. Session
+	// authentication already refuses a foreign org without a live support
+	// session, but the shared demo org is exempt there (no membership rows by
+	// design) — enrolling a real device into it would report the operator's
+	// transcripts into a shared workspace. Resolved via GetUserInfo so lookup
+	// failures surface as unexpected errors, not a misleading 403.
 	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load user info").LogError(ctx, s.logger)

--- a/server/internal/cliauth/impl.go
+++ b/server/internal/cliauth/impl.go
@@ -78,6 +78,7 @@ type Service struct {
 	db          *pgxpool.Pool
 	auth        *auth.Auth
 	authz       *authz.Engine
+	sessions    *sessions.Manager
 	pkce        *oauth.PKCEService
 	redis       *redis.Client
 	projectRepo *projectsrepo.Queries
@@ -110,6 +111,7 @@ func NewService(
 		db:          db,
 		auth:        auth.New(logger, db, sessionManager, authzEngine),
 		authz:       authzEngine,
+		sessions:    sessionManager,
 		pkce:        oauth.NewPKCEService(logger),
 		redis:       redisClient,
 		projectRepo: projectsrepo.New(db),
@@ -144,6 +146,44 @@ func (s *Service) Authorize(ctx context.Context, payload *gen.AuthorizePayload) 
 	}
 	if authCtx.Email == nil || *authCtx.Email == "" {
 		return nil, oops.E(oops.CodeUnauthorized, nil, "session has no resolved email").LogError(ctx, s.logger)
+	}
+
+	// Enrollment binds a physical device to the session's active org — its
+	// policies, plugins, hooks, and session-transcript reporting — and mints a
+	// durable per-user key there. None of that is ever legitimate under an
+	// assumed identity, so every impersonation shape is refused outright
+	// (DNO-938). RBAC cannot carry this: an impersonating admin holds every
+	// scope (see authz.Engine), so the org:read gate below would wave them
+	// through.
+	//
+	// Shape 1: Speakeasy admin impersonating a customer org via the dev-tools
+	// override. Same refusal as chat-transcript access in chat.LoadChat.
+	if _, impersonating := contextvalues.GetAdminOverrideFromContext(ctx); impersonating && authCtx.IsAdmin {
+		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating an organization").LogError(ctx, s.logger)
+	}
+
+	// Shape 2: WorkOS user impersonation. The session was minted by an admin
+	// impersonating this user through the IDP; enrolling would hand the
+	// impersonator's device a real key bearing the user's identity.
+	if authCtx.SessionID != nil && *authCtx.SessionID != "" {
+		session, err := s.sessions.GetSession(ctx, *authCtx.SessionID)
+		if err != nil {
+			// The session authenticated this same request, so a lookup failure
+			// here is infrastructure trouble, not a bad credential. Fail closed.
+			return nil, oops.E(oops.CodeUnexpected, err, "load session").LogError(ctx, s.logger)
+		}
+		if session.ImpersonatorEmail != "" {
+			return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating a user").LogError(ctx, s.logger)
+		}
+	}
+
+	// Shape 3 (backstop): a session parked on an org the user is not actually
+	// a member of — an admin session that outlived its override cookie, or
+	// anyone pointed at the shared demo org (which has no membership rows by
+	// design, yet grants org:read to every session). Enrollment requires real
+	// membership in the org the device would report to.
+	if _, _, member := s.sessions.HasAccessToOrganization(ctx, authCtx.ActiveOrganizationID, authCtx.UserID); !member {
+		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment requires membership in the active organization").LogError(ctx, s.logger)
 	}
 
 	// Member-available gate: any org member (org:read) may enroll their own

--- a/server/internal/cliauth/impl.go
+++ b/server/internal/cliauth/impl.go
@@ -152,8 +152,8 @@ func (s *Service) Authorize(ctx context.Context, payload *gen.AuthorizePayload) 
 	// Enrollment binds a physical device to the session's active org — its
 	// policies, plugins, hooks, and session-transcript reporting — and mints a
 	// durable per-user key there. None of that is ever legitimate under an
-	// assumed identity, so every impersonation shape is refused outright
-	// (DNO-938). RBAC cannot carry this: an impersonating admin holds every
+	// assumed identity, so every impersonation shape is refused outright.
+	// RBAC cannot carry this: an impersonating admin holds every
 	// scope (see authz.Engine), so the org:read gate below would wave them
 	// through.
 	//

--- a/server/internal/cliauth/impl.go
+++ b/server/internal/cliauth/impl.go
@@ -149,51 +149,33 @@ func (s *Service) Authorize(ctx context.Context, payload *gen.AuthorizePayload) 
 		return nil, oops.E(oops.CodeUnauthorized, nil, "session has no resolved email").LogError(ctx, s.logger)
 	}
 
-	// Enrollment binds a physical device to the session's active org — its
-	// policies, plugins, hooks, and session-transcript reporting — and mints a
-	// durable per-user key there. None of that is ever legitimate under an
-	// assumed identity, so every impersonation shape is refused outright.
-	// RBAC cannot carry this: an impersonating admin holds every
-	// scope (see authz.Engine), so the org:read gate below would wave them
-	// through.
-	//
-	// Shape 1: Speakeasy admin impersonating a customer org via the dev-tools
-	// override — same refusal as chat-transcript access in chat.LoadChat, but
-	// scoped to overrides that target THIS session's active org. The
-	// gram_admin_override cookie survives switching back to one's own org, so
-	// an unscoped check would 403 an admin's own-org enrollment for as long as
-	// the stale cookie lives; a stale override pointing elsewhere falls
-	// through, and Shape 3 still catches any genuine parked impersonation.
+	// Enrollment is refused under any form of impersonation: it would bind a
+	// device to the impersonated org's policies and transcript reporting.
+	// RBAC cannot gate this — impersonating admins hold every scope.
+
+	// Admin org-override impersonation. Only refused when the override
+	// targets the active org: the cookie outlives impersonation, and the
+	// membership check below still catches parked sessions.
 	if override, impersonating := contextvalues.GetAdminOverrideFromContext(ctx); impersonating && authCtx.IsAdmin && override == authCtx.OrganizationSlug {
 		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating an organization").LogError(ctx, s.logger)
 	}
 
-	// Shape 2: WorkOS user impersonation. The session was minted by an admin
-	// impersonating this user through the IDP; enrolling would hand the
-	// impersonator's device a real key bearing the user's identity. Authorize
-	// only runs under the Session scheme, so a missing session id is a broken
-	// auth context, not a skippable case.
+	// WorkOS user impersonation, recorded on the session. Authorize only runs
+	// under the Session scheme, so a missing session id is a broken context.
 	if authCtx.SessionID == nil || *authCtx.SessionID == "" {
 		return nil, oops.E(oops.CodeUnauthorized, nil, "session has no id").LogError(ctx, s.logger)
 	}
 	session, err := s.sessions.GetSession(ctx, *authCtx.SessionID)
 	if err != nil {
-		// The session authenticated this same request, so a lookup failure
-		// here is infrastructure trouble, not a bad credential. Fail closed.
 		return nil, oops.E(oops.CodeUnexpected, err, "load session").LogError(ctx, s.logger)
 	}
 	if session.ImpersonatorEmail != "" {
 		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating a user").LogError(ctx, s.logger)
 	}
 
-	// Shape 3 (backstop): a session parked on an org the user is not actually
-	// a member of — an admin session that outlived its override cookie, or
-	// anyone pointed at the shared demo org (which has no membership rows by
-	// design, yet grants org:read to every session). Enrollment requires real
-	// membership in the org the device would report to. Membership is resolved
-	// explicitly (not via HasAccessToOrganization, which folds lookup failures
-	// into "no") so an infra failure surfaces as an unexpected error, never as
-	// a misleading 403.
+	// Backstop: the user must be a real member of the active org (the demo
+	// org has no memberships). Resolved via GetUserInfo so lookup failures
+	// surface as unexpected errors, not a misleading 403.
 	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load user info").LogError(ctx, s.logger)

--- a/server/internal/cliauth/impl.go
+++ b/server/internal/cliauth/impl.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -181,8 +182,17 @@ func (s *Service) Authorize(ctx context.Context, payload *gen.AuthorizePayload) 
 	// a member of — an admin session that outlived its override cookie, or
 	// anyone pointed at the shared demo org (which has no membership rows by
 	// design, yet grants org:read to every session). Enrollment requires real
-	// membership in the org the device would report to.
-	if _, _, member := s.sessions.HasAccessToOrganization(ctx, authCtx.ActiveOrganizationID, authCtx.UserID); !member {
+	// membership in the org the device would report to. Membership is resolved
+	// explicitly (not via HasAccessToOrganization, which folds lookup failures
+	// into "no") so an infra failure surfaces as an unexpected error, never as
+	// a misleading 403.
+	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "load user info").LogError(ctx, s.logger)
+	}
+	if !slices.ContainsFunc(userInfo.Organizations, func(org sessions.Organization) bool {
+		return org.ID == authCtx.ActiveOrganizationID
+	}) {
 		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment requires membership in the active organization").LogError(ctx, s.logger)
 	}
 

--- a/server/internal/cliauth/impl.go
+++ b/server/internal/cliauth/impl.go
@@ -158,24 +158,32 @@ func (s *Service) Authorize(ctx context.Context, payload *gen.AuthorizePayload) 
 	// through.
 	//
 	// Shape 1: Speakeasy admin impersonating a customer org via the dev-tools
-	// override. Same refusal as chat-transcript access in chat.LoadChat.
-	if _, impersonating := contextvalues.GetAdminOverrideFromContext(ctx); impersonating && authCtx.IsAdmin {
+	// override — same refusal as chat-transcript access in chat.LoadChat, but
+	// scoped to overrides that target THIS session's active org. The
+	// gram_admin_override cookie survives switching back to one's own org, so
+	// an unscoped check would 403 an admin's own-org enrollment for as long as
+	// the stale cookie lives; a stale override pointing elsewhere falls
+	// through, and Shape 3 still catches any genuine parked impersonation.
+	if override, impersonating := contextvalues.GetAdminOverrideFromContext(ctx); impersonating && authCtx.IsAdmin && override == authCtx.OrganizationSlug {
 		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating an organization").LogError(ctx, s.logger)
 	}
 
 	// Shape 2: WorkOS user impersonation. The session was minted by an admin
 	// impersonating this user through the IDP; enrolling would hand the
-	// impersonator's device a real key bearing the user's identity.
-	if authCtx.SessionID != nil && *authCtx.SessionID != "" {
-		session, err := s.sessions.GetSession(ctx, *authCtx.SessionID)
-		if err != nil {
-			// The session authenticated this same request, so a lookup failure
-			// here is infrastructure trouble, not a bad credential. Fail closed.
-			return nil, oops.E(oops.CodeUnexpected, err, "load session").LogError(ctx, s.logger)
-		}
-		if session.ImpersonatorEmail != "" {
-			return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating a user").LogError(ctx, s.logger)
-		}
+	// impersonator's device a real key bearing the user's identity. Authorize
+	// only runs under the Session scheme, so a missing session id is a broken
+	// auth context, not a skippable case.
+	if authCtx.SessionID == nil || *authCtx.SessionID == "" {
+		return nil, oops.E(oops.CodeUnauthorized, nil, "session has no id").LogError(ctx, s.logger)
+	}
+	session, err := s.sessions.GetSession(ctx, *authCtx.SessionID)
+	if err != nil {
+		// The session authenticated this same request, so a lookup failure
+		// here is infrastructure trouble, not a bad credential. Fail closed.
+		return nil, oops.E(oops.CodeUnexpected, err, "load session").LogError(ctx, s.logger)
+	}
+	if session.ImpersonatorEmail != "" {
+		return nil, oops.E(oops.CodeForbidden, nil, "device enrollment is not available while impersonating a user").LogError(ctx, s.logger)
 	}
 
 	// Shape 3 (backstop): a session parked on an org the user is not actually

--- a/server/internal/cliauth/setup_test.go
+++ b/server/internal/cliauth/setup_test.go
@@ -51,10 +51,8 @@ type testInstance struct {
 	sessionManager *sessions.Manager
 }
 
-// newTestService wires a cliauth.Service over real test Postgres + Redis and
-// returns a context carrying an authenticated member session for the mock
-// user/org (seeded by authztest.InitAuthContext) with admin RBAC grants
-// prepared.
+// newTestService wires a cliauth.Service over test Postgres + Redis and returns
+// a context carrying an authenticated member session for the mock user/org.
 func newTestService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
@@ -99,9 +97,8 @@ func pkcePair(t *testing.T) (verifier, challenge string) {
 	return verifier, challenge
 }
 
-// authenticateSession stores the given session record and authenticates it,
-// returning a context whose auth context reflects that session. Fixture rows
-// (user, org metadata, membership) must already exist for the referenced ids.
+// authenticateSession stores the session record and authenticates it,
+// returning a context reflecting that session.
 func authenticateSession(t *testing.T, ctx context.Context, ti *testInstance, session sessions.Session) context.Context {
 	t.Helper()
 
@@ -111,8 +108,7 @@ func authenticateSession(t *testing.T, ctx context.Context, ti *testInstance, se
 	return authedCtx
 }
 
-// seedOrgMetadata inserts organization metadata for an org the mock IDP knows
-// nothing about, so sessions can be pointed at it without membership rows.
+// seedOrgMetadata inserts org metadata without any membership rows.
 func seedOrgMetadata(t *testing.T, ctx context.Context, conn *pgxpool.Pool, id, name, slug string) {
 	t.Helper()
 

--- a/server/internal/cliauth/setup_test.go
+++ b/server/internal/cliauth/setup_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -33,7 +32,6 @@ func TestMain(m *testing.M) {
 	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true})
 	if err != nil {
 		log.Fatalf("launch test infrastructure: %v", err)
-		os.Exit(1)
 	}
 
 	infra = res
@@ -42,7 +40,6 @@ func TestMain(m *testing.M) {
 
 	if err := cleanup(); err != nil {
 		log.Fatalf("cleanup test infrastructure: %v", err)
-		os.Exit(1)
 	}
 
 	os.Exit(code)
@@ -52,7 +49,6 @@ type testInstance struct {
 	service        *cliauth.Service
 	conn           *pgxpool.Pool
 	sessionManager *sessions.Manager
-	redis          *redis.Client
 }
 
 // newTestService wires a cliauth.Service over real test Postgres + Redis and
@@ -90,7 +86,6 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		service:        svc,
 		conn:           conn,
 		sessionManager: sessionManager,
-		redis:          redisClient,
 	}
 }
 

--- a/server/internal/cliauth/setup_test.go
+++ b/server/internal/cliauth/setup_test.go
@@ -1,0 +1,155 @@
+package cliauth_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/cliauth"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+		os.Exit(1)
+	}
+
+	infra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("cleanup test infrastructure: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+type testInstance struct {
+	service        *cliauth.Service
+	conn           *pgxpool.Pool
+	sessionManager *sessions.Manager
+	redis          *redis.Client
+}
+
+// newTestService wires a cliauth.Service over real test Postgres + Redis and
+// returns a context carrying an authenticated member session for the mock
+// user/org (seeded by authztest.InitAuthContext) with admin RBAC grants
+// prepared.
+func newTestService(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	billingClient := billing.NewStubClient(logger, tracerProvider)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+
+	ctx := authztest.InitAuthContext(t, t.Context(), conn, sessionManager)
+	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
+
+	svc := cliauth.NewService(
+		logger,
+		tracerProvider,
+		conn,
+		sessionManager,
+		authzEngine,
+		redisClient,
+		"local",
+	)
+
+	return ctx, &testInstance{
+		service:        svc,
+		conn:           conn,
+		sessionManager: sessionManager,
+		redis:          redisClient,
+	}
+}
+
+// pkcePair returns a fresh PKCE code_verifier and its S256 code_challenge.
+func pkcePair(t *testing.T) (verifier, challenge string) {
+	t.Helper()
+
+	verifier = "test-verifier-" + uuid.NewString() + "-" + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge
+}
+
+// authenticateSession stores the given session record and authenticates it,
+// returning a context whose auth context reflects that session. Fixture rows
+// (user, org metadata, membership) must already exist for the referenced ids.
+func authenticateSession(t *testing.T, ctx context.Context, ti *testInstance, session sessions.Session) context.Context {
+	t.Helper()
+
+	require.NoError(t, ti.sessionManager.StoreSession(ctx, session))
+	authedCtx, err := ti.sessionManager.Authenticate(ctx, session.SessionID)
+	require.NoError(t, err)
+	return authedCtx
+}
+
+// seedOrgMetadata inserts organization metadata for an org the mock IDP knows
+// nothing about, so sessions can be pointed at it without membership rows.
+func seedOrgMetadata(t *testing.T, ctx context.Context, conn *pgxpool.Pool, id, name, slug string) {
+	t.Helper()
+
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          id,
+		Name:        name,
+		Slug:        slug,
+		WorkosID:    pgtype.Text{String: id, Valid: true},
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	})
+	require.NoError(t, err)
+}
+
+// seedUser inserts a user row directly (no IDP round-trip), returning its id.
+func seedUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, id, email string, admin bool) string {
+	t.Helper()
+
+	user, err := userrepo.New(conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          id,
+		Email:       email,
+		DisplayName: "Test User " + id,
+		PhotoUrl:    pgtype.Text{String: "", Valid: false},
+		Admin:       admin,
+	})
+	require.NoError(t, err)
+	return user.ID
+}
+
+func requireOopsCode(t *testing.T, err error, code oops.Code) {
+	t.Helper()
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, code, oopsErr.Code)
+}


### PR DESCRIPTION
Fixes [DNO-938](https://linear.app/speakeasy/issue/DNO-938/bug-device-agent-enrollment-respects-impersonation).

## Why

Manual device-agent enrollment (`cliAuth.authorize`) binds the one-time code — and ultimately the minted per-user `agent_user` key — to the session's active organization. While a platform admin is impersonating a customer org via a support session, that meant their real laptop got enrolled into the customer org's management policies: their plugins, their hooks, and session-transcript reporting into their org. RBAC cannot carry this gate because impersonating admins are deliberately granted every scope (`authz.Engine`), so the existing `org:read` check waved them through.

## What

`cliAuth.authorize` now refuses (403) before minting a code, covering every impersonation shape:

- **Admin support-session impersonation** — reuses `contextvalues.IsSupportSession`, the same predicate chat uses to protect transcripts (`chat.LoadChat`). It is already scoped to the active org, so a support session opened against a different org does not block an admin enrolling into their own.
- **WorkOS user-impersonation sessions** — enrolling would hand the impersonator a durable key bearing the impersonated user's identity.
- **Membership backstop** — the session's user must be an actual member of the active org. Session auth already refuses a foreign org without a live support session, but the shared demo org is exempt there by design (no membership rows) and hands out `org:read` for free — so this check is what stops a real device enrolling into the demo workspace and reporting its transcripts there.

`redeem` is unchanged — it only consumes codes `authorize` minted. Goa design description updated to document the 403 contract (gen churn is description strings only; dashboard SDK regen left to the bot).

## Test plan

New test suite for the previously untested `cliauth` package (real Postgres + Redis via `testenv`):

- authorize→redeem happy path for a plain member (PKCE E2E, key prefix + email + project assertions)
- each refusal shape pinned by error message: admin support session on the active org, impersonated user session, demo-org session
- controls: a support session targeting another org, and a non-admin member with a support org recorded, both still enroll fine
- the parked-admin-on-foreign-org case is pinned at the session-auth layer, where it is now refused before reaching the handler

`go build ./...`, `go test ./internal/cliauth/`, and `mise run lint:server` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFPMpADydN1tKUVJ5sivfR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses manual device-agent enrollment in `cliAuth.authorize` while impersonating an org or user, or when the session user is not a member of the active org. Previously `org:read` allowed enrollment; now these requests return 403 (and 401 for a missing session id) to prevent enrolling admin devices into customer orgs and leaking transcripts.

- Uses the support-session predicate to block enrollment only when a live support session targets the active org; stale support context for other orgs and non-admin sessions do not block enrollment.
- Requires actual membership in the active org (demo org blocked); infra failures during membership lookup now return unexpected errors instead of 403.
- Refuses WorkOS user-impersonation sessions.
- `redeem` unchanged. API/CLI/OpenAPI descriptions updated and `client/dashboard` SDK regenerated; clients must handle 403 responses from `cliAuth.authorize`.
- Tests: new `server/internal/cliauth` suite covers success and refusal cases; the parked-admin-on-foreign-org case is now refused at session auth.

<sup>Written for commit 85e18d2354cbdc8ba6f54ae596eb6d4faa548f90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


