### PR TITLE
chore: bind shared LGTM to loopback and fix stale port docs

### DIFF
--- a/.agents/skills/grafana-lgtm/SKILL.md
+++ b/.agents/skills/grafana-lgtm/SKILL.md
@@ -170,9 +170,9 @@ Every span names its parent, so "did this cross the boundary?" is answered by th
 
 ## Common mistakes
 
-- Hardcoding `3000`, `3200` or `9090`. Those are container-internal; host ports are remapped per worktree.
+- Hardcoding `3000`, `3200` or `9090`. Those are container-internal; the host ports are the fixed shared ones (`GRAFANA_PORT`, `TEMPO_HTTP_PORT`, `PROMETHEUS_PORT`).
 - Treating an empty result as proof of absence — for traces retry and widen the window, for metrics wrap in `last_over_time`.
 - Querying a metric by its Go instrument name instead of the translated series name, or without a `service_name` filter.
 - Reading `traces_service_graph_request_total` as proof of propagation either way. That graph is built from CLIENT/SERVER span pairs, so an edge appears only where the caller recorded a CLIENT span — real `deployments.evolve` traffic does produce `client="gram-server", server="gram-worker"`, but a path that dispatches without a CLIENT span shows no edge while propagating perfectly well. `parentSpanId` is the authority.
-- Assuming the running services belong to the worktree you ran `mise env` in. Several worktrees can have stacks up at once; match the port back to a container with `docker ps --filter publish=…`.
+- Assuming the data you get back belongs to the worktree you ran `mise env` in. Several worktrees can have stacks up at once, and every port resolves to the one shared `gram-shared-lgtm-1` — the port tells you nothing. Separation comes only from the `worktree` resource attribute, so filter on it.
 - Reading a counter as an all-time total. OTLP counters are cumulative per process, so a local restart starts them over.

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -58,13 +58,18 @@ services:
   lgtm:
     image: grafana/otel-lgtm:0.30.1@sha256:bb182ac3174a20923fa58f00d1790fa71eb06cc0150078c0b0e8feb9e6611492
     restart: unless-stopped
+    # Bound to 127.0.0.1 for the same reason as Presidio: every one of these
+    # APIs is unauthenticated, and this container now holds every worktree's
+    # traces and metrics. All consumers are local host processes
+    # (OTEL_EXPORTER_OTLP_ENDPOINT points at localhost), so nothing needs it on
+    # the host's external interfaces.
     ports:
-      - "13000:3000" # Grafana UI
-      - "13200:3200" # Tempo HTTP API
-      - "13100:3100" # Loki HTTP API
-      - "9099:9090" # Prometheus UI/API
-      - "4317:4317" # OTLP gRPC receiver
-      - "4318:4318" # OTLP HTTP receiver
+      - "127.0.0.1:13000:3000" # Grafana UI
+      - "127.0.0.1:13200:3200" # Tempo HTTP API
+      - "127.0.0.1:13100:3100" # Loki HTTP API
+      - "127.0.0.1:9099:9090" # Prometheus UI/API
+      - "127.0.0.1:4317:4317" # OTLP gRPC receiver
+      - "127.0.0.1:4318:4318" # OTLP HTTP receiver
     volumes:
       # Runs as root, so wipe this from inside the container rather than sudo:
       # docker compose -f compose.shared.yml -p gram-shared exec lgtm \

--- a/local/clickhouse/config.d/limits.xml
+++ b/local/clickhouse/config.d/limits.xml
@@ -6,9 +6,11 @@
          enforced in every environment, in which case ClickHouse sees the whole host's RAM.
 
          Sized for N concurrent worktrees, not one: each worktree runs its own ClickHouse, so
-         this budget is multiplied by however many stacks are up. 512 MiB is ample for the
+         this budget is multiplied by however many stacks are up. 1 GiB is ample for the
          local dataset (dev seed plus whatever a test run writes) and keeps six worktrees
-         under 3 GiB of ClickHouse headroom instead of 12 GiB. -->
+         under 6 GiB of ClickHouse headroom instead of 12 GiB. It is also the floor that
+         boots: ClickHouse derives background_pool_size from this cap, and at 512 MiB the
+         pool shrinks until startup fails with BAD_ARGUMENTS (see the note below). -->
     <max_server_memory_usage>1073741824</max_server_memory_usage> <!-- 1 GiB -->
 
     <!-- Reduce cache sizes relative to available RAM -->

