### PR TITLE
fix: show shared remote sessions on consent regardless of minting issuer

### DIFF
--- a/.changeset/consent-shared-remote-session.md
+++ b/.changeset/consent-shared-remote-session.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-The MCP consent page now shows a connected upstream grant even when a different identity provider originally created the row, including after that provider is removed. Consent disconnect, auto-refresh, and user-session revocation follow the same client-scoped key, so they no longer miss the live tokens the MCP runtime was already sending.
+The MCP consent page now shows a connected upstream grant even when a different identity provider originally created the row, including after that provider is removed. Consent disconnect, auto-refresh, explicit refresh, scheduled keepalive, and user-session revocation follow the live client binding rather than the minting issuer, so they no longer miss the tokens the MCP runtime was already sending.

--- a/.changeset/consent-shared-remote-session.md
+++ b/.changeset/consent-shared-remote-session.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The MCP consent page now shows a connected upstream grant even when a different identity provider on the same project originally created the row. Consent disconnect, auto-refresh, and user-session revocation follow the same project-scoped key, so they no longer miss the live tokens the MCP runtime was already sending.

--- a/.changeset/consent-shared-remote-session.md
+++ b/.changeset/consent-shared-remote-session.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-The MCP consent page now shows a connected upstream grant even when a different identity provider on the same project originally created the row. Consent disconnect, auto-refresh, and user-session revocation follow the same project-scoped key, so they no longer miss the live tokens the MCP runtime was already sending.
+The MCP consent page now shows a connected upstream grant even when a different identity provider originally created the row, including after that provider is removed. Consent disconnect, auto-refresh, and user-session revocation follow the same client-scoped key, so they no longer miss the live tokens the MCP runtime was already sending.

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -960,7 +960,7 @@ func (s *Service) buildRemoteSessionCards(
 	// not-connected.
 	var statuses map[uuid.UUID]remotesessions.RemoteSessionState
 	if challengeState.Subject != nil && !challengeState.Subject.IsZero() {
-		statuses, err = s.remoteChallengeMgr.RemoteSessionStatuses(ctx, *challengeState.Subject, endpoint.ProjectID, endpoint.UserSessionIssuerID)
+		statuses, err = s.remoteChallengeMgr.RemoteSessionStatuses(ctx, *challengeState.Subject, endpoint.ProjectID)
 		if err != nil {
 			return nil, fmt.Errorf("remote session statuses: %w", err)
 		}

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -960,7 +960,11 @@ func (s *Service) buildRemoteSessionCards(
 	// not-connected.
 	var statuses map[uuid.UUID]remotesessions.RemoteSessionState
 	if challengeState.Subject != nil && !challengeState.Subject.IsZero() {
-		statuses, err = s.remoteChallengeMgr.RemoteSessionStatuses(ctx, *challengeState.Subject, endpoint.ProjectID)
+		clientIDs := make([]uuid.UUID, len(clients))
+		for i := range clients {
+			clientIDs[i] = clients[i].ID
+		}
+		statuses, err = s.remoteChallengeMgr.RemoteSessionStatuses(ctx, *challengeState.Subject, clientIDs)
 		if err != nil {
 			return nil, fmt.Errorf("remote session statuses: %w", err)
 		}

--- a/server/internal/mcp/authnchallenge_consent_action.go
+++ b/server/internal/mcp/authnchallenge_consent_action.go
@@ -146,7 +146,7 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		if cerr != nil {
 			return cerr
 		}
-		if _, err := s.remoteChallengeMgr.DisconnectRemoteSession(ctx, subject, endpoint.ProjectID, client.ID); err != nil {
+		if _, err := s.remoteChallengeMgr.DisconnectRemoteSession(ctx, subject, client.ID); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "disconnect remote session").LogError(ctx, logger)
 		}
 		http.Redirect(w, r, backURL, http.StatusSeeOther)
@@ -194,7 +194,7 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		}
 		enabled := r.PostForm.Get("auto_refresh") == "on"
 		for i := range clients {
-			if _, err := s.remoteChallengeMgr.SetRemoteSessionAutoRefresh(ctx, subject, endpoint.ProjectID, clients[i].ID, enabled); err != nil {
+			if _, err := s.remoteChallengeMgr.SetRemoteSessionAutoRefresh(ctx, subject, clients[i].ID, enabled); err != nil {
 				return oops.E(oops.CodeUnexpected, err, "set remote session auto refresh").LogError(ctx, logger)
 			}
 		}

--- a/server/internal/mcp/authnchallenge_consent_action.go
+++ b/server/internal/mcp/authnchallenge_consent_action.go
@@ -146,7 +146,7 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		if cerr != nil {
 			return cerr
 		}
-		if _, err := s.remoteChallengeMgr.DisconnectRemoteSession(ctx, subject, endpoint.ProjectID, endpoint.UserSessionIssuerID, client.ID); err != nil {
+		if _, err := s.remoteChallengeMgr.DisconnectRemoteSession(ctx, subject, endpoint.ProjectID, client.ID); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "disconnect remote session").LogError(ctx, logger)
 		}
 		http.Redirect(w, r, backURL, http.StatusSeeOther)
@@ -160,7 +160,6 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		result, refreshErr := s.remoteChallengeMgr.RefreshRemoteSession(
 			ctx,
 			subject,
-			endpoint.UserSessionIssuerID,
 			client.ID,
 			endpoint.UpstreamResource,
 		)
@@ -195,7 +194,7 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		}
 		enabled := r.PostForm.Get("auto_refresh") == "on"
 		for i := range clients {
-			if _, err := s.remoteChallengeMgr.SetRemoteSessionAutoRefresh(ctx, subject, endpoint.ProjectID, endpoint.UserSessionIssuerID, clients[i].ID, enabled); err != nil {
+			if _, err := s.remoteChallengeMgr.SetRemoteSessionAutoRefresh(ctx, subject, endpoint.ProjectID, clients[i].ID, enabled); err != nil {
 				return oops.E(oops.CodeUnexpected, err, "set remote session auto refresh").LogError(ctx, logger)
 			}
 		}

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -291,25 +291,27 @@ type RemoteSessionState struct {
 }
 
 // RemoteSessionStatuses returns, per remote_session_client_id, the state of
-// `subject`'s remote_session in the given project. Clients with no
-// non-deleted session are omitted (disconnected). Single round-trip; the
-// caller (consent renderer) then does O(1) lookups per card. Returns an
-// empty map for zero subjects so anonymous-pre-stamp renders are no-ops.
+// `subject`'s remote_session among clientIDs. Clients with no non-deleted
+// session are omitted (disconnected). Single round-trip; the caller
+// (consent renderer) then does O(1) lookups per card. Returns an empty map
+// for a zero subject or an empty client list so anonymous-pre-stamp
+// renders are no-ops.
 //
-// The stored user_session_issuer_id is provenance from INSERT, not a lookup
-// key, so a grant minted by a different issuer in the same project is still
-// returned.
+// Scope is the client IDs the caller already resolved (ListClients). The
+// stored user_session_issuer_id is provenance from INSERT, not a lookup
+// key, so a grant minted by a different issuer — including one that has
+// since been soft-deleted — is still returned.
 func (m *ChallengeManager) RemoteSessionStatuses(
 	ctx context.Context,
 	subject urn.SessionSubject,
-	projectID uuid.UUID,
+	clientIDs []uuid.UUID,
 ) (map[uuid.UUID]RemoteSessionState, error) {
-	if subject.IsZero() {
+	if subject.IsZero() || len(clientIDs) == 0 {
 		return map[uuid.UUID]RemoteSessionState{}, nil
 	}
 	rows, err := remotesessions_repo.New(m.db).ListRemoteSessionStatusesForSubject(ctx, remotesessions_repo.ListRemoteSessionStatusesForSubjectParams{
-		SubjectUrn: subject,
-		ProjectID:  projectID,
+		SubjectUrn:             subject,
+		RemoteSessionClientIds: clientIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list remote session statuses: %w", err)
@@ -385,11 +387,10 @@ func (m *ChallengeManager) RefreshRemoteSession(
 //
 // Returns the number of rows affected; zero means there was nothing to
 // disconnect and nothing is sent upstream.
-func (m *ChallengeManager) DisconnectRemoteSession(ctx context.Context, subject urn.SessionSubject, projectID uuid.UUID, clientID uuid.UUID) (int64, error) {
+func (m *ChallengeManager) DisconnectRemoteSession(ctx context.Context, subject urn.SessionSubject, clientID uuid.UUID) (int64, error) {
 	disconnected, err := remotesessions_repo.New(m.db).SoftDeleteRemoteSessionBySubjectAndClient(ctx, remotesessions_repo.SoftDeleteRemoteSessionBySubjectAndClientParams{
 		SubjectUrn:            subject,
 		RemoteSessionClientID: clientID,
-		ProjectID:             projectID,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("disconnect remote session: %w", err)
@@ -409,12 +410,11 @@ func (m *ChallengeManager) DisconnectRemoteSession(ctx context.Context, subject 
 // SetRemoteSessionAutoRefresh records the subject's consent-screen
 // auto-refresh choice for one client. Returns rows affected; zero means no
 // active session exists for the binding (e.g. disconnected in another tab).
-func (m *ChallengeManager) SetRemoteSessionAutoRefresh(ctx context.Context, subject urn.SessionSubject, projectID uuid.UUID, clientID uuid.UUID, enabled bool) (int64, error) {
+func (m *ChallengeManager) SetRemoteSessionAutoRefresh(ctx context.Context, subject urn.SessionSubject, clientID uuid.UUID, enabled bool) (int64, error) {
 	n, err := remotesessions_repo.New(m.db).SetRemoteSessionAutoRefresh(ctx, remotesessions_repo.SetRemoteSessionAutoRefreshParams{
 		AutoRefresh:           enabled,
 		SubjectUrn:            subject,
 		RemoteSessionClientID: clientID,
-		ProjectID:             projectID,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("set remote session auto refresh: %w", err)

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -291,23 +291,25 @@ type RemoteSessionState struct {
 }
 
 // RemoteSessionStatuses returns, per remote_session_client_id, the state of
-// `subject`'s remote_session under the given `userSessionIssuerID`. Clients
-// with no non-deleted session are omitted (disconnected). Single round-trip;
-// the caller (consent renderer) then does O(1) lookups per card. Returns an
+// `subject`'s remote_session in the given project. Clients with no
+// non-deleted session are omitted (disconnected). Single round-trip; the
+// caller (consent renderer) then does O(1) lookups per card. Returns an
 // empty map for zero subjects so anonymous-pre-stamp renders are no-ops.
+//
+// The stored user_session_issuer_id is provenance from INSERT, not a lookup
+// key, so a grant minted by a different issuer in the same project is still
+// returned.
 func (m *ChallengeManager) RemoteSessionStatuses(
 	ctx context.Context,
 	subject urn.SessionSubject,
 	projectID uuid.UUID,
-	userSessionIssuerID uuid.UUID,
 ) (map[uuid.UUID]RemoteSessionState, error) {
 	if subject.IsZero() {
 		return map[uuid.UUID]RemoteSessionState{}, nil
 	}
 	rows, err := remotesessions_repo.New(m.db).ListRemoteSessionStatusesForSubject(ctx, remotesessions_repo.ListRemoteSessionStatusesForSubjectParams{
-		SubjectUrn:          subject,
-		UserSessionIssuerID: userSessionIssuerID,
-		ProjectID:           projectID,
+		SubjectUrn: subject,
+		ProjectID:  projectID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list remote session statuses: %w", err)
@@ -347,7 +349,6 @@ var ErrRemoteSessionNotRefreshable = errors.New("remote session has no usable re
 func (m *ChallengeManager) RefreshRemoteSession(
 	ctx context.Context,
 	subject urn.SessionSubject,
-	userSessionIssuerID uuid.UUID,
 	clientID uuid.UUID,
 	fallbackResource string,
 ) (RefreshResult, error) {
@@ -363,8 +364,7 @@ func (m *ChallengeManager) RefreshRemoteSession(
 	if err != nil {
 		return zero, fmt.Errorf("get consent remote session: %w", err)
 	}
-	if session.UserSessionIssuerID != userSessionIssuerID ||
-		!session.RefreshTokenEncrypted.Valid ||
+	if !session.RefreshTokenEncrypted.Valid ||
 		session.RefreshTokenEncrypted.String == "" {
 		return zero, ErrRemoteSessionNotRefreshable
 	}
@@ -385,11 +385,10 @@ func (m *ChallengeManager) RefreshRemoteSession(
 //
 // Returns the number of rows affected; zero means there was nothing to
 // disconnect and nothing is sent upstream.
-func (m *ChallengeManager) DisconnectRemoteSession(ctx context.Context, subject urn.SessionSubject, projectID uuid.UUID, userSessionIssuerID uuid.UUID, clientID uuid.UUID) (int64, error) {
+func (m *ChallengeManager) DisconnectRemoteSession(ctx context.Context, subject urn.SessionSubject, projectID uuid.UUID, clientID uuid.UUID) (int64, error) {
 	disconnected, err := remotesessions_repo.New(m.db).SoftDeleteRemoteSessionBySubjectAndClient(ctx, remotesessions_repo.SoftDeleteRemoteSessionBySubjectAndClientParams{
 		SubjectUrn:            subject,
 		RemoteSessionClientID: clientID,
-		UserSessionIssuerID:   userSessionIssuerID,
 		ProjectID:             projectID,
 	})
 	if err != nil {
@@ -410,12 +409,11 @@ func (m *ChallengeManager) DisconnectRemoteSession(ctx context.Context, subject 
 // SetRemoteSessionAutoRefresh records the subject's consent-screen
 // auto-refresh choice for one client. Returns rows affected; zero means no
 // active session exists for the binding (e.g. disconnected in another tab).
-func (m *ChallengeManager) SetRemoteSessionAutoRefresh(ctx context.Context, subject urn.SessionSubject, projectID uuid.UUID, userSessionIssuerID uuid.UUID, clientID uuid.UUID, enabled bool) (int64, error) {
+func (m *ChallengeManager) SetRemoteSessionAutoRefresh(ctx context.Context, subject urn.SessionSubject, projectID uuid.UUID, clientID uuid.UUID, enabled bool) (int64, error) {
 	n, err := remotesessions_repo.New(m.db).SetRemoteSessionAutoRefresh(ctx, remotesessions_repo.SetRemoteSessionAutoRefreshParams{
 		AutoRefresh:           enabled,
 		SubjectUrn:            subject,
 		RemoteSessionClientID: clientID,
-		UserSessionIssuerID:   userSessionIssuerID,
 		ProjectID:             projectID,
 	})
 	if err != nil {

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -1,9 +1,9 @@
 // challenge_shared_grant_test.go is the regression guard for AIS-589: a
 // remote_sessions row is keyed on (subject_urn, remote_session_client_id).
 // user_session_issuer_id is provenance from INSERT and is never updated on
-// conflict. Consent reads and writes that filtered on that column hid a live
-// grant from a second MCP server whose issuer did not mint the row, while
-// GetActiveRemoteSession (the runtime) still found it.
+// conflict. Consent reads and writes must find that live grant from every
+// MCP server bound to the client, including after the minting issuer is
+// soft-deleted (ON DELETE CASCADE never fires on a soft delete).
 package remotesessions_test
 
 import (
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -89,6 +90,18 @@ func newTestUpstreamRevoker(t *testing.T, ti *testInstance) *remotesessions.Upst
 	)
 }
 
+func seedSharedGrantThenSoftDeleteMintingIssuer(t *testing.T) (context.Context, sharedGrantFixture) {
+	t.Helper()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+	err := testrepo.New(fx.ti.conn).ForceSoftDeleteUserSessionIssuer(ctx, testrepo.ForceSoftDeleteUserSessionIssuerParams{
+		ID:        fx.issuerA,
+		ProjectID: fx.projectID,
+	})
+	require.NoError(t, err)
+	return ctx, fx
+}
+
 func TestRemoteSessionStatuses_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	t.Parallel()
 
@@ -96,7 +109,7 @@ func TestRemoteSessionStatuses_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 
 	require.Equal(t, fx.issuerA, fx.session.UserSessionIssuerID)
 
-	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, fx.projectID)
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{fx.clientID})
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
 
@@ -106,7 +119,7 @@ func TestRemoteSessionStatuses_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	require.Equal(t, fx.session.ID, reconnect.ID)
 	require.Equal(t, fx.issuerA, reconnect.UserSessionIssuerID)
 
-	statuses, err = fx.mgr.RemoteSessionStatuses(ctx, fx.subject, fx.projectID)
+	statuses, err = fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{fx.clientID})
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
 }
@@ -118,7 +131,7 @@ func TestSetRemoteSessionAutoRefresh_FindsGrantMintedByDifferentIssuer(t *testin
 
 	require.False(t, fx.session.AutoRefresh)
 
-	n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, fx.projectID, fx.clientID, true)
+	n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, fx.clientID, true)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n)
 
@@ -136,7 +149,7 @@ func TestDisconnectRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T)
 
 	ctx, fx := seedSharedGrantAcrossIssuers(t)
 
-	n, err := fx.mgr.DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
+	n, err := fx.mgr.DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n)
 
@@ -191,13 +204,13 @@ func TestRemoteSessionStatuses_DoesNotCrossProjects(t *testing.T) {
 	}))
 	insertRemoteSession(t, ctx, fx.ti.conn, fx.subject, otherUserIssuer.String(), otherClient.ID.String())
 
-	homeStatuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, fx.projectID)
+	homeStatuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{fx.clientID})
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, homeStatuses[fx.clientID].Status)
 	_, leaked := homeStatuses[otherClient.ID]
 	require.False(t, leaked)
 
-	otherStatuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, otherProject)
+	otherStatuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{otherClient.ID})
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, otherStatuses[otherClient.ID].Status)
 	_, leaked = otherStatuses[fx.clientID]
@@ -247,4 +260,70 @@ func TestSoftDeleteSubjectSessions_DoesNotCrossProjects(t *testing.T) {
 		RemoteSessionClientID: otherClient.ID,
 	})
 	require.NoError(t, err)
+}
+
+func TestRemoteSessionStatuses_FindsGrantAfterMintingIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantThenSoftDeleteMintingIssuer(t)
+
+	_, err := repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.NoError(t, err)
+
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{fx.clientID})
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
+}
+
+func TestSetRemoteSessionAutoRefresh_FindsGrantAfterMintingIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantThenSoftDeleteMintingIssuer(t)
+
+	n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, fx.clientID, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	active, err := repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.NoError(t, err)
+	require.True(t, active.AutoRefresh)
+}
+
+func TestDisconnectRemoteSession_FindsGrantAfterMintingIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantThenSoftDeleteMintingIssuer(t)
+
+	n, err := fx.mgr.DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	_, err = repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestSoftDeleteSubjectSessions_FindsGrantAfterMintingIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantThenSoftDeleteMintingIssuer(t)
+
+	creds, err := newTestUpstreamRevoker(t, fx.ti).SoftDeleteSubjectSessions(ctx, fx.ti.conn, fx.subject, fx.projectID)
+	require.NoError(t, err)
+	require.Len(t, creds, 1)
+	require.Equal(t, fx.clientID, creds[0].RemoteSessionClientID)
+
+	_, err = repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -461,6 +461,58 @@ func TestListClients_ResolvesSharedClientAfterMintingIssuerSoftDeleted(t *testin
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
 }
 
+func TestListClients_ResolvesSharedClientAfterLookupIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+	err := testrepo.New(fx.ti.conn).ForceSoftDeleteUserSessionIssuer(ctx, testrepo.ForceSoftDeleteUserSessionIssuerParams{
+		ID:        fx.issuerB,
+		ProjectID: fx.projectID,
+	})
+	require.NoError(t, err)
+
+	// Consent is rendered for a live endpoint issuer. A deleted lookup
+	// issuer has no cards; the surviving minting issuer still lists the
+	// client and can mutate the grant.
+	boundB := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	require.Empty(t, boundB)
+
+	boundA := listBoundClientIDs(t, ctx, fx, fx.issuerA)
+	requireBoundClient(t, boundA, fx.clientID)
+
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, boundA)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
+
+	n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, fx.clientID, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	n, err = fx.mgr.DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+}
+
+func newSharedGrantRefreshHandler(refreshCount *atomic.Int64, accessToken string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		if r.PostForm.Get("grant_type") != "refresh_token" || r.PostForm.Get("refresh_token") != "upstream-refresh" {
+			http.Error(w, "unexpected grant", http.StatusBadRequest)
+			return
+		}
+		refreshCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + accessToken + `","token_type":"Bearer","expires_in":7200,"refresh_token":"rotated-refresh"}`))
+	}
+}
+
 func seedRefreshableSharedGrant(t *testing.T, slug string, handler http.HandlerFunc) (context.Context, sharedGrantFixture) {
 	t.Helper()
 
@@ -553,12 +605,7 @@ func TestRefreshRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	t.Parallel()
 
 	var refreshCount atomic.Int64
-	ctx, fx := seedRefreshableSharedGrant(t, "ais-589-refresh-v1", func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseForm()
-		refreshCount.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"rotated-access","token_type":"Bearer","expires_in":7200,"refresh_token":"rotated-refresh"}`))
-	})
+	ctx, fx := seedRefreshableSharedGrant(t, "ais-589-refresh-v1", newSharedGrantRefreshHandler(&refreshCount, "rotated-access"))
 
 	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
 	requireBoundClient(t, bound, fx.clientID)
@@ -575,12 +622,7 @@ func TestRefreshRemoteSession_FindsGrantAfterMintingIssuerSoftDeleted(t *testing
 	t.Parallel()
 
 	var refreshCount atomic.Int64
-	ctx, fx := seedRefreshableSharedGrant(t, "ais-589-refresh-v2", func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseForm()
-		refreshCount.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"rotated-after-delete","token_type":"Bearer","expires_in":7200,"refresh_token":"rotated-refresh"}`))
-	})
+	ctx, fx := seedRefreshableSharedGrant(t, "ais-589-refresh-v2", newSharedGrantRefreshHandler(&refreshCount, "rotated-after-delete"))
 	err := testrepo.New(fx.ti.conn).ForceSoftDeleteUserSessionIssuer(ctx, testrepo.ForceSoftDeleteUserSessionIssuerParams{
 		ID:        fx.issuerA,
 		ProjectID: fx.projectID,

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -8,14 +8,19 @@ package remotesessions_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
 	clientsgen "github.com/speakeasy-api/gram/server/gen/remote_session_clients"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -27,14 +32,15 @@ import (
 )
 
 type sharedGrantFixture struct {
-	ti        *testInstance
-	mgr       *remotesessions.ChallengeManager
-	projectID uuid.UUID
-	issuerA   uuid.UUID
-	issuerB   uuid.UUID
-	clientID  uuid.UUID
-	subject   urn.SessionSubject
-	session   repo.RemoteSession
+	ti             *testInstance
+	mgr            *remotesessions.ChallengeManager
+	projectID      uuid.UUID
+	organizationID string
+	issuerA        uuid.UUID
+	issuerB        uuid.UUID
+	clientID       uuid.UUID
+	subject        urn.SessionSubject
+	session        repo.RemoteSession
 }
 
 func seedSharedGrantAcrossIssuers(t *testing.T) (context.Context, sharedGrantFixture) {
@@ -64,14 +70,15 @@ func seedSharedGrantAcrossIssuers(t *testing.T) (context.Context, sharedGrantFix
 	session := insertRemoteSession(t, ctx, ti.conn, subject, issuerA.String(), created.ID)
 
 	return ctx, sharedGrantFixture{
-		ti:        ti,
-		mgr:       newDisconnectChallengeManager(t, ti),
-		projectID: *authCtx.ProjectID,
-		issuerA:   issuerA,
-		issuerB:   issuerB,
-		clientID:  uuid.MustParse(created.ID),
-		subject:   subject,
-		session:   session,
+		ti:             ti,
+		mgr:            newDisconnectChallengeManager(t, ti),
+		projectID:      *authCtx.ProjectID,
+		organizationID: authCtx.ActiveOrganizationID,
+		issuerA:        issuerA,
+		issuerB:        issuerB,
+		clientID:       uuid.MustParse(created.ID),
+		subject:        subject,
+		session:        session,
 	}
 }
 
@@ -102,6 +109,28 @@ func seedSharedGrantThenSoftDeleteMintingIssuer(t *testing.T) (context.Context, 
 	return ctx, fx
 }
 
+func listBoundClientIDs(t *testing.T, ctx context.Context, fx sharedGrantFixture, issuerID uuid.UUID) []uuid.UUID {
+	t.Helper()
+
+	clients, err := fx.mgr.ListClients(ctx, fx.projectID, fx.organizationID, issuerID)
+	require.NoError(t, err)
+	ids := make([]uuid.UUID, 0, len(clients))
+	for _, c := range clients {
+		ids = append(ids, c.ID)
+	}
+	return ids
+}
+
+func requireBoundClient(t *testing.T, ids []uuid.UUID, clientID uuid.UUID) {
+	t.Helper()
+	require.Contains(t, ids, clientID)
+}
+
+func requireUnboundClient(t *testing.T, ids []uuid.UUID, clientID uuid.UUID) {
+	t.Helper()
+	require.NotContains(t, ids, clientID)
+}
+
 func TestRemoteSessionStatuses_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	t.Parallel()
 
@@ -109,7 +138,10 @@ func TestRemoteSessionStatuses_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 
 	require.Equal(t, fx.issuerA, fx.session.UserSessionIssuerID)
 
-	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{fx.clientID})
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
+
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, bound)
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
 
@@ -119,7 +151,7 @@ func TestRemoteSessionStatuses_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	require.Equal(t, fx.session.ID, reconnect.ID)
 	require.Equal(t, fx.issuerA, reconnect.UserSessionIssuerID)
 
-	statuses, err = fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{fx.clientID})
+	statuses, err = fx.mgr.RemoteSessionStatuses(ctx, fx.subject, listBoundClientIDs(t, ctx, fx, fx.issuerB))
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
 }
