### PR TITLE
fix: reuse sole client for existing remote identity providers

### DIFF
--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -53,6 +53,7 @@ import {
   pickPreferredAuthMethod,
 } from "./issuerFormUtils";
 import { IdentityProviderAttachmentErrorAlert } from "./IdentityProviderAttachmentErrorAlert";
+import { selectExistingClient } from "./selectExistingClient";
 import { useAllRemoteSessionClients } from "./useAllRemoteSessionClients";
 import { useIssuerDiscovery } from "./useIssuerDiscovery";
 import { IssuerDuplicateWarning } from "./IssuerDuplicateWarning";
@@ -235,9 +236,12 @@ export function AttachRemoteIdentityProviderSheet({
   // directly (a brand-new issuer never has clients).
   const clientToggleVisible = attachableClients.length > 0;
   const effectiveClientMode: Mode = clientToggleVisible ? clientMode : "new";
-  const selectedClient = attachableClients.find(
-    (candidate) => candidate.id === selectedClientId,
+  const selectedClient = selectExistingClient(
+    attachableClients,
+    selectedClientId,
+    !isLoadingIssuerClients,
   );
+  const effectiveSelectedClientId = selectedClient?.id ?? "";
 
   // The Session Client section stays hidden until an identity provider is
   // determined — an existing one is picked, or a new one's Issuer URL has been
@@ -331,7 +335,7 @@ export function AttachRemoteIdentityProviderSheet({
         // Attach the picked existing client to this user_session_issuer.
         await client.remoteSessionClients.attachUserSessionIssuer({
           attachUserSessionIssuerForm: {
-            id: selectedClientId,
+            id: effectiveSelectedClientId,
             userSessionIssuerId: issuerId,
           },
         });
@@ -565,7 +569,7 @@ export function AttachRemoteIdentityProviderSheet({
       return false;
     }
     // Session client: attach an existing one, or complete the new-client form.
-    if (effectiveClientMode === "select") return !!selectedClientId;
+    if (effectiveClientMode === "select") return !!effectiveSelectedClientId;
     // Manual requires a client_id; DCR mints one; CIMD needs none.
     if (clientType === "manual" && !clientId.trim()) return false;
     return true;
@@ -575,7 +579,7 @@ export function AttachRemoteIdentityProviderSheet({
     slug,
     issuerUrl,
     effectiveClientMode,
-    selectedClientId,
+    effectiveSelectedClientId,
     clientType,
     clientId,
   ]);
@@ -603,7 +607,7 @@ export function AttachRemoteIdentityProviderSheet({
         {clientToggle}
         <SelectExistingClientFields
           clients={attachableClients}
-          selectedClientId={selectedClientId}
+          selectedClientId={effectiveSelectedClientId}
           onChange={setSelectedClientId}
           selectedClient={selectedClient}
         />

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerDuplicateWarning.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerDuplicateWarning.tsx
@@ -57,6 +57,19 @@ function tierCopy(match: RemoteSessionIssuerDuplicateMatch): string {
   }
 }
 
+function tierLabel(match: RemoteSessionIssuerDuplicateMatch): string {
+  switch (match.tier) {
+    case "platform-level":
+      return "Platform catalog";
+    case "organization-level":
+      return "Organization";
+    case "project-specific":
+      return match.projectName
+        ? `Project ${match.projectName}`
+        : "This project";
+  }
+}
+
 // matchDisplayName mirrors how issuers are named everywhere else: the display
 // name when it has one, otherwise the slug.
 function matchDisplayName(match: RemoteSessionIssuerDuplicateMatch): string {
@@ -74,7 +87,7 @@ function otherMatchesSentence(
   others: RemoteSessionIssuerDuplicateMatch[],
 ): string {
   const named = others
-    .map((match) => `${matchDisplayName(match)} (${tierCopy(match)})`)
+    .map((match) => `${matchDisplayName(match)} (${tierLabel(match)})`)
     .join(", ");
 
   if (others.length === 1) {
@@ -134,36 +147,38 @@ export function IssuerDuplicateWarning({
   ].filter(Boolean);
 
   return (
-    <Card className="border border-info-foreground">
-      <div className="flex gap-2 items-center">
-        <InfoIcon className="size-5" />
-        <Text>
-          <strong>Existing Issuer Available</strong>
-        </Text>
-      </div>
-      <Text small>{tierCopy(primary)}</Text>
-      <CodeBlock className="text-foreground">
-        {matchDisplayName(primary)}
-      </CodeBlock>
-      <Text small>{tierRationale(primary, viewerScope)}</Text>
+    <div role="alert">
+      <Card className="border border-info-foreground">
+        <div className="flex gap-2 items-center">
+          <InfoIcon className="size-5" />
+          <Text>
+            <strong>Existing Issuer Available</strong>
+          </Text>
+        </div>
+        <Text small>{tierCopy(primary)}</Text>
+        <CodeBlock className="text-foreground">
+          {matchDisplayName(primary)}
+        </CodeBlock>
+        <Text small>{tierRationale(primary, viewerScope)}</Text>
 
-      {rest.length > 0 && (
+        {rest.length > 0 && (
+          <Text muted small>
+            {otherMatchesSentence(rest)}
+          </Text>
+        )}
+
         <Text muted small>
-          {otherMatchesSentence(rest)}
+          {viewerScope === "platform"
+            ? "You can still continue if the two entries are meant to differ."
+            : "You can still continue. Add your own record when you need different documentation, branding or scopes."}
         </Text>
-      )}
 
-      <Text muted small>
-        {viewerScope === "platform"
-          ? "You can still continue if the two entries are meant to differ."
-          : "You can still continue. Add your own record when you need different documentation, branding or scopes."}
-      </Text>
-
-      {actions.length > 0 && (
-        <Stack direction="horizontal" gap={2}>
-          {actions}
-        </Stack>
-      )}
-    </Card>
+        {actions.length > 0 && (
+          <Stack direction="horizontal" gap={2}>
+            {actions}
+          </Stack>
+        )}
+      </Card>
+    </div>
   );
 }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerDuplicateWarning.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerDuplicateWarning.tsx
@@ -1,4 +1,3 @@
-import { Alert } from "@/components/ui/Alert";
 import { Button } from "@/components/ui/Button";
 import { Stack } from "@/components/ui/Stack";
 import { Text } from "@/components/ui/Text";
@@ -6,6 +5,9 @@ import type {
   IssuerDuplicateScope,
   RemoteSessionIssuerDuplicateMatch,
 } from "./useIssuerDuplicatePreflight";
+import { CodeBlock } from "@/components/code";
+import { Card } from "@/components/ui/Card";
+import { InfoIcon } from "lucide-react";
 
 // What reusing the existing record gives the operator instead of adding their
 // own. Phrased as what they gain, because duplicating is a legitimate choice and
@@ -25,9 +27,9 @@ function tierRationale(
 
   switch (match.tier) {
     case "platform-level":
-      return "Curated by Speakeasy and kept up to date centrally, so its metadata and setup documentation are maintained for you.";
+      return "It's curated by Speakeasy and kept up to date centrally, so its metadata and setup documentation are maintained for you.";
     case "organization-level":
-      return "Already available to every project in your organization, so reusing it keeps one record to maintain instead of two.";
+      return "It's already available to every project in your organization, so reusing it keeps one record to maintain instead of two.";
     case "project-specific":
       // A project match reaches the organization surfaces too, where it belongs
       // to some OTHER project and "already configured here" would be false.
@@ -36,23 +38,22 @@ function tierRationale(
       if (match.projectName) {
         return "Consolidating onto one record avoids each project maintaining its own metadata and documentation for the same provider.";
       }
-      return "Already configured here, so a second record would double the metadata and documentation you maintain.";
+      return "It's already configured here, so a second record would double the metadata and documentation you maintain.";
   }
 }
 
-// tierLabel names where a match lives. A project-specific match names the
-// project when the caller was told which one, since "Project" alone is not
-// placeable for an organization administrator looking across many.
-function tierLabel(match: RemoteSessionIssuerDuplicateMatch): string {
+// tierCopy explains where a matching issuer already exists. A project-specific
+// match names the project when the caller was told which one.
+function tierCopy(match: RemoteSessionIssuerDuplicateMatch): string {
   switch (match.tier) {
     case "platform-level":
-      return "Platform catalog";
+      return "Speakeasy already has an identity provider for this issuer URL.";
     case "organization-level":
-      return "Organization";
+      return "Your organization already has an identity provider for this issuer URL.";
     case "project-specific":
-      return match.projectName
-        ? `Project ${match.projectName}`
-        : "This project";
+      if (match.projectName)
+        return `Project "${match.projectName}" already has an identity provider for this issuer URL.`;
+      return `This project already has an identity provider for this issuer URL.`;
   }
 }
 
@@ -73,7 +74,7 @@ function otherMatchesSentence(
   others: RemoteSessionIssuerDuplicateMatch[],
 ): string {
   const named = others
-    .map((match) => `${matchDisplayName(match)} (${tierLabel(match)})`)
+    .map((match) => `${matchDisplayName(match)} (${tierCopy(match)})`)
     .join(", ");
 
   if (others.length === 1) {
@@ -133,31 +134,36 @@ export function IssuerDuplicateWarning({
   ].filter(Boolean);
 
   return (
-    <Alert variant="warning" dismissible={false}>
-      <Stack gap={2}>
-        <Text small>
-          <strong>{matchDisplayName(primary)}</strong> ({tierLabel(primary)})
-          already uses this issuer URL. {tierRationale(primary, viewerScope)}
+    <Card className="border border-info-foreground">
+      <div className="flex gap-2 items-center">
+        <InfoIcon className="size-5" />
+        <Text>
+          <strong>Existing Issuer Available</strong>
         </Text>
+      </div>
+      <Text small>{tierCopy(primary)}</Text>
+      <CodeBlock className="text-foreground">
+        {matchDisplayName(primary)}
+      </CodeBlock>
+      <Text small>{tierRationale(primary, viewerScope)}</Text>
 
-        {rest.length > 0 && (
-          <Text muted small>
-            {otherMatchesSentence(rest)}
-          </Text>
-        )}
-
+      {rest.length > 0 && (
         <Text muted small>
-          {viewerScope === "platform"
-            ? "You can still continue if the two entries are meant to differ."
-            : "You can still continue. Add your own record when you need different documentation, branding or scopes than the one above."}
+          {otherMatchesSentence(rest)}
         </Text>
+      )}
 
-        {actions.length > 0 && (
-          <Stack direction="horizontal" gap={2}>
-            {actions}
-          </Stack>
-        )}
-      </Stack>
-    </Alert>
+      <Text muted small>
+        {viewerScope === "platform"
+          ? "You can still continue if the two entries are meant to differ."
+          : "You can still continue. Add your own record when you need different documentation, branding or scopes."}
+      </Text>
+
+      {actions.length > 0 && (
+        <Stack direction="horizontal" gap={2}>
+          {actions}
+        </Stack>
+      )}
+    </Card>
   );
 }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/selectExistingClient.test.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/selectExistingClient.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { selectExistingClient } from "./selectExistingClient";
+
+describe("selectExistingClient", () => {
+  const clients = [{ id: "client-1" }, { id: "client-2" }];
+
+  it("selects the sole client when reusing an issuer", () => {
+    expect(selectExistingClient([clients[0]!], "", true)?.id).toBe("client-1");
+  });
+
+  it("requires an explicit choice when multiple clients are available", () => {
+    expect(selectExistingClient(clients, "", true)).toBeUndefined();
+  });
+
+  it("preserves an explicit valid choice", () => {
+    expect(selectExistingClient(clients, "client-2", true)?.id).toBe(
+      "client-2",
+    );
+  });
+
+  it("waits for every client page before selecting the sole loaded client", () => {
+    expect(selectExistingClient([clients[0]!], "", false)).toBeUndefined();
+  });
+});

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/selectExistingClient.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/selectExistingClient.ts
@@ -1,0 +1,13 @@
+// Keep an explicit valid choice, or choose the only available client. Reusing an
+// issuer should also reuse its sole client without asking for a redundant second
+// selection. Multiple clients remain an explicit operator choice.
+export function selectExistingClient<T extends { id: string }>(
+  clients: T[],
+  selectedClientId: string,
+  autoSelectSoleClient: boolean,
+): T | undefined {
+  return (
+    clients.find((client) => client.id === selectedClientId) ??
+    (autoSelectSoleClient && clients.length === 1 ? clients[0] : undefined)
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/useAllRemoteSessionClients.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/useAllRemoteSessionClients.ts
@@ -37,11 +37,10 @@ export function useAllRemoteSessionClients(
     [query.data],
   );
 
-  // Keep isLoading true while more pages are still being fetched so the
-  // consumer's spinner stays up until the list is complete — otherwise it
-  // would flicker off after the first page even though more rows are
-  // coming.
-  const isLoading = query.isLoading || hasNextPage;
+  // Keep isLoading true while any fetch is in flight or more pages remain. A
+  // background refetch can otherwise expose cached pages as complete and let a
+  // consumer make decisions from a stale partial list.
+  const isLoading = query.isFetching || hasNextPage;
 
   return { items, isLoading };
 }


### PR DESCRIPTION
## Summary
- automatically select the sole eligible client after all client pages finish loading
- preserve explicit client choices and continue requiring a choice when multiple clients exist
- refresh the duplicate issuer warning copy and presentation
- attach the existing stored client record without exposing or resubmitting its write-only secret

## Verification
- `aube run -F dashboard test -- src/pages/mcp/x/tabs/settings/sections/authentication/selectExistingClient.test.ts`
- `aube run -F dashboard type-check`
- `aube run -F dashboard lint:format`
- `git diff --check`
- browser QA against the local dev stack: discovered a duplicate organizational issuer, clicked **Use … instead**, confirmed the sole client was selected and the attach action enabled, then attached successfully
- verified the resulting local database link references the expected existing remote session client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-selects the sole eligible remote session client when attaching an existing identity provider to prevent attach failures. Previously no client was preselected; now a single client is reused automatically after clients finish loading. Multiple clients still require a choice.

- Adds `selectExistingClient` with unit tests; used in `AttachRemoteIdentityProviderSheet` to derive an effective selected client only after `useAllRemoteSessionClients` finishes.
- Form validation and submission use the effective client ID; explicit selections are preserved; no write-only secrets are exposed or resubmitted.
- Keeps `useAllRemoteSessionClients` in a loading state while any fetch is in flight or pages remain, preventing auto-selection from stale partial lists.
- Refreshes duplicate issuer warning copy and presentation (replaces `Alert` with `Card`, adds `CodeBlock` and `InfoIcon`); behavior is unchanged.
- Addresses Linear `AIS-585` (remote identity provider fails to attach when reusing an existing configuration).

<sup>Written for commit 1901cab1dffac61c376e74ce4becc0c97cea214b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

