### PR TITLE
fix: render frontend tools as elements so hook count stays stable

### DIFF
--- a/.changeset/assistant-onboarding-hook-count.md
+++ b/.changeset/assistant-onboarding-hook-count.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Loading the assistant onboarding page directly — a fresh navigation or a browser refresh on `/assistants/new` or `/assistants/:id` — no longer crashes the page with "Rendered more hooks than during the previous render". `FrontendTools` called each tool component inline instead of rendering it, so every tool's hooks ran inside `FrontendTools`' own hook list. The onboarding tool set is gated on RBAC grants and `hasScope` returns false until those grants load, so the first render after a hard load saw a trimmed set and a later render saw the full one — growing the component's hook count and tripping React's hook-order invariant. Reaching the page by in-app navigation happened to work because the grants query was already cached. Each tool now renders as its own keyed element, giving it its own hook list.

--- a/client/dashboard/src/elements/components/FrontendTools/index.test.tsx
+++ b/client/dashboard/src/elements/components/FrontendTools/index.test.tsx
@@ -1,0 +1,43 @@
+import type { AssistantTool } from "@assistant-ui/react";
+import { render } from "@testing-library/react";
+import { useEffect } from "react";
+import { describe, expect, it } from "vitest";
+import { FrontendTools } from ".";
+
+// Stand-in for a real frontend tool: `makeAssistantTool` returns a component
+// whose `useAssistantTool` calls `useEffect`, so any hook is representative.
+const makeTool = (): AssistantTool =>
+  (() => {
+    useEffect(() => {}, []);
+    return null;
+  }) as unknown as AssistantTool;
+
+describe("FrontendTools", () => {
+  it("survives a tool set that grows between renders", () => {
+    // The assistant onboarding tools are gated on RBAC grants, and `hasScope`
+    // returns false until the grants query resolves. So the first render after
+    // a hard page load sees a trimmed set and a later render sees the full one.
+    // Calling each tool inline ran its hooks inside FrontendTools' own hook
+    // list, so that growth threw "Rendered more hooks than during the previous
+    // render" and crashed the page.
+    const { rerender } = render(<FrontendTools tools={{ a: makeTool() }} />);
+
+    expect(() =>
+      rerender(
+        <FrontendTools
+          tools={{ a: makeTool(), b: makeTool(), c: makeTool() }}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("survives a tool set that shrinks between renders", () => {
+    const { rerender } = render(
+      <FrontendTools tools={{ a: makeTool(), b: makeTool() }} />,
+    );
+
+    expect(() =>
+      rerender(<FrontendTools tools={{ a: makeTool() }} />),
+    ).not.toThrow();
+  });
+});

--- a/client/dashboard/src/elements/components/FrontendTools/index.test.tsx
+++ b/client/dashboard/src/elements/components/FrontendTools/index.test.tsx
@@ -14,9 +14,6 @@ const makeTool = (): AssistantTool =>
 
 describe("FrontendTools", () => {
   it("survives a tool set that grows between renders", () => {
-    // Not hypothetical: the assistant onboarding tools are gated on RBAC
-    // grants, and `hasScope` returns false until the grants query resolves, so
-    // a hard page load renders a trimmed set before the full one.
     const { rerender } = render(<FrontendTools tools={{ a: makeTool() }} />);
 
     expect(() =>

--- a/client/dashboard/src/elements/components/FrontendTools/index.test.tsx
+++ b/client/dashboard/src/elements/components/FrontendTools/index.test.tsx
@@ -14,12 +14,9 @@ const makeTool = (): AssistantTool =>
 
 describe("FrontendTools", () => {
   it("survives a tool set that grows between renders", () => {
-    // The assistant onboarding tools are gated on RBAC grants, and `hasScope`
-    // returns false until the grants query resolves. So the first render after
-    // a hard page load sees a trimmed set and a later render sees the full one.
-    // Calling each tool inline ran its hooks inside FrontendTools' own hook
-    // list, so that growth threw "Rendered more hooks than during the previous
-    // render" and crashed the page.
+    // Not hypothetical: the assistant onboarding tools are gated on RBAC
+    // grants, and `hasScope` returns false until the grants query resolves, so
+    // a hard page load renders a trimmed set before the full one.
     const { rerender } = render(<FrontendTools tools={{ a: makeTool() }} />);
 
     expect(() =>

--- a/client/dashboard/src/elements/components/FrontendTools/index.tsx
+++ b/client/dashboard/src/elements/components/FrontendTools/index.tsx
@@ -9,8 +9,6 @@ export function FrontendTools({
   return (
     <>
       {Object.entries(frontendTools).map(([name, tool]) => {
-        // Each tool owns hooks, and the set is sized by RBAC grants that
-        // resolve after the first paint, so every tool needs its own fiber.
         const Tool = tool as AssistantTool;
         return <Tool key={name} />;
       })}

--- a/client/dashboard/src/elements/components/FrontendTools/index.tsx
+++ b/client/dashboard/src/elements/components/FrontendTools/index.tsx
@@ -9,12 +9,8 @@ export function FrontendTools({
   return (
     <>
       {Object.entries(frontendTools).map(([name, tool]) => {
-        // Render each tool as its own element rather than calling it inline:
-        // an inline call runs the tool's hooks inside THIS component, so a
-        // frontend-tool set whose size changes between renders (e.g. the
-        // assistant onboarding tools, which are gated on RBAC grants that
-        // resolve after the first paint) changes this component's hook count
-        // and trips "Rendered more hooks than during the previous render".
+        // Each tool owns hooks, and the set is sized by RBAC grants that
+        // resolve after the first paint, so every tool needs its own fiber.
         const Tool = tool as AssistantTool;
         return <Tool key={name} />;
       })}

--- a/client/dashboard/src/elements/components/FrontendTools/index.tsx
+++ b/client/dashboard/src/elements/components/FrontendTools/index.tsx
@@ -8,9 +8,16 @@ export function FrontendTools({
 }): React.JSX.Element {
   return (
     <>
-      {Object.entries(frontendTools).map(([, tool]) =>
-        (tool as AssistantTool)({}),
-      )}
+      {Object.entries(frontendTools).map(([name, tool]) => {
+        // Render each tool as its own element rather than calling it inline:
+        // an inline call runs the tool's hooks inside THIS component, so a
+        // frontend-tool set whose size changes between renders (e.g. the
+        // assistant onboarding tools, which are gated on RBAC grants that
+        // resolve after the first paint) changes this component's hook count
+        // and trips "Rendered more hooks than during the previous render".
+        const Tool = tool as AssistantTool;
+        return <Tool key={name} />;
+      })}
     </>
   );
 }


### PR DESCRIPTION
## What

Fixes the Assistants UI crash in DNO-826. Loading the assistant onboarding page directly — a browser refresh, or any first navigation to `/assistants/new` or `/assistants/:id` — crashed the page with React's hook-order error (minified as React error #310 in production):

> `Rendered more hooks than during the previous render.`

## Why

`FrontendTools` _called_ each tool component inline instead of rendering it:

```tsx
{
  Object.entries(frontendTools).map(([, tool]) => (tool as AssistantTool)({}));
}
```

Every tool's `useAssistantTool` (and its `useEffect`) therefore ran inside `FrontendTools`' own hook list, so the number of hooks that component renders is a function of how many tools are in the record.

The assistant onboarding tool set varies with permissions — `useOnboardingTools` trims `list_skills` / `attach_skill` / `detach_skill` based on `hasScope` — and `useRBAC`'s `hasScope` returns `false` until the grants query resolves ("If grants haven't loaded yet, returns false (safe default)"). On a cold load the first render sees the trimmed set, the grants land, three more tools appear, and the hook count grows mid-life. React throws and the error boundary takes down the page.

Reaching the page by in-app navigation worked only by luck: the grants query was already cached, so the tool count never changed between renders. That is the whole reason the bug looked refresh-only.

## Changes

- **`FrontendTools/index.tsx`** — render each tool as its own keyed element (`<Tool key={name} />`) so it gets its own fiber and its own hook list. Adding or removing a tool now mounts or unmounts a child instead of resizing the parent's hook list.
- **`FrontendTools/index.test.tsx`** (new) — regression tests covering a tool set that grows and one that shrinks between renders. Both fail with the exact "Rendered more hooks…" error against the old implementation.

## Note on #5153

#5153 targets the same ticket but a different failure — the nested `RemoteThreadListRuntime` error. That one was already fixed on main by #5208 (`pageOwnsRuntime` in `insights-dock.tsx`), which is shipped. I verified locally that no nesting error occurs on any affected route, so #5153 is redundant and can be closed. The crash that remained is the one fixed here.

## Testing

- `aube run -F dashboard type-check` and `hk fix` pass; the new vitest suite passes, and both cases fail against the pre-fix component.
- Verified end-to-end against the local stack with Playwright. Hard loads (not in-app navigation) of `/assistants/new`, `/assistants/:id`, `/assistants`, `/playground`, `/elements`, `/chat`, and `/mcp` all render with no React errors. Before the fix, a hard load of `/assistants/new` reproduced the crash every time while soft navigation to the same route succeeded.

Linear Issue: [DNO-826](https://linear.app/speakeasy/issue/DNO-826/bug-assistants-ui-totally-broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SA7rismZ7X39ZtncRh6t2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render frontend tools as elements so the hook count stays stable and Assistants onboarding pages stop crashing on hard loads. Previously `FrontendTools` invoked each tool inline, growing the parent’s hook list when RBAC‑gated tools appeared; now each tool renders as a keyed element and mounts/unmounts safely.

- Affected behavior: hard loads of `/assistants/new` and `/assistants/:id` no longer error; in‑app navigation and UI remain unchanged.
- Scope: render‑only change in client/dashboard/src/elements/components/FrontendTools/index.tsx; adds client/dashboard/src/elements/components/FrontendTools/index.test.tsx to verify growing/shrinking tool sets do not throw; includes a changeset. Latest commits remove explanatory comments. No API or migration required. Addresses Linear DNO-826.

<sup>Written for commit 64f341c8e687456abc97ee77260e1d0a78c81903. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

