### PR TITLE
fix: proxy session handoff URLs to the Go server

### DIFF
--- a/.changeset/shared-handoffs-routing.md
+++ b/.changeset/shared-handoffs-routing.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Proxy `/shared/handoffs` to the Go server in local dashboard dev so session-handoff capability URLs return markdown instead of the SPA shell. `/shared/skills` stays on the dashboard — it is a public React page, not a server document.

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -242,7 +242,10 @@ export default defineConfig(({ command }) => {
       https: key && cert ? { key, cert } : void 0,
       // Setting these up to side-step cors issues experienced during
       // development. Specifically, the Vercel AI SDK does not forward cookies
-      // (Eg: gram_session) to the server.
+      // (Eg: gram_session) to the server. Prefixes the Go server owns must
+      // stay in lockstep with gram-infra helm ingress, with local-only extras
+      // (/v1, /oauth-external). /shared/skills is the dashboard SPA and is
+      // intentionally omitted; /shared/handoffs is raw markdown and is not.
       proxy: devProxyTarget
         ? {
             "/rpc": devProxyTarget,
@@ -254,6 +257,7 @@ export default defineConfig(({ command }) => {
             "/.well-known": devProxyTarget,
             "/platform-mcp": devProxyTarget,
             "/v1": devProxyTarget,
+            "/shared/handoffs": devProxyTarget,
           }
         : undefined,
     },

--- a/server/internal/agent/handoffs.go
+++ b/server/internal/agent/handoffs.go
@@ -28,12 +28,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-// handoffRoutePrefix is the public serving path. Links are always minted
-// against serverURL, so this is served on the primary app domain only — it is
-// deliberately absent from the custom-domain ingress allowlist in
-// k8s/ingress_provisioner.go, which exists so customer domains can serve skill
-// share pages. It must stay in lockstep with the route attached in Attach and
-// with the token-redaction prefixes in middleware.logSafeURL.
+// handoffRoutePrefix is the public serving path. Links are minted against
+// serverURL (the primary app domain). That host splits traffic: the
+// dashboard SPA is the default backend, so this prefix must appear on the
+// gram-infra helm ingress path list and on the dashboard vite dev proxy.
+// It is deliberately absent from the custom-domain ingress allowlist in
+// k8s/ingress_provisioner.go — customer domains serve skill share pages,
+// not handoff documents. Must stay in lockstep with the route attached in
+// Attach and with the token-redaction prefixes in middleware.logSafeURL.
 const handoffRoutePrefix = "/shared/handoffs/"
 
 const (


### PR DESCRIPTION
## Summary
- Proxy `/shared/handoffs` to the Go server in the dashboard Vite config so locally minted session-handoff URLs return markdown instead of the SPA.

## Problem
Session-handoff capability URLs are minted against the dashboard origin. Without a Vite proxy entry they hit the SPA, so `GET /shared/handoffs/{token}` returned `index.html`. Production routing is the companion helm change: https://github.com/speakeasy-api/gram-infra/pull/2792

Do not proxy `/shared` — `/shared/skills` is a dashboard page.

## Test plan
- [ ] From the dashboard, mint a session handoff and fetch the URL in the same origin: response is `text/markdown`, not HTML
- [ ] `/shared/skills/...` still loads the dashboard share page


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxy `/shared/handoffs` to the Go server in local dashboard dev so session-handoff URLs return markdown instead of the SPA. Previously `GET /shared/handoffs/{token}` returned `index.html`; now it returns server `text/markdown`.

- Vite dev proxy adds `"/shared/handoffs": devProxyTarget`; `/shared/skills` stays on the dashboard SPA (no `/shared` catch-all).
- Server change is comments-only to document routing; no runtime behavior changes.
- Production routing is handled by the companion `gram-infra` helm update: https://github.com/speakeasy-api/gram-infra/pull/2792
- Verify locally: mint a session handoff, open the URL on the dashboard origin → `text/markdown`; `/shared/skills/...` still loads the share page.
- No API changes or migrations.

<sup>Written for commit e690b94e86ab4d2385e04dbf4b7750dbdd3a566a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