@@ -130,6 +162,9 @@ func TestSetRemoteSessionAutoRefresh_FindsGrantMintedByDifferentIssuer(t *testin
 	ctx, fx := seedSharedGrantAcrossIssuers(t)
 
 	require.False(t, fx.session.AutoRefresh)
+
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
 
 	n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, fx.clientID, true)
 	require.NoError(t, err)
@@ -148,6 +183,9 @@ func TestDisconnectRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T)
 	t.Parallel()
 
 	ctx, fx := seedSharedGrantAcrossIssuers(t)
+
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
 
 	n, err := fx.mgr.DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
 	require.NoError(t, err)
@@ -177,7 +215,7 @@ func TestSoftDeleteSubjectSessions_FindsGrantMintedByDifferentIssuer(t *testing.
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
-func TestRemoteSessionStatuses_DoesNotCrossProjects(t *testing.T) {
+func TestRemoteSessionStatuses_FiltersToSuppliedClientIDs(t *testing.T) {
 	t.Parallel()
 
 	ctx, fx := seedSharedGrantAcrossIssuers(t)
@@ -273,7 +311,10 @@ func TestRemoteSessionStatuses_FindsGrantAfterMintingIssuerSoftDeleted(t *testin
 	})
 	require.NoError(t, err)
 
-	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, []uuid.UUID{fx.clientID})
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
+
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, bound)
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
 }
