### PR TITLE
fix: stop counting Gram-hosted inference as employee usage

### DIFF
--- a/.changeset/employee-page-excludes-gram-hosted.md
+++ b/.changeset/employee-page-excludes-gram-hosted.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Per-user telemetry surfaces (employee page tiles, overview, employees list) no longer count Gram-hosted inference — risk-analysis judges and other platform-side completions logged under the session owner's identity — as the employee's usage.
+Per-user telemetry surfaces (employee page tiles, overview, employees list) no longer count Gram-hosted inference — risk-analysis judges and other platform-side completions logged under the session owner's identity — as the employee's usage. External-user surfaces are unaffected: an external user's hosted-chat completions are their usage, and an explicit hook_source filter still returns Gram-hosted rows when asked for by name.

--- a/.changeset/employee-page-excludes-gram-hosted.md
+++ b/.changeset/employee-page-excludes-gram-hosted.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Per-user telemetry surfaces (employee page tiles, overview, employees list) no longer count Gram-hosted inference — risk-analysis judges and other platform-side completions logged under the session owner's identity — as the employee's usage.

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -117,8 +117,8 @@ func GramHostedHookSourceStrings() []string {
 // GramHostedHookSourceNames lists only the NAMED Gram-hosted hook_source
 // values, without the empty-string entry. Raw telemetry_logs readers must use
 // this variant: on the summaries an untagged row can only be Gram-era
-// history, but raw logs legitimately carry hook_source = ” on hook, tool
-// call, and import rows, and excluding ” there would drop real usage.
+// history, but raw logs legitimately carry an empty hook_source on hook, tool
+// call, and import rows, and excluding the empty string there would drop real usage.
 func GramHostedHookSourceNames() []string {
 	return append(ModelUsageSourceStrings(), string(ModelUsageSourceAssistants), string(ModelUsageSourceSkillEfficacy), string(ModelUsageSourceSkillSuggestions), string(ModelUsageSourceChatAnalysis), string(ModelUsageSourceMCPResearch))
 }

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -111,7 +111,16 @@ func ModelUsageSourceStrings() []string {
 // traffic, and everything Gram itself spends (reactive scanning inference
 // and user-initiated hosted chat alike) is out of scope.
 func GramHostedHookSourceStrings() []string {
-	return append(ModelUsageSourceStrings(), string(ModelUsageSourceAssistants), string(ModelUsageSourceSkillEfficacy), string(ModelUsageSourceSkillSuggestions), string(ModelUsageSourceChatAnalysis), string(ModelUsageSourceMCPResearch), "")
+	return append(GramHostedHookSourceNames(), "")
+}
+
+// GramHostedHookSourceNames lists only the NAMED Gram-hosted hook_source
+// values, without the empty-string entry. Raw telemetry_logs readers must use
+// this variant: on the summaries an untagged row can only be Gram-era
+// history, but raw logs legitimately carry hook_source = ” on hook, tool
+// call, and import rows, and excluding ” there would drop real usage.
+func GramHostedHookSourceNames() []string {
+	return append(ModelUsageSourceStrings(), string(ModelUsageSourceAssistants), string(ModelUsageSourceSkillEfficacy), string(ModelUsageSourceSkillSuggestions), string(ModelUsageSourceChatAnalysis), string(ModelUsageSourceMCPResearch))
 }
 
 type ModelUsageEvent struct {

--- a/server/internal/telemetry/gram_hosted_exclusion_test.go
+++ b/server/internal/telemetry/gram_hosted_exclusion_test.go
@@ -12,6 +12,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 // insertGramHostedCompletionLog writes a completion row the way Gram-hosted
@@ -69,6 +70,73 @@ func insertGramHostedCompletionLog(t *testing.T, ctx context.Context, projectID 
 func insertGramHostedJudgeLog(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, email string, inputTokens, outputTokens int, cost float64) {
 	t.Helper()
 	insertGramHostedCompletionLog(t, ctx, projectID, timestamp, "risk-analysis", email, "", uuid.Nil.String(), inputTokens, outputTokens, cost)
+}
+
+// insertGramHostedJudgeLogWithUserID writes a judge completion attributed by
+// user_id with no email - the shape that could surface a phantom identity in
+// the enrollment directory's email-less supplement.
+func insertGramHostedJudgeLogWithUserID(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, userID string, inputTokens, outputTokens int) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gram.event.source":          string(tm.EventSourceChatCompletion),
+		"gram.hook.source":           "risk-analysis",
+		"user.id":                    userID,
+		"gen_ai.usage.input_tokens":  inputTokens,
+		"gen_ai.usage.output_tokens": outputTokens,
+		"gen_ai.usage.total_tokens":  inputTokens + outputTokens,
+		"gen_ai.response.model":      "judge-model",
+		"gen_ai.conversation.id":     "00000000-0000-0000-0000-000000000000",
+		"gen_ai.response.id":         uuid.New().String(),
+	}
+
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, "chat:completion", "gram-server"))
+}
+
+// The enrollment directory's email-less supplement scans raw telemetry_logs;
+// a gram-hosted completion carrying a user_id but no email must not surface
+// a phantom identity there (tokens were never at risk - the summaries MV
+// excludes gram-hosted rows by provenance - but presence is presence).
+func TestEnrollmentDirectory_ExcludesGramHostedPhantomIdentities(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	phantomID := "judge-only-" + uuid.NewString()
+
+	now := time.Now().UTC()
+	insertGramHostedJudgeLogWithUserID(t, ctx, projectID, now.Add(-10*time.Minute), phantomID, 5000, 5000)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter:   &gen.SearchUsersFilter{From: now.Add(-time.Hour).Format(time.RFC3339), To: now.Add(time.Hour).Format(time.RFC3339)},
+		UserType: "internal",
+		Source:   "agent_metrics",
+		Limit:    100,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	for _, u := range res.Users {
+		require.NotEqual(t, phantomID, u.UserID, "judge-only identity must not appear in the enrollment directory")
+	}
 }
 
 // The per-user surfaces must never count Gram-hosted inference as the

