### PR TITLE
chore: cache successful server lint runs

### DIFF
--- a/.mise-tasks/lint/server.sh
+++ b/.mise-tasks/lint/server.sh
@@ -49,6 +49,69 @@ common_git_dir=$(cd "$(git rev-parse --git-common-dir)" && pwd)
 lint_config=$(git hash-object .golangci.yaml)
 lint_cache_key=$(printf '%s\n%s\n' "$gcl_stamp" "$lint_config" | git hash-object --stdin)
 
+lint_input_fingerprint() (
+    cd "$current_worktree"
+
+    hash_paths() {
+        while IFS= read -r path; do
+            if [ -f "$path" ]; then
+                printf '%s\n' "$path"
+            fi
+        done | git hash-object --stdin-paths
+    }
+
+    untracked=$(git ls-files --others --exclude-standard)
+    special_index=$(
+        while IFS= read -r entry; do
+            tag=${entry%% *}
+            case "$tag" in
+                [a-z]|S) printf '%s\n' "${entry#? }" ;;
+            esac
+        done < <(git ls-files -v)
+    )
+    ignored_go_inputs=$(
+        git ls-files --others --ignored --exclude-standard -- \
+            '*.go' '*.c' '*.cc' '*.cxx' '*.cpp' '*.m' \
+            '*.h' '*.hh' '*.hpp' '*.f' '*.F' '*.for' '*.f90' \
+            '*.s' '*.S' '*.sx' '*.swig' '*.swigcxx' '*.syso' \
+            'go.mod' 'go.sum' 'go.work' 'go.work.sum'
+    )
+    go_work=$(go env GOWORK)
+    go_env_file=$(go env GOENV)
+    go_config_paths=$(
+        case "$go_work" in
+            ''|off) ;;
+            *) printf '%s\n%s.sum\n' "$go_work" "$go_work" ;;
+        esac
+        case "$go_env_file" in
+            ''|off) ;;
+            *) printf '%s\n' "$go_env_file" ;;
+        esac
+    )
+
+    {
+        printf 'head\n'
+        git rev-parse HEAD
+        printf 'staged\n'
+        git diff --cached --no-ext-diff --binary | git hash-object --stdin
+        printf 'unstaged\n'
+        git diff --no-ext-diff --binary | git hash-object --stdin
+        printf 'untracked-paths\n%s\nuntracked-contents\n' "$untracked"
+        printf '%s\n' "$untracked" | hash_paths
+        printf 'special-index-paths\n%s\nspecial-index-contents\n' "$special_index"
+        printf '%s\n' "$special_index" | hash_paths
+        printf 'ignored-go-paths\n%s\nignored-go-contents\n' "$ignored_go_inputs"
+        printf '%s\n' "$ignored_go_inputs" | hash_paths
+        printf 'go-config-paths\n%s\ngo-config-contents\n' "$go_config_paths"
+        printf '%s\n' "$go_config_paths" | hash_paths
+        printf 'go-env\n'
+        go env \
+            GOOS GOARCH GOAMD64 GOARM64 GOEXPERIMENT GOFLAGS GOVERSION GOROOT \
+            CGO_ENABLED CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS \
+            CC CXX PKG_CONFIG GOWORK GOENV GOMOD GOMODCACHE GOPATH GOTOOLCHAIN
+    } | git hash-object --stdin
+)
+
 # golangci-lint includes absolute filenames in its cache keys. Run worktrees
 # with the same binary and lint configuration through one stable path so they
 # share cache entries. Including the cache key in that path also prevents stale
@@ -94,6 +157,47 @@ trap release_lint_lock EXIT
 rm -f "$stable_worktree"
 ln -s "$current_worktree" "$stable_worktree"
 cd "${stable_worktree}/server"
