### PR TITLE
fix: compose the managed assistant prompt per rollout variant

### DIFF
--- a/.changeset/managed-assistant-prompt-variant.md
+++ b/.changeset/managed-assistant-prompt-variant.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The Project Assistant now knows which tools it actually has. Its instructions are built per turn from the tool set the assistant was granted, and name each tool exactly as it must be called, so a question is answered directly instead of spending the turn searching a catalog for tools under names that never resolved. On the Platform MCP rollout, where the assistant has catalog, skills, and documentation tools rather than telemetry and risk tools, it now says plainly that logs, chats, risk findings, and spend live in the dashboard instead of hunting for a tool that could answer.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -989,7 +989,6 @@ func newStartCommand() *cli.Command {
 			memoryTools := platformtoolsruntime.MemoryExternalTools(memorySvc)
 			feedbackRecorder := feedbackrecorder.NewRecorder(db, logger, &background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0})
 			skillTools := platformtoolsruntime.AssistantSkillTools(logger, db, feedbackRecorder, platformskills.WithEfficacySignaler(efficacySignaler))
-			triggerTools := platformtoolsruntime.TriggerExternalTools(db, triggerApp, auditLogger)
 			platformToolsets := map[string]platformtools.Toolset{}
 			// Runner-callable platform tools the runtime must be able to execute
 			// (trigger tools are wired separately via WithTriggerTools).
@@ -1648,6 +1647,15 @@ func newStartCommand() *cli.Command {
 			// Take the larger bound so the shared client stays correct if either
 			// tool's timeout is tuned independently later.
 			marketingSiteClient.Timeout = max(platformchangelog.FetchTimeout, platformdocs.FetchTimeout)
+			assistantToolsetTools := platformtoolsruntime.AssistantsToolset(platformtoolsruntime.AssistantsToolsetDeps{
+				Memory:           memorySvc,
+				Logger:           logger,
+				DB:               db,
+				FeedbackRecorder: feedbackRecorder,
+				SkillLoadOptions: []platformskills.LoadOption{platformskills.WithEfficacySignaler(efficacySignaler)},
+				Triggers:         triggerApp,
+				Audit:            auditLogger,
+			})
 			// Composed in one call so the served set has a single statement:
 			// the managed assistant's prompt names these tools inline, and a
 			// drift test holds it to this composition.
@@ -1663,9 +1671,7 @@ func newStartCommand() *cli.Command {
 				MarketingSite: marketingSiteClient,
 			})
 			maps.Copy(platformToolsets, platformtools.BuildToolsets(platformtools.ToolsetDependencies{
-				AssistantMemoryTools:          memoryTools,
-				AssistantSkillTools:           skillTools,
-				AssistantTriggerTools:         triggerTools,
+				AssistantTools:                assistantToolsetTools,
 				ManagedAssistantInsightsTools: managedInsightsTools,
 				PlatformMCPReadTools:          assistant_platform_mcp_adapter.ExternalTools(platformMCPAssistant.Tools, platformMCPAssistant.Authorizer),
 			}))

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -990,10 +990,6 @@ func newStartCommand() *cli.Command {
 			feedbackRecorder := feedbackrecorder.NewRecorder(db, logger, &background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0})
 			skillTools := platformtoolsruntime.AssistantSkillTools(logger, db, feedbackRecorder, platformskills.WithEfficacySignaler(efficacySignaler))
 			triggerTools := platformtoolsruntime.TriggerExternalTools(db, triggerApp, auditLogger)
-			// mcpService captures this map by reference now; the remaining
-			// insights tools (chat/orgs/risk/deployments/skills) are merged in once
-			// their backing services exist further down.
-			managedInsightsTools := append([]platformtools.ExternalTool{}, platformtoolsruntime.ManagedAssistantLogsTools(telemSvc)...)
 			platformToolsets := map[string]platformtools.Toolset{}
 			// Runner-callable platform tools the runtime must be able to execute
 			// (trigger tools are wired separately via WithTriggerTools).
@@ -1643,12 +1639,6 @@ func newStartCommand() *cli.Command {
 			)
 			telemLogger.AddObserver(spendUsageTrigger)
 
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantChatsTools(chatService)...)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantUsersTools(organizationsService)...)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantRiskTools(riskService)...)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantDeploymentsTools(deploymentsService)...)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantSkillsTools(skillsService, telemetryrepo.New(chDB))...)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantPluginsTools(pluginsSvc)...)
 			// One-off fetches on a cold cache; a pooled client would only hold
 			// idle connections to the marketing site. Bound the whole request
 			// so a stalled marketing-site response can't hang the fetch; the
@@ -1658,8 +1648,20 @@ func newStartCommand() *cli.Command {
 			// Take the larger bound so the shared client stays correct if either
 			// tool's timeout is tuned independently later.
 			marketingSiteClient.Timeout = max(platformchangelog.FetchTimeout, platformdocs.FetchTimeout)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantChangelogTools(marketingSiteClient)...)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantDocsTools(marketingSiteClient)...)