--- a/server/internal/telemetry/gram_hosted_exclusion_test.go
+++ b/server/internal/telemetry/gram_hosted_exclusion_test.go
@@ -1,0 +1,120 @@
+package telemetry_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+)
+
+// insertGramHostedJudgeLog writes a completion row the way the platform's
+// risk-analysis judges produce them: gram-hosted inference logged under the
+// session owner's email. These are the platform's spend, never the
+// employee's usage.
+func insertGramHostedJudgeLog(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, email string, inputTokens, outputTokens int, cost float64) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gram.event.source":          string(tm.EventSourceChatCompletion),
+		"gram.hook.source":           "risk-analysis",
+		"user.email":                 email,
+		"gen_ai.usage.input_tokens":  inputTokens,
+		"gen_ai.usage.output_tokens": outputTokens,
+		"gen_ai.usage.total_tokens":  inputTokens + outputTokens,
+		"gen_ai.usage.cost":          cost,
+		"gen_ai.response.model":      "judge-model",
+		"gen_ai.conversation.id":     uuid.New().String(),
+		"gen_ai.response.id":         uuid.New().String(),
+	}
+
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, "chat:completions", "gram-server"))
+}
+
+// The per-user surfaces must never count Gram-hosted inference as the
+// employee's usage: judge completions log under the session owner's email,
+// and before the exclusion one employee's page showed 60M+ judge tokens as
+// their own. Org-scope reads deliberately keep counting them, matching the
+// summaries fast path.
+func TestEmployeeSurfaces_ExcludeGramHostedInference(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.NewString()
+	email := "judged-" + uuid.NewString()[:8] + "@example.com"
+
+	now := time.Now().UTC()
+	// One real cursor usage row and one enormous judge row for the same
+	// person: the judge tokens must be invisible on every per-user surface.
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), email, 100, 50, 1.5)
+	insertGramHostedJudgeLog(t, ctx, projectID, now.Add(-9*time.Minute), email, 1_000_000, 1_000_000, 99.0)
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	// The employee page tiles.
+	metrics, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+		From:   from,
+		To:     to,
+		UserID: &email,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(150), metrics.Metrics.TotalTokens)
+	require.InDelta(t, 1.5, metrics.Metrics.TotalCost, 0.001)
+
+	// The employees list / per-user summary path over raw logs.
+	users, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter:   &gen.SearchUsersFilter{From: from, To: to, UserIds: []string{email}},
+		UserType: "internal",
+		Limit:    10,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, users.Users, 1)
+	require.Equal(t, int64(100), users.Users[0].TotalInputTokens)
+	require.Equal(t, int64(150), users.Users[0].TotalTokens)
+
+	// The user-scoped overview: the judge conversation must not count.
+	scoped, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
+		From:   from,
+		To:     to,
+		UserID: &email,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), scoped.Summary.TotalChats)
+
+	// The org-scope overview keeps current semantics: gram-hosted rows stay
+	// counted there (the summaries fast path cannot express the exclusion;
+	// changing org totals is a separate decision, pinned here on purpose).
+	org, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
+		From: from,
+		To:   to,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), org.Summary.TotalChats)
+}

--- a/server/internal/telemetry/gram_hosted_exclusion_test.go
+++ b/server/internal/telemetry/gram_hosted_exclusion_test.go
@@ -14,11 +14,13 @@ import (
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
-// insertGramHostedJudgeLog writes a completion row the way the platform's
-// risk-analysis judges produce them: gram-hosted inference logged under the
-// session owner's email. These are the platform's spend, never the
-// employee's usage.
-func insertGramHostedJudgeLog(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, email string, inputTokens, outputTokens int, cost float64) {
+// insertGramHostedCompletionLog writes a completion row the way Gram-hosted
+// inference produces them (completionTelemetryIdentity in the openrouter
+// client): resource URN chat:completion, a non-empty hook_source naming the
+// surface, and — for platform-initiated sources like the risk-analysis
+// judges — the nil-UUID conversation id, since those completions run outside
+// any chat.
+func insertGramHostedCompletionLog(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, hookSource, email, externalUserID, conversationID string, inputTokens, outputTokens int, cost float64) {
 	t.Helper()
 
 	conn, err := infra.NewClickhouseClient(t)
@@ -29,15 +31,21 @@ func insertGramHostedJudgeLog(t *testing.T, ctx context.Context, projectID strin
 
 	attributes := map[string]any{
 		"gram.event.source":          string(tm.EventSourceChatCompletion),
-		"gram.hook.source":           "risk-analysis",
-		"user.email":                 email,
+		"gram.hook.source":           hookSource,
+		"gram.resource.urn":          "chat:completion",
 		"gen_ai.usage.input_tokens":  inputTokens,
 		"gen_ai.usage.output_tokens": outputTokens,
 		"gen_ai.usage.total_tokens":  inputTokens + outputTokens,
 		"gen_ai.usage.cost":          cost,
 		"gen_ai.response.model":      "judge-model",
-		"gen_ai.conversation.id":     uuid.New().String(),
+		"gen_ai.conversation.id":     conversationID,
 		"gen_ai.response.id":         uuid.New().String(),
+	}
+	if email != "" {
+		attributes["user.email"] = email
+	}
+	if externalUserID != "" {
+		attributes["gram.external_user.id"] = externalUserID
 	}
 
 	attrsJSON, err := json.Marshal(attributes)
@@ -51,7 +59,16 @@ func insertGramHostedJudgeLog(t *testing.T, ctx context.Context, projectID strin
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
 		nil, nil, string(attrsJSON), "{}",
-		projectID, "chat:completions", "gram-server"))
+		projectID, "chat:completion", "gram-server"))
+}
+
+// insertGramHostedJudgeLog writes a completion row the way the platform's
+// risk-analysis judges produce them: gram-hosted inference logged under the
+// session owner's email. These are the platform's spend, never the
+// employee's usage.
+func insertGramHostedJudgeLog(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, email string, inputTokens, outputTokens int, cost float64) {
+	t.Helper()
+	insertGramHostedCompletionLog(t, ctx, projectID, timestamp, "risk-analysis", email, "", uuid.Nil.String(), inputTokens, outputTokens, cost)
 }
 
 // The per-user surfaces must never count Gram-hosted inference as the
@@ -87,6 +104,20 @@ func TestEmployeeSurfaces_ExcludeGramHostedInference(t *testing.T) {
 	require.Equal(t, int64(150), metrics.Metrics.TotalTokens)
 	require.InDelta(t, 1.5, metrics.Metrics.TotalCost, 0.001)
 
+	// An explicit hook_source filter overrides the exclusion: the caller
+	// named a specific source, so the judge row is exactly what they asked
+	// for — not a silently empty result.
+	judgeSource := "risk-analysis"
+	judgeOnly, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+		From:       from,
+		To:         to,
+		UserID:     &email,
+		HookSource: &judgeSource,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2_000_000), judgeOnly.Metrics.TotalTokens)
+	require.InDelta(t, 99.0, judgeOnly.Metrics.TotalCost, 0.001)
+
 	// The employees list / per-user summary path over raw logs.
 	users, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
 		Filter:   &gen.SearchUsersFilter{From: from, To: to, UserIds: []string{email}},
@@ -98,6 +129,20 @@ func TestEmployeeSurfaces_ExcludeGramHostedInference(t *testing.T) {
 	require.Len(t, users.Users, 1)
 	require.Equal(t, int64(100), users.Users[0].TotalInputTokens)
 	require.Equal(t, int64(150), users.Users[0].TotalTokens)
+
+	// The role rollup aggregates the same per-user summaries, so judge
+	// tokens must not inflate the (here Unassigned) role totals either.
+	roles, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter:   &gen.SearchUsersFilter{From: from, To: to, UserIds: []string{email}},
+		UserType: "internal",
+		GroupBy:  "role",
+		Limit:    10,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, roles.Roles, 1)
+	require.Equal(t, "Unassigned", roles.Roles[0].RoleName)
+	require.Equal(t, int64(100), roles.Roles[0].TotalInputTokens)
 
 	// The user-scoped overview: the judge conversation must not count.
 	scoped, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