+lint_inputs=$(lint_input_fingerprint)
+
+# A cold golangci-lint run over every server package holds the analysis graph
+# for thousands of files at once. Priming the cache from the server binary
+# first covers most shared dependencies with a much smaller live set; the full
+# run can then reuse those results. Once this cache/config pair has completed,
+# skip the prime so warm runs retain their existing fast path.
+lint_cache_location=${GOLANGCI_LINT_CACHE:-${XDG_CACHE_HOME:-$HOME}}
+lint_warm_key=$(printf '%s\n%s\n' "$lint_cache_key" "$lint_cache_location" | git hash-object --stdin)
+lint_warm_marker="${common_git_dir}/gcl-lint-warm-${lint_warm_key}"
+lint_success_file="${common_git_dir}/gcl-lint-success-${lint_cache_key}"
+lint_success=
+if [ -r "$lint_success_file" ]; then
+    IFS= read -r lint_success < "$lint_success_file"
+fi
+
+# A successful lint is deterministic for the linter, config, worktree, and
+# Go build environment fingerprinted above. Avoid starting go list and
+# golangci-lint again when another worktree has already checked the exact same
+# inputs. --long always runs because its purpose is to print detailed results.
+if [ "${usage_long:-false}" != "true" ] && [ "$lint_success" = "$lint_inputs" ]; then
+    release_lint_lock
+    trap - EXIT
+    exit 0
+fi
+
+if [ ! -e "$lint_warm_marker" ]; then
+    echo "Priming gcl cache..."
+    prime_started=$SECONDS
+    if ./bin/gcl run \
+        --issues-exit-code=0 \
+        --show-stats=false \
+        --output.text.path=/dev/null \
+        .
+    then
+        echo "Primed gcl cache in $((SECONDS - prime_started))s"
+        touch "$lint_warm_marker"
+    else
+        echo "Failed to prime gcl cache; continuing with full run" >&2
+    fi
+fi
 
 # Generated packages produce no diagnostics after golangci-lint's generated
 # file filter, but making them initial packages more than doubles cold runtime.
@@ -126,6 +230,14 @@ if ./bin/gcl run --max-issues-per-linter=0 "${args[@]}" "${lint_packages[@]}"; t
     lint_status=0
 else
     lint_status=$?
+fi
+
+if [ "$lint_status" -eq 0 ]; then
+    touch "$lint_warm_marker"
+    lint_inputs_after=$(lint_input_fingerprint)
+    if [ "$lint_inputs_after" = "$lint_inputs" ]; then
+        printf '%s\n' "$lint_inputs" > "$lint_success_file"
+    fi
 fi
 
 release_lint_lock


### PR DESCRIPTION
## Summary

- prime golangci-lint's cache from the server root package before a cold full-server run
- fingerprint the worktree's on-disk lint inputs and Go build environment, including Git-hidden/ignored Go inputs and the active workspace configuration
- reuse a successful result only for identical inputs, recomputing the fingerprint after the shared lock and after the full lint
- persist successful priming independently from lint findings; `--long` always performs the full lint
- keep the existing full package selection and diagnostics unchanged on every cache miss

## Benchmarks

Measured on this arm64 Linux workstation with `/usr/bin/time -p` after rebasing onto `origin/main`. The before case ran the exact `origin/main` task body; the after case ran this branch. Both used the same prebuilt custom gcl binary. Cold runs used distinct empty `GOLANGCI_LINT_CACHE` directories.

| Scenario | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Empty golangci-lint cache | 447.34s | 152.74s | -294.60s (-65.9%) |
| Unchanged second rerun | 7.16s | 0.58s | -6.58s (-91.9%) |

## Verification

- `mise lint:server --long` reports `0 issues`
- an ignored Go file invalidated the result cache, emitted the expected `unused` diagnostic, and exited nonzero
- an ignored active `go.work` invalidated the result cache and forced a full lint
- a worktree change made while lint waited for the shared lock was detected and linted after lock acquisition
- a persistently failing tree primed once; its second lint did not repeat priming
- `bash -n .mise-tasks/lint/server.sh`
- `hk fix .mise-tasks/lint/server.sh`