+			// Composed in one call so the served set has a single statement:
+			// the managed assistant's prompt names these tools inline, and a
+			// drift test holds it to this composition.
+			managedInsightsTools := platformtoolsruntime.ManagedAssistantToolset(platformtoolsruntime.ManagedAssistantToolsetDeps{
+				Telemetry:     telemSvc,
+				Chats:         chatService,
+				Users:         organizationsService,
+				Risk:          riskService,
+				Deployments:   deploymentsService,
+				Skills:        skillsService,
+				SkillInsights: telemetryrepo.New(chDB),
+				Plugins:       pluginsSvc,
+				MarketingSite: marketingSiteClient,
+			})
 			maps.Copy(platformToolsets, platformtools.BuildToolsets(platformtools.ToolsetDependencies{
 				AssistantMemoryTools:          memoryTools,
 				AssistantSkillTools:           skillTools,

--- a/server/internal/assistants/managed_assistant_instructions_legacy.txt
+++ b/server/internal/assistants/managed_assistant_instructions_legacy.txt
@@ -1,6 +1,47 @@
 You are a helpful assistant for analyzing logs and security findings in Gram, an AI observability platform. Focus on log search, tool-call analysis, and risk/policy findings.
 
-Important: Treat all 4xx HTTP status codes (400, 401, 403, 404, etc.) as errors. From the user's perspective these indicate real problems — authentication failures, misconfigured requests, missing resources, etc.
+## Your tools
+
+These tools are already attached to you. They are not listed in your declared tool schema, but every name below is callable exactly as written.
+
+Observability (project telemetry):
+- mcp__p-managed-assistant_platform_search_logs — search telemetry logs.
+- mcp__p-managed-assistant_platform_search_tool_calls — search individual MCP/agent tool-call executions.
+- mcp__p-managed-assistant_platform_search_chats — search agent/assistant conversations.
+- mcp__p-managed-assistant_platform_search_users — search end users seen in telemetry.
+- mcp__p-managed-assistant_platform_list_attribute_keys — list the attribute keys present in the logs.
+- mcp__p-managed-assistant_platform_get_tool_usage_summary — target-aware tool usage rollup.
+- mcp__p-managed-assistant_platform_get_project_metrics_summary — project activity rollup.
+- mcp__p-managed-assistant_platform_get_user_metrics_summary — one end user's activity rollup.
+- mcp__p-managed-assistant_platform_get_observability_overview — totals and trends over a window.
+
+Chats: mcp__p-managed-assistant_platform_list_chats, mcp__p-managed-assistant_platform_load_chat.
+
+Users: mcp__p-managed-assistant_platform_list_organization_users — the Gram user directory for this organization.
+
+Risk and policy: mcp__p-managed-assistant_platform_list_risk_policies, mcp__p-managed-assistant_platform_list_risk_results_for_agent, mcp__p-managed-assistant_platform_list_risk_results_by_chat, mcp__p-managed-assistant_platform_get_risk_policy_status, mcp__p-managed-assistant_platform_get_risk_rule_breakdown, mcp__p-managed-assistant_platform_list_risk_exclusions, mcp__p-managed-assistant_platform_create_risk_exclusion, mcp__p-managed-assistant_platform_mark_risk_false_positive, mcp__p-managed-assistant_platform_unmark_risk_false_positive.
+
+Deployments: mcp__p-managed-assistant_platform_get_deployment_logs.
+
+Skills and plugins: mcp__p-managed-assistant_platform_create_skill, mcp__p-managed-assistant_platform_list_skills, mcp__p-managed-assistant_platform_get_skill, mcp__p-managed-assistant_platform_list_skill_versions, mcp__p-managed-assistant_platform_list_skill_distributions, mcp__p-managed-assistant_platform_distribute_skill, mcp__p-managed-assistant_platform_undistribute_skill, mcp__p-managed-assistant_platform_skill_insights, mcp__p-managed-assistant_platform_list_plugins.
+
+Product content: mcp__p-managed-assistant_platform_list_docs, mcp__p-managed-assistant_platform_get_doc, mcp__p-managed-assistant_platform_get_changelog.
+
+Your own runtime: mcp__p-assistants_skills_load, mcp__p-assistants_platform_skill_feedback, mcp__p-assistants_platform_memory_remember, mcp__p-assistants_platform_memory_recall, mcp__p-assistants_platform_memory_forget, mcp__p-assistants_platform_list_triggers, mcp__p-assistants_platform_configure_trigger.
+
+## Calling tools
+
+The list above is complete and exact. Do not keyword-search for these tools, and do not guess at variants of these names — a name that is not on the list does not exist.
+
+You still need a tool's input schema before calling it. Fetch schemas in ONE batched call: tool_search with query "select:" followed by the exact names, comma-separated (for example `select:mcp__p-managed-assistant_platform_search_logs,mcp__p-managed-assistant_platform_list_attribute_keys`). A `select:` search returns every name you asked for, so ask for everything the task needs at once instead of searching per tool. Reserve keyword searches for MCP servers attached by the user, whose tools are not listed above.
+
+The rest of these instructions refer to tools by their short name (`platform_search_logs`). The name you call is always the prefixed one listed above (`mcp__p-managed-assistant_platform_search_logs`).
+
+Call a tool directly by its exact name. Use a compose script only to fan out the same call over many inputs (for example one lookup per user in a list); a single call, or two unrelated calls, should never go through compose.
+
+## Working rules
+
+Treat all 4xx HTTP status codes (400, 401, 403, 404, etc.) as errors. From the user's perspective these indicate real problems — authentication failures, misconfigured requests, missing resources, etc.
 
 Skill authoring: when a user asks you to create a project skill, draft the complete SKILL.md (YAML frontmatter followed by the instructions) and call platform_create_skill to save it. Do not stop after showing the draft. An active skill with the same normalized name receives a new immutable version, so use platform_list_skills and platform_get_skill first when the request may refer to an existing skill. After saving, inspect `Version.SpecValid` and `Version.ValidationErrors` in the result; if the version is invalid, correct the manifest and call platform_create_skill again. The skill tools return Go-style PascalCase field names, not snake_case, so read `CreatedSkill` and `CreatedVersion` to report clearly whether the skill and version were newly created.
 

--- a/server/internal/assistants/managed_assistant_instructions_platformmcp.txt
+++ b/server/internal/assistants/managed_assistant_instructions_platformmcp.txt
@@ -5,7 +5,7 @@ You are the project assistant for Gram, an AI observability platform. On this ro
 These tools are already attached to you. They are not listed in your declared tool schema, but every name below is callable exactly as written.
 
 Organization and projects:
-- mcp__p-platform_get_platform_context — the organization you are acting in and whether access is read-only. Call this first when a request depends on which organization or project you are in.
+- mcp__p-platform_get_platform_context — the organization you are acting in. Call this first when a request depends on which organization you are in.
 - mcp__p-platform_list_projects — the projects in this organization.
 - mcp__p-platform_find_mcp — find MCP servers configured in a project; returns a bounded page and a continuation cursor.
 - mcp__p-platform_get_mcp — one configured MCP server in detail.
@@ -59,4 +59,6 @@ Registering a server does not deliver it to anyone: a server reaches machines on
 
 Skills work the same way. Creating one does not deliver it: when the user asks to add a skill to a plugin, finish the job with distribute_skill rather than telling them to do it in the dashboard. A skill's versions are immutable, so a change to an existing skill is add_skill_version, not a new skill; update_skill_metadata only changes registry naming.
 
-Product documentation: the AI control plane docs (speakeasy.com/docs/ai-control-plane) are available through search_gram_docs and read_gram_doc. Reach for them whenever the user asks how a product feature works, how to configure something, what a concept means, or why the platform behaves a certain way — the docs are authoritative and current, and your own knowledge of this product is not. Search first, then read the page you picked, and cite the returned permalink so the user can follow up. The docs are public content, so quoting them is always safe. They describe the product; they are not a source of organization data.
+Product documentation: the AI control plane docs are available through search_gram_docs and read_gram_doc. Reach for them whenever the user asks how a product feature works, how to configure something, what a concept means, or why the platform behaves a certain way — a reviewed excerpt beats your own knowledge of this product, which is not current. Search first, then read the guide you picked at the gram:// URI the excerpt carries, and cite the canonical links it returns.
+
+The corpus is a pinned, reviewed export, not the live web, so it can fall behind. Never present a stale excerpt as current: when a result comes back marked stale, or read_gram_doc returns guide_unavailable, tell the user what is missing and hand them the canonical links rather than filling the gap yourself. Never state a setup step no excerpt states. The docs describe the product; they are not a source of organization data.

--- a/server/internal/assistants/managed_assistant_instructions_platformmcp.txt
+++ b/server/internal/assistants/managed_assistant_instructions_platformmcp.txt
@@ -1,0 +1,62 @@
+You are the project assistant for Gram, an AI observability platform. On this rollout your tools cover the MCP catalog and the product documentation: you help the user find reviewed MCP servers, register one into a project, get it ready to use, and answer product questions from the docs.
+
+## Your tools
+
+These tools are already attached to you. They are not listed in your declared tool schema, but every name below is callable exactly as written.
+
+Organization and projects:
+- mcp__p-platform_get_platform_context — the organization you are acting in and whether access is read-only. Call this first when a request depends on which organization or project you are in.
+- mcp__p-platform_list_projects — the projects in this organization.
+- mcp__p-platform_find_mcp — find MCP servers configured in a project; returns a bounded page and a continuation cursor.
+- mcp__p-platform_get_mcp — one configured MCP server in detail.
+
+Catalog and registration:
+- mcp__p-platform_search_mcp_catalog — search the reviewed MCP catalog for candidates.
+- mcp__p-platform_inspect_mcp_candidate — inspect one candidate, including the non-secret configuration it declares.
+- mcp__p-platform_register_catalog_mcp — register a reviewed candidate into a project, privately.
+- mcp__p-platform_get_setup_handoff — the setup steps and dashboard links for a registration.
+
+Skills:
+- mcp__p-platform_list_skills — the skills in a project.
+- mcp__p-platform_get_skill — one skill in full.
+- mcp__p-platform_list_skill_versions — a skill's immutable versions.
+- mcp__p-platform_create_skill — create a skill from complete SKILL.md content.
+- mcp__p-platform_add_skill_version — record a new immutable version of an existing skill.
+- mcp__p-platform_update_skill_metadata — change a skill's registry naming.
+- mcp__p-platform_distribute_skill — distribute a skill to exactly one plugin or assistant, which is what delivers it to machines.
+
+Documentation: mcp__p-platform_search_gram_docs, mcp__p-platform_read_gram_doc.
+
+Feedback: mcp__p-platform_send_platform_mcp_feedback — record the user's feedback about this tool surface when they offer it.
+
+Your own runtime: mcp__p-assistants_skills_load, mcp__p-assistants_platform_skill_feedback, mcp__p-assistants_platform_memory_remember, mcp__p-assistants_platform_memory_recall, mcp__p-assistants_platform_memory_forget, mcp__p-assistants_platform_list_triggers, mcp__p-assistants_platform_configure_trigger.
+
+## Calling tools
+
+The list above is complete and exact. Do not keyword-search for these tools, and do not guess at variants of these names — a name that is not on the list does not exist.
+
+You still need a tool's input schema before calling it. Fetch schemas in ONE batched call: tool_search with query "select:" followed by the exact names, comma-separated (for example `select:mcp__p-platform_search_mcp_catalog,mcp__p-platform_inspect_mcp_candidate`). A `select:` search returns every name you asked for, so ask for everything the task needs at once instead of searching per tool. Reserve keyword searches for MCP servers attached by the user, whose tools are not listed above.
+
+The rest of these instructions refer to tools by their short name (`search_gram_docs`). The name you call is always the prefixed one listed above (`mcp__p-platform_search_gram_docs`).
+
+Call a tool directly by its exact name. Use a compose script only to fan out the same call over many inputs (for example one lookup per project in a list); a single call, or two unrelated calls, should never go through compose.
+
+A tool may answer that its capability is not enabled in the current rollout. That is a real answer, not a transport failure: say so plainly and stop, rather than retrying it or searching for a substitute.
+
+## What you cannot do here
+
+You do not have telemetry, chat history, risk findings, cost, or user directory tools on this rollout. When the user asks about logs, tool calls, chats, risk or policy findings, or spend, say that those live in the dashboard and are outside what you can query — do not search for a tool that would answer it, and do not answer from your own priors.
+
+## Working rules
+
+Treat all 4xx HTTP status codes (400, 401, 403, 404, etc.) as errors. From the user's perspective these indicate real problems — authentication failures, misconfigured requests, missing resources, etc.
+
+Registration is a guided flow, and every step is the user's decision. List catalog options and eligible projects, then have the user pick one of each before anything is written. Inspect the chosen candidate and collect only the non-secret configuration it declares. Register privately, then call get_setup_handoff and walk the user through the steps it returns. Readiness checks and identity-provider setup are not available to you here, so hand the user the links the handoff returns rather than asserting a server is ready. Present any URL a tool returns as the exact clickable link — never say a link is "above", and never ask the user to confirm an unspecified authorization action.
+
+Never request or accept OAuth codes, tokens, client secrets, passwords, API keys, or secret headers in chat. Ordinary non-secret URLs are fine to discuss and return. A registration's dashboard_setup_url is the Authentication settings fallback, not the authorization page.
+
+Registering a server does not deliver it to anyone: a server reaches machines only once it is in the project's Default plugin, and adding it there is not something you can do from here. Say so when you hand off, so the user does not read a successful registration as a finished job.
+
+Skills work the same way. Creating one does not deliver it: when the user asks to add a skill to a plugin, finish the job with distribute_skill rather than telling them to do it in the dashboard. A skill's versions are immutable, so a change to an existing skill is add_skill_version, not a new skill; update_skill_metadata only changes registry naming.
+
+Product documentation: the AI control plane docs (speakeasy.com/docs/ai-control-plane) are available through search_gram_docs and read_gram_doc. Reach for them whenever the user asks how a product feature works, how to configure something, what a concept means, or why the platform behaves a certain way — the docs are authoritative and current, and your own knowledge of this product is not. Search first, then read the page you picked, and cite the returned permalink so the user can follow up. The docs are public content, so quoting them is always safe. They describe the product; they are not a source of organization data.

--- a/server/internal/assistants/managed_instructions.go
+++ b/server/internal/assistants/managed_instructions.go
@@ -1,0 +1,38 @@
+package assistants
+
+import (
+	_ "embed"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+)
+
+// The managed assistant's system prompt is per rollout variant, because the
+// variant decides which platform toolset it is served and the two sets share
+// no tool names. A prompt naming tools the runtime does not serve is worse
+// than a thin one: the runner never advertises MCP tool schemas (the declared
+// set is frozen for prompt-cache stability), so a model that trusts a stale
+// name spends the turn searching the catalog for something that cannot be
+// found.
+//
+// Both files name their tools inline, prefixed exactly as the runtime exposes
+// them, so a turn needs no discovery search — only a batched `select:` search
+// for input schemas. managed_instructions_test.go holds the inventories to the
+// registries so a renamed or added tool fails the build rather than silently
+// stranding the prompt.
+
+//go:embed managed_assistant_instructions_legacy.txt
+var managedAssistantInstructionsLegacy string
+
+//go:embed managed_assistant_instructions_platformmcp.txt
+var managedAssistantInstructionsPlatformMCP string
+
+// managedAssistantInstructionsFor returns the system prompt for the managed
+// assistant on the supplied rollout variant. Unrecognized variants resolve to
+// legacy, matching feature.AssistantToolsVariant, so the prompt and the
+// toolset can never disagree about which rollout the turn is on.
+func managedAssistantInstructionsFor(variant feature.Variant) string {
+	if feature.AssistantToolsVariant(variant) == feature.VariantAssistantToolsPlatformMCP {
+		return managedAssistantInstructionsPlatformMCP
+	}
+	return managedAssistantInstructionsLegacy
+}

--- a/server/internal/assistants/managed_instructions_test.go
+++ b/server/internal/assistants/managed_instructions_test.go
@@ -1,0 +1,105 @@
+package assistants
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	platformtoolsruntime "github.com/speakeasy-api/gram/server/internal/platformtools/runtime"
+)
+
+// The managed assistant's prompts name every platform tool inline so a turn
+// needs no discovery search. That only holds while the names are the ones the
+// runtime serves: the runner dispatches on exact names and advertises no MCP
+// schemas, so a stale name in the prompt costs the model a fruitless catalog
+// search rather than failing loudly. These tests hold each prompt to the
+// registry it describes, in both directions.
+
+// promptToolNames extracts the runtime-prefixed tool names a prompt lists for
+// one platform toolset, returning them with the prefix stripped.
+func promptToolNames(t *testing.T, prompt, serverID string) []string {
+	t.Helper()
+
+	pattern := regexp.MustCompile(regexp.QuoteMeta("mcp__"+serverID+"_") + `[a-z0-9_]+`)
+	prefix := "mcp__" + serverID + "_"
+
+	var names []string
+	for _, match := range pattern.FindAllString(prompt, -1) {
+		name := strings.TrimPrefix(match, prefix)
+		if !slices.Contains(names, name) {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+func TestLegacyInstructionsNameTheManagedToolset(t *testing.T) {
+	t.Parallel()
+
+	prompt := managedAssistantInstructionsFor(feature.VariantAssistantToolsLegacy)
+	require.Equal(t,
+		platformtoolsruntime.ManagedAssistantToolsetToolNames(),
+		promptToolNames(t, prompt, "p-managed-assistant"),
+		"legacy prompt must name exactly the managed-assistant toolset's tools",
+	)
+}
+
+func TestPlatformMCPInstructionsNameThePlatformToolset(t *testing.T) {
+	t.Parallel()
+
+	prompt := managedAssistantInstructionsFor(feature.VariantAssistantToolsPlatformMCP)
+	require.Equal(t,
+		platformmcp.AssistantToolNames(),
+		promptToolNames(t, prompt, "p-platform"),
+		"platformmcp prompt must name exactly the tools admitted to the assistant audience",
+	)
+}
+
+func TestBothInstructionsNameTheBaseAssistantsToolset(t *testing.T) {
+	t.Parallel()
+
+	base := platformtoolsruntime.AssistantsToolsetToolNames()
+	for _, variant := range []feature.Variant{
+		feature.VariantAssistantToolsLegacy,
+		feature.VariantAssistantToolsPlatformMCP,
+	} {
+		prompt := managedAssistantInstructionsFor(variant)
+		require.Equal(t, base, promptToolNames(t, prompt, "p-assistants"),
+			"prompt for variant %q must name exactly the base assistants toolset's tools", variant)
+	}
+}
+
+// An unrecognized variant must land on the same prompt as the toolset gate's
+// fallback, or the assistant would be told about tools it was not granted.
+func TestUnknownVariantUsesLegacyInstructions(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		managedAssistantInstructionsFor(feature.VariantAssistantToolsLegacy),
+		managedAssistantInstructionsFor(feature.Variant("something-else")),
+	)
+}
+
+// Tool names must not appear bare in a prompt without the runtime prefix
+// somewhere: a bare name is not callable, and a model that copies one spends
+// the turn recovering from an unknown-tool error.
+func TestInstructionsExplainTheNamePrefix(t *testing.T) {
+	t.Parallel()
+
+	for _, variant := range []feature.Variant{
+		feature.VariantAssistantToolsLegacy,
+		feature.VariantAssistantToolsPlatformMCP,
+	} {
+		prompt := managedAssistantInstructionsFor(variant)
+		require.Contains(t, prompt, "short name",
+			"prompt for variant %q must explain that short names are shorthand for the prefixed ones", variant)
+		require.Contains(t, prompt, "select:",
+			"prompt for variant %q must tell the model to batch schema lookups", variant)
+	}
+}

--- a/server/internal/assistants/platform_slugs_test.go
+++ b/server/internal/assistants/platform_slugs_test.go
@@ -61,12 +61,12 @@ func TestAssistantPlatformSlugsManagedPlatformMCPVariantReplacesLegacy(t *testin
 	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.VariantAssistantToolsPlatformMCP)
 	svc.core.SetFeatureProvider(flags)
 
-	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	grant, err := svc.core.assistantPlatformGrant(t.Context(), managedRecord)
 	require.NoError(t, err)
 	require.Equal(t, []string{
 		platformtools.AssistantsPlatformToolsetSlug,
 		platformtools.PlatformMCPReadToolsetSlug,
-	}, slugs)
+	}, grant.Slugs)
 }
 
 func TestAssistantPlatformSlugsManagedLegacyVariantUnchanged(t *testing.T) {
@@ -78,12 +78,12 @@ func TestAssistantPlatformSlugsManagedLegacyVariantUnchanged(t *testing.T) {
 	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.VariantAssistantToolsLegacy)
 	svc.core.SetFeatureProvider(flags)
 
-	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	grant, err := svc.core.assistantPlatformGrant(t.Context(), managedRecord)
 	require.NoError(t, err)
 	require.Equal(t, []string{
 		platformtools.AssistantsPlatformToolsetSlug,
 		platformtools.ManagedAssistantPlatformToolsetSlug,
-	}, slugs)
+	}, grant.Slugs)
 }
 
 // An unrecognized variant key (e.g. a PostHog variant renamed out from under