@@ -117,4 +162,55 @@ func TestEmployeeSurfaces_ExcludeGramHostedInference(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(2), org.Summary.TotalChats)
+}
+
+// An external user (Elements / hosted-chat consumer) has NO token-bearing
+// rows other than Gram-hosted completions — every hosted completion carries
+// a hook_source from the exclusion set. The exclusion therefore applies to
+// employee scope only; applying it to external scope would erase these users
+// entirely.
+func TestExternalUserSurfaces_KeepGramHostedInference(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	externalUserID := "ext-hosted-" + uuid.NewString()
+
+	now := time.Now().UTC()
+	insertGramHostedCompletionLog(t, ctx, projectID, now.Add(-10*time.Minute), "elements", "", externalUserID, uuid.New().String(), 100, 50, 1.5)
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	// The external-user metrics tiles.
+	metrics, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+		From:           from,
+		To:             to,
+		ExternalUserID: &externalUserID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(150), metrics.Metrics.TotalTokens)
+	require.InDelta(t, 1.5, metrics.Metrics.TotalCost, 0.001)
+
+	// The external users list.
+	users, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter:   &gen.SearchUsersFilter{From: from, To: to, UserIds: []string{externalUserID}},
+		UserType: "external",
+		Limit:    10,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, users.Users, 1)
+	require.Equal(t, externalUserID, users.Users[0].UserID)
+	require.Equal(t, int64(150), users.Users[0].TotalTokens)
+
+	// The external-user-scoped overview.
+	scoped, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
+		From:           from,
+		To:             to,
+		ExternalUserID: &externalUserID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), scoped.Summary.TotalChats)
 }

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -580,10 +580,11 @@ func (s *Service) searchEmployeesFromAgentMetrics(ctx context.Context, userType 
 	})
 	g.Go(func() error {
 		items, err := s.chRepo.ListEmaillessIdentities(gctx, repo.ListEmaillessIdentitiesParams{
-			GramProjectID: params.projectID,
-			TimeStart:     params.timeStart,
-			TimeEnd:       params.timeEnd,
-			Limit:         agentMetricsDirectoryCap,
+			ExcludedHookSources: billing.GramHostedHookSourceNames(),
+			GramProjectID:       params.projectID,
+			TimeStart:           params.timeStart,
+			TimeEnd:             params.timeEnd,
+			Limit:               agentMetricsDirectoryCap,
 		})
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "error listing email-less identities")

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -455,8 +455,17 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 		canonicalOrg = params.organizationID
 	}
 