--- a/local/clickhouse/config.d/limits.xml
+++ b/local/clickhouse/config.d/limits.xml
@@ -9,18 +9,21 @@
          this budget is multiplied by however many stacks are up. 1 GiB is ample for the
          local dataset (dev seed plus whatever a test run writes) and keeps six worktrees
          under 6 GiB of ClickHouse headroom instead of 12 GiB. It is also the floor that
-         boots: ClickHouse derives background_pool_size from this cap, and at 512 MiB the
-         pool shrinks until startup fails with BAD_ARGUMENTS (see the note below). -->
+         boots: 512 MiB fails startup with BAD_ARGUMENTS on the background-pool constraint
+         described below, which the <background_pool_size> setting does not rescue — that
+         override is a no-op here (system.settings reports 20 while 8 is enforced), so the
+         effective pool tracks this cap rather than the value written below. -->
     <max_server_memory_usage>1073741824</max_server_memory_usage> <!-- 1 GiB -->
 
     <!-- Reduce cache sizes relative to available RAM -->
     <cache_size_to_ram_max_ratio>0.20</cache_size_to_ram_max_ratio>
 
     <!-- Reduce background thread pools so ClickHouse doesn't spawn too many workers.
-         Do not lower this further without also lowering
-         number_of_free_entries_in_pool_to_execute_mutation (default 20): startup fails with
-         BAD_ARGUMENTS unless background_pool_size * background_merges_mutations_concurrency_ratio
-         is at least that value. -->
+         The constraint that bounds this: startup fails with BAD_ARGUMENTS unless
+         background_pool_size * background_merges_mutations_concurrency_ratio is at least
+         number_of_free_entries_in_pool_to_execute_mutation (default 20). Note that
+         background_pool_size is not actually honoured from this file (see above), so raising
+         it is not a way to buy room under a smaller memory cap. -->
     <background_pool_size>20</background_pool_size>
     <background_schedule_pool_size>2</background_schedule_pool_size>
 </clickhouse>


### PR DESCRIPTION
Follow-ups to #5542, from the cubic review comments left after it merged. All three were valid.

**Bind the shared LGTM ports to `127.0.0.1`.** Grafana, Tempo, Loki, Prometheus and both OTLP receivers were published on all host interfaces. That was fine while LGTM was per-worktree scratch data; as a machine-wide singleton it now holds every worktree's traces and metrics behind six unauthenticated APIs. Every consumer is a local host process (`OTEL_EXPORTER_OTLP_ENDPOINT` points at localhost, `zero:summary` reads localhost), and nothing in `compose.yml` reaches it through `host.docker.internal`, so loopback binding is transparent. Same rationale already applied to `gram-presidio` in this file.

**Correct the ClickHouse memory comment.** It justified a 512 MiB budget while the configured value is 1 GiB. The value is right — 512 MiB does not boot, because ClickHouse derives `background_pool_size` from the cap and startup fails with `BAD_ARGUMENTS` below that floor — so the comment now says 1 GiB, 6 GiB across six worktrees, and records why it cannot go lower.

**Drop the stale port advice from the `grafana-lgtm` skill.** Its "Common mistakes" section still told the agent that host ports are remapped per worktree and to identify a stack with `docker ps --filter publish=…`. Both are now false, and this is agent-facing, so they led to exactly the wrong-stack conclusion the shared-LGTM change set out to prevent. Replaced with the fixed shared ports and a pointer to the `worktree` resource attribute as the only thing that separates data.

## Verification

- `docker compose -f compose.shared.yml -p gram-shared config` parses; `limits.xml` parses.
- Checked for in-container OTLP consumers that would break under loopback binding — there are none.

Existing shared stacks keep the old bindings until the container is recreated (`docker compose -f compose.shared.yml -p gram-shared up -d`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds the shared LGTM stack’s Grafana/Tempo/Loki/Prometheus and OTLP ports to 127.0.0.1, updates the `grafana-lgtm` skill to reflect fixed shared ports and `worktree` filtering, and corrects ClickHouse memory/pool comments. This closes unauthenticated LAN APIs and documents the 1 GiB boot floor.

- Behavior: Ports were exposed on all interfaces; now they’re loopback-only. Local exporters and tools using localhost are unchanged; external hosts can’t reach Grafana, Tempo, Loki, Prometheus, or OTLP.
- Rollout: Existing `gram-shared` stacks keep old bindings until `lgtm` is recreated; run: docker compose -f compose.shared.yml -p gram-shared up -d.
- ClickHouse: Comment now states 1 GiB and explains the BAD_ARGUMENTS floor and that `<background_pool_size>` from this file is not honored; the effective background pool tracks the memory cap.

<sup>Written for commit 03e373c181e893070bdb2074db0216159533d571. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