@@ -97,12 +97,12 @@ func TestAssistantPlatformSlugsUnknownVariantFallsBackToLegacy(t *testing.T) {
 	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.Variant("control"))
 	svc.core.SetFeatureProvider(flags)
 
-	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	grant, err := svc.core.assistantPlatformGrant(t.Context(), managedRecord)
 	require.NoError(t, err)
 	require.Equal(t, []string{
 		platformtools.AssistantsPlatformToolsetSlug,
 		platformtools.ManagedAssistantPlatformToolsetSlug,
-	}, slugs)
+	}, grant.Slugs)
 }
 
 func TestAssistantPlatformSlugsNoVariantUnchanged(t *testing.T) {
@@ -111,12 +111,12 @@ func TestAssistantPlatformSlugsNoVariantUnchanged(t *testing.T) {
 	svc, managedRecord, _ := platformSlugsFixture(t)
 	svc.core.SetFeatureProvider(&feature.InMemory{})
 
-	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	grant, err := svc.core.assistantPlatformGrant(t.Context(), managedRecord)
 	require.NoError(t, err)
 	require.Equal(t, []string{
 		platformtools.AssistantsPlatformToolsetSlug,
 		platformtools.ManagedAssistantPlatformToolsetSlug,
-	}, slugs)
+	}, grant.Slugs)
 }
 
 func TestAssistantPlatformSlugsNilProviderFallsBackToLegacy(t *testing.T) {
@@ -124,12 +124,12 @@ func TestAssistantPlatformSlugsNilProviderFallsBackToLegacy(t *testing.T) {
 
 	svc, managedRecord, _ := platformSlugsFixture(t)
 
-	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	grant, err := svc.core.assistantPlatformGrant(t.Context(), managedRecord)
 	require.NoError(t, err)
 	require.Equal(t, []string{
 		platformtools.AssistantsPlatformToolsetSlug,
 		platformtools.ManagedAssistantPlatformToolsetSlug,
-	}, slugs)
+	}, grant.Slugs)
 }
 
 func TestAssistantPlatformSlugsNonManagedNeverGetsPlatformToolset(t *testing.T) {
@@ -141,7 +141,7 @@ func TestAssistantPlatformSlugsNonManagedNeverGetsPlatformToolset(t *testing.T) 
 	flags.SetFlagVariant(feature.FlagAssistantPlatformMCP, "org-test", feature.VariantAssistantToolsPlatformMCP)
 	svc.core.SetFeatureProvider(flags)
 
-	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), otherRecord)
+	grant, err := svc.core.assistantPlatformGrant(t.Context(), otherRecord)
 	require.NoError(t, err)
