### PR TITLE
fix: retire legacy Temporal workflows

### DIFF
--- a/server/internal/background/legacy_risk_analysis.go
+++ b/server/internal/background/legacy_risk_analysis.go
@@ -1,0 +1,22 @@
+package background
+
+import (
+	"github.com/google/uuid"
+	"go.temporal.io/sdk/workflow"
+)
+
+const legacyDrainRiskAnalysisWorkflowName = "DrainRiskAnalysisWorkflow"
+
+// legacyDrainRiskAnalysisParams preserves the payload contract for executions
+// created before risk analysis moved to a per-project coordinator.
+type legacyDrainRiskAnalysisParams struct {
+	ProjectID    uuid.UUID
+	RiskPolicyID uuid.UUID
+	MaxMessages  int32
+}
+
+// legacyDrainRiskAnalysisWorkflow retires obsolete per-policy executions. New
+// risk analysis work is handled by RiskAnalysisCoordinatorWorkflow.
+func legacyDrainRiskAnalysisWorkflow(workflow.Context, legacyDrainRiskAnalysisParams) error {
+	return nil
+}

--- a/server/internal/background/legacy_risk_analysis_test.go
+++ b/server/internal/background/legacy_risk_analysis_test.go
@@ -1,0 +1,29 @@
+package background
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestLegacyDrainRiskAnalysisWorkflowCompletes(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflowWithOptions(legacyDrainRiskAnalysisWorkflow, workflow.RegisterOptions{
+		Name:                          legacyDrainRiskAnalysisWorkflowName,
+		DisableAlreadyRegisteredCheck: false,
+	})
+	env.ExecuteWorkflow(legacyDrainRiskAnalysisWorkflowName, legacyDrainRiskAnalysisParams{
+		ProjectID:    uuid.New(),
+		RiskPolicyID: uuid.New(),
+		MaxMessages:  100,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 
 	otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
@@ -568,6 +569,11 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(TriggerWakeWorkflow)
 	// Risk analysis coordinator workflow
 	temporalWorker.RegisterWorkflow(RiskAnalysisCoordinatorWorkflow)
+	// Retire per-policy executions created before the coordinator migration.
+	temporalWorker.RegisterWorkflowWithOptions(legacyDrainRiskAnalysisWorkflow, workflow.RegisterOptions{
+		Name:                          legacyDrainRiskAnalysisWorkflowName,
+		DisableAlreadyRegisteredCheck: false,
+	})
 	temporalWorker.RegisterWorkflow(RiskExclusionReconcileWorkflow)
 	temporalWorker.RegisterWorkflow(ReconcileSkillObservationsWorkflow)
 	temporalWorker.RegisterWorkflow(SkillObservationReconciliationSweepWorkflow)


### PR DESCRIPTION
## Summary

- register a compatibility handler for obsolete per-policy risk analysis workflows
- preserve the legacy input contract so existing Temporal executions can complete
- keep all new risk analysis work on the current per-project coordinator

## Testing

- `mise run test:server ./internal/background/`
- `mise lint:server`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires legacy per-policy Temporal risk analysis by registering a no‑op workflow under the original name so in‑flight executions complete cleanly. New work remains on the per‑project coordinator with no behavior change.

- Registers legacyDrainRiskAnalysisWorkflow as "DrainRiskAnalysisWorkflow" and preserves the legacy input contract.
- Keeps RiskAnalysisCoordinatorWorkflow unchanged for all new risk analysis.
- Adds a unit test ensuring the legacy workflow completes without error.

**Rollout**
- Deploy updated workers to any clusters processing the risk analysis task queue so legacy executions can drain. No caller changes required.

<sup>Written for commit 4db5c81f19056bc322593f5b8119d43f982aea5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

