### PR TITLE
fix: match stat tile skeleton height to loaded card

### DIFF
--- a/client/dashboard/src/components/chart/stat-tile.tsx
+++ b/client/dashboard/src/components/chart/stat-tile.tsx
@@ -11,6 +11,7 @@ export const StatTileGroup = UiMetricCard.Group;
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { formatCompact } from "@/lib/format";
 import { ThresholdConfig } from "./chartUtils";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { Loader2 } from "lucide-react";
 import { Link } from "react-router";
 
@@ -172,5 +173,18 @@ export function StatTile(props: StatTileProps): JSX.Element {
       deltaTone={isGood ? "success" : "destructive"}
       description={description}
     />
+  );
+}
+
+/**
+ * Loading placeholder shaped like a value-only StatTile — same padding, gap
+ * and line heights, so the group doesn't shift when the figures land.
+ */
+export function StatTileSkeleton(): JSX.Element {
+  return (
+    <div className="bg-card flex min-w-0 flex-1 flex-col gap-4 p-6">
+      <Skeleton className="h-[14.3px] w-24" />
+      <Skeleton className="h-[34px] w-20" />
+    </div>
   );
 }

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -1,6 +1,10 @@
 import { Link, useNavigate } from "react-router";
 import { useOrganization } from "@/contexts/Auth";
-import { StatTile, StatTileGroup } from "@/components/chart/stat-tile";
+import {
+  StatTile,
+  StatTileGroup,
+  StatTileSkeleton,
+} from "@/components/chart/stat-tile";
 import { RankedBarList } from "@/components/chart/RankedBarList";
 import { Page } from "@/components/page-layout";
 import { Avatar, AvatarFallback } from "@/components/ui/Avatar";
@@ -491,7 +495,7 @@ export function ProjectDashboard(): JSX.Element {
               {/* Row 0: KPI Cards */}
               <StatTileGroup>
                 {isOverviewPending ? (
-                  <Skeleton className="h-[100px] flex-1" />
+                  <StatTileSkeleton />
                 ) : (
                   <StatTile
                     title="Active Servers"
@@ -503,7 +507,7 @@ export function ProjectDashboard(): JSX.Element {
                   />
                 )}
                 {isOverviewPending ? (
-                  <Skeleton className="h-[100px] flex-1" />
+                  <StatTileSkeleton />
                 ) : (
                   <StatTile
                     title="Tool Calls"
@@ -515,7 +519,7 @@ export function ProjectDashboard(): JSX.Element {
                   />
                 )}
                 {modePending || (!hasHookData && mcpUsersPending) ? (
-                  <Skeleton className="h-[100px] flex-1" />
+                  <StatTileSkeleton />
                 ) : hasHookData ? (
                   <StatTile
                     title="Total Spend"
@@ -535,7 +539,7 @@ export function ProjectDashboard(): JSX.Element {
                   />
                 )}
                 {modePending || isOverviewPending ? (
-                  <Skeleton className="h-[100px] flex-1" />
+                  <StatTileSkeleton />
                 ) : hasHookData ? (
                   <StatTile
                     title="Sessions"

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -1,4 +1,8 @@
-import { StatTile, StatTileGroup } from "@/components/chart/stat-tile";
+import {
+  StatTile,
+  StatTileGroup,
+  StatTileSkeleton,
+} from "@/components/chart/stat-tile";
 import { ChartCard } from "@/components/chart/ChartCard";
 import { AXIS, TOOLTIP } from "@/components/chart/palette";
 import { useSeriesColors } from "@/components/chart/useSeriesColors";
@@ -373,7 +377,7 @@ function SecurityOverviewContent() {
         )}
         <StatTileGroup>
           {isOverviewLoading ? (
-            <Skeleton className="h-[100px] flex-1" />
+            <StatTileSkeleton />
           ) : (
             <StatTile
               title="Events Scanned"
@@ -384,7 +388,7 @@ function SecurityOverviewContent() {
             />
           )}
           {isOverviewLoading ? (
-            <Skeleton className="h-[100px] flex-1" />
+            <StatTileSkeleton />
           ) : (
             <StatTile
               title="Findings"
@@ -395,7 +399,7 @@ function SecurityOverviewContent() {
             />
           )}
           {isOverviewLoading ? (
-            <Skeleton className="h-[100px] flex-1" />
+            <StatTileSkeleton />
           ) : (
             <StatTile
               title="Flagged Sessions"
@@ -408,7 +412,7 @@ function SecurityOverviewContent() {
             />
           )}
           {isOverviewLoading ? (
-            <Skeleton className="h-[100px] flex-1" />
+            <StatTileSkeleton />
           ) : (
             <StatTile
               title="Active Policies"

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -1,4 +1,8 @@
-import { StatTile, StatTileGroup } from "@/components/chart/stat-tile";
+import {
+  StatTile,
+  StatTileGroup,
+  StatTileSkeleton,
+} from "@/components/chart/stat-tile";
 import { TimeRangePicker } from "@/components/DashboardTimeRangePicker";
 import { defineFilters, useFilterState } from "@/components/filters";
 import {
@@ -579,10 +583,10 @@ function KPIRow({
   if (!data && isLoading) {
     return (
       <StatTileGroup>
-        <Skeleton className="h-[100px] flex-1" />
-        <Skeleton className="h-[100px] flex-1" />
-        <Skeleton className="h-[100px] flex-1" />
-        <Skeleton className="h-[100px] flex-1" />
+        <StatTileSkeleton />
+        <StatTileSkeleton />
+        <StatTileSkeleton />
+        <StatTileSkeleton />
       </StatTileGroup>
     );
   }


### PR DESCRIPTION
Stat tile skeletons were hardcoded to `h-[100px]`, but a loaded `StatTile` is ~112px (`p-6` top+bottom, 14.3px eyebrow line, `gap-4`, 34px value line). During load the strip sat short and the row jumped when data landed.

Replaces the ad-hoc `<Skeleton className="h-[100px] flex-1" />` with a `StatTileSkeleton` that reuses the MetricCard shell (same padding, gap and line heights), so the placeholder can't drift from the real card again.

Applied to all three stat strips that had the same bug: Project Overview, Risk Watchdog, Security Overview.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates layout jump in stat tile rows by replacing the hardcoded 100px skeleton with `StatTileSkeleton` that matches the loaded card’s dimensions. Previously, rows were ~12px shorter during load; now height is consistent and no shift occurs when data renders.

- Introduces `StatTileSkeleton` in `client/dashboard/src/components/chart/stat-tile.tsx` with the same padding, gap, and line heights as `StatTile`.
- Replaces `<Skeleton className="h-[100px] flex-1" />` with `<StatTileSkeleton />` in Project Overview (`ProjectDashboard.tsx`), Security Overview, and Risk Watchdog.
- No API or data changes; only visual placeholders updated. When adding new stat tiles, use `StatTileSkeleton` during loading.

<sup>Written for commit f8681504c97e8be4a32d243c42f0b4db078a2a6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

