### PR TITLE
fix: send existing WorkOS users to sign-in during email signup

### DIFF
--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -50,6 +50,11 @@ type mockWorkOSFetcher struct {
 	// must not hit either path; see TestE2E_Callback_LinkedOrgsSkipWorkOSReads.
 	getOrgCalls           int
 	ensureExternalIDCalls int
+
+	// Signup-time email lookup. Ordinary login must not touch this path.
+	usersByEmail        map[string]*workos.User
+	getUserByEmailErr   error
+	getUserByEmailCalls int
 }
 
 type createdOrgRecord struct {
@@ -102,6 +107,17 @@ func (m *mockWorkOSFetcher) GetOrgMembership(_ context.Context, workosUserID, wo
 		}
 	}
 	return nil, nil
+}
+
+func (m *mockWorkOSFetcher) GetUserByEmail(_ context.Context, email string) (*workos.User, error) {
+	m.getUserByEmailCalls++
+	if m.getUserByEmailErr != nil {
+		return nil, m.getUserByEmailErr
+	}
+	if m.usersByEmail == nil {
+		return nil, nil
+	}
+	return m.usersByEmail[email], nil
 }
 
 func (m *mockWorkOSFetcher) UpdateMemberRoles(_ context.Context, membershipID string, roleSlugs []string) (*workos.Member, error) {

--- a/server/internal/auth/identity/authorization_url_test.go
+++ b/server/internal/auth/identity/authorization_url_test.go
@@ -110,3 +110,12 @@ func TestBuildAuthorizationURL_DevIDP(t *testing.T) {
 	// "openid". Dropping it here would break local login.
 	require.Equal(t, "openid email profile", q.Get("scope"))
 }
+
+func TestHasWorkOSUser_NilClient(t *testing.T) {
+	t.Parallel()
+
+	r := newURLResolver(t, "https://unused.example.com", "client_test123")
+	exists, err := r.HasWorkOSUser(t.Context(), "someone@example.com")
+	require.NoError(t, err)
+	require.False(t, exists)
+}

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -82,7 +82,9 @@ type AuthenticatedUser struct {
 }
 
 // WorkOSClient is the subset of workos.Client needed for identity resolution:
-// org membership sync, cross-system ID synchronization, and org provisioning.
+// org membership sync, cross-system ID synchronization, org provisioning, and
+// the signup-time email lookup that keeps existing AuthKit users off the
+// hosted sign-up screen.
 type WorkOSClient interface {
 	ListUserMemberships(ctx context.Context, userID string) ([]workos.Member, error)
 	GetOrganization(ctx context.Context, orgID string) (*workos.Organization, error)
@@ -93,6 +95,7 @@ type WorkOSClient interface {
 	CreateOrganizationMembership(ctx context.Context, workosUserID, workosOrgID, roleSlug string) (string, error)
 	GetOrgMembership(ctx context.Context, workosUserID, workosOrgID string) (*workos.Member, error)
 	UpdateMemberRoles(ctx context.Context, membershipID string, roleSlugs []string) (*workos.Member, error)
+	GetUserByEmail(ctx context.Context, email string) (*workos.User, error)
 }
 
 // IDPUserInfo represents the user identity returned by the IDP after code exchange.
@@ -589,6 +592,22 @@ func (r *Resolver) InvalidateUserInfoCache(ctx context.Context, userID string) e
 
 const workosAuthorizeEndpoint = "https://api.workos.com/user_management/authorize"
 
+// HasWorkOSUser reports whether WorkOS already has an account for email.
+// An unset client is treated as "no such user" so local and test environments
+// keep the current signup flow. Callers must fail open on error: a temporary
+// WorkOS problem must not block new signups.
+func (r *Resolver) HasWorkOSUser(ctx context.Context, email string) (bool, error) {
+	if r.workosClient == nil || email == "" {
+		return false, nil
+	}
+
+	user, err := r.workosClient.GetUserByEmail(ctx, email)
+	if err != nil {
+		return false, fmt.Errorf("lookup workos user by email: %w", err)
+	}
+	return user != nil, nil
+}
+
 // BuildAuthorizationURL constructs the OIDC authorization URL that the
 // browser should be redirected to.
 func (r *Resolver) BuildAuthorizationURL(ctx context.Context, params AuthorizationURLParams) (*url.URL, error) {
@@ -599,8 +618,9 @@ func (r *Resolver) BuildAuthorizationURL(ctx context.Context, params Authorizati
 	q.Set("state", params.State)
 	q.Set("scope", "openid email profile")
 	q.Set("provider", "authkit")
-	// Both hints are AuthKit features and both are sign-up only, so an
-	// ordinary login produces the same URL it always has.
+	// Both hints are AuthKit features. Ordinary login leaves them empty so
+	// the authorization URL stays unchanged. Signup may set login_hint for
+	// either screen, and screen_hint only when the address is new.
 	if params.LoginHint != "" {
 		q.Set("login_hint", params.LoginHint)
 	}

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -706,14 +706,26 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 
 	state := encodeStateParam(destination, nonce)
 
-	// The company name is what marks a login as having begun on /sign-up, so it
-	// alone selects AuthKit's sign-up screen. Keeping one signal authoritative
-	// beats a second flag that can drift out of sync with it. The email only
-	// fills the field in, so a sign-up without one still lands on the right
-	// screen.
+	// The company name is what marks a login as having begun on /sign-up.
+	// AuthKit's hosted sign-up screen rejects emails that already have a
+	// WorkOS account ("This email is not available"), so look the address up
+	// first and send known users to sign-in with the field pre-filled. The
+	// lookup is signup-only: ordinary login must not pay the extra WorkOS
+	// round trip. Fail open on a lookup error so a temporary API problem
+	// cannot block new users. Signup intent is still stored either way —
+	// a WorkOS account with no Gram org still provisions on callback.
 	screenHint := ""
 	if orgName != "" {
 		screenHint = "sign-up"
+		if email != "" {
+			exists, lookupErr := s.identity.HasWorkOSUser(ctx, email)
+			switch {
+			case lookupErr != nil:
+				s.logger.WarnContext(ctx, "workos user lookup failed, continuing signup", attr.SlogError(lookupErr), attr.SlogAuthUserEmail(email))
+			case exists:
+				screenHint = ""
+			}
+		}
 	}
 
 	authURL, err := s.identity.BuildAuthorizationURL(ctx, identity.AuthorizationURLParams{

--- a/server/internal/auth/login_test.go
+++ b/server/internal/auth/login_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
 	"github.com/speakeasy-api/gram/server/internal/supporthandoff"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
 func TestService_Login(t *testing.T) {
@@ -411,6 +413,165 @@ func TestService_LoginRejectsOrgNameWithTooFewLetters(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, result)
 	require.Contains(t, err.Error(), "organization name must contain at least 2 letters or numbers")
+}
+
+func TestService_LoginSignupExistingWorkOSUserUsesSignIn(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	email := "someone@example.com"
+	orgName := "Acme Inc"
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{},
+		orgs:    map[string]*workos.Organization{},
+		usersByEmail: map[string]*workos.User{
+			email: {ID: "user_existing", Email: email},
+		},
+	}
+	ctx, instance := newTestAuthServiceWithWorkOSClient(t, userInfo, fetcher)
+
+	result, err := instance.service.Login(ctx, &gen.LoginPayload{
+		OrgName: &orgName,
+		Email:   &email,
+	})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(result.Location)
+	require.NoError(t, err)
+	q := parsed.Query()
+	require.Equal(t, email, q.Get("login_hint"))
+	require.False(t, q.Has("screen_hint"), "existing WorkOS users must land on sign-in, not hosted sign-up")
+	require.Equal(t, 1, fetcher.getUserByEmailCalls)
+}
+
+func TestService_LoginSignupNewWorkOSUserUsesSignUp(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	email := "new@example.com"
+	orgName := "Acme Inc"
+	fetcher := &mockWorkOSFetcher{
+		members:      map[string][]workos.Member{},
+		orgs:         map[string]*workos.Organization{},
+		usersByEmail: map[string]*workos.User{},
+	}
+	ctx, instance := newTestAuthServiceWithWorkOSClient(t, userInfo, fetcher)
+
+	result, err := instance.service.Login(ctx, &gen.LoginPayload{
+		OrgName: &orgName,
+		Email:   &email,
+	})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(result.Location)
+	require.NoError(t, err)
+	q := parsed.Query()
+	require.Equal(t, email, q.Get("login_hint"))
+	require.Equal(t, "sign-up", q.Get("screen_hint"))
+	require.Equal(t, 1, fetcher.getUserByEmailCalls)
+
+	nonce := nonceFromLocation(t, result.Location)
+	var intent struct {
+		OrgName string
+	}
+	require.NoError(t, instance.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent))
+	require.Equal(t, "Acme Inc", intent.OrgName)
+}
+
+func TestService_LoginSignupLookupFailureFailsOpenToSignUp(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	email := "someone@example.com"
+	orgName := "Acme Inc"
+	fetcher := &mockWorkOSFetcher{
+		members:           map[string][]workos.Member{},
+		orgs:              map[string]*workos.Organization{},
+		getUserByEmailErr: errors.New("workos unavailable"),
+	}
+	ctx, instance := newTestAuthServiceWithWorkOSClient(t, userInfo, fetcher)
+
+	result, err := instance.service.Login(ctx, &gen.LoginPayload{
+		OrgName: &orgName,
+		Email:   &email,
+	})
+	require.NoError(t, err, "a WorkOS lookup failure must not block signup")
+
+	parsed, err := url.Parse(result.Location)
+	require.NoError(t, err)
+	q := parsed.Query()
+	require.Equal(t, email, q.Get("login_hint"))
+	require.Equal(t, "sign-up", q.Get("screen_hint"))
+	require.Equal(t, 1, fetcher.getUserByEmailCalls)
+}
+
+func TestService_LoginSignupExistingUserPreservesSignupIntent(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	email := "someone@example.com"
+	orgName := "Acme Inc"
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{},
+		orgs:    map[string]*workos.Organization{},
+		usersByEmail: map[string]*workos.User{
+			email: {ID: "user_existing", Email: email},
+		},
+	}
+	ctx, instance := newTestAuthServiceWithWorkOSClient(t, userInfo, fetcher)
+
+	result, err := instance.service.Login(ctx, &gen.LoginPayload{
+		OrgName: &orgName,
+		Email:   &email,
+	})
+	require.NoError(t, err)
+
+	nonce := nonceFromLocation(t, result.Location)
+	var intent struct {
+		OrgName string
+	}
+	require.NoError(t, instance.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent))
+	require.Equal(t, "Acme Inc", intent.OrgName)
+}
+
+func TestService_LoginOrdinaryDoesNotLookupWorkOSUser(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{},
+		orgs:    map[string]*workos.Organization{},
+	}
+	ctx, instance := newTestAuthServiceWithWorkOSClient(t, userInfo, fetcher)
+
+	result, err := instance.service.Login(ctx, &gen.LoginPayload{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0, fetcher.getUserByEmailCalls, "ordinary login must not look up WorkOS users")
+}
+
+func TestService_LoginEmailWithoutOrgNameDoesNotLookupWorkOSUser(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	email := "someone@example.com"
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{},
+		orgs:    map[string]*workos.Organization{},
+		usersByEmail: map[string]*workos.User{
+			email: {ID: "user_existing", Email: email},
+		},
+	}
+	ctx, instance := newTestAuthServiceWithWorkOSClient(t, userInfo, fetcher)
+
+	result, err := instance.service.Login(ctx, &gen.LoginPayload{Email: &email})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(result.Location)
+	require.NoError(t, err)
+	require.Equal(t, email, parsed.Query().Get("login_hint"))
+	require.False(t, parsed.Query().Has("screen_hint"))
+	require.Equal(t, 0, fetcher.getUserByEmailCalls, "email without org_name is not a signup")
 }
 
 // nonceFromLocation pulls the nonce out of the state param on an authorization


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [AGE-3144](https://linear.app/speakeasy/issue/AGE-3144/fix-handle-existing-workos-account-error-during-email-sign-up).

## Problem

During signup, using an email address that already has a WorkOS account lands the user on AuthKit’s hosted sign-up screen, which shows **This email is not available**. WorkOS does not let us customize that error or bounce the user back to Gram.

## Change

On `/sign-up` only (`auth.login` with an organization name and email), look the email up in WorkOS before redirecting to AuthKit:

- **Existing WorkOS user** → AuthKit sign-in with `login_hint` prefilled (no `screen_hint=sign-up`)
- **New user** → current signup flow (`screen_hint=sign-up` + org provisioning)
- **Lookup failure or unset WorkOS client** → fail open to the current signup flow
- **Ordinary login** → unchanged; no extra WorkOS request

Signup intent is still stored when an existing user is diverted to sign-in. Callback already ignores that intent if the user has Gram orgs, and still provisions if they have a WorkOS account but no Gram org.

## Tests

`mise run test:server ./internal/auth/ -count=1 -run 'TestService_LoginSignup|TestService_LoginOrdinary|TestService_LoginEmailWithoutOrgName'`

- existing users land on sign-in
- new users keep `screen_hint=sign-up` and signup intent
- lookup failures fail open
- signup intent is preserved for diverted existing users
- ordinary login (and email without `org_name`) does not call `GetUserByEmail`

`mise lint:server` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3144](https://linear.app/speakeasy/issue/AGE-3144/fix-handle-existing-workos-account-error-during-email-sign-up)

<div><a href="https://cursor.com/agents/bc-14f9b94d-1d82-46b6-9f34-539caa7ff1c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14f9b94d-1d82-46b6-9f34-539caa7ff1c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends existing WorkOS users who start email signup to AuthKit sign-in with their email prefilled, avoiding the hosted “This email is not available” error. New users still go through sign-up; ordinary login is unchanged.

- Adds `HasWorkOSUser` to `identity.Resolver` and extends `WorkOSClient` with `GetUserByEmail`; a nil client returns “no user.”
- On `/sign-up` only (when `org_name` and email are present), looks up the email before building the auth URL:
  - Existing user → omit `screen_hint`, set `login_hint` to email (AuthKit sign-in).
  - New user or lookup error → `screen_hint=sign-up`, `login_hint` set (fail open on error).
- Preserves signup intent when diverting to sign-in; callback still provisions if the user has a WorkOS account but no Gram org.
- Leaves ordinary login behavior and WorkOS request volume unchanged; tests cover existing/new users, lookup failures, intent preservation, and no lookup outside `/sign-up`.
- Satisfies Linear AGE-3144.

<sup>Written for commit 0b5adb4635da9acfa5f39828b77fc6762550d28b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



