### PR TITLE
fix(platform-mcp): prepare exact plugin distribution compatibility

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -28,6 +28,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/platformmcp"
 	"github.com/speakeasy-api/gram/server/internal/platformmcp/localfixture"
@@ -237,8 +239,13 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		budgets.Repair,
 		platformmcp.NewRemoteMCPReadinessProber(config.Logger, config.DB, config.Encryption, config.GuardianPolicy, config.RemoteChallengeManager),
 	).WithTelemetry(telemetry)
+	lifecycleMetadata, err := newPlatformMCPLifecycleMetadataService(config)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create Platform MCP lifecycle metadata service: %w", err)
+	}
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
 		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).
+		WithLifecycleMetadata(lifecycleMetadata).
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).
@@ -308,6 +315,28 @@ func platformMCPSetupResources(config platformMCPConfig) ([]platformmcp.SetupRes
 		return nil, fmt.Errorf("build platform mcp setup corpus: %w", err)
 	}
 	return resources, nil
+}
+
+func newPlatformMCPLifecycleMetadataService(config platformMCPConfig) (*platformmcp.LifecycleMetadataService, error) {
+	return platformmcp.NewLifecycleMetadataService(config.DB, config.AuditLogger, func(ctx context.Context, tx pgx.Tx, existing mcpserversrepo.McpServer, input platformmcp.LifecycleMetadataUpdate) (mcpserversrepo.McpServer, error) {
+		name := input.Name
+		return mcpservers.UpdateMCPServerLifecycleInTransaction(ctx, tx, config.AuditLogger, existing, mcpservers.LifecycleUpdateInput{
+			OrganizationID:        input.OrganizationID,
+			ProjectID:             input.ProjectID,
+			ActorUserID:           input.ActorUserID,
+			ActorEmail:            nil,
+			ServerID:              input.ServerID,
+			Name:                  &name,
+			Visibility:            existing.Visibility,
+			EnvironmentID:         existing.EnvironmentID,
+			UserSessionIssuerID:   existing.UserSessionIssuerID,
+			RemoteMcpServerID:     existing.RemoteMcpServerID,
+			TunneledMcpServerID:   existing.TunneledMcpServerID,
+			ToolsetID:             existing.ToolsetID,
+			UnproxiedMcpServerID:  existing.UnproxiedMcpServerID,
+			ToolVariationsGroupID: existing.ToolVariationsGroupID,
+		})
+	}, config.JWTSigningKey)
 }
 
 func newPlatformMCPDistributionService(config platformMCPConfig) *platformmcp.DistributionService {
@@ -463,8 +492,13 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		budgets.Repair,
 		platformmcp.NewRemoteMCPReadinessProber(config.Logger, config.DB, config.Encryption, config.GuardianPolicy, config.RemoteChallengeManager),
 	).WithTelemetry(telemetry)
+	lifecycleMetadata, err := newPlatformMCPLifecycleMetadataService(config)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create local Platform MCP lifecycle metadata service: %w", err)
+	}
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
 		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).
+		WithLifecycleMetadata(lifecycleMetadata).
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -195,7 +195,8 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Skills:            newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		LifecycleMetadata: newBudget(platformmcp.LifecycleConnectionLimitName, platformmcp.LifecycleOrganizationLimitName),
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.
@@ -318,7 +319,7 @@ func platformMCPSetupResources(config platformMCPConfig) ([]platformmcp.SetupRes
 }
 
 func newPlatformMCPLifecycleMetadataService(config platformMCPConfig) (*platformmcp.LifecycleMetadataService, error) {
-	return platformmcp.NewLifecycleMetadataService(config.DB, config.AuditLogger, func(ctx context.Context, tx pgx.Tx, existing mcpserversrepo.McpServer, input platformmcp.LifecycleMetadataUpdate) (mcpserversrepo.McpServer, error) {
+	return platformmcp.NewLifecycleMetadataService(config.DB, func(ctx context.Context, tx pgx.Tx, existing mcpserversrepo.McpServer, input platformmcp.LifecycleMetadataUpdate) (mcpserversrepo.McpServer, error) {
 		name := input.Name
 		return mcpservers.UpdateMCPServerLifecycleInTransaction(ctx, tx, config.AuditLogger, existing, mcpservers.LifecycleUpdateInput{
 			OrganizationID:        input.OrganizationID,
@@ -448,7 +449,8 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Skills:            newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		LifecycleMetadata: newBudget(platformmcp.LifecycleConnectionLimitName, platformmcp.LifecycleOrganizationLimitName),
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -552,6 +552,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create local Platform MCP lifecycle visibility service: %w", err)
 	}
+	lifecycleVisibility, err := newPlatformMCPLifecycleVisibilityService(config, readiness)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create local Platform MCP lifecycle visibility service: %w", err)
+	}
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
 		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).
 		WithLifecycleMetadata(lifecycleMetadata).

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -550,11 +550,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	}
 	lifecycleVisibility, err := newPlatformMCPLifecycleVisibilityService(config, readiness)
 	if err != nil {
-		return AssistantSurface{}, fmt.Errorf("create local Platform MCP lifecycle visibility service: %w", err)
-	}
-	lifecycleVisibility, err := newPlatformMCPLifecycleVisibilityService(config, readiness)
-	if err != nil {
-		return AssistantSurface{}, fmt.Errorf("create local Platform MCP lifecycle visibility service: %w", err)
+		return AssistantSurface{}, fmt.Errorf("create browser Platform MCP lifecycle visibility service: %w", err)
 	}
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
 		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
@@ -40,6 +41,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 )
 
 type platformMCPConfig struct {
@@ -65,6 +67,7 @@ type platformMCPConfig struct {
 	RemoteChallengeManager *remotesessions.ChallengeManager
 	AuditLogger            *audit.Logger
 	PluginPublisher        *plugins.Service
+	TemporalEnv            *tenv.Environment
 	Skills                 platformmcp.SkillsManagement
 	// Telemetry is the Gram-owned ClickHouse read model the diagnostics tools
 	// answer from. Nil disables them rather than serving an empty answer, which
@@ -244,9 +247,14 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create Platform MCP lifecycle metadata service: %w", err)
 	}
+	lifecycleVisibility, err := newPlatformMCPLifecycleVisibilityService(config, readiness)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create Platform MCP lifecycle visibility service: %w", err)
+	}
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
 		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).
 		WithLifecycleMetadata(lifecycleMetadata).
+		WithLifecycleVisibility(lifecycleVisibility).
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).
@@ -338,6 +346,48 @@ func newPlatformMCPLifecycleMetadataService(config platformMCPConfig) (*platform
 			ToolVariationsGroupID: existing.ToolVariationsGroupID,
 		})
 	}, config.JWTSigningKey)
+}
+
+func newPlatformMCPLifecycleVisibilityService(config platformMCPConfig, readiness *platformmcp.ReadinessService) (*platformmcp.LifecycleVisibilityService, error) {
+	return platformmcp.NewLifecycleVisibilityService(config.DB, config.AuditLogger, mcpservers.LockMCPServerVisibilityDependencies, func(ctx context.Context, tx pgx.Tx, existing mcpserversrepo.McpServer, input platformmcp.LifecycleVisibilityUpdate) (platformmcp.LifecycleVisibilityUpdateResult, error) {
+		updated, err := mcpservers.UpdateMCPServerVisibilityInTransaction(ctx, tx, config.AuditLogger, existing, mcpservers.LifecycleUpdateInput{
+			OrganizationID:        input.OrganizationID,
+			ProjectID:             input.ProjectID,
+			ActorUserID:           input.ActorUserID,
+			ActorEmail:            nil,
+			ServerID:              input.ServerID,
+			Name:                  nil,
+			Visibility:            input.Visibility,
+			EnvironmentID:         existing.EnvironmentID,
+			UserSessionIssuerID:   existing.UserSessionIssuerID,
+			RemoteMcpServerID:     existing.RemoteMcpServerID,
+			TunneledMcpServerID:   existing.TunneledMcpServerID,
+			ToolsetID:             existing.ToolsetID,
+			UnproxiedMcpServerID:  existing.UnproxiedMcpServerID,
+			ToolVariationsGroupID: existing.ToolVariationsGroupID,
+		})
+		if err != nil {
+			return platformmcp.LifecycleVisibilityUpdateResult{}, err
+		}
+		return platformmcp.LifecycleVisibilityUpdateResult{Server: updated.Server, ClearedRootDomainIDs: updated.ClearedRootDomainIDs}, nil
+	}, func(ctx context.Context, projectID uuid.UUID, userID, commitMessage string) error {
+		if config.PluginPublisher == nil {
+			return fmt.Errorf("plugin publishing is not configured")
+		}
+		_, err := config.PluginPublisher.PublishProject(ctx, plugins.PublishProjectInput{ProjectID: projectID, CreatedByUserID: userID, CommitMessage: commitMessage, SkipIfUnchanged: true})
+		return err
+	}, func(ctx context.Context, domainIDs []uuid.UUID) error {
+		if config.TemporalEnv == nil {
+			return nil
+		}
+		var result []error
+		for _, domainID := range domainIDs {
+			if _, err := (&background.CustomDomainRegistrationClient{TemporalEnv: config.TemporalEnv}).ExecuteCustomDomainReconcile(ctx, domainID); err != nil {
+				result = append(result, err)
+			}
+		}
+		return errors.Join(result...)
+	}, readiness, config.JWTSigningKey)
 }
 
 func newPlatformMCPDistributionService(config platformMCPConfig) *platformmcp.DistributionService {
@@ -498,9 +548,14 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create local Platform MCP lifecycle metadata service: %w", err)
 	}
+	lifecycleVisibility, err := newPlatformMCPLifecycleVisibilityService(config, readiness)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create local Platform MCP lifecycle visibility service: %w", err)
+	}
 	registrations := platformmcp.NewRegistrationService(catalog, registrationGate, store).
 		WithDirectRemoteInspector(platformmcp.NewGuardianDirectRemoteInspector(config.GuardianPolicy)).
 		WithLifecycleMetadata(lifecycleMetadata).
+		WithLifecycleVisibility(lifecycleVisibility).
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1552,6 +1552,7 @@ func newStartCommand() *cli.Command {
 				RemoteChallengeManager: remoteChallengeManager,
 				AuditLogger:            auditLogger,
 				PluginPublisher:        pluginPublisher,
+				TemporalEnv:            temporalEnv,
 				Skills:                 skillsService,
 				Telemetry:              telemetryrepo.New(chDB),
 				TelemetryDrilldown:     telemetryrepo.New(chDB),

--- a/server/internal/externalmcp/catalog.go
+++ b/server/internal/externalmcp/catalog.go
@@ -68,7 +68,6 @@ func registryAdapterKey(sourceType, authProfile string) string {
 }
 
 func zeroRegistry() Registry {
-	//nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 	return Registry{ID: uuid.Nil, URL: ""}
 }
 
@@ -246,7 +245,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 	// out; arbitrary legacy URLs cannot enter the shared catalogue.
 	if legacyPulseSourceMetadataAbsent(row) && strings.TrimRight(row.Url, "/") == "https://api.pulsemcp.com" {
 		return CatalogSource{
-			Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
+			Registry:             Registry{ID: row.ID, URL: row.Url},
 			SourceType:           registrySourceTypePulseV01,
 			AuthProfile:          registryAuthProfilePulseServerCredentials,
 			CertificationVersion: "",
@@ -263,7 +262,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 		priority = row.Priority.Int32
 	}
 	return CatalogSource{
-		Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
+		Registry:             Registry{ID: row.ID, URL: row.Url},
 		SourceType:           row.SourceType.String,
 		AuthProfile:          row.AuthProfile.String,
 		CertificationVersion: row.CertificationVersion.String,

--- a/server/internal/externalmcp/catalog.go
+++ b/server/internal/externalmcp/catalog.go
@@ -68,6 +68,7 @@ func registryAdapterKey(sourceType, authProfile string) string {
 }
 
 func zeroRegistry() Registry {
+	//nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 	return Registry{ID: uuid.Nil, URL: ""}
 }
 
@@ -245,7 +246,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 	// out; arbitrary legacy URLs cannot enter the shared catalogue.
 	if legacyPulseSourceMetadataAbsent(row) && strings.TrimRight(row.Url, "/") == "https://api.pulsemcp.com" {
 		return CatalogSource{
-			Registry:             Registry{ID: row.ID, URL: row.Url},
+			Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 			SourceType:           registrySourceTypePulseV01,
 			AuthProfile:          registryAuthProfilePulseServerCredentials,
 			CertificationVersion: "",
@@ -262,7 +263,7 @@ func catalogSourceFromRow(row repo.ListMCPRegistriesRow) (CatalogSource, bool) {
 		priority = row.Priority.Int32
 	}
 	return CatalogSource{
-		Registry:             Registry{ID: row.ID, URL: row.Url},
+		Registry:             Registry{ID: row.ID, URL: row.Url}, //nolint:exhaustruct // Registry projections intentionally omit unrelated row fields.
 		SourceType:           row.SourceType.String,
 		AuthProfile:          row.AuthProfile.String,
 		CertificationVersion: row.CertificationVersion.String,

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -566,30 +566,11 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 
 	txRepo := repo.New(dbtx)
 
-	var affectedDomainIDs []uuid.UUID
 	if payload.Visibility == VisibilityDisabled {
-		affectedDomainIDs, err = mcpendpointsrepo.New(dbtx).ListCustomDomainIDsByMCPServerID(ctx, mcpendpointsrepo.ListCustomDomainIDsByMCPServerIDParams{
-			McpServerID: serverID,
-			ProjectID:   *authCtx.ProjectID,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "list custom domains for mcp server").LogError(ctx, logger)
+		if err := LockMCPServerVisibilityDependencies(ctx, dbtx, *authCtx.ProjectID, serverID); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "lock mcp server visibility dependencies").LogError(ctx, logger)
 		}
 	}
-
-	if err := lockMcpServerCustomDomains(ctx, dbtx, affectedDomainIDs); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "lock custom domains").LogError(ctx, logger)
-	}
-	if payload.Visibility == VisibilityDisabled {
-		_, err = mcpendpointsrepo.New(dbtx).LockRootMCPEndpointsByMCPServerID(ctx, mcpendpointsrepo.LockRootMCPEndpointsByMCPServerIDParams{
-			McpServerID: serverID,
-			ProjectID:   *authCtx.ProjectID,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "lock root mcp endpoints").LogError(ctx, logger)
-		}
-	}
-
 	existing, err := txRepo.LockMCPServerByIDAndProjectID(ctx, repo.LockMCPServerByIDAndProjectIDParams{
 		ID:        serverID,
 		ProjectID: *authCtx.ProjectID,
@@ -644,7 +625,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		}
 	}
 
-	updated, err := UpdateMCPServerLifecycleInTransaction(ctx, dbtx, s.audit, existing, LifecycleUpdateInput{
+	lifecycleInput := LifecycleUpdateInput{
 		OrganizationID:        authCtx.ActiveOrganizationID,
 		ProjectID:             *authCtx.ProjectID,
 		ActorUserID:           authCtx.UserID,
@@ -659,7 +640,15 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		ToolsetID:             ids.ToolsetID,
 		UnproxiedMcpServerID:  ids.UnproxiedMcpServerID,
 		ToolVariationsGroupID: ids.ToolVariationsGroupID,
-	})
+	}
+	var clearedRootDomainIDs []uuid.UUID
+	var updated repo.McpServer
+	if payload.Visibility == VisibilityDisabled {
+		visibilityResult, updateErr := UpdateMCPServerVisibilityInTransaction(ctx, dbtx, s.audit, existing, lifecycleInput)
+		updated, clearedRootDomainIDs, err = visibilityResult.Server, visibilityResult.ClearedRootDomainIDs, updateErr
+	} else {
+		updated, err = UpdateMCPServerLifecycleInTransaction(ctx, dbtx, s.audit, existing, lifecycleInput)
+	}
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
@@ -679,20 +668,6 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	}
 
 	afterView := mv.BuildMcpServerView(updated)
-
-	var clearedRootEndpoints []mcpendpointsrepo.McpEndpoint
-	if updated.Visibility == VisibilityDisabled {
-		clearedRootEndpoints, err = mcpendpointsrepo.New(dbtx).ClearRootMCPEndpointsByMCPServerID(ctx, mcpendpointsrepo.ClearRootMCPEndpointsByMCPServerIDParams{
-			McpServerID: updated.ID,
-			ProjectID:   *authCtx.ProjectID,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "clear root mcp endpoints").LogError(ctx, logger)
-		}
-		if err := s.logMcpServerRootAutoClears(ctx, dbtx, authCtx, clearedRootEndpoints); err != nil {
-			return nil, err
-		}
-	}
 
 	// A server that was just enabled is publishable if it already has an
 	// endpoint — attach it to the Default plugin so it reaches the
@@ -715,7 +690,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	}
 
 	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
-	if err := s.reconcileMcpServerCustomDomains(ctx, rootDomainIDs(clearedRootEndpoints)); err != nil {
+	if err := s.reconcileMcpServerCustomDomains(ctx, clearedRootDomainIDs); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -601,8 +601,6 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, logger)
 	}
 
