### PR TITLE
chore: updates the suppression buttons

### DIFF
--- a/.changeset/suppress-menu-dropdown.md
+++ b/.changeset/suppress-menu-dropdown.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The signal drawer and the signal list's multi-select toolbar now offer one "Suppress" dropdown in place of the separate suppress and exclusion-rule buttons, with "Suppress Once" (manual suppression) and "Create Rule" (exclusion rule creation) options.

--- a/client/dashboard/src/pages/security/useDismissFinding.ts
+++ b/client/dashboard/src/pages/security/useDismissFinding.ts
@@ -103,29 +103,43 @@ export function useDismissFinding(): {
   const unmarkMutation = useRiskUnmarkResultsFalsePositiveMutation();
 
   const invalidateLists = useCallback(() => {
-    // RiskEvents.tsx and RiskOverviewCategoryDetail.tsx each query results
-    // directly via useInfiniteQuery (not a generated hook), under their own
-    // queryKey under this shared ["risk", "results", ...] prefix (e.g.
-    // ["risk","results","list"]). Invalidate the whole prefix rather than each
-    // exact key — suppressing from one surface (e.g. Risk Events) must be
-    // reflected on every other surface, and matching each new custom key
-    // one-by-one here is exactly the kind of thing that's easy to add a
-    // surface and forget to wire up.
-    void queryClient.invalidateQueries({
-      queryKey: ["risk", "results"],
-    });
-    void invalidateAllRiskListDismissedResults(queryClient);
-    // The chat transcript's ChatDetailPanel reads findings through the
-    // *generated* useRiskListResults hook (a separate ["@gram/client",
-    // "results", "list", ...] key namespace the prefix above never touches),
-    // so a tool-call-section dismiss left the transcript showing a finding
-    // as still flagged until a manual reload.
-    void invalidateAllRiskListResults(queryClient);
-    void invalidateAllRiskOverview(queryClient);
-    void invalidateAllRiskRuleBreakdown(queryClient);
-    void invalidateAllRiskUserBreakdown(queryClient);
-    // The Watchdog page clusters the same findings into signals.
-    void invalidateAllRiskSignals(queryClient);
+    const invalidate = () => {
+      // RiskEvents.tsx and RiskOverviewCategoryDetail.tsx each query results
+      // directly via useInfiniteQuery (not a generated hook), under their own
+      // queryKey under this shared ["risk", "results", ...] prefix (e.g.
+      // ["risk","results","list"]). Invalidate the whole prefix rather than
+      // each exact key — suppressing from one surface (e.g. Risk Events) must
+      // be reflected on every other surface, and matching each new custom key
+      // one-by-one here is exactly the kind of thing that's easy to add a
+      // surface and forget to wire up.
+      void queryClient.invalidateQueries({
+        queryKey: ["risk", "results"],
+      });
+      void invalidateAllRiskListDismissedResults(queryClient);
+      // The chat transcript's ChatDetailPanel reads findings through the
+      // *generated* useRiskListResults hook (a separate ["@gram/client",
+      // "results", "list", ...] key namespace the prefix above never touches),
+      // so a tool-call-section dismiss left the transcript showing a finding
+      // as still flagged until a manual reload.
+      void invalidateAllRiskListResults(queryClient);
+      void invalidateAllRiskOverview(queryClient);
+      void invalidateAllRiskRuleBreakdown(queryClient);
+      void invalidateAllRiskUserBreakdown(queryClient);
+      // The Watchdog page clusters the same findings into signals.
+      void invalidateAllRiskSignals(queryClient);
+    };
+
+    invalidate();
+    // These surfaces read from ClickHouse, which trails the Postgres write by
+    // a few seconds (the suppression state arrives via an async mirror), so
+    // the immediate refetch above usually re-serves the pre-suppression data.
+    // Re-invalidate after the mirror's typical catch-up window, and once more
+    // as a backstop, so the content settles without a manual reload. The
+    // timers deliberately outlive the component: invalidating a long-lived
+    // query client is a safe no-op when nothing is mounted.
+    for (const delayMs of [4_000, 12_000]) {
+      setTimeout(invalidate, delayMs);
+    }
   }, [queryClient]);
 
   const removeOptimistic = useCallback((ids: string[]) => {

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -36,6 +36,7 @@ import {
 import { useDismissFinding } from "../useDismissFinding";
 import { collectFindingsForRules } from "./collect-findings";
 import { SuppressFindingsDialog } from "./SuppressFindingsDialog";
+import { SuppressMenu } from "./SuppressMenu";
 import { SCORE_TEXT_COLOR } from "./signals-helpers";
 import { SignalTrend } from "./SignalsList";
 
@@ -122,10 +123,9 @@ function EvidenceRow({
   // so the evidence cell shows the rationale with the audited event dialog
   // behind it instead of a redaction chip over content that may not exist.
   // Judge findings also can't be excluded (their rule id is a constant for
-  // the whole detector), so the row offers only suppression.
-  // Every other detector gets only Exclude: exclusion rules are the reviewed
-  // suppression path for pattern detectors, and offering both actions side by
-  // side made per-row suppression the path of least resistance.
+  // the whole detector), so the row offers only suppression. Every other
+  // detector gets the shared Suppress menu: a one-off manual suppression or
+  // exclusion rule creation, same affordance as the drawer and list actions.
   const judge = isJudgeSource(result.source);
   return (
     <div className="border-border overflow-hidden rounded-md border">
@@ -175,13 +175,12 @@ function EvidenceRow({
               <Button.Text>Suppress</Button.Text>
             </Button>
           ) : (
-            <Button
+            <SuppressMenu
               variant="tertiary"
               size="sm"
-              onClick={() => onExclude(result)}
-            >
-              <Button.Text>Exclude</Button.Text>
-            </Button>
+              onSuppressOnce={() => onDismiss(result)}
+              onCreateRule={() => onExclude(result)}
+            />
           )}
         </span>
       </div>
@@ -328,6 +327,9 @@ export function SignalDrawer({
     if (!pendingDismiss) return;
     dismiss(pendingDismiss);
     setPendingDismiss(null);
+    // The whole signal was just suppressed, so the drawer has nothing left to
+    // show — close it rather than leaving it open over a vanished signal.
+    onClose();
   };
 
   return (
@@ -437,9 +439,12 @@ export function SignalDrawer({
                         </Text>
                       </>
                     ) : (
-                      <Button variant="primary" onClick={openSignalExclusion}>
-                        <Button.Text>Create exclusion rule</Button.Text>
-                      </Button>
+                      <SuppressMenu
+                        variant="primary"
+                        busy={collecting}
+                        onSuppressOnce={() => void openSignalDismiss()}
+                        onCreateRule={openSignalExclusion}
+                      />
                     )}
                   </div>
                   <div className="relative flex-1">

--- a/client/dashboard/src/pages/security/watchdog/SuppressMenu.test.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SuppressMenu.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SuppressMenu } from "./SuppressMenu";
+
+afterEach(cleanup);
+
+describe("SuppressMenu", () => {
+  it("opens and fires the two actions", async () => {
+    const user = userEvent.setup();
+    const onSuppressOnce = vi.fn();
+    const onCreateRule = vi.fn();
+
+    render(
+      <SuppressMenu
+        variant="secondary"
+        onSuppressOnce={onSuppressOnce}
+        onCreateRule={onCreateRule}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Suppress" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Suppress Once" }),
+    );
+    expect(onSuppressOnce).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Suppress" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Create Rule" }),
+    );
+    expect(onCreateRule).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the trigger while busy", () => {
+    render(
+      <SuppressMenu
+        variant="secondary"
+        busy
+        onSuppressOnce={vi.fn()}
+        onCreateRule={vi.fn()}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: "Suppress" });
+    expect(trigger.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/client/dashboard/src/pages/security/watchdog/SuppressMenu.test.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SuppressMenu.test.tsx
@@ -8,8 +8,8 @@ afterEach(cleanup);
 describe("SuppressMenu", () => {
   it("opens and fires the two actions", async () => {
     const user = userEvent.setup();
-    const onSuppressOnce = vi.fn();
-    const onCreateRule = vi.fn();
+    const onSuppressOnce = vi.fn<() => void>();
+    const onCreateRule = vi.fn<() => void>();
 
     render(
       <SuppressMenu
@@ -37,8 +37,8 @@ describe("SuppressMenu", () => {
       <SuppressMenu
         variant="secondary"
         busy
-        onSuppressOnce={vi.fn()}
-        onCreateRule={vi.fn()}
+        onSuppressOnce={vi.fn<() => void>()}
+        onCreateRule={vi.fn<() => void>()}
       />,
     );
     const trigger = screen.getByRole("button", { name: "Suppress" });

--- a/client/dashboard/src/pages/security/watchdog/SuppressMenu.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SuppressMenu.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@/components/ui/Button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/Dropdown";
+import { ChevronDown, Loader2 } from "lucide-react";
+
+/**
+ * The single suppression entry point: a "Suppress" menu offering the two ways
+ * a set of findings can be hidden — a one-off manual suppression of the
+ * current findings, or an exclusion rule that also suppresses matching
+ * findings going forward. Shared by the signal drawer and the signal list's
+ * multi-select toolbar so the affordance reads identically everywhere.
+ */
+export function SuppressMenu({
+  variant,
+  size,
+  busy = false,
+  onSuppressOnce,
+  onCreateRule,
+}: {
+  variant: "primary" | "secondary" | "tertiary";
+  size?: "sm";
+  /** Disables the menu and shows a spinner while either action is running. */
+  busy?: boolean;
+  /** Manually suppress the findings in scope (excluded_at, reason manual). */
+  onSuppressOnce: () => void;
+  /** Take the user to exclusion rule creation for the findings in scope. */
+  onCreateRule: () => void;
+}): JSX.Element {
+  return (
+    // Default (modal) menu on purpose: the drawer usage renders inside a
+    // modal Sheet, which puts pointer-events: none on the body — a non-modal
+    // menu portaled there would render but never receive clicks.
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant={variant} size={size} disabled={busy}>
+          {busy && (
+            <Button.LeftIcon>
+              <Loader2 className="size-4 animate-spin" />
+            </Button.LeftIcon>
+          )}
+          <Button.Text>Suppress</Button.Text>
+          <Button.RightIcon>
+            <ChevronDown className="size-4" />
+          </Button.RightIcon>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={onSuppressOnce}>
+          Suppress Once
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onCreateRule}>Create Rule</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/client/dashboard/src/pages/security/watchdog/SuppressMenu.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SuppressMenu.tsx
@@ -36,7 +36,7 @@ export function SuppressMenu({
     // menu portaled there would render but never receive clicks.
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant={variant} size={size} disabled={busy}>
+        <Button variant={variant} size={size} disabled={busy} aria-busy={busy}>
           {busy && (
             <Button.LeftIcon>
               <Loader2 className="size-4 animate-spin" />

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -45,6 +45,7 @@ import {
 } from "./signals-helpers";
 import { collectFindingsForRules } from "./collect-findings";
 import { SuppressFindingsDialog } from "./SuppressFindingsDialog";
+import { SuppressMenu } from "./SuppressMenu";
 import { ExposureBar } from "./ExposureBar";
 import { SignalDrawer } from "./SignalDrawer";
 import { SignalsList } from "./SignalsList";
@@ -339,32 +340,13 @@ function WatchdogContent(): JSX.Element {
                 </div>
                 {hasSelection ? (
                   <div className="flex items-center gap-2">
-                    <Button
+                    <SuppressMenu
                       variant="secondary"
                       size="sm"
-                      disabled={collecting}
-                      onClick={() => void handleDismissSelected()}
-                    >
-                      {collecting && (
-                        <Button.LeftIcon>
-                          <Loader2 className="size-4 animate-spin" />
-                        </Button.LeftIcon>
-                      )}
-                      <Button.Text>Suppress</Button.Text>
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      disabled={creatingExclusions}
-                      onClick={handleExcludeSelected}
-                    >
-                      {creatingExclusions && (
-                        <Button.LeftIcon>
-                          <Loader2 className="size-4 animate-spin" />
-                        </Button.LeftIcon>
-                      )}
-                      <Button.Text>Set up exclusion rules</Button.Text>
-                    </Button>
+                      busy={collecting || creatingExclusions}
+                      onSuppressOnce={() => void handleDismissSelected()}
+                      onCreateRule={handleExcludeSelected}
+                    />
                     <Button
                       variant="secondary"
                       size="sm"


### PR DESCRIPTION
https://github.com/user-attachments/assets/a8879fa9-2df4-49ec-b91e-1677ce210a9f


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces separate Suppress and Exclusion Rule buttons with a single “Suppress” dropdown across Watchdog, and improves data freshness after suppression. Previously two buttons; now the menu offers “Suppress Once” and “Create Rule,” and the drawer closes after suppressing a whole signal.

- Introduces `SuppressMenu` with a spinner and aria-busy exposure for assistive tech; used in the Signal Drawer primary action, the signals list multi-select toolbar, and per-result rows (judge detectors only offer suppression; others get the menu). The dropdown is modal by design to work inside the drawer’s Sheet.
- Improves post-action data consistency in `useDismissFinding`: refetches immediately and re-invalidates after 4s and 12s to cover ClickHouse lag so lists/overviews/signals settle without manual reloads. Adds tests for menu trigger/actions and busy state.

<sup>Written for commit 6c7f2a134d7e1a6cff0c11df4ecf5248af0227c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

