### PR TITLE
chore: new menu layout

### DIFF
--- a/.changeset/control-center-nav.md
+++ b/.changeset/control-center-nav.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The Secure section's navigation is now Watchdog, Control Center, and Shadow MCP: the Risk Policies page is renamed Control Center and gains a Detection Rules tab alongside Policies and Exclusion Rules, replacing the standalone Detection Rules page (its old URL redirects, deep links included).

--- a/.changeset/control-center-nav.md
+++ b/.changeset/control-center-nav.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-The Secure section's navigation is now Watchdog, Control Center, and Shadow MCP: the Risk Policies page is renamed Control Center and gains a Detection Rules tab alongside Policies and Exclusion Rules, replacing the standalone Detection Rules page (its old URL redirects, deep links included).
+The Secure section's navigation is now Watchdog, Guardrails, and Shadow MCP: the Risk Policies page is renamed Guardrails and gains a Detection Rules tab alongside Policies and Exclusion Rules, replacing the standalone Detection Rules page (its old URL redirects, deep links included).

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -228,10 +228,6 @@ export function AppSidebar({
                     },
                   ]),
               { item: routes.shadowMCP, ...accessFor(routes.shadowMCP) },
-              {
-                item: routes.detectionRules,
-                ...accessFor(routes.detectionRules),
-              },
             ]}
           />
 

