### PR TITLE
chore: add Hermes Agent to CIMD admission preset catalog

### DIFF
--- a/server/internal/usersessions/cimd/admission/catalog.go
+++ b/server/internal/usersessions/cimd/admission/catalog.go
@@ -253,6 +253,18 @@ var catalog = []Preset{
 		DisplayOnly: false,
 		Enabled:     true,
 	},
+
+	// Verified 2026-08-21. Hermes Agent is served from GitHub Pages
+	// (nousresearch.github.io). Exact-match admission keeps this scoped to
+	// the single document path; the shared github.io apex is not a widening
+	// concern.
+	{
+		VendorKey:   "nousresearch",
+		DisplayName: "Hermes Agent",
+		URL:         "https://nousresearch.github.io/hermes-agent/docs/oauth/client-metadata.json",
+		DisplayOnly: false,
+		Enabled:     true,
+	},
 }
 
 // catalogURLs and catalogPatterns index the enabled catalog entries for the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Production Datadog shows `denied_not_listed` CIMD admission decisions for the Hermes Agent client (Nous Research). The presented `client_id` is:

```
https://nousresearch.github.io/hermes-agent/docs/oauth/client-metadata.json
```

Observed in prod: 4 `cimd admission would deny` events between 2026-08-20 23:02 UTC and 2026-08-21 00:00 UTC, all with `gram.cimd.admission_mode: reporting` and `gram.cimd.admission_outcome: denied_not_listed`. Because admission is still in reporting mode, the same requests then resolved successfully, so this client works today. 

Once admission enforcement is flipped to presets mode, Hermes Agent will be hard-rejected at `/authorize` with no client-side recourse. Adding this preset before the enforcement flip avoids that breakage.

## Changes

- Added Hermes Agent entry to the CIMD admission preset catalog in `server/internal/usersessions/cimd/admission/catalog.go`
- Entry uses exact-match URL (no wildcard needed)
- VendorKey: `nousresearch`
- DisplayName: `Hermes Agent`
- Included comment noting it's served from GitHub Pages

## Document Verification

Verified live on 2026-08-21:
- ✅ HTTP 200, valid JSON
- ✅ `client_id` equals the document URL byte for byte
- ✅ `client_name`: `Hermes Agent`
- ✅ `client_uri`: `https://hermes-agent.nousresearch.com`
- ✅ `token_endpoint_auth_method`: `none` (public client)
- ✅ `application_type`: `native`
- ✅ `grant_types`: `authorization_code`, `refresh_token`
- ✅ `response_types`: `code`
- ✅ `redirect_uris`: loopback only (127.0.0.1 and localhost on fixed ports 27890-27894)
- ✅ No `client_secret`, no JWKS material

## Testing

All admission package tests pass:
```
ok  	github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission	0.003s
```

Tests verify:
- Enabled entries are admitted
- Well-formed catalog entries
- Exact string matching
- DisplayOnly entries are covered by rules
- Disabled entries are not admitted

## Notes

The URL is served from GitHub Pages (`nousresearch.github.io/hermes-agent/...`). Exact-match admission keeps this scoped to the single document path, so the shared `github.io` host is not a widening concern.

Resolves AIS-593
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-593](https://linear.app/speakeasy/issue/AIS-593/add-hermes-agent-to-the-cimd-admission-preset-catalog)

<div><a href="https://cursor.com/agents/bc-3c337465-383d-4a34-bf42-ca87f6d25919?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c337465-383d-4a34-bf42-ca87f6d25919&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Hermes Agent (`nousresearch`) to the CIMD admission preset catalog to prevent hard rejects when CIMD admission switches to presets enforcement. Previously, requests logged `denied_not_listed` in reporting mode but succeeded; with enforcement they would be rejected at `/authorize`.

- Verified client metadata at exact URL: https://nousresearch.github.io/hermes-agent/docs/oauth/client-metadata.json (public client, native, loopback redirects only). Change is confined to `server/internal/usersessions/cimd/admission/catalog.go`. Satisfies Linear AIS-593.

- Rollout: No migrations or config changes. After deploy, it is safe to enable presets enforcement; Hermes Agent will be admitted. Monitor Datadog for unexpected `denied_*` outcomes.

<sup>Written for commit ce6c45e3bc448c8c7bf6889cb17a12ea755b919d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

