### PR TITLE
feat: put the raw Risk Events list back in the Secure nav

### DIFF
--- a/.changeset/risk-events-nav-return.md
+++ b/.changeset/risk-events-nav-return.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Bring the raw Risk Events list back into the Secure navigation alongside Watchdog, so blocks and policies under test can be traced to their events.

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -208,8 +208,9 @@ export function AppSidebar({
             label="Secure"
             Icon={(p) => <Icon {...p} name="shield" />}
             items={[
-              // Watchdog supersedes Risk Overview and Risk Events: exactly one
-              // of the two sets shows, mirroring useProjectNavRoutes.
+              // Watchdog supersedes Risk Overview: exactly one of the two
+              // shows, mirroring useProjectNavRoutes. Risk Events stays either
+              // way — it is the raw event list behind Watchdog's grouping.
               ...(isRiskWatchdogEnabled
                 ? [{ item: routes.watchdog, ...accessFor(routes.watchdog) }]
                 : [
@@ -219,14 +220,7 @@ export function AppSidebar({
                     },
                   ]),
               { item: routes.policyCenter, ...accessFor(routes.policyCenter) },
-              ...(isRiskWatchdogEnabled
-                ? []
-                : [
-                    {
-                      item: routes.riskEvents,
-                      ...accessFor(routes.riskEvents),
-                    },
-                  ]),
+              { item: routes.riskEvents, ...accessFor(routes.riskEvents) },
               { item: routes.shadowMCP, ...accessFor(routes.shadowMCP) },
             ]}
           />

--- a/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
@@ -135,7 +135,8 @@ describe("useProjectNavRoutes", () => {
       expect(navRoutes).not.toContain(routes.assistants);
       expect(navRoutes).not.toContain(routes.watchdog);
       expect(navRoutes).toContain(routes.deployments);
-      // Without Watchdog, the legacy risk pages stay in the nav.
+      // Without Watchdog, Risk Overview stays in the nav; Risk Events is
+      // always there.
       expect(navRoutes).toContain(routes.riskOverview);
       expect(navRoutes).toContain(routes.riskEvents);
     },
@@ -154,8 +155,8 @@ describe("useProjectNavRoutes", () => {
     expect(navRoutes).toContain(routes.assistants);
     expect(navRoutes).toContain(routes.watchdog);
     expect(navRoutes).not.toContain(routes.deployments);
-    // Watchdog supersedes the legacy risk pages in the nav.
+    // Watchdog supersedes Risk Overview only; Risk Events stays in the nav.
     expect(navRoutes).not.toContain(routes.riskOverview);
-    expect(navRoutes).not.toContain(routes.riskEvents);
+    expect(navRoutes).toContain(routes.riskEvents);
   });
 });

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -89,16 +89,16 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
         ? [{ route: routes.orgMemory, scope: observe }]
         : []),
       { route: routes.logs, scope: observe },
-      // Watchdog supersedes the Risk Overview and Risk Events pages: with the
-      // flag on, it is the Secure section's landing surface and the two
-      // legacy nav items hide (their routes stay reachable by direct URL).
+      // Watchdog supersedes the Risk Overview page: with the flag on, it is
+      // the Secure section's landing surface and the legacy overview nav item
+      // hides (its route stays reachable by direct URL). Risk Events stays in
+      // the nav either way — Watchdog groups events, and the raw list is how
+      // a block or a policy under test is traced back to its event (AIS-595).
       ...(isRiskWatchdogEnabled
         ? [{ route: routes.watchdog, scope: read }]
         : [{ route: routes.riskOverview, scope: read }]),
       { route: routes.policyCenter, scope: readWrite },
-      ...(isRiskWatchdogEnabled
-        ? []
-        : [{ route: routes.riskEvents, scope: ["org:admin"] as Scope[] }]),
+      { route: routes.riskEvents, scope: ["org:admin"] },
       { route: routes.shadowMCP, scope: readWrite },
       { route: routes.settings, scope: ["project:write"] },
     ];


### PR DESCRIPTION
## Summary

- Show the raw **Risk Events** list in the Secure nav again, even when Watchdog is enabled — Watchdog now supersedes only Risk Overview. Watchdog's grouping is great for triage, but investigating a block or testing a new policy needs the raw event list to trace back to the corresponding event.
- The item returns to its old spot (between Guardrails and Shadow MCP) with its previous `org:admin` gate, in both the sidebar and the command palette (single source of truth in `useProjectNavRoutes`).
- On update frequency (raised on the ticket): the current Risk Events page has no auto-polling — it fetches on mount/filter change, pages on scroll, and refreshes only via the toolbar button — so the old endless-feed churn is already gone; no further throttling added.

Closes [AIS-595](https://linear.app/speakeasy/issue/AIS-595/feat-re-enable-raw-risk-events-view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7xTyqWnkYQcVFDtpSCXsP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables the raw Risk Events list in the Secure navigation to support tracing blocks and testing policies (AIS-595). Previously, enabling Watchdog hid both Risk Overview and Risk Events; now Watchdog replaces only Risk Overview while Risk Events remains visible.

- `useProjectNavRoutes`: Risk Events is always included with `org:admin` scope; Watchdog only supersedes Risk Overview.
- Sidebar and command palette both derive from the same route source; Risk Events appears in its prior position between Policy Center and Shadow MCP.
- Tests updated to reflect the new visibility rules.
- Risk Events page behavior unchanged: fetch on mount/filter change, paginate on scroll, manual refresh only; no auto-polling added.
- No migration or config changes required.

<sup>Written for commit f71ec60c094246f78f47edfb8902355d2b5870ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