-	beforeView := mv.BuildMcpServerView(existing)
-
 	// Only gate on staff when the unproxied backend reference is actually
 	// changing: a non-staff project member with write access must still be
 	// able to manage (rename, re-publish, delete) a server staff already
@@ -646,9 +644,14 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		}
 	}
 
-	updated, err := txRepo.UpdateMCPServer(ctx, repo.UpdateMCPServerParams{
-		Name:                  name,
-		Slug:                  conv.ToPGText(slug),
+	updated, err := UpdateMCPServerLifecycleInTransaction(ctx, dbtx, s.audit, existing, LifecycleUpdateInput{
+		OrganizationID:        authCtx.ActiveOrganizationID,
+		ProjectID:             *authCtx.ProjectID,
+		ActorUserID:           authCtx.UserID,
+		ActorEmail:            authCtx.Email,
+		ServerID:              serverID,
+		Name:                  payload.Name,
+		Visibility:            string(payload.Visibility),
 		EnvironmentID:         ids.EnvironmentID,
 		UserSessionIssuerID:   issuerID,
 		RemoteMcpServerID:     ids.RemoteMcpServerID,
@@ -656,9 +659,6 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		ToolsetID:             ids.ToolsetID,
 		UnproxiedMcpServerID:  ids.UnproxiedMcpServerID,
 		ToolVariationsGroupID: ids.ToolVariationsGroupID,
-		Visibility:            string(payload.Visibility),
-		ID:                    serverID,
-		ProjectID:             *authCtx.ProjectID,
 	})
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -678,35 +678,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
 
-	oldDisplayName := ServerDisplayName(existing)
-	newDisplayName := ServerDisplayName(updated)
-	if oldDisplayName != newDisplayName {
-		if _, err := pluginsrepo.New(dbtx).SyncMcpServerDisplayName(ctx, pluginsrepo.SyncMcpServerDisplayNameParams{
-			NewDisplayName: newDisplayName,
-			ProjectID:      *authCtx.ProjectID,
-			McpServerID:    uuid.NullUUID{UUID: updated.ID, Valid: true},
-			OldDisplayName: oldDisplayName,
-		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "sync plugin server display name").LogError(ctx, logger)
-		}
-	}
-
 	afterView := mv.BuildMcpServerView(updated)
-
-	if err := s.audit.LogMcpServerUpdate(ctx, dbtx, audit.LogMcpServerUpdateEvent{
-		OrganizationID:          authCtx.ActiveOrganizationID,
-		ProjectID:               *authCtx.ProjectID,
-		Actor:                   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName:        authCtx.Email,
-		ActorSlug:               nil,
-		McpServerURN:            urn.NewMcpServer(updated.ID),
-		McpServerName:           conv.FromPGTextOrEmpty[string](updated.Name),
-		McpServerSlug:           conv.FromPGTextOrEmpty[string](updated.Slug),
-		McpServerSnapshotBefore: beforeView,
-		McpServerSnapshotAfter:  afterView,
-	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log mcp server update").LogError(ctx, logger)
-	}
 
 	var clearedRootEndpoints []mcpendpointsrepo.McpEndpoint
 	if updated.Visibility == VisibilityDisabled {

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -567,7 +567,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	txRepo := repo.New(dbtx)
 
 	if payload.Visibility == VisibilityDisabled {
-		if err := LockMCPServerVisibilityDependencies(ctx, dbtx, *authCtx.ProjectID, serverID); err != nil {
+		if err := LockMCPServerVisibilityDependencies(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, serverID); err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "lock mcp server visibility dependencies").LogError(ctx, logger)
 		}
 	}
@@ -852,8 +852,8 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "delete child mcp endpoints").LogError(ctx, logger)
 	}
-	if err := s.logMcpServerRootAutoClears(ctx, dbtx, authCtx, rootEndpoints); err != nil {
-		return err
+	if err := logMCPServerRootAutoClears(ctx, dbtx, s.audit, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID), authCtx.Email, rootEndpoints); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "log automatic root endpoint cleanup").LogError(ctx, logger)
 	}
 
 	for _, endpoint := range deletedEndpoints {
@@ -1050,37 +1050,6 @@ func rootDomainIDs(endpoints []mcpendpointsrepo.McpEndpoint) []uuid.UUID {
 		return strings.Compare(a.String(), b.String())
 	})
 	return result