+	// Gram-hosted inference is excluded only for internal (employee)
+	// grouping. External users are the opposite case: their hosted-chat
+	// completions ARE their usage — and their only token-bearing rows, so
+	// excluding them would zero the external surfaces entirely.
+	var excludedHookSources []string
+	if groupBy == "user_id" {
+		excludedHookSources = billing.GramHostedHookSourceNames()
+	}
+
 	searchParams := repo.SearchUsersParams{
-		ExcludedHookSources:  billing.GramHostedHookSourceNames(),
+		ExcludedHookSources:  excludedHookSources,
 		GramProjectID:        params.projectID,
 		TimeStart:            params.timeStart,
 		TimeEnd:              params.timeEnd,
@@ -1337,11 +1346,18 @@ func (s *Service) GetUserMetricsSummary(ctx context.Context, payload *telem_gen.
 		return nil, err
 	}
 
+	// An employee's page never counts Gram-hosted inference (risk-analysis
+	// judges and friends) as their usage. An external user is the opposite
+	// case: their hosted-chat completions ARE their usage — and their only
+	// token-bearing rows, so the exclusion would zero their page.
+	var excludedHookSources []string
+	if userID != "" {
+		excludedHookSources = billing.GramHostedHookSourceNames()
+	}
+
 	user, canonicalUser := s.resolveUserScope(ctx, authCtx.ActiveOrganizationID, userID)
 	metrics, err := s.chRepo.GetUserMetricsSummary(ctx, repo.GetUserMetricsSummaryParams{
-		// A per-user page never counts Gram-hosted inference (risk-analysis
-		// judges and friends) as the employee's usage.
-		ExcludedHookSources: billing.GramHostedHookSourceNames(),
+		ExcludedHookSources: excludedHookSources,
 		GramProjectID:       authCtx.ProjectID.String(),
 		TimeStart:           timeStart,
 		TimeEnd:             timeEnd,
@@ -1885,14 +1901,17 @@ func (s *Service) GetObservabilityOverview(ctx context.Context, payload *telem_g
 	// the same set of identities.
 	user, canonicalUser := s.resolveUserScope(ctx, authCtx.ActiveOrganizationID, userID)
 
-	// Per-user views exclude Gram-hosted inference (risk-analysis judges and
-	// friends): those completions log under the session owner's identity but
-	// are the platform's spend, not the employee's usage — counting them made
-	// one employee's page show 60M+ judge tokens as their own. Org-wide views
-	// keep the current semantics (the summaries fast path cannot express the
-	// exclusion; changing org totals is a separate decision).
+	// Employee-scoped views exclude Gram-hosted inference (risk-analysis
+	// judges and friends): those completions log under the session owner's
+	// identity but are the platform's spend, not the employee's usage —
+	// counting them made one employee's page show 60M+ judge tokens as their
+	// own. External-user scope keeps them: an external user's hosted-chat
+	// completions ARE their usage, and their only token-bearing rows.
+	// Org-wide views also keep the current semantics (the summaries fast path
+	// cannot express the exclusion; changing org totals is a separate
+	// decision).
 	var excludedHookSources []string
-	if userID != "" || externalUserID != "" {
+	if userID != "" {
 		excludedHookSources = billing.GramHostedHookSourceNames()
 	}
 

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -455,6 +456,7 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	}
 
 	searchParams := repo.SearchUsersParams{
+		ExcludedHookSources:  billing.GramHostedHookSourceNames(),
 		GramProjectID:        params.projectID,
 		TimeStart:            params.timeStart,
 		TimeEnd:              params.timeEnd,
@@ -1065,6 +1067,7 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 	eg.Go(func() error {
 		var fetchErr error
 		items, fetchErr = s.chRepo.SearchUsers(egCtx, repo.SearchUsersParams{
+			ExcludedHookSources:  billing.GramHostedHookSourceNames(),
 			GramProjectID:        params.projectID,
 			TimeStart:            params.timeStart,
 			TimeEnd:              params.timeEnd,
@@ -1336,16 +1339,19 @@ func (s *Service) GetUserMetricsSummary(ctx context.Context, payload *telem_gen.
 
 	user, canonicalUser := s.resolveUserScope(ctx, authCtx.ActiveOrganizationID, userID)
 	metrics, err := s.chRepo.GetUserMetricsSummary(ctx, repo.GetUserMetricsSummaryParams{
-		GramProjectID:  authCtx.ProjectID.String(),
-		TimeStart:      timeStart,
-		TimeEnd:        timeEnd,
-		User:           user,
-		CanonicalUser:  canonicalUser,
-		ExternalUserID: externalUserID,
-		EventSource:    conv.PtrValOr(payload.EventSource, ""),
-		HookSource:     conv.PtrValOr(payload.HookSource, ""),
-		AccountType:    conv.PtrValOr(payload.AccountType, ""),
-		ExternalOrgID:  conv.PtrValOr(payload.ExternalOrgID, ""),
+		// A per-user page never counts Gram-hosted inference (risk-analysis
+		// judges and friends) as the employee's usage.
+		ExcludedHookSources: billing.GramHostedHookSourceNames(),
+		GramProjectID:       authCtx.ProjectID.String(),
+		TimeStart:           timeStart,
+		TimeEnd:             timeEnd,
+		User:                user,
+		CanonicalUser:       canonicalUser,
+		ExternalUserID:      externalUserID,
+		EventSource:         conv.PtrValOr(payload.EventSource, ""),
+		HookSource:          conv.PtrValOr(payload.HookSource, ""),
+		AccountType:         conv.PtrValOr(payload.AccountType, ""),
+		ExternalOrgID:       conv.PtrValOr(payload.ExternalOrgID, ""),
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error retrieving user metrics")
@@ -1879,6 +1885,17 @@ func (s *Service) GetObservabilityOverview(ctx context.Context, payload *telem_g
 	// the same set of identities.
 	user, canonicalUser := s.resolveUserScope(ctx, authCtx.ActiveOrganizationID, userID)
 
+	// Per-user views exclude Gram-hosted inference (risk-analysis judges and
+	// friends): those completions log under the session owner's identity but
+	// are the platform's spend, not the employee's usage — counting them made
+	// one employee's page show 60M+ judge tokens as their own. Org-wide views
+	// keep the current semantics (the summaries fast path cannot express the
+	// exclusion; changing org totals is a separate decision).
+	var excludedHookSources []string
+	if userID != "" || externalUserID != "" {
+		excludedHookSources = billing.GramHostedHookSourceNames()
+	}
+
 	// Auto-calculate interval based on time range
 	intervalSeconds := calculateInterval(timeStart, timeEnd)
 
@@ -1889,40 +1906,42 @@ func (s *Service) GetObservabilityOverview(ctx context.Context, payload *telem_g
 
 	// Fetch all data sequentially to avoid ClickHouse concurrent query limits
 	summary, err := s.chRepo.GetOverviewSummary(ctx, repo.GetOverviewSummaryParams{
-		GramProjectID:     projectID,
-		TimeStart:         timeStart,
-		TimeEnd:           timeEnd,
-		User:              user,
-		CanonicalUser:     canonicalUser,
-		ExternalUserID:    externalUserID,
-		APIKeyID:          apiKeyID,
-		ToolsetSlug:       toolsetSlug,
-		RemoteMCPServerID: remoteMCPServerID,
-		MCPServerID:       mcpServerID,
-		EventSource:       eventSource,
-		HookSource:        hookSource,
-		AccountType:       accountType,
-		ExternalOrgID:     externalOrgID,
+		ExcludedHookSources: excludedHookSources,
+		GramProjectID:       projectID,
+		TimeStart:           timeStart,
+		TimeEnd:             timeEnd,
+		User:                user,
+		CanonicalUser:       canonicalUser,
+		ExternalUserID:      externalUserID,
+		APIKeyID:            apiKeyID,
+		ToolsetSlug:         toolsetSlug,
+		RemoteMCPServerID:   remoteMCPServerID,
+		MCPServerID:         mcpServerID,
+		EventSource:         eventSource,
+		HookSource:          hookSource,
+		AccountType:         accountType,
+		ExternalOrgID:       externalOrgID,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error retrieving overview summary")
 	}
 
 	comparison, err := s.chRepo.GetOverviewSummary(ctx, repo.GetOverviewSummaryParams{
-		GramProjectID:     projectID,
-		TimeStart:         comparisonStart,
-		TimeEnd:           comparisonEnd,
-		User:              user,
-		CanonicalUser:     canonicalUser,
-		ExternalUserID:    externalUserID,
-		APIKeyID:          apiKeyID,
-		ToolsetSlug:       toolsetSlug,
-		RemoteMCPServerID: remoteMCPServerID,
-		MCPServerID:       mcpServerID,
-		EventSource:       eventSource,
-		HookSource:        hookSource,
-		AccountType:       accountType,
-		ExternalOrgID:     externalOrgID,
+		ExcludedHookSources: excludedHookSources,
+		GramProjectID:       projectID,
+		TimeStart:           comparisonStart,
+		TimeEnd:             comparisonEnd,
+		User:                user,
+		CanonicalUser:       canonicalUser,
+		ExternalUserID:      externalUserID,
+		APIKeyID:            apiKeyID,
+		ToolsetSlug:         toolsetSlug,
+		RemoteMCPServerID:   remoteMCPServerID,
+		MCPServerID:         mcpServerID,
+		EventSource:         eventSource,
+		HookSource:          hookSource,
+		AccountType:         accountType,
+		ExternalOrgID:       externalOrgID,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error retrieving comparison summary")
@@ -1931,21 +1950,22 @@ func (s *Service) GetObservabilityOverview(ctx context.Context, payload *telem_g
 	var timeSeries []repo.TimeSeriesBucket
 	if payload.IncludeTimeSeries {
 		timeSeries, err = s.chRepo.GetTimeSeriesMetrics(ctx, repo.GetTimeSeriesMetricsParams{
-			GramProjectID:     projectID,
-			TimeStart:         timeStart,
-			TimeEnd:           timeEnd,
-			IntervalSeconds:   intervalSeconds,
-			User:              user,
-			CanonicalUser:     canonicalUser,
-			ExternalUserID:    externalUserID,
-			APIKeyID:          apiKeyID,
-			ToolsetSlug:       toolsetSlug,
-			RemoteMCPServerID: remoteMCPServerID,
-			MCPServerID:       mcpServerID,
-			EventSource:       eventSource,
-			HookSource:        hookSource,
-			AccountType:       accountType,
-			ExternalOrgID:     externalOrgID,
+			ExcludedHookSources: excludedHookSources,
+			GramProjectID:       projectID,
+			TimeStart:           timeStart,
+			TimeEnd:             timeEnd,
+			IntervalSeconds:     intervalSeconds,
+			User:                user,
+			CanonicalUser:       canonicalUser,
+			ExternalUserID:      externalUserID,
+			APIKeyID:            apiKeyID,
+			ToolsetSlug:         toolsetSlug,
+			RemoteMCPServerID:   remoteMCPServerID,
+			MCPServerID:         mcpServerID,
+			EventSource:         eventSource,
+			HookSource:          hookSource,
+			AccountType:         accountType,
+			ExternalOrgID:       externalOrgID,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "error retrieving time series")
@@ -1953,44 +1973,46 @@ func (s *Service) GetObservabilityOverview(ctx context.Context, payload *telem_g
 	}
 
 	toolsByCount, err := s.chRepo.GetToolMetricsBreakdown(ctx, repo.GetToolMetricsBreakdownParams{
-		GramProjectID:     projectID,
-		TimeStart:         timeStart,
-		TimeEnd:           timeEnd,
-		User:              user,
-		CanonicalUser:     canonicalUser,
-		ExternalUserID:    externalUserID,
-		APIKeyID:          apiKeyID,
-		ToolsetSlug:       toolsetSlug,
-		RemoteMCPServerID: remoteMCPServerID,
-		MCPServerID:       mcpServerID,
-		EventSource:       eventSource,
-		HookSource:        hookSource,
-		AccountType:       accountType,
-		ExternalOrgID:     externalOrgID,
-		Limit:             10,
-		SortBy:            "count",
+		ExcludedHookSources: excludedHookSources,
+		GramProjectID:       projectID,
+		TimeStart:           timeStart,
+		TimeEnd:             timeEnd,
+		User:                user,
+		CanonicalUser:       canonicalUser,
+		ExternalUserID:      externalUserID,
+		APIKeyID:            apiKeyID,
+		ToolsetSlug:         toolsetSlug,
+		RemoteMCPServerID:   remoteMCPServerID,
+		MCPServerID:         mcpServerID,
+		EventSource:         eventSource,
+		HookSource:          hookSource,
+		AccountType:         accountType,
+		ExternalOrgID:       externalOrgID,
+		Limit:               10,
+		SortBy:              "count",
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error retrieving tools by count")
 	}
 
 	toolsByFailure, err := s.chRepo.GetToolMetricsBreakdown(ctx, repo.GetToolMetricsBreakdownParams{
-		GramProjectID:     projectID,
-		TimeStart:         timeStart,
-		TimeEnd:           timeEnd,
-		User:              user,
-		CanonicalUser:     canonicalUser,
-		ExternalUserID:    externalUserID,
-		APIKeyID:          apiKeyID,
-		ToolsetSlug:       toolsetSlug,
-		RemoteMCPServerID: remoteMCPServerID,
-		MCPServerID:       mcpServerID,
-		EventSource:       eventSource,
-		HookSource:        hookSource,
-		AccountType:       accountType,
-		ExternalOrgID:     externalOrgID,
-		Limit:             10,
-		SortBy:            "failure_rate",
+		ExcludedHookSources: excludedHookSources,
+		GramProjectID:       projectID,
+		TimeStart:           timeStart,
+		TimeEnd:             timeEnd,
+		User:                user,
+		CanonicalUser:       canonicalUser,
+		ExternalUserID:      externalUserID,
+		APIKeyID:            apiKeyID,
+		ToolsetSlug:         toolsetSlug,
+		RemoteMCPServerID:   remoteMCPServerID,
+		MCPServerID:         mcpServerID,
+		EventSource:         eventSource,
+		HookSource:          hookSource,
+		AccountType:         accountType,
+		ExternalOrgID:       externalOrgID,
+		Limit:               10,
+		SortBy:              "failure_rate",
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error retrieving tools by failure rate")

--- a/server/internal/telemetry/project_overview.go
+++ b/server/internal/telemetry/project_overview.go
@@ -48,20 +48,23 @@ func fetchProjectOverviewClickHouse(
 	eg.Go(func() error {
 		var queryErr error
 		result.toolMetrics, queryErr = reader.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
-			GramProjectID:     params.projectID,
-			TimeStart:         params.timeStart,
-			TimeEnd:           params.timeEnd,
-			User:              repo.UserIdentity{UserIDs: nil, Emails: nil},
-			CanonicalUser:     repo.CanonicalUserIdentity{OrgID: "", UserID: "", EmailLower: ""},
-			ExternalUserID:    "",
-			APIKeyID:          "",
-			ToolsetSlug:       "",
-			RemoteMCPServerID: "",
-			MCPServerID:       "",
-			EventSource:       "",
-			HookSource:        "",
-			AccountType:       "",
-			ExternalOrgID:     "",
+			// Org-scope read: Gram-hosted sources stay counted, matching the
+			// summaries fast path.
+			ExcludedHookSources: nil,
+			GramProjectID:       params.projectID,
+			TimeStart:           params.timeStart,
+			TimeEnd:             params.timeEnd,
+			User:                repo.UserIdentity{UserIDs: nil, Emails: nil},
+			CanonicalUser:       repo.CanonicalUserIdentity{OrgID: "", UserID: "", EmailLower: ""},
+			ExternalUserID:      "",
+			APIKeyID:            "",
+			ToolsetSlug:         "",
+			RemoteMCPServerID:   "",
+			MCPServerID:         "",
+			EventSource:         "",
+			HookSource:          "",
+			AccountType:         "",
+			ExternalOrgID:       "",
 		})
 		if queryErr != nil {
 			return oops.E(oops.CodeUnexpected, queryErr, "error retrieving tool call metrics")
@@ -72,20 +75,23 @@ func fetchProjectOverviewClickHouse(
 	eg.Go(func() error {
 		var queryErr error
 		result.toolMetricsComparison, queryErr = reader.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
-			GramProjectID:     params.projectID,
-			TimeStart:         params.comparisonStart,
-			TimeEnd:           params.comparisonEnd,
-			User:              repo.UserIdentity{UserIDs: nil, Emails: nil},
-			CanonicalUser:     repo.CanonicalUserIdentity{OrgID: "", UserID: "", EmailLower: ""},
-			ExternalUserID:    "",
-			APIKeyID:          "",
-			ToolsetSlug:       "",
-			RemoteMCPServerID: "",
-			MCPServerID:       "",
-			EventSource:       "",
-			HookSource:        "",
-			AccountType:       "",
-			ExternalOrgID:     "",
+			// Org-scope read: Gram-hosted sources stay counted, matching the
+			// summaries fast path.
+			ExcludedHookSources: nil,
+			GramProjectID:       params.projectID,
+			TimeStart:           params.comparisonStart,
+			TimeEnd:             params.comparisonEnd,
+			User:                repo.UserIdentity{UserIDs: nil, Emails: nil},
+			CanonicalUser:       repo.CanonicalUserIdentity{OrgID: "", UserID: "", EmailLower: ""},
+			ExternalUserID:      "",
+			APIKeyID:            "",
+			ToolsetSlug:         "",
+			RemoteMCPServerID:   "",
+			MCPServerID:         "",
+			EventSource:         "",
+			HookSource:          "",
+			AccountType:         "",
+			ExternalOrgID:       "",
 		})
 		if queryErr != nil {
 			return oops.E(oops.CodeUnexpected, queryErr, "error retrieving comparison tool call metrics")

--- a/server/internal/telemetry/repo/employee_agent_usage.go
+++ b/server/internal/telemetry/repo/employee_agent_usage.go
@@ -3,6 +3,8 @@ package repo
 import (
 	"context"
 	"fmt"
+
+	"github.com/Masterminds/squirrel"
 )
 
 // SearchEmployeeAgentUsageParams parameterizes the MV-backed employee usage read.
@@ -114,6 +116,11 @@ type ListEmaillessIdentitiesParams struct {
 	TimeStart     int64 // inclusive window start, unix nanoseconds
 	TimeEnd       int64 // inclusive window end, unix nanoseconds
 	Limit         int
+	// ExcludedHookSources drops rows whose hook_source names a Gram-hosted
+	// completion surface, so a platform-side completion carrying a user_id
+	// but no email cannot surface a phantom identity in the enrollment
+	// directory. Never include the empty string here.
+	ExcludedHookSources []string
 }
 
 // ListEmaillessIdentities returns telemetry identities that carry a user_id but
@@ -143,8 +150,11 @@ func (q *Queries) ListEmaillessIdentities(ctx context.Context, arg ListEmailless
 		Where("gram_project_id = ?", arg.GramProjectID).
 		Where("time_unix_nano >= ?", arg.TimeStart).
 		Where("time_unix_nano <= ?", arg.TimeEnd).
-		Where("user_id != ''").
-		GroupBy("user_id").
+		Where("user_id != ''")
+	if len(arg.ExcludedHookSources) > 0 {
+		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
+	}
+	sb = sb.GroupBy("user_id").
 		// Keep only user_ids that never co-occur with an email in the window;
 		// those that do are folded into an email key by SearchEmployeeAgentUsage.
 		Having("max(user_email != '') = 0"). //nolint:glint // fold-neutral emptiness check partitioning email-less identities

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -2385,7 +2385,8 @@ type GetTimeSeriesMetricsParams struct {
 	// inference such as the risk-analysis judges, logged under the session
 	// owner's identity but not their usage. Never include the empty string
 	// here: raw-log hook, tool-call, and import rows are legitimately
-	// untagged.
+	// untagged. Ignored when HookSource is set: an explicit source filter
+	// overrides the exclusion.
 	ExcludedHookSources []string
 	GramProjectID       string
 	TimeStart           int64
@@ -2468,7 +2469,10 @@ func (q *Queries) GetTimeSeriesMetrics(ctx context.Context, arg GetTimeSeriesMet
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
 	}
-	if len(arg.ExcludedHookSources) > 0 {
+	// The exclusion is a default, not a veto: a caller naming a specific
+	// hook_source gets that source, even a Gram-hosted one — otherwise the
+	// two filters would conjoin into a silently empty result.
+	if len(arg.ExcludedHookSources) > 0 && arg.HookSource == "" {
 		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
@@ -2517,7 +2521,8 @@ type GetToolMetricsBreakdownParams struct {
 	// inference such as the risk-analysis judges, logged under the session
 	// owner's identity but not their usage. Never include the empty string
 	// here: raw-log hook, tool-call, and import rows are legitimately
-	// untagged.
+	// untagged. Ignored when HookSource is set: an explicit source filter
+	// overrides the exclusion.
 	ExcludedHookSources []string
 	GramProjectID       string
 	TimeStart           int64
@@ -2579,7 +2584,10 @@ func (q *Queries) GetToolMetricsBreakdown(ctx context.Context, arg GetToolMetric
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
 	}
-	if len(arg.ExcludedHookSources) > 0 {
+	// The exclusion is a default, not a veto: a caller naming a specific
+	// hook_source gets that source, even a Gram-hosted one — otherwise the
+	// two filters would conjoin into a silently empty result.
+	if len(arg.ExcludedHookSources) > 0 && arg.HookSource == "" {
 		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
@@ -2632,7 +2640,8 @@ type GetOverviewSummaryParams struct {
 	// inference such as the risk-analysis judges, logged under the session
 	// owner's identity but not their usage. Never include the empty string
 	// here: raw-log hook, tool-call, and import rows are legitimately
-	// untagged.
+	// untagged. Ignored when HookSource is set: an explicit source filter
+	// overrides the exclusion.
 	ExcludedHookSources []string
 	GramProjectID       string
 	TimeStart           int64
@@ -2779,7 +2788,10 @@ func (q *Queries) getOverviewSummaryRaw(arg GetOverviewSummaryParams) squirrel.S
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
 	}
-	if len(arg.ExcludedHookSources) > 0 {
+	// The exclusion is a default, not a veto: a caller naming a specific
+	// hook_source gets that source, even a Gram-hosted one — otherwise the
+	// two filters would conjoin into a silently empty result.
+	if len(arg.ExcludedHookSources) > 0 && arg.HookSource == "" {
 		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
@@ -3199,6 +3211,9 @@ type SearchUsersParams struct {
 	// inference logged under an employee's identity never counts as their
 	// usage. Aligns the raw-logs path with the agent-metrics summaries path,
 	// which never ingests those rows. Never include the empty string here.
+	// Ignored when HookSource is set (an explicit source filter overrides
+	// the exclusion) and under external_user_id grouping (an external user's
+	// Gram-hosted completions ARE their usage).
 	ExcludedHookSources []string
 	GramProjectID       string
 	TimeStart           int64
@@ -3350,7 +3365,12 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 	if arg.HookSource != "" {
 		sb = sb.Where("hook_source = ?", arg.HookSource)
 	}
-	if len(arg.ExcludedHookSources) > 0 {
+	// The exclusion is a default, not a veto: a caller naming a specific
+	// hook_source gets that source, even a Gram-hosted one — otherwise the
+	// two filters would conjoin into a silently empty result. External
+	// grouping never applies it either: an external user's Gram-hosted
+	// completions ARE their usage, and their only token-bearing rows.
+	if len(arg.ExcludedHookSources) > 0 && arg.HookSource == "" && arg.GroupBy != "external_user_id" {
 		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
@@ -3416,7 +3436,8 @@ type GetUserMetricsSummaryParams struct {
 	// inference such as the risk-analysis judges, logged under the session
 	// owner's identity but not their usage. Never include the empty string
 	// here: raw-log hook, tool-call, and import rows are legitimately
-	// untagged.
+	// untagged. Ignored when HookSource is set: an explicit source filter
+	// overrides the exclusion.
 	ExcludedHookSources []string
 	GramProjectID       string
 	TimeStart           int64
@@ -3506,7 +3527,10 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
 	}
-	if len(arg.ExcludedHookSources) > 0 {
+	// The exclusion is a default, not a veto: a caller naming a specific
+	// hook_source gets that source, even a Gram-hosted one — otherwise the
+	// two filters would conjoin into a silently empty result.
+	if len(arg.ExcludedHookSources) > 0 && arg.HookSource == "" {
 		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -2380,21 +2380,28 @@ func (q *Queries) GetMetricsSummary(ctx context.Context, arg GetMetricsSummaryPa
 
 // GetTimeSeriesMetricsParams contains the parameters for getting time series metrics.
 type GetTimeSeriesMetricsParams struct {
-	GramProjectID     string
-	TimeStart         int64
-	TimeEnd           int64
-	IntervalSeconds   int64                 // Bucket interval in seconds
-	User              UserIdentity          // Optional filter - scopes to one employee across all their identities
-	CanonicalUser     CanonicalUserIdentity // When enabled, scopes via the identity_map fold instead of the expanded User set
-	ExternalUserID    string                // Optional filter
-	APIKeyID          string                // Optional filter
-	ToolsetSlug       string                // Optional filter - filters by toolset/MCP server slug
-	RemoteMCPServerID string                // Optional filter - filters by remote_mcp_server_id
-	MCPServerID       string                // Optional filter - filters by mcp_server_id
-	EventSource       string                // Optional filter - filters by event_source
-	HookSource        string                // Optional filter - filters by hook_source
-	AccountType       string                // Optional filter - filters by account_type
-	ExternalOrgID     string                // Optional filter - scopes to a single account by provider org id
+	// ExcludedHookSources drops rows whose hook_source names a Gram-hosted
+	// completion surface (billing.GramHostedHookSourceNames) - platform-side
+	// inference such as the risk-analysis judges, logged under the session
+	// owner's identity but not their usage. Never include the empty string
+	// here: raw-log hook, tool-call, and import rows are legitimately
+	// untagged.
+	ExcludedHookSources []string
+	GramProjectID       string
+	TimeStart           int64
+	TimeEnd             int64
+	IntervalSeconds     int64                 // Bucket interval in seconds
+	User                UserIdentity          // Optional filter - scopes to one employee across all their identities
+	CanonicalUser       CanonicalUserIdentity // When enabled, scopes via the identity_map fold instead of the expanded User set
+	ExternalUserID      string                // Optional filter
+	APIKeyID            string                // Optional filter
+	ToolsetSlug         string                // Optional filter - filters by toolset/MCP server slug
+	RemoteMCPServerID   string                // Optional filter - filters by remote_mcp_server_id
+	MCPServerID         string                // Optional filter - filters by mcp_server_id
+	EventSource         string                // Optional filter - filters by event_source
+	HookSource          string                // Optional filter - filters by hook_source
+	AccountType         string                // Optional filter - filters by account_type
+	ExternalOrgID       string                // Optional filter - scopes to a single account by provider org id
 }
 
 // GetTimeSeriesMetrics retrieves time-bucketed metrics for the observability overview charts.
@@ -2461,6 +2468,9 @@ func (q *Queries) GetTimeSeriesMetrics(ctx context.Context, arg GetTimeSeriesMet
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
 	}
+	if len(arg.ExcludedHookSources) > 0 {
+		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
+	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
 	if arg.ExternalOrgID != "" {
 		sb = sb.Where(squirrel.Eq{"external_org_id": arg.ExternalOrgID})
@@ -2502,22 +2512,29 @@ func (q *Queries) GetTimeSeriesMetrics(ctx context.Context, arg GetTimeSeriesMet
 
 // GetToolMetricsBreakdownParams contains the parameters for getting tool metrics breakdown.
 type GetToolMetricsBreakdownParams struct {
-	GramProjectID     string
-	TimeStart         int64
-	TimeEnd           int64
-	User              UserIdentity          // Optional filter - scopes to one employee across all their identities
-	CanonicalUser     CanonicalUserIdentity // When enabled, scopes via the identity_map fold instead of the expanded User set
-	ExternalUserID    string                // Optional filter
-	APIKeyID          string                // Optional filter
-	ToolsetSlug       string                // Optional filter - filters by toolset/MCP server slug
-	RemoteMCPServerID string                // Optional filter - filters by remote_mcp_server_id
-	MCPServerID       string                // Optional filter - filters by mcp_server_id
-	EventSource       string                // Optional filter - filters by event_source
-	HookSource        string                // Optional filter - filters by hook_source
-	AccountType       string                // Optional filter - filters by account_type
-	ExternalOrgID     string                // Optional filter - scopes to a single account by provider org id
-	Limit             int
-	SortBy            string // "count" or "failure_rate"
+	// ExcludedHookSources drops rows whose hook_source names a Gram-hosted
+	// completion surface (billing.GramHostedHookSourceNames) - platform-side
+	// inference such as the risk-analysis judges, logged under the session
+	// owner's identity but not their usage. Never include the empty string
+	// here: raw-log hook, tool-call, and import rows are legitimately
+	// untagged.
+	ExcludedHookSources []string
+	GramProjectID       string
+	TimeStart           int64
+	TimeEnd             int64
+	User                UserIdentity          // Optional filter - scopes to one employee across all their identities
+	CanonicalUser       CanonicalUserIdentity // When enabled, scopes via the identity_map fold instead of the expanded User set
+	ExternalUserID      string                // Optional filter
+	APIKeyID            string                // Optional filter
+	ToolsetSlug         string                // Optional filter - filters by toolset/MCP server slug
+	RemoteMCPServerID   string                // Optional filter - filters by remote_mcp_server_id
+	MCPServerID         string                // Optional filter - filters by mcp_server_id
+	EventSource         string                // Optional filter - filters by event_source
+	HookSource          string                // Optional filter - filters by hook_source
+	AccountType         string                // Optional filter - filters by account_type
+	ExternalOrgID       string                // Optional filter - scopes to a single account by provider org id
+	Limit               int
+	SortBy              string // "count" or "failure_rate"
 }
 
 // GetToolMetricsBreakdown retrieves per-tool aggregated metrics for top tools tables.
@@ -2561,6 +2578,9 @@ func (q *Queries) GetToolMetricsBreakdown(ctx context.Context, arg GetToolMetric
 	}
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
+	}
+	if len(arg.ExcludedHookSources) > 0 {
+		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
 	if arg.ExternalOrgID != "" {
@@ -2607,20 +2627,27 @@ func (q *Queries) GetToolMetricsBreakdown(ctx context.Context, arg GetToolMetric
 
 // GetOverviewSummaryParams contains the parameters for getting overview summary metrics.
 type GetOverviewSummaryParams struct {
-	GramProjectID     string
-	TimeStart         int64
-	TimeEnd           int64
-	User              UserIdentity          // Optional filter - scopes to one employee across all their identities
-	CanonicalUser     CanonicalUserIdentity // When enabled, scopes via the identity_map fold instead of the expanded User set
-	ExternalUserID    string                // Optional filter
-	APIKeyID          string                // Optional filter
-	ToolsetSlug       string                // Optional filter - filters by toolset/MCP server slug
-	RemoteMCPServerID string                // Optional filter - filters by remote_mcp_server_id
-	MCPServerID       string                // Optional filter - filters by mcp_server_id
-	EventSource       string                // Optional filter - filters by event_source
-	HookSource        string                // Optional filter - filters by hook_source
-	AccountType       string                // Optional filter - filters by account_type
-	ExternalOrgID     string                // Optional filter - scopes to a single account by provider org id
+	// ExcludedHookSources drops rows whose hook_source names a Gram-hosted
+	// completion surface (billing.GramHostedHookSourceNames) - platform-side
+	// inference such as the risk-analysis judges, logged under the session
+	// owner's identity but not their usage. Never include the empty string
+	// here: raw-log hook, tool-call, and import rows are legitimately
+	// untagged.
+	ExcludedHookSources []string
+	GramProjectID       string
+	TimeStart           int64
+	TimeEnd             int64
+	User                UserIdentity          // Optional filter - scopes to one employee across all their identities
+	CanonicalUser       CanonicalUserIdentity // When enabled, scopes via the identity_map fold instead of the expanded User set
+	ExternalUserID      string                // Optional filter
+	APIKeyID            string                // Optional filter
+	ToolsetSlug         string                // Optional filter - filters by toolset/MCP server slug
+	RemoteMCPServerID   string                // Optional filter - filters by remote_mcp_server_id
+	MCPServerID         string                // Optional filter - filters by mcp_server_id
+	EventSource         string                // Optional filter - filters by event_source
+	HookSource          string                // Optional filter - filters by hook_source
+	AccountType         string                // Optional filter - filters by account_type
+	ExternalOrgID       string                // Optional filter - scopes to a single account by provider org id
 }
 
 // GetOverviewSummary retrieves aggregated summary metrics for the observability overview.
@@ -2631,7 +2658,7 @@ type GetOverviewSummaryParams struct {
 func (q *Queries) GetOverviewSummary(ctx context.Context, arg GetOverviewSummaryParams) (*OverviewSummary, error) {
 	// A canonical user scope is a user filter even though arg.User stays empty
 	// in fold mode, so it must force the raw path off the unfiltered MV.
-	hasFilters := !arg.User.IsEmpty() || arg.CanonicalUser.Enabled() || arg.ExternalUserID != "" || arg.APIKeyID != "" || arg.ToolsetSlug != "" || arg.RemoteMCPServerID != "" || arg.MCPServerID != "" || arg.EventSource != "" || arg.HookSource != "" || arg.AccountType != "" || arg.ExternalOrgID != ""
+	hasFilters := !arg.User.IsEmpty() || arg.CanonicalUser.Enabled() || arg.ExternalUserID != "" || arg.APIKeyID != "" || arg.ToolsetSlug != "" || arg.RemoteMCPServerID != "" || arg.MCPServerID != "" || arg.EventSource != "" || arg.HookSource != "" || arg.AccountType != "" || arg.ExternalOrgID != "" || len(arg.ExcludedHookSources) > 0
 
 	var sb squirrel.SelectBuilder
 	if hasFilters {
@@ -2751,6 +2778,9 @@ func (q *Queries) getOverviewSummaryRaw(arg GetOverviewSummaryParams) squirrel.S
 	}
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
+	}
+	if len(arg.ExcludedHookSources) > 0 {
+		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
 	if arg.ExternalOrgID != "" {
@@ -3164,19 +3194,25 @@ func chAny(conditions ...string) string {
 
 // SearchUsersParams contains the parameters for searching users with aggregated metrics.
 type SearchUsersParams struct {
-	GramProjectID    string
-	TimeStart        int64
-	TimeEnd          int64
-	GramDeploymentID string // optional
-	EventSource      string // optional; e.g. "hook"
-	HookSource       string // optional; e.g. "cursor"
-	AccountType      string // optional; e.g. "personal"
-	ExternalOrgID    string // optional; scopes to a single account by provider org id
-	GroupBy          string // "user_id" or "external_user_id"
-	UserIDs          []string
-	SortOrder        string // "asc" or "desc"
-	Cursor           string // user identifier to paginate from
-	Limit            int
+	// ExcludedHookSources drops rows whose hook_source names a Gram-hosted
+	// completion surface (billing.GramHostedHookSourceNames), so platform-side
+	// inference logged under an employee's identity never counts as their
+	// usage. Aligns the raw-logs path with the agent-metrics summaries path,
+	// which never ingests those rows. Never include the empty string here.
+	ExcludedHookSources []string
+	GramProjectID       string
+	TimeStart           int64
+	TimeEnd             int64
+	GramDeploymentID    string // optional
+	EventSource         string // optional; e.g. "hook"
+	HookSource          string // optional; e.g. "cursor"
+	AccountType         string // optional; e.g. "personal"
+	ExternalOrgID       string // optional; scopes to a single account by provider org id
+	GroupBy             string // "user_id" or "external_user_id"
+	UserIDs             []string
+	SortOrder           string // "asc" or "desc"
+	Cursor              string // user identifier to paginate from
+	Limit               int
 	// MetricsDetail selects how many aggregates to compute: one of the
 	// MetricsDetail* constants. MetricsDetailBasic projects only identity,
 	// first/last activity, input/output token sums, and raw_user_ids — skipping
@@ -3314,6 +3350,9 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 	if arg.HookSource != "" {
 		sb = sb.Where("hook_source = ?", arg.HookSource)
 	}
+	if len(arg.ExcludedHookSources) > 0 {
+		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
+	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
 	if arg.ExternalOrgID != "" {
 		sb = sb.Where("external_org_id = ?", arg.ExternalOrgID)
@@ -3372,16 +3411,23 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 
 // GetUserMetricsSummaryParams contains the parameters for getting a user's metrics summary.
 type GetUserMetricsSummaryParams struct {
-	GramProjectID  string
-	TimeStart      int64
-	TimeEnd        int64
-	User           UserIdentity          // the employee's identities (mutually exclusive with ExternalUserID)
-	CanonicalUser  CanonicalUserIdentity // when enabled, scopes via the identity_map fold instead of the expanded User set
-	ExternalUserID string                // external_user_id (mutually exclusive with User)
-	EventSource    string                // Optional filter - filters by event_source
-	HookSource     string                // Optional filter - filters by hook_source
-	AccountType    string                // Optional filter - filters by account_type
-	ExternalOrgID  string                // Optional filter - scopes to a single account by provider org id
+	// ExcludedHookSources drops rows whose hook_source names a Gram-hosted
+	// completion surface (billing.GramHostedHookSourceNames) - platform-side
+	// inference such as the risk-analysis judges, logged under the session
+	// owner's identity but not their usage. Never include the empty string
+	// here: raw-log hook, tool-call, and import rows are legitimately
+	// untagged.
+	ExcludedHookSources []string
+	GramProjectID       string
+	TimeStart           int64
+	TimeEnd             int64
+	User                UserIdentity          // the employee's identities (mutually exclusive with ExternalUserID)
+	CanonicalUser       CanonicalUserIdentity // when enabled, scopes via the identity_map fold instead of the expanded User set
+	ExternalUserID      string                // external_user_id (mutually exclusive with User)
+	EventSource         string                // Optional filter - filters by event_source
+	HookSource          string                // Optional filter - filters by hook_source
+	AccountType         string                // Optional filter - filters by account_type
+	ExternalOrgID       string                // Optional filter - scopes to a single account by provider org id
 }
 
 // GetUserMetricsSummary retrieves aggregated metrics for a specific user.
@@ -3459,6 +3505,9 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 	}
 	if arg.HookSource != "" {
 		sb = sb.Where(squirrel.Eq{"hook_source": arg.HookSource})
+	}
+	if len(arg.ExcludedHookSources) > 0 {
+		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
 	}
 	sb = withAccountTypeFilter(sb, arg.AccountType)
 	if arg.ExternalOrgID != "" {


### PR DESCRIPTION
Found while investigating INC-444: an employee's detail page showed 62.4M tokens over 30 days, of which 61.4M were the platform's own risk-analysis judge completions — Gram-hosted inference that logs under the session owner's identity but is the platform's spend, not the employee's usage.

## What

The TUM and costs paths already exclude Gram-hosted `hook_source` values (`billing.GramHostedHookSourceStrings`), and the agent-metrics summaries never ingest them — but the per-user raw-log queries applied no exclusion at all, making the employee page the one surface that counts judge spend as employee usage.

- New `billing.GramHostedHookSourceNames()`: the named exclusion list **without** the empty-string entry. Raw `telemetry_logs` readers must use this variant — hook, tool-call, and import rows are legitimately untagged there, so excluding `''` (correct on the summaries, where an untagged row can only be Gram-era history) would drop real usage.
- Threaded as `ExcludedHookSources` through the per-user query params: the employee page tiles (`GetUserMetricsSummary`), the user-scoped observability overview (summary, comparison, time series, tool breakdowns — exclusions also force the raw path, since the summaries fast path cannot express them), and the `searchUsers` raw path + role rollup, aligning them with the agent-metrics summaries path.
- **Employee scope only.** Every hosted completion carries a non-empty `hook_source` from the exclusion set, and an external user (Elements / hosted-chat consumer) has no other token-bearing rows — so the exclusion applies only when the query is scoped to an internal user (`GetUserMetricsSummary` by `user_id`, overview by `user_id`, `searchUsers` internal grouping and role rollup). External-user surfaces are unaffected.
- **An explicit `hook_source` filter overrides the exclusion.** A user-scoped call filtering on e.g. `risk-analysis` returns that source's rows instead of a silently empty result — the exclusion is a default, not a veto.
- **Org-scope reads keep current semantics** (Gram-hosted rows stay counted, matching the summaries fast path) — changing org totals is a separate decision, and the test pins this deliberately.

## Verification

- New integration test: a judge completion row (2M tokens, nil-UUID conversation id, `chat:completion` URN — the prod shape) next to a real usage row for the same person — invisible on the employee tiles, the searchUsers summary, the role rollup, and the user-scoped overview; still counted by the org-scope overview, and returned in full when the caller filters on `hook_source=risk-analysis` explicitly.
- New external-user test: a hosted completion tagged `elements` with only an `external_user_id` still shows up on `GetUserMetricsSummary`, the external `searchUsers` listing, and the external-user-scoped overview.
- 572 tests across telemetry/billing/usage; `mise lint:server` green (exhaustruct satisfied at every construction site, org-scope sites explicitly `nil` with a comment).

## Known residuals (out of scope, by decision)

- `SearchChats` shows a phantom nil-UUID chat holding judge tokens for a user.
- `GetTopUsers` session mode still ranks users by judge completions.
- `ListFilterOptions` / `GetActiveCounts` count judge rows as activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop counting Gram-hosted inference as employee usage on per-user telemetry surfaces. Previously, judge completions logged under the session owner inflated employee totals; now employee-scoped views exclude them by default, while org-wide totals remain unchanged and external-user views still count hosted-chat usage.

- Adds `billing.GramHostedHookSourceNames()` (named sources only; raw `telemetry_logs` must keep the empty string).
- Threads the exclusion as `ExcludedHookSources` through `GetUserMetricsSummary`, employee-scoped `GetObservabilityOverview` (summary, comparison, time series, tool breakdowns), `SearchUsers` (including role rollup), and `ListEmaillessIdentities` to prevent Gram-hosted, email-less rows from surfacing phantom identities in the enrollment directory.
- Gates the exclusion to internal (employee) scope only; external-user surfaces are unaffected.
- An explicit `hook_source` filter overrides the exclusion.
- Org-scope reads keep current semantics; exclusions force the raw overview path since the summaries fast path cannot express them.

<sup>Written for commit 65a5227ff54270b4075aa497a3a0f772ef7b6999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

