### PR TITLE
feat: subject assistant tool calls to realtime security enforcement

### DIFF
--- a/.changeset/assistant-inline-enforcement.md
+++ b/.changeset/assistant-inline-enforcement.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Hosted assistant tool calls now consult the same realtime risk-policy and spend-gate enforcement used for hook-ingested agent traffic, at the runner's tool-dispatch chokepoint. Public hook ingest still rejects the reserved `assistant` adapter so clients cannot forge that attribution.

--- a/agents/runner/src/enforce.rs
+++ b/agents/runner/src/enforce.rs
@@ -168,7 +168,8 @@ mod tests {
     use super::*;
     use crate::gram_client::GramBootstrapClient;
     use crate::http_layer::build_bootstrap_client;
-    use agentkit_core::ToolCallId;
+    use agentkit_core::{MetadataMap, SessionId, TurnId};
+    use agentkit_tools_core::{AllowAllPermissions, OwnedToolContext};
     use axum::Json;
     use axum::extract::State;
     use axum::routing::post;
@@ -282,10 +283,19 @@ mod tests {
     }
 
     fn tool_request(name: &str, call_id: &str) -> ToolRequest {
-        ToolRequest {
-            tool_name: ToolName::new(name),
-            call_id: ToolCallId::new(call_id),
-            input: json!({"code": "1"}),
+        ToolRequest::new(call_id, name, json!({"code": "1"}), "s", "t")
+    }
+
+    fn owned_tool_context() -> OwnedToolContext {
+        OwnedToolContext {
+            session_id: SessionId::new("s"),
+            turn_id: TurnId::new("t"),
+            metadata: MetadataMap::new(),
+            permissions: Arc::new(AllowAllPermissions),
+            resources: Arc::new(()),
+            cancellation: None,
+            execution_scope: None,
+            approved_request: None,
         }
     }
 
@@ -310,7 +320,8 @@ mod tests {
             Arc::new(DashSet::new()),
         );
         let tool = source.get(&ToolName::new("bun_run")).expect("tool");
-        let mut ctx = unused_tool_context();
+        let owned = owned_tool_context();
+        let mut ctx = owned.borrowed();
         let result = tool
             .invoke(tool_request("bun_run", "call_deny"), &mut ctx)
             .await
@@ -344,7 +355,8 @@ mod tests {
             Arc::new(DashSet::new()),
         );
         let tool = source.get(&ToolName::new("bun_run")).expect("tool");
-        let mut ctx = unused_tool_context();
+        let owned = owned_tool_context();
+        let mut ctx = owned.borrowed();
         let result = tool
             .invoke(tool_request("bun_run", "call_allow"), &mut ctx)
             .await
@@ -378,7 +390,8 @@ mod tests {
             Arc::new(DashSet::new()),
         );
         let tool = source.get(&ToolName::new("bun_run")).expect("tool");
-        let mut ctx = unused_tool_context();
+        let owned = owned_tool_context();
+        let mut ctx = owned.borrowed();
         let result = tool
             .invoke(tool_request("bun_run", "call_5xx"), &mut ctx)
             .await
@@ -415,7 +428,8 @@ mod tests {
             Arc::clone(&consulted),
         );
         let tool = source.get(&ToolName::new("bun_run")).expect("tool");
-        let mut ctx = unused_tool_context();
+        let owned = owned_tool_context();
+        let mut ctx = owned.borrowed();
         tool.invoke(tool_request("bun_run", "call_dup"), &mut ctx)
             .await
             .unwrap();
@@ -425,9 +439,5 @@ mod tests {
         assert_eq!(hits.load(Ordering::SeqCst), 1);
         assert_eq!(invocations.load(Ordering::SeqCst), 2);
         let _ = shutdown.send(());
-    }
-
-    fn unused_tool_context() -> ToolContext<'static> {
-        ToolContext::default()
     }
 }