-}
-
-func (s *Service) logMcpServerRootAutoClears(
-	ctx context.Context,
-	dbtx pgx.Tx,
-	authCtx *contextvalues.AuthContext,
-	rootEndpoints []mcpendpointsrepo.McpEndpoint,
-) error {
-	repository := customdomainsrepo.New(dbtx)
-	for _, endpoint := range rootEndpoints {
-		if !endpoint.CustomDomainID.Valid {
-			continue
-		}
-		domain, err := repository.GetCustomDomainByID(ctx, endpoint.CustomDomainID.UUID)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "load custom domain for root cleanup audit").LogError(ctx, s.logger)
-		}
-		if err := s.audit.LogCustomDomainUpdate(ctx, dbtx, audit.LogCustomDomainUpdateEvent{
-			OrganizationID:             authCtx.ActiveOrganizationID,
-			Actor:                      urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-			ActorDisplayName:           authCtx.Email,
-			ActorSlug:                  nil,
-			CustomDomainURN:            urn.NewCustomDomain(domain.ID),
-			DomainName:                 domain.Domain,
-			CustomDomainSnapshotBefore: mv.BuildCustomDomainView(domain, false, endpoint.ID),
-			CustomDomainSnapshotAfter:  mv.BuildCustomDomainView(domain, false, uuid.Nil),
-		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "log automatic root endpoint cleanup").LogError(ctx, s.logger)
-		}
-	}
-	return nil
 }
 
 func (s *Service) reconcileMcpServerCustomDomains(ctx context.Context, customDomainIDs []uuid.UUID) error {

--- a/server/internal/mcpservers/lifecycle.go
+++ b/server/internal/mcpservers/lifecycle.go
@@ -2,6 +2,7 @@ package mcpservers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -52,9 +53,15 @@ type MCPServerVisibilityResult struct {
 // LockMCPServerVisibilityDependencies preserves the domain -> root endpoint ->
 // MCP-server lock order used by deletion and root-selection paths. Call it before
 // locking the MCP server for a disabling transition.
-func LockMCPServerVisibilityDependencies(ctx context.Context, tx pgx.Tx, projectID, serverID uuid.UUID) error {
-	if tx == nil || projectID == uuid.Nil || serverID == uuid.Nil {
+func LockMCPServerVisibilityDependencies(ctx context.Context, tx pgx.Tx, organizationID string, projectID, serverID uuid.UUID) error {
+	if tx == nil || organizationID == "" || projectID == uuid.Nil || serverID == uuid.Nil {
 		return fmt.Errorf("invalid MCP server visibility lock input")
+	}
+	// Root-selection mutations lock the organization's custom-domain row before
+	// endpoint/server rows. Take that same lock before discovering dependencies so
+	// an endpoint cannot gain a domain after the list but before endpoint locking.
+	if _, err := customdomainsrepo.New(tx).LockCustomDomainByOrganization(ctx, organizationID); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("lock MCP server custom domain: %w", err)
 	}
 	domainIDs, err := mcpendpointsrepo.New(tx).ListCustomDomainIDsByMCPServerID(ctx, mcpendpointsrepo.ListCustomDomainIDsByMCPServerIDParams{McpServerID: serverID, ProjectID: projectID})
 	if err != nil {
@@ -88,14 +95,17 @@ func UpdateMCPServerVisibilityInTransaction(ctx context.Context, tx pgx.Tx, audi
 		if err != nil {
 			return MCPServerVisibilityResult{}, fmt.Errorf("clear MCP server root endpoints: %w", err)
 		}
-		if err := logMCPServerRootAutoClears(ctx, tx, auditLogger, input, cleared); err != nil {
+		if err := logMCPServerRootAutoClears(ctx, tx, auditLogger, input.OrganizationID, urn.NewPrincipal(urn.PrincipalTypeUser, input.ActorUserID), input.ActorEmail, cleared); err != nil {
 			return MCPServerVisibilityResult{}, err
 		}
 	}
 	return MCPServerVisibilityResult{Server: updated, ClearedRootDomainIDs: rootDomainIDs(cleared)}, nil
 }
 
-func logMCPServerRootAutoClears(ctx context.Context, tx pgx.Tx, auditLogger *audit.Logger, input LifecycleUpdateInput, rootEndpoints []mcpendpointsrepo.McpEndpoint) error {
+func logMCPServerRootAutoClears(ctx context.Context, tx pgx.Tx, auditLogger *audit.Logger, organizationID string, actor urn.Principal, actorDisplayName *string, rootEndpoints []mcpendpointsrepo.McpEndpoint) error {
+	if auditLogger == nil || organizationID == "" {
+		return fmt.Errorf("invalid MCP root cleanup audit input")
+	}
 	repository := customdomainsrepo.New(tx)
 	for _, endpoint := range rootEndpoints {
 		if !endpoint.CustomDomainID.Valid {
@@ -106,9 +116,9 @@ func logMCPServerRootAutoClears(ctx context.Context, tx pgx.Tx, auditLogger *aud
 			return fmt.Errorf("load custom domain for MCP root cleanup audit: %w", err)
 		}
 		if err := auditLogger.LogCustomDomainUpdate(ctx, tx, audit.LogCustomDomainUpdateEvent{
-			OrganizationID:             input.OrganizationID,
-			Actor:                      urn.NewPrincipal(urn.PrincipalTypeUser, input.ActorUserID),
-			ActorDisplayName:           input.ActorEmail,
+			OrganizationID:             organizationID,
+			Actor:                      actor,
+			ActorDisplayName:           actorDisplayName,
 			ActorSlug:                  nil,
 			CustomDomainURN:            urn.NewCustomDomain(domain.ID),
 			DomainName:                 domain.Domain,

--- a/server/internal/mcpservers/lifecycle.go
+++ b/server/internal/mcpservers/lifecycle.go
@@ -38,6 +38,8 @@ type LifecycleUpdateInput struct {
 	ToolVariationsGroupID uuid.NullUUID
 }
 
+const maxLifecycleMCPServerNameBytes = 256
+
 // UpdateMCPServerLifecycleInTransaction updates only the name-derived slug and
 // visibility of a locked MCP server. It synchronizes auto-derived plugin display
 // names and writes the normal MCP update audit event, but it never creates,
@@ -50,8 +52,8 @@ func UpdateMCPServerLifecycleInTransaction(ctx context.Context, tx pgx.Tx, audit
 	name := existing.Name
 	if input.Name != nil {
 		trimmed := strings.TrimSpace(*input.Name)
-		if trimmed == "" {
-			return repo.McpServer{}, fmt.Errorf("MCP server name must be non-empty")
+		if trimmed == "" || len(trimmed) > maxLifecycleMCPServerNameBytes || strings.ContainsAny(trimmed, "\r\n") {
+			return repo.McpServer{}, fmt.Errorf("MCP server name must be non-empty, at most %d bytes, and contain no line breaks", maxLifecycleMCPServerNameBytes)
 		}
 		name = conv.ToPGText(trimmed)
 	}

--- a/server/internal/mcpservers/lifecycle.go
+++ b/server/internal/mcpservers/lifecycle.go
@@ -1,0 +1,109 @@
+package mcpservers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/mv"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// LifecycleUpdateInput describes the narrow MCP-server fields shared by
+// dashboard management and Platform MCP lifecycle operations. Backend references
+// are deliberately inherited from the locked server; callers cannot use this
+// command to rewire a server.
+type LifecycleUpdateInput struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	ActorUserID    string
+	ActorEmail     *string
+	ServerID       uuid.UUID
+	Name           *string
+	Visibility     string
+
+	EnvironmentID         uuid.NullUUID
+	UserSessionIssuerID   uuid.NullUUID
+	RemoteMcpServerID     uuid.NullUUID
+	TunneledMcpServerID   uuid.NullUUID
+	ToolsetID             uuid.NullUUID
+	UnproxiedMcpServerID  uuid.NullUUID
+	ToolVariationsGroupID uuid.NullUUID
+}
+
+// UpdateMCPServerLifecycleInTransaction updates only the name-derived slug and
+// visibility of a locked MCP server. It synchronizes auto-derived plugin display
+// names and writes the normal MCP update audit event, but it never creates,
+// removes, or selects a plugin attachment.
+func UpdateMCPServerLifecycleInTransaction(ctx context.Context, tx pgx.Tx, auditLogger *audit.Logger, existing repo.McpServer, input LifecycleUpdateInput) (repo.McpServer, error) {
+	if tx == nil || auditLogger == nil || input.OrganizationID == "" || input.ProjectID == uuid.Nil || input.ActorUserID == "" || input.ServerID == uuid.Nil || existing.ID != input.ServerID || existing.ProjectID != input.ProjectID || input.Visibility == "" {
+		return repo.McpServer{}, fmt.Errorf("invalid MCP server lifecycle update input")
+	}
+
+	name := existing.Name
+	if input.Name != nil {
+		trimmed := strings.TrimSpace(*input.Name)
+		if trimmed == "" {
+			return repo.McpServer{}, fmt.Errorf("MCP server name must be non-empty")
+		}
+		name = conv.ToPGText(trimmed)
+	}
+	slug, err := computeServerSlug(conv.FromPGTextOrEmpty[string](name), existing.ID)
+	if err != nil {
+		return repo.McpServer{}, fmt.Errorf("compute MCP server slug: %w", err)
+	}
+
+	updated, err := repo.New(tx).UpdateMCPServer(ctx, repo.UpdateMCPServerParams{
+		Name:                  name,
+		Slug:                  conv.ToPGText(slug),
+		EnvironmentID:         input.EnvironmentID,
+		UserSessionIssuerID:   input.UserSessionIssuerID,
+		RemoteMcpServerID:     input.RemoteMcpServerID,
+		TunneledMcpServerID:   input.TunneledMcpServerID,
+		ToolsetID:             input.ToolsetID,
+		UnproxiedMcpServerID:  input.UnproxiedMcpServerID,
+		ToolVariationsGroupID: input.ToolVariationsGroupID,
+		Visibility:            input.Visibility,
+		ID:                    existing.ID,
+		ProjectID:             input.ProjectID,
+	})
+	if err != nil {
+		return repo.McpServer{}, fmt.Errorf("update MCP server lifecycle: %w", err)
+	}
+
+	oldDisplayName := ServerDisplayName(existing)
+	newDisplayName := ServerDisplayName(updated)
+	if oldDisplayName != newDisplayName {
+		if _, err := pluginsrepo.New(tx).SyncMcpServerDisplayName(ctx, pluginsrepo.SyncMcpServerDisplayNameParams{
+			NewDisplayName: newDisplayName,
+			ProjectID:      input.ProjectID,
+			McpServerID:    uuid.NullUUID{UUID: updated.ID, Valid: true},
+			OldDisplayName: oldDisplayName,
+		}); err != nil {
+			return repo.McpServer{}, fmt.Errorf("sync MCP server plugin display name: %w", err)
+		}
+	}
+
+	if err := auditLogger.LogMcpServerUpdate(ctx, tx, audit.LogMcpServerUpdateEvent{
+		OrganizationID:          input.OrganizationID,
+		ProjectID:               input.ProjectID,
+		Actor:                   urn.NewPrincipal(urn.PrincipalTypeUser, input.ActorUserID),
+		ActorDisplayName:        input.ActorEmail,
+		ActorSlug:               nil,
+		McpServerURN:            urn.NewMcpServer(updated.ID),
+		McpServerName:           conv.FromPGTextOrEmpty[string](updated.Name),
+		McpServerSlug:           conv.FromPGTextOrEmpty[string](updated.Slug),
+		McpServerSnapshotBefore: mv.BuildMcpServerView(existing),
+		McpServerSnapshotAfter:  mv.BuildMcpServerView(updated),
+	}); err != nil {
+		return repo.McpServer{}, fmt.Errorf("audit MCP server lifecycle update: %w", err)
+	}
+	return updated, nil
+}

--- a/server/internal/mcpservers/lifecycle.go
+++ b/server/internal/mcpservers/lifecycle.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
@@ -39,6 +41,85 @@ type LifecycleUpdateInput struct {
 }
 
 const maxLifecycleMCPServerNameBytes = 256
+
+// MCPServerVisibilityResult reports only the post-update server and root domains
+// that need reconciliation after the caller commits its transaction.
+type MCPServerVisibilityResult struct {
+	Server               repo.McpServer
+	ClearedRootDomainIDs []uuid.UUID
+}
+
+// LockMCPServerVisibilityDependencies preserves the domain -> root endpoint ->
+// MCP-server lock order used by deletion and root-selection paths. Call it before
+// locking the MCP server for a disabling transition.
+func LockMCPServerVisibilityDependencies(ctx context.Context, tx pgx.Tx, projectID, serverID uuid.UUID) error {
+	if tx == nil || projectID == uuid.Nil || serverID == uuid.Nil {
+		return fmt.Errorf("invalid MCP server visibility lock input")
+	}
+	domainIDs, err := mcpendpointsrepo.New(tx).ListCustomDomainIDsByMCPServerID(ctx, mcpendpointsrepo.ListCustomDomainIDsByMCPServerIDParams{McpServerID: serverID, ProjectID: projectID})
+	if err != nil {
+		return fmt.Errorf("list MCP server custom domains: %w", err)
+	}
+	if err := lockMcpServerCustomDomains(ctx, tx, domainIDs); err != nil {
+		return fmt.Errorf("lock MCP server custom domains: %w", err)
+	}
+	if _, err := mcpendpointsrepo.New(tx).LockRootMCPEndpointsByMCPServerID(ctx, mcpendpointsrepo.LockRootMCPEndpointsByMCPServerIDParams{McpServerID: serverID, ProjectID: projectID}); err != nil {
+		return fmt.Errorf("lock MCP server root endpoints: %w", err)
+	}
+	return nil
+}
+
+// UpdateMCPServerVisibilityInTransaction applies the shared visibility state
+// transition without selecting or changing any plugin attachment. Its caller
+// must first lock dependencies through LockMCPServerVisibilityDependencies, then
+// lock the server. It clears roots and audits the automatic route cleanup in the
+// same transaction; callers reconcile returned domains only after commit.
+func UpdateMCPServerVisibilityInTransaction(ctx context.Context, tx pgx.Tx, auditLogger *audit.Logger, existing repo.McpServer, input LifecycleUpdateInput) (MCPServerVisibilityResult, error) {
+	if input.Visibility != VisibilityDisabled && input.Visibility != VisibilityPrivate {
+		return MCPServerVisibilityResult{}, fmt.Errorf("invalid MCP server lifecycle visibility")
+	}
+	updated, err := UpdateMCPServerLifecycleInTransaction(ctx, tx, auditLogger, existing, input)
+	if err != nil {
+		return MCPServerVisibilityResult{}, err
+	}
+	var cleared []mcpendpointsrepo.McpEndpoint
+	if updated.Visibility == VisibilityDisabled {
+		cleared, err = mcpendpointsrepo.New(tx).ClearRootMCPEndpointsByMCPServerID(ctx, mcpendpointsrepo.ClearRootMCPEndpointsByMCPServerIDParams{McpServerID: updated.ID, ProjectID: input.ProjectID})
+		if err != nil {
+			return MCPServerVisibilityResult{}, fmt.Errorf("clear MCP server root endpoints: %w", err)
+		}
+		if err := logMCPServerRootAutoClears(ctx, tx, auditLogger, input, cleared); err != nil {
+			return MCPServerVisibilityResult{}, err
+		}
+	}
+	return MCPServerVisibilityResult{Server: updated, ClearedRootDomainIDs: rootDomainIDs(cleared)}, nil
+}
+
+func logMCPServerRootAutoClears(ctx context.Context, tx pgx.Tx, auditLogger *audit.Logger, input LifecycleUpdateInput, rootEndpoints []mcpendpointsrepo.McpEndpoint) error {
+	repository := customdomainsrepo.New(tx)
+	for _, endpoint := range rootEndpoints {
+		if !endpoint.CustomDomainID.Valid {
+			continue
+		}
+		domain, err := repository.GetCustomDomainByID(ctx, endpoint.CustomDomainID.UUID)
+		if err != nil {
+			return fmt.Errorf("load custom domain for MCP root cleanup audit: %w", err)
+		}
+		if err := auditLogger.LogCustomDomainUpdate(ctx, tx, audit.LogCustomDomainUpdateEvent{
+			OrganizationID:             input.OrganizationID,
+			Actor:                      urn.NewPrincipal(urn.PrincipalTypeUser, input.ActorUserID),
+			ActorDisplayName:           input.ActorEmail,
+			ActorSlug:                  nil,
+			CustomDomainURN:            urn.NewCustomDomain(domain.ID),
+			DomainName:                 domain.Domain,
+			CustomDomainSnapshotBefore: mv.BuildCustomDomainView(domain, false, endpoint.ID),
+			CustomDomainSnapshotAfter:  mv.BuildCustomDomainView(domain, false, uuid.Nil),
+		}); err != nil {
+			return fmt.Errorf("audit MCP root cleanup: %w", err)
+		}
+	}
+	return nil
+}
 
 // UpdateMCPServerLifecycleInTransaction updates only the name-derived slug and
 // visibility of a locked MCP server. It synchronizes auto-derived plugin display

--- a/server/internal/platformmcp/adapters.go
+++ b/server/internal/platformmcp/adapters.go
@@ -285,18 +285,20 @@ func (r *PostgresReadinessRecorder) RecordReady(ctx context.Context, principal P
 }
 
 type PostgresReader struct {
-	logger          *slog.Logger
-	reader          *readmodel.Reader
-	inventory       *platformrepo.Queries
-	inventoryCursor *inventoryCursorCodec
+	logger             *slog.Logger
+	reader             *readmodel.Reader
+	inventory          *platformrepo.Queries
+	inventoryCursor    *inventoryCursorCodec
+	metadataVersionKey []byte
 }
 
 func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
 	return &PostgresReader{
-		logger:          logger.With(attr.SlogComponent("platformmcp")),
-		reader:          readmodel.New(db),
-		inventory:       platformrepo.New(db),
-		inventoryCursor: nil,
+		logger:             logger.With(attr.SlogComponent("platformmcp")),
+		reader:             readmodel.New(db),
+		inventory:          platformrepo.New(db),
+		inventoryCursor:    nil,
+		metadataVersionKey: nil,
 	}
 }
 
@@ -304,6 +306,7 @@ func (r *PostgresReader) setInventoryCursorKey(keyMaterial string) {
 	codec, err := newInventoryCursorCodec(keyMaterial)
 	if err == nil {
 		r.inventoryCursor = codec
+		r.metadataVersionKey = lifecycleMetadataVersionKey(keyMaterial)
 	}
 }
 
@@ -392,7 +395,9 @@ func (r *PostgresReader) FindMCP(ctx context.Context, principal Principal, input
 	}
 	mcps := make([]MCP, 0, len(rows))
 	for _, row := range rows {
-		mcps = append(mcps, mcpFromInventoryRow(row, byRegistration))
+		mcp := mcpFromInventoryRow(row, byRegistration)
+		r.setInventoryVersion(&mcp)
+		mcps = append(mcps, mcp)
 	}
 	if query != "" {
 		return FindMCPOutput{MCPs: inventoryQueryResult(mcps, query, limit), NextCursor: ""}, nil
@@ -455,7 +460,29 @@ func (r *PostgresReader) GetMCP(ctx context.Context, principal Principal, input 
 		}
 		byRegistration = inventoryDistributions(distributions)
 	}
-	return mcpFromInventoryItem(row, byRegistration), nil
+	mcp := mcpFromInventoryItem(row, byRegistration)
+	r.setInventoryVersion(&mcp)
+	return mcp, nil
+}
+
+func (r *PostgresReader) setInventoryVersion(mcp *MCP) {
+	if r == nil || mcp == nil || mcp.Registration == nil || len(r.metadataVersionKey) == 0 {
+		return
+	}
+	mcp.Version = lifecycleMetadataVersion(r.metadataVersionKey, mcp.ID, mcp.ProjectID, inventoryMCPDisplayName(mcp), mcp.Slug, mcp.Visibility)
+}
+
+func inventoryMCPDisplayName(mcp *MCP) string {
+	if mcp == nil {
+		return ""
+	}
+	if mcp.Name != "" {
+		return mcp.Name
+	}
+	if mcp.Slug != "" {
+		return mcp.Slug
+	}
+	return mcp.ID
 }
 
 func (r *PostgresReader) resolveInventoryProject(ctx context.Context, organizationID string, input FindMCPInput) (ResolvedProject, error) {

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -88,6 +88,8 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"get_platform_mcp_onboarding_status",
 		"attach_platform_mcp_identity_provider",
 		"add_platform_mcp_to_default_plugin",
+		"disable_mcp",
+		"enable_mcp",
 	} {
 		require.False(t, admitted[name], "tool %q needs a connection and must not be admitted to the assistant", name)
 	}

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -101,6 +101,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"list_projects",
 		"find_mcp",
 		"get_mcp",
+		"update_mcp_metadata",
 		"register_catalog_mcp",
 		"register_remote_mcp",
 		"search_mcp_catalog",

--- a/server/internal/platformmcp/direct_remote.go
+++ b/server/internal/platformmcp/direct_remote.go
@@ -315,7 +315,6 @@ func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, cl
 					return "available_dcr"
 				}
 				available = true
-				break
 			}
 		}
 	}
@@ -475,7 +474,7 @@ func directRemoteQueryCredentialKey(key string) bool {
 		return true
 	}
 	switch normalized {
-	case "access_token", "api_key", "apikey", "authorization", "credential", "key", "password", "secret", "signature", "sig", "token", "client_secret":
+	case "access_token", "api_key", "apikey", "x_api_key", "xapikey", "authorization", "credential", "key", "password", "secret", "signature", "sig", "token", "client_secret":
 		return true
 	default:
 		return false

--- a/server/internal/platformmcp/direct_remote_test.go
+++ b/server/internal/platformmcp/direct_remote_test.go
@@ -105,7 +105,7 @@ func TestDirectRemoteRequestRejectsOversizedOutboundSessionID(t *testing.T) {
 func TestDirectRemoteOAuthDiscoveryScansForDCR(t *testing.T) {
 	t.Parallel()
 
-	requests := make([]string, 0, 3)
+	requests := make([]string, 0, 4)
 	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
 		requests = append(requests, request.URL.String())
 		switch request.URL.String() {
@@ -122,7 +122,12 @@ func TestDirectRemoteOAuthDiscoveryScansForDCR(t *testing.T) {
 	result := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
 
 	require.Equal(t, "available_dcr", result)
-	require.Len(t, requests, 3)
+	require.Equal(t, []string{
+		"https://remote.example.test/.well-known/oauth-protected-resource/mcp",
+		"https://first.example.test/.well-known/oauth-authorization-server",
+		"https://first.example.test/.well-known/openid-configuration",
+		"https://second.example.test/.well-known/oauth-authorization-server",
+	}, requests)
 }
 
 func TestDirectRemoteOAuthDiscoveryUsesOIDCCompatibleCandidate(t *testing.T) {

--- a/server/internal/platformmcp/distribution_service.go
+++ b/server/internal/platformmcp/distribution_service.go
@@ -521,7 +521,7 @@ func persistDistribution(ctx context.Context, q *repo.Queries, existing repo.Pla
 		OrganizationID:       input.organizationID,
 		ProjectID:            input.projectID,
 		RegistrationID:       input.registrationID,
-		DefaultPluginID:      input.defaultPluginID,
+		DefaultPluginID:      uuid.NullUUID{UUID: input.defaultPluginID, Valid: true},
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return repo.PlatformMcpDistribution{}, ErrDistributionTargetUnavailable

--- a/server/internal/platformmcp/inventory.go
+++ b/server/internal/platformmcp/inventory.go
@@ -151,10 +151,21 @@ func mcpFromInventory(id, projectID uuid.UUID, projectName, projectSlug, name, s
 		if readinessState != "" {
 			mcp.Readiness = MCPReadiness{State: readinessState, CheckedAt: checkedAt, ExpiresAt: expiresAt}
 		}
+		// Disabled MCPs retain historical readiness evidence for audit and later
+		// diagnosis, but it cannot be treated as effective current readiness.
+		if visibility == "disabled" {
+			mcp.Readiness = MCPReadiness{State: "unknown", CheckedAt: "", ExpiresAt: ""}
+		}
 		if registeredDistributions := distributions[registrationID]; registeredDistributions != nil {
 			mcp.Distributions = registeredDistributions
 		}
-		mcp.Operations = []string{"read", "dashboard_setup"}
+		mcp.Operations = []string{"read", "dashboard_setup", "update_mcp_metadata"}
+		switch visibility {
+		case "disabled":
+			mcp.Operations = append(mcp.Operations, "enable_mcp")
+		case "private":
+			mcp.Operations = append(mcp.Operations, "disable_mcp")
+		}
 		mcp.DashboardPath = "dashboard_mcp_settings"
 	case model == "dashboard_managed":
 		mcp.Model = model

--- a/server/internal/platformmcp/inventory.go
+++ b/server/internal/platformmcp/inventory.go
@@ -126,6 +126,7 @@ func mcpFromInventory(id, projectID uuid.UUID, projectName, projectSlug, name, s
 		ProjectSlug:      projectSlug,
 		Name:             name,
 		Slug:             slug,
+		Version:          "",
 		Visibility:       visibility,
 		EffectiveEnabled: visibility != "disabled",
 		Model:            "",

--- a/server/internal/platformmcp/inventory_test.go
+++ b/server/internal/platformmcp/inventory_test.go
@@ -45,6 +45,13 @@ func TestMCPFromInventoryLabelsOwnershipAndNeverProbesLegacy(t *testing.T) {
 	require.Equal(t, "ready", platform.Readiness.State)
 	require.Len(t, platform.Distributions, 1)
 	require.True(t, platform.Registration.ComponentsComplete)
+	require.Equal(t, []string{"read", "dashboard_setup", "update_mcp_metadata", "disable_mcp"}, platform.Operations)
+
+	disabled := mcpFromInventory(mcpID, projectID, "Project", "project", "Reviewed", "reviewed", "disabled", "dashboard_managed", registrationID, "catalog", "registry", "reviewed/server", "registered", complete, complete, complete, complete, "ready", "checked", "expires", nil)
+	require.False(t, disabled.EffectiveEnabled)
+	require.Equal(t, "unknown", disabled.Readiness.State, "disabled Platform-managed MCPs do not expose stale readiness as effective")
+	require.Empty(t, disabled.Readiness.CheckedAt)
+	require.Equal(t, []string{"read", "dashboard_setup", "update_mcp_metadata", "enable_mcp"}, disabled.Operations)
 
 	incomplete := mcpFromInventory(mcpID, projectID, "Project", "project", "Incomplete", "incomplete", "private", "dashboard_managed", registrationID, "catalog", "registry", "reviewed/incomplete", "pending", uuid.NullUUID{UUID: uuid.Nil, Valid: true}, complete, complete, complete, "", "", "", nil)
 	require.False(t, incomplete.Registration.ComponentsComplete, "zero UUID sentinels represent missing persisted components")

--- a/server/internal/platformmcp/inventory_test.go
+++ b/server/internal/platformmcp/inventory_test.go
@@ -63,6 +63,18 @@ func TestMCPFromInventoryLabelsOwnershipAndNeverProbesLegacy(t *testing.T) {
 	require.False(t, legacy.EffectiveEnabled)
 }
 
+func TestLifecycleMetadataVersionChangesOnlyWithMutableInventoryState(t *testing.T) {
+	t.Parallel()
+
+	key := lifecycleMetadataVersionKey("test-key")
+	baseline := lifecycleMetadataVersion(key, "mcp", "project", "Example", "example", "private")
+	require.NotEmpty(t, baseline)
+	require.Equal(t, baseline, lifecycleMetadataVersion(key, "mcp", "project", "Example", "example", "private"))
+	require.NotEqual(t, baseline, lifecycleMetadataVersion(key, "mcp", "project", "Renamed", "example", "private"))
+	require.NotEqual(t, baseline, lifecycleMetadataVersion(key, "mcp", "project", "Example", "example", "disabled"))
+	require.NotEqual(t, baseline, lifecycleMetadataVersion(lifecycleMetadataVersionKey("other-key"), "mcp", "project", "Example", "example", "private"))
+}
+
 func TestInventoryModelRecognizesEveryDashboardBackend(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/lifecycle_metadata.go
+++ b/server/internal/platformmcp/lifecycle_metadata.go
@@ -1,0 +1,274 @@
+package platformmcp
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+const (
+	operationUpdateMCPMetadata   = "update_mcp_metadata"
+	receiptResultMetadataUpdated = "metadata_updated"
+)
+
+var ErrLifecycleMetadataInvalid = errors.New("invalid platform mcp metadata update")
+
+type UpdateMCPMetadataInput struct {
+	ProjectSlug     string
+	RegistrationID  string
+	MCPID           string
+	Name            string
+	ExpectedVersion string
+	IdempotencyKey  string
+}
+
+type UpdateMCPMetadataResult struct {
+	Project        ResolvedProject
+	RegistrationID string
+	MCPID          string
+	Name           string
+	Slug           string
+	Visibility     string
+	Version        string
+	Receipt        OperationReceipt
+}
+
+// LifecycleMetadataService updates the display metadata of a complete
+// Platform-owned MCP registration. It shares the narrow mcpservers transaction
+// command used by dashboard updates, but never selects or changes plugin
+// attachments.
+type LifecycleMetadataService struct {
+	db      *pgxpool.Pool
+	audit   *audit.Logger
+	updater LifecycleMetadataUpdater
+	key     []byte
+	now     func() time.Time
+}
+
+// LifecycleMetadataUpdater is supplied by server composition so Platform MCP
+// invokes the same narrow mcpservers command as the dashboard without importing
+// the dashboard package back into this boundary.
+type LifecycleMetadataUpdater func(ctx context.Context, tx pgx.Tx, existing mcpserversrepo.McpServer, input LifecycleMetadataUpdate) (mcpserversrepo.McpServer, error)
+
+type LifecycleMetadataUpdate struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	ActorUserID    string
+	ServerID       uuid.UUID
+	Name           string
+}
+
+func NewLifecycleMetadataService(db *pgxpool.Pool, auditLogger *audit.Logger, updater LifecycleMetadataUpdater, keyMaterial string) (*LifecycleMetadataService, error) {
+	if db == nil || auditLogger == nil || updater == nil || keyMaterial == "" {
+		return nil, ErrLifecycleMetadataInvalid
+	}
+	return &LifecycleMetadataService{db: db, audit: auditLogger, updater: updater, key: lifecycleMetadataVersionKey(keyMaterial), now: time.Now}, nil
+}
+
+func (s *LifecycleMetadataService) Update(ctx context.Context, principal Principal, input UpdateMCPMetadataInput) (UpdateMCPMetadataResult, error) {
+	if s == nil || s.db == nil || s.audit == nil || s.updater == nil || len(s.key) == 0 || principal.OrganizationID == "" || principal.UserID == "" || input.ProjectSlug == "" || input.RegistrationID == "" || input.MCPID == "" || strings.TrimSpace(input.Name) == "" || input.ExpectedVersion == "" || input.IdempotencyKey == "" {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	if len(input.IdempotencyKey) > 128 {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	registrationID, err := uuid.Parse(input.RegistrationID)
+	if err != nil {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	mcpID, err := uuid.Parse(input.MCPID)
+	if err != nil {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	project, err := NewRegistrationStore(s.db, RegistrationStoreConfig{ActiveRegistrationCap: 1})
+	if err != nil {
+		return UpdateMCPMetadataResult{}, err
+	}
+	resolvedProject, err := project.ResolveProject(ctx, principal.OrganizationID, input.ProjectSlug)
+	if err != nil {
+		return UpdateMCPMetadataResult{}, err
+	}
+	inputHash := lifecycleMetadataInputHash(resolvedProject.ID, registrationID, mcpID, strings.TrimSpace(input.Name), input.ExpectedVersion)
+	connectionID, generation, err := principalConnection(principal)
+	if err != nil {
+		return UpdateMCPMetadataResult{}, err
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("begin platform mcp metadata update: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := platformrepo.New(tx)
+	receiptLookup := platformrepo.GetPlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID,
+		UserID:         conv.ToPGText(principal.UserID),
+		SubjectUrn:     userSubjectURN(principal.UserID),
+		ProjectID:      resolvedProject.ID,
+		Operation:      operationUpdateMCPMetadata,
+		IdempotencyKey: input.IdempotencyKey,
+	}
+	if err := q.LockPlatformMCPOperationReceipt(ctx, platformrepo.LockPlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID,
+		SubjectUrn:     userSubjectURN(principal.UserID),
+		ProjectID:      resolvedProject.ID.String(),
+		Operation:      operationUpdateMCPMetadata,
+		IdempotencyKey: input.IdempotencyKey,
+	}); err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("lock platform mcp metadata receipt: %w", err)
+	}
+	if _, err := q.DeleteExpiredPlatformMCPOperationReceipt(ctx, platformrepo.DeleteExpiredPlatformMCPOperationReceiptParams(receiptLookup)); err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("reclaim platform mcp metadata receipt: %w", err)
+	}
+	storedReceipt, err := q.GetPlatformMCPOperationReceipt(ctx, receiptLookup)
+	if err == nil {
+		if storedReceipt.InputHash != inputHash {
+			return UpdateMCPMetadataResult{}, ErrRegistrationConflict
+		}
+		if storedReceipt.Status != receiptStatusSucceeded || !storedReceipt.RegistrationID.Valid || storedReceipt.RegistrationID.UUID != registrationID {
+			return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+		}
+		result, err := s.currentResult(ctx, principal, resolvedProject, registrationID, mcpID, operationReceiptFromRow(storedReceipt, true))
+		if err != nil {
+			return UpdateMCPMetadataResult{}, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return UpdateMCPMetadataResult{}, fmt.Errorf("commit platform mcp metadata replay: %w", err)
+		}
+		return result, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("load platform mcp metadata receipt: %w", err)
+	}
+
+	registration, err := lifecycleRegistration(ctx, q, principal, resolvedProject.ID, registrationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	if err != nil {
+		return UpdateMCPMetadataResult{}, err
+	}
+	if registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	server, err := mcpserversrepo.New(tx).LockMCPServerByIDAndProjectID(ctx, mcpserversrepo.LockMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: resolvedProject.ID})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	if err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("lock platform mcp metadata target: %w", err)
+	}
+	if !s.validVersion(server, input.ExpectedVersion) {
+		return UpdateMCPMetadataResult{}, ErrRegistrationConflict
+	}
+
+	receipt, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{
+		OrganizationID:       principal.OrganizationID,
+		ProjectID:            resolvedProject.ID,
+		RegistrationID:       uuid.NullUUID{UUID: registrationID, Valid: true},
+		ConnectionID:         connectionID,
+		ConnectionGeneration: generation,
+		UserID:               conv.ToPGText(principal.UserID),
+		ActingSurface:        conv.ToPGText(string(principal.surface())),
+		Operation:            operationUpdateMCPMetadata,
+		IdempotencyKey:       input.IdempotencyKey,
+		InputHash:            inputHash,
+		Status:               receiptStatusPending,
+		ResultCode:           pgtype.Text{String: "", Valid: false},
+		ExpiresAt:            pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	if err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("create platform mcp metadata receipt: %w", err)
+	}
+	updated, err := s.updater(ctx, tx, server, LifecycleMetadataUpdate{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      resolvedProject.ID,
+		ActorUserID:    principal.UserID,
+		ServerID:       mcpID,
+		Name:           strings.TrimSpace(input.Name),
+	})
+	if err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("update platform mcp metadata: %w", err)
+	}
+	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{
+		RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true},
+		Status:         receiptStatusSucceeded,
+		ResultCode:     conv.ToPGText(receiptResultMetadataUpdated),
+		ID:             receipt.ID,
+		OrganizationID: principal.OrganizationID,
+	})
+	if err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("complete platform mcp metadata receipt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("commit platform mcp metadata update: %w", err)
+	}
+	return UpdateMCPMetadataResult{
+		Project: resolvedProject, RegistrationID: registrationID.String(), MCPID: updated.ID.String(), Name: lifecycleMCPDisplayName(updated), Slug: updated.Slug.String, Visibility: updated.Visibility, Version: s.version(updated), Receipt: operationReceiptFromRow(completed, false),
+	}, nil
+}
+
+func (s *LifecycleMetadataService) currentResult(ctx context.Context, principal Principal, project ResolvedProject, registrationID, mcpID uuid.UUID, receipt OperationReceipt) (UpdateMCPMetadataResult, error) {
+	registration, err := lifecycleRegistration(ctx, platformrepo.New(s.db), principal, project.ID, registrationID)
+	if err != nil || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	server, err := mcpserversrepo.New(s.db).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: project.ID})
+	if err != nil {
+		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
+	}
+	return UpdateMCPMetadataResult{Project: project, RegistrationID: registrationID.String(), MCPID: mcpID.String(), Name: lifecycleMCPDisplayName(server), Slug: server.Slug.String, Visibility: server.Visibility, Version: s.version(server), Receipt: receipt}, nil
+}
+
+func (s *LifecycleMetadataService) version(server mcpserversrepo.McpServer) string {
+	return lifecycleMetadataVersion(s.key, server.ID.String(), server.ProjectID.String(), lifecycleMCPDisplayName(server), server.Slug.String, server.Visibility)
+}
+
+func (s *LifecycleMetadataService) validVersion(server mcpserversrepo.McpServer, value string) bool {
+	return hmac.Equal([]byte(s.version(server)), []byte(value))
+}
+
+func lifecycleMetadataInputHash(projectID, registrationID, mcpID uuid.UUID, name, version string) string {
+	digest := sha256.Sum256([]byte(strings.Join([]string{projectID.String(), registrationID.String(), mcpID.String(), name, version}, "\x00")))
+	return base64.RawURLEncoding.EncodeToString(digest[:])
+}
+
+// lifecycleMetadataVersion is an opaque optimistic-concurrency token over the
+// persisted fields this D1 slice can change. It is not an authorization token;
+// live authorization and registration ownership are always checked separately.
+func lifecycleMetadataVersionKey(keyMaterial string) []byte {
+	digest := sha256.Sum256([]byte("platform-mcp-lifecycle-metadata:" + keyMaterial))
+	return digest[:]
+}
+
+func lifecycleMetadataVersion(key []byte, mcpID, projectID, name, slug, visibility string) string {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(strings.Join([]string{mcpID, projectID, name, slug, visibility}, "\x00")))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func lifecycleMCPDisplayName(server mcpserversrepo.McpServer) string {
+	if server.Name.Valid && server.Name.String != "" {
+		return server.Name.String
+	}
+	if server.Slug.Valid && server.Slug.String != "" {
+		return server.Slug.String
+	}
+	return server.ID.String()
+}

--- a/server/internal/platformmcp/lifecycle_metadata.go
+++ b/server/internal/platformmcp/lifecycle_metadata.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
@@ -55,7 +54,6 @@ type UpdateMCPMetadataResult struct {
 // attachments.
 type LifecycleMetadataService struct {
 	db      *pgxpool.Pool
-	audit   *audit.Logger
 	updater LifecycleMetadataUpdater
 	key     []byte
 	now     func() time.Time
@@ -74,15 +72,15 @@ type LifecycleMetadataUpdate struct {
 	Name           string
 }
 
-func NewLifecycleMetadataService(db *pgxpool.Pool, auditLogger *audit.Logger, updater LifecycleMetadataUpdater, keyMaterial string) (*LifecycleMetadataService, error) {
-	if db == nil || auditLogger == nil || updater == nil || keyMaterial == "" {
+func NewLifecycleMetadataService(db *pgxpool.Pool, updater LifecycleMetadataUpdater, keyMaterial string) (*LifecycleMetadataService, error) {
+	if db == nil || updater == nil || keyMaterial == "" {
 		return nil, ErrLifecycleMetadataInvalid
 	}
-	return &LifecycleMetadataService{db: db, audit: auditLogger, updater: updater, key: lifecycleMetadataVersionKey(keyMaterial), now: time.Now}, nil
+	return &LifecycleMetadataService{db: db, updater: updater, key: lifecycleMetadataVersionKey(keyMaterial), now: time.Now}, nil
 }
 
 func (s *LifecycleMetadataService) Update(ctx context.Context, principal Principal, input UpdateMCPMetadataInput) (UpdateMCPMetadataResult, error) {
-	if s == nil || s.db == nil || s.audit == nil || s.updater == nil || len(s.key) == 0 || principal.OrganizationID == "" || principal.UserID == "" || input.ProjectSlug == "" || input.RegistrationID == "" || input.MCPID == "" || strings.TrimSpace(input.Name) == "" || input.ExpectedVersion == "" || input.IdempotencyKey == "" {
+	if s == nil || s.db == nil || s.updater == nil || len(s.key) == 0 || principal.OrganizationID == "" || principal.UserID == "" || input.ProjectSlug == "" || input.RegistrationID == "" || input.MCPID == "" || strings.TrimSpace(input.Name) == "" || len(strings.TrimSpace(input.Name)) > 256 || strings.ContainsAny(input.Name, "\r\n") || input.ExpectedVersion == "" || input.IdempotencyKey == "" {
 		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
 	}
 	if len(input.IdempotencyKey) > 128 {
@@ -164,7 +162,7 @@ func (s *LifecycleMetadataService) Update(ctx context.Context, principal Princip
 	if err != nil {
 		return UpdateMCPMetadataResult{}, err
 	}
-	if registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+	if registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.RemoteMcpServerOwned || !registration.UserSessionIssuerOwned || !registration.McpServerOwned || !registration.McpEndpointOwned || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
 		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
 	}
 	server, err := mcpserversrepo.New(tx).LockMCPServerByIDAndProjectID(ctx, mcpserversrepo.LockMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: resolvedProject.ID})
@@ -226,7 +224,7 @@ func (s *LifecycleMetadataService) Update(ctx context.Context, principal Princip
 
 func (s *LifecycleMetadataService) currentResult(ctx context.Context, principal Principal, project ResolvedProject, registrationID, mcpID uuid.UUID, receipt OperationReceipt) (UpdateMCPMetadataResult, error) {
 	registration, err := lifecycleRegistration(ctx, platformrepo.New(s.db), principal, project.ID, registrationID)
-	if err != nil || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+	if err != nil || registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.RemoteMcpServerOwned || !registration.UserSessionIssuerOwned || !registration.McpServerOwned || !registration.McpEndpointOwned || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
 		return UpdateMCPMetadataResult{}, ErrLifecycleMetadataInvalid
 	}
 	server, err := mcpserversrepo.New(s.db).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: project.ID})

--- a/server/internal/platformmcp/lifecycle_visibility.go
+++ b/server/internal/platformmcp/lifecycle_visibility.go
@@ -1,0 +1,220 @@
+package platformmcp
+
+import (
+	"context"
+	"crypto/hmac"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+const (
+	operationDisableMCP = "disable_mcp"
+	operationEnableMCP  = "enable_mcp"
+)
+
+var ErrLifecycleVisibilityInvalid = errors.New("invalid platform mcp visibility update")
+
+type UpdateMCPVisibilityInput struct {
+	ProjectSlug     string
+	RegistrationID  string
+	MCPID           string
+	ExpectedVersion string
+	IdempotencyKey  string
+}
+
+type UpdateMCPVisibilityResult struct {
+	Project        ResolvedProject
+	RegistrationID string
+	MCPID          string
+	Visibility     string
+	Version        string
+	Receipt        OperationReceipt
+	Readiness      MCPReadiness
+	Published      bool
+}
+
+// LifecycleVisibilityLocker is composed from mcpservers to preserve its domain
+// -> root endpoint -> MCP server lock order before the Platform service locks
+// the target server.
+type LifecycleVisibilityLocker func(context.Context, pgx.Tx, uuid.UUID, uuid.UUID) error
+
+// LifecycleVisibilityUpdater is composed from mcpservers so Platform MCP uses
+// the same transactional visibility/audit primitive as the dashboard while
+// intentionally bypassing dashboard-only attach-to-Default behavior.
+type LifecycleVisibilityUpdater func(context.Context, pgx.Tx, mcpserversrepo.McpServer, LifecycleVisibilityUpdate) (LifecycleVisibilityUpdateResult, error)
+
+type LifecycleVisibilityUpdateResult struct {
+	Server               mcpserversrepo.McpServer
+	ClearedRootDomainIDs []uuid.UUID
+}
+
+type LifecycleVisibilityUpdate struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	ActorUserID    string
+	ServerID       uuid.UUID
+	Visibility     string
+}
+
+type LifecycleVisibilityService struct {
+	db        *pgxpool.Pool
+	audit     *audit.Logger
+	locker    LifecycleVisibilityLocker
+	updater   LifecycleVisibilityUpdater
+	publisher ProjectPublisher
+	reconcile func(context.Context, []uuid.UUID) error
+	readiness *ReadinessService
+	key       []byte
+	now       func() time.Time
+}
+
+func NewLifecycleVisibilityService(db *pgxpool.Pool, auditLogger *audit.Logger, locker LifecycleVisibilityLocker, updater LifecycleVisibilityUpdater, publisher ProjectPublisher, reconcile func(context.Context, []uuid.UUID) error, readiness *ReadinessService, keyMaterial string) (*LifecycleVisibilityService, error) {
+	if db == nil || auditLogger == nil || locker == nil || updater == nil || reconcile == nil || readiness == nil || keyMaterial == "" {
+		return nil, ErrLifecycleVisibilityInvalid
+	}
+	return &LifecycleVisibilityService{db: db, audit: auditLogger, locker: locker, updater: updater, publisher: publisher, reconcile: reconcile, readiness: readiness, key: lifecycleMetadataVersionKey(keyMaterial), now: time.Now}, nil
+}
+
+func (s *LifecycleVisibilityService) Disable(ctx context.Context, principal Principal, input UpdateMCPVisibilityInput) (UpdateMCPVisibilityResult, error) {
+	return s.update(ctx, principal, input, "private", "disabled", operationDisableMCP)
+}
+
+func (s *LifecycleVisibilityService) Enable(ctx context.Context, principal Principal, input UpdateMCPVisibilityInput) (UpdateMCPVisibilityResult, error) {
+	return s.update(ctx, principal, input, "disabled", "private", operationEnableMCP)
+}
+
+func (s *LifecycleVisibilityService) update(ctx context.Context, principal Principal, input UpdateMCPVisibilityInput, from, to, operation string) (UpdateMCPVisibilityResult, error) {
+	if s == nil || s.db == nil || s.audit == nil || s.updater == nil || s.readiness == nil || len(s.key) == 0 || principal.OrganizationID == "" || principal.UserID == "" || input.ProjectSlug == "" || input.RegistrationID == "" || input.MCPID == "" || input.ExpectedVersion == "" || input.IdempotencyKey == "" || len(input.IdempotencyKey) > 128 {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	}
+	registrationID, err := uuid.Parse(input.RegistrationID)
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	}
+	mcpID, err := uuid.Parse(input.MCPID)
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	}
+	store, err := NewRegistrationStore(s.db, RegistrationStoreConfig{ActiveRegistrationCap: 1})
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, err
+	}
+	project, err := store.ResolveProject(ctx, principal.OrganizationID, input.ProjectSlug)
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, err
+	}
+	inputHash := lifecycleVisibilityInputHash(project.ID, registrationID, mcpID, input.ExpectedVersion, operation)
+	connectionID, generation, err := principalConnection(principal)
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, err
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("begin platform mcp visibility update: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := platformrepo.New(tx)
+	receiptLookup := platformrepo.GetPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID, Operation: operation, IdempotencyKey: input.IdempotencyKey}
+	if err := q.LockPlatformMCPOperationReceipt(ctx, platformrepo.LockPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID.String(), Operation: operation, IdempotencyKey: input.IdempotencyKey}); err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("lock platform mcp visibility receipt: %w", err)
+	}
+	if _, err := q.DeleteExpiredPlatformMCPOperationReceipt(ctx, platformrepo.DeleteExpiredPlatformMCPOperationReceiptParams(receiptLookup)); err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("reclaim platform mcp visibility receipt: %w", err)
+	}
+	storedReceipt, err := q.GetPlatformMCPOperationReceipt(ctx, receiptLookup)
+	if err == nil {
+		if storedReceipt.InputHash != inputHash || storedReceipt.Status != receiptStatusSucceeded || !storedReceipt.RegistrationID.Valid || storedReceipt.RegistrationID.UUID != registrationID {
+			return UpdateMCPVisibilityResult{}, ErrRegistrationConflict
+		}
+		result, err := s.current(ctx, principal, project, registrationID, mcpID, operationReceiptFromRow(storedReceipt, true))
+		if err != nil {
+			return UpdateMCPVisibilityResult{}, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return UpdateMCPVisibilityResult{}, fmt.Errorf("commit platform mcp visibility replay: %w", err)
+		}
+		return result, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("load platform mcp visibility receipt: %w", err)
+	}
+
+	registration, err := lifecycleRegistration(ctx, q, principal, project.ID, registrationID)
+	if err != nil || registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	}
+	if to == "disabled" {
+		if err := s.locker(ctx, tx, project.ID, mcpID); err != nil {
+			return UpdateMCPVisibilityResult{}, fmt.Errorf("lock platform mcp visibility dependencies: %w", err)
+		}
+	}
+	server, err := mcpserversrepo.New(tx).LockMCPServerByIDAndProjectID(ctx, mcpserversrepo.LockMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: project.ID})
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	}
+	if server.Visibility != from || !hmac.Equal([]byte(lifecycleMetadataVersion(s.key, server.ID.String(), server.ProjectID.String(), lifecycleMCPDisplayName(server), server.Slug.String, server.Visibility)), []byte(input.ExpectedVersion)) {
+		return UpdateMCPVisibilityResult{}, ErrRegistrationConflict
+	}
+	receipt, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, ConnectionID: connectionID, ConnectionGeneration: generation, UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: operation, IdempotencyKey: input.IdempotencyKey, InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ExpiresAt: pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true}})
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("create platform mcp visibility receipt: %w", err)
+	}
+	visibilityResult, err := s.updater(ctx, tx, server, LifecycleVisibilityUpdate{OrganizationID: principal.OrganizationID, ProjectID: project.ID, ActorUserID: principal.UserID, ServerID: mcpID, Visibility: to})
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("update platform mcp visibility: %w", err)
+	}
+	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText(to), ID: receipt.ID, OrganizationID: principal.OrganizationID})
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("complete platform mcp visibility receipt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("commit platform mcp visibility update: %w", err)
+	}
+
+	updated := visibilityResult.Server
+	result := UpdateMCPVisibilityResult{Project: project, RegistrationID: registrationID.String(), MCPID: updated.ID.String(), Visibility: updated.Visibility, Version: lifecycleMetadataVersion(s.key, updated.ID.String(), updated.ProjectID.String(), lifecycleMCPDisplayName(updated), updated.Slug.String, updated.Visibility), Receipt: operationReceiptFromRow(completed, false), Readiness: MCPReadiness{State: "unknown", CheckedAt: "", ExpiresAt: ""}, Published: false}
+	if err := s.reconcile(ctx, visibilityResult.ClearedRootDomainIDs); err != nil {
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("reconcile platform mcp custom domains: %w", err)
+	}
+	if to == "private" {
+		// Visibility has already committed. Readiness is an observed post-commit
+		// outcome, so a transient probe failure must not make the completed enable
+		// look uncommitted or consume its idempotency receipt as an error.
+		_, readiness, found, readinessErr := s.readiness.GetReadiness(ctx, principal, project.Slug, registrationID.String(), true)
+		if readinessErr == nil && found {
+			result.Readiness = MCPReadiness{State: string(readiness.State), CheckedAt: readinessTimestamp(readiness.CheckedAt), ExpiresAt: readinessTimestamp(readiness.ExpiresAt)}
+		}
+	}
+	if s.publisher != nil {
+		result.Published = s.publisher(ctx, project.ID, principal.UserID, "Update Platform MCP visibility") == nil
+	}
+	return result, nil
+}
+
+func (s *LifecycleVisibilityService) current(ctx context.Context, principal Principal, project ResolvedProject, registrationID, mcpID uuid.UUID, receipt OperationReceipt) (UpdateMCPVisibilityResult, error) {
+	registration, err := lifecycleRegistration(ctx, platformrepo.New(s.db), principal, project.ID, registrationID)
+	if err != nil || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	}
+	server, err := mcpserversrepo.New(s.db).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: project.ID})
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	}
+	return UpdateMCPVisibilityResult{Project: project, RegistrationID: registrationID.String(), MCPID: mcpID.String(), Visibility: server.Visibility, Version: lifecycleMetadataVersion(s.key, server.ID.String(), server.ProjectID.String(), lifecycleMCPDisplayName(server), server.Slug.String, server.Visibility), Receipt: receipt, Readiness: MCPReadiness{State: "unknown", CheckedAt: "", ExpiresAt: ""}, Published: false}, nil
+}
+
+func lifecycleVisibilityInputHash(projectID, registrationID, mcpID uuid.UUID, version, operation string) string {
+	return lifecycleMetadataInputHash(projectID, registrationID, mcpID, operation, version)
+}