@@ -282,6 +323,9 @@ func TestSetRemoteSessionAutoRefresh_FindsGrantAfterMintingIssuerSoftDeleted(t *
 	t.Parallel()
 
 	ctx, fx := seedSharedGrantThenSoftDeleteMintingIssuer(t)
+
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
 
 	n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, fx.clientID, true)
 	require.NoError(t, err)
@@ -299,6 +343,9 @@ func TestDisconnectRemoteSession_FindsGrantAfterMintingIssuerSoftDeleted(t *test
 	t.Parallel()
 
 	ctx, fx := seedSharedGrantThenSoftDeleteMintingIssuer(t)
+
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
 
 	n, err := fx.mgr.DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
 	require.NoError(t, err)
@@ -326,4 +373,227 @@ func TestSoftDeleteSubjectSessions_FindsGrantAfterMintingIssuerSoftDeleted(t *te
 		RemoteSessionClientID: fx.clientID,
 	})
 	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func seedOtherProjectClient(
+	t *testing.T,
+	ctx context.Context,
+	fx sharedGrantFixture,
+	slug string,
+) uuid.UUID {
+	t.Helper()
+
+	otherProject := createProject(t, ctx, fx.ti.conn, slug+"-project")
+	otherUserIssuer := createUserSessionIssuerInProject(t, ctx, fx.ti.conn, otherProject, slug+"-usi")
+	otherRemoteIssuer := createRemoteIssuerInProject(t, ctx, fx.ti.conn, otherProject, slug+"-rsi")
+
+	q := repo.New(fx.ti.conn)
+	otherClient, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:             conv.ToNullUUID(otherProject),
+		OrganizationID:        conv.ToPGTextEmpty(fx.organizationID),
+		RemoteSessionIssuerID: otherRemoteIssuer,
+		ClientID:              slug + "-client",
+		ClientIDIssuedAt:      conv.ToPGTimestamptz(time.Now()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: otherClient.ID,
+		UserSessionIssuerID:   otherUserIssuer,
+	}))
+	insertRemoteSession(t, ctx, fx.ti.conn, fx.subject, otherUserIssuer.String(), otherClient.ID.String())
+	return otherClient.ID
+}
+
+func TestListClients_ResolvesSharedClientThroughSecondIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+	otherClientID := seedOtherProjectClient(t, ctx, fx, "ais-589-list-xproj")
+
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
+	requireUnboundClient(t, bound, otherClientID)
+
+	// ListClients is the allowlist ServeConsentAction re-resolves posted
+	// client_id against. A UUID from another project is not returned, so a
+	// crafted form posting it never reaches SetRemoteSessionAutoRefresh.
+
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, bound)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
+	_, leaked := statuses[otherClientID]
+	require.False(t, leaked)
+
+	for _, clientID := range bound {
+		n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, clientID, true)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), n)
+	}
+
+	home, err := repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.NoError(t, err)
+	require.True(t, home.AutoRefresh)
+
+	other, err := repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: otherClientID,
+	})
+	require.NoError(t, err)
+	require.False(t, other.AutoRefresh)
+}
+
+func TestListClients_ResolvesSharedClientAfterMintingIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantThenSoftDeleteMintingIssuer(t)
+
+	boundA := listBoundClientIDs(t, ctx, fx, fx.issuerA)
+	require.Empty(t, boundA)
+
+	boundB := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, boundB, fx.clientID)
+
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, boundB)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
+}
+
+func seedRefreshableSharedGrant(t *testing.T, slug string, handler http.HandlerFunc) (context.Context, sharedGrantFixture) {
+	t.Helper()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	tokenServer := httptest.NewServer(handler)
+	t.Cleanup(tokenServer.Close)
+
+	enc := testenv.NewEncryptionClient(t)
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	mgr := remotesessions.NewChallengeManager(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		enc,
+		policy,
+		cache.NoopCache,
+		mustURL(t, "http://localhost"),
+	)
+
+	q := repo.New(ti.conn)
+	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:                    conv.ToPGText(authCtx.ActiveOrganizationID),
+		Slug:                              slug + "-rsi",
+		Issuer:                            tokenServer.URL,
+		AuthorizationEndpoint:             conv.ToPGText(tokenServer.URL + "/authorize"),
+		TokenEndpoint:                     conv.ToPGText(tokenServer.URL + "/token"),
+		ScopesSupported:                   []string{"openid"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+	})
+	require.NoError(t, err)
+
+	issuerA := createUserSessionIssuer(t, ctx, ti.conn, slug+"-usi-a")
+	issuerB := createUserSessionIssuer(t, ctx, ti.conn, slug+"-usi-b")
+	created, err := ti.service.CreateRemoteSessionClient(ctx, &clientsgen.CreateRemoteSessionClientPayload{
+		RemoteSessionIssuerID: issuer.ID.String(),
+		UserSessionIssuerIds:  []string{issuerA.String(), issuerB.String()},
+		ClientID:              slug + "-client",
+		ClientSecret:          nil,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	require.NoError(t, err)
+	clientID := uuid.MustParse(created.ID)
+
+	accessEnc, err := enc.Encrypt([]byte("stale-access"))
+	require.NoError(t, err)
+	refreshEnc, err := enc.Encrypt([]byte("upstream-refresh"))
+	require.NoError(t, err)
+	refreshEncStr := refreshEnc
+	subject := urn.NewUserSubject(slug + "-subject")
+	session, err := q.UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+		SubjectUrn:             subject,
+		UserSessionIssuerID:    issuerA,
+		RemoteSessionClientID:  clientID,
+		AccessTokenEncrypted:   accessEnc,
+		AccessExpiresAt:        conv.ToPGTimestamptz(time.Now().Add(time.Hour)),
+		RefreshTokenEncrypted:  conv.PtrToPGText(&refreshEncStr),
+		AuthorizationExpiresAt: conv.ToPGTimestamptz(time.Now().Add(24 * time.Hour)),
+		RefreshExpiresAt:       conv.ToPGTimestamptz(time.Now().Add(2 * time.Hour)),
+		Scopes:                 []string{},
+		Resource:               pgtype.Text{},
+		AutoRefresh:            true,
+	})
+	require.NoError(t, err)
+
+	return ctx, sharedGrantFixture{
+		ti:             ti,
+		mgr:            mgr,
+		projectID:      *authCtx.ProjectID,
+		organizationID: authCtx.ActiveOrganizationID,
+		issuerA:        issuerA,
+		issuerB:        issuerB,
+		clientID:       clientID,
+		subject:        subject,
+		session:        session,
+	}
+}
+
+func TestRefreshRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	ctx, fx := seedRefreshableSharedGrant(t, "ais-589-refresh-v1", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		refreshCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"rotated-access","token_type":"Bearer","expires_in":7200,"refresh_token":"rotated-refresh"}`))
+	})
+
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
+
+	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.clientID, "")
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, "rotated-access", result.AccessToken)
+	require.Equal(t, fx.issuerA, result.Session.UserSessionIssuerID)
+	require.Equal(t, int64(1), refreshCount.Load())
+}
+
+func TestRefreshRemoteSession_FindsGrantAfterMintingIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	ctx, fx := seedRefreshableSharedGrant(t, "ais-589-refresh-v2", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		refreshCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"rotated-after-delete","token_type":"Bearer","expires_in":7200,"refresh_token":"rotated-refresh"}`))
+	})
+	err := testrepo.New(fx.ti.conn).ForceSoftDeleteUserSessionIssuer(ctx, testrepo.ForceSoftDeleteUserSessionIssuerParams{
+		ID:        fx.issuerA,
+		ProjectID: fx.projectID,
+	})
+	require.NoError(t, err)
+
+	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
+	requireBoundClient(t, bound, fx.clientID)
+
+	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.clientID, "")
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, "rotated-after-delete", result.AccessToken)
+	require.Equal(t, fx.issuerA, result.Session.UserSessionIssuerID)
+	require.Equal(t, int64(1), refreshCount.Load())
 }

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -1,0 +1,250 @@
+// challenge_shared_grant_test.go is the regression guard for AIS-589: a
+// remote_sessions row is keyed on (subject_urn, remote_session_client_id).
+// user_session_issuer_id is provenance from INSERT and is never updated on
+// conflict. Consent reads and writes that filtered on that column hid a live
+// grant from a second MCP server whose issuer did not mint the row, while
+// GetActiveRemoteSession (the runtime) still found it.
+package remotesessions_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	clientsgen "github.com/speakeasy-api/gram/server/gen/remote_session_clients"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type sharedGrantFixture struct {
+	ti        *testInstance
+	mgr       *remotesessions.ChallengeManager
+	projectID uuid.UUID
+	issuerA   uuid.UUID
+	issuerB   uuid.UUID
+	clientID  uuid.UUID
+	subject   urn.SessionSubject
+	session   repo.RemoteSession
+}
+
+func seedSharedGrantAcrossIssuers(t *testing.T) (context.Context, sharedGrantFixture) {
+	t.Helper()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	remoteIssuerID := createRemoteIssuer(t, ctx, ti, "ais-589-upstream", "")
+	issuerA := createUserSessionIssuer(t, ctx, ti.conn, "ais-589-usi-a")
+	issuerB := createUserSessionIssuer(t, ctx, ti.conn, "ais-589-usi-b")
+
+	created, err := ti.service.CreateRemoteSessionClient(ctx, &clientsgen.CreateRemoteSessionClientPayload{
+		RemoteSessionIssuerID: remoteIssuerID,
+		UserSessionIssuerIds:  []string{issuerA.String(), issuerB.String()},
+		ClientID:              "ais-589-client",
+		ClientSecret:          nil,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	require.NoError(t, err)
+
+	subject := urn.NewUserSubject("ais-589-subject")
+	session := insertRemoteSession(t, ctx, ti.conn, subject, issuerA.String(), created.ID)
+
+	return ctx, sharedGrantFixture{
+		ti:        ti,
+		mgr:       newDisconnectChallengeManager(t, ti),
+		projectID: *authCtx.ProjectID,
+		issuerA:   issuerA,
+		issuerB:   issuerB,
+		clientID:  uuid.MustParse(created.ID),
+		subject:   subject,
+		session:   session,
+	}
+}
+
+func newTestUpstreamRevoker(t *testing.T, ti *testInstance) *remotesessions.UpstreamRevoker {
+	t.Helper()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	return remotesessions.NewUpstreamRevoker(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		testenv.NewEncryptionClient(t),
+		policy,
+	)
+}
+
+func TestRemoteSessionStatuses_FindsGrantMintedByDifferentIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+
+	require.Equal(t, fx.issuerA, fx.session.UserSessionIssuerID)
+
+	statuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, fx.projectID)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
+
+	// A second Connect on issuer B refreshes tokens but must not rewrite
+	// provenance. The consent page still has to see the live grant.
+	reconnect := insertRemoteSession(t, ctx, fx.ti.conn, fx.subject, fx.issuerB.String(), fx.clientID.String())
+	require.Equal(t, fx.session.ID, reconnect.ID)
+	require.Equal(t, fx.issuerA, reconnect.UserSessionIssuerID)
+
+	statuses, err = fx.mgr.RemoteSessionStatuses(ctx, fx.subject, fx.projectID)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, statuses[fx.clientID].Status)
+}
+
+func TestSetRemoteSessionAutoRefresh_FindsGrantMintedByDifferentIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+
+	require.False(t, fx.session.AutoRefresh)
+
+	n, err := fx.mgr.SetRemoteSessionAutoRefresh(ctx, fx.subject, fx.projectID, fx.clientID, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	active, err := repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.NoError(t, err)
+	require.True(t, active.AutoRefresh)
+	require.Equal(t, fx.issuerA, active.UserSessionIssuerID)
+}
+
+func TestDisconnectRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+
+	n, err := fx.mgr.DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	_, err = repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestSoftDeleteSubjectSessions_FindsGrantMintedByDifferentIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+
+	creds, err := newTestUpstreamRevoker(t, fx.ti).SoftDeleteSubjectSessions(ctx, fx.ti.conn, fx.subject, fx.projectID)
+	require.NoError(t, err)
+	require.Len(t, creds, 1)
+	require.Equal(t, fx.clientID, creds[0].RemoteSessionClientID)
+
+	_, err = repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestRemoteSessionStatuses_DoesNotCrossProjects(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	otherProject := createProject(t, ctx, fx.ti.conn, "ais-589-other")
+	otherUserIssuer := createUserSessionIssuerInProject(t, ctx, fx.ti.conn, otherProject, "ais-589-usi-other")
+	otherRemoteIssuer := createRemoteIssuerInProject(t, ctx, fx.ti.conn, otherProject, "ais-589-rsi-other")
+
+	q := repo.New(fx.ti.conn)
+	otherClient, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:             conv.ToNullUUID(otherProject),
+		OrganizationID:        conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
+		RemoteSessionIssuerID: otherRemoteIssuer,
+		ClientID:              "ais-589-other-client",
+		ClientIDIssuedAt:      conv.ToPGTimestamptz(time.Now()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: otherClient.ID,
+		UserSessionIssuerID:   otherUserIssuer,
+	}))
+	insertRemoteSession(t, ctx, fx.ti.conn, fx.subject, otherUserIssuer.String(), otherClient.ID.String())
+
+	homeStatuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, fx.projectID)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, homeStatuses[fx.clientID].Status)
+	_, leaked := homeStatuses[otherClient.ID]
+	require.False(t, leaked)
+
+	otherStatuses, err := fx.mgr.RemoteSessionStatuses(ctx, fx.subject, otherProject)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, otherStatuses[otherClient.ID].Status)
+	_, leaked = otherStatuses[fx.clientID]
+	require.False(t, leaked)
+}
+
+func TestSoftDeleteSubjectSessions_DoesNotCrossProjects(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedSharedGrantAcrossIssuers(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	otherProject := createProject(t, ctx, fx.ti.conn, "ais-589-other-revoke")
+	otherUserIssuer := createUserSessionIssuerInProject(t, ctx, fx.ti.conn, otherProject, "ais-589-usi-other-revoke")
+	otherRemoteIssuer := createRemoteIssuerInProject(t, ctx, fx.ti.conn, otherProject, "ais-589-rsi-other-revoke")
+
+	q := repo.New(fx.ti.conn)
+	otherClient, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:             conv.ToNullUUID(otherProject),
+		OrganizationID:        conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
+		RemoteSessionIssuerID: otherRemoteIssuer,
+		ClientID:              "ais-589-other-revoke-client",
+		ClientIDIssuedAt:      conv.ToPGTimestamptz(time.Now()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: otherClient.ID,
+		UserSessionIssuerID:   otherUserIssuer,
+	}))
+	insertRemoteSession(t, ctx, fx.ti.conn, fx.subject, otherUserIssuer.String(), otherClient.ID.String())
+
+	creds, err := newTestUpstreamRevoker(t, fx.ti).SoftDeleteSubjectSessions(ctx, fx.ti.conn, fx.subject, fx.projectID)
+	require.NoError(t, err)
+	require.Len(t, creds, 1)
+	require.Equal(t, fx.clientID, creds[0].RemoteSessionClientID)
+
+	_, err = q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: fx.clientID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	_, err = q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		RemoteSessionClientID: otherClient.ID,
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -129,7 +129,7 @@ func TestRemoteLoginCallback_StandardRefreshExpirationFields(t *testing.T) {
 	states, err := env.mgr.RemoteSessionStatuses(
 		t.Context(),
 		env.subject,
-		env.projectID,
+		[]uuid.UUID{env.clientID},
 	)
 	require.NoError(t, err)
 	state := states[env.clientID]

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -130,7 +130,6 @@ func TestRemoteLoginCallback_StandardRefreshExpirationFields(t *testing.T) {
 		t.Context(),
 		env.subject,
 		env.projectID,
-		env.session.UserSessionIssuerID,
 	)
 	require.NoError(t, err)
 	state := states[env.clientID]

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -989,15 +989,39 @@ RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_
 --
 -- Preferences are read, never rewritten, so restoring the opt-in policy
 -- restores each subject's original choice.
+--
+-- A live Gram identity provider bound to this client, plus an unexpired user
+-- session on that issuer, is what keeps the grant eligible. user_session_issuer_id
+-- on the remote_sessions row is provenance from INSERT and is never rewritten
+-- on reconnect, so requiring that exact issuer to still be live would skip a
+-- grant whose minting provider was replaced while another bound issuer still
+-- holds the subject's login.
 
 -- name: ClaimDueRemoteSessionRefreshCandidates :many
 WITH due AS (
-  SELECT s.id, s.updated_at, p.organization_id, i.token_endpoint
+  SELECT s.id, s.updated_at, eligible.organization_id, i.token_endpoint
   FROM remote_sessions AS s
   JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id AND c.deleted IS FALSE
   JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id AND i.deleted IS FALSE
-  JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id AND usi.deleted IS FALSE
-  JOIN projects AS p ON p.id = usi.project_id AND p.deleted IS FALSE
+  JOIN LATERAL (
+    SELECT p.organization_id
+    FROM remote_session_client_user_session_issuers AS link
+    JOIN user_session_issuers AS usi
+      ON usi.id = link.user_session_issuer_id AND usi.deleted IS FALSE
+    JOIN projects AS p
+      ON p.id = usi.project_id AND p.deleted IS FALSE
+    WHERE link.remote_session_client_id = c.id
+      AND EXISTS (
+        SELECT 1 FROM user_sessions AS gs
+        WHERE gs.project_id = usi.project_id
+          AND gs.user_session_issuer_id = usi.id
+          AND gs.subject_urn = s.subject_urn
+          AND gs.deleted IS FALSE
+          AND gs.refresh_expires_at > @now_ts::timestamptz
+      )
+    ORDER BY usi.id
+    LIMIT 1
+  ) AS eligible ON TRUE
   WHERE s.deleted IS FALSE
     AND s.refresh_token_encrypted IS NOT NULL
     AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > @now_ts::timestamptz)
@@ -1010,7 +1034,7 @@ WITH due AS (
     AND (
       EXISTS (
         SELECT 1 FROM organization_features AS orgf
-        WHERE orgf.organization_id = p.organization_id
+        WHERE orgf.organization_id = eligible.organization_id
           AND orgf.feature_name = 'remote_session_auto_refresh_enforced'
           AND orgf.deleted IS FALSE
       )
@@ -1018,24 +1042,11 @@ WITH due AS (
         s.auto_refresh IS TRUE
         AND EXISTS (
           SELECT 1 FROM organization_features AS orgf
-          WHERE orgf.organization_id = p.organization_id
+          WHERE orgf.organization_id = eligible.organization_id
             AND orgf.feature_name = 'remote_session_auto_refresh'
             AND orgf.deleted IS FALSE
         )
       )
-    )
-    AND EXISTS (
-      SELECT 1 FROM remote_session_client_user_session_issuers AS link
-      WHERE link.remote_session_client_id = c.id
-        AND link.user_session_issuer_id = s.user_session_issuer_id
-    )
-    AND EXISTS (
-      SELECT 1 FROM user_sessions AS gs
-      WHERE gs.project_id = usi.project_id
-        AND gs.user_session_issuer_id = s.user_session_issuer_id
-        AND gs.subject_urn = s.subject_urn
-        AND gs.deleted IS FALSE
-        AND gs.refresh_expires_at > @now_ts::timestamptz
     )
   ORDER BY s.updated_at, s.id
   LIMIT @limit_value
@@ -1060,10 +1071,7 @@ SELECT sqlc.embed(s)
 FROM remote_sessions AS s
 JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id AND c.deleted IS FALSE
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id AND i.deleted IS FALSE
-JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id AND usi.deleted IS FALSE
-JOIN projects AS p ON p.id = usi.project_id AND p.deleted IS FALSE
 WHERE s.id = @id
-  AND p.organization_id = @organization_id
   AND s.deleted IS FALSE
   AND s.refresh_token_encrypted IS NOT NULL
   AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > @now_ts::timestamptz)
@@ -1076,7 +1084,7 @@ WHERE s.id = @id
   AND (
     EXISTS (
       SELECT 1 FROM organization_features AS orgf
-      WHERE orgf.organization_id = p.organization_id
+      WHERE orgf.organization_id = @organization_id
         AND orgf.feature_name = 'remote_session_auto_refresh_enforced'
         AND orgf.deleted IS FALSE
     )
@@ -1084,24 +1092,29 @@ WHERE s.id = @id
       s.auto_refresh IS TRUE
       AND EXISTS (
         SELECT 1 FROM organization_features AS orgf
-        WHERE orgf.organization_id = p.organization_id
+        WHERE orgf.organization_id = @organization_id
           AND orgf.feature_name = 'remote_session_auto_refresh'
           AND orgf.deleted IS FALSE
       )
     )
   )
   AND EXISTS (
-    SELECT 1 FROM remote_session_client_user_session_issuers AS link
+    SELECT 1
+    FROM remote_session_client_user_session_issuers AS link
+    JOIN user_session_issuers AS usi
+      ON usi.id = link.user_session_issuer_id AND usi.deleted IS FALSE
+    JOIN projects AS p
+      ON p.id = usi.project_id AND p.deleted IS FALSE
     WHERE link.remote_session_client_id = c.id
-      AND link.user_session_issuer_id = s.user_session_issuer_id
-  )
-  AND EXISTS (
-    SELECT 1 FROM user_sessions AS gs
-    WHERE gs.project_id = usi.project_id
-      AND gs.user_session_issuer_id = s.user_session_issuer_id
-      AND gs.subject_urn = s.subject_urn
-      AND gs.deleted IS FALSE
-      AND gs.refresh_expires_at > @now_ts::timestamptz
+      AND p.organization_id = @organization_id
+      AND EXISTS (
+        SELECT 1 FROM user_sessions AS gs
+        WHERE gs.project_id = usi.project_id
+          AND gs.user_session_issuer_id = usi.id
+          AND gs.subject_urn = s.subject_urn
+          AND gs.deleted IS FALSE
+          AND gs.refresh_expires_at > @now_ts::timestamptz
+      )
   );
 
 -- Organization administrator surface (AIS-119) — cross-project visibility into

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -710,19 +710,20 @@ RETURNING *;
 
 -- name: ListRemoteSessionStatusesForSubject :many
 -- Bulk lookup for the consent renderer: returns each non-deleted
