### PR TITLE
fix: stack platform tile text under the logo

### DIFF
--- a/.changeset/device-agent-tile-layout.md
+++ b/.changeset/device-agent-tile-layout.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Stack the Device Agent platform tiles vertically (logo on top, name and subtitle underneath) so all four tiles fit a row without the labels wrapping one word per line, and drop the "Cowork needs separate setup" callout from the onboarding instrument-agents step.

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -19,7 +19,7 @@ import { useOrgRoutes } from "@/routes";
 import { Button } from "@/components/ui/Button";
 import { Icon } from "@/components/ui/Icon";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, ChevronRight, Download } from "lucide-react";
+import { ArrowLeft, Download } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router";
 import {
@@ -1253,8 +1253,10 @@ function DeviceAgentSetupSheet({
   );
 }
 
-// PlatformTile is a clickable setup card. Local operating systems use their
-// platform marks; Remote sessions uses a cloud icon but opens the same sheet.
+// PlatformTile is a clickable setup card: logo on top, name and subtitle
+// stacked underneath, so four tiles fit a row without the text wrapping.
+// Local operating systems use their platform marks; Remote sessions uses a
+// cloud icon but opens the same sheet.
 function PlatformTile({
   platform,
   onClick,
@@ -1267,9 +1269,9 @@ function PlatformTile({
     <button
       type="button"
       onClick={onClick}
-      className="border-border bg-card hover:border-foreground/20 flex w-full items-center gap-4 border p-4 text-left transition-all"
+      className="border-border bg-card hover:border-foreground/20 flex w-full flex-col items-center gap-3 border p-5 text-center transition-all"
     >
-      <div className="bg-secondary flex h-14 w-14 flex-shrink-0 items-center justify-center">
+      <div className="bg-secondary flex h-14 w-14 shrink-0 items-center justify-center">
         {platform === "remote" ? (
           <Icon name="cloud" className="h-7 w-7" />
         ) : (
@@ -1284,11 +1286,10 @@ function PlatformTile({
           />
         )}
       </div>
-      <div className="min-w-0 flex-1 space-y-1">
+      <div className="space-y-1">
         <p className="text-foreground text-sm font-medium">{cfg.label}</p>
         <p className="text-muted-foreground text-xs">{cfg.tileDesc}</p>
       </div>
-      <ChevronRight className="text-muted-foreground h-4 w-4 flex-shrink-0" />
     </button>
   );
 }

--- a/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
@@ -9,7 +9,6 @@ import { PlatformInstrumentationSheet } from "../platform-instrumentation-sheet"
 import { platformStatusBadge } from "../platform-status-badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
 import { DeviceAgentSetup } from "@/pages/device-agent/device-agent-setup";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
 
 interface InstrumentAgentsStepProps {
   onComplete: () => void;
@@ -26,18 +25,6 @@ export function InstrumentAgentsStep({
   >(() =>
     Object.fromEntries(AGENT_PLATFORMS.map((p) => [p.id, "not_started"])),
   );
-  // Controlled so the Cowork note can jump to Manual Setup and open that drawer.
-  const [activeTab, setActiveTab] = useState("device-agent");
-
-  // The device agent enforces required plugins/MCP config on-device — it has
-  // no reach into Claude.ai's org-level Cowork plugin settings, so Cowork
-  // always needs its own manual step regardless of which tab the user picks.
-  // This jumps them straight to that step from the Device Agent tab.
-  const openCoworkManualSetup = () => {
-    setActiveTab("manual");
-    setDrawerPlatformId("claude-cowork");
-  };
-
   const availablePlatforms = AGENT_PLATFORMS.filter(
     (p) => p.available !== false,
   );
@@ -62,7 +49,7 @@ export function InstrumentAgentsStep({
       showBack
       onBack={onBack}
     >
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="gap-8">
+      <Tabs defaultValue="device-agent" className="gap-8">
         <TabsList className="grid h-auto w-full grid-cols-1 items-stretch gap-4 divide-x-0 border-0 bg-transparent p-0 sm:grid-cols-2">
           <ChoiceTab
             value="device-agent"
@@ -78,22 +65,7 @@ export function InstrumentAgentsStep({
           />
         </TabsList>
 
-        <TabsContent value="device-agent" className="space-y-4">
-          <Alert variant="info">
-            <AlertTitle>Cowork needs separate setup</AlertTitle>
-            <AlertDescription>
-              The Remote sessions tile below covers Claude Code on the web.
-              Cowork isn&apos;t covered by the device agent.{" "}
-              <button
-                type="button"
-                onClick={openCoworkManualSetup}
-                className="text-foreground underline underline-offset-2"
-              >
-                Set it up manually
-              </button>
-              .
-            </AlertDescription>
-          </Alert>
+        <TabsContent value="device-agent">
           <DeviceAgentSetup />
         </TabsContent>
 


### PR DESCRIPTION
## Summary

Two follow-ups to #5489 (which added the "Remote sessions" tile to the Device Agent setup platform picker):

- **Stack platform tile text under the logo.** With four tiles in a row, the old side-by-side tile layout (logo left, text right) left the text column so narrow that subtitles wrapped one word per line ("Apple Silicon or Intel", "Claude Code on the web"). Adam flagged this in review. Each tile is now a vertical stack — logo on top, platform name underneath, subtitle below — so all four tiles render cleanly at typical dashboard widths. The trailing chevron is dropped since it has no natural edge in the centered design; the hover border still signals clickability. Click behavior (opening the platform's setup sheet) is unchanged.
- **Drop the "Cowork needs separate setup" callout** from the onboarding instrument-agents step — it didn't need that much prominence. Its jump-to-manual-setup handler and the controlled-tab state that existed only for that jump are removed with it.

## Verification

- `aube run -F dashboard type-check` and the full dashboard test suite (248 files / 2456 tests) pass.
- Verified in the local dashboard at 1440x900: all four tiles equal height, single-line subtitles, and clicking a tile still opens its setup sheet.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch platform tiles from side-by-side to a vertical stack to prevent subtitle wrapping when four tiles render in a row. Remove the trailing chevron; hover still indicates clickability, and clicking a tile still opens its setup sheet.

Remove the “Cowork needs separate setup” callout from the instrument-agents step and delete its manual-setup jump; Tabs are now uncontrolled since the controlled state existed only for that jump.

<sup>Written for commit c68300ffed9e476623a794ab3a4db685593ebeef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