--- a/agents/runner/src/enforce.rs
+++ b/agents/runner/src/enforce.rs
@@ -1,0 +1,433 @@
+//! Inline security consult before assistant tool execution.
+//!
+//! Hosted assistant tool calls used to skip the risk scanner and spend gate
+//! because those live on the hook-ingest path. This wrapper asks the
+//! management API whether a call may proceed and, on deny, returns a tool
+//! error result without invoking the inner tool. Transport failures fail
+//! open so a control-plane blip does not wedge the loop.
+//!
+//! [`EnforcingToolSource`] is applied twice: around the hidden MCP catalog
+//! (so compose-inner MCP calls are scanned) and around the outermost clipped
+//! source (native tools, compose, unknown). A shared [`DashSet`] of call ids
+//! dedupes a direct MCP invocation that would otherwise consult twice.
+
+use std::sync::Arc;
+
+use agentkit_core::{ToolOutput, ToolResultPart};
+use agentkit_tools_core::{
+    PermissionRequest, Tool, ToolCatalogEvent, ToolContext, ToolError, ToolName, ToolRequest,
+    ToolResult, ToolSource, ToolSpec,
+};
+use async_trait::async_trait;
+use dashmap::DashSet;
+
+use crate::gram_client::GramBootstrapClient;
+use crate::http_layer::TokenRegistry;
+
+/// Wraps a [`ToolSource`] so every `invoke` consults Gram enforcement first.
+pub struct EnforcingToolSource<S> {
+    inner: S,
+    gram_client: GramBootstrapClient,
+    tokens: TokenRegistry,
+    thread_id: String,
+    consulted: Arc<DashSet<String>>,
+}
+
+impl<S> EnforcingToolSource<S> {
+    pub fn new(
+        inner: S,
+        gram_client: GramBootstrapClient,
+        tokens: TokenRegistry,
+        thread_id: impl Into<String>,
+        consulted: Arc<DashSet<String>>,
+    ) -> Self {
+        Self {
+            inner,
+            gram_client,
+            tokens,
+            thread_id: thread_id.into(),
+            consulted,
+        }
+    }
+}
+
+impl<S> ToolSource for EnforcingToolSource<S>
+where
+    S: ToolSource,
+{
+    fn specs(&self) -> Vec<ToolSpec> {
+        self.inner.specs()
+    }
+
+    fn get(&self, name: &ToolName) -> Option<Arc<dyn Tool>> {
+        self.inner.get(name).map(|inner| {
+            Arc::new(EnforcingTool {
+                inner,
+                gram_client: self.gram_client.clone(),
+                tokens: self.tokens.clone(),
+                thread_id: self.thread_id.clone(),
+                consulted: Arc::clone(&self.consulted),
+            }) as Arc<dyn Tool>
+        })
+    }
+
+    fn drain_catalog_events(&self) -> Vec<ToolCatalogEvent> {
+        self.inner.drain_catalog_events()
+    }
+}
+
+struct EnforcingTool {
+    inner: Arc<dyn Tool>,
+    gram_client: GramBootstrapClient,
+    tokens: TokenRegistry,
+    thread_id: String,
+    consulted: Arc<DashSet<String>>,
+}
+
+#[async_trait]
+impl Tool for EnforcingTool {
+    fn spec(&self) -> &ToolSpec {
+        self.inner.spec()
+    }
+
+    fn current_spec(&self) -> Option<ToolSpec> {
+        self.inner.current_spec()
+    }
+
+    fn proposed_requests(
+        &self,
+        request: &ToolRequest,
+    ) -> Result<Vec<Box<dyn PermissionRequest>>, ToolError> {
+        self.inner.proposed_requests(request)
+    }
+
+    async fn invoke(
+        &self,
+        request: ToolRequest,
+        ctx: &mut ToolContext<'_>,
+    ) -> Result<ToolResult, ToolError> {
+        if let Some(denied) = consult_tool_invocation(
+            &self.gram_client,
+            &self.tokens,
+            &self.thread_id,
+            &self.consulted,
+            &request,
+        )
+        .await
+        {
+            return Ok(denied);
+        }
+        self.inner.invoke(request, ctx).await
+    }
+}
+
+/// Returns a deny tool result when enforcement blocks the call, or `None`
+/// when the call may proceed (including fail-open on consult errors).
+async fn consult_tool_invocation(
+    client: &GramBootstrapClient,
+    tokens: &TokenRegistry,
+    thread_id: &str,
+    consulted: &DashSet<String>,
+    request: &ToolRequest,
+) -> Option<ToolResult> {
+    let call_id = request.call_id.0.clone();
+    if !call_id.is_empty() && !consulted.insert(call_id.clone()) {
+        return None;
+    }
+
+    match client
+        .consult_tool_call(
+            thread_id,
+            request.tool_name.0.as_str(),
+            &request.input,
+            &call_id,
+            tokens,
+        )
+        .await
+    {
+        Ok(response) if response.is_deny() => Some(ToolResult::new(ToolResultPart::error(
+            request.call_id.clone(),
+            ToolOutput::text(response.deny_message()),
+        ))),
+        Ok(_) => None,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                thread_id,
+                tool_name = %request.tool_name.0,
+                "assistant tool-call consult failed; allowing"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::gram_client::GramBootstrapClient;
+    use crate::http_layer::build_bootstrap_client;
+    use agentkit_core::ToolCallId;
+    use axum::Json;
+    use axum::extract::State;
+    use axum::routing::post;
+    use serde_json::{Value, json};
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::oneshot;
+
+    struct EchoTool {
+        spec: ToolSpec,
+        invocations: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for EchoTool {
+        fn spec(&self) -> &ToolSpec {
+            &self.spec
+        }
+
+        async fn invoke(
+            &self,
+            request: ToolRequest,
+            _ctx: &mut ToolContext<'_>,
+        ) -> Result<ToolResult, ToolError> {
+            self.invocations.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult::new(ToolResultPart::success(
+                request.call_id,
+                ToolOutput::text("echo"),
+            )))
+        }
+    }
+
+    struct StaticSource {
+        tool: Arc<dyn Tool>,
+    }
+
+    impl ToolSource for StaticSource {
+        fn specs(&self) -> Vec<ToolSpec> {
+            vec![self.tool.spec().clone()]
+        }
+
+        fn get(&self, name: &ToolName) -> Option<Arc<dyn Tool>> {
+            if name.0 == self.tool.spec().name.0 {
+                Some(Arc::clone(&self.tool))
+            } else {
+                None
+            }
+        }
+
+        fn drain_catalog_events(&self) -> Vec<ToolCatalogEvent> {
+            Vec::new()
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockState {
+        decision: &'static str,
+        message: &'static str,
+        status: u16,
+        hits: Arc<AtomicUsize>,
+    }
+
+    async fn spawn_consult_server(
+        decision: &'static str,
+        message: &'static str,
+        status: u16,
+    ) -> (String, oneshot::Sender<()>, Arc<AtomicUsize>) {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let state = MockState {
+            decision,
+            message,
+            status,
+            hits: Arc::clone(&hits),
+        };
+        let app = axum::Router::new()
+            .route(
+                "/rpc/assistants.consultToolCall",
+                post(
+                    |State(state): State<MockState>, Json(_body): Json<Value>| async move {
+                        state.hits.fetch_add(1, Ordering::SeqCst);
+                        let body = json!({
+                            "decision": state.decision,
+                            "message": state.message,
+                        });
+                        (
+                            axum::http::StatusCode::from_u16(state.status)
+                                .unwrap_or(axum::http::StatusCode::OK),
+                            Json(body),
+                        )
+                    },
+                ),
+            )
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        (format!("http://{addr}"), shutdown_tx, hits)
+    }
+
+    fn client(base_url: String) -> GramBootstrapClient {
+        GramBootstrapClient::new(base_url, build_bootstrap_client(reqwest::Client::new()))
+    }
+
+    fn tool_request(name: &str, call_id: &str) -> ToolRequest {
+        ToolRequest {
+            tool_name: ToolName::new(name),
+            call_id: ToolCallId::new(call_id),
+            input: json!({"code": "1"}),
+        }
+    }
+
+    #[tokio::test]
+    async fn deny_returns_error_result_without_invoking_inner() {
+        let (base, shutdown, hits) =
+            spawn_consult_server("deny", "Speakeasy blocked this tool call", 200).await;
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let inner = Arc::new(EchoTool {
+            spec: ToolSpec::new(
+                "bun_run",
+                "runs bun",
+                json!({"type": "object", "properties": {}}),
+            ),
+            invocations: Arc::clone(&invocations),
+        });
+        let source = EnforcingToolSource::new(
+            StaticSource { tool: inner },
+            client(base),
+            TokenRegistry::new("token"),
+            "thread-1",
+            Arc::new(DashSet::new()),
+        );
+        let tool = source.get(&ToolName::new("bun_run")).expect("tool");
+        let mut ctx = unused_tool_context();
+        let result = tool
+            .invoke(tool_request("bun_run", "call_deny"), &mut ctx)
+            .await
+            .expect("invoke");
+        match result.result.output {
+            ToolOutput::Text(text) => assert!(text.contains("Speakeasy blocked this tool call")),
+            other => panic!("expected text deny, got {other:?}"),
+        }
+        assert_eq!(invocations.load(Ordering::SeqCst), 0);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn allow_invokes_inner() {
+        let (base, shutdown, hits) = spawn_consult_server("allow", "", 200).await;
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let inner = Arc::new(EchoTool {
+            spec: ToolSpec::new(
+                "bun_run",
+                "runs bun",
+                json!({"type": "object", "properties": {}}),
+            ),
+            invocations: Arc::clone(&invocations),
+        });
+        let source = EnforcingToolSource::new(
+            StaticSource { tool: inner },
+            client(base),
+            TokenRegistry::new("token"),
+            "thread-1",
+            Arc::new(DashSet::new()),
+        );
+        let tool = source.get(&ToolName::new("bun_run")).expect("tool");
+        let mut ctx = unused_tool_context();
+        let result = tool
+            .invoke(tool_request("bun_run", "call_allow"), &mut ctx)
+            .await
+            .expect("invoke");
+        match result.result.output {
+            ToolOutput::Text(text) => assert_eq!(text, "echo"),
+            other => panic!("expected echo, got {other:?}"),
+        }
+        assert_eq!(invocations.load(Ordering::SeqCst), 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn server_error_fails_open_and_invokes_inner() {
+        let (base, shutdown, hits) = spawn_consult_server("allow", "", 500).await;
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let inner = Arc::new(EchoTool {
+            spec: ToolSpec::new(
+                "bun_run",
+                "runs bun",
+                json!({"type": "object", "properties": {}}),
+            ),
+            invocations: Arc::clone(&invocations),
+        });
+        let source = EnforcingToolSource::new(
+            StaticSource { tool: inner },
+            client(base),
+            TokenRegistry::new("token"),
+            "thread-1",
+            Arc::new(DashSet::new()),
+        );
+        let tool = source.get(&ToolName::new("bun_run")).expect("tool");
+        let mut ctx = unused_tool_context();
+        let result = tool
+            .invoke(tool_request("bun_run", "call_5xx"), &mut ctx)
+            .await
+            .expect("invoke");
+        match result.result.output {
+            ToolOutput::Text(text) => assert_eq!(text, "echo"),
+            other => panic!("expected echo, got {other:?}"),
+        }
+        assert_eq!(invocations.load(Ordering::SeqCst), 1);
+        assert!(hits.load(Ordering::SeqCst) >= 1);
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn duplicate_call_id_consults_once() {
+        let (base, shutdown, hits) = spawn_consult_server("allow", "", 200).await;
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let inner = Arc::new(EchoTool {
+            spec: ToolSpec::new(
+                "bun_run",
+                "runs bun",
+                json!({"type": "object", "properties": {}}),
+            ),
+            invocations: Arc::clone(&invocations),
+        });
+        let consulted = Arc::new(DashSet::new());
+        let source = EnforcingToolSource::new(
+            StaticSource {
+                tool: Arc::clone(&inner) as Arc<dyn Tool>,
+            },
+            client(base),
+            TokenRegistry::new("token"),
+            "thread-1",
+            Arc::clone(&consulted),
+        );
+        let tool = source.get(&ToolName::new("bun_run")).expect("tool");
+        let mut ctx = unused_tool_context();
+        tool.invoke(tool_request("bun_run", "call_dup"), &mut ctx)
+            .await
+            .unwrap();
+        tool.invoke(tool_request("bun_run", "call_dup"), &mut ctx)
+            .await
+            .unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        assert_eq!(invocations.load(Ordering::SeqCst), 2);
+        let _ = shutdown.send(());
+    }
+
+    fn unused_tool_context() -> ToolContext<'static> {
+        ToolContext::default()
+    }
+}

--- a/agents/runner/src/gram_client.rs
+++ b/agents/runner/src/gram_client.rs
@@ -27,6 +27,9 @@ const RECORD_COMPACTION_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct GramBootstrapClient {
     base_url: String,
     http: ClientWithMiddleware,
+    /// Consult is fail-open and on the tool-call hot path, so it must not
+    /// inherit the bootstrap client's 5xx retry budget.
+    consult_http: reqwest::Client,
 }
 
 #[derive(Debug, Error)]
@@ -104,7 +107,11 @@ pub struct CreateMcpAuthFlowResponse {
 
 impl GramBootstrapClient {
     pub fn new(base_url: String, http: ClientWithMiddleware) -> Self {
-        Self { base_url, http }
+        Self {
+            base_url,
+            http,
+            consult_http: reqwest::Client::new(),
+        }
     }
 
     /// Fetches the bootstrap blob for a thread. Caller is responsible for
@@ -238,7 +245,7 @@ impl GramBootstrapClient {
         let bearer = tokens.current().map_err(|_| GramClientError::Token)?;
 
         let resp = self
-            .http
+            .consult_http
             .post(&url)
             .timeout(CONSULT_TIMEOUT)
             .bearer_auth(&bearer)
@@ -249,7 +256,8 @@ impl GramBootstrapClient {
                 tool_call_id,
             })
             .send()
-            .await?;
+            .await
+            .map_err(|err| GramClientError::Send(reqwest_middleware::Error::from(err)))?;
 
         let status = resp.status();
         let body = resp.text().await?;

--- a/agents/runner/src/gram_client.rs
+++ b/agents/runner/src/gram_client.rs
@@ -10,7 +10,9 @@ use crate::wire::{RunnerMessage, ThreadBootstrap};
 const BOOTSTRAP_PATH: &str = "/rpc/assistants.getThreadBootstrap";
 const CREATE_MCP_AUTH_FLOW_PATH: &str = "/rpc/assistantMcpAuth.create";
 const RECORD_COMPACTED_GENERATION_PATH: &str = "/rpc/assistants.recordCompactedGeneration";
+const CONSULT_TOOL_CALL_PATH: &str = "/rpc/assistants.consultToolCall";
 const BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(15);
+const CONSULT_TIMEOUT: Duration = Duration::from_secs(30);
 // Compaction persistence runs off the loop's critical path, so a longer
 // budget is fine; the post-compaction call body can be sizable and the
 // server walks all rows in a single transaction.
@@ -61,6 +63,36 @@ struct CreateMcpAuthFlowRequest<'a> {
 struct RecordCompactedGenerationRequest<'a> {
     thread_id: &'a str,
     messages: &'a [RunnerMessage],
+}
+
+#[derive(Serialize)]
+struct ConsultToolCallRequest<'a> {
+    thread_id: &'a str,
+    tool_name: &'a str,
+    tool_input: &'a serde_json::Value,
+    tool_call_id: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConsultToolCallResponse {
+    pub decision: String,
+    #[serde(default)]
+    pub message: String,
+}
+
+impl ConsultToolCallResponse {
+    pub fn is_deny(&self) -> bool {
+        self.decision.eq_ignore_ascii_case("deny")
+    }
+
+    pub fn deny_message(&self) -> String {
+        let trimmed = self.message.trim();
+        if trimmed.is_empty() {
+            "Request denied by Speakeasy policy.".to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -184,5 +216,50 @@ impl GramBootstrapClient {
             });
         }
         Ok(())
+    }
+
+    /// Asks the management API whether this tool call may execute. The
+    /// server consults spend-gate and risk-policy enforcement. Callers must
+    /// fail open on transport/decode errors so a control-plane blip does not
+    /// wedge the assistant loop.
+    pub async fn consult_tool_call(
+        &self,
+        thread_id: &str,
+        tool_name: &str,
+        tool_input: &serde_json::Value,
+        tool_call_id: &str,
+        tokens: &TokenRegistry,
+    ) -> Result<ConsultToolCallResponse, GramClientError> {
+        let url = format!(
+            "{}{}",
+            self.base_url.trim_end_matches('/'),
+            CONSULT_TOOL_CALL_PATH
+        );
+        let bearer = tokens.current().map_err(|_| GramClientError::Token)?;
+
+        let resp = self
+            .http
+            .post(&url)
+            .timeout(CONSULT_TIMEOUT)
+            .bearer_auth(&bearer)
+            .json(&ConsultToolCallRequest {
+                thread_id,
+                tool_name,
+                tool_input,
+                tool_call_id,
+            })
+            .send()
+            .await?;
+
+        let status = resp.status();
+        let body = resp.text().await?;
+        if !status.is_success() {
+            return Err(GramClientError::Status {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        let parsed: ConsultToolCallResponse = serde_json::from_str(&body)?;
+        Ok(parsed)
     }
 }

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -1,6 +1,7 @@
 mod catalog;
 mod clip;
 mod compaction;
+mod enforce;
 mod errors;
 mod gram_client;
 mod http_layer;

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -19,6 +19,7 @@ use agentkit_tools_core::{
     CompositePermissionChecker, PathPolicy, PermissionDecision, ToolRegistry,
 };
 use dashmap::DashMap;
+use dashmap::DashSet;
 use futures::FutureExt;
 use serde_json::Value;
 use tokio::sync::OnceCell;
@@ -30,6 +31,7 @@ use agentkit_compaction::{AgentBuilderCompactorExt, CompactionReason, Compactor}
 use crate::catalog::{HiddenCatalogSource, UnknownToolSource};
 use crate::clip::ClippedToolSource;
 use crate::compaction::{Compaction, PersistingCompactor, PrimaryCompaction, build_compactor};
+use crate::enforce::EnforcingToolSource;
 use crate::errors::RunnerError;
 use crate::gram_client::GramBootstrapClient;
 use crate::http_layer::{TokenRegistry, build_bootstrap_client, build_http};
@@ -409,17 +411,34 @@ async fn spawn_thread(
     // cache survives catalog churn. UnknownToolSource sits last so a call
     // to an undiscovered or hallucinated name returns a recovery hint
     // instead of a bare not-found.
-    let compose_source = agentkit_tool_compose::ComposeTool::wrap(HiddenCatalogSource::new(
-        mcp_catalog,
-        mcp_cmd_tx.clone(),
-    ))
-    .with_source(native_tools.merge(agentkit_tool_fs::registry()))
-    .with_source(UnknownToolSource);
+    //
+    // Enforcement wraps the hidden catalog (compose-inner MCP calls) and
+    // the outermost clipped source (native / compose / unknown). A shared
+    // call-id set dedupes a direct MCP invoke that would otherwise consult
+    // twice.
+    let consulted = Arc::new(DashSet::new());
+    let hidden_source = EnforcingToolSource::new(
+        HiddenCatalogSource::new(mcp_catalog, mcp_cmd_tx.clone()),
+        host.gram_client.clone(),
+        tokens.clone(),
+        thread_id.clone(),
+        Arc::clone(&consulted),
+    );
+    let compose_source = agentkit_tool_compose::ComposeTool::wrap(hidden_source)
+        .with_source(native_tools.merge(agentkit_tool_fs::registry()))
+        .with_source(UnknownToolSource);
     let clipped_source = ClippedToolSource::new(compose_source, host.spill_root.clone());
+    let enforcing_source = EnforcingToolSource::new(
+        clipped_source,
+        host.gram_client.clone(),
+        tokens.clone(),
+        thread_id.clone(),
+        consulted,
+    );
 
     let mut builder = Agent::builder()
         .model(adapter)
-        .add_tool_source(clipped_source)
+        .add_tool_source(enforcing_source)
         .permissions(permissions)
         .resources(fs_resources)
         .observer(TracingReporter::new())
@@ -722,13 +741,12 @@ fn normalize_history(history: &[RunnerMessage]) -> Result<Vec<Item>, RunnerError
                     .as_deref()
                     .filter(|s| !s.is_empty())
                     .ok_or(RunnerError::MissingToolCallId)?;
-                items.push(Item::new(
-                    ItemKind::Tool,
-                    vec![Part::ToolResult(ToolResultPart::success(
+                items.push(Item::new(ItemKind::Tool, vec![Part::ToolResult(
+                    ToolResultPart::success(
                         call_id,
                         ToolOutput::text(text_with_image_placeholders(&message.content)),
-                    ))],
-                ));
+                    ),
+                )]));
             }
             "system" => {
                 items.push(Item::text(
@@ -929,12 +947,9 @@ mod tests {
             tool_call_id: None,
         }];
         let items = normalize_history(&history).unwrap();
-        assert_eq!(
-            items[0].parts,
-            vec![Part::Text(TextPart::new(
-                "here you go\n[image: https://example.com/out.png]"
-            ))]
-        );
+        assert_eq!(items[0].parts, vec![Part::Text(TextPart::new(
+            "here you go\n[image: https://example.com/out.png]"
+        ))]);
     }
 
     #[test]

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1352,6 +1352,7 @@ func newStartCommand() *cli.Command {
 				c.String("jwt-signing-key"),
 			)
 			hooks.Attach(mux, hooksService)
+			assistantsCore.SetHookIngester(hooksService)
 			litellmService = litellm.NewService(logger, tracerProvider, db, chDB, sessionManager, authzEngine, hooksService, litellmCalls, litellmTraceProcessor, litellmMetricProcessor, litellmHealthProcessor, litellmInstanceResolver, auditLogger, c.String("environment"))
 			litellm.Attach(mux, litellmService)
 			aiintegrations.Attach(mux, aiintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, &background.TemporalAIUsagePoller{TemporalEnv: temporalEnv}))

--- a/server/internal/assistants/consult.go
+++ b/server/internal/assistants/consult.go
@@ -1,0 +1,208 @@
+package assistants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	hooksgen "github.com/speakeasy-api/gram/server/gen/hooks"
+	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/hooks"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+const (
+	assistantHookAdapter      = "assistant"
+	assistantHookSchemaV1     = "hook.ingest.v1"
+	consultDecisionAllow      = "allow"
+	consultDecisionDeny       = "deny"
+	consultDefaultDenyMessage = "Request denied by Speakeasy policy."
+)
+
+// HookIngester is the trusted in-process canonical ingest surface used to
+// subject hosted assistant tool calls to the same risk-policy and spend-gate
+// enforcement as hook-ingested agent traffic.
+type HookIngester interface {
+	// IngestAuthenticatedDetailed applies canonical hook evaluation for a
+	// caller that has already authenticated the organization and project.
+	IngestAuthenticatedDetailed(context.Context, *contextvalues.AuthContext, *hooksgen.IngestPayload, hooks.AuthenticatedIngestOptions) (*hooks.AuthenticatedIngestResult, error)
+}
+
+type consultToolCallRequest struct {
+	ThreadID   string          `json:"thread_id"`
+	ToolName   string          `json:"tool_name"`
+	ToolInput  json.RawMessage `json:"tool_input"`
+	ToolCallID string          `json:"tool_call_id"`
+}
+
+type consultToolCallResult struct {
+	Decision string `json:"decision"`
+	Message  string `json:"message,omitempty"`
+}
+
+func consultAllowResult() consultToolCallResult {
+	return consultToolCallResult{Decision: consultDecisionAllow, Message: ""}
+}
+
+func consultDenyResult(message string) consultToolCallResult {
+	if strings.TrimSpace(message) == "" {
+		message = consultDefaultDenyMessage
+	}
+	return consultToolCallResult{Decision: consultDecisionDeny, Message: message}
+}
+
+// ConsultToolCall evaluates a pending assistant tool invocation against
+// canonical hook enforcement (spend gate, risk policy). The session identity
+// is the server-owned chat id, never a client-supplied conversation id. A
+// nil ingester, or an ingest error, fails open so a control-plane blip does
+// not wedge the assistant loop.
+func (s *ServiceCore) ConsultToolCall(ctx context.Context, projectID, principalAssistantID uuid.UUID, req consultToolCallRequest) (consultToolCallResult, error) {
+	threadID, err := uuid.Parse(strings.TrimSpace(req.ThreadID))
+	if err != nil {
+		return consultToolCallResult{}, oops.E(oops.CodeBadRequest, err, "invalid thread_id")
+	}
+	toolName := strings.TrimSpace(req.ToolName)
+	if toolName == "" {
+		return consultToolCallResult{}, oops.E(oops.CodeBadRequest, nil, "tool_name is required")
+	}
+	toolCallID := strings.TrimSpace(req.ToolCallID)
+	if toolCallID == "" {
+		return consultToolCallResult{}, oops.E(oops.CodeBadRequest, nil, "tool_call_id is required")
+	}
+
+	logAttrs := []slog.Attr{
+		attr.SlogProjectID(projectID.String()),
+		attr.SlogAssistantID(principalAssistantID.String()),
+		attr.SlogAssistantThreadID(threadID.String()),
+		attr.SlogToolName(toolName),
+	}
+
+	row, err := assistantrepo.New(s.db).LoadAssistantThreadForBootstrap(ctx, assistantrepo.LoadAssistantThreadForBootstrapParams{
+		ThreadID:  threadID,
+		ProjectID: projectID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return consultToolCallResult{}, oops.E(oops.CodeNotFound, nil, "assistant thread not found").LogError(ctx, s.logger, logAttrs...)
+		}
+		return consultToolCallResult{}, oops.E(oops.CodeUnexpected, err, "load assistant thread").LogError(ctx, s.logger, logAttrs...)
+	}
+	if row.AssistantID != principalAssistantID {
+		return consultToolCallResult{}, oops.E(oops.CodeForbidden, nil, "thread does not belong to assistant").LogError(ctx, s.logger, logAttrs...)
+	}
+
+	if s.hookIngester == nil {
+		s.logger.WarnContext(ctx, "assistant tool-call consult has no hook ingester; allowing",
+			attr.SlogEvent("assistant_tool_consult_ingester_missing"),
+			attr.SlogAssistantID(principalAssistantID.String()),
+			attr.SlogAssistantThreadID(threadID.String()),
+			attr.SlogToolName(toolName),
+		)
+		return consultAllowResult(), nil
+	}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil {
+		return consultToolCallResult{}, oops.E(oops.CodeUnauthorized, nil, "missing auth context")
+	}
+
+	sessionID := row.ChatID.String()
+	idempotencyKey := fmt.Sprintf("assistant:%s:%s", threadID.String(), toolCallID)
+	toolInput := decodeConsultToolInput(req.ToolInput)
+
+	payload := &hooksgen.IngestPayload{
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Replayed:         nil,
+		SchemaVersion:    assistantHookSchemaV1,
+		IdempotencyKey:   &idempotencyKey,
+		Source: &hooksgen.HookIngestSource{
+			Adapter:        assistantHookAdapter,
+			AdapterVersion: nil,
+			RawEventName:   nil,
+			Hostname:       nil,
+			UserEmail:      nil,
+		},
+		Session: &hooksgen.HookIngestSession{
+			ID:     &sessionID,
+			TurnID: nil,
+			Cwd:    nil,
+			Model:  conv.PtrEmpty(row.Model),
+		},
+		Event: &hooksgen.HookIngestEvent{
+			Type:       "tool.requested",
+			OccurredAt: nil,
+		},
+		Data: &hooksgen.HookIngestData{
+			Prompt: nil,
+			ToolCall: &hooksgen.HookToolCallData{
+				ID:             &toolCallID,
+				Name:           &toolName,
+				Input:          toolInput,
+				Output:         nil,
+				Error:          nil,
+				IsInterrupt:    nil,
+				PermissionType: nil,
+				DurationMs:     nil,
+				Status:         nil,
+			},
+			Mcp:                   nil,
+			McpInventory:          nil,
+			McpInventoryCollected: nil,
+			Usage:                 nil,
+			Message:               nil,
+			Skill:                 nil,
+			Notification:          nil,
+			McpAttribution:        nil,
+			PromptAttachments:     nil,
+		},
+		Raw: nil,
+	}
+
+	outcome, err := s.hookIngester.IngestAuthenticatedDetailed(ctx, authCtx, payload, hooks.AuthenticatedIngestOptions{
+		AllowWarnAcknowledgement:     true,
+		AllowSessionIdentityFallback: false,
+		SourceAttributes:             nil,
+		OutputToolCalls:              nil,
+		OriginatingClient:            "assistant",
+		AllowReservedAdapter:         true,
+	})
+	if err != nil {
+		s.logger.WarnContext(ctx, "assistant tool-call consult ingest failed; allowing",
+			attr.SlogEvent("assistant_tool_consult_ingest_error"),
+			attr.SlogError(err),
+			attr.SlogAssistantID(principalAssistantID.String()),
+			attr.SlogAssistantThreadID(threadID.String()),
+			attr.SlogToolName(toolName),
+		)
+		return consultAllowResult(), nil
+	}
+	if outcome != nil && outcome.Result != nil && strings.EqualFold(strings.TrimSpace(outcome.Result.Decision), consultDecisionDeny) {
+		return consultDenyResult(strings.TrimSpace(conv.PtrValOr(outcome.Result.Message, ""))), nil
+	}
+	return consultAllowResult(), nil
+}
+
+func decodeConsultToolInput(raw json.RawMessage) any {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return map[string]any{}
+	}
+	var input any
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return map[string]any{}
+	}
+	if input == nil {
+		return map[string]any{}
+	}
+	return input
+}

--- a/server/internal/assistants/consult.go
+++ b/server/internal/assistants/consult.go
@@ -16,7 +16,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/hooks"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -32,9 +31,9 @@ const (
 // subject hosted assistant tool calls to the same risk-policy and spend-gate
 // enforcement as hook-ingested agent traffic.
 type HookIngester interface {
-	// IngestAuthenticatedDetailed applies canonical hook evaluation for a
-	// caller that has already authenticated the organization and project.
-	IngestAuthenticatedDetailed(context.Context, *contextvalues.AuthContext, *hooksgen.IngestPayload, hooks.AuthenticatedIngestOptions) (*hooks.AuthenticatedIngestResult, error)
+	// IngestAssistantToolCall applies canonical hook evaluation for a hosted
+	// assistant tool call, including the reserved assistant adapter.
+	IngestAssistantToolCall(context.Context, *contextvalues.AuthContext, *hooksgen.IngestPayload) (*hooksgen.IngestHookResult, error)
 }
 
 type consultToolCallRequest struct {
@@ -168,14 +167,7 @@ func (s *ServiceCore) ConsultToolCall(ctx context.Context, projectID, principalA
 		Raw: nil,
 	}
 
-	outcome, err := s.hookIngester.IngestAuthenticatedDetailed(ctx, authCtx, payload, hooks.AuthenticatedIngestOptions{
-		AllowWarnAcknowledgement:     true,
-		AllowSessionIdentityFallback: false,
-		SourceAttributes:             nil,
-		OutputToolCalls:              nil,
-		OriginatingClient:            "assistant",
-		AllowReservedAdapter:         true,
-	})
+	outcome, err := s.hookIngester.IngestAssistantToolCall(ctx, authCtx, payload)
 	if err != nil {
 		s.logger.WarnContext(ctx, "assistant tool-call consult ingest failed; allowing",
 			attr.SlogEvent("assistant_tool_consult_ingest_error"),
@@ -186,8 +178,8 @@ func (s *ServiceCore) ConsultToolCall(ctx context.Context, projectID, principalA
 		)
 		return consultAllowResult(), nil
 	}
-	if outcome != nil && outcome.Result != nil && strings.EqualFold(strings.TrimSpace(outcome.Result.Decision), consultDecisionDeny) {
-		return consultDenyResult(strings.TrimSpace(conv.PtrValOr(outcome.Result.Message, ""))), nil
+	if outcome != nil && strings.EqualFold(strings.TrimSpace(outcome.Decision), consultDecisionDeny) {
+		return consultDenyResult(strings.TrimSpace(conv.PtrValOr(outcome.Message, ""))), nil
 	}
 	return consultAllowResult(), nil
 }

--- a/server/internal/assistants/consult_handler.go
+++ b/server/internal/assistants/consult_handler.go
@@ -1,0 +1,80 @@
+package assistants
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+const consultToolCallMaxBodyBytes = 1 * 1024 * 1024
+
+func (s *Service) handleConsultToolCall(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	token := r.Header.Get("Authorization")
+	if token == "" {
+		return oops.C(oops.CodeUnauthorized)
+	}
+
+	authedCtx, claims, err := s.core.assistantTokens.Authorize(ctx, token)
+	if err != nil {
+		return fmt.Errorf("authorize assistant runtime token: %w", err)
+	}
+	ctx = authedCtx
+
+	principal, ok := contextvalues.GetAssistantPrincipal(ctx)
+	if !ok {
+		return oops.C(oops.CodeUnauthorized)
+	}
+
+	projectID, err := uuid.Parse(claims.ProjectID)
+	if err != nil {
+		return oops.E(oops.CodeUnauthorized, err, "invalid token project")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, consultToolCallMaxBodyBytes))
+	if err != nil {
+		return oops.E(oops.CodeBadRequest, err, "read consult request")
+	}
+	var req consultToolCallRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return oops.E(oops.CodeBadRequest, err, "decode consult request")
+	}
+
+	threadID, err := uuid.Parse(req.ThreadID)
+	if err != nil {
+		return oops.E(oops.CodeBadRequest, err, "invalid thread_id")
+	}
+	if principal.ThreadID != uuid.Nil && principal.ThreadID != threadID {
+		return oops.E(oops.CodeForbidden, nil, "token thread does not match requested thread")
+	}
+
+	result, err := s.core.ConsultToolCall(ctx, projectID, principal.AssistantID, req)
+	if err != nil {
+		return err
+	}
+
+	s.logger.InfoContext(ctx, "assistant tool-call consult served",
+		attr.SlogAssistantID(principal.AssistantID.String()),
+		attr.SlogAssistantThreadID(threadID.String()),
+		attr.SlogProjectID(projectID.String()),
+		attr.SlogToolName(req.ToolName),
+	)
+
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "encode consult response")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("write consult response: %w", err)
+	}
+	return nil
+}

--- a/server/internal/assistants/consult_handler_test.go
+++ b/server/internal/assistants/consult_handler_test.go
@@ -1,0 +1,32 @@
+package assistants
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestHandleConsultToolCallUnauthorizedWithoutToken(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_consult_http_unauth")
+	require.NoError(t, err)
+	logger := testenv.NewLogger(t)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
+	svc := &Service{logger: logger, core: core}
+
+	req := httptest.NewRequest(http.MethodPost, "/rpc/assistants.consultToolCall", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	err = svc.handleConsultToolCall(rec, req)
+	require.Error(t, err)
+	var se *oops.ShareableError
+	require.ErrorAs(t, err, &se)
+	require.Equal(t, oops.CodeUnauthorized, se.Code)
+}

--- a/server/internal/assistants/consult_test.go
+++ b/server/internal/assistants/consult_test.go
@@ -1,0 +1,173 @@
+package assistants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	hooksgen "github.com/speakeasy-api/gram/server/gen/hooks"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/hooks"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type capturedConsultCall struct {
+	auth    *contextvalues.AuthContext
+	payload *hooksgen.IngestPayload
+	options hooks.AuthenticatedIngestOptions
+}
+
+type captureConsultIngester struct {
+	result *hooks.AuthenticatedIngestResult
+	err    error
+	calls  []capturedConsultCall
+}
+
+func (c *captureConsultIngester) IngestAuthenticatedDetailed(_ context.Context, authCtx *contextvalues.AuthContext, payload *hooksgen.IngestPayload, options hooks.AuthenticatedIngestOptions) (*hooks.AuthenticatedIngestResult, error) {
+	c.calls = append(c.calls, capturedConsultCall{auth: authCtx, payload: payload, options: options})
+	return c.result, c.err
+}
+
+func consultAuthContext(projectID uuid.UUID) *contextvalues.AuthContext {
+	return &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-test",
+		UserID:               "user-test",
+		ProjectID:            &projectID,
+	}
+}
+
+func consultRequest(threadID uuid.UUID) consultToolCallRequest {
+	return consultToolCallRequest{
+		ThreadID:   threadID.String(),
+		ToolName:   "bun_run",
+		ToolInput:  json.RawMessage(`{"code":"1"}`),
+		ToolCallID: "call_1",
+	}
+}
+
+func TestConsultToolCallAllowsWhenIngesterNil(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_consult_nil_ingester")
+	require.NoError(t, err)
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+
+	logger := testenv.NewLogger(t)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
+	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
+
+	result, err := core.ConsultToolCall(ctx, projectID, assistantID, consultRequest(threadID))
+	require.NoError(t, err)
+	require.Equal(t, consultDecisionAllow, result.Decision)
+}
+
+func TestConsultToolCallAllowsAndDeniesViaIngester(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_consult_ingester")
+	require.NoError(t, err)
+	projectID, assistantID, chatID, threadID := insertAssistantFixture(t, conn)
+
+	logger := testenv.NewLogger(t)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
+	ingester := &captureConsultIngester{
+		result: &hooks.AuthenticatedIngestResult{
+			Result: &hooksgen.IngestHookResult{Decision: consultDecisionAllow},
+		},
+	}
+	core.SetHookIngester(ingester)
+	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
+	req := consultRequest(threadID)
+
+	result, err := core.ConsultToolCall(ctx, projectID, assistantID, req)
+	require.NoError(t, err)
+	require.Equal(t, consultDecisionAllow, result.Decision)
+	require.Len(t, ingester.calls, 1)
+	call := ingester.calls[0]
+	require.Equal(t, assistantHookAdapter, call.payload.Source.Adapter)
+	require.Equal(t, "tool.requested", call.payload.Event.Type)
+	require.Equal(t, chatID.String(), *call.payload.Session.ID)
+	require.Equal(t, "assistant:"+threadID.String()+":call_1", *call.payload.IdempotencyKey)
+	require.Equal(t, "bun_run", *call.payload.Data.ToolCall.Name)
+	require.True(t, call.options.AllowReservedAdapter)
+	require.True(t, call.options.AllowWarnAcknowledgement)
+	require.False(t, call.options.AllowSessionIdentityFallback)
+	require.Nil(t, call.payload.Data.Mcp)
+
+	denyMessage := "Speakeasy blocked this tool call"
+	ingester.result = &hooks.AuthenticatedIngestResult{
+		Result: &hooksgen.IngestHookResult{Decision: consultDecisionDeny, Message: &denyMessage},
+	}
+	req.ToolCallID = "call_2"
+	result, err = core.ConsultToolCall(ctx, projectID, assistantID, req)
+	require.NoError(t, err)
+	require.Equal(t, consultDecisionDeny, result.Decision)
+	require.Equal(t, denyMessage, result.Message)
+}
+
+func TestConsultToolCallFailsOpenOnIngestError(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_consult_ingest_error")
+	require.NoError(t, err)
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+
+	logger := testenv.NewLogger(t)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
+	core.SetHookIngester(&captureConsultIngester{err: errors.New("ingest unavailable")})
+	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
+
+	result, err := core.ConsultToolCall(ctx, projectID, assistantID, consultRequest(threadID))
+	require.NoError(t, err)
+	require.Equal(t, consultDecisionAllow, result.Decision)
+}
+
+func TestConsultToolCallRejectsAssistantMismatch(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_consult_mismatch")
+	require.NoError(t, err)
+	projectID, _, _, threadID := insertAssistantFixture(t, conn)
+
+	logger := testenv.NewLogger(t)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
+	core.SetHookIngester(&captureConsultIngester{
+		result: &hooks.AuthenticatedIngestResult{Result: &hooksgen.IngestHookResult{Decision: consultDecisionAllow}},
+	})
+	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
+
+	_, err = core.ConsultToolCall(ctx, projectID, uuid.New(), consultRequest(threadID))
+	require.Error(t, err)
+	var se *oops.ShareableError
+	require.ErrorAs(t, err, &se)
+	require.Equal(t, oops.CodeForbidden, se.Code)
+}
+
+func TestConsultToolCallUsesDefaultDenyMessage(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_consult_default_deny")
+	require.NoError(t, err)
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+
+	logger := testenv.NewLogger(t)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
+	core.SetHookIngester(&captureConsultIngester{
+		result: &hooks.AuthenticatedIngestResult{
+			Result: &hooksgen.IngestHookResult{Decision: consultDecisionDeny, Message: conv.PtrEmpty("")},
+		},
+	})
+	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
+
+	result, err := core.ConsultToolCall(ctx, projectID, assistantID, consultRequest(threadID))
+	require.NoError(t, err)
+	require.Equal(t, consultDecisionDeny, result.Decision)
+	require.Equal(t, consultDefaultDenyMessage, result.Message)
+}

--- a/server/internal/assistants/consult_test.go
+++ b/server/internal/assistants/consult_test.go
@@ -12,7 +12,6 @@ import (
 	hooksgen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/hooks"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -21,17 +20,16 @@ import (
 type capturedConsultCall struct {
 	auth    *contextvalues.AuthContext
 	payload *hooksgen.IngestPayload
-	options hooks.AuthenticatedIngestOptions
 }
 
 type captureConsultIngester struct {
-	result *hooks.AuthenticatedIngestResult
+	result *hooksgen.IngestHookResult
 	err    error
 	calls  []capturedConsultCall
 }
 
-func (c *captureConsultIngester) IngestAuthenticatedDetailed(_ context.Context, authCtx *contextvalues.AuthContext, payload *hooksgen.IngestPayload, options hooks.AuthenticatedIngestOptions) (*hooks.AuthenticatedIngestResult, error) {
-	c.calls = append(c.calls, capturedConsultCall{auth: authCtx, payload: payload, options: options})
+func (c *captureConsultIngester) IngestAssistantToolCall(_ context.Context, authCtx *contextvalues.AuthContext, payload *hooksgen.IngestPayload) (*hooksgen.IngestHookResult, error) {
+	c.calls = append(c.calls, capturedConsultCall{auth: authCtx, payload: payload})
 	return c.result, c.err
 }
 
@@ -78,9 +76,7 @@ func TestConsultToolCallAllowsAndDeniesViaIngester(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
 	ingester := &captureConsultIngester{
-		result: &hooks.AuthenticatedIngestResult{
-			Result: &hooksgen.IngestHookResult{Decision: consultDecisionAllow},
-		},
+		result: &hooksgen.IngestHookResult{Decision: consultDecisionAllow},
 	}
 	core.SetHookIngester(ingester)
 	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
@@ -96,15 +92,10 @@ func TestConsultToolCallAllowsAndDeniesViaIngester(t *testing.T) {
 	require.Equal(t, chatID.String(), *call.payload.Session.ID)
 	require.Equal(t, "assistant:"+threadID.String()+":call_1", *call.payload.IdempotencyKey)
 	require.Equal(t, "bun_run", *call.payload.Data.ToolCall.Name)
-	require.True(t, call.options.AllowReservedAdapter)
-	require.True(t, call.options.AllowWarnAcknowledgement)
-	require.False(t, call.options.AllowSessionIdentityFallback)
 	require.Nil(t, call.payload.Data.Mcp)
 
 	denyMessage := "Speakeasy blocked this tool call"
-	ingester.result = &hooks.AuthenticatedIngestResult{
-		Result: &hooksgen.IngestHookResult{Decision: consultDecisionDeny, Message: &denyMessage},
-	}
+	ingester.result = &hooksgen.IngestHookResult{Decision: consultDecisionDeny, Message: &denyMessage}
 	req.ToolCallID = "call_2"
 	result, err = core.ConsultToolCall(ctx, projectID, assistantID, req)
 	require.NoError(t, err)
@@ -139,7 +130,7 @@ func TestConsultToolCallRejectsAssistantMismatch(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
 	core.SetHookIngester(&captureConsultIngester{
-		result: &hooks.AuthenticatedIngestResult{Result: &hooksgen.IngestHookResult{Decision: consultDecisionAllow}},
+		result: &hooksgen.IngestHookResult{Decision: consultDecisionAllow},
 	})
 	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
 
@@ -160,9 +151,7 @@ func TestConsultToolCallUsesDefaultDenyMessage(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil, newTestAuditLogger())
 	core.SetHookIngester(&captureConsultIngester{
-		result: &hooks.AuthenticatedIngestResult{
-			Result: &hooksgen.IngestHookResult{Decision: consultDecisionDeny, Message: conv.PtrEmpty("")},
-		},
+		result: &hooksgen.IngestHookResult{Decision: consultDecisionDeny, Message: conv.PtrEmpty("")},
 	})
 	ctx := contextvalues.SetAuthContext(t.Context(), consultAuthContext(projectID))
 

--- a/server/internal/assistants/impl.go
+++ b/server/internal/assistants/impl.go
@@ -81,6 +81,7 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		srv.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, nil, nil),
 	)
 	o11y.AttachHandler(mux, "POST", "/rpc/assistants.getThreadBootstrap", oops.ErrHandle(service.logger, service.handleGetThreadBootstrap).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", "/rpc/assistants.consultToolCall", oops.ErrHandle(service.logger, service.handleConsultToolCall).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/rpc/assistants.recordCompactedGeneration", oops.ErrHandle(service.logger, service.handleRecordCompactedGeneration).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/rpc/assistantMcpAuth.create", oops.ErrHandle(service.logger, service.handleCreateMCPAuthFlow).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/rpc/assistantMcpAuth/{id}/oauth/callback", oops.ErrHandle(service.logger, service.handleMCPAuthCallback).ServeHTTP)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -408,6 +408,7 @@ type ServiceCore struct {
 	dashboardIngestor DashboardIngestor
 	featureFlags      feature.Provider
 	turnClassified    metric.Int64Counter
+	hookIngester      HookIngester
 }
 
 func NewServiceCore(
@@ -457,6 +458,7 @@ func NewServiceCore(
 		dashboardIngestor: nil,
 		featureFlags:      nil,
 		turnClassified:    turnClassified,
+		hookIngester:      nil,
 	}
 }
 
@@ -495,6 +497,14 @@ func (s *ServiceCore) SetAssetStorage(storage assets.BlobStore) {
 // grant off (fail closed).
 func (s *ServiceCore) SetFeatureProvider(p feature.Provider) {
 	s.featureFlags = p
+}
+
+// SetHookIngester wires canonical hook ingest so the runner's tool-call
+// consult can reuse risk-policy and spend-gate enforcement. Set after
+// construction because hooks.Service is created later in server startup.
+// A nil ingester fails open (allow).
+func (s *ServiceCore) SetHookIngester(ingester HookIngester) {
+	s.hookIngester = ingester
 }
 
 // resolveAssistantContextWindow returns the smallest context_length the gram

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -43,6 +43,12 @@ type AuthenticatedIngestOptions struct {
 	SourceAttributes             map[attr.Key]any
 	OutputToolCalls              []any
 	OriginatingClient            string
+
+	// AllowReservedAdapter lets a trusted in-process caller claim the
+	// reserved assistant adapter so hosted assistant tool calls can reuse
+	// canonical ingest enforcement. Public hook ingest always rejects that
+	// adapter so a client cannot forge assistant attribution.
+	AllowReservedAdapter bool
 }
 
 // ResolvedActor is the exact actor selected by canonical hook attribution.
@@ -65,6 +71,7 @@ func defaultAuthenticatedIngestOptions() AuthenticatedIngestOptions {
 		SourceAttributes:             nil,
 		OutputToolCalls:              nil,
 		OriginatingClient:            "",
+		AllowReservedAdapter:         false,
 	}
 }
 
@@ -171,7 +178,7 @@ func (s *Service) ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 		s.metrics.RecordHookEventDuration(ctx, source, eventType, outcome, decision, orgSlug, *riskScanned, time.Since(start))
 	}()
 
-	if err := validateCanonicalIngestPayload(payload); err != nil {
+	if err := validateCanonicalIngestPayload(ctx, payload); err != nil {
 		return nil, err
 	}
 	source = strings.TrimSpace(payload.Source.Adapter)
@@ -508,7 +515,7 @@ func canonicalSourceUserEmail(payload *gen.IngestPayload) string {
 	return ""
 }
 
-func validateCanonicalIngestPayload(payload *gen.IngestPayload) error {
+func validateCanonicalIngestPayload(ctx context.Context, payload *gen.IngestPayload) error {
 	if payload == nil || payload.Source == nil || payload.Event == nil {
 		return oops.E(oops.CodeInvalid, nil, "source and event are required")
 	}
@@ -518,8 +525,9 @@ func validateCanonicalIngestPayload(payload *gen.IngestPayload) error {
 	}
 	// The assistant surface is derived from the observation provider, and only
 	// server-side assistant runs may claim it. Reserve those values so a client
-	// hook cannot forge assistant-attributed skill activity.
-	if isReservedAssistantAdapter(adapter) {
+	// hook cannot forge assistant-attributed skill activity. Trusted in-process
+	// callers (hosted assistant consult) opt in via AllowReservedAdapter.
+	if isReservedAssistantAdapter(adapter) && !authenticatedIngestOptions(ctx).AllowReservedAdapter {
 		return oops.E(oops.CodeInvalid, nil, "source.adapter is reserved")
 	}
 	if strings.TrimSpace(payload.Event.Type) == "" {
@@ -545,7 +553,8 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 	eventType := strings.TrimSpace(payload.Event.Type)
 
 	// Spend gate runs before any risk-policy evaluation, for every adapter
-	// with a per-provider enforcement surface (claude, codex, cursor) — the
+	// with a per-provider enforcement surface (claude, codex, cursor, and
+	// the reserved assistant adapter used by hosted assistant consult) — the
 	// risk scans below already run adapter-agnostically, and an over-budget
 	// actor is over budget regardless of which agent carries the event.
 	// Adapters are self-reported slugs, so this remains a cooperative-client
@@ -1383,6 +1392,12 @@ func telemetryHookEventName(payload *gen.IngestPayload) string {
 // server-resolved time for one event — a recomputed fallback or clamp would
 // drift by the handler's processing latency.
 func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, hookSource string, occurredAt time.Time) (bool, error) {
+	if payload != nil && payload.Source != nil && isReservedAssistantAdapter(payload.Source.Adapter) {
+		// Hosted assistant transcripts are already captured by the completions
+		// pipeline. Persisting consult events would duplicate tool_calls rows
+		// against the same chat id.
+		return false, nil
+	}
 	sessionID := canonicalSessionID(payload)
 	if sessionID == "" || authCtx.ProjectID == nil {
 		return false, nil

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -140,6 +140,25 @@ func (s *Service) IngestAuthenticatedDetailed(ctx context.Context, authCtx *cont
 	return s.ingest(ctx, &payloadCopy)
 }
 
+// IngestAssistantToolCall is the trusted in-process entry used by hosted
+// assistant tool-call consult. It claims the reserved assistant adapter,
+// keeps warn-acknowledgement, and does not fall back to session identity
+// from untrusted client fields.
+func (s *Service) IngestAssistantToolCall(ctx context.Context, authCtx *contextvalues.AuthContext, payload *gen.IngestPayload) (*gen.IngestHookResult, error) {
+	result, err := s.IngestAuthenticatedDetailed(ctx, authCtx, payload, AuthenticatedIngestOptions{
+		AllowWarnAcknowledgement:     true,
+		AllowSessionIdentityFallback: false,
+		SourceAttributes:             nil,
+		OutputToolCalls:              nil,
+		OriginatingClient:            "assistant",
+		AllowReservedAdapter:         true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Result, nil
+}
+
 // Ingest is the feature-first hook endpoint; this path only accepts the
 // canonical Gram contract. Auth is optional so hook senders stay non-blocking
 // for machines that never signed in: a keyless request is acknowledged without

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -167,27 +167,6 @@ func TestIngest_RequiresCurrentSchemaVersion(t *testing.T) {
 	require.Contains(t, err.Error(), "unsupported hook schema_version")
 }
 
-func TestIngest_RejectsReservedAssistantAdapter(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestHooksService(t)
-	payload := canonicalIngestPayload("assistant", "tool.requested", "reserved-adapter")
-	toolName := "bun_run"
-	toolCallID := "call-reserved"
-	payload.Data = &gen.HookIngestData{
-		ToolCall: &gen.HookToolCallData{
-			ID:    &toolCallID,
-			Name:  &toolName,
-			Input: map[string]any{},
-		},
-	}
-
-	result, err := ti.service.Ingest(ctx, payload)
-	require.Error(t, err)
-	require.Nil(t, result)
-	require.Contains(t, err.Error(), "source.adapter is reserved")
-}
-
 func TestIngestAuthenticated_RejectsReservedAssistantAdapterByDefault(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -251,6 +251,30 @@ func TestIngestAuthenticated_AllowsReservedAssistantAdapter(t *testing.T) {
 	require.Empty(t, messages)
 }
 
+func TestIngestAssistantToolCall_AllowsReservedAdapter(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	payload := canonicalIngestPayload("assistant", "tool.requested", uuid.NewString())
+	toolName := "bun_run"
+	toolCallID := "call-assistant-method"
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"code": "1"},
+		},
+	}
+
+	result, err := ti.service.IngestAssistantToolCall(t.Context(), authCtx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "allow", result.Decision)
+}
+
 // A keyless request on the optional-auth ingest endpoint is acknowledged
 // without processing: hook senders must stay non-blocking for machines that
 // never signed in, and without credentials there is no org to attribute the

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -167,6 +167,90 @@ func TestIngest_RequiresCurrentSchemaVersion(t *testing.T) {
 	require.Contains(t, err.Error(), "unsupported hook schema_version")
 }
 
+func TestIngest_RejectsReservedAssistantAdapter(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	payload := canonicalIngestPayload("assistant", "tool.requested", "reserved-adapter")
+	toolName := "bun_run"
+	toolCallID := "call-reserved"
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{},
+		},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "source.adapter is reserved")
+}
+
+func TestIngestAuthenticated_RejectsReservedAssistantAdapterByDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	payload := canonicalIngestPayload("assistant", "tool.requested", "reserved-adapter-auth")
+	toolName := "bun_run"
+	toolCallID := "call-reserved-auth"
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{},
+		},
+	}
+
+	result, err := ti.service.IngestAuthenticated(t.Context(), authCtx, payload)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "source.adapter is reserved")
+}
+
+func TestIngestAuthenticated_AllowsReservedAssistantAdapter(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := uuid.NewString()
+	payload := canonicalIngestPayload("assistant", "tool.requested", sessionID)
+	toolName := "bun_run"
+	toolCallID := "call-assistant-allow"
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"code": "1"},
+		},
+	}
+
+	result, err := ti.service.IngestAuthenticatedWithOptions(t.Context(), authCtx, payload, AuthenticatedIngestOptions{
+		AllowWarnAcknowledgement:     true,
+		AllowSessionIdentityFallback: false,
+		SourceAttributes:             nil,
+		OutputToolCalls:              nil,
+		OriginatingClient:            "assistant",
+		AllowReservedAdapter:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "allow", result.Decision)
+
+	messages, err := chatRepo.New(ti.conn).ListChatMessages(t.Context(), chatRepo.ListChatMessagesParams{
+		ChatID:    sessionIDToUUID(sessionID),
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, messages)
+}
+
 // A keyless request on the optional-auth ingest endpoint is acknowledged
 // without processing: hook senders must stay non-blocking for machines that
 // never signed in, and without credentials there is no org to attribute the

--- a/server/internal/hooks/spend_gate.go
+++ b/server/internal/hooks/spend_gate.go
@@ -41,11 +41,12 @@ func (s *Service) checkSpendGate(ctx context.Context, ev hookevents.Event) *spen
 
 // spendGatedAdapter reports whether a self-reported ingest source adapter
 // has spend enforcement on the unified ingest path: the adapters with a
-// per-provider enforcement surface. Matching is case-insensitive so a case
+// per-provider enforcement surface, plus the reserved assistant adapter
+// used by hosted assistant consult. Matching is case-insensitive so a case
 // variant cannot dodge the gate.
 func spendGatedAdapter(adapter string) bool {
 	switch strings.ToLower(strings.TrimSpace(adapter)) {
-	case "claude", "codex", "cursor":
+	case "claude", "codex", "cursor", "assistant", "assistants":
 		return true
 	default:
 		return false

--- a/server/internal/hooks/spend_gate_test.go
+++ b/server/internal/hooks/spend_gate_test.go
@@ -304,6 +304,41 @@ func TestIngest_SpendGateDeniesClaudeToolCallWithBlockURL(t *testing.T) {
 	assert.Contains(t, *result.Message, "/blocks/")
 }
 
+func TestIngestAuthenticated_SpendGateDeniesAssistantToolCall(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.Email)
+
+	payload := canonicalIngestPayload("assistant", "tool.requested", "spend-gate-ingest-assistant")
+	toolName := "bun_run"
+	toolCallID := "call-spend-assistant-1"
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"code": "1"},
+		},
+	}
+
+	result, err := ti.service.IngestAuthenticatedWithOptions(ctx, authCtx, payload, AuthenticatedIngestOptions{
+		AllowWarnAcknowledgement:     true,
+		AllowSessionIdentityFallback: false,
+		SourceAttributes:             nil,
+		OutputToolCalls:              nil,
+		OriginatingClient:            "assistant",
+		AllowReservedAdapter:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "deny", result.Decision)
+	require.NotNil(t, result.Message)
+	assert.Contains(t, *result.Message, "Intern hard limit")
+}
+
 func TestIngest_SpendGateDeniesCodexToolCallWithBlockURL(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)

--- a/server/internal/litellm/impl.go
+++ b/server/internal/litellm/impl.go
@@ -215,6 +215,7 @@ func (s *Service) ingestRequest(ctx context.Context, payload *gen.IngestPayload,
 		SourceAttributes:             sourceAttributes(payload),
 		OutputToolCalls:              nil,
 		OriginatingClient:            attribution.OriginatingClient,
+		AllowReservedAdapter:         false,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("ingest LiteLLM hook: %w", err)
@@ -345,6 +346,7 @@ func (s *Service) ingestResponse(ctx context.Context, payload *gen.IngestPayload
 		SourceAttributes:             sourceAttributes(payload),
 		OutputToolCalls:              payload.ToolCalls,
 		OriginatingClient:            originatingClient,
+		AllowReservedAdapter:         false,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("ingest LiteLLM hook: %w", err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Gram-hosted assistant conversations used to dispatch tool calls without consulting the risk scanner or spend gate. Enforcement lived only on the external-agent hook ingest path, so a policy that blocked a Claude Code tool call did nothing against the same call from a hosted assistant.

This adds an inline enforcement consult at the runner’s tool-dispatch chokepoint:

- **Runner:** `EnforcingToolSource` wraps hidden MCP tools and the outermost tool source, calls `POST /rpc/assistants.consultToolCall` before invoke, and returns a tool-error result on deny (not `ToolError::ExecutionFailed`, which would trigger MCP reconnect). HTTP/timeout failures fail open. Call-id dedupe avoids scanning a direct MCP invoke twice. Consult uses a non-retrying HTTP client so a 5xx fail-open stays on the hot path.
- **Server:** assistant-JWT consult loads the thread, uses the **server** chat id as the session id, and runs `IngestAssistantToolCall` (canonical ingest with reserved adapter `assistant`). Assistants does not import the hooks package, avoiding a cycle through background activities.
- **Hooks:** trusted in-process ingest can opt into `AllowReservedAdapter`. Public ingest still rejects `assistant` / `assistants` so clients cannot forge that attribution. Assistant consult events skip chat-message persistence (completions capture already owns the transcript) but still run spend gate, risk scans, telemetry, and tool-call blocks.

This is the seam AGE-2708 quarantine will use later; v1 stays hook-session-only until that lands.

Fixes AIS-588.

## Test plan

- [x] `mise run test:assistant-runner` — 66 passed, including allow/deny/fail-open/dedupe consult tests
- [x] `mise run test:server ./internal/hooks/` — 488 passed (reserved adapter, spend-gate deny for assistant, no duplicate chat rows)
- [x] `mise run test:server ./internal/assistants/` — consult allow/deny/fail-open/mismatch/HTTP 401
- [x] `mise lint:server`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-588](https://linear.app/speakeasy/issue/AIS-588/feat-subject-assistant-conversations-to-realtime-inline-security)

<div><a href="https://cursor.com/agents/bc-9ac0a07c-7993-48af-acfa-41f0264e640e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ac0a07c-7993-48af-acfa-41f0264e640e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces realtime risk-policy and spend-gate for hosted assistant tool calls. Previously these calls bypassed enforcement; now the runner consults the server before invoking a tool, denials return a tool-error result, and consult errors fail open.

- Runner: wraps hidden MCP and the outer tool source with an enforcing layer; calls POST /rpc/assistants.consultToolCall with the assistant JWT; dedupes by call_id; denial returns a tool error result (not ExecutionFailed) to avoid MCP reconnects; consult uses a non-retrying HTTP client; HTTP/timeout errors allow execution.
- Server: adds assistants.consultToolCall that validates the token, checks thread ownership, uses the server chat id as the session id, and routes via hooks’ IngestAssistantToolCall (reserved adapter `assistant`). Trusted in-process ingest opts into AllowReservedAdapter; public ingest still rejects `assistant`/`assistants`. Consult events skip chat-message persistence but still run spend gate (now includes `assistant`), risk scans, telemetry, and blocks.
- Wiring: `assistants` core accepts a hook ingester and is wired at startup to avoid an assistants/hooks import cycle.
- Rollout: no migrations; runner and server can roll independently—older servers cause consult to fail open. Linear AIS-588.

<sup>Written for commit cbe45fab5551548869921a5710e4986c012b74b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