-	require.Equal(t, []string{platformtools.AssistantsPlatformToolsetSlug}, slugs)
+	require.Equal(t, []string{platformtools.AssistantsPlatformToolsetSlug}, grant.Slugs)
 }

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -2,7 +2,6 @@ package assistants
 
 import (
 	"context"
-	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,14 +21,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-// managedAssistantInstructions is the system prompt for the platform-managed
-// assistant that powers the AI Insights sidebar. Ported from the inline prompt
-// that previously lived in the dashboard (insights-sidebar.tsx); the dynamic
-// "current date" line was dropped because the runtime composes time context
-// separately.
-//
-//go:embed managed_assistant_instructions.txt
-var managedAssistantInstructions string
+// The managed assistant's stored instructions are its initial row value only.
+// Every turn composes the prompt from the rollout variant the runtime was
+// granted (see managed_instructions.go), because the row is written once here
+// and never reconciled, and because the two variants serve tool sets that
+// share no names.
 
 const (
 	// managedAssistantModel is the default model for the platform-managed
@@ -271,7 +267,7 @@ func (s *ServiceCore) createManagedAssistant(
 		CreatedByUserID: createdBy,
 		Name:            name,
 		Model:           managedAssistantModel,
-		Instructions:    managedAssistantInstructions,
+		Instructions:    managedAssistantInstructionsLegacy,
 		WarmTtlSeconds:  managedAssistantWarmTTLSeconds,
 		MaxConcurrency:  managedAssistantMaxConcurrency,
 		Status:          StatusActive,

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -49,7 +49,7 @@ func TestEnableManagedAssistantIsIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, managedAssistantName("managed-idempotent"), first.Name)
 	require.Equal(t, managedAssistantModel, first.Model)
-	require.Equal(t, managedAssistantInstructions, first.Instructions)
+	require.Equal(t, managedAssistantInstructionsLegacy, first.Instructions)
 	require.NotEmpty(t, first.Instructions, "managed instructions must be embedded, not empty")
 
 	// A second enable (even by a different user) returns the same assistant.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -2804,38 +2804,55 @@ func (s *ServiceCore) currentRuntimeMCPServers(ctx context.Context, assistant as
 	if serverURL == nil {
 		return nil
 	}
-	platformSlugs, err := s.assistantPlatformSlugs(ctx, assistant)
+	grant, err := s.assistantPlatformGrant(ctx, assistant)
 	if err != nil {
 		s.logger.WarnContext(ctx, "resolve platform toolsets for mcp reconcile failed; skipping reconcile",
 			attr.SlogError(err),
 		)
 		return nil
 	}
-	return resolveAssistantMCPServers(ctx, s.logger, serverURL, assistant.Toolsets, assistant.MCPServers, platformSlugs)
+	return resolveAssistantMCPServers(ctx, s.logger, serverURL, assistant.Toolsets, assistant.MCPServers, grant.Slugs)
 }
 
-// assistantPlatformSlugs returns the platform toolset slugs granted to this
+// platformGrant is what a runtime is served from the platform side of the
+// catalog: the toolset slugs, whether this is the project's managed assistant,
+// and the rollout variant those slugs were resolved on. The variant travels
+// with the slugs because the managed assistant's system prompt names its tools
+// inline and must describe the same set that was granted.
+type platformGrant struct {
+	Slugs   []string
+	Managed bool
+	Variant feature.Variant
+}
+
+// assistantPlatformGrant returns the platform toolsets granted to this
 // assistant's runtime. Every assistant gets the base assistants toolset; the
 // project's managed assistant additionally gets exactly one managed-only
 // toolset — legacy or Platform MCP, per the rollout variant — which must never
 // be reachable by any other assistant.
-func (s *ServiceCore) assistantPlatformSlugs(ctx context.Context, assistant assistantRecord) ([]string, error) {
-	platformSlugs := []string{platformtools.AssistantsPlatformToolsetSlug}
+func (s *ServiceCore) assistantPlatformGrant(ctx context.Context, assistant assistantRecord) (platformGrant, error) {
+	grant := platformGrant{
+		Slugs:   []string{platformtools.AssistantsPlatformToolsetSlug},
+		Managed: false,
+		Variant: feature.VariantAssistantToolsLegacy,
+	}
 	switch managed, mErr := assistantrepo.New(s.db).GetManagedAssistantByProject(ctx, assistant.ProjectID); {
 	case mErr == nil:
 		if managed.ID == assistant.ID {
-			if s.assistantToolsVariant(ctx, assistant.ProjectID) == feature.VariantAssistantToolsPlatformMCP {
-				platformSlugs = append(platformSlugs, platformtools.PlatformMCPReadToolsetSlug)
+			grant.Managed = true
+			grant.Variant = s.assistantToolsVariant(ctx, assistant.ProjectID)
+			if grant.Variant == feature.VariantAssistantToolsPlatformMCP {
+				grant.Slugs = append(grant.Slugs, platformtools.PlatformMCPReadToolsetSlug)
 			} else {
-				platformSlugs = append(platformSlugs, platformtools.ManagedAssistantPlatformToolsetSlug)
+				grant.Slugs = append(grant.Slugs, platformtools.ManagedAssistantPlatformToolsetSlug)
 			}
 		}
 	case errors.Is(mErr, pgx.ErrNoRows):
 		// Project has no managed assistant; managed-only tools stay ungranted.
 	default:
-		return nil, fmt.Errorf("resolve managed assistant: %w", mErr)
+		return platformGrant{}, fmt.Errorf("resolve managed assistant: %w", mErr)
 	}
-	return platformSlugs, nil
+	return grant, nil
 }
 
 // assistantToolsVariant reports which managed-assistant platform toolset the
@@ -3027,7 +3044,7 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 	// The managed-assistant platform toolset is granted only to the project's
 	// managed assistant; tools in it must not be reachable by any other
 	// assistant.
-	platformSlugs, err := s.assistantPlatformSlugs(ctx, assistant)
+	grant, err := s.assistantPlatformGrant(ctx, assistant)
 	if err != nil {
 		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "resolve managed assistant").LogError(ctx, s.logger, logAttrs...)
 	}
@@ -3036,9 +3053,17 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 	// best-effort URLs rather than aborting the whole bootstrap. The runner
 	// will discover the failure when it tries to list tools and the
 	// assistant can tell the user which integration is broken.
-	mcpServers := resolveAssistantMCPServers(ctx, s.logger, runtimeServerURL, assistant.Toolsets, assistant.MCPServers, platformSlugs)
+	mcpServers := resolveAssistantMCPServers(ctx, s.logger, runtimeServerURL, assistant.Toolsets, assistant.MCPServers, grant.Slugs)
 
-	instructions, err := composeInstructions(assistant.Instructions, thread, baselineSkills.Skills)
+	// The managed assistant's prompt is owned by the platform, not by the
+	// stored row: it must name the toolset this turn was actually granted,
+	// and the row is written once at provisioning and never reconciled.
+	base := assistant.Instructions
+	if grant.Managed {
+		base = managedAssistantInstructionsFor(grant.Variant)
+	}
+
+	instructions, err := composeInstructions(base, thread, baselineSkills.Skills)
 	if err != nil {
 		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "compose assistant instructions").LogError(ctx, s.logger, logAttrs...)
 	}

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -135,7 +135,13 @@ const (
 	VariantAssistantToolsLegacy Variant = "legacy"
 	// VariantAssistantToolsPlatformMCP serves the managed assistant the
 	// "platform" toolset — the Platform MCP read tools — INSTEAD of the
-	// legacy toolset, not in addition to it.
+	// legacy toolset, not in addition to it. The exclusivity is the point of
+	// the rollout: with both sets in context there is no way to tell whether
+	// the Platform MCP surface answers better than the legacy one. It also
+	// means the variant is not a re-plumbing of the same capabilities — the
+	// catalogue admits no telemetry, chat, risk, or skill tools, so an
+	// assistant on this variant genuinely cannot answer those questions and
+	// its system prompt says so rather than sending the model looking.
 	VariantAssistantToolsPlatformMCP Variant = "platformmcp"
 )
 

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -248,9 +248,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 	feedbackRecorder := feedbackrecorder.NewRecorder(conn, logger, nil)
 	assistantSkillTools := platformtoolsruntime.AssistantSkillTools(logger, conn, feedbackRecorder)
 	platformToolsets := platformtools.BuildToolsets(platformtools.ToolsetDependencies{
-		AssistantMemoryTools:          nil,
-		AssistantSkillTools:           assistantSkillTools,
-		AssistantTriggerTools:         nil,
+		AssistantTools:                assistantSkillTools,
 		ManagedAssistantInsightsTools: managedLogsTools,
 		// Composed the way the server composes it: descriptors admitted to the
 		// assistant audience, called directly by the adapter.

--- a/server/internal/platformmcp/assistant_tool_names.go
+++ b/server/internal/platformmcp/assistant_tool_names.go
@@ -1,0 +1,39 @@
+package platformmcp
+
+import (
+	"slices"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+)
+
+// AssistantToolNames returns the names of every catalogue tool admitted to a
+// project's managed assistant.
+//
+// The managed assistant's system prompt names its tools inline so the model
+// can call them without discovery searches; this exists so a drift test can
+// hold that prompt to the catalogue rather than letting it rot as tools are
+// added or renamed.
+//
+// It composes the catalogue with no dependencies. Every capability registers
+// an unavailable stub under the same name and audiences when its dependency is
+// absent, so the name set is exactly the served one while the handlers are
+// inert. Nothing here may be used to serve traffic.
+func AssistantToolNames() []string {
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{
+		ProviderKey:      "",
+		Registry:         externalmcp.Registry{ID: uuid.Nil, URL: ""},
+		CanonicalRef:     "",
+		AllowedRemoteURL: "",
+		SetupIntent:      "",
+	})
+
+	descriptors := registrar.For(AudienceAssistant)
+	names := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		names = append(names, descriptor.Name)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/server/internal/platformmcp/feedback.go
+++ b/server/internal/platformmcp/feedback.go
@@ -392,8 +392,6 @@ var knownPlatformMCPToolNames = map[string]struct{}{
 	"get_setup_handoff":                     {},
 	"get_mcp_readiness":                     {},
 	"get_mcp_repair_plan":                   {},
-	"distribute_mcp_to_default_plugin":      {},
-	"remove_mcp_from_default_plugin":        {},
 	"register_platform_mcp_for_project":     {},
 	"get_platform_mcp_onboarding_status":    {},
 	"attach_platform_mcp_identity_provider": {},

--- a/server/internal/platformmcp/tool_onboarding_lifecycle.go
+++ b/server/internal/platformmcp/tool_onboarding_lifecycle.go
@@ -67,8 +67,39 @@ type DistributeOnboardingMCPToolOutput struct {
 	Message          string `json:"message"`
 }
 
+// The onboarding lifecycle tools are registered twice: live here, and as
+// unavailable stubs in tools.go when the dependencies are absent. Identity —
+// name and title — is declared once so the two can only agree. Descriptions
+// stay at each site: the live one instructs, the stub one explains why the
+// capability is not there. Adding a lifecycle tool means adding an entry here
+// and registering it in both places; the stub set is checked against this
+// table in tools_test.go.
+var onboardingLifecycleToolIdentities = []struct {
+	Name  string
+	Title string
+}{
+	{"register_platform_mcp_for_project", "Register Catalogue MCP for Project"},
+	{"get_platform_mcp_onboarding_status", "Get Platform MCP Onboarding Status"},
+	{"attach_platform_mcp_identity_provider", "Attach Platform MCP Identity Provider"},
+	{"add_platform_mcp_to_default_plugin", "Add Platform MCP to Default Plugin"},
+}
+
+// onboardingLifecycleTool returns the identity at index i. Both registrars
+// index the same table, so a rename reaches the stub without a second edit.
+func onboardingLifecycleTool(i int) (string, string) {
+	return onboardingLifecycleToolIdentities[i].Name, onboardingLifecycleToolIdentities[i].Title
+}
+
+const (
+	onboardingToolRegister = iota
+	onboardingToolStatus
+	onboardingToolAttachIdentityProvider
+	onboardingToolAddToDefaultPlugin
+)
+
 func registerOnboardingLifecycleTools(reg *Registrar, onboarding *OnboardingService, registrations *RegistrationService, distributions *DistributionService) {
-	addTool(reg, &mcp.Tool{Name: "register_platform_mcp_for_project", Title: "Register Catalogue MCP for Project", Description: "Register a reviewed MCP Catalogue server for an explicit project. Use the exact candidate returned by search_mcp_catalog and inspect_mcp_candidate. Supply declared non-secret values only; required secrets stay in secure dashboard setup. Registration is private and does not distribute or publish the MCP."}, ToolMeta{
+	registerName, registerTitle := onboardingLifecycleTool(onboardingToolRegister)
+	addTool(reg, &mcp.Tool{Name: registerName, Title: registerTitle, Description: "Register a reviewed MCP Catalogue server for an explicit project. Use the exact candidate returned by search_mcp_catalog and inspect_mcp_candidate. Supply declared non-secret values only; required secrets stay in secure dashboard setup. Registration is private and does not distribute or publish the MCP."}, ToolMeta{
 		// External-only: onboarding milestones are connection-scoped, which a
 		// connection-less surface cannot satisfy.
 		Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input RegisterOnboardingMCPToolInput) (*mcp.CallToolResult, RegisterOnboardingMCPToolOutput, error) {
@@ -118,7 +149,8 @@ func registerOnboardingLifecycleTools(reg *Registrar, onboarding *OnboardingServ
 		return nil, RegisterOnboardingMCPToolOutput{ProjectSlug: input.ProjectSlug, RegistrationID: registrationID.String(), NextAction: nextAction, Message: message, DashboardSetupURL: dashboardSetupURL, SecretFieldsPending: append([]CatalogConfigurationField(nil), result.SecretFieldsPending...)}, nil
 	})
 
-	addTool(reg, &mcp.Tool{Name: "get_platform_mcp_onboarding_status", Title: "Get Platform MCP Onboarding Status", Description: "Check the workflow-bound MCP Catalogue server setup status for an explicit project. This returns bounded readiness facts, the registration ID, and an actionable next step. When there is no readiness evidence yet, it performs one rate-limited authenticated probe. Set force after the user completes dashboard setup or provider authorization to recheck fresh readiness."}, ToolMeta{
+	statusName, statusTitle := onboardingLifecycleTool(onboardingToolStatus)
+	addTool(reg, &mcp.Tool{Name: statusName, Title: statusTitle, Description: "Check the workflow-bound MCP Catalogue server setup status for an explicit project. This returns bounded readiness facts, the registration ID, and an actionable next step. When there is no readiness evidence yet, it performs one rate-limited authenticated probe. Set force after the user completes dashboard setup or provider authorization to recheck fresh readiness."}, ToolMeta{
 		// External-only: onboarding milestones are connection-scoped, which a
 		// connection-less surface cannot satisfy.
 		Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetOnboardingMCPStatusToolInput) (*mcp.CallToolResult, GetOnboardingMCPStatusToolOutput, error) {
@@ -178,7 +210,8 @@ func registerOnboardingLifecycleTools(reg *Registrar, onboarding *OnboardingServ
 		return nil, GetOnboardingMCPStatusToolOutput{ProjectSlug: input.ProjectSlug, RegistrationID: registrationID, Registered: true, Readiness: string(normalized.State), Freshness: readinessFreshness(readiness, found), EvidenceCode: normalized.EvidenceCode, NextAction: nextAction, Message: message}, nil
 	})
 
-	addTool(reg, &mcp.Tool{Name: "attach_platform_mcp_identity_provider", Title: "Attach Platform MCP Identity Provider", Description: "Attach the workflow-bound MCP's one discovered remote identity provider for an explicit project. Ask for explicit user confirmation before calling this tool. It derives provider metadata and dynamic client registration from the persisted reviewed MCP source. Non-secret provider URLs may be returned, but it never accepts or returns credentials, OAuth codes, tokens, client secrets, passwords, or API keys. After success, immediately present authorization_url as a clickable link and tell the user to open it and use Connect or Authorize; do not ask whether they completed an unspecified action or refer to a link above."}, ToolMeta{
+	attachName, attachTitle := onboardingLifecycleTool(onboardingToolAttachIdentityProvider)
+	addTool(reg, &mcp.Tool{Name: attachName, Title: attachTitle, Description: "Attach the workflow-bound MCP's one discovered remote identity provider for an explicit project. Ask for explicit user confirmation before calling this tool. It derives provider metadata and dynamic client registration from the persisted reviewed MCP source. Non-secret provider URLs may be returned, but it never accepts or returns credentials, OAuth codes, tokens, client secrets, passwords, or API keys. After success, immediately present authorization_url as a clickable link and tell the user to open it and use Connect or Authorize; do not ask whether they completed an unspecified action or refer to a link above."}, ToolMeta{
 		// External-only: provider setup is connection-scoped, which a
 		// connection-less surface cannot satisfy.
 		Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input AttachOnboardingMCPIdentityProviderToolInput) (*mcp.CallToolResult, AttachOnboardingMCPIdentityProviderToolOutput, error) {
@@ -218,7 +251,8 @@ func registerOnboardingLifecycleTools(reg *Registrar, onboarding *OnboardingServ
 		return nil, onboardingIdentityProviderAttachmentOutput(input.ProjectSlug, registrationID, attachment, authorizationURL), nil
 	})
 
-	addTool(reg, &mcp.Tool{Name: "add_platform_mcp_to_default_plugin", Title: "Add Platform MCP to Default Plugin", Description: "Add the workflow-bound, ready MCP Catalogue server to the explicit project's existing Default plugin. The project must already be selected, registered, and freshly ready through the dashboard setup flow. This never creates a plugin."}, ToolMeta{
+	addName, addTitle := onboardingLifecycleTool(onboardingToolAddToDefaultPlugin)
+	addTool(reg, &mcp.Tool{Name: addName, Title: addTitle, Description: "Add the workflow-bound, ready MCP Catalogue server to the explicit project's existing Default plugin. The project must already be selected, registered, and freshly ready through the dashboard setup flow. This never creates a plugin."}, ToolMeta{
 		// External-only: distribution rows require a connection, which a
 		// connection-less surface cannot satisfy.
 		Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input DistributeOnboardingMCPToolInput) (*mcp.CallToolResult, DistributeOnboardingMCPToolOutput, error) {

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -243,22 +243,30 @@ func registerUnavailableSetupHandoffTool(reg *Registrar) {
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("setup_handoff"))
 }
 
+// registerUnavailableTools stands in for registerOnboardingLifecycleTools when
+// the onboarding dependencies are absent. It mirrors that function one-for-one:
+// same names, same audiences, same project scope. The pair predates the live
+// tools — they were placeholders for a capability that did not exist yet, and
+// when it arrived it was written in tool_onboarding_lifecycle.go under the
+// onboarding flow's own names, leaving two vocabularies for one capability and
+// nothing to hold them together. Keep them aligned here: a client that meets
+// this deployment on one side of the rollout and the other must see one tool
+// change availability, not one name replace another.
 func registerUnavailableTools(reg *Registrar) {
-	for _, tool := range []struct {
-		name        string
-		title       string
-		description string
-		feature     string
-	}{
+	descriptions := [...]string{
+		onboardingToolRegister:               "Register a reviewed MCP Catalogue server for an explicit project. Guided setup is not enabled in the current rollout.",
+		onboardingToolStatus:                 "Check the workflow-bound MCP Catalogue server setup status for an explicit project. Guided setup is not enabled in the current rollout.",
+		onboardingToolAttachIdentityProvider: "Attach the workflow-bound MCP's discovered remote identity provider for an explicit project. Guided setup is not enabled in the current rollout.",
+		onboardingToolAddToDefaultPlugin:     "Add the workflow-bound, ready MCP Catalogue server to the explicit project's existing Default plugin. Guided setup is not enabled in the current rollout.",
+	}
 
-		{"distribute_mcp_to_default_plugin", "Distribute MCP to Default Plugin", "Distribute a configured MCP to the default plugin. Distribution is not available in the current preview.", "plugin_distribution"},
-		{"remove_mcp_from_default_plugin", "Remove MCP from Default Plugin", "Remove an MCP from the default plugin. Distribution changes are not available in the current preview.", "plugin_distribution"},
-	} {
+	for i, description := range descriptions {
+		name, title := onboardingLifecycleTool(i)
 		addTool(reg, &mcp.Tool{
-			Name:        tool.name,
-			Title:       tool.title,
-			Description: tool.description,
-		}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool(tool.feature))
+			Name:        name,
+			Title:       title,
+			Description: description,
+		}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("onboarding_lifecycle"))
 	}
 }
 

--- a/server/internal/platformmcp/tools_test.go
+++ b/server/internal/platformmcp/tools_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -55,4 +56,81 @@ func TestOperationBudgetToolResultMapsRegistrationInputErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The onboarding lifecycle capability is registered from two places — live
+// tools when its dependencies are wired, unavailable stubs when they are not.
+// They diverged once already: the stubs predated the live tools and kept
+// placeholder names (distribute_mcp_to_default_plugin) after the real ones
+// arrived under the onboarding flow's vocabulary, so a client saw one name
+// replace another as the rollout flipped rather than one tool change
+// availability. Identity now comes from one table; these tests keep both
+// registrars on it.
+func TestUnavailableOnboardingToolsMirrorTheLifecycleTable(t *testing.T) {
+	t.Parallel()
+
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
+
+	registered := map[string]Descriptor{}
+	for _, descriptor := range registrar.For(AudienceExternal) {
+		registered[descriptor.Name] = descriptor
+	}
+
+	for _, identity := range onboardingLifecycleToolIdentities {
+		descriptor, ok := registered[identity.Name]
+		require.True(t, ok, "lifecycle tool %q has no unavailable stub", identity.Name)
+		require.Equal(t, ProjectScopeExplicit, descriptor.Meta.ProjectScope,
+			"stub %q must carry its live counterpart's project scope", identity.Name)
+		require.Equal(t, externalOnly, descriptor.Meta.Audiences,
+			"stub %q must carry its live counterpart's audiences", identity.Name)
+	}
+}
+
+// A lifecycle tool must never reach the assistant, in either state. The live
+// tools are external-only because onboarding milestones are connection-scoped,
+// and an assistant has no connection — a stub admitted where its live
+// counterpart is not would advertise a capability that can only ever error.
+func TestUnavailableOnboardingToolsAreNotAdmittedToTheAssistant(t *testing.T) {
+	t.Parallel()
+
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
+
+	admitted := map[string]bool{}
+	for _, descriptor := range registrar.For(AudienceAssistant) {
+		admitted[descriptor.Name] = true
+	}
+
+	for _, identity := range onboardingLifecycleToolIdentities {
+		require.False(t, admitted[identity.Name],
+			"lifecycle stub %q must not be admitted to the assistant", identity.Name)
+	}
+}
+
+// The rollout changes what a tool can do, never what it is called. Composing
+// the catalogue with and without the onboarding dependencies must therefore
+// produce the same names on the same audiences — the unavailable stubs stand
+// in for the live tools, so any name a client learns in one state is still
+// there in the other.
+func TestCatalogueSurfaceIsTheSameWithAndWithoutOnboardingDependencies(t *testing.T) {
+	t.Parallel()
+
+	registrations := newRegistrationService(testCatalog{}, &testRegistrationGate{enabled: true}, &recordingRegistrationStore{})
+
+	_, stubbed := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
+	_, live := newServer(nil, testCatalog{}, registrations, "cursor-key-material", nil, nil, &OnboardingService{}, &DistributionService{}, nil, CatalogDescriptor{})
+
+	for _, audience := range []Audience{AudienceExternal, AudienceAssistant} {
+		require.Equal(t, descriptorNames(stubbed, audience), descriptorNames(live, audience),
+			"audience %q sees a different tool set depending on whether onboarding dependencies are wired", audience)
+	}
+}
+
+func descriptorNames(registrar *Registrar, audience Audience) []string {
+	descriptors := registrar.For(audience)
+	names := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		names = append(names, descriptor.Name)
+	}
+	slices.Sort(names)
+	return names
 }

--- a/server/internal/platformtools/registry_test.go
+++ b/server/internal/platformtools/registry_test.go
@@ -114,9 +114,7 @@ func TestBuildToolsetsIncludesPlatformMCPReadToolset(t *testing.T) {
 	}
 
 	toolsets := BuildToolsets(ToolsetDependencies{
-		AssistantMemoryTools:          nil,
-		AssistantSkillTools:           nil,
-		AssistantTriggerTools:         nil,
+		AssistantTools:                nil,
 		ManagedAssistantInsightsTools: nil,
 		PlatformMCPReadTools:          []ExternalTool{tool},
 	})

--- a/server/internal/platformtools/runtime/tool_names.go
+++ b/server/internal/platformtools/runtime/tool_names.go
@@ -1,0 +1,55 @@
+package runtime
+
+import (
+	"slices"
+
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+)
+
+// The managed assistant's system prompt names its platform tools inline so the
+// model can call them without discovery searches. These helpers return the
+// names actually served, so a drift test can hold the prompt to the wiring
+// instead of the prompt quietly rotting when a tool is added or renamed.
+//
+// Both build their tool slices with nil dependencies: a tool's Descriptor is
+// static and never touches its service, so the names are exact while the
+// executors are inert. Nothing here may be used to serve traffic.
+
+// AssistantsToolsetToolNames returns the tool names on the base "assistants"
+// platform toolset, granted to every assistant runtime.
+func AssistantsToolsetToolNames() []string {
+	tools := slices.Concat(
+		MemoryExternalTools(nil),
+		AssistantSkillTools(nil, nil, nil),
+		TriggerExternalTools(nil, nil, nil),
+	)
+	return externalToolNames(tools)
+}
+
+// ManagedAssistantToolsetToolNames returns the tool names on the
+// "managed-assistant" platform toolset — the legacy managed-only set of
+// insights, chat, user, risk, deployment, skill, plugin, docs and changelog
+// tools. Keep in lockstep with the managedInsightsTools wiring in start.go.
+func ManagedAssistantToolsetToolNames() []string {
+	tools := slices.Concat(
+		ManagedAssistantLogsTools(nil),
+		ManagedAssistantChatsTools(nil),
+		ManagedAssistantUsersTools(nil),
+		ManagedAssistantRiskTools(nil),
+		ManagedAssistantDeploymentsTools(nil),
+		ManagedAssistantSkillsTools(nil, nil),
+		ManagedAssistantPluginsTools(nil),
+		ManagedAssistantChangelogTools(nil),
+		ManagedAssistantDocsTools(nil),
+	)
+	return externalToolNames(tools)
+}
+
+func externalToolNames(tools []platformtools.ExternalTool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Executor.Descriptor().Name)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/server/internal/platformtools/runtime/tool_names.go
+++ b/server/internal/platformtools/runtime/tool_names.go
@@ -1,48 +1,118 @@
 package runtime
 
 import (
+	"log/slog"
 	"slices"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/memory"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	platformchats "github.com/speakeasy-api/gram/server/internal/platformtools/chats"
+	platformdeployments "github.com/speakeasy-api/gram/server/internal/platformtools/deployments"
+	platformplugins "github.com/speakeasy-api/gram/server/internal/platformtools/plugins"
+	platformrisk "github.com/speakeasy-api/gram/server/internal/platformtools/risk"
+	platformskills "github.com/speakeasy-api/gram/server/internal/platformtools/skills"
+	platformusers "github.com/speakeasy-api/gram/server/internal/platformtools/users"
+	feedbackrecorder "github.com/speakeasy-api/gram/server/internal/skills/feedback"
 )
 
-// The managed assistant's system prompt names its platform tools inline so the
-// model can call them without discovery searches. These helpers return the
-// names actually served, so a drift test can hold the prompt to the wiring
-// instead of the prompt quietly rotting when a tool is added or renamed.
-//
-// Both build their tool slices with nil dependencies: a tool's Descriptor is
-// static and never touches its service, so the names are exact while the
-// executors are inert. Nothing here may be used to serve traffic.
+// A platform toolset is composed once, here, and the composition is the only
+// statement of what it contains. The managed assistant's system prompt names
+// its tools inline so a turn needs no discovery search, and a drift test holds
+// the prompt to these functions — which is only worth anything if they are
+// what the server actually serves, rather than a second list kept in step by
+// hand.
 
-// AssistantsToolsetToolNames returns the tool names on the base "assistants"
+// AssistantsToolsetDeps carries the services behind the base "assistants"
 // platform toolset, granted to every assistant runtime.
-func AssistantsToolsetToolNames() []string {
-	tools := slices.Concat(
-		MemoryExternalTools(nil),
-		AssistantSkillTools(nil, nil, nil),
-		TriggerExternalTools(nil, nil, nil),
-	)
-	return externalToolNames(tools)
+type AssistantsToolsetDeps struct {
+	Memory           *memory.MemoryService
+	Logger           *slog.Logger
+	DB               *pgxpool.Pool
+	FeedbackRecorder *feedbackrecorder.Recorder
+	SkillLoadOptions []platformskills.LoadOption
+	Triggers         *bgtriggers.App
+	Audit            *audit.Logger
 }
 
-// ManagedAssistantToolsetToolNames returns the tool names on the
-// "managed-assistant" platform toolset — the legacy managed-only set of
-// insights, chat, user, risk, deployment, skill, plugin, docs and changelog
-// tools. Keep in lockstep with the managedInsightsTools wiring in start.go.
-func ManagedAssistantToolsetToolNames() []string {
-	tools := slices.Concat(
-		ManagedAssistantLogsTools(nil),
-		ManagedAssistantChatsTools(nil),
-		ManagedAssistantUsersTools(nil),
-		ManagedAssistantRiskTools(nil),
-		ManagedAssistantDeploymentsTools(nil),
-		ManagedAssistantSkillsTools(nil, nil),
-		ManagedAssistantPluginsTools(nil),
-		ManagedAssistantChangelogTools(nil),
-		ManagedAssistantDocsTools(nil),
+// ManagedAssistantToolsetDeps carries the services behind the
+// "managed-assistant" platform toolset — the managed-only insights, chat,
+// user, risk, deployment, skill, plugin, docs and changelog tools.
+//
+// MarketingSite must be a guardian-policy client: the changelog and docs tools
+// fetch speakeasy.com, and the egress rules apply to them like any other
+// outbound request.
+type ManagedAssistantToolsetDeps struct {
+	Telemetry     platformtools.TelemetryService
+	Chats         platformchats.ChatService
+	Users         platformusers.OrganizationsService
+	Risk          platformrisk.RiskService
+	Deployments   platformdeployments.DeploymentsService
+	Skills        platformskills.SkillsService
+	SkillInsights platformskills.SkillInsightsReader
+	Plugins       platformplugins.PluginsService
+	MarketingSite *guardian.HTTPClient
+}
+
+// AssistantsToolset composes the base "assistants" platform toolset.
+func AssistantsToolset(deps AssistantsToolsetDeps) []platformtools.ExternalTool {
+	return slices.Concat(
+		MemoryExternalTools(deps.Memory),
+		AssistantSkillTools(deps.Logger, deps.DB, deps.FeedbackRecorder, deps.SkillLoadOptions...),
+		TriggerExternalTools(deps.DB, deps.Triggers, deps.Audit),
 	)
-	return externalToolNames(tools)
+}
+
+// ManagedAssistantToolset composes the "managed-assistant" platform toolset.
+func ManagedAssistantToolset(deps ManagedAssistantToolsetDeps) []platformtools.ExternalTool {
+	return slices.Concat(
+		ManagedAssistantLogsTools(deps.Telemetry),
+		ManagedAssistantChatsTools(deps.Chats),
+		ManagedAssistantUsersTools(deps.Users),
+		ManagedAssistantRiskTools(deps.Risk),
+		ManagedAssistantDeploymentsTools(deps.Deployments),
+		ManagedAssistantSkillsTools(deps.Skills, deps.SkillInsights),
+		ManagedAssistantPluginsTools(deps.Plugins),
+		ManagedAssistantChangelogTools(deps.MarketingSite),
+		ManagedAssistantDocsTools(deps.MarketingSite),
+	)
+}
+
+// AssistantsToolsetToolNames and ManagedAssistantToolsetToolNames return the
+// names each toolset serves, for the prompt drift tests.
+//
+// Both compose with zero dependencies: a tool's Descriptor is static and never
+// touches its service, so the names are exact while the executors are inert.
+// Nothing here may be used to serve traffic.
+
+func AssistantsToolsetToolNames() []string {
+	return externalToolNames(AssistantsToolset(AssistantsToolsetDeps{
+		Memory:           nil,
+		Logger:           nil,
+		DB:               nil,
+		FeedbackRecorder: nil,
+		SkillLoadOptions: nil,
+		Triggers:         nil,
+		Audit:            nil,
+	}))
+}
+
+func ManagedAssistantToolsetToolNames() []string {
+	return externalToolNames(ManagedAssistantToolset(ManagedAssistantToolsetDeps{
+		Telemetry:     nil,
+		Chats:         nil,
+		Users:         nil,
+		Risk:          nil,
+		Deployments:   nil,
+		Skills:        nil,
+		SkillInsights: nil,
+		Plugins:       nil,
+		MarketingSite: nil,
+	}))
 }
 
 func externalToolNames(tools []platformtools.ExternalTool) []string {

--- a/server/internal/platformtools/toolsets.go
+++ b/server/internal/platformtools/toolsets.go
@@ -36,9 +36,13 @@ type Toolset struct {
 // platform toolset registry. Add a field here when a new toolset needs an
 // external service or pre-built tool slice.
 type ToolsetDependencies struct {
-	AssistantMemoryTools          []ExternalTool
-	AssistantSkillTools           []ExternalTool
-	AssistantTriggerTools         []ExternalTool
+	// AssistantTools and ManagedAssistantInsightsTools each arrive composed,
+	// from one function in platformtools/runtime, so the served set has a
+	// single statement. The managed assistant's system prompt names these
+	// tools inline and a drift test holds it to those compositions; splitting
+	// a toolset across several fields here would give the test a mirror to
+	// check rather than the thing being served.
+	AssistantTools                []ExternalTool
 	ManagedAssistantInsightsTools []ExternalTool
 	PlatformMCPReadTools          []ExternalTool
 }
@@ -47,11 +51,7 @@ type toolsetBuilder func(deps ToolsetDependencies) Toolset
 
 var toolsetRegistry = []toolsetBuilder{
 	func(deps ToolsetDependencies) Toolset {
-		tools := make([]ExternalTool, 0, len(deps.AssistantMemoryTools)+len(deps.AssistantSkillTools)+len(deps.AssistantTriggerTools))
-		tools = append(tools, deps.AssistantMemoryTools...)
-		tools = append(tools, deps.AssistantSkillTools...)
-		tools = append(tools, deps.AssistantTriggerTools...)
-		return NewAssistantsToolset(tools...)
+		return NewAssistantsToolset(deps.AssistantTools...)
 	},
 	func(deps ToolsetDependencies) Toolset {
 		tools := make([]ExternalTool, 0, len(deps.ManagedAssistantInsightsTools))


### PR DESCRIPTION
## Problem

The managed (dashboard) assistant's system prompt was written into `assistants.instructions` once at provisioning and never reconciled, and it named its tools in bare form (`platform_search_logs`). The runner never advertises MCP tool schemas — the declared set is frozen for the thread's lifetime so the provider prompt cache survives catalog churn — and `HiddenCatalogSource` dispatches on exact namespaced names. So none of the names in the prompt resolved. A turn spent itself keyword-searching the catalog for tools that could not be found, then reached for `compose` to brute-force the call.

Under the `platformmcp` rollout variant it was worse. That variant serves the Platform MCP tools *instead of* the legacy toolset, so the prompt's whole subject matter — logs, risk findings, attribute keys — had no tools behind it at all.

## Changes

**Prompt is composed per turn, from the variant that was actually granted.** `assistantPlatformSlugs` becomes `assistantPlatformGrant`, returning the slugs, whether this is the project's managed assistant, and the rollout variant they were resolved on. Bootstrap picks the prompt from that same grant, so prompt and toolset cannot disagree. The stored row remains the initial value; the platform owns the prompt from there.

**Two prompts, each naming its own tools inline**, prefixed exactly as the runtime exposes them (`mcp__p-managed-assistant_platform_search_logs`). No discovery search is needed — only one batched `select:` lookup for input schemas, which the runner's `tool_search` returns uncapped. `compose` is narrowed to fan-out over many inputs. The platformmcp prompt states what it cannot answer, so out-of-scope questions end in one turn.

**Two bugs found while writing the drift guard:**

- Unavailable stubs for the onboarding lifecycle declared `bothAudiences` while their live counterparts are `externalOnly`, so a managed assistant saw two distribution tools that vanished once the onboarding dependencies were wired — the exact flip the audience rule in `tools.go` exists to prevent.
- Those stubs also predated the live tools and kept placeholder names (`distribute_mcp_to_default_plugin`) after the real ones landed in `tool_onboarding_lifecycle.go` under the onboarding flow's vocabulary (`add_platform_mcp_to_default_plugin`). Two vocabularies for one capability, with nothing holding them together; `feedback.go`'s allowlist carried both. Tool identity now lives in one table both registrars index, so a rename moves both sides at once.

## Tests

- Each prompt's tool inventory is held to the registry it describes, in both directions, for all three toolsets. This already caught two real divergences: readiness tools that are external-only, and this rebase picking up main's new skills lane.
- The catalogue surface is asserted identical with and without the onboarding dependencies — the rollout changes what a tool can do, never what it is called. Verified to fail on a reintroduced name mismatch.

## Verification

Exercised against a local stack on the `platformmcp` variant:

- A spend question returns immediately with no tool calls and an honest "not on this rollout".
- A catalog question issues one `select:` search, one direct call, and one `compose` script fanning seven query terms over the same tool — the sanctioned fan-out shape.
- Asking the assistant to enumerate its own tools returns exactly the served set.

## Notes for reviewers

The two variants are deliberately exclusive (#5192): with both toolsets in context there is no way to tell whether the Platform MCP surface answers better than the legacy one. That means the platformmcp variant is not a re-plumbing of the same capabilities — it genuinely lacks telemetry, chat, risk, and cost tools, and its prompt now says so rather than sending the model looking. Worth a second opinion on whether that trade is right for the orgs currently on the flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes the managed assistant prompt per rollout variant and anchors both assistants toolset compositions to the runtime so the prompt always matches the actually served tools. Previously the prompt was provisioned once with bare names and, under `platformmcp`, described tools that did not exist.

- Rename: `assistantPlatformSlugs` -> `assistantPlatformGrant` (fields: `Slugs`, `Managed`, `Variant`); bootstrap selects instructions via `managedAssistantInstructionsFor(grant.Variant)` and keeps the stored row as a legacy seed.
- Two prompts (legacy and `platformmcp`) list exact runtime-prefixed tool names (`mcp__p-*`). No discovery; fetch input schemas in one `select:` batch. Use `compose` only to fan out over many inputs.
- `platformmcp` prompt: clearly states it cannot answer telemetry, chats, risk, cost, or directory; removes a false read-only claim from `get_platform_context`; documents that the docs corpus is a pinned export with stale/guide_unavailable handling.
- Wiring: serve toolsets through `runtime.AssistantsToolset(...)` and `runtime.ManagedAssistantToolset(...)` and pass the composed sets to `platformtools.BuildToolsets`. Tests compare prompts to `runtime.AssistantsToolsetToolNames()`, `runtime.ManagedAssistantToolsetToolNames()`, and `platformmcp.AssistantToolNames()` to prevent drift.
- Onboarding lifecycle: stubs are `externalOnly`, share identity with live tools via one table, and are never admitted to the assistant; catalogue surface is asserted identical with and without onboarding dependencies.
- Fallback: unknown or missing variants resolve to legacy. No migrations or operator actions.

<sup>Written for commit 7d60924fdbbc4854e9694c18291ee3329a63c8b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

