### PR TITLE
fix: improve existing identity provider picker

### DIFF
--- a/client/dashboard/src/components/ui/Combobox/index.tsx
+++ b/client/dashboard/src/components/ui/Combobox/index.tsx
@@ -22,6 +22,7 @@ export type DropdownItem = {
   value: string;
   label: string;
   icon?: ReactNode;
+  keywords?: string[];
   onClick?: () => void;
 };
 
@@ -36,6 +37,9 @@ export function Combobox<T extends DropdownItem>({
   label,
   disabledMessage,
   tooltip,
+  searchable = false,
+  searchPlaceholder = "Search...",
+  contentClassName,
 }: {
   items: T[];
   selected: T | string | undefined;
@@ -47,6 +51,9 @@ export function Combobox<T extends DropdownItem>({
   label?: string;
   disabledMessage?: string;
   tooltip?: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  contentClassName?: string;
 }): JSX.Element {
   const [open, setOpen] = useState(false);
 
@@ -91,10 +98,10 @@ export function Combobox<T extends DropdownItem>({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       {trigger}
-      <PopoverContent className="w-[200px] p-0">
-        <Command>
-          {items.length > 4 && (
-            <CommandInput placeholder="Search..." className="h-9" />
+      <PopoverContent className={cn("w-[200px] p-0", contentClassName)}>
+        <Command label={searchPlaceholder}>
+          {(searchable || items.length > 4) && (
+            <CommandInput placeholder={searchPlaceholder} className="h-9" />
           )}
           <CommandList>
             <CommandEmpty>No items found.</CommandEmpty>
@@ -103,6 +110,7 @@ export function Combobox<T extends DropdownItem>({
                 <CommandItem
                   key={item.value}
                   value={item.value}
+                  keywords={[item.label, ...(item.keywords ?? [])]}
                   className="cursor-pointer truncate"
                   onSelect={(v) => {
                     onSelectionChange(items.find((item) => item.value === v)!);

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -1,4 +1,5 @@
 import { AssetImageUploadField } from "@/components/asset-image-upload-field";
+import { Combobox } from "@/components/ui/Combobox";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
 import {
@@ -877,21 +878,35 @@ function SelectExistingFields({
   selectedIssuerId: string;
   onChange: (id: string) => void;
 }) {
+  const issuerOptions = useMemo(
+    () =>
+      selectableIssuers
+        .map((issuer) => ({
+          value: issuer.id,
+          label: `${issuer.name?.trim() || issuer.slug} — ${issuer.issuer}`,
+          keywords: [issuer.name ?? "", issuer.slug, issuer.issuer],
+        }))
+        .toSorted((a, b) => a.label.localeCompare(b.label)),
+    [selectableIssuers],
+  );
+  const selectedIssuer = issuerOptions.find(
+    (issuer) => issuer.value === selectedIssuerId,
+  );
+
   return (
     <Stack gap={2}>
       <Label className="text-muted-foreground text-xs">Identity Provider</Label>
-      <Select value={selectedIssuerId} onValueChange={onChange}>
-        <SelectTrigger>
-          <SelectValue placeholder="Choose an identity provider…" />
-        </SelectTrigger>
-        <SelectContent>
-          {selectableIssuers.map((issuer) => (
-            <SelectItem key={issuer.id} value={issuer.id}>
-              {issuer.name?.trim() || issuer.slug} — {issuer.issuer}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <Combobox
+        items={issuerOptions}
+        selected={selectedIssuer}
+        onSelectionChange={(issuer) => onChange(issuer.value)}
+        searchable
+        searchPlaceholder="Search identity providers…"
+        className="w-full justify-between"
+        contentClassName="w-[min(500px,calc(100vw-2rem))]"
+      >
+        {selectedIssuer?.label ?? "Choose an identity provider…"}
+      </Combobox>
       <Text muted small>
         Pick an organization-level or project identity provider already
         configured on this project.


### PR DESCRIPTION
## Summary
- replace the existing identity provider select with a searchable combobox
- sort identity providers alphabetically by their display label
- rank search matches using provider names, slugs, and issuer URLs
- keep long provider labels readable in a wider responsive results panel

## Testing
- `aube run -F dashboard type-check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the identity provider select with a searchable combobox and enhances `Combobox` with opt‑in search and keyword matching. This improves provider discoverability, sorts options alphabetically, and keeps long labels readable in a wider panel.

- Settings > Authentication > Attach Remote Identity Provider: swaps `Select` for `Combobox`; option label is "name or slug — issuer"; options sort alphabetically; search matches name, slug, and issuer; popover width grows to fit long labels.
- `Combobox`: adds `keywords` on items and `searchable`, `searchPlaceholder`, `contentClassName` props; shows the search input when `searchable` is true (or items >4); forwards `keywords` to the command list for matching.
- No migration required; existing `Combobox` usages behave the same unless `searchable` is enabled.

<sup>Written for commit ac4b89e86a84552e73ca9968d88b3fdb19f4c05a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