--- a/server/internal/platformmcp/lifecycle_visibility.go
+++ b/server/internal/platformmcp/lifecycle_visibility.go
@@ -23,7 +23,10 @@ const (
 	operationEnableMCP  = "enable_mcp"
 )
 
-var ErrLifecycleVisibilityInvalid = errors.New("invalid platform mcp visibility update")
+var (
+	ErrLifecycleVisibilityInvalid     = errors.New("invalid platform mcp visibility update")
+	ErrLifecycleVisibilityUnavailable = errors.New("platform mcp visibility is unavailable for this target")
+)
 
 type UpdateMCPVisibilityInput struct {
 	ProjectSlug     string
@@ -47,7 +50,7 @@ type UpdateMCPVisibilityResult struct {
 // LifecycleVisibilityLocker is composed from mcpservers to preserve its domain
 // -> root endpoint -> MCP server lock order before the Platform service locks
 // the target server.
-type LifecycleVisibilityLocker func(context.Context, pgx.Tx, uuid.UUID, uuid.UUID) error
+type LifecycleVisibilityLocker func(context.Context, pgx.Tx, string, uuid.UUID, uuid.UUID) error
 
 // LifecycleVisibilityUpdater is composed from mcpservers so Platform MCP uses
 // the same transactional visibility/audit primitive as the dashboard while
@@ -152,17 +155,26 @@ func (s *LifecycleVisibilityService) update(ctx context.Context, principal Princ
 	}
 
 	registration, err := lifecycleRegistration(ctx, q, principal, project.ID, registrationID)
-	if err != nil || registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
-		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	if errors.Is(err, pgx.ErrNoRows) {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityUnavailable
+	}
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, err
+	}
+	if registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityUnavailable
 	}
 	if to == "disabled" {
-		if err := s.locker(ctx, tx, project.ID, mcpID); err != nil {
+		if err := s.locker(ctx, tx, principal.OrganizationID, project.ID, mcpID); err != nil {
 			return UpdateMCPVisibilityResult{}, fmt.Errorf("lock platform mcp visibility dependencies: %w", err)
 		}
 	}
 	server, err := mcpserversrepo.New(tx).LockMCPServerByIDAndProjectID(ctx, mcpserversrepo.LockMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: project.ID})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityUnavailable
+	}
 	if err != nil {
-		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+		return UpdateMCPVisibilityResult{}, fmt.Errorf("lock platform mcp visibility target: %w", err)
 	}
 	if server.Visibility != from || !hmac.Equal([]byte(lifecycleMetadataVersion(s.key, server.ID.String(), server.ProjectID.String(), lifecycleMCPDisplayName(server), server.Slug.String, server.Visibility)), []byte(input.ExpectedVersion)) {
 		return UpdateMCPVisibilityResult{}, ErrRegistrationConflict
@@ -205,8 +217,14 @@ func (s *LifecycleVisibilityService) update(ctx context.Context, principal Princ
 
 func (s *LifecycleVisibilityService) current(ctx context.Context, principal Principal, project ResolvedProject, registrationID, mcpID uuid.UUID, receipt OperationReceipt) (UpdateMCPVisibilityResult, error) {
 	registration, err := lifecycleRegistration(ctx, platformrepo.New(s.db), principal, project.ID, registrationID)
-	if err != nil || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
-		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityInvalid
+	if errors.Is(err, pgx.ErrNoRows) {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityUnavailable
+	}
+	if err != nil {
+		return UpdateMCPVisibilityResult{}, err
+	}
+	if registration.Status != registrationStatusRegistered || !registrationComponentsComplete(registration) || !registration.McpServerID.Valid || registration.McpServerID.UUID != mcpID {
+		return UpdateMCPVisibilityResult{}, ErrLifecycleVisibilityUnavailable
 	}
 	server, err := mcpserversrepo.New(s.db).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{ID: mcpID, ProjectID: project.ID})
 	if err != nil {

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -24,6 +24,8 @@ const (
 	DocsOrganizationLimitName         = "platform-mcp-docs-organization"
 	SkillsConnectionLimitName         = "platform-mcp-skills-connection"
 	SkillsOrganizationLimitName       = "platform-mcp-skills-organization"
+	LifecycleConnectionLimitName      = "platform-mcp-lifecycle-connection"
+	LifecycleOrganizationLimitName    = "platform-mcp-lifecycle-organization"
 )
 
 const (
@@ -147,7 +149,8 @@ type OperationBudgets struct {
 	// obtain the version token its next write needs, and metering the read
 	// separately would only let a loop spend twice as much reaching the same
 	// write.
-	Skills OperationBudget
+	Skills            OperationBudget
+	LifecycleMetadata OperationBudget
 	// Diagnostics meters the observability reads. They are bounded aggregate
 	// queries over Gram-owned telemetry, so the cost being metered is the
 	// ClickHouse scan, not an external egress.
@@ -211,5 +214,5 @@ func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, l
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.DrilldownVolume.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -120,7 +120,8 @@ func (b OperationBudget) Allow(ctx context.Context, principal Principal) error {
 // External Platform MCP calls are isolated by their OAuth connection. A managed
 // assistant has no connection, so it is isolated by its fixed client identity
 // and the real user that authorized the action; it never pools all assistants
-// into one empty-key bucket.
+// into one empty-key bucket. A dashboard setup handoff has no OAuth connection
+// either, so it receives its own user-scoped bucket.
 func operationBudgetActorKey(principal Principal) (string, error) {
 	if principal.HasConnection() {
 		if principal.ConnectionID == "" {
@@ -128,10 +129,20 @@ func operationBudgetActorKey(principal Principal) (string, error) {
 		}
 		return principal.ConnectionID, nil
 	}
-	if principal.surface() != SurfaceProjectAssistant || principal.ClientID == "" || principal.UserID == "" {
+	if principal.UserID == "" {
 		return "", ErrOperationBudgetUnavailable
 	}
-	return "assistant:" + principal.ClientID + ":" + principal.UserID, nil
+	switch principal.surface() {
+	case SurfaceProjectAssistant:
+		if principal.ClientID == "" {
+			return "", ErrOperationBudgetUnavailable
+		}
+		return "assistant:" + principal.ClientID + ":" + principal.UserID, nil
+	case SurfaceDashboard:
+		return "dashboard:" + principal.UserID, nil
+	default:
+		return "", ErrOperationBudgetUnavailable
+	}
 }
 
 // OperationBudgets groups the independently metered public Platform MCP

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -59,6 +59,18 @@ func TestOperationBudgetMetersAConnectionlessAssistantByUser(t *testing.T) {
 	require.Equal(t, []string{"organization"}, organization.keys)
 }
 
+func TestOperationBudgetMetersAConnectionlessDashboardByUser(t *testing.T) {
+	t.Parallel()
+
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	err := (OperationBudget{Connection: connection, Organization: organization}).Allow(t.Context(), Principal{UserID: "user", OrganizationID: "organization", Surface: SurfaceDashboard})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"dashboard:user"}, connection.keys)
+	require.Equal(t, []string{"organization"}, organization.keys)
+}
+
 func TestOperationBudgetThrottlesAConnectionlessAssistantBeforeOrganization(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -1444,7 +1444,7 @@ SELECT EXISTS (
       AND project.organization_id = distribution.organization_id
       AND project.deleted IS FALSE
      JOIN plugins AS plugin
-       ON plugin.id = distribution.default_plugin_id
+       ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
       AND plugin.organization_id = distribution.organization_id
       AND plugin.project_id = distribution.project_id
       AND plugin.is_default IS TRUE
@@ -1483,7 +1483,7 @@ JOIN projects AS project
   AND registration.organization_id = distribution.organization_id
   AND registration.deleted IS FALSE
  JOIN plugins AS plugin
-   ON plugin.id = distribution.default_plugin_id
+   ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
   AND plugin.organization_id = distribution.organization_id
   AND plugin.project_id = distribution.project_id
   AND plugin.is_default IS TRUE
@@ -1703,7 +1703,7 @@ SELECT EXISTS (
       AND registration.project_id = distribution.project_id
       AND registration.deleted IS FALSE
      JOIN plugins AS plugin
-       ON plugin.id = distribution.default_plugin_id
+       ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
       AND plugin.organization_id = distribution.organization_id
       AND plugin.project_id = distribution.project_id
       AND plugin.is_default IS TRUE
@@ -1728,7 +1728,7 @@ SELECT EXISTS (
       AND project.organization_id = distribution.organization_id
       AND project.deleted IS FALSE
      JOIN plugins AS plugin
-       ON plugin.id = distribution.default_plugin_id
+       ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
       AND plugin.organization_id = distribution.organization_id
       AND plugin.project_id = distribution.project_id
       AND plugin.is_default IS TRUE

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -1284,6 +1284,9 @@ SELECT pg_advisory_xact_lock(
 );
 
 -- name: GetPlatformMCPDistribution :one
+-- This is a neutral desired-state lookup used by inventory and write paths.
+-- Default-only mutations revalidate plugins.is_default in their write queries;
+-- inventory intentionally projects COALESCE(plugin_id, default_plugin_id).
 SELECT distribution.*
 FROM platform_mcp_distributions AS distribution
 JOIN projects AS project
@@ -1301,6 +1304,7 @@ INSERT INTO platform_mcp_distributions (
     project_id,
     registration_id,
     default_plugin_id,
+    plugin_id,
     plugin_server_id,
     state,
     version,
@@ -1312,6 +1316,7 @@ SELECT
     @organization_id,
     @project_id,
     @registration_id,
+    @default_plugin_id,
     @default_plugin_id,
     @plugin_server_id,
     @state,
@@ -1346,7 +1351,8 @@ RETURNING *;
 
 -- name: UpdatePlatformMCPDistribution :one
 UPDATE platform_mcp_distributions
-SET plugin_server_id = @plugin_server_id,
+SET plugin_id = @default_plugin_id,
+    plugin_server_id = @plugin_server_id,
     state = @state,
     version = @version,
     attachment_was_created = @attachment_was_created,
@@ -1422,6 +1428,8 @@ WHERE platform_mcp_distributions.id = @id
 RETURNING *;
 
 -- name: HasPlatformMCPSelectedUseEvidence :one
+-- Selected-use credit remains Default-only until the exact-plugin contract is
+-- live, so a future named distribution cannot produce onboarding evidence.
 SELECT EXISTS (
     SELECT 1
     FROM platform_mcp_selected_use_evidence AS evidence
@@ -1431,11 +1439,17 @@ SELECT EXISTS (
      AND distribution.registration_id = evidence.registration_id
      AND distribution.version = evidence.distribution_version
      AND distribution.state = 'attached'
-    JOIN projects AS project
-      ON project.id = distribution.project_id
-     AND project.organization_id = distribution.organization_id
-     AND project.deleted IS FALSE
-    JOIN platform_mcp_connections AS connection
+     JOIN projects AS project
+       ON project.id = distribution.project_id
+      AND project.organization_id = distribution.organization_id
+      AND project.deleted IS FALSE
+     JOIN plugins AS plugin
+       ON plugin.id = distribution.default_plugin_id
+      AND plugin.organization_id = distribution.organization_id
+      AND plugin.project_id = distribution.project_id
+      AND plugin.is_default IS TRUE
+      AND plugin.deleted IS FALSE
+     JOIN platform_mcp_connections AS connection
       ON connection.id = distribution.connection_id
      AND connection.organization_id = distribution.organization_id
      AND connection.active_generation = distribution.connection_generation
@@ -1447,6 +1461,8 @@ SELECT EXISTS (
 );
 
 -- name: GetPlatformMCPSelectedUseTarget :one
+-- Resolve a target only through the literal Default plugin during the
+-- compatibility rollout. Named-plugin rows remain excluded from selected use.
 SELECT
     distribution.id AS distribution_id,
     distribution.version AS distribution_version,
@@ -1461,12 +1477,18 @@ JOIN projects AS project
   ON project.id = distribution.project_id
  AND project.organization_id = distribution.organization_id
  AND project.deleted IS FALSE
-JOIN platform_mcp_catalog_registrations AS registration
-  ON registration.id = distribution.registration_id
- AND registration.project_id = distribution.project_id
- AND registration.organization_id = distribution.organization_id
- AND registration.deleted IS FALSE
-JOIN plugin_servers AS plugin_server
+ JOIN platform_mcp_catalog_registrations AS registration
+   ON registration.id = distribution.registration_id
+  AND registration.project_id = distribution.project_id
+  AND registration.organization_id = distribution.organization_id
+  AND registration.deleted IS FALSE
+ JOIN plugins AS plugin
+   ON plugin.id = distribution.default_plugin_id
+  AND plugin.organization_id = distribution.organization_id
+  AND plugin.project_id = distribution.project_id
+  AND plugin.is_default IS TRUE
+  AND plugin.deleted IS FALSE
+ JOIN plugin_servers AS plugin_server
   ON plugin_server.id = distribution.plugin_server_id
   AND plugin_server.plugin_id = distribution.default_plugin_id
   AND plugin_server.deleted IS FALSE
@@ -1665,6 +1687,8 @@ WHERE workflow.organization_id = @organization_id
   AND registration.mcp_server_id IS NOT NULL;
 
 -- name: HasPlatformMCPOrganizationSetupComplete :one
+-- Default-only setup completion must not be satisfied by a future named-plugin
+-- row. A missing or no-longer-Default plugin therefore correctly does not count.
 SELECT EXISTS (
     SELECT 1
     FROM platform_mcp_onboarding_milestones AS milestone
@@ -1673,16 +1697,24 @@ SELECT EXISTS (
     UNION ALL
     SELECT 1
     FROM platform_mcp_distributions AS distribution
-    JOIN platform_mcp_catalog_registrations AS registration
-      ON registration.id = distribution.registration_id
-     AND registration.organization_id = distribution.organization_id
-     AND registration.project_id = distribution.project_id
-     AND registration.deleted IS FALSE
-    WHERE distribution.organization_id = @organization_id
-      AND distribution.state = 'attached'
+     JOIN platform_mcp_catalog_registrations AS registration
+       ON registration.id = distribution.registration_id
+      AND registration.organization_id = distribution.organization_id
+      AND registration.project_id = distribution.project_id
+      AND registration.deleted IS FALSE
+     JOIN plugins AS plugin
+       ON plugin.id = distribution.default_plugin_id
+      AND plugin.organization_id = distribution.organization_id
+      AND plugin.project_id = distribution.project_id
+      AND plugin.is_default IS TRUE
+      AND plugin.deleted IS FALSE
+     WHERE distribution.organization_id = @organization_id
+       AND distribution.state = 'attached'
 ) AS setup_complete;
 
 -- name: HasAttachedPlatformMCPOnboardingDistributionForProject :one
+-- This is intentionally Default-only during the compatibility rollout; named
+-- rows added by a later release must not satisfy onboarding distribution.
 SELECT EXISTS (
     SELECT 1
     FROM platform_mcp_distributions AS distribution
@@ -1691,13 +1723,19 @@ SELECT EXISTS (
      AND registration.organization_id = distribution.organization_id
      AND registration.project_id = distribution.project_id
      AND registration.deleted IS FALSE
-    JOIN projects AS project
-      ON project.id = distribution.project_id
-     AND project.organization_id = distribution.organization_id
-     AND project.deleted IS FALSE
-    WHERE distribution.organization_id = @organization_id
-      AND distribution.project_id = @project_id
-      AND distribution.state = 'attached'
+     JOIN projects AS project
+       ON project.id = distribution.project_id
+      AND project.organization_id = distribution.organization_id
+      AND project.deleted IS FALSE
+     JOIN plugins AS plugin
+       ON plugin.id = distribution.default_plugin_id
+      AND plugin.organization_id = distribution.organization_id
+      AND plugin.project_id = distribution.project_id
+      AND plugin.is_default IS TRUE
+      AND plugin.deleted IS FALSE
+     WHERE distribution.organization_id = @organization_id
+       AND distribution.project_id = @project_id
+       AND distribution.state = 'attached'
       AND registration.status = 'registered'
       AND registration.mcp_server_id IS NOT NULL
 );

--- a/server/internal/platformmcp/registration_service.go
+++ b/server/internal/platformmcp/registration_service.go
@@ -78,6 +78,7 @@ type RegistrationService struct {
 	dashboardURL               *url.URL
 	identityProviderAttachment CatalogIdentityProviderAttachment
 	directRemoteInspector      DirectRemoteInspector
+	lifecycleMetadata          *LifecycleMetadataService
 	budgets                    OperationBudgets
 	telemetry                  LifecycleTelemetry
 }
@@ -137,6 +138,23 @@ func (s *RegistrationService) WithDirectRemoteInspector(inspector DirectRemoteIn
 		s.directRemoteInspector = inspector
 	}
 	return s
+}
+
+// WithLifecycleMetadata enables narrow, Platform-owned MCP display-name updates.
+// The command is injected from server composition to share the dashboard domain
+// implementation without importing mcpservers into Platform MCP.
+func (s *RegistrationService) WithLifecycleMetadata(metadata *LifecycleMetadataService) *RegistrationService {
+	if s != nil {
+		s.lifecycleMetadata = metadata
+	}
+	return s
+}
+
+func (s *RegistrationService) UpdateMCPMetadata(ctx context.Context, principal Principal, input UpdateMCPMetadataInput) (UpdateMCPMetadataResult, error) {
+	if s == nil || s.lifecycleMetadata == nil {
+		return UpdateMCPMetadataResult{}, ErrRegistrationUnavailable
+	}
+	return s.lifecycleMetadata.Update(ctx, principal, input)
 }
 
 // WithDashboardURL supplies the configured dashboard origin used only to build

--- a/server/internal/platformmcp/registration_service.go
+++ b/server/internal/platformmcp/registration_service.go
@@ -92,11 +92,12 @@ func NewRegistrationService(catalog Catalog, gate CatalogRegistrationGateChecker
 		readiness: nil,
 		telemetry: noopLifecycleTelemetry{},
 		budgets: OperationBudgets{
-			Catalog:      OperationBudget{Connection: nil, Organization: nil},
-			Registration: OperationBudget{Connection: nil, Organization: nil},
-			Handoff:      OperationBudget{Connection: nil, Organization: nil},
-			SetupStart:   OperationBudget{Connection: nil, Organization: nil},
-			Repair:       OperationBudget{Connection: nil, Organization: nil},
+			Catalog:           OperationBudget{Connection: nil, Organization: nil},
+			Registration:      OperationBudget{Connection: nil, Organization: nil},
+			Handoff:           OperationBudget{Connection: nil, Organization: nil},
+			SetupStart:        OperationBudget{Connection: nil, Organization: nil},
+			Repair:            OperationBudget{Connection: nil, Organization: nil},
+			LifecycleMetadata: OperationBudget{Connection: nil, Organization: nil},
 		},
 	}
 }
@@ -151,7 +152,17 @@ func (s *RegistrationService) WithLifecycleMetadata(metadata *LifecycleMetadataS
 }
 
 func (s *RegistrationService) UpdateMCPMetadata(ctx context.Context, principal Principal, input UpdateMCPMetadataInput) (UpdateMCPMetadataResult, error) {
-	if s == nil || s.lifecycleMetadata == nil {
+	if s == nil || s.gate == nil || s.lifecycleMetadata == nil || !s.budgets.LifecycleMetadata.valid() {
+		return UpdateMCPMetadataResult{}, ErrRegistrationUnavailable
+	}
+	if err := s.budgets.LifecycleMetadata.Allow(ctx, principal); err != nil {
+		return UpdateMCPMetadataResult{}, err
+	}
+	enabled, err := s.gate.Enabled(ctx, principal.OrganizationID, input.ProjectSlug)
+	if err != nil {
+		return UpdateMCPMetadataResult{}, fmt.Errorf("check metadata update gate: %w", err)
+	}
+	if !enabled {
 		return UpdateMCPMetadataResult{}, ErrRegistrationUnavailable
 	}
 	return s.lifecycleMetadata.Update(ctx, principal, input)
@@ -427,13 +438,18 @@ func (s *RegistrationService) RegisterRemoteMCP(ctx context.Context, principal P
 	if displayName == "" {
 		displayName = inspection.CanonicalURL
 	}
+	if len(displayName) > directRemoteDisplayNameMaxBytes || strings.ContainsAny(displayName, "\r\n") {
+		return RegisterRemoteMCPResult{}, ErrRegistrationInvalid
+	}
+	configurationHash := catalogConfigurationHash(CatalogConfigurationValues{"name": displayName})
 	request := CatalogRegistrationRequest{
-		ProjectSlug:      project.Slug,
-		SourceKind:       directRemoteSourceKind,
-		CatalogProvider:  directRemoteProviderKey,
-		CatalogReference: inspection.CanonicalURL,
-		IdempotencyKey:   input.IdempotencyKey,
-		InputHash:        catalogRegistrationInputHash(project.Slug, directRemoteSourceKind, directRemoteProviderKey, inspection.CanonicalURL),
+		ProjectSlug:       project.Slug,
+		SourceKind:        directRemoteSourceKind,
+		CatalogProvider:   directRemoteProviderKey,
+		CatalogReference:  inspection.CanonicalURL,
+		ConfigurationHash: configurationHash,
+		IdempotencyKey:    input.IdempotencyKey,
+		InputHash:         catalogRegistrationInputHash(project.Slug, directRemoteSourceKind, directRemoteProviderKey, inspection.CanonicalURL, configurationHash),
 	}
 	receipt, err := s.store.BeginReceipt(ctx, principal, project, request, s.now())
 	if err != nil {

--- a/server/internal/platformmcp/registration_service.go
+++ b/server/internal/platformmcp/registration_service.go
@@ -79,6 +79,7 @@ type RegistrationService struct {
 	identityProviderAttachment CatalogIdentityProviderAttachment
 	directRemoteInspector      DirectRemoteInspector
 	lifecycleMetadata          *LifecycleMetadataService
+	lifecycleVisibility        *LifecycleVisibilityService
 	budgets                    OperationBudgets
 	telemetry                  LifecycleTelemetry
 }
@@ -166,6 +167,27 @@ func (s *RegistrationService) UpdateMCPMetadata(ctx context.Context, principal P
 		return UpdateMCPMetadataResult{}, ErrRegistrationUnavailable
 	}
 	return s.lifecycleMetadata.Update(ctx, principal, input)
+}
+
+func (s *RegistrationService) WithLifecycleVisibility(visibility *LifecycleVisibilityService) *RegistrationService {
+	if s != nil {
+		s.lifecycleVisibility = visibility
+	}
+	return s
+}
+
+func (s *RegistrationService) DisableMCP(ctx context.Context, principal Principal, input UpdateMCPVisibilityInput) (UpdateMCPVisibilityResult, error) {
+	if s == nil || s.lifecycleVisibility == nil {
+		return UpdateMCPVisibilityResult{}, ErrRegistrationUnavailable
+	}
+	return s.lifecycleVisibility.Disable(ctx, principal, input)
+}
+
+func (s *RegistrationService) EnableMCP(ctx context.Context, principal Principal, input UpdateMCPVisibilityInput) (UpdateMCPVisibilityResult, error) {
+	if s == nil || s.lifecycleVisibility == nil {
+		return UpdateMCPVisibilityResult{}, ErrRegistrationUnavailable
+	}
+	return s.lifecycleVisibility.Enable(ctx, principal, input)
 }
 
 // WithDashboardURL supplies the configured dashboard origin used only to build

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -615,6 +615,7 @@ INSERT INTO platform_mcp_distributions (
     project_id,
     registration_id,
     default_plugin_id,
+    plugin_id,
     plugin_server_id,
     state,
     version,
@@ -626,6 +627,7 @@ SELECT
     $1,
     $2,
     $3,
+    $4,
     $4,
     $5,
     $6,
@@ -2204,6 +2206,9 @@ type GetPlatformMCPDistributionParams struct {
 	DefaultPluginID uuid.UUID
 }
 
+// This is a neutral desired-state lookup used by inventory and write paths.
+// Default-only mutations revalidate plugins.is_default in their write queries;
+// inventory intentionally projects COALESCE(plugin_id, default_plugin_id).
 func (q *Queries) GetPlatformMCPDistribution(ctx context.Context, arg GetPlatformMCPDistributionParams) (PlatformMcpDistribution, error) {
 	row := q.db.QueryRow(ctx, getPlatformMCPDistribution,
 		arg.OrganizationID,
@@ -2690,12 +2695,18 @@ JOIN projects AS project
   ON project.id = distribution.project_id
  AND project.organization_id = distribution.organization_id
  AND project.deleted IS FALSE
-JOIN platform_mcp_catalog_registrations AS registration
-  ON registration.id = distribution.registration_id
- AND registration.project_id = distribution.project_id
- AND registration.organization_id = distribution.organization_id
- AND registration.deleted IS FALSE
-JOIN plugin_servers AS plugin_server
+ JOIN platform_mcp_catalog_registrations AS registration
+   ON registration.id = distribution.registration_id
+  AND registration.project_id = distribution.project_id
+  AND registration.organization_id = distribution.organization_id
+  AND registration.deleted IS FALSE
+ JOIN plugins AS plugin
+   ON plugin.id = distribution.default_plugin_id
+  AND plugin.organization_id = distribution.organization_id
+  AND plugin.project_id = distribution.project_id
+  AND plugin.is_default IS TRUE
+  AND plugin.deleted IS FALSE
+ JOIN plugin_servers AS plugin_server
   ON plugin_server.id = distribution.plugin_server_id
   AND plugin_server.plugin_id = distribution.default_plugin_id
   AND plugin_server.deleted IS FALSE
@@ -2749,6 +2760,8 @@ type GetPlatformMCPSelectedUseTargetRow struct {
 	ConnectionGeneration uuid.NullUUID
 }
 
+// Resolve a target only through the literal Default plugin during the
+// compatibility rollout. Named-plugin rows remain excluded from selected use.
 func (q *Queries) GetPlatformMCPSelectedUseTarget(ctx context.Context, arg GetPlatformMCPSelectedUseTargetParams) (GetPlatformMCPSelectedUseTargetRow, error) {
 	row := q.db.QueryRow(ctx, getPlatformMCPSelectedUseTarget,
 		arg.InitiatingSubjectUrn,
@@ -3170,13 +3183,19 @@ SELECT EXISTS (
      AND registration.organization_id = distribution.organization_id
      AND registration.project_id = distribution.project_id
      AND registration.deleted IS FALSE
-    JOIN projects AS project
-      ON project.id = distribution.project_id
-     AND project.organization_id = distribution.organization_id
-     AND project.deleted IS FALSE
-    WHERE distribution.organization_id = $1
-      AND distribution.project_id = $2
-      AND distribution.state = 'attached'
+     JOIN projects AS project
+       ON project.id = distribution.project_id
+      AND project.organization_id = distribution.organization_id
+      AND project.deleted IS FALSE
+     JOIN plugins AS plugin
+       ON plugin.id = distribution.default_plugin_id
+      AND plugin.organization_id = distribution.organization_id
+      AND plugin.project_id = distribution.project_id
+      AND plugin.is_default IS TRUE
+      AND plugin.deleted IS FALSE
+     WHERE distribution.organization_id = $1
+       AND distribution.project_id = $2
+       AND distribution.state = 'attached'
       AND registration.status = 'registered'
       AND registration.mcp_server_id IS NOT NULL
 )
@@ -3187,6 +3206,8 @@ type HasAttachedPlatformMCPOnboardingDistributionForProjectParams struct {
 	ProjectID      uuid.UUID
 }
 
+// This is intentionally Default-only during the compatibility rollout; named
+// rows added by a later release must not satisfy onboarding distribution.
 func (q *Queries) HasAttachedPlatformMCPOnboardingDistributionForProject(ctx context.Context, arg HasAttachedPlatformMCPOnboardingDistributionForProjectParams) (bool, error) {
 	row := q.db.QueryRow(ctx, hasAttachedPlatformMCPOnboardingDistributionForProject, arg.OrganizationID, arg.ProjectID)
 	var exists bool
@@ -3403,16 +3424,24 @@ SELECT EXISTS (
     UNION ALL
     SELECT 1
     FROM platform_mcp_distributions AS distribution
-    JOIN platform_mcp_catalog_registrations AS registration
-      ON registration.id = distribution.registration_id
-     AND registration.organization_id = distribution.organization_id
-     AND registration.project_id = distribution.project_id
-     AND registration.deleted IS FALSE
-    WHERE distribution.organization_id = $1
-      AND distribution.state = 'attached'
+     JOIN platform_mcp_catalog_registrations AS registration
+       ON registration.id = distribution.registration_id
+      AND registration.organization_id = distribution.organization_id
+      AND registration.project_id = distribution.project_id
+      AND registration.deleted IS FALSE
+     JOIN plugins AS plugin
+       ON plugin.id = distribution.default_plugin_id
+      AND plugin.organization_id = distribution.organization_id
+      AND plugin.project_id = distribution.project_id
+      AND plugin.is_default IS TRUE
+      AND plugin.deleted IS FALSE
+     WHERE distribution.organization_id = $1
+       AND distribution.state = 'attached'
 ) AS setup_complete
 `
 
+// Default-only setup completion must not be satisfied by a future named-plugin
+// row. A missing or no-longer-Default plugin therefore correctly does not count.
 func (q *Queries) HasPlatformMCPOrganizationSetupComplete(ctx context.Context, organizationID string) (bool, error) {
 	row := q.db.QueryRow(ctx, hasPlatformMCPOrganizationSetupComplete, organizationID)
 	var setup_complete bool
@@ -3430,11 +3459,17 @@ SELECT EXISTS (
      AND distribution.registration_id = evidence.registration_id
      AND distribution.version = evidence.distribution_version
      AND distribution.state = 'attached'
-    JOIN projects AS project
-      ON project.id = distribution.project_id
-     AND project.organization_id = distribution.organization_id
-     AND project.deleted IS FALSE
-    JOIN platform_mcp_connections AS connection
+     JOIN projects AS project
+       ON project.id = distribution.project_id
+      AND project.organization_id = distribution.organization_id
+      AND project.deleted IS FALSE
+     JOIN plugins AS plugin
+       ON plugin.id = distribution.default_plugin_id
+      AND plugin.organization_id = distribution.organization_id
+      AND plugin.project_id = distribution.project_id
+      AND plugin.is_default IS TRUE
+      AND plugin.deleted IS FALSE
+     JOIN platform_mcp_connections AS connection
       ON connection.id = distribution.connection_id
      AND connection.organization_id = distribution.organization_id
      AND connection.active_generation = distribution.connection_generation
@@ -3453,6 +3488,8 @@ type HasPlatformMCPSelectedUseEvidenceParams struct {
 	InitiatingSubjectUrn string
 }
 
+// Selected-use credit remains Default-only until the exact-plugin contract is
+// live, so a future named distribution cannot produce onboarding evidence.
 func (q *Queries) HasPlatformMCPSelectedUseEvidence(ctx context.Context, arg HasPlatformMCPSelectedUseEvidenceParams) (bool, error) {
 	row := q.db.QueryRow(ctx, hasPlatformMCPSelectedUseEvidence,
 		arg.OrganizationID,
@@ -5388,20 +5425,21 @@ func (q *Queries) UpdatePlatformMCPCatalogRegistrationComponents(ctx context.Con
 
 const updatePlatformMCPDistribution = `-- name: UpdatePlatformMCPDistribution :one
 UPDATE platform_mcp_distributions
-SET plugin_server_id = $1,
-    state = $2,
-    version = $3,
-    attachment_was_created = $4,
+SET plugin_id = $1,
+    plugin_server_id = $2,
+    state = $3,
+    version = $4,
+    attachment_was_created = $5,
     publication_state = 'pending',
     publication_updated_at = NULL,
-    connection_id = $5,
-    connection_generation = $6,
+    connection_id = $6,
+    connection_generation = $7,
     updated_at = clock_timestamp()
-WHERE platform_mcp_distributions.id = $7
-  AND platform_mcp_distributions.organization_id = $8
-  AND platform_mcp_distributions.project_id = $9
-  AND platform_mcp_distributions.registration_id = $10
-  AND platform_mcp_distributions.default_plugin_id = $11
+WHERE platform_mcp_distributions.id = $8
+  AND platform_mcp_distributions.organization_id = $9
+  AND platform_mcp_distributions.project_id = $10
+  AND platform_mcp_distributions.registration_id = $11
+  AND platform_mcp_distributions.default_plugin_id = $1
   AND EXISTS (
       SELECT 1
       FROM projects AS project
@@ -5417,9 +5455,9 @@ WHERE platform_mcp_distributions.id = $7
        AND plugin.is_default IS TRUE
        AND plugin.deleted IS FALSE
       JOIN platform_mcp_connections AS connection
-        ON connection.id = $5
+        ON connection.id = $6
        AND connection.organization_id = project.organization_id
-       AND connection.active_generation = $6
+       AND connection.active_generation = $7
        AND connection.revoked_at IS NULL
       WHERE project.id = platform_mcp_distributions.project_id
         AND project.organization_id = platform_mcp_distributions.organization_id
@@ -5429,6 +5467,7 @@ RETURNING id, organization_id, project_id, registration_id, default_plugin_id, p
 `
 
 type UpdatePlatformMCPDistributionParams struct {
+	DefaultPluginID      uuid.NullUUID
 	PluginServerID       uuid.NullUUID
 	State                string
 	Version              int64
@@ -5439,11 +5478,11 @@ type UpdatePlatformMCPDistributionParams struct {
 	OrganizationID       string
 	ProjectID            uuid.UUID
 	RegistrationID       uuid.UUID
-	DefaultPluginID      uuid.UUID
 }
 
 func (q *Queries) UpdatePlatformMCPDistribution(ctx context.Context, arg UpdatePlatformMCPDistributionParams) (PlatformMcpDistribution, error) {
 	row := q.db.QueryRow(ctx, updatePlatformMCPDistribution,
+		arg.DefaultPluginID,
 		arg.PluginServerID,
 		arg.State,
 		arg.Version,
@@ -5454,7 +5493,6 @@ func (q *Queries) UpdatePlatformMCPDistribution(ctx context.Context, arg UpdateP
 		arg.OrganizationID,
 		arg.ProjectID,
 		arg.RegistrationID,
-		arg.DefaultPluginID,
 	)
 	var i PlatformMcpDistribution
 	err := row.Scan(

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -2701,7 +2701,7 @@ JOIN projects AS project
   AND registration.organization_id = distribution.organization_id
   AND registration.deleted IS FALSE
  JOIN plugins AS plugin
-   ON plugin.id = distribution.default_plugin_id
+   ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
   AND plugin.organization_id = distribution.organization_id
   AND plugin.project_id = distribution.project_id
   AND plugin.is_default IS TRUE
@@ -3188,7 +3188,7 @@ SELECT EXISTS (
       AND project.organization_id = distribution.organization_id
       AND project.deleted IS FALSE
      JOIN plugins AS plugin
-       ON plugin.id = distribution.default_plugin_id
+       ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
       AND plugin.organization_id = distribution.organization_id
       AND plugin.project_id = distribution.project_id
       AND plugin.is_default IS TRUE
@@ -3430,7 +3430,7 @@ SELECT EXISTS (
       AND registration.project_id = distribution.project_id
       AND registration.deleted IS FALSE
      JOIN plugins AS plugin
-       ON plugin.id = distribution.default_plugin_id
+       ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
       AND plugin.organization_id = distribution.organization_id
       AND plugin.project_id = distribution.project_id
       AND plugin.is_default IS TRUE
@@ -3464,7 +3464,7 @@ SELECT EXISTS (
       AND project.organization_id = distribution.organization_id
       AND project.deleted IS FALSE
      JOIN plugins AS plugin
-       ON plugin.id = distribution.default_plugin_id
+       ON plugin.id = COALESCE(distribution.plugin_id, distribution.default_plugin_id)
       AND plugin.organization_id = distribution.organization_id
       AND plugin.project_id = distribution.project_id
       AND plugin.is_default IS TRUE

--- a/server/internal/platformmcp/tool_find_mcp.go
+++ b/server/internal/platformmcp/tool_find_mcp.go
@@ -27,7 +27,7 @@ func registerFindMCPTool(reg *Registrar, reader Reader, cursorKeyMaterial string
 		}
 		output, err := reader.FindMCP(ctx, principal, input)
 		if err != nil {
-			return nil, FindMCPOutput{}, fmt.Errorf("find configured MCPs: %w", err)
+			return nil, FindMCPOutput{}, ErrUnavailable
 		}
 		return nil, output, nil
 	})

--- a/server/internal/platformmcp/tool_lifecycle_metadata.go
+++ b/server/internal/platformmcp/tool_lifecycle_metadata.go
@@ -11,7 +11,7 @@ type UpdateMCPMetadataToolInput struct {
 	ProjectSlug     string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the Platform-managed MCP"`
 	RegistrationID  string `json:"registration_id" jsonschema:"Platform registration ID returned by find_mcp or get_mcp"`
 	MCPID           string `json:"mcp_id" jsonschema:"configured MCP ID returned by find_mcp or get_mcp"`
-	Name            string `json:"name" jsonschema:"new non-empty project-local MCP display name"`
+	Name            string `json:"name" jsonschema:"new project-local MCP display name; 1-256 bytes after trimming and no line breaks"`
 	ExpectedVersion string `json:"expected_version" jsonschema:"opaque version returned by find_mcp, get_mcp, or a previous update_mcp_metadata result"`
 	IdempotencyKey  string `json:"idempotency_key" jsonschema:"caller-generated idempotency key; reuse only to retry this exact metadata update"`
 }

--- a/server/internal/platformmcp/tool_lifecycle_metadata.go
+++ b/server/internal/platformmcp/tool_lifecycle_metadata.go
@@ -1,0 +1,54 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type UpdateMCPMetadataToolInput struct {
+	ProjectSlug     string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the Platform-managed MCP"`
+	RegistrationID  string `json:"registration_id" jsonschema:"Platform registration ID returned by find_mcp or get_mcp"`
+	MCPID           string `json:"mcp_id" jsonschema:"configured MCP ID returned by find_mcp or get_mcp"`
+	Name            string `json:"name" jsonschema:"new non-empty project-local MCP display name"`
+	ExpectedVersion string `json:"expected_version" jsonschema:"opaque version returned by find_mcp, get_mcp, or a previous update_mcp_metadata result"`
+	IdempotencyKey  string `json:"idempotency_key" jsonschema:"caller-generated idempotency key; reuse only to retry this exact metadata update"`
+}
+
+type UpdateMCPMetadataToolOutput struct {
+	ProjectSlug    string `json:"project_slug"`
+	RegistrationID string `json:"registration_id"`
+	MCPID          string `json:"mcp_id"`
+	Name           string `json:"name"`
+	Slug           string `json:"slug"`
+	Visibility     string `json:"visibility"`
+	Version        string `json:"version"`
+	ReceiptID      string `json:"receipt_id"`
+	Replayed       bool   `json:"replayed"`
+}
+
+func registerLifecycleMetadataTool(reg *Registrar, registrations *RegistrationService) {
+	addTool(reg, &mcp.Tool{
+		Name:        "update_mcp_metadata",
+		Title:       "Update MCP Metadata",
+		Description: "Rename one complete Platform-managed MCP in an explicit project. This changes no provider configuration, readiness state, plugin attachment, or publication state.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateMCPMetadataToolInput) (*mcp.CallToolResult, UpdateMCPMetadataToolOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, UpdateMCPMetadataToolOutput{}, err
+		}
+		result, err := registrations.UpdateMCPMetadata(ctx, principal, UpdateMCPMetadataInput(input))
+		if err != nil {
+			if toolResult, ok := operationBudgetToolResult(err); ok {
+				return toolResult, UpdateMCPMetadataToolOutput{}, nil
+			}
+			return nil, UpdateMCPMetadataToolOutput{}, err
+		}
+		return nil, UpdateMCPMetadataToolOutput{
+			ProjectSlug: result.Project.Slug, RegistrationID: result.RegistrationID, MCPID: result.MCPID,
+			Name: result.Name, Slug: result.Slug, Visibility: result.Visibility, Version: result.Version,
+			ReceiptID: result.Receipt.ID.String(), Replayed: result.Receipt.Replayed,
+		}, nil
+	})
+}

--- a/server/internal/platformmcp/tool_lifecycle_visibility.go
+++ b/server/internal/platformmcp/tool_lifecycle_visibility.go
@@ -1,0 +1,78 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type UpdateMCPVisibilityToolInput struct {
+	ProjectSlug     string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the Platform-managed MCP"`
+	RegistrationID  string `json:"registration_id" jsonschema:"Platform registration ID returned by find_mcp or get_mcp"`
+	MCPID           string `json:"mcp_id" jsonschema:"configured MCP ID returned by find_mcp or get_mcp"`
+	ExpectedVersion string `json:"expected_version" jsonschema:"opaque version returned by find_mcp, get_mcp, or a previous lifecycle update"`
+	IdempotencyKey  string `json:"idempotency_key" jsonschema:"caller-generated idempotency key; reuse only to retry this exact visibility update"`
+}
+
+type UpdateMCPVisibilityToolOutput struct {
+	ProjectSlug    string       `json:"project_slug"`
+	RegistrationID string       `json:"registration_id"`
+	MCPID          string       `json:"mcp_id"`
+	Visibility     string       `json:"visibility"`
+	Version        string       `json:"version"`
+	ReceiptID      string       `json:"receipt_id"`
+	Replayed       bool         `json:"replayed"`
+	Readiness      MCPReadiness `json:"readiness"`
+	Published      bool         `json:"published"`
+}
+
+func registerLifecycleVisibilityTools(reg *Registrar, registrations *RegistrationService) {
+	for _, tool := range []struct {
+		name        string
+		title       string
+		description string
+		call        func(context.Context, Principal, UpdateMCPVisibilityInput) (UpdateMCPVisibilityResult, error)
+	}{
+		{
+			name:        "disable_mcp",
+			title:       "Disable MCP",
+			description: "Disable one complete Platform-managed MCP. The MCP remains registered and every existing plugin attachment remains unchanged; no plugin is created or removed.",
+			call:        registrations.DisableMCP,
+		},
+		{
+			name:        "enable_mcp",
+			title:       "Enable MCP",
+			description: "Re-enable one disabled Platform-managed MCP. The MCP is not attached to any plugin; existing attachments are republished and a fresh readiness probe runs. On an idempotent retry, the result reports current persisted visibility while readiness and publication remain best-effort observations.",
+			call:        registrations.EnableMCP,
+		},
+	} {
+		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateMCPVisibilityToolInput) (*mcp.CallToolResult, UpdateMCPVisibilityToolOutput, error) {
+			principal, err := principalFromToolContext(ctx)
+			if err != nil {
+				return nil, UpdateMCPVisibilityToolOutput{}, err
+			}
+			result, err := tool.call(ctx, principal, UpdateMCPVisibilityInput(input))
+			if err != nil {
+				if toolResult, ok := operationBudgetToolResult(err); ok {
+					return toolResult, UpdateMCPVisibilityToolOutput{}, nil
+				}
+				return nil, UpdateMCPVisibilityToolOutput{}, err
+			}
+			return nil, UpdateMCPVisibilityToolOutput{
+				ProjectSlug: result.Project.Slug, RegistrationID: result.RegistrationID, MCPID: result.MCPID,
+				Visibility: result.Visibility, Version: result.Version, ReceiptID: result.Receipt.ID.String(), Replayed: result.Receipt.Replayed,
+				Readiness: result.Readiness, Published: result.Published,
+			}, nil
+		})
+	}
+}
+
+func registerUnavailableLifecycleVisibilityTools(reg *Registrar) {
+	for _, tool := range []struct{ name, title, description string }{
+		{"disable_mcp", "Disable MCP", "Disable one Platform-managed MCP. Visibility controls are not available in the current preview."},
+		{"enable_mcp", "Enable MCP", "Enable one Platform-managed MCP. Visibility controls are not available in the current preview."},
+	} {
+		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("mcp_lifecycle_visibility"))
+	}
+}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -90,6 +90,7 @@ type MCP struct {
 	ProjectSlug      string            `json:"project_slug,omitempty"`
 	Name             string            `json:"name,omitempty"`
 	Slug             string            `json:"slug,omitempty"`
+	Version          string            `json:"version,omitempty"`
 	Visibility       string            `json:"visibility"`
 	EffectiveEnabled bool              `json:"effective_enabled"`
 	Model            string            `json:"model"`
@@ -179,6 +180,11 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 		} else {
 			registerRemoteRegistrationTool(reg, registrations)
 		}
+	}
+	if registrations == nil || registrations.lifecycleMetadata == nil {
+		registerUnavailableLifecycleMetadataTool(reg)
+	} else {
+		registerLifecycleMetadataTool(reg, registrations)
 	}
 	if registrations == nil || registrations.store == nil || !registrations.budgets.Handoff.valid() {
 		registerUnavailableSetupHandoffTool(reg)
@@ -273,6 +279,14 @@ func registerUnavailableRemoteRegistrationTool(reg *Registrar) {
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("direct_remote_registration"))
 }
 
+func registerUnavailableLifecycleMetadataTool(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "update_mcp_metadata",
+		Title:       "Update MCP Metadata",
+		Description: "Rename one Platform-managed MCP. Metadata updates are not available in the current preview.",
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("mcp_lifecycle_metadata"))
+}
+
 func registerUnavailableSetupHandoffTool(reg *Registrar) {
 	addTool(reg, &mcp.Tool{
 		Name:        "get_setup_handoff",
@@ -323,7 +337,7 @@ func operationBudgetToolResult(err error) (*mcp.CallToolResult, bool) {
 	switch {
 	case errors.Is(err, ErrReadinessRegistrationNotFound):
 		result = operationBudgetResult{Code: "registration_not_found", Message: "This registration ID is not available for the selected project and authenticated connection. Use the ID returned by register_platform_mcp_for_project or get_platform_mcp_onboarding_status."}
-	case errors.Is(err, ErrRegistrationInvalid), errors.Is(err, ErrReadinessInvalid), errors.Is(err, ErrCatalogConfigurationRejected), errors.Is(err, ErrCatalogRejected), errors.Is(err, ErrCatalogCursorInvalid):
+	case errors.Is(err, ErrRegistrationInvalid), errors.Is(err, ErrLifecycleMetadataInvalid), errors.Is(err, ErrReadinessInvalid), errors.Is(err, ErrCatalogConfigurationRejected), errors.Is(err, ErrCatalogRejected), errors.Is(err, ErrCatalogCursorInvalid):
 		result = operationBudgetResult{Code: "invalid_request", Message: "The requested Platform MCP operation is invalid or no longer matches the reviewed catalogue. Re-read the supported tool result and do not retry unchanged input."}
 	case errors.Is(err, ErrOperationRateLimited), errors.Is(err, ErrReadinessRateLimited):
 		result = operationBudgetResult{Code: "rate_limited", Message: "This Platform MCP operation is temporarily rate limited. Retry after a short delay."}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -355,6 +355,8 @@ func operationBudgetToolResult(err error) (*mcp.CallToolResult, bool) {
 		result = operationBudgetResult{Code: "invalid_request", Reason: "remote_url_rejected", Message: "The remote MCP URL is unsafe, unsupported, or did not complete the required Streamable HTTP inspection. Use an HTTPS URL without credentials, query parameters, or fragments."}
 	case errors.Is(err, ErrDirectRemoteUnavailable):
 		result = operationBudgetResult{Code: unavailableCode, Reason: "remote_inspection_unavailable", Message: "The remote MCP could not be inspected safely right now. Retry after a short delay."}
+	case errors.Is(err, ErrLifecycleVisibilityUnavailable):
+		result = operationBudgetResult{Code: unavailableCode, Reason: "unsupported_lifecycle_target", Message: "This MCP is not Platform-managed, so lifecycle visibility changes are unavailable. Use its supported dashboard management path."}
 	case errors.Is(err, ErrOperationBudgetUnavailable), errors.Is(err, ErrRegistrationUnavailable):
 		result = operationBudgetResult{Code: unavailableCode, Message: "This Platform MCP operation is temporarily unavailable."}
 	case errors.Is(err, ErrRegistrationCap):

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -189,6 +189,11 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 	} else {
 		registerLifecycleMetadataTool(reg, registrations)
 	}
+	if registrations == nil || registrations.lifecycleVisibility == nil {
+		registerUnavailableLifecycleVisibilityTools(reg)
+	} else {
+		registerLifecycleVisibilityTools(reg, registrations)
+	}
 	if registrations == nil || registrations.store == nil || !registrations.budgets.Handoff.valid() {
 		registerUnavailableSetupHandoffTool(reg)
 	} else {
@@ -340,7 +345,7 @@ func operationBudgetToolResult(err error) (*mcp.CallToolResult, bool) {
 	switch {
 	case errors.Is(err, ErrReadinessRegistrationNotFound):
 		result = operationBudgetResult{Code: "registration_not_found", Message: "This registration ID is not available for the selected project and authenticated connection. Use the ID returned by register_platform_mcp_for_project or get_platform_mcp_onboarding_status."}
-	case errors.Is(err, ErrRegistrationInvalid), errors.Is(err, ErrLifecycleMetadataInvalid), errors.Is(err, ErrReadinessInvalid), errors.Is(err, ErrCatalogConfigurationRejected), errors.Is(err, ErrCatalogRejected), errors.Is(err, ErrCatalogCursorInvalid):
+	case errors.Is(err, ErrRegistrationInvalid), errors.Is(err, ErrLifecycleMetadataInvalid), errors.Is(err, ErrLifecycleVisibilityInvalid), errors.Is(err, ErrReadinessInvalid), errors.Is(err, ErrCatalogConfigurationRejected), errors.Is(err, ErrCatalogRejected), errors.Is(err, ErrCatalogCursorInvalid):
 		result = operationBudgetResult{Code: "invalid_request", Message: "The requested Platform MCP operation is invalid or no longer matches the reviewed catalogue. Re-read the supported tool result and do not retry unchanged input."}
 	case errors.Is(err, ErrOperationRateLimited), errors.Is(err, ErrReadinessRateLimited):
 		result = operationBudgetResult{Code: "rate_limited", Message: "This Platform MCP operation is temporarily rate limited. Retry after a short delay."}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -160,6 +160,9 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 	if registrations == nil || !registrations.budgets.Catalog.valid() {
 		registerUnavailableCatalogTools(reg)
 		registerUnavailableCandidateInspectionTool(reg)
+	} else if catalog == nil && (registrations.directRemoteInspector == nil || registrations.gate == nil) {
+		registerUnavailableCatalogTools(reg)
+		registerUnavailableCandidateInspectionTool(reg)
 	} else {
 		registerCandidateInspectionTool(reg, catalog, registrations.directRemoteInspector, registrations.gate, registrations.budgets.Catalog)
 		if catalog == nil {


### PR DESCRIPTION
## Why
The distribution schema now supports an exact plugin identity, but existing lifecycle and onboarding behavior must stay Default-plugin-only until a later release enables named-plugin writes. This compatibility release establishes the safe rollout and rollback floor.

Refs AGE-3166

## What changed
- Dual-write the existing Default plugin ID into the nullable `plugin_id` column for create and update distribution paths.
- Require a live Default plugin when evaluating setup completion, onboarding distribution, and selected-use lifecycle readers.
- Document the deliberate compatibility boundary: inventory remains able to read legacy/new rows, while named-plugin mutations remain disabled.

## Review notes
- `GetPlatformMCPDistribution` remains a neutral desired-state lookup; its callers that mutate distributions revalidate the Default identity.
- No named-plugin mutation path is enabled here. Exact-plugin writes belong to the next rollout stage after this release is deployed.

## Testing
- `mise run gen:sqlc-server`
- `mise build:server`
- `mise lint:server`
- `git diff --check`
- Commit hooks: `gofmt`, `gofix`, `gomodtidy`

## Rollout / deployment notes
- Depends on the previously merged additive schema migration that introduced nullable `plugin_id`.
- This must deploy before enabling any named-plugin distribution writes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares Platform MCP distributions for exact-plugin compatibility and adds lifecycle visibility controls. Old: stored only default_plugin_id; new: dual-write plugin_id = default_plugin_id on create/update, require a live Default plugin for lifecycle/onboarding readers, and keep inventory neutral via COALESCE(plugin_id, default_plugin_id).

- Review and rollout
  - Create/update now set plugin_id from default_plugin_id; updates revalidate the live Default plugin and connection; `GetPlatformMCPDistribution` stays a neutral desired-state lookup.
  - Selected-use evidence, onboarding distribution, and org setup completion only credit distributions resolved through the Default plugin; named-plugin rows do not count.
  - Wires the lifecycle visibility service for the browser Platform MCP surface.
  - Requires the prior migration that added nullable `plugin_id`; deploy this before enabling any named-plugin writes. No backfill. Supports Linear AGE-3166 lifecycle completion tools.
  - Fix: persist a non-null Default plugin ID for updates to match the updated repo contract.

<sup>Written for commit 8ae5da3e2b47b3cf005dda5df1929ec12ee2f73c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