--- remote_session for the given subject in the project's issuers, tagged with
--- whether it is still usable. Folds the N per-card lookups into one
+-- remote_session for the given subject among the supplied clients, tagged
+-- with whether it is still usable. Folds the N per-card lookups into one
 -- round-trip. The partial unique index on (subject_urn,
 -- remote_session_client_id) WHERE deleted IS FALSE means at most one row per
 -- (subject, client), so the result doubles as a per-client map without
 -- DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
 --
--- user_session_issuer_id on the row is provenance from INSERT, not a lookup
--- key: UpsertRemoteSession conflicts on (subject_urn, remote_session_client_id)
--- and never updates that column. Filtering on it would hide a live grant from
--- a second MCP server whose issuer did not mint the row, while
--- GetActiveRemoteSession (the runtime) still finds it. Tenant scope is the
--- stored issuer's project.
+-- Scope is the client IDs the caller already resolved (ListClients / posted
+-- client_id). Project scoping is intentionally NOT applied: re-joining
+-- user_session_issuers would only repeat that check, and that table is
+-- soft-deleted — ON DELETE CASCADE never fires, so a live grant minted by a
+-- now-deleted issuer would disappear from consent while GetActiveRemoteSession
+-- still finds it. user_session_issuer_id on the row is provenance from INSERT,
+-- not a lookup key.
 --
 -- The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
 -- session is usable while the upstream authorization remains valid and its
@@ -753,10 +754,8 @@ SELECT
     ELSE 'expired'
   END)::text AS status
 FROM remote_sessions AS s
-JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
 WHERE s.subject_urn = @subject_urn
-  AND usi.project_id = @project_id
-  AND usi.deleted IS FALSE
+  AND s.remote_session_client_id = ANY(@remote_session_client_ids::uuid[])
   AND s.deleted IS FALSE;
 
 -- name: SetRemoteSessionUpdatedAt :exec
@@ -922,26 +921,23 @@ RETURNING s.*;
 -- Records the subject's consent-screen auto-refresh choice. Deliberately does
 -- NOT touch updated_at: that column doubles as the refresh CAS token-version
 -- signal and keepalive clock, and a preference toggle must not perturb either.
--- Scoped through the stored issuer's project so the write cannot cross tenant
--- boundaries. A subject's grant is shared across every MCP server in the
--- project because remote_sessions is keyed on (subject_urn,
--- remote_session_client_id); the stored user_session_issuer_id is provenance
--- and is not a write predicate.
+-- Scope is the client ID the caller already resolved through the endpoint's
+-- current bindings. Project scoping is intentionally NOT applied: re-joining
+-- user_session_issuers would only repeat that check, and a live grant minted
+-- by a now-soft-deleted issuer must still accept the preference toggle.
 UPDATE remote_sessions AS s
 SET auto_refresh = @auto_refresh
-FROM user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
   AND s.remote_session_client_id = @remote_session_client_id
-  AND usi.id = s.user_session_issuer_id
-  AND usi.project_id = @project_id
-  AND usi.deleted IS FALSE
   AND s.deleted IS FALSE;
 
 -- name: SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer :many
 -- Cascade for a revoked user session: tombstones every upstream grant the
--- subject holds in the issuer's project and returns their stored credentials.
--- Scoped through the stored issuer's project so the write cannot cross
--- tenants.
+-- subject holds in the stored issuer's project and returns their stored
+-- credentials. Join user_session_issuers for that project scope, including a
+-- now-soft-deleted issuer: that table is soft-deleted, ON DELETE CASCADE
+-- never fires, and a live grant still points at the deleted row. Filtering
+-- usi.deleted would skip those grants and silently skip RFC 7009.
 --
 -- A subject's grant is shared by every MCP client it authenticates, because
 -- remote_sessions is keyed on (subject_urn, remote_session_client_id) with no
@@ -955,28 +951,24 @@ FROM user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
   AND usi.id = s.user_session_issuer_id
   AND usi.project_id = @project_id
-  AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_encrypted;
 
 -- name: SoftDeleteRemoteSessionBySubjectAndClient :many
 -- Consent-screen disconnect: soft-deletes the subject's own binding for one
 -- upstream client. Subject and client are derived server-side from the
--- challenge state and the endpoint's bindings, never from the form; scoped
--- through the stored issuer's project so the write cannot cross tenants.
+-- challenge state and the endpoint's bindings, never from the form.
 --
 -- Returns the stored credentials it tombstones; the partial unique index on
--- (subject_urn, remote_session_client_id) caps that at one row. The stored
--- user_session_issuer_id is provenance, not a lookup key, so disconnect from
--- a second MCP server still finds the row.
+-- (subject_urn, remote_session_client_id) caps that at one row. Project
+-- scoping is intentionally NOT applied: the acted-on client is already
+-- re-resolved through the endpoint's current bindings, and re-joining
+-- user_session_issuers would hide a live grant minted by a now-soft-deleted
+-- issuer, skipping RFC 7009.
 UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp()
-FROM user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
   AND s.remote_session_client_id = @remote_session_client_id
-  AND usi.id = s.user_session_issuer_id
-  AND usi.project_id = @project_id
-  AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_encrypted;
 

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -710,12 +710,19 @@ RETURNING *;
 
 -- name: ListRemoteSessionStatusesForSubject :many
 -- Bulk lookup for the consent renderer: returns each non-deleted
--- remote_session for the given subject under a single user_session_issuer,
--- tagged with whether it is still usable. Folds the N per-card lookups into
--- one round-trip. The partial unique index on (subject_urn,
+-- remote_session for the given subject in the project's issuers, tagged with
+-- whether it is still usable. Folds the N per-card lookups into one
+-- round-trip. The partial unique index on (subject_urn,
 -- remote_session_client_id) WHERE deleted IS FALSE means at most one row per
 -- (subject, client), so the result doubles as a per-client map without
 -- DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
+--
+-- user_session_issuer_id on the row is provenance from INSERT, not a lookup
+-- key: UpsertRemoteSession conflicts on (subject_urn, remote_session_client_id)
+-- and never updates that column. Filtering on it would hide a live grant from
+-- a second MCP server whose issuer did not mint the row, while
+-- GetActiveRemoteSession (the runtime) still finds it. Tenant scope is the
+-- stored issuer's project.
 --
 -- The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
 -- session is usable while the upstream authorization remains valid and its
@@ -748,7 +755,6 @@ SELECT
 FROM remote_sessions AS s
 JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
 WHERE s.subject_urn = @subject_urn
-  AND s.user_session_issuer_id = @user_session_issuer_id
   AND usi.project_id = @project_id
   AND usi.deleted IS FALSE
   AND s.deleted IS FALSE;
@@ -916,16 +922,16 @@ RETURNING s.*;
 -- Records the subject's consent-screen auto-refresh choice. Deliberately does
 -- NOT touch updated_at: that column doubles as the refresh CAS token-version
 -- signal and keepalive clock, and a preference toggle must not perturb either.
--- Scoped through the endpoint's user_session_issuer project so the write
--- cannot cross tenant boundaries. A client may be bound to several
--- user_session_issuers; the issuer predicate pins the write to the binding the
--- consent screen displayed (reads filter by issuer the same way).
+-- Scoped through the stored issuer's project so the write cannot cross tenant
+-- boundaries. A subject's grant is shared across every MCP server in the
+-- project because remote_sessions is keyed on (subject_urn,
+-- remote_session_client_id); the stored user_session_issuer_id is provenance
+-- and is not a write predicate.
 UPDATE remote_sessions AS s
 SET auto_refresh = @auto_refresh
 FROM user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
   AND s.remote_session_client_id = @remote_session_client_id
-  AND s.user_session_issuer_id = @user_session_issuer_id
   AND usi.id = s.user_session_issuer_id
   AND usi.project_id = @project_id
   AND usi.deleted IS FALSE
@@ -933,20 +939,20 @@ WHERE s.subject_urn = @subject_urn
 
 -- name: SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer :many
 -- Cascade for a revoked user session: tombstones every upstream grant the
--- subject holds through one user session issuer and returns their stored
--- credentials. Scoped through the issuer's project so the write cannot
--- cross tenants.
+-- subject holds in the issuer's project and returns their stored credentials.
+-- Scoped through the stored issuer's project so the write cannot cross
+-- tenants.
 --
 -- A subject's grant is shared by every MCP client it authenticates, because
 -- remote_sessions is keyed on (subject_urn, remote_session_client_id) with no
--- user-session-client column. Revoking one client's session therefore drops
--- the provider link for all of them, which is the intended blast radius: a
--- revoke that left the upstream tokens alive would not be a revoke.
+-- user-session-client column. The stored user_session_issuer_id is provenance
+-- from INSERT, not a lookup key, so a revoke through one issuer in the
+-- project must still tombstone a row minted by another. A revoke that left
+-- the upstream tokens alive would not be a revoke.
 UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp()
 FROM user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
-  AND s.user_session_issuer_id = @user_session_issuer_id
   AND usi.id = s.user_session_issuer_id
   AND usi.project_id = @project_id
   AND usi.deleted IS FALSE
@@ -955,18 +961,19 @@ RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_
 
 -- name: SoftDeleteRemoteSessionBySubjectAndClient :many
 -- Consent-screen disconnect: soft-deletes the subject's own binding for one
--- upstream client. Subject, client and issuer all derived server-side from
--- the challenge state and the endpoint's bindings, never from the form;
--- scoped through the issuer's project so the write cannot cross tenants.
+-- upstream client. Subject and client are derived server-side from the
+-- challenge state and the endpoint's bindings, never from the form; scoped
+-- through the stored issuer's project so the write cannot cross tenants.
 --
 -- Returns the stored credentials it tombstones; the partial unique index on
--- (subject_urn, remote_session_client_id) caps that at one row.
+-- (subject_urn, remote_session_client_id) caps that at one row. The stored
+-- user_session_issuer_id is provenance, not a lookup key, so disconnect from
+-- a second MCP server still finds the row.
 UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp()
 FROM user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
   AND s.remote_session_client_id = @remote_session_client_id
-  AND s.user_session_issuer_id = @user_session_issuer_id
   AND usi.id = s.user_session_issuer_id
   AND usi.project_id = @project_id
   AND usi.deleted IS FALSE

--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -68,7 +69,7 @@ func TestRefreshNow_InvalidGrant_ClearsRefreshGrantWhenCacheUnavailable(t *testi
 	statuses, err := env.mgr.RemoteSessionStatuses(
 		ctx,
 		env.subject,
-		env.projectID,
+		[]uuid.UUID{env.clientID},
 	)
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[env.clientID].Status)

--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -69,7 +69,6 @@ func TestRefreshNow_InvalidGrant_ClearsRefreshGrantWhenCacheUnavailable(t *testi
 		ctx,
 		env.subject,
 		env.projectID,
-		env.session.UserSessionIssuerID,
 	)
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, statuses[env.clientID].Status)

--- a/server/internal/remotesessions/refreshsweep_test.go
+++ b/server/internal/remotesessions/refreshsweep_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	productfeaturesrepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -408,4 +409,108 @@ func TestRefreshSweep_ClaimAdvancesPastOldestSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, secondPage, 1)
 	require.Equal(t, secondID, secondPage[0].ID)
