### PR TITLE
fix: forward Guardian idle connection cleanup

### DIFF
--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -50,6 +50,15 @@ import (
 
 type HTTPClient = http.Client
 
+type closeIdleRoundTripper struct {
+	http.RoundTripper
+	closeIdleConnections func()
+}
+
+func (t *closeIdleRoundTripper) CloseIdleConnections() {
+	t.closeIdleConnections()
+}
+
 var (
 	ErrBadHost   = fmt.Errorf("bad host")
 	ErrBlockedIP = fmt.Errorf("blocked ip")
@@ -364,6 +373,10 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 			breaker: p.breaker,
 		}
 	}
+	roundTripper = &closeIdleRoundTripper{
+		RoundTripper:         roundTripper,
+		closeIdleConnections: transport.CloseIdleConnections,
+	}
 
 	if opts.retryConfig == nil {
 		return &http.Client{Transport: roundTripper}
@@ -395,7 +408,12 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 		retryClient.Backoff = opts.retryConfig.Backoff
 	}
 
-	return retryClient.StandardClient()
+	client := retryClient.StandardClient()
+	client.Transport = &closeIdleRoundTripper{
+		RoundTripper:         client.Transport,
+		closeIdleConnections: transport.CloseIdleConnections,
+	}
+	return client
 }
 
 type dialerOptions struct {

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +15,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestNewUnsafePolicy(t *testing.T) {
@@ -166,26 +169,54 @@ func TestPolicy_DialerAllowedCIDRBlocksOverridesBlock(t *testing.T) {
 
 func TestPolicy_ClientWrapsTransportWithOtel(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
-	client := policy.Client()
 
-	require.NotNil(t, client)
-	require.NotNil(t, client.Transport)
-
-	_, ok := client.Transport.(*otelhttp.Transport)
-	require.True(t, ok)
+	requirePolicyClientCreatesHTTPSpan(t, false)
 }
 
 func TestPolicy_PooledClientWrapsTransportWithOtel(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
-	client := policy.PooledClient()
 
-	require.NotNil(t, client)
-	require.NotNil(t, client.Transport)
+	requirePolicyClientCreatesHTTPSpan(t, true)
+}
 
-	_, ok := client.Transport.(*otelhttp.Transport)
-	require.True(t, ok)
+func requirePolicyClientCreatesHTTPSpan(t *testing.T, pooled bool) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() {
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, nil)
+	require.NoError(t, err)
+	var client *guardian.HTTPClient
+	if pooled {
+		client = policy.PooledClient()
+	} else {
+		client = policy.Client()
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	response, err := client.Do(req)
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	var foundHTTPSpan bool
+	for _, span := range recorder.Ended() {
+		if span.SpanKind() == trace.SpanKindClient {
+			foundHTTPSpan = true
+			break
+		}
+	}
+	require.True(t, foundHTTPSpan)
 }
 
 func TestDefaultPolicyBlocksPrivateIPs(t *testing.T) {

--- a/server/internal/guardian/retry_test.go
+++ b/server/internal/guardian/retry_test.go
@@ -3,9 +3,12 @@ package guardian_test
 import (
 	"context"
 	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,6 +24,56 @@ func fastRetryConfig() *guardian.RetryConfig {
 	cfg.WaitMax = 5 * time.Millisecond
 	cfg.MaxAttempts = 2
 	return cfg
+}
+
+func TestPooledClientClosesIdleConnections(t *testing.T) {
+	t.Parallel()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+	requirePooledClientClosesIdleConnections(t, policy.PooledClient())
+}
+
+func TestRetryingPooledClientClosesIdleConnections(t *testing.T) {
+	t.Parallel()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+	requirePooledClientClosesIdleConnections(t, policy.PooledClient(guardian.WithRetryConfig(fastRetryConfig())))
+}
+
+func requirePooledClientClosesIdleConnections(t *testing.T, client *http.Client) {
+	t.Helper()
+
+	var newConnections atomic.Int64
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	request := func() {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		response, err := client.Do(req)
+		require.NoError(t, err)
+		_, err = io.Copy(io.Discard, response.Body)
+		require.NoError(t, err)
+		require.NoError(t, response.Body.Close())
+	}
+
+	request()
+	request()
+	require.Equal(t, int64(1), newConnections.Load())
+
+	client.CloseIdleConnections()
+	request()
+	require.Equal(t, int64(2), newConnections.Load())
 }
 
 func TestClient_RetriesExhausted_PreservesFinalStatusAndBody(t *testing.T) {


### PR DESCRIPTION
## Summary

- forward `CloseIdleConnections` through Guardian's OpenTelemetry and retry transport wrappers
- verify pooled clients release idle connections with and without retries
- preserve HTTP client tracing coverage with behavioral span assertions

## Verification

- `mise run test:server ./internal/guardian/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward CloseIdleConnections through Guardian’s OTel and retry transport wrappers so pooled clients actually close idle connections when requested. Previously, calling CloseIdleConnections on clients from Policy.Client()/PooledClient() did not close underlying connections; now it does without changing tracing behavior.

- Add a closeIdleRoundTripper that delegates CloseIdleConnections to the base `http.Transport` and wrap both OTel and retry transports with it.
- Verify pooled clients release idle connections with and without retries; assert an HTTP client span still records via the tracer.

<sup>Written for commit 12910989450c5605036ee3c5a5edac825f66d539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