--- a/client/dashboard/src/components/command-palette/ResourceResults.tsx
+++ b/client/dashboard/src/components/command-palette/ResourceResults.tsx
@@ -253,7 +253,7 @@ function RiskPoliciesGroup({ onNavigate }: GroupProps) {
   const policies = data?.policies ?? [];
   if (!policies.length) return null;
   return (
-    <CommandGroup heading="Control Center">
+    <CommandGroup heading="Guardrails">
       {policies.map((policy) => (
         <ResultItem
           key={policy.id}
@@ -309,7 +309,7 @@ function DetectionRulesGroup({ onNavigate }: GroupProps) {
           icon="scan-search"
           onSelect={() => {
             // No per-rule route; deep-link opens the rule's sheet by id on
-            // the Control Center's Detection Rules tab.
+            // the Guardrails page's Detection Rules tab.
             void navigate(
               `${routes.policyCenter.href()}?tab=detection-rules&rule=${encodeURIComponent(rule.id)}`,
             );

--- a/client/dashboard/src/components/command-palette/ResourceResults.tsx
+++ b/client/dashboard/src/components/command-palette/ResourceResults.tsx
@@ -253,7 +253,7 @@ function RiskPoliciesGroup({ onNavigate }: GroupProps) {
   const policies = data?.policies ?? [];
   if (!policies.length) return null;
   return (
-    <CommandGroup heading="Risk Policies">
+    <CommandGroup heading="Control Center">
       {policies.map((policy) => (
         <ResultItem
           key={policy.id}
@@ -308,9 +308,10 @@ function DetectionRulesGroup({ onNavigate }: GroupProps) {
           sublabel={rule.severity}
           icon="scan-search"
           onSelect={() => {
-            // No per-rule route; deep-link opens the rule's sheet by id.
+            // No per-rule route; deep-link opens the rule's sheet by id on
+            // the Control Center's Detection Rules tab.
             void navigate(
-              `${routes.detectionRules.href()}?rule=${encodeURIComponent(rule.id)}`,
+              `${routes.policyCenter.href()}?tab=detection-rules&rule=${encodeURIComponent(rule.id)}`,
             );
             onNavigate();
           }}

--- a/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
@@ -41,7 +41,7 @@ const routes = {
   orgMemory: route("Org Memory", "org-memory"),
   playground: route("Playground", "playground"),
   plugins: route("Plugins", "plugins"),
-  policyCenter: route("Control Center", "risk-policies"),
+  policyCenter: route("Guardrails", "risk-policies"),
   riskEvents: route("Risk Events", "risk-events"),
   riskOverview: route("Risk Overview", "risk"),
   watchdog: route("Watchdog", "watchdog"),

--- a/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
@@ -41,7 +41,7 @@ const routes = {
   orgMemory: route("Org Memory", "org-memory"),
   playground: route("Playground", "playground"),
   plugins: route("Plugins", "plugins"),
-  policyCenter: route("Risk Policies", "risk-policies"),
+  policyCenter: route("Control Center", "risk-policies"),
   riskEvents: route("Risk Events", "risk-events"),
   riskOverview: route("Risk Overview", "risk"),
   watchdog: route("Watchdog", "watchdog"),

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -100,7 +100,6 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
         ? []
         : [{ route: routes.riskEvents, scope: ["org:admin"] as Scope[] }]),
       { route: routes.shadowMCP, scope: readWrite },
-      { route: routes.detectionRules, scope: readWrite },
       { route: routes.settings, scope: ["project:write"] },
     ];
   }, [

--- a/client/dashboard/src/pages/security/DetectionRules.tsx
+++ b/client/dashboard/src/pages/security/DetectionRules.tsx
@@ -83,7 +83,7 @@ type SelectedRule =
   | { kind: "custom"; rule: CustomDetectionRule };
 
 /**
- * Legacy route target: Detection Rules now lives as a Control Center tab, so
+ * Legacy route target: Detection Rules now lives as a Guardrails tab, so
  * the old standalone page redirects there, carrying the `?rule=` deep link
  * along so existing bookmarks and palette links keep resolving.
  */
@@ -101,7 +101,7 @@ export default function DetectionRules(): JSX.Element {
 }
 
 /**
- * The Detection Rules tab body, rendered inside the Control Center's
+ * The Detection Rules tab body, rendered inside the Guardrails page's
  * TabbedPage — no page frame of its own. The create sheet is controlled by
  * the parent so the page-level primary action can open it.
  */

--- a/client/dashboard/src/pages/security/DetectionRules.tsx
+++ b/client/dashboard/src/pages/security/DetectionRules.tsx
@@ -1,5 +1,6 @@
-import { ResourceListPage } from "@/components/page-templates";
 import { RequireScope } from "@/components/require-scope";
+import { useRoutes } from "@/routes";
+import { Navigate, useSearchParams } from "react-router";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -21,7 +22,6 @@ import {
   Check,
   ChevronRight,
   Loader2,
-  Plus,
   Sparkles,
   Trash2,
 } from "lucide-react";
@@ -82,15 +82,53 @@ type SelectedRule =
   | { kind: "builtin"; rule: BuiltinRule }
   | { kind: "custom"; rule: CustomDetectionRule };
 
+/**
+ * Legacy route target: Detection Rules now lives as a Control Center tab, so
+ * the old standalone page redirects there, carrying the `?rule=` deep link
+ * along so existing bookmarks and palette links keep resolving.
+ */
 export default function DetectionRules(): JSX.Element {
+  const routes = useRoutes();
+  const [searchParams] = useSearchParams();
+  const rule = searchParams.get("rule");
+  const ruleSuffix = rule ? `&rule=${encodeURIComponent(rule)}` : "";
   return (
-    <RequireScope scope="org:admin" level="page">
-      <DetectionRulesContent />
+    <Navigate
+      to={`${routes.policyCenter.href()}?tab=detection-rules${ruleSuffix}`}
+      replace
+    />
+  );
+}
+
+/**
+ * The Detection Rules tab body, rendered inside the Control Center's
+ * TabbedPage — no page frame of its own. The create sheet is controlled by
+ * the parent so the page-level primary action can open it.
+ */
+export function DetectionRulesTab({
+  createOpen,
+  onCreateOpenChange,
+}: {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+}): JSX.Element {
+  return (
+    <RequireScope scope="org:admin" level="component">
+      <DetectionRulesContent
+        createOpen={createOpen}
+        onCreateOpenChange={onCreateOpenChange}
+      />
     </RequireScope>
   );
 }
 
-function DetectionRulesContent() {
+function DetectionRulesContent({
+  createOpen,
+  onCreateOpenChange,
+}: {
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+}) {
   const {
     customRules,
     isLoading: customRulesLoading,
@@ -100,7 +138,6 @@ function DetectionRulesContent() {
     removeCustomRule,
   } = useDetectionRulesStore();
 
-  const [createOpen, setCreateOpen] = useState(false);
   const [selected, setSelected] = useState<SelectedRule | null>(null);
   const [expanded, setExpanded] = useState<RuleCategory | "custom" | null>(
     null,
@@ -143,46 +180,34 @@ function DetectionRulesContent() {
 
   return (
     <>
-      <ResourceListPage
-        title="Detection Rules"
-        stage="beta"
-        description="Reusable built-in and custom rules your policies use to flag — or exempt — messages."
-        primaryAction={
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Custom Detection Rule
-          </Button>
-        }
-      >
-        <div className="space-y-8">
-          {customRulesLoading && (
-            <div className="text-muted-foreground text-sm">
-              Loading custom rules...
-            </div>
-          )}
-          {customRulesError && (
-            <div className="text-destructive text-sm">
-              Failed to load custom rules.
-            </div>
-          )}
-          {customRules.length > 0 && (
-            <CustomRulesSection
-              rules={customRules}
-              expanded={expanded === "custom"}
-              onToggle={() =>
-                setExpanded(expanded === "custom" ? null : "custom")
-              }
-              onSelect={(rule) => setSelected({ kind: "custom", rule })}
-            />
-          )}
-
-          <BuiltinRulesSection
-            expanded={expanded}
-            onToggle={(cat) => setExpanded(expanded === cat ? null : cat)}
-            onSelect={(rule) => setSelected({ kind: "builtin", rule })}
+      <div className="space-y-8">
+        {customRulesLoading && (
+          <div className="text-muted-foreground text-sm">
+            Loading custom rules...
+          </div>
+        )}
+        {customRulesError && (
+          <div className="text-destructive text-sm">
+            Failed to load custom rules.
+          </div>
+        )}
+        {customRules.length > 0 && (
+          <CustomRulesSection
+            rules={customRules}
+            expanded={expanded === "custom"}
+            onToggle={() =>
+              setExpanded(expanded === "custom" ? null : "custom")
+            }
+            onSelect={(rule) => setSelected({ kind: "custom", rule })}
           />
-        </div>
-      </ResourceListPage>
+        )}
+
+        <BuiltinRulesSection
+          expanded={expanded}
+          onToggle={(cat) => setExpanded(expanded === cat ? null : cat)}
+          onSelect={(rule) => setSelected({ kind: "builtin", rule })}
+        />
+      </div>
 
       <RuleDetailSheet
         selection={selected}
@@ -201,11 +226,11 @@ function DetectionRulesContent() {
 
       <CreateCustomRuleSheet
         open={createOpen}
-        onOpenChange={setCreateOpen}
+        onOpenChange={onCreateOpenChange}
         existingCustomIds={customRules.map((r) => r.id)}
         onCreate={(rule) => {
           addCustomRule(rule);
-          setCreateOpen(false);
+          onCreateOpenChange(false);
           toast.success(`Created custom rule ${rule.id}`);
         }}
       />

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -97,6 +97,7 @@ import {
   getPolicyDeleteRuleListItems,
   getPolicyRuleGroupNamesForDeleteDialog,
 } from "./policy-delete-dialog";
+import { DetectionRulesTab } from "./DetectionRules";
 import { SeverityBadge } from "./risk-ui";
 import { policySummary } from "./policy-summary";
 import { policyEnabledActionLabel } from "./policy-enabled";
@@ -554,7 +555,34 @@ function PolicyDateCell({ date }: { date: Date }): JSX.Element {
 // Watchdog page's Suppressed section. `tab` is parsed as a string literal
 // union, so a stale `?tab=dismissed` link falls back to "policies" rather
 // than rendering an empty page.
-const POLICY_CENTER_TABS = ["policies", "exclusions"] as const;
+const POLICY_CENTER_TABS = [
+  "policies",
+  "detection-rules",
+  "exclusions",
+] as const;
+
+/** The page-level primary action follows the active tab: each tab creates its
+ *  own kind of resource. */
+function policyCenterHeaderAction(
+  activeTab: (typeof POLICY_CENTER_TABS)[number],
+  actions: {
+    newPolicy: () => void;
+    newDetectionRule: () => void;
+    newExclusion: () => void;
+  },
+): { label: string; onClick: () => void } {
+  switch (activeTab) {
+    case "policies":
+      return { label: "New Policy", onClick: actions.newPolicy };
+    case "detection-rules":
+      return {
+        label: "Custom Detection Rule",
+        onClick: actions.newDetectionRule,
+      };
+    case "exclusions":
+      return { label: "Set up Exclusion Rule", onClick: actions.newExclusion };
+  }
+}
 
 export default function PolicyCenter(): JSX.Element {
   return (
@@ -600,6 +628,9 @@ function PolicyCenterContent() {
   );
   const [exclusionSheet, setExclusionSheet] =
     useState<ExclusionSheetState | null>(null);
+  // The Detection Rules tab's create sheet is owned here so the page-level
+  // primary action can open it.
+  const [ruleCreateOpen, setRuleCreateOpen] = useState(false);
 
   // Deep-link support: `?policy=<id>` redirects to that policy's detail page.
   // The command palette uses this since policies have no per-item list route.
@@ -913,13 +944,11 @@ function PolicyCenterContent() {
     },
   ];
 
-  const headerAction =
-    activeTab === "policies"
-      ? { label: "New Policy", onClick: () => routes.policyCenter.new.goTo() }
-      : {
-          label: "Set up Exclusion Rule",
-          onClick: () => setExclusionSheet({ mode: "create" }),
-        };
+  const headerAction = policyCenterHeaderAction(activeTab, {
+    newPolicy: () => routes.policyCenter.new.goTo(),
+    newDetectionRule: () => setRuleCreateOpen(true),
+    newExclusion: () => setExclusionSheet({ mode: "create" }),
+  });
   const policyDeleteRuleListItems = policyToDelete
     ? getPolicyDeleteRuleListItems(
         getPolicyRuleGroupNamesForDeleteDialog(policyToDelete.policy),
@@ -970,16 +999,21 @@ function PolicyCenterContent() {
 
   return (
     <TabbedPage
-      title="Policies"
+      title="Control Center"
       stage="beta"
-      description="Configure policies to detect secrets, sensitive information, and prompt-defined risks in agent session interactions."
+      description="Configure the policies, detection rules, and exclusion rules that govern risk detection in agent session interactions."
       primaryAction={primaryAction}
       activeTab={activeTab}
       tabs={[
         { value: "policies", label: "Policies", href: "?tab=policies" },
         {
+          value: "detection-rules",
+          label: "Detection Rules",
+          href: "?tab=detection-rules",
+        },
+        {
           value: "exclusions",
-          label: "Exclusion rules",
+          label: "Exclusion Rules",
           href: "?tab=exclusions",
         },
       ]}
@@ -991,6 +1025,12 @@ function PolicyCenterContent() {
         subtitle="Ask about policy status, coverage, and detector capabilities. Match content is redacted before it reaches the assistant."
       />
       {activeTab === "policies" && policiesBody}
+      {activeTab === "detection-rules" && (
+        <DetectionRulesTab
+          createOpen={ruleCreateOpen}
+          onCreateOpenChange={setRuleCreateOpen}
+        />
+      )}
       {activeTab === "exclusions" && (
         <ExclusionsTab
           policies={data?.policies ?? []}

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -1016,7 +1016,6 @@ function PolicyCenterContent() {
   return (
     <TabbedPage
       title="Control Center"
-      stage="beta"
       description="Configure the policies, detection rules, and exclusion rules that govern risk detection in agent session interactions."
       primaryAction={primaryAction}
       activeTab={activeTab}

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -629,8 +629,12 @@ function PolicyCenterContent() {
   const [exclusionSheet, setExclusionSheet] =
     useState<ExclusionSheetState | null>(null);
   // The Detection Rules tab's create sheet is owned here so the page-level
-  // primary action can open it.
+  // primary action can open it. Leaving the tab closes it — otherwise the
+  // sheet would silently reopen when the tab is next visited.
   const [ruleCreateOpen, setRuleCreateOpen] = useState(false);
+  useEffect(() => {
+    if (activeTab !== "detection-rules") setRuleCreateOpen(false);
+  }, [activeTab]);
 
   // Deep-link support: `?policy=<id>` redirects to that policy's detail page.
   // The command palette uses this since policies have no per-item list route.
@@ -1018,12 +1022,23 @@ function PolicyCenterContent() {
         },
       ]}
     >
-      <InsightsConfig
-        contextInfo={insightsContext}
-        suggestions={INSIGHTS_SUGGESTIONS["risk-policies"]}
-        title="Policy insights"
-        subtitle="Ask about policy status, coverage, and detector capabilities. Match content is redacted before it reaches the assistant."
-      />
+      {/* The dock follows the active tab: the Detection Rules tab took over
+          the standalone page whose URL used to select these suggestions. */}
+      {activeTab === "detection-rules" ? (
+        <InsightsConfig
+          contextInfo={insightsContext}
+          suggestions={INSIGHTS_SUGGESTIONS["detection-rules"]}
+          title="Detection rule insights"
+          subtitle="Ask about rule activity, noisy rules, and coverage gaps. Match content is redacted before it reaches the assistant."
+        />
+      ) : (
+        <InsightsConfig
+          contextInfo={insightsContext}
+          suggestions={INSIGHTS_SUGGESTIONS["risk-policies"]}
+          title="Policy insights"
+          subtitle="Ask about policy status, coverage, and detector capabilities. Match content is redacted before it reaches the assistant."
+        />
+      )}
       {activeTab === "policies" && policiesBody}
       {activeTab === "detection-rules" && (
         <DetectionRulesTab

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -805,7 +805,7 @@ function PolicyCenterContent() {
   );
 
   const insightsContext = [
-    "Page: Control Center, Policies tab.",
+    `Page: Control Center, ${activeTab === "exclusions" ? "Exclusion Rules" : "Policies"} tab.`,
     `Total policies: ${policyRows.length}.`,
     `Active policies: ${policyRows.filter((r) => r.policy.enabled).length}.`,
     `Policy actions: ${policyRows.map((r) => `${r.policy.name} (${r.policy.action}${r.policy.enabled ? "" : ", inactive"})`).join(", ") || "none"}.`,

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -98,6 +98,7 @@ import {
   getPolicyRuleGroupNamesForDeleteDialog,
 } from "./policy-delete-dialog";
 import { DetectionRulesTab } from "./DetectionRules";
+import { BUILTIN_RULE_ID_LIST } from "./detection-rules-data";
 import { SeverityBadge } from "./risk-ui";
 import { policySummary } from "./policy-summary";
 import { policyEnabledActionLabel } from "./policy-enabled";
@@ -561,6 +562,17 @@ const POLICY_CENTER_TABS = [
   "exclusions",
 ] as const;
 
+/** Assistant context for the Detection Rules tab: assembled from the static
+ *  client-side rule catalog so the other tabs pay no extra queries for it.
+ *  Rule-activity questions route through the finding-level tools. */
+const DETECTION_RULES_INSIGHTS_CONTEXT = [
+  "Page: Control Center, Detection Rules tab — the catalog of built-in and custom detection rules that policies compose.",
+  `Built-in rule ids: ${BUILTIN_RULE_ID_LIST.join(", ")}.`,
+  "Custom rules are organization-defined CEL expressions with ids prefixed 'custom.'; list them with listCustomDetectionRules.",
+  "For rule activity, query findings by rule_id via listRiskResultsForAgent (match content is redacted).",
+  "Never echo match_redacted values verbatim. Refer to findings by rule_id and source.",
+].join(" ");
+
 /** The page-level primary action follows the active tab: each tab creates its
  *  own kind of resource. */
 function policyCenterHeaderAction(
@@ -793,7 +805,7 @@ function PolicyCenterContent() {
   );
 
   const insightsContext = [
-    "Page: Policy Center.",
+    "Page: Control Center, Policies tab.",
     `Total policies: ${policyRows.length}.`,
     `Active policies: ${policyRows.filter((r) => r.policy.enabled).length}.`,
     `Policy actions: ${policyRows.map((r) => `${r.policy.name} (${r.policy.action}${r.policy.enabled ? "" : ", inactive"})`).join(", ") || "none"}.`,
@@ -1026,7 +1038,7 @@ function PolicyCenterContent() {
           the standalone page whose URL used to select these suggestions. */}
       {activeTab === "detection-rules" ? (
         <InsightsConfig
-          contextInfo={insightsContext}
+          contextInfo={DETECTION_RULES_INSIGHTS_CONTEXT}
           suggestions={INSIGHTS_SUGGESTIONS["detection-rules"]}
           title="Detection rule insights"
           subtitle="Ask about rule activity, noisy rules, and coverage gaps. Match content is redacted before it reaches the assistant."

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -566,7 +566,7 @@ const POLICY_CENTER_TABS = [
  *  client-side rule catalog so the other tabs pay no extra queries for it.
  *  Rule-activity questions route through the finding-level tools. */
 const DETECTION_RULES_INSIGHTS_CONTEXT = [
-  "Page: Control Center, Detection Rules tab — the catalog of built-in and custom detection rules that policies compose.",
+  "Page: Guardrails, Detection Rules tab — the catalog of built-in and custom detection rules that policies compose.",
   `Built-in rule ids: ${BUILTIN_RULE_ID_LIST.join(", ")}.`,
   "Custom rules are organization-defined CEL expressions with ids prefixed 'custom.'; list them with listCustomDetectionRules.",
   "For rule activity, query findings by rule_id via listRiskResultsForAgent (match content is redacted).",
@@ -805,7 +805,7 @@ function PolicyCenterContent() {
   );
 
   const insightsContext = [
-    `Page: Control Center, ${activeTab === "exclusions" ? "Exclusion Rules" : "Policies"} tab.`,
+    `Page: Guardrails, ${activeTab === "exclusions" ? "Exclusion Rules" : "Policies"} tab.`,
     `Total policies: ${policyRows.length}.`,
     `Active policies: ${policyRows.filter((r) => r.policy.enabled).length}.`,
     `Policy actions: ${policyRows.map((r) => `${r.policy.name} (${r.policy.action}${r.policy.enabled ? "" : ", inactive"})`).join(", ") || "none"}.`,
@@ -1015,7 +1015,7 @@ function PolicyCenterContent() {
 
   return (
     <TabbedPage
-      title="Control Center"
+      title="Guardrails"
       description="Configure the policies, detection rules, and exclusion rules that govern risk detection in agent session interactions."
       primaryAction={primaryAction}
       activeTab={activeTab}

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -674,6 +674,9 @@ const ROUTE_STRUCTURE = {
       },
     },
   },
+  // Legacy URL: Detection Rules lives as a Control Center tab now; the
+  // component redirects there (carrying ?rule= deep links along). Kept out of
+  // the sidebar.
   detectionRules: {
     title: "Detection Rules",
     url: "detection-rules",
@@ -681,7 +684,7 @@ const ROUTE_STRUCTURE = {
     component: DetectionRules,
   },
   policyCenter: {
-    title: "Risk Policies",
+    title: "Control Center",
     url: "risk-policies",
     icon: "shield-check",
     // Layout route: renders the policy list (index) or a policy detail subpage.

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -674,7 +674,7 @@ const ROUTE_STRUCTURE = {
       },
     },
   },
-  // Legacy URL: Detection Rules lives as a Control Center tab now; the
+  // Legacy URL: Detection Rules lives as a Guardrails tab now; the
   // component redirects there (carrying ?rule= deep links along). Kept out of
   // the sidebar.
   detectionRules: {
@@ -684,7 +684,7 @@ const ROUTE_STRUCTURE = {
     component: DetectionRules,
   },
   policyCenter: {
-    title: "Control Center",
+    title: "Guardrails",
     url: "risk-policies",
     icon: "shield-check",
     // Layout route: renders the policy list (index) or a policy detail subpage.


### PR DESCRIPTION
<img width="1702" height="841" alt="Screenshot 2026-08-20 at 11 50 10" src="https://github.com/user-attachments/assets/d39c4857-22e9-4c8f-aff3-caa7ee2e3404" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames Risk Policies to Guardrails and moves Detection Rules into a Guardrails tab, replacing the standalone page. This consolidates risk configuration and scopes the primary action and insights to the active tab.

- Navigation: Secure shows Watchdog, Guardrails, and Shadow MCP; Detection Rules is removed from the sidebar; the route label is now Guardrails.
- Routing and palette: the legacy `detection-rules` URL redirects to Guardrails’ Detection Rules tab and preserves `?rule=` deep links; the command palette group is “Guardrails,” and Detection Rules results open that tab with the deep link.
- Guardrails tabs: adds Policies, Detection Rules, and Exclusion Rules; the page-level primary action changes by tab (New Policy, Custom Detection Rule, Set up Exclusion Rule); the Detection Rules tab hosts its list and creation sheet, and leaving the tab closes the sheet.
- Insights: the dock’s title, context, and suggestions reflect the active tab; the Detection Rules tab has its own assistant context.
- Migration: no action required; existing bookmarks and palette links continue to resolve via redirect.

<sup>Written for commit cda8031858da123033b0a882346db5ce74508349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