+}
+
+func seedSweepSharedGrant(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	slug string,
+	gramOnIssuerB bool,
+) (sessionID uuid.UUID, issuerA uuid.UUID, issuerB uuid.UUID, org string) {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	remoteIssuerID := createRemoteIssuer(t, ctx, ti, slug+"-issuer", "")
+	issuerA = createUserSessionIssuer(t, ctx, ti.conn, slug+"-usi-a")
+	issuerB = createUserSessionIssuer(t, ctx, ti.conn, slug+"-usi-b")
+	clientID := createRemoteClient(t, ctx, ti, remoteIssuerID, issuerA.String(), slug+"-client")
+	clientUUID, err := uuid.Parse(clientID)
+	require.NoError(t, err)
+	require.NoError(t, repo.New(ti.conn).AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: clientUUID,
+		UserSessionIssuerID:   issuerB,
+	}))
+
+	subject := urn.NewUserSubject("subject-" + slug)
+	session, err := repo.New(ti.conn).UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+		SubjectUrn:            subject,
+		UserSessionIssuerID:   issuerA,
+		RemoteSessionClientID: clientUUID,
+		AccessTokenEncrypted:  "access-ciphertext",
+		AccessExpiresAt:       conv.ToPGTimestamptz(time.Now().Add(time.Hour)),
+		RefreshTokenEncrypted: conv.ToPGText("refresh-ciphertext"),
+		RefreshExpiresAt:      pgtype.Timestamptz{},
+		Scopes:                []string{},
+		Resource:              pgtype.Text{},
+		AutoRefresh:           true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.New(ti.conn).SetRemoteSessionUpdatedAt(ctx, repo.SetRemoteSessionUpdatedAtParams{
+		ID:        session.ID,
+		ProjectID: conv.ToNullUUID(*authCtx.ProjectID),
+		UpdatedAt: conv.ToPGTimestamptz(time.Now().Add(-25 * time.Hour)),
+	}))
+
+	gramIssuer := issuerA
+	if gramOnIssuerB {
+		gramIssuer = issuerB
+	}
+	seedGramSession(t, ctx, ti, subject, gramIssuer, slug, 24*time.Hour)
+
+	return session.ID, issuerA, issuerB, authCtx.ActiveOrganizationID
+}
+
+func TestRefreshSweep_FindsGrantAfterMintingIssuerSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sessionID, issuerA, _, org := seedSweepSharedGrant(t, ctx, ti, "sweep-v2-deleted-a", true)
+	enableOrgAutoRefreshFeature(t, ctx, ti, org, productfeatures.FeatureRemoteSessionAutoRefresh)
+	err := testrepo.New(ti.conn).ForceSoftDeleteUserSessionIssuer(ctx, testrepo.ForceSoftDeleteUserSessionIssuerParams{
+		ID:        issuerA,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	window := newSweepWindow()
+	q := repo.New(ti.conn)
+	rows, err := q.ClaimDueRemoteSessionRefreshCandidates(ctx, window.claimParams())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, sessionID, rows[0].ID)
+	require.Equal(t, org, rows[0].OrganizationID)
+
+	candidate, err := q.GetDueRemoteSessionRefreshCandidate(ctx, window.candidateParams(sessionID, org))
+	require.NoError(t, err)
+	require.Equal(t, sessionID, candidate.RemoteSession.ID)
+	require.Equal(t, issuerA, candidate.RemoteSession.UserSessionIssuerID)
+}
+
+func TestRefreshSweep_SkipsWhenLiveBindingHasNoGramSession(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sessionID, issuerA, _, org := seedSweepSharedGrant(t, ctx, ti, "sweep-v2-session-on-a", false)
+	enableOrgAutoRefreshFeature(t, ctx, ti, org, productfeatures.FeatureRemoteSessionAutoRefresh)
+	err := testrepo.New(ti.conn).ForceSoftDeleteUserSessionIssuer(ctx, testrepo.ForceSoftDeleteUserSessionIssuerParams{
+		ID:        issuerA,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	rows, err := repo.New(ti.conn).ClaimDueRemoteSessionRefreshCandidates(ctx, newSweepWindow().claimParams())
+	require.NoError(t, err)
+	for _, row := range rows {
+		require.NotEqual(t, sessionID, row.ID)
+	}
 }

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -3674,16 +3674,14 @@ SELECT
 FROM remote_sessions AS s
 JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
 WHERE s.subject_urn = $1
-  AND s.user_session_issuer_id = $2
-  AND usi.project_id = $3
+  AND usi.project_id = $2
   AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 `
 
 type ListRemoteSessionStatusesForSubjectParams struct {
-	SubjectUrn          urn.SessionSubject
-	UserSessionIssuerID uuid.UUID
-	ProjectID           uuid.UUID
+	SubjectUrn urn.SessionSubject
+	ProjectID  uuid.UUID
 }
 
 type ListRemoteSessionStatusesForSubjectRow struct {
@@ -3697,12 +3695,19 @@ type ListRemoteSessionStatusesForSubjectRow struct {
 }
 
 // Bulk lookup for the consent renderer: returns each non-deleted
-// remote_session for the given subject under a single user_session_issuer,
-// tagged with whether it is still usable. Folds the N per-card lookups into
-// one round-trip. The partial unique index on (subject_urn,
+// remote_session for the given subject in the project's issuers, tagged with
+// whether it is still usable. Folds the N per-card lookups into one
+// round-trip. The partial unique index on (subject_urn,
 // remote_session_client_id) WHERE deleted IS FALSE means at most one row per
 // (subject, client), so the result doubles as a per-client map without
 // DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
+//
+// user_session_issuer_id on the row is provenance from INSERT, not a lookup
+// key: UpsertRemoteSession conflicts on (subject_urn, remote_session_client_id)
+// and never updates that column. Filtering on it would hide a live grant from
+// a second MCP server whose issuer did not mint the row, while
+// GetActiveRemoteSession (the runtime) still finds it. Tenant scope is the
+// stored issuer's project.
 //
 // The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
 // session is usable while the upstream authorization remains valid and its
@@ -3714,7 +3719,7 @@ type ListRemoteSessionStatusesForSubjectRow struct {
 // so the runtime gate (which rejects the same row as ErrNoValidToken) stops
 // disagreeing with a green "Connected" badge.
 func (q *Queries) ListRemoteSessionStatusesForSubject(ctx context.Context, arg ListRemoteSessionStatusesForSubjectParams) ([]ListRemoteSessionStatusesForSubjectRow, error) {
-	rows, err := q.db.Query(ctx, listRemoteSessionStatusesForSubject, arg.SubjectUrn, arg.UserSessionIssuerID, arg.ProjectID)
+	rows, err := q.db.Query(ctx, listRemoteSessionStatusesForSubject, arg.SubjectUrn, arg.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -4214,9 +4219,8 @@ SET auto_refresh = $1
 FROM user_session_issuers AS usi
 WHERE s.subject_urn = $2
   AND s.remote_session_client_id = $3
-  AND s.user_session_issuer_id = $4
   AND usi.id = s.user_session_issuer_id
-  AND usi.project_id = $5
+  AND usi.project_id = $4
   AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 `
@@ -4225,23 +4229,22 @@ type SetRemoteSessionAutoRefreshParams struct {
 	AutoRefresh           bool
 	SubjectUrn            urn.SessionSubject
 	RemoteSessionClientID uuid.UUID
-	UserSessionIssuerID   uuid.UUID
 	ProjectID             uuid.UUID
 }
 
 // Records the subject's consent-screen auto-refresh choice. Deliberately does
 // NOT touch updated_at: that column doubles as the refresh CAS token-version
 // signal and keepalive clock, and a preference toggle must not perturb either.
-// Scoped through the endpoint's user_session_issuer project so the write
-// cannot cross tenant boundaries. A client may be bound to several
-// user_session_issuers; the issuer predicate pins the write to the binding the
-// consent screen displayed (reads filter by issuer the same way).
+// Scoped through the stored issuer's project so the write cannot cross tenant
+// boundaries. A subject's grant is shared across every MCP server in the
+// project because remote_sessions is keyed on (subject_urn,
+// remote_session_client_id); the stored user_session_issuer_id is provenance
+// and is not a write predicate.
 func (q *Queries) SetRemoteSessionAutoRefresh(ctx context.Context, arg SetRemoteSessionAutoRefreshParams) (int64, error) {
 	result, err := q.db.Exec(ctx, setRemoteSessionAutoRefresh,
 		arg.AutoRefresh,
 		arg.SubjectUrn,
 		arg.RemoteSessionClientID,
-		arg.UserSessionIssuerID,
 		arg.ProjectID,
 	)
 	if err != nil {
@@ -4279,9 +4282,8 @@ SET deleted_at = clock_timestamp()
 FROM user_session_issuers AS usi
 WHERE s.subject_urn = $1
   AND s.remote_session_client_id = $2
-  AND s.user_session_issuer_id = $3
   AND usi.id = s.user_session_issuer_id
-  AND usi.project_id = $4
+  AND usi.project_id = $3
   AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_encrypted
@@ -4290,7 +4292,6 @@ RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_
 type SoftDeleteRemoteSessionBySubjectAndClientParams struct {
 	SubjectUrn            urn.SessionSubject
 	RemoteSessionClientID uuid.UUID
-	UserSessionIssuerID   uuid.UUID
 	ProjectID             uuid.UUID
 }
 
@@ -4301,19 +4302,16 @@ type SoftDeleteRemoteSessionBySubjectAndClientRow struct {
 }
 
 // Consent-screen disconnect: soft-deletes the subject's own binding for one
-// upstream client. Subject, client and issuer all derived server-side from
-// the challenge state and the endpoint's bindings, never from the form;
-// scoped through the issuer's project so the write cannot cross tenants.
+// upstream client. Subject and client are derived server-side from the
+// challenge state and the endpoint's bindings, never from the form; scoped
+// through the stored issuer's project so the write cannot cross tenants.
 //
 // Returns the stored credentials it tombstones; the partial unique index on
-// (subject_urn, remote_session_client_id) caps that at one row.
+// (subject_urn, remote_session_client_id) caps that at one row. The stored
+// user_session_issuer_id is provenance, not a lookup key, so disconnect from
+// a second MCP server still finds the row.
 func (q *Queries) SoftDeleteRemoteSessionBySubjectAndClient(ctx context.Context, arg SoftDeleteRemoteSessionBySubjectAndClientParams) ([]SoftDeleteRemoteSessionBySubjectAndClientRow, error) {
-	rows, err := q.db.Query(ctx, softDeleteRemoteSessionBySubjectAndClient,
-		arg.SubjectUrn,
-		arg.RemoteSessionClientID,
-		arg.UserSessionIssuerID,
-		arg.ProjectID,
-	)
+	rows, err := q.db.Query(ctx, softDeleteRemoteSessionBySubjectAndClient, arg.SubjectUrn, arg.RemoteSessionClientID, arg.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -4371,18 +4369,16 @@ UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp()
 FROM user_session_issuers AS usi
 WHERE s.subject_urn = $1
-  AND s.user_session_issuer_id = $2
   AND usi.id = s.user_session_issuer_id
-  AND usi.project_id = $3
+  AND usi.project_id = $2
   AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_encrypted
 `
 
 type SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerParams struct {
-	SubjectUrn          urn.SessionSubject
-	UserSessionIssuerID uuid.UUID
-	ProjectID           uuid.UUID
+	SubjectUrn urn.SessionSubject
+	ProjectID  uuid.UUID
 }
 
 type SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerRow struct {
@@ -4392,17 +4388,18 @@ type SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerRow struct {
 }
 
 // Cascade for a revoked user session: tombstones every upstream grant the
-// subject holds through one user session issuer and returns their stored
-// credentials. Scoped through the issuer's project so the write cannot
-// cross tenants.
+// subject holds in the issuer's project and returns their stored credentials.
+// Scoped through the stored issuer's project so the write cannot cross
+// tenants.
 //
 // A subject's grant is shared by every MCP client it authenticates, because
 // remote_sessions is keyed on (subject_urn, remote_session_client_id) with no
-// user-session-client column. Revoking one client's session therefore drops
-// the provider link for all of them, which is the intended blast radius: a
-// revoke that left the upstream tokens alive would not be a revoke.
+// user-session-client column. The stored user_session_issuer_id is provenance
+// from INSERT, not a lookup key, so a revoke through one issuer in the
+// project must still tombstone a row minted by another. A revoke that left
+// the upstream tokens alive would not be a revoke.
 func (q *Queries) SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer(ctx context.Context, arg SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerParams) ([]SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerRow, error) {
-	rows, err := q.db.Query(ctx, softDeleteRemoteSessionsBySubjectAndUserSessionIssuer, arg.SubjectUrn, arg.UserSessionIssuerID, arg.ProjectID)
+	rows, err := q.db.Query(ctx, softDeleteRemoteSessionsBySubjectAndUserSessionIssuer, arg.SubjectUrn, arg.ProjectID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -3672,16 +3672,14 @@ SELECT
     ELSE 'expired'
   END)::text AS status
 FROM remote_sessions AS s
-JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
 WHERE s.subject_urn = $1
-  AND usi.project_id = $2
-  AND usi.deleted IS FALSE
+  AND s.remote_session_client_id = ANY($2::uuid[])
   AND s.deleted IS FALSE
 `
 
 type ListRemoteSessionStatusesForSubjectParams struct {
-	SubjectUrn urn.SessionSubject
-	ProjectID  uuid.UUID
+	SubjectUrn             urn.SessionSubject
+	RemoteSessionClientIds []uuid.UUID
 }
 
 type ListRemoteSessionStatusesForSubjectRow struct {
@@ -3695,19 +3693,20 @@ type ListRemoteSessionStatusesForSubjectRow struct {
 }
 
 // Bulk lookup for the consent renderer: returns each non-deleted
-// remote_session for the given subject in the project's issuers, tagged with
-// whether it is still usable. Folds the N per-card lookups into one
+// remote_session for the given subject among the supplied clients, tagged
+// with whether it is still usable. Folds the N per-card lookups into one
 // round-trip. The partial unique index on (subject_urn,
 // remote_session_client_id) WHERE deleted IS FALSE means at most one row per
 // (subject, client), so the result doubles as a per-client map without
 // DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
 //
-// user_session_issuer_id on the row is provenance from INSERT, not a lookup
-// key: UpsertRemoteSession conflicts on (subject_urn, remote_session_client_id)
-// and never updates that column. Filtering on it would hide a live grant from
-// a second MCP server whose issuer did not mint the row, while
-// GetActiveRemoteSession (the runtime) still finds it. Tenant scope is the
-// stored issuer's project.
+// Scope is the client IDs the caller already resolved (ListClients / posted
+// client_id). Project scoping is intentionally NOT applied: re-joining
+// user_session_issuers would only repeat that check, and that table is
+// soft-deleted — ON DELETE CASCADE never fires, so a live grant minted by a
+// now-deleted issuer would disappear from consent while GetActiveRemoteSession
+// still finds it. user_session_issuer_id on the row is provenance from INSERT,
+// not a lookup key.
 //
 // The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
 // session is usable while the upstream authorization remains valid and its
@@ -3719,7 +3718,7 @@ type ListRemoteSessionStatusesForSubjectRow struct {
 // so the runtime gate (which rejects the same row as ErrNoValidToken) stops
 // disagreeing with a green "Connected" badge.
 func (q *Queries) ListRemoteSessionStatusesForSubject(ctx context.Context, arg ListRemoteSessionStatusesForSubjectParams) ([]ListRemoteSessionStatusesForSubjectRow, error) {
-	rows, err := q.db.Query(ctx, listRemoteSessionStatusesForSubject, arg.SubjectUrn, arg.ProjectID)
+	rows, err := q.db.Query(ctx, listRemoteSessionStatusesForSubject, arg.SubjectUrn, arg.RemoteSessionClientIds)
 	if err != nil {
 		return nil, err
 	}
@@ -4216,12 +4215,8 @@ func (q *Queries) SetRemoteSessionAccessExpiresAt(ctx context.Context, arg SetRe
 const setRemoteSessionAutoRefresh = `-- name: SetRemoteSessionAutoRefresh :execrows
 UPDATE remote_sessions AS s
 SET auto_refresh = $1
-FROM user_session_issuers AS usi
 WHERE s.subject_urn = $2
   AND s.remote_session_client_id = $3
-  AND usi.id = s.user_session_issuer_id
-  AND usi.project_id = $4
-  AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 `
 
@@ -4229,24 +4224,17 @@ type SetRemoteSessionAutoRefreshParams struct {
 	AutoRefresh           bool
 	SubjectUrn            urn.SessionSubject
 	RemoteSessionClientID uuid.UUID
-	ProjectID             uuid.UUID
 }
 
 // Records the subject's consent-screen auto-refresh choice. Deliberately does
 // NOT touch updated_at: that column doubles as the refresh CAS token-version
 // signal and keepalive clock, and a preference toggle must not perturb either.
-// Scoped through the stored issuer's project so the write cannot cross tenant
-// boundaries. A subject's grant is shared across every MCP server in the
-// project because remote_sessions is keyed on (subject_urn,
-// remote_session_client_id); the stored user_session_issuer_id is provenance
-// and is not a write predicate.
+// Scope is the client ID the caller already resolved through the endpoint's
+// current bindings. Project scoping is intentionally NOT applied: re-joining
+// user_session_issuers would only repeat that check, and a live grant minted
+// by a now-soft-deleted issuer must still accept the preference toggle.
 func (q *Queries) SetRemoteSessionAutoRefresh(ctx context.Context, arg SetRemoteSessionAutoRefreshParams) (int64, error) {
-	result, err := q.db.Exec(ctx, setRemoteSessionAutoRefresh,
-		arg.AutoRefresh,
-		arg.SubjectUrn,
-		arg.RemoteSessionClientID,
-		arg.ProjectID,
-	)
+	result, err := q.db.Exec(ctx, setRemoteSessionAutoRefresh, arg.AutoRefresh, arg.SubjectUrn, arg.RemoteSessionClientID)
 	if err != nil {
 		return 0, err
 	}
@@ -4279,12 +4267,8 @@ func (q *Queries) SetRemoteSessionUpdatedAt(ctx context.Context, arg SetRemoteSe
 const softDeleteRemoteSessionBySubjectAndClient = `-- name: SoftDeleteRemoteSessionBySubjectAndClient :many
 UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp()
-FROM user_session_issuers AS usi
 WHERE s.subject_urn = $1
   AND s.remote_session_client_id = $2
-  AND usi.id = s.user_session_issuer_id
-  AND usi.project_id = $3
-  AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_encrypted
 `
@@ -4292,7 +4276,6 @@ RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_
 type SoftDeleteRemoteSessionBySubjectAndClientParams struct {
 	SubjectUrn            urn.SessionSubject
 	RemoteSessionClientID uuid.UUID
-	ProjectID             uuid.UUID
 }
 
 type SoftDeleteRemoteSessionBySubjectAndClientRow struct {
@@ -4303,15 +4286,16 @@ type SoftDeleteRemoteSessionBySubjectAndClientRow struct {
 
 // Consent-screen disconnect: soft-deletes the subject's own binding for one
 // upstream client. Subject and client are derived server-side from the
-// challenge state and the endpoint's bindings, never from the form; scoped
-// through the stored issuer's project so the write cannot cross tenants.
+// challenge state and the endpoint's bindings, never from the form.
 //
 // Returns the stored credentials it tombstones; the partial unique index on
-// (subject_urn, remote_session_client_id) caps that at one row. The stored
-// user_session_issuer_id is provenance, not a lookup key, so disconnect from
-// a second MCP server still finds the row.
+// (subject_urn, remote_session_client_id) caps that at one row. Project
+// scoping is intentionally NOT applied: the acted-on client is already
+// re-resolved through the endpoint's current bindings, and re-joining
+// user_session_issuers would hide a live grant minted by a now-soft-deleted
+// issuer, skipping RFC 7009.
 func (q *Queries) SoftDeleteRemoteSessionBySubjectAndClient(ctx context.Context, arg SoftDeleteRemoteSessionBySubjectAndClientParams) ([]SoftDeleteRemoteSessionBySubjectAndClientRow, error) {
-	rows, err := q.db.Query(ctx, softDeleteRemoteSessionBySubjectAndClient, arg.SubjectUrn, arg.RemoteSessionClientID, arg.ProjectID)
+	rows, err := q.db.Query(ctx, softDeleteRemoteSessionBySubjectAndClient, arg.SubjectUrn, arg.RemoteSessionClientID)
 	if err != nil {
 		return nil, err
 	}
@@ -4371,7 +4355,6 @@ FROM user_session_issuers AS usi
 WHERE s.subject_urn = $1
   AND usi.id = s.user_session_issuer_id
   AND usi.project_id = $2
-  AND usi.deleted IS FALSE
   AND s.deleted IS FALSE
 RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_encrypted
 `
@@ -4388,9 +4371,11 @@ type SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerRow struct {
 }
 
 // Cascade for a revoked user session: tombstones every upstream grant the
-// subject holds in the issuer's project and returns their stored credentials.
-// Scoped through the stored issuer's project so the write cannot cross
-// tenants.
+// subject holds in the stored issuer's project and returns their stored
+// credentials. Join user_session_issuers for that project scope, including a
+// now-soft-deleted issuer: that table is soft-deleted, ON DELETE CASCADE
+// never fires, and a live grant still points at the deleted row. Filtering
+// usi.deleted would skip those grants and silently skip RFC 7009.
 //
 // A subject's grant is shared by every MCP client it authenticates, because
 // remote_sessions is keyed on (subject_urn, remote_session_client_id) with no

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -37,12 +37,29 @@ func (q *Queries) AttachRemoteSessionClientToUserSessionIssuer(ctx context.Conte
 const claimDueRemoteSessionRefreshCandidates = `-- name: ClaimDueRemoteSessionRefreshCandidates :many
 
 WITH due AS (
-  SELECT s.id, s.updated_at, p.organization_id, i.token_endpoint
+  SELECT s.id, s.updated_at, eligible.organization_id, i.token_endpoint
   FROM remote_sessions AS s
   JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id AND c.deleted IS FALSE
   JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id AND i.deleted IS FALSE
-  JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id AND usi.deleted IS FALSE
-  JOIN projects AS p ON p.id = usi.project_id AND p.deleted IS FALSE
+  JOIN LATERAL (
+    SELECT p.organization_id
+    FROM remote_session_client_user_session_issuers AS link
+    JOIN user_session_issuers AS usi
+      ON usi.id = link.user_session_issuer_id AND usi.deleted IS FALSE
+    JOIN projects AS p
+      ON p.id = usi.project_id AND p.deleted IS FALSE
+    WHERE link.remote_session_client_id = c.id
+      AND EXISTS (
+        SELECT 1 FROM user_sessions AS gs
+        WHERE gs.project_id = usi.project_id
+          AND gs.user_session_issuer_id = usi.id
+          AND gs.subject_urn = s.subject_urn
+          AND gs.deleted IS FALSE
+          AND gs.refresh_expires_at > $1::timestamptz
+      )
+    ORDER BY usi.id
+    LIMIT 1
+  ) AS eligible ON TRUE
   WHERE s.deleted IS FALSE
     AND s.refresh_token_encrypted IS NOT NULL
     AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > $1::timestamptz)
@@ -55,7 +72,7 @@ WITH due AS (
     AND (
       EXISTS (
         SELECT 1 FROM organization_features AS orgf
-        WHERE orgf.organization_id = p.organization_id
+        WHERE orgf.organization_id = eligible.organization_id
           AND orgf.feature_name = 'remote_session_auto_refresh_enforced'
           AND orgf.deleted IS FALSE
       )
@@ -63,24 +80,11 @@ WITH due AS (
         s.auto_refresh IS TRUE
         AND EXISTS (
           SELECT 1 FROM organization_features AS orgf
-          WHERE orgf.organization_id = p.organization_id
+          WHERE orgf.organization_id = eligible.organization_id
             AND orgf.feature_name = 'remote_session_auto_refresh'
             AND orgf.deleted IS FALSE
         )
       )
-    )
-    AND EXISTS (
-      SELECT 1 FROM remote_session_client_user_session_issuers AS link
-      WHERE link.remote_session_client_id = c.id
-        AND link.user_session_issuer_id = s.user_session_issuer_id
-    )
-    AND EXISTS (
-      SELECT 1 FROM user_sessions AS gs
-      WHERE gs.project_id = usi.project_id
-        AND gs.user_session_issuer_id = s.user_session_issuer_id
-        AND gs.subject_urn = s.subject_urn
-        AND gs.deleted IS FALSE
-        AND gs.refresh_expires_at > $1::timestamptz
     )
   ORDER BY s.updated_at, s.id
   LIMIT $4
@@ -128,6 +132,13 @@ type ClaimDueRemoteSessionRefreshCandidatesRow struct {
 //
 // Preferences are read, never rewritten, so restoring the opt-in policy
 // restores each subject's original choice.
+//
+// A live Gram identity provider bound to this client, plus an unexpired user
+// session on that issuer, is what keeps the grant eligible. user_session_issuer_id
+// on the remote_sessions row is provenance from INSERT and is never rewritten
+// on reconnect, so requiring that exact issuer to still be live would skip a
+// grant whose minting provider was replaced while another bound issuer still
+// holds the subject's login.
 func (q *Queries) ClaimDueRemoteSessionRefreshCandidates(ctx context.Context, arg ClaimDueRemoteSessionRefreshCandidatesParams) ([]ClaimDueRemoteSessionRefreshCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, claimDueRemoteSessionRefreshCandidates,
 		arg.NowTs,
@@ -1112,15 +1123,12 @@ SELECT s.id, s.subject_urn, s.user_session_issuer_id, s.remote_session_client_id
 FROM remote_sessions AS s
 JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id AND c.deleted IS FALSE
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id AND i.deleted IS FALSE
-JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id AND usi.deleted IS FALSE
-JOIN projects AS p ON p.id = usi.project_id AND p.deleted IS FALSE
 WHERE s.id = $1
-  AND p.organization_id = $2
   AND s.deleted IS FALSE
   AND s.refresh_token_encrypted IS NOT NULL
-  AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > $3::timestamptz)
-  AND (s.refresh_expires_at IS NULL OR s.refresh_expires_at > $3::timestamptz)
-  AND s.updated_at <= $4::timestamptz
+  AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > $2::timestamptz)
+  AND (s.refresh_expires_at IS NULL OR s.refresh_expires_at > $2::timestamptz)
+  AND s.updated_at <= $3::timestamptz
   -- The organization's automatic-refresh policy applied to this session's own
   -- preference. This predicate is spelled out again in
   -- ClaimDueRemoteSessionRefreshCandidates; the two must agree, and
@@ -1128,7 +1136,7 @@ WHERE s.id = $1
   AND (
     EXISTS (
       SELECT 1 FROM organization_features AS orgf
-      WHERE orgf.organization_id = p.organization_id
+      WHERE orgf.organization_id = $4
         AND orgf.feature_name = 'remote_session_auto_refresh_enforced'
         AND orgf.deleted IS FALSE
     )
@@ -1136,32 +1144,37 @@ WHERE s.id = $1
       s.auto_refresh IS TRUE
       AND EXISTS (
         SELECT 1 FROM organization_features AS orgf
-        WHERE orgf.organization_id = p.organization_id
+        WHERE orgf.organization_id = $4
           AND orgf.feature_name = 'remote_session_auto_refresh'
           AND orgf.deleted IS FALSE
       )
     )
   )
   AND EXISTS (
-    SELECT 1 FROM remote_session_client_user_session_issuers AS link
+    SELECT 1
+    FROM remote_session_client_user_session_issuers AS link
+    JOIN user_session_issuers AS usi
+      ON usi.id = link.user_session_issuer_id AND usi.deleted IS FALSE
+    JOIN projects AS p
+      ON p.id = usi.project_id AND p.deleted IS FALSE
     WHERE link.remote_session_client_id = c.id
-      AND link.user_session_issuer_id = s.user_session_issuer_id
-  )
-  AND EXISTS (
-    SELECT 1 FROM user_sessions AS gs
-    WHERE gs.project_id = usi.project_id
-      AND gs.user_session_issuer_id = s.user_session_issuer_id
-      AND gs.subject_urn = s.subject_urn
-      AND gs.deleted IS FALSE
-      AND gs.refresh_expires_at > $3::timestamptz
+      AND p.organization_id = $4
+      AND EXISTS (
+        SELECT 1 FROM user_sessions AS gs
+        WHERE gs.project_id = usi.project_id
+          AND gs.user_session_issuer_id = usi.id
+          AND gs.subject_urn = s.subject_urn
+          AND gs.deleted IS FALSE
+          AND gs.refresh_expires_at > $2::timestamptz
+      )
   )
 `
 
 type GetDueRemoteSessionRefreshCandidateParams struct {
 	ID              uuid.UUID
-	OrganizationID  string
 	NowTs           pgtype.Timestamptz
 	KeepaliveCutoff pgtype.Timestamptz
+	OrganizationID  string
 }
 
 type GetDueRemoteSessionRefreshCandidateRow struct {
@@ -1174,9 +1187,9 @@ type GetDueRemoteSessionRefreshCandidateRow struct {
 func (q *Queries) GetDueRemoteSessionRefreshCandidate(ctx context.Context, arg GetDueRemoteSessionRefreshCandidateParams) (GetDueRemoteSessionRefreshCandidateRow, error) {
 	row := q.db.QueryRow(ctx, getDueRemoteSessionRefreshCandidate,
 		arg.ID,
-		arg.OrganizationID,
 		arg.NowTs,
 		arg.KeepaliveCutoff,
+		arg.OrganizationID,
 	)
 	var i GetDueRemoteSessionRefreshCandidateRow
 	err := row.Scan(

--- a/server/internal/remotesessions/upstreamrevoke.go
+++ b/server/internal/remotesessions/upstreamrevoke.go
@@ -215,7 +215,7 @@ func revokedCredentials(rows []repo.SoftDeleteRemoteSessionsByClientIDRow) []Rev
 //
 // The stored user_session_issuer_id is provenance from INSERT, not a lookup
 // key, so a grant minted by a different issuer in the same project is still
-// tombstoned.
+// tombstoned, including when that issuer has since been soft-deleted.
 //
 // Split in two on purpose. The tombstone belongs in the caller's transaction so
 // it commits or rolls back with the revocation that triggered it; the upstream

--- a/server/internal/remotesessions/upstreamrevoke.go
+++ b/server/internal/remotesessions/upstreamrevoke.go
@@ -209,9 +209,13 @@ func revokedCredentials(rows []repo.SoftDeleteRemoteSessionsByClientIDRow) []Rev
 }
 
 // SoftDeleteSubjectSessions tombstones every upstream grant a subject holds
-// through one user session issuer, inside the caller's transaction, and returns
-// the credentials to hand to [UpstreamRevoker.RevokeAllDetached] once that
+// in the given project, inside the caller's transaction, and returns the
+// credentials to hand to [UpstreamRevoker.RevokeAllDetached] once that
 // transaction commits.
+//
+// The stored user_session_issuer_id is provenance from INSERT, not a lookup
+// key, so a grant minted by a different issuer in the same project is still
+// tombstoned.
 //
 // Split in two on purpose. The tombstone belongs in the caller's transaction so
 // it commits or rolls back with the revocation that triggered it; the upstream
@@ -222,11 +226,10 @@ func revokedCredentials(rows []repo.SoftDeleteRemoteSessionsByClientIDRow) []Rev
 //
 // Takes a DBTX rather than a transaction type so callers in other packages can
 // pass whichever handle their own transaction gave them.
-func (r *UpstreamRevoker) SoftDeleteSubjectSessions(ctx context.Context, tx repo.DBTX, subject urn.SessionSubject, userSessionIssuerID uuid.UUID, projectID uuid.UUID) ([]RevokedCredentials, error) {
+func (r *UpstreamRevoker) SoftDeleteSubjectSessions(ctx context.Context, tx repo.DBTX, subject urn.SessionSubject, projectID uuid.UUID) ([]RevokedCredentials, error) {
 	rows, err := repo.New(tx).SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer(ctx, repo.SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerParams{
-		SubjectUrn:          subject,
-		UserSessionIssuerID: userSessionIssuerID,
-		ProjectID:           projectID,
+		SubjectUrn: subject,
+		ProjectID:  projectID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("soft delete remote sessions for subject: %w", err)

--- a/server/internal/remotesessions/upstreamrevoke_test.go
+++ b/server/internal/remotesessions/upstreamrevoke_test.go
@@ -634,7 +634,7 @@ func TestDisconnectRemoteSession_RevokesUpstream(t *testing.T) {
 
 	fx := seedRevocableSession(t, ctx, ti, "disconnect-revokes", upstream.URL+"/revoke", "s3cret", true)
 
-	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
+	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n)
 
@@ -661,7 +661,7 @@ func TestDisconnectRemoteSession_NoRevocationEndpointSkipsUpstream(t *testing.T)
 
 	fx := seedRevocableSession(t, ctx, ti, "disconnect-no-endpoint", "", "s3cret", true)
 
-	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
+	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n)
 
@@ -684,7 +684,7 @@ func TestDisconnectRemoteSession_UpstreamErrorStillDisconnects(t *testing.T) {
 
 	fx := seedRevocableSession(t, ctx, ti, "disconnect-upstream-500", upstream.URL+"/revoke", "s3cret", true)
 
-	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
+	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.clientID)
 	require.NoError(t, err, "an upstream failure must not surface to the consent screen")
 	require.Equal(t, int64(1), n)
 

--- a/server/internal/remotesessions/upstreamrevoke_test.go
+++ b/server/internal/remotesessions/upstreamrevoke_test.go
@@ -634,7 +634,7 @@ func TestDisconnectRemoteSession_RevokesUpstream(t *testing.T) {
 
 	fx := seedRevocableSession(t, ctx, ti, "disconnect-revokes", upstream.URL+"/revoke", "s3cret", true)
 
-	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.userIssuerID, fx.clientID)
+	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n)
 
@@ -661,7 +661,7 @@ func TestDisconnectRemoteSession_NoRevocationEndpointSkipsUpstream(t *testing.T)
 
 	fx := seedRevocableSession(t, ctx, ti, "disconnect-no-endpoint", "", "s3cret", true)
 
-	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.userIssuerID, fx.clientID)
+	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n)
 
@@ -684,7 +684,7 @@ func TestDisconnectRemoteSession_UpstreamErrorStillDisconnects(t *testing.T) {
 
 	fx := seedRevocableSession(t, ctx, ti, "disconnect-upstream-500", upstream.URL+"/revoke", "s3cret", true)
 
-	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.userIssuerID, fx.clientID)
+	n, err := newDisconnectChallengeManager(t, ti).DisconnectRemoteSession(ctx, fx.subject, fx.projectID, fx.clientID)
 	require.NoError(t, err, "an upstream failure must not surface to the consent screen")
 	require.Equal(t, int64(1), n)
 

--- a/server/internal/usersessions/clienthandlers.go
+++ b/server/internal/usersessions/clienthandlers.go
@@ -436,7 +436,7 @@ func (s *Service) RevokeUserSessionClient(ctx context.Context, payload *gen.Revo
 		}
 		seenSubjects[key] = struct{}{}
 
-		creds, err := s.revoker.SoftDeleteSubjectSessions(ctx, dbtx, session.SubjectUrn, session.UserSessionIssuerID, *authCtx.ProjectID)
+		creds, err := s.revoker.SoftDeleteSubjectSessions(ctx, dbtx, session.SubjectUrn, *authCtx.ProjectID)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "revoke upstream remote sessions").LogError(ctx, logger)
 		}

--- a/server/internal/usersessions/sessionhandlers.go
+++ b/server/internal/usersessions/sessionhandlers.go
@@ -223,7 +223,7 @@ func (s *Service) RevokeUserSession(ctx context.Context, payload *gen.RevokeUser
 
 	// Tombstone the subject's upstream grants in the same transaction; the
 	// RFC 7009 pushes wait until it commits.
-	revokedUpstream, err := s.revoker.SoftDeleteSubjectSessions(ctx, dbtx, revoked.SubjectUrn, revoked.UserSessionIssuerID, *authCtx.ProjectID)
+	revokedUpstream, err := s.revoker.SoftDeleteSubjectSessions(ctx, dbtx, revoked.SubjectUrn, *authCtx.ProjectID)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "revoke upstream remote sessions").LogError(ctx, logger)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AIS-589.

## Problem

`remote_sessions` holds at most one live row per `(subject_urn, remote_session_client_id)`. `user_session_issuer_id` is written once on `INSERT` and is not part of `ON CONFLICT DO UPDATE`.

Two variants hid that live grant from consent:

- **V1.** A second MCP server in the same project used a different, still-live identity provider. Filtering on `user_session_issuer_id` missed the row.
- **V2.** An administrator replaced or removed the identity provider. `user_session_issuers` is soft-deleted, so `ON DELETE CASCADE` never fires. The session row survives pointing at the deleted issuer. Joining `user_session_issuers` with `usi.deleted IS FALSE` still hid the card and skipped RFC 7009 on revoke.

In both cases the MCP runtime (`GetActiveRemoteSession`) kept sending the stored token. Scheduled keepalive had the same V2 hole: claim and recheck required the minting issuer to still be live, so an idle refresh token could expire after consent through the replacement provider had already enabled auto-refresh.

## Fix

Consent reads and writes no longer join `user_session_issuers`. Scope is the client IDs the caller already resolved:

- `ListRemoteSessionStatusesForSubject` takes the client IDs from `ListClients`
- `SoftDeleteRemoteSessionBySubjectAndClient` and `SetRemoteSessionAutoRefresh` take the posted `client_id` after it is re-resolved through those same bindings
- `RefreshRemoteSession` keys on `(subject, client)` and no longer requires an issuer match

The user-session revoke cascade (`SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer`) still joins `user_session_issuers` for **project** scope — including a now-soft-deleted issuer — so org-level client grants stay associated with the minting project's issuer. It no longer filters `usi.deleted IS FALSE`.

Scheduled keepalive (`ClaimDueRemoteSessionRefreshCandidates` and `GetDueRemoteSessionRefreshCandidate`) no longer keys on the stored minting issuer. Eligibility is a currently live issuer/client binding plus an unexpired Gram user session on that issuer, with organization auto-refresh policy applied to that issuer's org. Org-level clients with a null `project_id` still qualify through the live issuer's project.

Keep the column as provenance. Do not write it on conflict — that would only alternate which consent page hides the card.

## Tests

`challenge_shared_grant_test.go` seeds one upstream client bound to two user-session issuers, mints the row with issuer A, then:

- Resolves the shared client through issuer B's `ListClients` (the same allowlist `ServeConsentAction` re-resolves posted `client_id` against)
- Consent statuses, auto-refresh, disconnect, and explicit refresh find the row from issuer B
- A client UUID from another project is not in B's `ListClients` list, so mutations only run against bound IDs
- A second upsert with issuer B refreshes tokens without rewriting provenance
- User-session revoke in the project tombstones the row minted by A
- `RemoteSessionStatuses` filters to the supplied client IDs
- After soft-deleting issuer A, `ListClients(A)` is empty, `ListClients(B)` still returns the client, and statuses, auto-refresh, disconnect, refresh, and revoke still find the live grant

`refreshsweep_test.go` covers V2 keepalive: after issuer A is soft-deleted, claim and recheck still pick the row when the subject is logged into issuer B, and skip it when the remaining live binding has no Gram session.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-589](https://linear.app/speakeasy/issue/AIS-589/consent-page-hides-a-valid-remote-session-when-a-different-issuer-made)

<div><a href="https://cursor.com/agents/bc-fa692b11-35c1-4817-8f88-4ae38f7a8178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa692b11-35c1-4817-8f88-4ae38f7a8178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show all connected remote sessions on the consent page regardless of which issuer minted them, and keep auto-refresh working after issuer replacement or removal (AIS-589). Previously consent filtered by issuer, which hid valid grants, skipped RFC 7009 revocation, and stopped scheduled keepalive while the runtime still used the token.

- Consent status, disconnect, auto-refresh, and explicit refresh now scope by caller-resolved client IDs and drop the issuer join; `user_session_issuer_id` is treated as provenance only.
- User-session revoke now cascades by project via the stored issuer join (without filtering on deleted), so grants from removed issuers are still tombstoned and revoked upstream.
- Scheduled keepalive selects candidates with any current client–issuer binding plus a live Gram user session; recheck enforces the same org policy without requiring the minting issuer.
- Tests cover cross-issuer visibility/mutation, project isolation, behavior after minting issuer removal, behavior after the lookup issuer is removed, and stricter refresh mocking.

**API changes**
- `RemoteSessionStatuses(ctx, subject, clientIDs []uuid.UUID)` — pass client IDs only.
- `DisconnectRemoteSession(ctx, subject, clientID uuid.UUID)` — drop issuer/project args.
- `SetRemoteSessionAutoRefresh(ctx, subject, clientID uuid.UUID, enabled bool)` — drop issuer/project args.
- `UpstreamRevoker.SoftDeleteSubjectSessions(ctx, tx, subject, projectID uuid.UUID)` — drop issuer arg; scope by project.
- `RefreshRemoteSession(ctx, subject, clientID uuid.UUID, fallbackResource string)` — drop issuer arg.

<sup>Written for commit 910dfa69eac341fcc93e76493e46d20b3c98cd37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

