### PR TITLE
feat: platform MCP diagnostics and project overview tools

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -67,8 +67,12 @@ type platformMCPConfig struct {
 	// Telemetry is the Gram-owned ClickHouse read model the diagnostics tools
 	// answer from. Nil disables them rather than serving an empty answer, which
 	// a caller would read as "nothing is wrong".
-	Telemetry    platformmcp.DiagnosticsTelemetryReader
-	LocalFixture *platformMCPLocalFixtureConfig
+	Telemetry platformmcp.DiagnosticsTelemetryReader
+	// SessionCapture resolves the organization's metrics mode, which decides
+	// what a project overview's active-user count measures. Shared with the
+	// telemetry service so both surfaces answer from the same source.
+	SessionCapture platformmcp.FeatureChecker
+	LocalFixture   *platformMCPLocalFixtureConfig
 }
 
 var platformMCPLocalFixtureLoopbackCIDRBlocks = []string{"127.0.0.0/8", "::1/128"}
@@ -226,7 +230,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
-	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, platformReader, readiness, budgets.Diagnostics)
+	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -430,7 +434,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
-	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, platformReader, readiness, budgets.Diagnostics)
+	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -64,7 +64,11 @@ type platformMCPConfig struct {
 	AuditLogger            *audit.Logger
 	PluginPublisher        *plugins.Service
 	Skills                 platformmcp.SkillsManagement
-	LocalFixture           *platformMCPLocalFixtureConfig
+	// Telemetry is the Gram-owned ClickHouse read model the diagnostics tools
+	// answer from. Nil disables them rather than serving an empty answer, which
+	// a caller would read as "nothing is wrong".
+	Telemetry    platformmcp.DiagnosticsTelemetryReader
+	LocalFixture *platformMCPLocalFixtureConfig
 }
 
 var platformMCPLocalFixtureLoopbackCIDRBlocks = []string{"127.0.0.0/8", "::1/128"}
@@ -181,7 +185,8 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Skills:      newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Diagnostics: newBudget(platformmcp.DiagnosticsConnectionLimitName, platformmcp.DiagnosticsOrganizationLimitName),
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("local Platform MCP operation budgets are incomplete")
@@ -220,6 +225,8 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	config.Mux.Handle(http.MethodPost, "/platform-mcp/local-fixture/mcp", fixtureMCP.Handler().ServeHTTP)
 
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
+	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
+	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, platformReader, readiness, budgets.Diagnostics)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -227,7 +234,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		authorizer,
 		oauth.ProtectedResourceURL(),
 		config.JWTSigningKey,
-		platformmcp.NewPostgresReader(config.Logger, config.DB),
+		platformReader,
 		catalog,
 		registrations,
 		platformmcp.NewPostgresReadinessRecorder(config.DB),
@@ -239,6 +246,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		platformmcp.NewOnboardingService(config.DB),
 		distributions,
 		skillAuthoring,
+		diagnostics,
 		fixtureConfig.CatalogDescriptor(),
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
@@ -372,7 +380,8 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Skills:      newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Diagnostics: newBudget(platformmcp.DiagnosticsConnectionLimitName, platformmcp.DiagnosticsOrganizationLimitName),
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("platform MCP operation budgets are incomplete")
@@ -420,6 +429,8 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		},
 	)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
+	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
+	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, platformReader, readiness, budgets.Diagnostics)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -427,7 +438,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		authorizer,
 		oauth.ProtectedResourceURL(),
 		config.JWTSigningKey,
-		platformmcp.NewPostgresReader(config.Logger, config.DB),
+		platformReader,
 		catalog,
 		registrations,
 		platformmcp.NewPostgresReadinessRecorder(config.DB),
@@ -436,6 +447,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		platformmcp.NewOnboardingService(config.DB),
 		distributions,
 		skillAuthoring,
+		diagnostics,
 		platformmcp.CatalogDescriptor{},
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -189,8 +189,11 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		Skills:      newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
-		Diagnostics: newBudget(platformmcp.DiagnosticsConnectionLimitName, platformmcp.DiagnosticsOrganizationLimitName),
+		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Diagnostics: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.DiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.DiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("local Platform MCP operation budgets are incomplete")
@@ -384,8 +387,11 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.DocsConnectionLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		Skills:      newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
-		Diagnostics: newBudget(platformmcp.DiagnosticsConnectionLimitName, platformmcp.DiagnosticsOrganizationLimitName),
+		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		Diagnostics: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.DiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.DiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("platform MCP operation budgets are incomplete")

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1549,6 +1549,7 @@ func newStartCommand() *cli.Command {
 				PluginPublisher:        pluginPublisher,
 				Skills:                 skillsService,
 				Telemetry:              telemetryrepo.New(chDB),
+				SessionCapture:         platformmcp.FeatureChecker(sessionCaptureEnabled),
 				LocalFixture:           platformFixture,
 			})
 			if err != nil {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1548,6 +1548,7 @@ func newStartCommand() *cli.Command {
 				AuditLogger:            auditLogger,
 				PluginPublisher:        pluginPublisher,
 				Skills:                 skillsService,
+				Telemetry:              telemetryrepo.New(chDB),
 				LocalFixture:           platformFixture,
 			})
 			if err != nil {

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -284,7 +284,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 		PlatformMCPReadTools: assistant_platform_mcp_adapter.ExternalTools(
 			platformmcp.NewRuntimeWithLifecycle(
 				logger, nil, nil, platformmcp.NewLiveOrgAdminAuthorizer(conn, authzEngine), "", "",
-				platformmcp.NewPostgresReader(logger, conn), nil, nil, nil, nil, nil, nil, nil, nil,
+				platformmcp.NewPostgresReader(logger, conn), nil, nil, nil, nil, nil, nil, nil, nil, nil,
 				platformmcp.CatalogDescriptor{},
 			).AssistantTools(),
 			platformmcp.NewLiveOrgAdminAuthorizer(conn, authzEngine),

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -13,7 +13,7 @@ import (
 func TestEveryRegisteredToolDeclaresAnAudience(t *testing.T) {
 	t.Parallel()
 
-	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 	descriptors := registrar.Descriptors()
 	require.NotEmpty(t, descriptors, "the deployment registers tools even when every dependency is absent")
 
@@ -72,7 +72,7 @@ func names(descriptors []Descriptor) []string {
 func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 	t.Parallel()
 
-	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 
 	admitted := map[string]bool{}
 	for _, descriptor := range registrar.For(AudienceAssistant) {
@@ -117,7 +117,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 func TestExternalEndpointServesOnlyExternallyAdmittedTools(t *testing.T) {
 	t.Parallel()
 
-	server, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, CatalogDescriptor{})
+	server, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 
 	admitted := make(map[string]bool)
 	for _, descriptor := range registrar.For(AudienceExternal) {

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -174,9 +174,11 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 		GramProjectID: input.ProjectID,
 		TimeStart:     start,
 		TimeEnd:       end,
-		// Carried so the active-server count is aggregated the same way the
-		// dashboard aggregates it for this organization's metrics mode.
-		SessionMode: sessionMode,
+		// SessionMode is deliberately left false. It switches only the
+		// active-user expression, and under session capture that value is
+		// replaced below by the PostgreSQL chat-participant count; the
+		// active-server count it does not affect at all.
+		SessionMode: false,
 	})
 	if err != nil {
 		return GetProjectOverviewOutput{}, fmt.Errorf("read project overview active counts: %w", err)

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -343,7 +343,12 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 	if err != nil {
 		return GetMCPDiagnosticsOutput{}, fmt.Errorf("read organization outcome breakdown: %w", err)
 	}
-	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{GramProjectIDs: projectIDs})
+	// Scoped to the diagnosed project, not to the organization the comparison
+	// spans. An organization-wide watermark reports the freshest observation
+	// anywhere, so a busy sibling project would stamp this result fresh while
+	// the diagnosed project's own observations had stopped arriving — exactly
+	// the reading that turns an absence of evidence into evidence of health.
+	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{GramProjectIDs: []string{input.ProjectID}})
 	if err != nil {
 		return GetMCPDiagnosticsOutput{}, fmt.Errorf("read diagnostics watermark: %w", err)
 	}

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -1,0 +1,457 @@
+//nolint:exhaustruct // Diagnostic projections intentionally omit documented optional fields.
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+const (
+	DiagnosticsConnectionLimitName   = "platform-mcp-diagnostics-connection"
+	DiagnosticsOrganizationLimitName = "platform-mcp-diagnostics-organization"
+)
+
+// maxDiagnosticClients bounds the per-client evidence list. Client evidence is
+// self-reported and exists to point at a suspect, not to enumerate a fleet.
+const maxDiagnosticClients = 10
+
+// maxOverviewServers bounds the top-server list on a project overview.
+const maxOverviewServers = 10
+
+var ErrDiagnosticsTargetNotFound = errors.New("platform mcp diagnostics target not found")
+
+// DiagnosticsTelemetryReader is the Gram-owned telemetry this surface reads.
+// It is deliberately two bounded aggregate queries: there is no query grammar
+// here and no way to reach a raw row.
+type DiagnosticsTelemetryReader interface {
+	GetMCPOutcomeBreakdown(ctx context.Context, arg telemetryrepo.GetMCPOutcomeBreakdownParams) ([]telemetryrepo.MCPOutcomeBreakdownRow, error)
+	GetTelemetryWatermark(ctx context.Context, arg telemetryrepo.GetTelemetryWatermarkParams) (int64, error)
+	GetOverviewSummary(ctx context.Context, arg telemetryrepo.GetOverviewSummaryParams) (*telemetryrepo.OverviewSummary, error)
+	GetActiveCounts(ctx context.Context, arg telemetryrepo.GetActiveCountsParams) (*telemetryrepo.ActiveCounts, error)
+	GetTopServers(ctx context.Context, arg telemetryrepo.GetTopServersParams) ([]telemetryrepo.TopServer, error)
+}
+
+// DiagnosticsService answers the two overview-first questions: what is this
+// project doing, and why is this one MCP not working.
+type DiagnosticsService struct {
+	db        *pgxpool.Pool
+	telemetry DiagnosticsTelemetryReader
+	reader    Reader
+	readiness *ReadinessService
+	budget    OperationBudget
+	now       func() time.Time
+}
+
+func NewDiagnosticsService(db *pgxpool.Pool, telemetry DiagnosticsTelemetryReader, reader Reader, readiness *ReadinessService, budget OperationBudget) *DiagnosticsService {
+	return &DiagnosticsService{
+		db:        db,
+		telemetry: telemetry,
+		reader:    reader,
+		readiness: readiness,
+		budget:    budget,
+		now:       time.Now,
+	}
+}
+
+func (s *DiagnosticsService) valid() bool {
+	return s != nil && s.db != nil && s.telemetry != nil && s.reader != nil && s.budget.valid()
+}
+
+// GetProjectOverviewInput asks for one project's activity. It carries no
+// filters: the overview is the entry point, and narrowing happens through the
+// drill-down tools once it has identified something to look at.
+type GetProjectOverviewInput struct {
+	ProjectID string `json:"project_id" jsonschema:"AICP project ID to summarize"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+}
+
+// ProjectOverviewServer is one MCP server's share of the project's tool calls.
+type ProjectOverviewServer struct {
+	Name      string `json:"name"`
+	ToolCalls int64  `json:"tool_calls"`
+}
+
+// GetProjectOverviewOutput is the Platform subset of the project overview: the
+// activity and failure shape of a project, aggregated server-side.
+//
+// It carries no users, no clients, no tokens, and no cost. Those are either
+// personal data this surface does not project or a billing concern that does
+// not belong in a diagnostic.
+type GetProjectOverviewOutput struct {
+	ProjectID string       `json:"project_id"`
+	Envelope  DataEnvelope `json:"data"`
+	// MetricsMode is the organization's metrics mode. It is reported because it
+	// changes what the numbers count, not so a caller can switch on it.
+	MetricsMode     string                  `json:"metrics_mode"`
+	ToolCalls       int64                   `json:"tool_calls"`
+	FailedToolCalls int64                   `json:"failed_tool_calls"`
+	ActiveServers   int64                   `json:"active_servers"`
+	ActiveUsers     SubjectCount            `json:"active_users"`
+	TopServers      []ProjectOverviewServer `json:"top_servers"`
+}
+
+func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal Principal, input GetProjectOverviewInput) (GetProjectOverviewOutput, error) {
+	if !s.valid() {
+		return GetProjectOverviewOutput{}, ErrUnavailable
+	}
+	if input.ProjectID == "" {
+		return GetProjectOverviewOutput{}, fmt.Errorf("project_id is required")
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return GetProjectOverviewOutput{}, err
+	}
+	now := s.now()
+	window, err := resolveWindow(input.Window, now)
+	if err != nil {
+		return GetProjectOverviewOutput{}, err
+	}
+	// Reading the MCP inventory for the project is what establishes that this
+	// principal may see the project at all; the telemetry queries below are
+	// project-scoped and must not run before it.
+	if _, err := s.reader.FindMCP(ctx, principal, FindMCPInput{ProjectID: input.ProjectID, Limit: 1}); err != nil {
+		return GetProjectOverviewOutput{}, fmt.Errorf("resolve project overview project: %w", err)
+	}
+
+	projectIDs := []string{input.ProjectID}
+	start, end := window.start.UnixNano(), window.end.UnixNano()
+
+	summary, err := s.telemetry.GetOverviewSummary(ctx, telemetryrepo.GetOverviewSummaryParams{
+		GramProjectID: input.ProjectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+	})
+	if err != nil {
+		return GetProjectOverviewOutput{}, fmt.Errorf("read project overview summary: %w", err)
+	}
+	counts, err := s.telemetry.GetActiveCounts(ctx, telemetryrepo.GetActiveCountsParams{
+		GramProjectID: input.ProjectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+	})
+	if err != nil {
+		return GetProjectOverviewOutput{}, fmt.Errorf("read project overview active counts: %w", err)
+	}
+	servers, err := s.telemetry.GetTopServers(ctx, telemetryrepo.GetTopServersParams{
+		GramProjectID: input.ProjectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+		Limit:         maxOverviewServers,
+	})
+	if err != nil {
+		return GetProjectOverviewOutput{}, fmt.Errorf("read project overview top servers: %w", err)
+	}
+	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{GramProjectIDs: projectIDs})
+	if err != nil {
+		return GetProjectOverviewOutput{}, fmt.Errorf("read project overview watermark: %w", err)
+	}
+
+	output := GetProjectOverviewOutput{
+		ProjectID:   input.ProjectID,
+		Envelope:    newDataEnvelope(now, watermarkTime(watermark), window),
+		MetricsMode: "tool_call",
+		TopServers:  make([]ProjectOverviewServer, 0, len(servers)),
+	}
+	if summary != nil {
+		output.ToolCalls = boundedCount(summary.TotalToolCalls)
+		output.FailedToolCalls = boundedCount(summary.FailedToolCalls)
+	}
+	if counts != nil {
+		output.ActiveServers = boundedCount(counts.ActiveServersCount)
+		output.ActiveUsers = NewSubjectCount(boundedCount(counts.ActiveUsersCount))
+	}
+	for _, server := range servers {
+		output.TopServers = append(output.TopServers, ProjectOverviewServer{
+			Name:      server.ServerName,
+			ToolCalls: boundedCount(server.ToolCallCount),
+		})
+	}
+	return output, nil
+}
+
+// GetMCPDiagnosticsInput names one configured MCP, using the same identity
+// find_mcp and get_mcp return.
+type GetMCPDiagnosticsInput struct {
+	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
+	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+}
+
+// MCPOutcomeSummary is a server's calls in the window, already summed per
+// outcome class. There is no per-bucket series: an external MCP client has no
+// scratch compute to add one up with.
+type MCPOutcomeSummary struct {
+	Total        int64 `json:"total"`
+	Success      int64 `json:"success"`
+	Unauthorized int64 `json:"unauthorized"`
+	ClientError  int64 `json:"client_error"`
+	ServerError  int64 `json:"server_error"`
+	Failed       int64 `json:"failed"`
+	Unknown      int64 `json:"unknown"`
+}
+
+// MCPClientEvidence is what one client reported about its own calls. The name
+// is self-reported by that client and is evidence, not a dimension: nothing in
+// this surface lets a caller filter or group by it.
+type MCPClientEvidence struct {
+	Client   string `json:"client"`
+	Calls    int64  `json:"calls"`
+	Failures int64  `json:"failures"`
+}
+
+// MCPDiagnosticsReadiness is the latest server-side readiness result, with the
+// freshness that decides whether it can exonerate anything.
+type MCPDiagnosticsReadiness struct {
+	State     string `json:"state"`
+	Freshness string `json:"freshness"`
+	CheckedAt string `json:"checked_at,omitempty"`
+}
+
+type GetMCPDiagnosticsOutput struct {
+	ProjectID string       `json:"project_id"`
+	MCPID     string       `json:"mcp_id"`
+	Envelope  DataEnvelope `json:"data"`
+
+	Readiness MCPDiagnosticsReadiness `json:"readiness"`
+	Outcomes  MCPOutcomeSummary       `json:"outcomes"`
+	// OrganizationOutcomes is the same summary across every project in the
+	// organization. It is what makes the scope check answerable server-side.
+	OrganizationOutcomes MCPOutcomeSummary   `json:"organization_outcomes"`
+	Clients              []MCPClientEvidence `json:"clients"`
+	ClientsTruncated     bool                `json:"clients_truncated"`
+	Attribution          FaultAttribution    `json:"attribution"`
+}
+
+func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Principal, input GetMCPDiagnosticsInput) (GetMCPDiagnosticsOutput, error) {
+	if !s.valid() {
+		return GetMCPDiagnosticsOutput{}, ErrUnavailable
+	}
+	if input.ProjectID == "" || input.MCPID == "" {
+		return GetMCPDiagnosticsOutput{}, fmt.Errorf("project_id and mcp_id are required")
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return GetMCPDiagnosticsOutput{}, err
+	}
+	now := s.now()
+	window, err := resolveWindow(input.Window, now)
+	if err != nil {
+		return GetMCPDiagnosticsOutput{}, err
+	}
+
+	// GetMCP is the authorization boundary: it fails closed for an MCP this
+	// principal cannot see, and everything below reads only what it returned.
+	mcp, err := s.reader.GetMCP(ctx, principal, GetMCPInput{ProjectID: input.ProjectID, MCPID: input.MCPID})
+	if err != nil {
+		return GetMCPDiagnosticsOutput{}, fmt.Errorf("resolve diagnostics mcp: %w", err)
+	}
+	target, err := s.diagnosticsTarget(ctx, principal.OrganizationID, input.ProjectID, input.MCPID)
+	if err != nil {
+		return GetMCPDiagnosticsOutput{}, err
+	}
+
+	projectIDs, err := s.organizationProjectIDs(ctx, principal)
+	if err != nil {
+		return GetMCPDiagnosticsOutput{}, err
+	}
+	start, end := window.start.UnixNano(), window.end.UnixNano()
+
+	serverRows, err := s.telemetry.GetMCPOutcomeBreakdown(ctx, telemetryrepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs:       []string{input.ProjectID},
+		ToolsetSlugs:         nonEmpty(target.ToolsetSlug),
+		MCPServerURLSuffixes: mcpURLSuffixes(target.McpSlug),
+		TimeStart:            start,
+		TimeEnd:              end,
+	})
+	if err != nil {
+		return GetMCPDiagnosticsOutput{}, fmt.Errorf("read mcp outcome breakdown: %w", err)
+	}
+	organizationRows, err := s.telemetry.GetMCPOutcomeBreakdown(ctx, telemetryrepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: projectIDs,
+		TimeStart:      start,
+		TimeEnd:        end,
+	})
+	if err != nil {
+		return GetMCPDiagnosticsOutput{}, fmt.Errorf("read organization outcome breakdown: %w", err)
+	}
+	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{GramProjectIDs: projectIDs})
+	if err != nil {
+		return GetMCPDiagnosticsOutput{}, fmt.Errorf("read diagnostics watermark: %w", err)
+	}
+
+	serverTotals := totalsFromRows(serverRows)
+	organizationTotals := totalsFromRows(organizationRows)
+	readiness, readinessFound := s.currentReadiness(ctx, principal, mcp)
+	clients, truncated := clientEvidence(serverRows)
+
+	return GetMCPDiagnosticsOutput{
+		ProjectID: input.ProjectID,
+		MCPID:     input.MCPID,
+		Envelope:  newDataEnvelope(now, watermarkTime(watermark), window),
+		Readiness: MCPDiagnosticsReadiness{
+			State:     string(normalizedReadiness(readiness, readinessFound).State),
+			Freshness: readinessFreshness(readiness, readinessFound),
+			CheckedAt: readinessTimestamp(readiness.CheckedAt),
+		},
+		Outcomes:             summaryFromTotals(serverTotals),
+		OrganizationOutcomes: summaryFromTotals(organizationTotals),
+		Clients:              clients,
+		ClientsTruncated:     truncated,
+		Attribution:          attributeFault(readiness, readinessFound, serverTotals, organizationTotals),
+	}, nil
+}
+
+func (s *DiagnosticsService) diagnosticsTarget(ctx context.Context, organizationID, projectID, mcpID string) (platformrepo.GetPlatformMCPDiagnosticsTargetRow, error) {
+	parsedProject, err := uuid.Parse(projectID)
+	if err != nil {
+		return platformrepo.GetPlatformMCPDiagnosticsTargetRow{}, fmt.Errorf("parse project id: %w", err)
+	}
+	parsedMCP, err := uuid.Parse(mcpID)
+	if err != nil {
+		return platformrepo.GetPlatformMCPDiagnosticsTargetRow{}, fmt.Errorf("parse mcp id: %w", err)
+	}
+	row, err := platformrepo.New(s.db).GetPlatformMCPDiagnosticsTarget(ctx, platformrepo.GetPlatformMCPDiagnosticsTargetParams{
+		OrganizationID: organizationID,
+		McpServerID:    parsedMCP,
+		ProjectID:      parsedProject,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return platformrepo.GetPlatformMCPDiagnosticsTargetRow{}, ErrDiagnosticsTargetNotFound
+	}
+	if err != nil {
+		return platformrepo.GetPlatformMCPDiagnosticsTargetRow{}, fmt.Errorf("resolve diagnostics target: %w", err)
+	}
+	return row, nil
+}
+
+// organizationProjectIDs collects the projects the scope comparison spans. It
+// reuses the same listing the caller can already read, so the comparison never
+// covers a project the principal cannot see.
+func (s *DiagnosticsService) organizationProjectIDs(ctx context.Context, principal Principal) ([]string, error) {
+	projects, err := s.reader.ListProjects(ctx, principal, ListProjectsInput{Limit: 100})
+	if err != nil {
+		return nil, fmt.Errorf("list organization projects: %w", err)
+	}
+	ids := make([]string, 0, len(projects.Projects))
+	for _, project := range projects.Projects {
+		ids = append(ids, project.ID)
+	}
+	return ids, nil
+}
+
+// currentReadiness loads the persisted readiness result without probing the
+// provider or spending the repair budget. A missing registration or an
+// unavailable readiness service is reported as "not found", which
+// attributeFault treats as no evidence rather than as a healthy result.
+func (s *DiagnosticsService) currentReadiness(ctx context.Context, principal Principal, mcp MCP) (Readiness, bool) {
+	if s.readiness == nil || mcp.Registration == nil || mcp.Registration.ID == "" || mcp.ProjectSlug == "" {
+		return Readiness{}, false
+	}
+	_, readiness, found, err := s.readiness.CurrentReadiness(ctx, principal, mcp.ProjectSlug, mcp.Registration.ID)
+	if err != nil {
+		return Readiness{}, false
+	}
+	return readiness, found
+}
+
+func totalsFromRows(rows []telemetryrepo.MCPOutcomeBreakdownRow) outcomeTotals {
+	var totals outcomeTotals
+	for _, row := range rows {
+		count := boundedCount(row.CallCount)
+		totals.Total += count
+		switch row.Outcome {
+		case telemetryrepo.MCPOutcomeSuccess:
+			totals.Success += count
+		case telemetryrepo.MCPOutcomeUnauthorized:
+			totals.Unauthorized += count
+		case telemetryrepo.MCPOutcomeClientError:
+			totals.ClientError += count
+		case telemetryrepo.MCPOutcomeServerError:
+			totals.ServerError += count
+		case telemetryrepo.MCPOutcomeFailed:
+			totals.Failed += count
+		default:
+			totals.Unknown += count
+		}
+	}
+	return totals
+}
+
+// summaryFromTotals converts the internal tally into the serialized summary.
+// The two types are field-identical on purpose: outcomeTotals is what fault
+// attribution reasons over, MCPOutcomeSummary is what a caller receives, and
+// keeping them separate stops a JSON tag change from silently altering either.
+func summaryFromTotals(totals outcomeTotals) MCPOutcomeSummary {
+	return MCPOutcomeSummary(totals)
+}
+
+// clientEvidence folds the breakdown to one row per client, ordered by failures
+// then calls so the suspect leads. The list is capped and says when it was cut,
+// because a silently truncated list reads as complete coverage.
+func clientEvidence(rows []telemetryrepo.MCPOutcomeBreakdownRow) ([]MCPClientEvidence, bool) {
+	byClient := map[string]*MCPClientEvidence{}
+	for _, row := range rows {
+		evidence, ok := byClient[row.Client]
+		if !ok {
+			evidence = &MCPClientEvidence{Client: row.Client}
+			byClient[row.Client] = evidence
+		}
+		count := boundedCount(row.CallCount)
+		evidence.Calls += count
+		if row.Outcome != telemetryrepo.MCPOutcomeSuccess && row.Outcome != telemetryrepo.MCPOutcomeUnknown {
+			evidence.Failures += count
+		}
+	}
+	clients := make([]MCPClientEvidence, 0, len(byClient))
+	for _, evidence := range byClient {
+		clients = append(clients, *evidence)
+	}
+	sort.Slice(clients, func(i, j int) bool {
+		if clients[i].Failures != clients[j].Failures {
+			return clients[i].Failures > clients[j].Failures
+		}
+		if clients[i].Calls != clients[j].Calls {
+			return clients[i].Calls > clients[j].Calls
+		}
+		return clients[i].Client < clients[j].Client
+	})
+	if len(clients) > maxDiagnosticClients {
+		return clients[:maxDiagnosticClients], true
+	}
+	return clients, false
+}
+
+func nonEmpty(value string) []string {
+	if value == "" {
+		return nil
+	}
+	return []string{value}
+}
+
+// mcpURLSuffixes is how a hosted MCP appears in the URL a hook-observed client
+// called.
+func mcpURLSuffixes(mcpSlug string) []string {
+	if mcpSlug == "" {
+		return nil
+	}
+	return []string{"/mcp/" + mcpSlug}
+}
+
+// boundedCount narrows a ClickHouse unsigned count. Counts of observed events
+// never approach the int64 ceiling, and a negative result would be a worse
+// answer than a saturated one.
+func boundedCount(value uint64) int64 {
+	const maxInt64 = uint64(1)<<63 - 1
+	if value > maxInt64 {
+		return int64(maxInt64)
+	}
+	return int64(value)
+}

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
@@ -28,7 +30,24 @@ const maxDiagnosticClients = 10
 // maxOverviewServers bounds the top-server list on a project overview.
 const maxOverviewServers = 10
 
+// maxOverviewProjects bounds the organization-wide scope comparison. When an
+// organization has more projects than this, the comparison covers a subset and
+// the diagnosis says so rather than asserting a scope from partial coverage.
+const maxOverviewProjects = 100
+
 var ErrDiagnosticsTargetNotFound = errors.New("platform mcp diagnostics target not found")
+
+// FeatureChecker answers whether an organization has a product feature enabled.
+// It mirrors the telemetry service's checker so both surfaces resolve the
+// organization's metrics mode from the same source.
+type FeatureChecker func(ctx context.Context, organizationID string) (bool, error)
+
+// ProjectOverviewSessionReader is the PostgreSQL side of a session-mode
+// overview. In session mode the active-user count is a count of chat
+// participants, which ClickHouse's tool-call lane cannot answer.
+type ProjectOverviewSessionReader interface {
+	GetActiveUserCountByMessages(ctx context.Context, arg chatrepo.GetActiveUserCountByMessagesParams) (int64, error)
+}
 
 // DiagnosticsTelemetryReader is the Gram-owned telemetry this surface reads.
 // It is deliberately two bounded aggregate queries: there is no query grammar
@@ -44,27 +63,35 @@ type DiagnosticsTelemetryReader interface {
 // DiagnosticsService answers the two overview-first questions: what is this
 // project doing, and why is this one MCP not working.
 type DiagnosticsService struct {
-	db        *pgxpool.Pool
-	telemetry DiagnosticsTelemetryReader
-	reader    Reader
-	readiness *ReadinessService
-	budget    OperationBudget
-	now       func() time.Time
+	db             *pgxpool.Pool
+	telemetry      DiagnosticsTelemetryReader
+	sessions       ProjectOverviewSessionReader
+	sessionCapture FeatureChecker
+	reader         Reader
+	readiness      *ReadinessService
+	budget         OperationBudget
+	now            func() time.Time
 }
 
-func NewDiagnosticsService(db *pgxpool.Pool, telemetry DiagnosticsTelemetryReader, reader Reader, readiness *ReadinessService, budget OperationBudget) *DiagnosticsService {
+func NewDiagnosticsService(db *pgxpool.Pool, telemetry DiagnosticsTelemetryReader, sessionCapture FeatureChecker, reader Reader, readiness *ReadinessService, budget OperationBudget) *DiagnosticsService {
+	var sessions ProjectOverviewSessionReader
+	if db != nil {
+		sessions = chatrepo.New(db)
+	}
 	return &DiagnosticsService{
-		db:        db,
-		telemetry: telemetry,
-		reader:    reader,
-		readiness: readiness,
-		budget:    budget,
-		now:       time.Now,
+		db:             db,
+		telemetry:      telemetry,
+		sessions:       sessions,
+		sessionCapture: sessionCapture,
+		reader:         reader,
+		readiness:      readiness,
+		budget:         budget,
+		now:            time.Now,
 	}
 }
 
 func (s *DiagnosticsService) valid() bool {
-	return s != nil && s.db != nil && s.telemetry != nil && s.reader != nil && s.budget.valid()
+	return s != nil && s.db != nil && s.telemetry != nil && s.sessions != nil && s.sessionCapture != nil && s.reader != nil && s.budget.valid()
 }
 
 // GetProjectOverviewInput asks for one project's activity. It carries no
@@ -90,8 +117,9 @@ type ProjectOverviewServer struct {
 type GetProjectOverviewOutput struct {
 	ProjectID string       `json:"project_id"`
 	Envelope  DataEnvelope `json:"data"`
-	// MetricsMode is the organization's metrics mode. It is reported because it
-	// changes what the numbers count, not so a caller can switch on it.
+	// MetricsMode is the organization's metrics mode, resolved server-side. It
+	// is reported because it changes what ActiveUsers counts: chat participants
+	// under "session", tool-call actors under "tool_call".
 	MetricsMode     string                  `json:"metrics_mode"`
 	ToolCalls       int64                   `json:"tool_calls"`
 	FailedToolCalls int64                   `json:"failed_tool_calls"`
@@ -115,11 +143,20 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 	if err != nil {
 		return GetProjectOverviewOutput{}, err
 	}
+	projectUUID, err := uuid.Parse(input.ProjectID)
+	if err != nil {
+		return GetProjectOverviewOutput{}, fmt.Errorf("parse project id: %w", err)
+	}
 	// Reading the MCP inventory for the project is what establishes that this
 	// principal may see the project at all; the telemetry queries below are
 	// project-scoped and must not run before it.
 	if _, err := s.reader.FindMCP(ctx, principal, FindMCPInput{ProjectID: input.ProjectID, Limit: 1}); err != nil {
 		return GetProjectOverviewOutput{}, fmt.Errorf("resolve project overview project: %w", err)
+	}
+
+	sessionMode, err := s.sessionCapture(ctx, principal.OrganizationID)
+	if err != nil {
+		return GetProjectOverviewOutput{}, fmt.Errorf("resolve organization metrics mode: %w", err)
 	}
 
 	projectIDs := []string{input.ProjectID}
@@ -158,7 +195,7 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 	output := GetProjectOverviewOutput{
 		ProjectID:   input.ProjectID,
 		Envelope:    newDataEnvelope(now, watermarkTime(watermark), window),
-		MetricsMode: "tool_call",
+		MetricsMode: metricsMode(sessionMode),
 		TopServers:  make([]ProjectOverviewServer, 0, len(servers)),
 	}
 	if summary != nil {
@@ -168,6 +205,21 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 	if counts != nil {
 		output.ActiveServers = boundedCount(counts.ActiveServersCount)
 		output.ActiveUsers = NewSubjectCount(boundedCount(counts.ActiveUsersCount))
+	}
+	if sessionMode {
+		// Under session capture the active-user count is a count of chat
+		// participants held in PostgreSQL. Reporting ClickHouse's tool-call
+		// actors here would answer a different question than metrics_mode says
+		// this number answers.
+		activeUsers, err := s.sessions.GetActiveUserCountByMessages(ctx, chatrepo.GetActiveUserCountByMessagesParams{
+			ProjectID: projectUUID,
+			TimeStart: conv.ToPGTimestamptz(window.start),
+			TimeEnd:   conv.ToPGTimestamptz(window.end),
+		})
+		if err != nil {
+			return GetProjectOverviewOutput{}, fmt.Errorf("read project overview active users: %w", err)
+		}
+		output.ActiveUsers = NewSubjectCount(activeUsers)
 	}
 	for _, server := range servers {
 		output.TopServers = append(output.TopServers, ProjectOverviewServer{
@@ -223,12 +275,16 @@ type GetMCPDiagnosticsOutput struct {
 
 	Readiness MCPDiagnosticsReadiness `json:"readiness"`
 	Outcomes  MCPOutcomeSummary       `json:"outcomes"`
-	// OrganizationOutcomes is the same summary across every project in the
-	// organization. It is what makes the scope check answerable server-side.
-	OrganizationOutcomes MCPOutcomeSummary   `json:"organization_outcomes"`
-	Clients              []MCPClientEvidence `json:"clients"`
-	ClientsTruncated     bool                `json:"clients_truncated"`
-	Attribution          FaultAttribution    `json:"attribution"`
+	// OrganizationOutcomes is the same summary across the organization's
+	// projects. It is what makes the scope check answerable server-side.
+	OrganizationOutcomes MCPOutcomeSummary `json:"organization_outcomes"`
+	// OrganizationOutcomesPartial reports that the comparison covered only the
+	// first maxOverviewProjects projects. When it is true the attribution's
+	// scope is forced to unknown rather than asserted from partial coverage.
+	OrganizationOutcomesPartial bool                `json:"organization_outcomes_partial"`
+	Clients                     []MCPClientEvidence `json:"clients"`
+	ClientsTruncated            bool                `json:"clients_truncated"`
+	Attribution                 FaultAttribution    `json:"attribution"`
 }
 
 func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Principal, input GetMCPDiagnosticsInput) (GetMCPDiagnosticsOutput, error) {
@@ -258,7 +314,7 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 		return GetMCPDiagnosticsOutput{}, err
 	}
 
-	projectIDs, err := s.organizationProjectIDs(ctx, principal)
+	projectIDs, projectsTruncated, err := s.organizationProjectIDs(ctx, principal)
 	if err != nil {
 		return GetMCPDiagnosticsOutput{}, err
 	}
@@ -292,6 +348,13 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 	readiness, readinessFound := s.currentReadiness(ctx, principal, mcp)
 	clients, truncated := clientEvidence(serverRows)
 
+	attribution := attributeFault(readiness, readinessFound, serverTotals, organizationTotals)
+	if projectsTruncated {
+		// The organization comparison covered a subset, so it cannot support a
+		// claim either way about where the pattern lives.
+		attribution.Scope = FaultScopeUnknown
+	}
+
 	return GetMCPDiagnosticsOutput{
 		ProjectID: input.ProjectID,
 		MCPID:     input.MCPID,
@@ -301,11 +364,12 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 			Freshness: readinessFreshness(readiness, readinessFound),
 			CheckedAt: readinessTimestamp(readiness.CheckedAt),
 		},
-		Outcomes:             summaryFromTotals(serverTotals),
-		OrganizationOutcomes: summaryFromTotals(organizationTotals),
-		Clients:              clients,
-		ClientsTruncated:     truncated,
-		Attribution:          attributeFault(readiness, readinessFound, serverTotals, organizationTotals),
+		Outcomes:                    summaryFromTotals(serverTotals),
+		OrganizationOutcomes:        summaryFromTotals(organizationTotals),
+		OrganizationOutcomesPartial: projectsTruncated,
+		Clients:                     clients,
+		ClientsTruncated:            truncated,
+		Attribution:                 attribution,
 	}, nil
 }
 
@@ -332,19 +396,24 @@ func (s *DiagnosticsService) diagnosticsTarget(ctx context.Context, organization
 	return row, nil
 }
 
-// organizationProjectIDs collects the projects the scope comparison spans. It
-// reuses the same listing the caller can already read, so the comparison never
-// covers a project the principal cannot see.
-func (s *DiagnosticsService) organizationProjectIDs(ctx context.Context, principal Principal) ([]string, error) {
-	projects, err := s.reader.ListProjects(ctx, principal, ListProjectsInput{Limit: 100})
+// organizationProjectIDs collects the projects the scope comparison spans, and
+// reports whether that listing was cut short. It reuses the same listing the
+// caller can already read, so the comparison never covers a project the
+// principal cannot see.
+//
+// The truncation flag is returned rather than swallowed: a comparison over an
+// unstated subset of an organization reads as a comparison over all of it, and
+// would let a partial view assert a scope it cannot support.
+func (s *DiagnosticsService) organizationProjectIDs(ctx context.Context, principal Principal) ([]string, bool, error) {
+	projects, err := s.reader.ListProjects(ctx, principal, ListProjectsInput{Limit: maxOverviewProjects})
 	if err != nil {
-		return nil, fmt.Errorf("list organization projects: %w", err)
+		return nil, false, fmt.Errorf("list organization projects: %w", err)
 	}
 	ids := make([]string, 0, len(projects.Projects))
 	for _, project := range projects.Projects {
 		ids = append(ids, project.ID)
 	}
-	return ids, nil
+	return ids, projects.Truncated, nil
 }
 
 // currentReadiness loads the persisted readiness result without probing the
@@ -427,6 +496,14 @@ func clientEvidence(rows []telemetryrepo.MCPOutcomeBreakdownRow) ([]MCPClientEvi
 		return clients[:maxDiagnosticClients], true
 	}
 	return clients, false
+}
+
+// metricsMode names what the overview's counts measure.
+func metricsMode(sessionMode bool) string {
+	if sessionMode {
+		return "session"
+	}
+	return "tool_call"
 }
 
 func nonEmpty(value string) []string {

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -23,6 +23,16 @@ const (
 	DiagnosticsOrganizationLimitName = "platform-mcp-diagnostics-organization"
 )
 
+const (
+	// DiagnosticQueriesPerConnectionPerMinute and
+	// DiagnosticQueriesPerOrganizationPerMinute bound the observability reads.
+	// A diagnosis is an interactive loop — an agent asks, narrows, and asks
+	// again — so the allowance is wider than a mutation's, and what it meters
+	// is the ClickHouse scan rather than any external egress.
+	DiagnosticQueriesPerConnectionPerMinute   = 30
+	DiagnosticQueriesPerOrganizationPerMinute = 300
+)
+
 // maxDiagnosticClients bounds the per-client evidence list. Client evidence is
 // self-reported and exists to point at a suspect, not to enumerate a fleet.
 const maxDiagnosticClients = 10
@@ -139,7 +149,7 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 		return GetProjectOverviewOutput{}, err
 	}
 	now := s.now()
-	window, err := resolveWindow(input.Window, now)
+	window, err := resolveWindow(input.Window, now, overviewWindowPolicy)
 	if err != nil {
 		return GetProjectOverviewOutput{}, err
 	}
@@ -240,7 +250,7 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 type GetMCPDiagnosticsInput struct {
 	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
 	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
-	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h (default) or 24h"`
 }
 
 // MCPOutcomeSummary is a server's calls in the window, already summed per
@@ -303,7 +313,7 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 		return GetMCPDiagnosticsOutput{}, err
 	}
 	now := s.now()
-	window, err := resolveWindow(input.Window, now)
+	window, err := resolveWindow(input.Window, now, diagnosticsWindowPolicy)
 	if err != nil {
 		return GetMCPDiagnosticsOutput{}, err
 	}

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -174,6 +174,9 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 		GramProjectID: input.ProjectID,
 		TimeStart:     start,
 		TimeEnd:       end,
+		// Carried so the active-server count is aggregated the same way the
+		// dashboard aggregates it for this organization's metrics mode.
+		SessionMode: sessionMode,
 	})
 	if err != nil {
 		return GetProjectOverviewOutput{}, fmt.Errorf("read project overview active counts: %w", err)

--- a/server/internal/platformmcp/diagnostics_test.go
+++ b/server/internal/platformmcp/diagnostics_test.go
@@ -48,7 +48,7 @@ func TestGetProjectOverviewOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("24h", now)
+	window, err := resolveWindow("24h", now, overviewWindowPolicy)
 	require.NoError(t, err)
 
 	output := GetProjectOverviewOutput{
@@ -78,7 +78,7 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("7d", now)
+	window, err := resolveWindow("1h", now, diagnosticsWindowPolicy)
 	require.NoError(t, err)
 
 	output := GetMCPDiagnosticsOutput{

--- a/server/internal/platformmcp/diagnostics_test.go
+++ b/server/internal/platformmcp/diagnostics_test.go
@@ -82,14 +82,15 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	require.NoError(t, err)
 
 	output := GetMCPDiagnosticsOutput{
-		ProjectID:            "00000000-0000-0000-0000-000000000001",
-		MCPID:                "00000000-0000-0000-0000-000000000002",
-		Envelope:             newDataEnvelope(now, now.Add(-time.Minute), window),
-		Readiness:            MCPDiagnosticsReadiness{State: string(ReadinessReady), Freshness: "fresh", CheckedAt: now.Format(time.RFC3339)},
-		Outcomes:             MCPOutcomeSummary{Total: 10, Success: 4, Unauthorized: 6},
-		OrganizationOutcomes: MCPOutcomeSummary{Total: 100, Success: 98, ServerError: 2},
-		Clients:              []MCPClientEvidence{{Client: "claude-code", Calls: 6, Failures: 6}},
-		ClientsTruncated:     false,
+		ProjectID:                   "00000000-0000-0000-0000-000000000001",
+		MCPID:                       "00000000-0000-0000-0000-000000000002",
+		Envelope:                    newDataEnvelope(now, now.Add(-time.Minute), window),
+		Readiness:                   MCPDiagnosticsReadiness{State: string(ReadinessReady), Freshness: "fresh", CheckedAt: now.Format(time.RFC3339)},
+		Outcomes:                    MCPOutcomeSummary{Total: 10, Success: 4, Unauthorized: 6},
+		OrganizationOutcomes:        MCPOutcomeSummary{Total: 100, Success: 98, ServerError: 2},
+		OrganizationOutcomesPartial: false,
+		Clients:                     []MCPClientEvidence{{Client: "claude-code", Calls: 6, Failures: 6}},
+		ClientsTruncated:            false,
 		Attribution: FaultAttribution{
 			Fault:               FaultGramConfiguration,
 			Reason:              reasonUnauthorizedDominant,
@@ -104,10 +105,18 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 		"readiness", "state", "freshness", "checked_at",
 		"outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
 		"organization_outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
+		"organization_outcomes_partial",
 		"clients", "client", "calls", "failures",
 		"clients_truncated",
 		"attribution", "fault", "reason", "readiness_exonerates", "scope",
 	}, decodeKeys(t, output))
+}
+
+func TestMetricsMode_NamesWhatTheCountsMeasure(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "session", metricsMode(true))
+	require.Equal(t, "tool_call", metricsMode(false))
 }
 
 func TestTotalsFromRows_SumsPerOutcomeClass(t *testing.T) {

--- a/server/internal/platformmcp/diagnostics_test.go
+++ b/server/internal/platformmcp/diagnostics_test.go
@@ -1,0 +1,181 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+// jsonKeys walks a decoded result and returns every key that appears anywhere
+// in it, so a leak test asserts on the whole shape rather than the top level.
+func jsonKeys(value any) []string {
+	var keys []string
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			keys = append(keys, key)
+			keys = append(keys, jsonKeys(nested)...)
+		}
+	case []any:
+		for _, nested := range typed {
+			keys = append(keys, jsonKeys(nested)...)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func decodeKeys(t *testing.T, value any) []string {
+	t.Helper()
+
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	var decoded any
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	return jsonKeys(decoded)
+}
+
+// TestGetProjectOverviewOutput_ProjectsOnlyAllowlistedFields pins the overview's
+// serialized shape. The projection is positive: a field that is not listed here
+// is not served, so a future addition has to be made deliberately in this test
+// before it can reach a caller.
+func TestGetProjectOverviewOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	window, err := resolveWindow("24h", now)
+	require.NoError(t, err)
+
+	output := GetProjectOverviewOutput{
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		Envelope:        newDataEnvelope(now, now.Add(-time.Minute), window),
+		MetricsMode:     "tool_call",
+		ToolCalls:       120,
+		FailedToolCalls: 4,
+		ActiveServers:   3,
+		ActiveUsers:     NewSubjectCount(11),
+		TopServers:      []ProjectOverviewServer{{Name: "billing", ToolCalls: 40}},
+	}
+
+	require.ElementsMatch(t, []string{
+		"project_id",
+		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"metrics_mode",
+		"tool_calls", "failed_tool_calls", "active_servers", "active_users",
+		"top_servers", "name", "tool_calls",
+	}, decodeKeys(t, output))
+}
+
+// TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields does the same for
+// the diagnosis. Nothing here carries a prompt, an argument, a result, a
+// header, a URL, an email, an external user id, or a raw status code.
+func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	window, err := resolveWindow("7d", now)
+	require.NoError(t, err)
+
+	output := GetMCPDiagnosticsOutput{
+		ProjectID:            "00000000-0000-0000-0000-000000000001",
+		MCPID:                "00000000-0000-0000-0000-000000000002",
+		Envelope:             newDataEnvelope(now, now.Add(-time.Minute), window),
+		Readiness:            MCPDiagnosticsReadiness{State: string(ReadinessReady), Freshness: "fresh", CheckedAt: now.Format(time.RFC3339)},
+		Outcomes:             MCPOutcomeSummary{Total: 10, Success: 4, Unauthorized: 6},
+		OrganizationOutcomes: MCPOutcomeSummary{Total: 100, Success: 98, ServerError: 2},
+		Clients:              []MCPClientEvidence{{Client: "claude-code", Calls: 6, Failures: 6}},
+		ClientsTruncated:     false,
+		Attribution: FaultAttribution{
+			Fault:               FaultGramConfiguration,
+			Reason:              reasonUnauthorizedDominant,
+			ReadinessExonerates: false,
+			Scope:               FaultScopeServerSpecific,
+		},
+	}
+
+	require.ElementsMatch(t, []string{
+		"project_id", "mcp_id",
+		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"readiness", "state", "freshness", "checked_at",
+		"outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
+		"organization_outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
+		"clients", "client", "calls", "failures",
+		"clients_truncated",
+		"attribution", "fault", "reason", "readiness_exonerates", "scope",
+	}, decodeKeys(t, output))
+}
+
+func TestTotalsFromRows_SumsPerOutcomeClass(t *testing.T) {
+	t.Parallel()
+
+	totals := totalsFromRows([]telemetryrepo.MCPOutcomeBreakdownRow{
+		{Client: "claude-code", Outcome: telemetryrepo.MCPOutcomeSuccess, CallCount: 10},
+		{Client: "claude-code", Outcome: telemetryrepo.MCPOutcomeUnauthorized, CallCount: 3},
+		{Client: telemetryrepo.MCPClientUnattributed, Outcome: telemetryrepo.MCPOutcomeServerError, CallCount: 2},
+		{Client: telemetryrepo.MCPClientUnattributed, Outcome: telemetryrepo.MCPOutcomeClientError, CallCount: 1},
+		{Client: "cursor", Outcome: telemetryrepo.MCPOutcomeFailed, CallCount: 4},
+		// An outcome this build does not know classifies as unknown rather
+		// than being dropped, so the totals still add up.
+		{Client: "cursor", Outcome: "something-new", CallCount: 5},
+	})
+
+	require.Equal(t, outcomeTotals{Total: 25, Success: 10, Unauthorized: 3, ClientError: 1, ServerError: 2, Failed: 4, Unknown: 5}, totals)
+	require.Equal(t, int64(10), totals.failures())
+}
+
+func TestClientEvidence_OrdersSuspectsFirstAndReportsTruncation(t *testing.T) {
+	t.Parallel()
+
+	rows := []telemetryrepo.MCPOutcomeBreakdownRow{
+		{Client: "quiet", Outcome: telemetryrepo.MCPOutcomeSuccess, CallCount: 50},
+		{Client: "noisy", Outcome: telemetryrepo.MCPOutcomeSuccess, CallCount: 1},
+		{Client: "noisy", Outcome: telemetryrepo.MCPOutcomeUnauthorized, CallCount: 9},
+	}
+
+	clients, truncated := clientEvidence(rows)
+	require.False(t, truncated)
+	require.Equal(t, []MCPClientEvidence{
+		{Client: "noisy", Calls: 10, Failures: 9},
+		{Client: "quiet", Calls: 50, Failures: 0},
+	}, clients)
+
+	// A cut list says it was cut: a silently truncated list reads as complete
+	// coverage of the clients calling this server.
+	var many []telemetryrepo.MCPOutcomeBreakdownRow
+	for index := range maxDiagnosticClients + 3 {
+		many = append(many, telemetryrepo.MCPOutcomeBreakdownRow{
+			Client:    string(rune('a' + index)),
+			Outcome:   telemetryrepo.MCPOutcomeUnauthorized,
+			CallCount: uint64(index + 1),
+		})
+	}
+	capped, truncated := clientEvidence(many)
+	require.True(t, truncated)
+	require.Len(t, capped, maxDiagnosticClients)
+}
+
+// TestClientEvidence_UnknownOutcomesAreNotFailures pins that an outcome the
+// server could not classify is not counted against a client. Charging a client
+// for a call nobody could classify would manufacture a suspect.
+func TestClientEvidence_UnknownOutcomesAreNotFailures(t *testing.T) {
+	t.Parallel()
+
+	clients, _ := clientEvidence([]telemetryrepo.MCPOutcomeBreakdownRow{
+		{Client: "claude-code", Outcome: telemetryrepo.MCPOutcomeUnknown, CallCount: 7},
+	})
+	require.Equal(t, []MCPClientEvidence{{Client: "claude-code", Calls: 7, Failures: 0}}, clients)
+}
+
+func TestMCPURLSuffixes_OnlyWhenSlugKnown(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, mcpURLSuffixes(""))
+	require.Equal(t, []string{"/mcp/billing"}, mcpURLSuffixes("billing"))
+	require.Nil(t, nonEmpty(""))
+	require.Equal(t, []string{"billing"}, nonEmpty("billing"))
+}

--- a/server/internal/platformmcp/fault_attribution.go
+++ b/server/internal/platformmcp/fault_attribution.go
@@ -51,6 +51,7 @@ const (
 const (
 	reasonNoObservations       = "no_observations"
 	reasonNoFailures           = "no_failures"
+	reasonUnclassifiedOnly     = "unclassified_observations_only"
 	reasonReadyAndFailing      = "ready_but_failing"
 	reasonUnauthorizedDominant = "unauthorized_dominant"
 	reasonServerErrorDominant  = "server_error_dominant"
@@ -131,6 +132,14 @@ func attributeFault(readiness Readiness, readinessFound bool, server, organizati
 		return attribution
 	}
 	if server.failures() == 0 {
+		// Calls whose trace carried neither a status nor a result are not
+		// evidence of success. A window that produced only those says nothing
+		// about the server, so it is indeterminate rather than healthy.
+		if server.Success == 0 {
+			attribution.Fault = FaultIndeterminate
+			attribution.Reason = reasonUnclassifiedOnly
+			return attribution
+		}
 		attribution.Fault = FaultNone
 		attribution.Reason = reasonNoFailures
 		return attribution

--- a/server/internal/platformmcp/fault_attribution.go
+++ b/server/internal/platformmcp/fault_attribution.go
@@ -75,6 +75,29 @@ func (t outcomeTotals) failures() int64 {
 	return t.Unauthorized + t.ClientError + t.ServerError + t.Failed
 }
 
+// without removes one server's calls from a wider tally, so a comparison can be
+// taken against the rest of the organization rather than against a total that
+// already contains the server under diagnosis.
+//
+// Each class is floored at zero. The two tallies come from separate reads, so a
+// subset can legitimately arrive larger than the set it was taken from — a call
+// observed by one read and not the other — and a negative class would otherwise
+// travel into a rate.
+func (t outcomeTotals) without(other outcomeTotals) outcomeTotals {
+	sub := func(a, b int64) int64 {
+		return max(a-b, 0)
+	}
+	return outcomeTotals{
+		Total:        sub(t.Total, other.Total),
+		Success:      sub(t.Success, other.Success),
+		Unauthorized: sub(t.Unauthorized, other.Unauthorized),
+		ClientError:  sub(t.ClientError, other.ClientError),
+		ServerError:  sub(t.ServerError, other.ServerError),
+		Failed:       sub(t.Failed, other.Failed),
+		Unknown:      sub(t.Unknown, other.Unknown),
+	}
+}
+
 // dominant reports whether one failure class accounts for most of the failures.
 // A single class carrying the majority is a signal; an even spread is not, and
 // resolves to indeterminate rather than to whichever class happened to lead.
@@ -166,10 +189,12 @@ func attributeFault(readiness Readiness, readinessFound bool, server, organizati
 		attribution.Fault = FaultClient
 	case reasonUnauthorizedDominant:
 		if exonerates {
-			// Gram's own probe authorized successfully, so the credentials the
-			// server holds are good and the rejections belong to how callers
-			// are presenting themselves.
-			attribution.Fault = FaultClient
+			// A contradiction, not a diagnosis: the status classified here is
+			// the one the provider returned to Gram's own call, so a probe that
+			// authorized successfully and calls the provider rejects cannot
+			// both describe the same credentials. Reporting the caller at fault
+			// would blame the one party this evidence says nothing about.
+			attribution.Fault = FaultIndeterminate
 			attribution.Reason = reasonReadyAndFailing
 			return attribution
 		}
@@ -196,15 +221,23 @@ func attributeFault(readiness Readiness, readinessFound bool, server, organizati
 }
 
 // compareScope answers whether this server fails materially more often than the
-// organization as a whole. It is computed server-side: an external caller has
+// rest of the organization. It is computed server-side: an external caller has
 // no way to divide two numbers it was never given.
+//
+// The organization totals span every project in scope, so they include this
+// server's own calls. Comparing against them directly makes the comparison
+// self-cancelling wherever this server is most of the organization's traffic:
+// the two rates converge, every pattern reads organization_wide, and a genuine
+// single-server fault is reported as a fault of everything. The comparison is
+// therefore taken against the organization minus this server.
 func compareScope(server, organization outcomeTotals) FaultScope {
-	if organization.Total < organizationWideComparisonFloor || server.Total == 0 {
+	others := organization.without(server)
+	if others.Total < organizationWideComparisonFloor || server.Total == 0 {
 		return FaultScopeUnknown
 	}
 	serverRate := float64(server.failures()) / float64(server.Total)
-	organizationRate := float64(organization.failures()) / float64(organization.Total)
-	if serverRate-organizationRate > organizationWideFailureMargin {
+	othersRate := float64(others.failures()) / float64(others.Total)
+	if serverRate-othersRate > organizationWideFailureMargin {
 		return FaultScopeServerSpecific
 	}
 	return FaultScopeOrganizationWide

--- a/server/internal/platformmcp/fault_attribution.go
+++ b/server/internal/platformmcp/fault_attribution.go
@@ -1,0 +1,202 @@
+package platformmcp
+
+// Fault is where a diagnosed problem lives. The set is closed and the values
+// are the only vocabulary a caller receives.
+type Fault string
+
+const (
+	// FaultNone is a server with no evidence of a problem in the window.
+	FaultNone Fault = "none"
+	// FaultGramConfiguration is a problem in how the MCP is configured in Gram:
+	// missing or expired authorization, incomplete required configuration.
+	FaultGramConfiguration Fault = "gram_configuration"
+	// FaultProvider is a problem upstream of Gram — the provider the MCP
+	// fronts is failing or unreachable.
+	FaultProvider Fault = "provider"
+	// FaultClient is a problem in the calling client: malformed or rejected
+	// requests that never became a provider call.
+	FaultClient Fault = "client"
+	// FaultIndeterminate is the honest answer when the evidence does not
+	// separate the candidates. It is always preferred over a guess.
+	FaultIndeterminate Fault = "indeterminate"
+)
+
+// FaultAttribution is a diagnosis and the evidence it rests on. Reasons are
+// server-authored codes from a closed set, never provider or client text.
+type FaultAttribution struct {
+	Fault Fault `json:"fault"`
+	// Reason names the single rule that decided this attribution.
+	Reason string `json:"reason"`
+	// ReadinessExonerates records whether a fresh, ready server-side readiness
+	// result was available. When true, Gram-side configuration and the provider
+	// are both known good as of that check.
+	ReadinessExonerates bool `json:"readiness_exonerates"`
+	// Scope says whether the failure pattern is confined to this server or
+	// present across the organization; an organization-wide pattern points away
+	// from this server's own configuration.
+	Scope FaultScope `json:"scope"`
+}
+
+// FaultScope is the server-computed answer to "is this only happening here?".
+type FaultScope string
+
+const (
+	FaultScopeServerSpecific   FaultScope = "server_specific"
+	FaultScopeOrganizationWide FaultScope = "organization_wide"
+	// FaultScopeUnknown is returned when the organization-wide comparison had
+	// too little traffic to say either way.
+	FaultScopeUnknown FaultScope = "unknown"
+)
+
+const (
+	reasonNoObservations       = "no_observations"
+	reasonNoFailures           = "no_failures"
+	reasonReadyAndFailing      = "ready_but_failing"
+	reasonUnauthorizedDominant = "unauthorized_dominant"
+	reasonServerErrorDominant  = "server_error_dominant"
+	reasonClientErrorDominant  = "client_error_dominant"
+	reasonMixedFailures        = "mixed_failures"
+	reasonReadinessNotReady    = "readiness_not_ready"
+)
+
+// outcomeTotals is one server's calls in the window, split by outcome class.
+type outcomeTotals struct {
+	Total        int64
+	Success      int64
+	Unauthorized int64
+	ClientError  int64
+	ServerError  int64
+	Failed       int64
+	Unknown      int64
+}
+
+func (t outcomeTotals) failures() int64 {
+	return t.Unauthorized + t.ClientError + t.ServerError + t.Failed
+}
+
+// dominant reports whether one failure class accounts for most of the failures.
+// A single class carrying the majority is a signal; an even spread is not, and
+// resolves to indeterminate rather than to whichever class happened to lead.
+func (t outcomeTotals) dominant() (string, bool) {
+	failures := t.failures()
+	if failures == 0 {
+		return "", false
+	}
+	majority := failures/2 + 1
+	switch {
+	case t.Unauthorized >= majority:
+		return reasonUnauthorizedDominant, true
+	case t.ServerError >= majority:
+		return reasonServerErrorDominant, true
+	case t.ClientError >= majority:
+		return reasonClientErrorDominant, true
+	default:
+		return "", false
+	}
+}
+
+// organizationWideComparisonFloor is the least organization-wide traffic that
+// makes the scope comparison meaningful. Below it the comparison is noise and
+// the scope is reported unknown rather than asserted.
+const organizationWideComparisonFloor = 20
+
+// organizationWideFailureMargin is how much higher this server's failure rate
+// must be than the organization's before the pattern counts as specific to it.
+const organizationWideFailureMargin = 0.2
+
+// attributeFault composes a diagnosis from the three independent pieces of
+// evidence the RFC names: the latest server-side readiness result, the
+// outcome breakdown for this server, and the same breakdown across the
+// organization.
+//
+// It never guesses. Every branch that cannot separate the candidates returns
+// FaultIndeterminate with the reason that left it undecided.
+func attributeFault(readiness Readiness, readinessFound bool, server, organization outcomeTotals) FaultAttribution {
+	scope := compareScope(server, organization)
+	// A fresh ready result is a positive statement made by Gram's own probe:
+	// the configuration resolved and the provider answered. It cannot exonerate
+	// anything if it is stale or missing.
+	exonerates := readinessFound && readiness.Fresh && readiness.State == ReadinessReady
+
+	attribution := FaultAttribution{
+		Fault:               FaultIndeterminate,
+		Reason:              reasonMixedFailures,
+		ReadinessExonerates: exonerates,
+		Scope:               scope,
+	}
+
+	if server.Total == 0 {
+		attribution.Fault = FaultIndeterminate
+		attribution.Reason = reasonNoObservations
+		return attribution
+	}
+	if server.failures() == 0 {
+		attribution.Fault = FaultNone
+		attribution.Reason = reasonNoFailures
+		return attribution
+	}
+
+	// Readiness states other than ready are a direct statement about this
+	// server's Gram-side setup, and outrank inference from call outcomes.
+	if readinessFound && readiness.Fresh && readiness.State != ReadinessReady {
+		attribution.Fault = FaultGramConfiguration
+		attribution.Reason = reasonReadinessNotReady
+		return attribution
+	}
+
+	dominant, decided := server.dominant()
+	if !decided {
+		return attribution
+	}
+	attribution.Reason = dominant
+
+	switch dominant {
+	case reasonClientErrorDominant:
+		// Requests rejected before they became a provider call. Neither Gram's
+		// configuration nor the provider produced them.
+		attribution.Fault = FaultClient
+	case reasonUnauthorizedDominant:
+		if exonerates {
+			// Gram's own probe authorized successfully, so the credentials the
+			// server holds are good and the rejections belong to how callers
+			// are presenting themselves.
+			attribution.Fault = FaultClient
+			attribution.Reason = reasonReadyAndFailing
+			return attribution
+		}
+		attribution.Fault = FaultGramConfiguration
+	case reasonServerErrorDominant:
+		if exonerates {
+			// The provider answered a probe but is failing real calls: still
+			// upstream, but the readiness check cannot confirm it, so say so.
+			attribution.Fault = FaultIndeterminate
+			attribution.Reason = reasonReadyAndFailing
+			return attribution
+		}
+		attribution.Fault = FaultProvider
+	default:
+		attribution.Fault = FaultIndeterminate
+	}
+
+	// A pattern present across the whole organization is not this server's
+	// configuration, whatever its own outcomes suggest.
+	if attribution.Fault == FaultGramConfiguration && scope == FaultScopeOrganizationWide {
+		attribution.Fault = FaultIndeterminate
+	}
+	return attribution
+}
+
+// compareScope answers whether this server fails materially more often than the
+// organization as a whole. It is computed server-side: an external caller has
+// no way to divide two numbers it was never given.
+func compareScope(server, organization outcomeTotals) FaultScope {
+	if organization.Total < organizationWideComparisonFloor || server.Total == 0 {
+		return FaultScopeUnknown
+	}
+	serverRate := float64(server.failures()) / float64(server.Total)
+	organizationRate := float64(organization.failures()) / float64(organization.Total)
+	if serverRate-organizationRate > organizationWideFailureMargin {
+		return FaultScopeServerSpecific
+	}
+	return FaultScopeOrganizationWide
+}

--- a/server/internal/platformmcp/fault_attribution_test.go
+++ b/server/internal/platformmcp/fault_attribution_test.go
@@ -1,0 +1,171 @@
+package platformmcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func freshReadiness(state ReadinessState) Readiness {
+	return Readiness{State: state, Fresh: true}
+}
+
+func TestAttributeFault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		readiness      Readiness
+		readinessFound bool
+		server         outcomeTotals
+		organization   outcomeTotals
+		wantFault      Fault
+		wantReason     string
+		wantScope      FaultScope
+	}{
+		{
+			// Silence is not health. A server nobody called cannot be
+			// pronounced working.
+			name:       "no observations is indeterminate",
+			server:     outcomeTotals{},
+			wantFault:  FaultIndeterminate,
+			wantReason: reasonNoObservations,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
+			name:       "no failures is no fault",
+			server:     outcomeTotals{Total: 40, Success: 40},
+			wantFault:  FaultNone,
+			wantReason: reasonNoFailures,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
+			// A fresh readiness result is a direct statement about this
+			// server's Gram-side setup and outranks inference from outcomes.
+			name:           "not-ready readiness attributes to gram configuration",
+			readiness:      freshReadiness(ReadinessNeedsGramAuthorization),
+			readinessFound: true,
+			server:         outcomeTotals{Total: 10, Success: 2, ServerError: 8},
+			wantFault:      FaultGramConfiguration,
+			wantReason:     reasonReadinessNotReady,
+			wantScope:      FaultScopeUnknown,
+		},
+		{
+			name:       "unauthorized dominant without readiness is gram configuration",
+			server:     outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
+			wantFault:  FaultGramConfiguration,
+			wantReason: reasonUnauthorizedDominant,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
+			// The probe authorized with the credentials the server holds, so
+			// the rejections are about how callers present themselves.
+			name:           "fresh ready exonerates gram on unauthorized calls",
+			readiness:      freshReadiness(ReadinessReady),
+			readinessFound: true,
+			server:         outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
+			wantFault:      FaultClient,
+			wantReason:     reasonReadyAndFailing,
+			wantScope:      FaultScopeUnknown,
+		},
+		{
+			name:       "server errors without readiness point upstream",
+			server:     outcomeTotals{Total: 20, Success: 2, ServerError: 18},
+			wantFault:  FaultProvider,
+			wantReason: reasonServerErrorDominant,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
+			// The provider answered a probe yet fails real calls. That is a
+			// real contradiction, and saying so beats picking a side.
+			name:           "fresh ready with server errors is indeterminate",
+			readiness:      freshReadiness(ReadinessReady),
+			readinessFound: true,
+			server:         outcomeTotals{Total: 20, Success: 2, ServerError: 18},
+			wantFault:      FaultIndeterminate,
+			wantReason:     reasonReadyAndFailing,
+			wantScope:      FaultScopeUnknown,
+		},
+		{
+			name:       "client errors are the caller's",
+			server:     outcomeTotals{Total: 20, Success: 2, ClientError: 18},
+			wantFault:  FaultClient,
+			wantReason: reasonClientErrorDominant,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
+			// An even spread across failure classes names no candidate; the
+			// leading class by a single call is not evidence.
+			name:       "evenly mixed failures stay indeterminate",
+			server:     outcomeTotals{Total: 30, Success: 0, Unauthorized: 10, ClientError: 10, ServerError: 10},
+			wantFault:  FaultIndeterminate,
+			wantReason: reasonMixedFailures,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
+			// Everything in the organization fails the same way, so this
+			// server's own configuration is not what distinguishes it.
+			name:         "organization-wide unauthorized pattern is not this server's configuration",
+			server:       outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
+			organization: outcomeTotals{Total: 200, Success: 20, Unauthorized: 180},
+			wantFault:    FaultIndeterminate,
+			wantReason:   reasonUnauthorizedDominant,
+			wantScope:    FaultScopeOrganizationWide,
+		},
+		{
+			name:         "server-specific unauthorized pattern is this server's configuration",
+			server:       outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
+			organization: outcomeTotals{Total: 200, Success: 190, Unauthorized: 10},
+			wantFault:    FaultGramConfiguration,
+			wantReason:   reasonUnauthorizedDominant,
+			wantScope:    FaultScopeServerSpecific,
+		},
+		{
+			// A stale readiness result states nothing about the system as it is
+			// now, so it must not exonerate anything.
+			name:           "stale ready does not exonerate",
+			readiness:      Readiness{State: ReadinessReady, Fresh: false},
+			readinessFound: true,
+			server:         outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
+			wantFault:      FaultGramConfiguration,
+			wantReason:     reasonUnauthorizedDominant,
+			wantScope:      FaultScopeUnknown,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			attribution := attributeFault(test.readiness, test.readinessFound, test.server, test.organization)
+			require.Equal(t, test.wantFault, attribution.Fault)
+			require.Equal(t, test.wantReason, attribution.Reason)
+			require.Equal(t, test.wantScope, attribution.Scope)
+		})
+	}
+}
+
+// TestAttributeFault_ExonerationRequiresFreshReady pins the one condition that
+// lets a diagnosis clear Gram's configuration and the provider at once.
+func TestAttributeFault_ExonerationRequiresFreshReady(t *testing.T) {
+	t.Parallel()
+
+	server := outcomeTotals{Total: 10, Success: 10}
+
+	require.True(t, attributeFault(freshReadiness(ReadinessReady), true, server, outcomeTotals{}).ReadinessExonerates)
+	require.False(t, attributeFault(freshReadiness(ReadinessReady), false, server, outcomeTotals{}).ReadinessExonerates)
+	require.False(t, attributeFault(Readiness{State: ReadinessReady, Fresh: false}, true, server, outcomeTotals{}).ReadinessExonerates)
+	require.False(t, attributeFault(freshReadiness(ReadinessDegraded), true, server, outcomeTotals{}).ReadinessExonerates)
+}
+
+func TestCompareScope_NeedsEnoughOrganizationTraffic(t *testing.T) {
+	t.Parallel()
+
+	server := outcomeTotals{Total: 20, Success: 2, Unauthorized: 18}
+
+	// Below the floor the comparison is noise, so the scope is reported unknown
+	// rather than asserted from a handful of calls.
+	require.Equal(t, FaultScopeUnknown, compareScope(server, outcomeTotals{Total: 19, Success: 19}))
+	require.Equal(t, FaultScopeServerSpecific, compareScope(server, outcomeTotals{Total: 20, Success: 20}))
+	require.Equal(t, FaultScopeUnknown, compareScope(outcomeTotals{}, outcomeTotals{Total: 500, Success: 500}))
+}

--- a/server/internal/platformmcp/fault_attribution_test.go
+++ b/server/internal/platformmcp/fault_attribution_test.go
@@ -40,6 +40,23 @@ func TestAttributeFault(t *testing.T) {
 			wantScope:  FaultScopeUnknown,
 		},
 		{
+			// Calls nobody could classify are not successes. Counting the
+			// absence of classified failures as health is the same mistake as
+			// reading an empty result as a healthy one.
+			name:       "unclassified-only observations are indeterminate",
+			server:     outcomeTotals{Total: 12, Unknown: 12},
+			wantFault:  FaultIndeterminate,
+			wantReason: reasonUnclassifiedOnly,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
+			name:       "successes alongside unclassified calls are still no fault",
+			server:     outcomeTotals{Total: 12, Success: 8, Unknown: 4},
+			wantFault:  FaultNone,
+			wantReason: reasonNoFailures,
+			wantScope:  FaultScopeUnknown,
+		},
+		{
 			// A fresh readiness result is a direct statement about this
 			// server's Gram-side setup and outranks inference from outcomes.
 			name:           "not-ready readiness attributes to gram configuration",

--- a/server/internal/platformmcp/fault_attribution_test.go
+++ b/server/internal/platformmcp/fault_attribution_test.go
@@ -75,13 +75,15 @@ func TestAttributeFault(t *testing.T) {
 			wantScope:  FaultScopeUnknown,
 		},
 		{
-			// The probe authorized with the credentials the server holds, so
-			// the rejections are about how callers present themselves.
-			name:           "fresh ready exonerates gram on unauthorized calls",
+			// The rejections classified here are the provider's answer to
+			// Gram's own calls, so a probe that authorized with the same
+			// credentials contradicts them. Naming the caller at fault would
+			// blame the one party this evidence says nothing about.
+			name:           "fresh ready with unauthorized calls is indeterminate",
 			readiness:      freshReadiness(ReadinessReady),
 			readinessFound: true,
 			server:         outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
-			wantFault:      FaultClient,
+			wantFault:      FaultIndeterminate,
 			wantReason:     reasonReadyAndFailing,
 			wantScope:      FaultScopeUnknown,
 		},
@@ -138,6 +140,19 @@ func TestAttributeFault(t *testing.T) {
 			wantScope:    FaultScopeServerSpecific,
 		},
 		{
+			// The organization totals contain this server's own calls. When it
+			// is the only thing generating traffic, comparing against them
+			// unmodified makes every pattern look organization-wide and
+			// downgrades the diagnosis to indeterminate — silencing the answer
+			// in exactly the case a small tenant asks for it.
+			name:         "sole server in the organization still gets its own diagnosis",
+			server:       outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
+			organization: outcomeTotals{Total: 20, Success: 2, Unauthorized: 18},
+			wantFault:    FaultGramConfiguration,
+			wantReason:   reasonUnauthorizedDominant,
+			wantScope:    FaultScopeUnknown,
+		},
+		{
 			// A stale readiness result states nothing about the system as it is
 			// now, so it must not exonerate anything.
 			name:           "stale ready does not exonerate",
@@ -175,14 +190,38 @@ func TestAttributeFault_ExonerationRequiresFreshReady(t *testing.T) {
 	require.False(t, attributeFault(freshReadiness(ReadinessDegraded), true, server, outcomeTotals{}).ReadinessExonerates)
 }
 
-func TestCompareScope_NeedsEnoughOrganizationTraffic(t *testing.T) {
+// TestCompareScope_ComparesAgainstTheRestOfTheOrganization pins that the floor
+// and the rates are both taken over the organization minus this server. The
+// organization totals a caller of attributeFault supplies always contain the
+// server under diagnosis, so every case here includes it.
+func TestCompareScope_ComparesAgainstTheRestOfTheOrganization(t *testing.T) {
 	t.Parallel()
 
 	server := outcomeTotals{Total: 20, Success: 2, Unauthorized: 18}
+	withServer := func(rest outcomeTotals) outcomeTotals {
+		return outcomeTotals{
+			Total:        server.Total + rest.Total,
+			Success:      server.Success + rest.Success,
+			Unauthorized: server.Unauthorized + rest.Unauthorized,
+			ClientError:  rest.ClientError,
+			ServerError:  rest.ServerError,
+			Failed:       rest.Failed,
+			Unknown:      rest.Unknown,
+		}
+	}
 
 	// Below the floor the comparison is noise, so the scope is reported unknown
 	// rather than asserted from a handful of calls.
-	require.Equal(t, FaultScopeUnknown, compareScope(server, outcomeTotals{Total: 19, Success: 19}))
-	require.Equal(t, FaultScopeServerSpecific, compareScope(server, outcomeTotals{Total: 20, Success: 20}))
+	require.Equal(t, FaultScopeUnknown, compareScope(server, withServer(outcomeTotals{Total: 19, Success: 19})))
+	require.Equal(t, FaultScopeServerSpecific, compareScope(server, withServer(outcomeTotals{Total: 20, Success: 20})))
+
+	// The rest of the organization fails the same way, so nothing here is
+	// specific to this server.
+	require.Equal(t, FaultScopeOrganizationWide, compareScope(server, withServer(outcomeTotals{Total: 100, Success: 10, Unauthorized: 90})))
+
+	// A server that is the organization's only traffic leaves nothing to
+	// compare against, which is unknown rather than organization-wide.
+	require.Equal(t, FaultScopeUnknown, compareScope(server, server))
+
 	require.Equal(t, FaultScopeUnknown, compareScope(outcomeTotals{}, outcomeTotals{Total: 500, Success: 500}))
 }

--- a/server/internal/platformmcp/freshness.go
+++ b/server/internal/platformmcp/freshness.go
@@ -1,0 +1,144 @@
+package platformmcp
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// StaleWatermarkThreshold is how far behind the observation watermark may fall
+// before a diagnostic reports itself stale. Telemetry reaches the read model
+// through batched ingestion, so a small lag is normal; beyond this the answer
+// is old enough that a caller acting on it could be reasoning about a system
+// state that has already changed.
+const StaleWatermarkThreshold = 5 * time.Minute
+
+// Freshness qualifies every diagnostic result. It is deliberately reported
+// beside the data rather than folded into it: an empty result is
+// FreshnessNoObservations, which is the absence of evidence and never evidence
+// of health.
+type Freshness string
+
+const (
+	FreshnessFresh Freshness = "fresh"
+	FreshnessStale Freshness = "stale"
+	// FreshnessNoObservations means nothing was observed for the scope at all.
+	// A caller must not read it as "nothing went wrong".
+	FreshnessNoObservations Freshness = "no_observations"
+)
+
+// DiagnosticWindow is the closed set of windows a diagnostic may be asked for.
+// Callers name a window rather than supplying timestamps: an open time grammar
+// is a query language, and this surface deliberately has none.
+type DiagnosticWindow string
+
+const (
+	DiagnosticWindowLastHour  DiagnosticWindow = "1h"
+	DiagnosticWindowLastDay   DiagnosticWindow = "24h"
+	DiagnosticWindowLastWeek  DiagnosticWindow = "7d"
+	DiagnosticWindowLastMonth DiagnosticWindow = "30d"
+)
+
+// DefaultDiagnosticWindow is what an unspecified window resolves to.
+const DefaultDiagnosticWindow = DiagnosticWindowLastDay
+
+// ErrDiagnosticWindowInvalid is returned for a window outside the closed set.
+var ErrDiagnosticWindowInvalid = fmt.Errorf("window must be one of %s, %s, %s, %s",
+	DiagnosticWindowLastHour, DiagnosticWindowLastDay, DiagnosticWindowLastWeek, DiagnosticWindowLastMonth)
+
+func (w DiagnosticWindow) duration() (time.Duration, bool) {
+	switch w {
+	case DiagnosticWindowLastHour:
+		return time.Hour, true
+	case DiagnosticWindowLastDay:
+		return 24 * time.Hour, true
+	case DiagnosticWindowLastWeek:
+		return 7 * 24 * time.Hour, true
+	case DiagnosticWindowLastMonth:
+		return 30 * 24 * time.Hour, true
+	default:
+		return 0, false
+	}
+}
+
+// ResolvedWindow is the window a diagnostic actually read, echoed on every
+// result. A caller never has to infer it from what it asked for.
+type ResolvedWindow struct {
+	Window DiagnosticWindow `json:"window"`
+	From   string           `json:"from"`
+	To     string           `json:"to"`
+
+	start time.Time
+	end   time.Time
+}
+
+// resolveWindow turns a requested window name into the interval to read.
+// An empty request resolves to DefaultDiagnosticWindow; anything outside the
+// closed set is refused rather than silently clamped, so a caller never
+// receives a different window than it believes it asked for.
+func resolveWindow(requested string, now time.Time) (ResolvedWindow, error) {
+	window := DiagnosticWindow(strings.ToLower(strings.TrimSpace(requested)))
+	if window == "" {
+		window = DefaultDiagnosticWindow
+	}
+	duration, ok := window.duration()
+	if !ok {
+		return ResolvedWindow{}, ErrDiagnosticWindowInvalid
+	}
+	end := now.UTC()
+	start := end.Add(-duration)
+	return ResolvedWindow{
+		Window: window,
+		From:   start.Format(time.RFC3339),
+		To:     end.Format(time.RFC3339),
+		start:  start,
+		end:    end,
+	}, nil
+}
+
+// DataEnvelope accompanies every diagnostic result. It says when the answer was
+// computed, how far the underlying observations reach, and whether that is
+// current enough to act on.
+type DataEnvelope struct {
+	QueriedAt      string         `json:"queried_at"`
+	DataThrough    string         `json:"data_through,omitempty"`
+	Freshness      Freshness      `json:"freshness"`
+	ResolvedWindow ResolvedWindow `json:"resolved_window"`
+}
+
+// newDataEnvelope classifies a read against its observation watermark.
+//
+// A watermark at or past the end of the window means the window is fully
+// covered, so a historical read stays fresh instead of being reported stale
+// merely for being about the past. Otherwise the lag is measured against the
+// moment of the read.
+func newDataEnvelope(now time.Time, watermark time.Time, window ResolvedWindow) DataEnvelope {
+	envelope := DataEnvelope{
+		QueriedAt:      now.UTC().Format(time.RFC3339),
+		DataThrough:    "",
+		Freshness:      FreshnessNoObservations,
+		ResolvedWindow: window,
+	}
+	if watermark.IsZero() {
+		return envelope
+	}
+	envelope.DataThrough = watermark.UTC().Format(time.RFC3339)
+	switch {
+	case !watermark.Before(window.end):
+		envelope.Freshness = FreshnessFresh
+	case now.Sub(watermark) > StaleWatermarkThreshold:
+		envelope.Freshness = FreshnessStale
+	default:
+		envelope.Freshness = FreshnessFresh
+	}
+	return envelope
+}
+
+// watermarkTime converts a ClickHouse nanosecond watermark, where zero means
+// "no observations", into a time. It does not treat the Unix epoch as data.
+func watermarkTime(unixNano int64) time.Time {
+	if unixNano <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, unixNano).UTC()
+}

--- a/server/internal/platformmcp/freshness.go
+++ b/server/internal/platformmcp/freshness.go
@@ -85,7 +85,11 @@ func resolveWindow(requested string, now time.Time) (ResolvedWindow, error) {
 	if !ok {
 		return ResolvedWindow{}, ErrDiagnosticWindowInvalid
 	}
-	end := now.UTC()
+	// Truncated to the second the window is advertised at, so the interval a
+	// caller is told about is exactly the interval that was queried. Formatting
+	// a sub-second `now` as RFC3339 would round the boundary away and quietly
+	// disagree with the nanosecond bounds the reads use.
+	end := now.UTC().Truncate(time.Second)
 	start := end.Add(-duration)
 	return ResolvedWindow{
 		Window: window,

--- a/server/internal/platformmcp/freshness.go
+++ b/server/internal/platformmcp/freshness.go
@@ -1,7 +1,9 @@
 package platformmcp
 
 import (
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 )
@@ -39,12 +41,57 @@ const (
 	DiagnosticWindowLastMonth DiagnosticWindow = "30d"
 )
 
-// DefaultDiagnosticWindow is what an unspecified window resolves to.
-const DefaultDiagnosticWindow = DiagnosticWindowLastDay
+// ErrDiagnosticWindowInvalid is returned for a window outside a tool's closed
+// set. The set differs per tool, so the message names the windows that tool
+// accepts rather than every window the type can express.
+var ErrDiagnosticWindowInvalid = errors.New("unsupported window")
 
-// ErrDiagnosticWindowInvalid is returned for a window outside the closed set.
-var ErrDiagnosticWindowInvalid = fmt.Errorf("window must be one of %s, %s, %s, %s",
-	DiagnosticWindowLastHour, DiagnosticWindowLastDay, DiagnosticWindowLastWeek, DiagnosticWindowLastMonth)
+// windowPolicy is one tool's closed set of windows and the one an unspecified
+// request resolves to. Each tool carries its own: a window that answers "what
+// has this project been doing" is not the window that answers "why is this MCP
+// failing right now", and a diagnosis read over weeks averages a live fault
+// into healthy traffic until the attribution can no longer see it.
+type windowPolicy struct {
+	allowed  []DiagnosticWindow
+	fallback DiagnosticWindow
+}
+
+// overviewWindowPolicy bounds get_project_overview: a project summary is a
+// trend question, so it reaches back a month.
+var overviewWindowPolicy = windowPolicy{
+	allowed: []DiagnosticWindow{
+		DiagnosticWindowLastHour,
+		DiagnosticWindowLastDay,
+		DiagnosticWindowLastWeek,
+		DiagnosticWindowLastMonth,
+	},
+	fallback: DiagnosticWindowLastDay,
+}
+
+// diagnosticsWindowPolicy bounds get_mcp_diagnostics. It is deliberately
+// tighter than the overview's. Fault attribution reasons in ratios — a
+// dominant failure class, and this server's failure rate against the rest of
+// the organization's — and readiness can only exonerate while it is fresh, so
+// a long window pairs a minutes-old probe with weeks of outcomes and dilutes a
+// current fault below every threshold that would have caught it.
+var diagnosticsWindowPolicy = windowPolicy{
+	allowed:  []DiagnosticWindow{DiagnosticWindowLastHour, DiagnosticWindowLastDay},
+	fallback: DiagnosticWindowLastHour,
+}
+
+func (p windowPolicy) permits(window DiagnosticWindow) bool {
+	return slices.Contains(p.allowed, window)
+}
+
+// invalid names the windows this policy accepts, so a refused caller learns
+// what to ask for instead of only that it asked wrongly.
+func (p windowPolicy) invalid() error {
+	names := make([]string, 0, len(p.allowed))
+	for _, window := range p.allowed {
+		names = append(names, string(window))
+	}
+	return fmt.Errorf("%w: window must be one of %s", ErrDiagnosticWindowInvalid, strings.Join(names, ", "))
+}
 
 func (w DiagnosticWindow) duration() (time.Duration, bool) {
 	switch w {
@@ -72,18 +119,19 @@ type ResolvedWindow struct {
 	end   time.Time
 }
 
-// resolveWindow turns a requested window name into the interval to read.
-// An empty request resolves to DefaultDiagnosticWindow; anything outside the
-// closed set is refused rather than silently clamped, so a caller never
-// receives a different window than it believes it asked for.
-func resolveWindow(requested string, now time.Time) (ResolvedWindow, error) {
+// resolveWindow turns a requested window name into the interval to read, under
+// the asking tool's policy. An empty request resolves to that policy's
+// fallback; anything outside its closed set is refused rather than silently
+// clamped, so a caller never receives a different window than it believes it
+// asked for.
+func resolveWindow(requested string, now time.Time, policy windowPolicy) (ResolvedWindow, error) {
 	window := DiagnosticWindow(strings.ToLower(strings.TrimSpace(requested)))
 	if window == "" {
-		window = DefaultDiagnosticWindow
+		window = policy.fallback
 	}
 	duration, ok := window.duration()
-	if !ok {
-		return ResolvedWindow{}, ErrDiagnosticWindowInvalid
+	if !ok || !policy.permits(window) {
+		return ResolvedWindow{}, policy.invalid()
 	}
 	// Truncated to the second the window is advertised at, so the interval a
 	// caller is told about is exactly the interval that was queried. Formatting

--- a/server/internal/platformmcp/freshness_test.go
+++ b/server/internal/platformmcp/freshness_test.go
@@ -14,28 +14,37 @@ func TestResolveWindow_DefaultsAndClosedSet(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		policy    windowPolicy
 		requested string
 		want      DiagnosticWindow
 		wantSpan  time.Duration
 		wantErr   bool
 	}{
-		{name: "empty defaults to a day", requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
-		{name: "hour", requested: "1h", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
-		{name: "week", requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
-		{name: "month", requested: "30d", want: DiagnosticWindowLastMonth, wantSpan: 30 * 24 * time.Hour},
-		{name: "case and space tolerated", requested: " 24H ", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "empty defaults to a day", policy: overviewWindowPolicy, requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "hour", policy: overviewWindowPolicy, requested: "1h", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
+		{name: "week", policy: overviewWindowPolicy, requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
+		{name: "month", policy: overviewWindowPolicy, requested: "30d", want: DiagnosticWindowLastMonth, wantSpan: 30 * 24 * time.Hour},
+		{name: "case and space tolerated", policy: overviewWindowPolicy, requested: " 24H ", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
 		// Refused, not clamped: a caller must never receive a different window
 		// than the one it believes it asked for.
-		{name: "arbitrary duration refused", requested: "90m", wantErr: true},
-		{name: "timestamp grammar refused", requested: "2026-08-01T00:00:00Z", wantErr: true},
-		{name: "year refused", requested: "365d", wantErr: true},
+		{name: "arbitrary duration refused", policy: overviewWindowPolicy, requested: "90m", wantErr: true},
+		{name: "timestamp grammar refused", policy: overviewWindowPolicy, requested: "2026-08-01T00:00:00Z", wantErr: true},
+		{name: "year refused", policy: overviewWindowPolicy, requested: "365d", wantErr: true},
+
+		// A diagnosis reads a narrower set. Its default is the hour, and the
+		// longer windows the overview accepts are refused here rather than
+		// answered over a span the attribution cannot reason across.
+		{name: "diagnostics empty defaults to an hour", policy: diagnosticsWindowPolicy, requested: "", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
+		{name: "diagnostics day", policy: diagnosticsWindowPolicy, requested: "24h", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "diagnostics week refused", policy: diagnosticsWindowPolicy, requested: "7d", wantErr: true},
+		{name: "diagnostics month refused", policy: diagnosticsWindowPolicy, requested: "30d", wantErr: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			window, err := resolveWindow(test.requested, now)
+			window, err := resolveWindow(test.requested, now, test.policy)
 			if test.wantErr {
 				require.ErrorIs(t, err, ErrDiagnosticWindowInvalid)
 				return
@@ -54,7 +63,7 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("24h", now)
+	window, err := resolveWindow("24h", now, overviewWindowPolicy)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -125,7 +134,7 @@ func TestResolveWindow_AdvertisedBoundsMatchTheQueriedBounds(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 987_654_321, time.UTC)
-	window, err := resolveWindow("1h", now)
+	window, err := resolveWindow("1h", now, overviewWindowPolicy)
 	require.NoError(t, err)
 
 	require.Equal(t, window.start.Format(time.RFC3339), window.From)

--- a/server/internal/platformmcp/freshness_test.go
+++ b/server/internal/platformmcp/freshness_test.go
@@ -1,0 +1,129 @@
+package platformmcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveWindow_DefaultsAndClosedSet(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		requested string
+		want      DiagnosticWindow
+		wantSpan  time.Duration
+		wantErr   bool
+	}{
+		{name: "empty defaults to a day", requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "hour", requested: "1h", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
+		{name: "week", requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
+		{name: "month", requested: "30d", want: DiagnosticWindowLastMonth, wantSpan: 30 * 24 * time.Hour},
+		{name: "case and space tolerated", requested: " 24H ", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		// Refused, not clamped: a caller must never receive a different window
+		// than the one it believes it asked for.
+		{name: "arbitrary duration refused", requested: "90m", wantErr: true},
+		{name: "timestamp grammar refused", requested: "2026-08-01T00:00:00Z", wantErr: true},
+		{name: "year refused", requested: "365d", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			window, err := resolveWindow(test.requested, now)
+			if test.wantErr {
+				require.ErrorIs(t, err, ErrDiagnosticWindowInvalid)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, window.Window)
+			require.Equal(t, test.wantSpan, window.end.Sub(window.start))
+			require.Equal(t, now, window.end)
+			require.Equal(t, now.Add(-test.wantSpan).Format(time.RFC3339), window.From)
+			require.Equal(t, now.Format(time.RFC3339), window.To)
+		})
+	}
+}
+
+func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	window, err := resolveWindow("24h", now)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		watermark     time.Time
+		want          Freshness
+		wantThrough   bool
+		wantThroughAt string
+	}{
+		{
+			// Absence of observations is its own answer. Reporting it as fresh
+			// would let a caller read an empty result as a healthy one.
+			name:      "no watermark is no observations",
+			watermark: time.Time{},
+			want:      FreshnessNoObservations,
+		},
+		{
+			name:        "watermark inside the threshold is fresh",
+			watermark:   now.Add(-2 * time.Minute),
+			want:        FreshnessFresh,
+			wantThrough: true,
+		},
+		{
+			name:        "watermark past the threshold is stale",
+			watermark:   now.Add(-30 * time.Minute),
+			want:        FreshnessStale,
+			wantThrough: true,
+		},
+		{
+			name:        "watermark exactly at the threshold is still fresh",
+			watermark:   now.Add(-StaleWatermarkThreshold),
+			want:        FreshnessFresh,
+			wantThrough: true,
+		},
+		{
+			// A watermark at or past the window's end means the window is fully
+			// covered, so a read about a completed interval is not stale merely
+			// for being about the past.
+			name:        "watermark at the window end is fresh",
+			watermark:   window.end,
+			want:        FreshnessFresh,
+			wantThrough: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			envelope := newDataEnvelope(now, test.watermark, window)
+			require.Equal(t, test.want, envelope.Freshness)
+			require.Equal(t, now.Format(time.RFC3339), envelope.QueriedAt)
+			require.Equal(t, window, envelope.ResolvedWindow)
+			if test.wantThrough {
+				require.Equal(t, test.watermark.Format(time.RFC3339), envelope.DataThrough)
+			} else {
+				require.Empty(t, envelope.DataThrough)
+			}
+		})
+	}
+}
+
+// TestWatermarkTime_ZeroIsNotTheEpoch pins that an absent watermark stays
+// absent. Treating 0 as a real time would report every empty scope as data
+// through 1970 and mark it stale rather than unobserved.
+func TestWatermarkTime_ZeroIsNotTheEpoch(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, watermarkTime(0).IsZero())
+	require.True(t, watermarkTime(-1).IsZero())
+	require.Equal(t, time.Unix(0, 1_700_000_000_000_000_000).UTC(), watermarkTime(1_700_000_000_000_000_000))
+}

--- a/server/internal/platformmcp/freshness_test.go
+++ b/server/internal/platformmcp/freshness_test.go
@@ -117,6 +117,23 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 	}
 }
 
+// TestResolveWindow_AdvertisedBoundsMatchTheQueriedBounds pins that the window
+// a caller is told about is exactly the interval that was read. Formatting a
+// sub-second now as RFC3339 would round the boundary away, so the advertised
+// window and the nanosecond bounds behind it would silently disagree.
+func TestResolveWindow_AdvertisedBoundsMatchTheQueriedBounds(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 987_654_321, time.UTC)
+	window, err := resolveWindow("1h", now)
+	require.NoError(t, err)
+
+	require.Equal(t, window.start.Format(time.RFC3339), window.From)
+	require.Equal(t, window.end.Format(time.RFC3339), window.To)
+	require.Equal(t, time.Hour, window.end.Sub(window.start))
+	require.Zero(t, window.end.Nanosecond())
+}
+
 // TestWatermarkTime_ZeroIsNotTheEpoch pins that an absent watermark stays
 // absent. Treating 0 as a real time would report every empty scope as data
 // through 1970 and mark it stale rather than unobserved.

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -109,8 +109,12 @@ type OperationBudgets struct {
 	// separately would only let a loop spend twice as much reaching the same
 	// write.
 	Skills OperationBudget
+	// Diagnostics meters the observability reads. They are bounded aggregate
+	// queries over Gram-owned telemetry, so the cost being metered is the
+	// ClickHouse scan, not an external egress.
+	Diagnostics OperationBudget
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.Diagnostics.valid()
 }

--- a/server/internal/platformmcp/privacy.go
+++ b/server/internal/platformmcp/privacy.go
@@ -55,16 +55,20 @@ func (c SubjectCount) MarshalJSON() ([]byte, error) {
 func (c *SubjectCount) UnmarshalJSON(data []byte) error {
 	var number int64
 	if err := json.Unmarshal(data, &number); err == nil {
-		c.value = number
+		// Normalized the same way the constructor does, so a decoded value can
+		// never re-serialize as something NewSubjectCount would have rejected.
+		*c = NewSubjectCount(number)
 		return nil
 	}
 	var label string
 	if err := json.Unmarshal(data, &label); err != nil {
 		return fmt.Errorf("decode subject count: %w", err)
 	}
+	// An unrecognized label is refused rather than read as zero: silently
+	// decoding a future or malformed suppression token into "nobody" would
+	// turn a value this build cannot read into a positive claim about people.
 	if label != subjectSuppressedLabel {
-		c.value = 0
-		return nil
+		return fmt.Errorf("decode subject count: unknown suppression label %q", label)
 	}
 	c.value = SubjectSuppressionThreshold - 1
 	return nil

--- a/server/internal/platformmcp/privacy.go
+++ b/server/internal/platformmcp/privacy.go
@@ -1,0 +1,71 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// SubjectSuppressionThreshold is the smallest subject count a diagnostic will
+// state exactly. Below it the count itself identifies: "one active user in this
+// project last hour" names a person to anyone who knows the team.
+const SubjectSuppressionThreshold = 5
+
+// subjectSuppressedLabel is what a suppressed count reports instead of a
+// number. It is a stable token, not prose, so a caller can branch on it.
+const subjectSuppressedLabel = "less_than_5"
+
+// SubjectCount is a count of people — users, members, operators. It serializes
+// as a number when it is zero or at least SubjectSuppressionThreshold, and as
+// "less_than_5" in between.
+//
+// Zero is reported exactly because it identifies nobody: it is the difference
+// between "no one used this" and "someone did", which a diagnostic caller needs
+// and which reveals no subject. Counts of events — calls, failures — are not
+// subject counts and are reported exactly; they are plain integers, not this
+// type.
+type SubjectCount struct {
+	value int64
+}
+
+// NewSubjectCount wraps a raw subject count for suppression at the boundary.
+func NewSubjectCount(value int64) SubjectCount {
+	if value < 0 {
+		value = 0
+	}
+	return SubjectCount{value: value}
+}
+
+// Suppressed reports whether this count will be withheld.
+func (c SubjectCount) Suppressed() bool {
+	return c.value > 0 && c.value < SubjectSuppressionThreshold
+}
+
+func (c SubjectCount) MarshalJSON() ([]byte, error) {
+	if c.Suppressed() {
+		return []byte(strconv.Quote(subjectSuppressedLabel)), nil
+	}
+	return []byte(strconv.FormatInt(c.value, 10)), nil
+}
+
+// UnmarshalJSON exists so a result round-trips through JSON in tests and in any
+// caller that decodes its own output. A suppressed value decodes back to the
+// suppression floor rather than to a real count, because the real count was
+// never transmitted.
+func (c *SubjectCount) UnmarshalJSON(data []byte) error {
+	var number int64
+	if err := json.Unmarshal(data, &number); err == nil {
+		c.value = number
+		return nil
+	}
+	var label string
+	if err := json.Unmarshal(data, &label); err != nil {
+		return fmt.Errorf("decode subject count: %w", err)
+	}
+	if label != subjectSuppressedLabel {
+		c.value = 0
+		return nil
+	}
+	c.value = SubjectSuppressionThreshold - 1
+	return nil
+}

--- a/server/internal/platformmcp/privacy_test.go
+++ b/server/internal/platformmcp/privacy_test.go
@@ -1,0 +1,65 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubjectCount_SuppressesSmallCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		//nolint:revive // The raw count is the subject of the test.
+		value int64
+		want  string
+	}{
+		// Zero identifies nobody and is the difference a diagnostic caller
+		// needs between "no one used this" and "someone did".
+		{name: "zero is reported exactly", value: 0, want: "0"},
+		{name: "one is suppressed", value: 1, want: `"less_than_5"`},
+		{name: "four is suppressed", value: 4, want: `"less_than_5"`},
+		{name: "the threshold is reported", value: 5, want: "5"},
+		{name: "large counts are reported", value: 4210, want: "4210"},
+		{name: "negative counts floor at zero", value: -3, want: "0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := json.Marshal(NewSubjectCount(test.value))
+			require.NoError(t, err)
+			require.Equal(t, test.want, string(encoded))
+		})
+	}
+}
+
+// TestSubjectCount_SuppressedValueNeverRoundTrips pins that a suppressed count
+// cannot be recovered from what was transmitted. If decoding restored the real
+// value, the suppression would only be cosmetic.
+func TestSubjectCount_SuppressedValueNeverRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(NewSubjectCount(1))
+	require.NoError(t, err)
+
+	var decoded SubjectCount
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.True(t, decoded.Suppressed())
+	require.Equal(t, int64(SubjectSuppressionThreshold-1), decoded.value)
+}
+
+func TestSubjectCount_ReportedValueRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(NewSubjectCount(42))
+	require.NoError(t, err)
+
+	var decoded SubjectCount
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.False(t, decoded.Suppressed())
+	require.Equal(t, int64(42), decoded.value)
+}

--- a/server/internal/platformmcp/privacy_test.go
+++ b/server/internal/platformmcp/privacy_test.go
@@ -52,6 +52,31 @@ func TestSubjectCount_SuppressedValueNeverRoundTrips(t *testing.T) {
 	require.Equal(t, int64(SubjectSuppressionThreshold-1), decoded.value)
 }
 
+// TestSubjectCount_RejectsUnknownSuppressionLabel pins that a label this build
+// does not recognise is an error, not a zero. Decoding an unreadable value into
+// "nobody" would turn ignorance into a positive claim about people.
+func TestSubjectCount_RejectsUnknownSuppressionLabel(t *testing.T) {
+	t.Parallel()
+
+	var decoded SubjectCount
+	require.Error(t, json.Unmarshal([]byte(`"less_than_50"`), &decoded))
+	require.Error(t, json.Unmarshal([]byte(`"redacted"`), &decoded))
+}
+
+// TestSubjectCount_DecodedNegativeIsNormalized pins that decoding applies the
+// same clamp the constructor does, so a negative count cannot survive a
+// round-trip and re-serialize as a negative number.
+func TestSubjectCount_DecodedNegativeIsNormalized(t *testing.T) {
+	t.Parallel()
+
+	var decoded SubjectCount
+	require.NoError(t, json.Unmarshal([]byte("-1"), &decoded))
+
+	encoded, err := json.Marshal(decoded)
+	require.NoError(t, err)
+	require.Equal(t, "0", string(encoded))
+}
+
 func TestSubjectCount_ReportedValueRoundTrips(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2215,6 +2215,8 @@ JOIN projects AS project
  AND project.deleted IS FALSE
 LEFT JOIN toolsets AS toolset
   ON toolset.id = m.toolset_id
+ AND toolset.project_id = m.project_id
+ AND toolset.organization_id = @organization_id
  AND toolset.deleted IS FALSE
 WHERE m.id = @mcp_server_id
   AND m.project_id = @project_id

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2196,3 +2196,26 @@ WHERE assistants.project_id = @project_id
   AND assistants.status = 'active'
 ORDER BY assistants.name ASC
 LIMIT @result_limit;
+
+-- name: GetPlatformMCPDiagnosticsTarget :one
+-- Resolves one configured MCP to the identities its telemetry is recorded
+-- under: the toolset slug that calls arriving directly at Gram carry, and the
+-- MCP slug that appears in the URL an agent-hook-observed client called.
+-- Scoped to the organization's own project, so a caller cannot diagnose an MCP
+-- it cannot already see through the inventory.
+SELECT
+    m.id AS mcp_server_id,
+    m.project_id,
+    COALESCE(m.slug, '') AS mcp_slug,
+    COALESCE(toolset.slug, '') AS toolset_slug
+FROM mcp_servers AS m
+JOIN projects AS project
+  ON project.id = m.project_id
+ AND project.organization_id = @organization_id
+ AND project.deleted IS FALSE
+LEFT JOIN toolsets AS toolset
+  ON toolset.id = m.toolset_id
+ AND toolset.deleted IS FALSE
+WHERE m.id = @mcp_server_id
+  AND m.project_id = @project_id
+  AND m.deleted IS FALSE;

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -2146,6 +2146,8 @@ JOIN projects AS project
  AND project.deleted IS FALSE
 LEFT JOIN toolsets AS toolset
   ON toolset.id = m.toolset_id
+ AND toolset.project_id = m.project_id
+ AND toolset.organization_id = $1
  AND toolset.deleted IS FALSE
 WHERE m.id = $2
   AND m.project_id = $3

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -2133,6 +2133,55 @@ func (q *Queries) GetPlatformMCPConnectionForUpdate(ctx context.Context, arg Get
 	return i, err
 }
 
+const getPlatformMCPDiagnosticsTarget = `-- name: GetPlatformMCPDiagnosticsTarget :one
+SELECT
+    m.id AS mcp_server_id,
+    m.project_id,
+    COALESCE(m.slug, '') AS mcp_slug,
+    COALESCE(toolset.slug, '') AS toolset_slug
+FROM mcp_servers AS m
+JOIN projects AS project
+  ON project.id = m.project_id
+ AND project.organization_id = $1
+ AND project.deleted IS FALSE
+LEFT JOIN toolsets AS toolset
+  ON toolset.id = m.toolset_id
+ AND toolset.deleted IS FALSE
+WHERE m.id = $2
+  AND m.project_id = $3
+  AND m.deleted IS FALSE
+`
+
+type GetPlatformMCPDiagnosticsTargetParams struct {
+	OrganizationID string
+	McpServerID    uuid.UUID
+	ProjectID      uuid.UUID
+}
+
+type GetPlatformMCPDiagnosticsTargetRow struct {
+	McpServerID uuid.UUID
+	ProjectID   uuid.UUID
+	McpSlug     string
+	ToolsetSlug string
+}
+
+// Resolves one configured MCP to the identities its telemetry is recorded
+// under: the toolset slug that calls arriving directly at Gram carry, and the
+// MCP slug that appears in the URL an agent-hook-observed client called.
+// Scoped to the organization's own project, so a caller cannot diagnose an MCP
+// it cannot already see through the inventory.
+func (q *Queries) GetPlatformMCPDiagnosticsTarget(ctx context.Context, arg GetPlatformMCPDiagnosticsTargetParams) (GetPlatformMCPDiagnosticsTargetRow, error) {
+	row := q.db.QueryRow(ctx, getPlatformMCPDiagnosticsTarget, arg.OrganizationID, arg.McpServerID, arg.ProjectID)
+	var i GetPlatformMCPDiagnosticsTargetRow
+	err := row.Scan(
+		&i.McpServerID,
+		&i.ProjectID,
+		&i.McpSlug,
+		&i.ToolsetSlug,
+	)
+	return i, err
+}
+
 const getPlatformMCPDistribution = `-- name: GetPlatformMCPDistribution :one
 SELECT distribution.id, distribution.organization_id, distribution.project_id, distribution.registration_id, distribution.default_plugin_id, distribution.plugin_id, distribution.plugin_server_id, distribution.state, distribution.version, distribution.attachment_was_created, distribution.publication_state, distribution.publication_updated_at, distribution.connection_id, distribution.connection_generation, distribution.user_id, distribution.acting_surface, distribution.created_at, distribution.updated_at
 FROM platform_mcp_distributions AS distribution

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -119,18 +119,18 @@ func NewRuntime(logger *slog.Logger, authenticator Authenticator, gate Gate, aut
 }
 
 func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService) *Runtime {
-	return NewRuntimeWithLifecycle(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, nil, nil, nil, CatalogDescriptor{})
+	return NewRuntimeWithLifecycle(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, nil, nil, nil, nil, CatalogDescriptor{})
 }
 
 // NewRuntimeWithLifecycle wires the Platform MCP onboarding lifecycle. Catalogue
 // selection remains server-validated: callers receive only search/inspect
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
-func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, candidate CatalogDescriptor) *Runtime {
+func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, candidate CatalogDescriptor) *Runtime {
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		postgresReader.setInventoryCursorKey(cursorKeyMaterial)
 	}
-	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, candidate)
+	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, candidate)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/skills_integration_test.go
+++ b/server/internal/platformmcp/skills_integration_test.go
@@ -344,7 +344,7 @@ func newSkillsVerticalFixture(t *testing.T, ctx context.Context, name string, op
 
 	runtime := NewRuntimeWithLifecycle(
 		logger, &testAuthenticator{principal: principal}, testGate{enabled: true}, &testAuthorizer{},
-		"", "test-cursor-key", nil, nil, nil, nil, nil, nil, nil, nil, skillsSurface, CatalogDescriptor{},
+		"", "test-cursor-key", nil, nil, nil, nil, nil, nil, nil, nil, skillsSurface, nil, CatalogDescriptor{},
 	)
 	server := httptest.NewServer(runtime.Handler())
 	t.Cleanup(server.Close)

--- a/server/internal/platformmcp/skills_test.go
+++ b/server/internal/platformmcp/skills_test.go
@@ -614,7 +614,7 @@ func TestSkillsToolsAreDeclaredWithAndWithoutTheirDependencies(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, test.build(), CatalogDescriptor{})
+			_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, test.build(), nil, CatalogDescriptor{})
 
 			registered := make(map[string]Descriptor, len(wanted))
 			for _, descriptor := range registrar.Descriptors() {

--- a/server/internal/platformmcp/tool_diagnostics.go
+++ b/server/internal/platformmcp/tool_diagnostics.go
@@ -1,0 +1,68 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func registerDiagnosticsTools(reg *Registrar, diagnostics *DiagnosticsService) {
+	addTool(reg, &mcp.Tool{
+		Name:        "get_project_overview",
+		Title:       "Get Project Overview",
+		Description: "Summarize one project's MCP activity and failures over a bounded window. This is the normal entry point for any question about how a project or its MCPs are behaving; use the drill-down diagnostics only after this identifies a specific MCP or failure to look into. Results are aggregated server-side and carry the window they were computed over, how fresh the underlying observations are, and whether there were any observations at all.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetProjectOverviewInput) (*mcp.CallToolResult, GetProjectOverviewOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, GetProjectOverviewOutput{}, err
+		}
+		output, err := diagnostics.GetProjectOverview(ctx, principal, input)
+		if err != nil {
+			if budgetResult, ok := operationBudgetToolResult(err); ok {
+				return budgetResult, GetProjectOverviewOutput{}, nil
+			}
+			return nil, GetProjectOverviewOutput{}, err
+		}
+		return nil, output, nil
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "get_mcp_diagnostics",
+		Title:       "Get MCP Diagnostics",
+		Description: "Diagnose one configured MCP that is not working, using the mcp_id find_mcp or get_mcp returned. Returns the latest server-side readiness result, this MCP's call outcomes and the organization's for comparison, the clients that reported failures, and an explicit fault attribution: gram_configuration, provider, client, or indeterminate. An indeterminate answer means the evidence does not separate the candidates and is preferred over a guess. No observations is never evidence that the MCP is healthy.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetMCPDiagnosticsInput) (*mcp.CallToolResult, GetMCPDiagnosticsOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, GetMCPDiagnosticsOutput{}, err
+		}
+		output, err := diagnostics.GetMCPDiagnostics(ctx, principal, input)
+		if err != nil {
+			if budgetResult, ok := operationBudgetToolResult(err); ok {
+				return budgetResult, GetMCPDiagnosticsOutput{}, nil
+			}
+			return nil, GetMCPDiagnosticsOutput{}, err
+		}
+		return nil, output, nil
+	})
+}
+
+func registerUnavailableDiagnosticsTools(reg *Registrar) {
+	for _, tool := range []struct {
+		name        string
+		title       string
+		description string
+	}{
+		{"get_project_overview", "Get Project Overview", "Summarize one project's MCP activity and failures. Diagnostics are not enabled in the current rollout."},
+		{"get_mcp_diagnostics", "Get MCP Diagnostics", "Diagnose one configured MCP that is not working. Diagnostics are not enabled in the current rollout."},
+	} {
+		addTool(reg, &mcp.Tool{
+			Name:        tool.name,
+			Title:       tool.title,
+			Description: tool.description,
+			Annotations: readOnlyAnnotations(),
+		}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("diagnostics"))
+	}
+}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -133,7 +133,7 @@ type operationBudgetResult struct {
 // registrar alongside the server so another admitted audience — the project
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
-func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
+func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "speakeasy-aicp-platform-mcp",
 		Title:   "Speakeasy AICP Platform MCP",
@@ -182,6 +182,11 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 		registerUnavailableTools(reg)
 	} else {
 		registerOnboardingLifecycleTools(reg, onboarding, registrations, distributions)
+	}
+	if !diagnostics.valid() {
+		registerUnavailableDiagnosticsTools(reg)
+	} else {
+		registerDiagnosticsTools(reg, diagnostics)
 	}
 	if !skills.valid() {
 		registerUnavailableSkillsTools(reg)

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -35,6 +35,7 @@ import (
 	orgsRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/telemetry/overview"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/telemetryerrs"
 	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -2352,7 +2353,7 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 	var (
 		chatMetrics           chatRepo.GetChatMetricsSummaryRow
 		chatMetricsComparison chatRepo.GetChatMetricsSummaryRow
-		clickHouseResult      projectOverviewClickHouseResult
+		clickHouseResult      overview.Result
 		serverNameOverrides   []hooksRepo.ListHooksServerNameOverridesRow
 
 		// Session-mode (PostgreSQL) results; only populated when sessionMode is true.
@@ -2365,15 +2366,18 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 
 	eg.Go(func() error {
 		var fetchErr error
-		clickHouseResult, fetchErr = fetchProjectOverviewClickHouse(egCtx, s.chRepo, projectOverviewClickHouseParams{
-			projectID:       projectID,
-			timeStart:       timeStart,
-			timeEnd:         timeEnd,
-			comparisonStart: comparisonStart,
-			comparisonEnd:   comparisonEnd,
-			sessionMode:     sessionMode,
+		clickHouseResult, fetchErr = overview.FetchClickHouse(egCtx, s.chRepo, overview.Params{
+			ProjectID:       projectID,
+			TimeStart:       timeStart,
+			TimeEnd:         timeEnd,
+			ComparisonStart: comparisonStart,
+			ComparisonEnd:   comparisonEnd,
+			SessionMode:     sessionMode,
 		})
-		return fetchErr
+		if fetchErr != nil {
+			return oops.E(oops.CodeUnexpected, fetchErr, "error retrieving project overview ClickHouse data")
+		}
+		return nil
 	})
 
 	// PostgreSQL lanes: the pgxpool is safe for concurrent use, so fan these out.
@@ -2460,7 +2464,7 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 	}
 
 	// Resolve active counts and top lists now that every query has returned.
-	activeServersCount := int64(clickHouseResult.activeCounts.ActiveServersCount) //nolint:gosec // Bounded count that won't overflow int64
+	activeServersCount := int64(clickHouseResult.ActiveCounts.ActiveServersCount) //nolint:gosec // Bounded count that won't overflow int64
 	var activeUsersCount int64
 	var topUsers []*telem_gen.TopUser
 	var llmClientBreakdown []*telem_gen.LLMClientUsage
@@ -2469,9 +2473,9 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 		topUsers = toTopUsersFromPG(topUsersPG)
 		llmClientBreakdown = toLLMClientUsageFromPG(llmClientsPG)
 	} else {
-		activeUsersCount = int64(clickHouseResult.activeCounts.ActiveUsersCount) //nolint:gosec // Bounded count that won't overflow int64
-		topUsers = toTopUsers(clickHouseResult.topUsers)
-		llmClientBreakdown = toLLMClientUsage(clickHouseResult.llmClients)
+		activeUsersCount = int64(clickHouseResult.ActiveCounts.ActiveUsersCount) //nolint:gosec // Bounded count that won't overflow int64
+		topUsers = toTopUsers(clickHouseResult.TopUsers)
+		llmClientBreakdown = toLLMClientUsage(clickHouseResult.LLMClients)
 	}
 
 	// Build a map for quick lookup: raw_server_name -> display_name
@@ -2481,13 +2485,13 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 	}
 
 	// Apply overrides to top servers
-	topServersWithOverrides := applyServerNameOverrides(clickHouseResult.topServers, overrideMap)
+	topServersWithOverrides := applyServerNameOverrides(clickHouseResult.TopServers, overrideMap)
 
 	// Convert to API types - build summaries with nested fields
 	return &telem_gen.GetProjectOverviewResult{
 		Summary: buildProjectOverviewSummary(
 			chatMetrics,
-			clickHouseResult.toolMetrics,
+			clickHouseResult.ToolMetrics,
 			activeServersCount,
 			activeUsersCount,
 			topUsers,
@@ -2496,7 +2500,7 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 		),
 		Comparison: buildProjectOverviewSummary(
 			chatMetricsComparison,
-			clickHouseResult.toolMetricsComparison,
+			clickHouseResult.ToolMetricsComparison,
 			0, // Don't need active counts for comparison
 			0,
 			nil, // Don't need top lists for comparison

--- a/server/internal/telemetry/mcp_diagnostics_test.go
+++ b/server/internal/telemetry/mcp_diagnostics_test.go
@@ -1,0 +1,284 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	telemetryRepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+// flushAsyncInserts commits ClickHouse's async insert buffer. InsertTelemetryLogs
+// acks once rows are queued, not once they are readable, so a test that inserts
+// and immediately queries would otherwise race the buffer's flush timer.
+func flushAsyncInserts(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+	require.NoError(t, conn.Exec(ctx, "SYSTEM FLUSH ASYNC INSERT QUEUE"))
+}
+
+// outcomeCounts folds a breakdown into outcome -> count so assertions do not
+// depend on the row order the query happens to return.
+func outcomeCounts(rows []telemetryRepo.MCPOutcomeBreakdownRow) map[string]uint64 {
+	counts := make(map[string]uint64, len(rows))
+	for _, row := range rows {
+		counts[row.Outcome] += row.CallCount
+	}
+	return counts
+}
+
+func clientCounts(rows []telemetryRepo.MCPOutcomeBreakdownRow) map[string]uint64 {
+	counts := make(map[string]uint64, len(rows))
+	for _, row := range rows {
+		counts[row.Client] += row.CallCount
+	}
+	return counts
+}
+
+func TestGetMCPOutcomeBreakdown_Empty(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	now := time.Now().UTC()
+
+	flushAsyncInserts(t, ctx)
+
+	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: []string{authCtx.ProjectID.String()},
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	})
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}
+
+// TestGetMCPOutcomeBreakdown_NoProjectsIsNotAnUnscopedRead pins that an empty
+// project list reads nothing rather than every project in the deployment.
+func TestGetMCPOutcomeBreakdown_NoProjectsIsNotAnUnscopedRead(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	now := time.Now().UTC()
+
+	flushAsyncInserts(t, ctx)
+
+	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: nil,
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	})
+	require.NoError(t, err)
+	require.Empty(t, rows)
+
+	watermark, err := ti.chClient.GetTelemetryWatermark(ctx, telemetryRepo.GetTelemetryWatermarkParams{GramProjectIDs: nil})
+	require.NoError(t, err)
+	require.Zero(t, watermark)
+}
+
+func TestGetMCPOutcomeBreakdown_ClassifiesDirectCallsByStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	for _, status := range []int{200, 401, 403, 404, 500, 503} {
+		insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+			projectID:   projectID,
+			timestamp:   now.Add(-10 * time.Minute),
+			toolsetSlug: "billing",
+			toolName:    "charge",
+			userEmail:   "alice@example.com",
+			statusCode:  status,
+		})
+	}
+	// A second server's traffic must not be counted against the first.
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   now.Add(-10 * time.Minute),
+		toolsetSlug: "shipping",
+		toolName:    "quote",
+		userEmail:   "alice@example.com",
+		statusCode:  500,
+	})
+
+	flushAsyncInserts(t, ctx)
+
+	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: []string{projectID},
+		ToolsetSlugs:   []string{"billing"},
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]uint64{
+		telemetryRepo.MCPOutcomeSuccess:      1,
+		telemetryRepo.MCPOutcomeUnauthorized: 2,
+		telemetryRepo.MCPOutcomeClientError:  1,
+		telemetryRepo.MCPOutcomeServerError:  2,
+	}, outcomeCounts(rows))
+
+	// Nothing records which client made a direct call yet, so every one of them
+	// is attributed to the explicit "we do not know" label rather than to a
+	// client name inferred from something else.
+	require.Equal(t, map[string]uint64{telemetryRepo.MCPClientUnattributed: 6}, clientCounts(rows))
+
+	// Unfiltered, the same read covers the whole organization scope.
+	all, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: []string{projectID},
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), outcomeCounts(all)[telemetryRepo.MCPOutcomeServerError])
+}
+
+func TestGetMCPOutcomeBreakdown_AttributesHookObservedCallsToTheirClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+	now := time.Now().UTC()
+
+	insertHookEvent(t, ctx, hookEventParams{
+		projectID:    projectID,
+		deploymentID: deploymentID,
+		timestamp:    now.Add(-5 * time.Minute),
+		traceID:      uuid.New().String(),
+		hookSource:   "claude-code",
+		toolSource:   "billing",
+		toolName:     "charge",
+		result:       `"ok"`,
+		mcpServerURL: "https://api.getgram.ai/mcp/billing",
+	})
+	insertHookEvent(t, ctx, hookEventParams{
+		projectID:    projectID,
+		deploymentID: deploymentID,
+		timestamp:    now.Add(-4 * time.Minute),
+		traceID:      uuid.New().String(),
+		hookSource:   "claude-code",
+		toolSource:   "billing",
+		toolName:     "charge",
+		errorMsg:     "boom",
+		mcpServerURL: "https://api.getgram.ai/mcp/billing",
+	})
+	// A different server behind the same client must not be folded in.
+	insertHookEvent(t, ctx, hookEventParams{
+		projectID:    projectID,
+		deploymentID: deploymentID,
+		timestamp:    now.Add(-3 * time.Minute),
+		traceID:      uuid.New().String(),
+		hookSource:   "claude-code",
+		toolSource:   "shipping",
+		toolName:     "quote",
+		errorMsg:     "boom",
+		mcpServerURL: "https://api.getgram.ai/mcp/shipping",
+	})
+
+	flushAsyncInserts(t, ctx)
+
+	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs:       []string{projectID},
+		MCPServerURLSuffixes: []string{"/mcp/billing"},
+		TimeStart:            now.Add(-time.Hour).UnixNano(),
+		TimeEnd:              now.UnixNano(),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]uint64{
+		telemetryRepo.MCPOutcomeSuccess: 1,
+		telemetryRepo.MCPOutcomeFailed:  1,
+	}, outcomeCounts(rows))
+	require.Equal(t, map[string]uint64{"claude-code": 2}, clientCounts(rows))
+}
+
+func TestGetMCPOutcomeBreakdown_ExcludesCallsOutsideTheWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   now.Add(-10 * time.Minute),
+		toolsetSlug: "billing",
+		toolName:    "charge",
+		userEmail:   "alice@example.com",
+		statusCode:  200,
+	})
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   now.Add(-30 * 24 * time.Hour),
+		toolsetSlug: "billing",
+		toolName:    "charge",
+		userEmail:   "alice@example.com",
+		statusCode:  500,
+	})
+
+	flushAsyncInserts(t, ctx)
+
+	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: []string{projectID},
+		ToolsetSlugs:   []string{"billing"},
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]uint64{telemetryRepo.MCPOutcomeSuccess: 1}, outcomeCounts(rows))
+}
+
+func TestGetTelemetryWatermark_ReportsNewestObservation(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	// A project with no telemetry reports zero, which the caller reads as "no
+	// observations" rather than as a timestamp.
+	watermark, err := ti.chClient.GetTelemetryWatermark(ctx, telemetryRepo.GetTelemetryWatermarkParams{
+		GramProjectIDs: []string{uuid.New().String()},
+	})
+	require.NoError(t, err)
+	require.Zero(t, watermark)
+
+	newest := now.Add(-2 * time.Minute)
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   now.Add(-time.Hour),
+		toolsetSlug: "billing",
+		toolName:    "charge",
+		userEmail:   "alice@example.com",
+		statusCode:  200,
+	})
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   newest,
+		toolsetSlug: "billing",
+		toolName:    "charge",
+		userEmail:   "alice@example.com",
+		statusCode:  200,
+	})
+
+	flushAsyncInserts(t, ctx)
+
+	watermark, err = ti.chClient.GetTelemetryWatermark(ctx, telemetryRepo.GetTelemetryWatermarkParams{
+		GramProjectIDs: []string{projectID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, newest.UnixNano(), watermark)
+}

--- a/server/internal/telemetry/mcp_diagnostics_test.go
+++ b/server/internal/telemetry/mcp_diagnostics_test.go
@@ -1,7 +1,6 @@
 package telemetry_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -10,18 +9,8 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	telemetryRepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
-
-// flushAsyncInserts commits ClickHouse's async insert buffer. InsertTelemetryLogs
-// acks once rows are queued, not once they are readable, so a test that inserts
-// and immediately queries would otherwise race the buffer's flush timer.
-func flushAsyncInserts(t *testing.T, ctx context.Context) {
-	t.Helper()
-
-	conn, err := infra.NewClickhouseClient(t)
-	require.NoError(t, err)
-	require.NoError(t, conn.Exec(ctx, "SYSTEM FLUSH ASYNC INSERT QUEUE"))
-}
 
 // outcomeCounts folds a breakdown into outcome -> count so assertions do not
 // depend on the row order the query happens to return.
@@ -48,7 +37,7 @@ func TestGetMCPOutcomeBreakdown_Empty(t *testing.T) {
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
 	now := time.Now().UTC()
 
-	flushAsyncInserts(t, ctx)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
 		GramProjectIDs: []string{authCtx.ProjectID.String()},
@@ -67,7 +56,7 @@ func TestGetMCPOutcomeBreakdown_NoProjectsIsNotAnUnscopedRead(t *testing.T) {
 	ctx, ti := newTestLogsService(t)
 	now := time.Now().UTC()
 
-	flushAsyncInserts(t, ctx)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
 		GramProjectIDs: nil,
@@ -110,7 +99,7 @@ func TestGetMCPOutcomeBreakdown_ClassifiesDirectCallsByStatus(t *testing.T) {
 		statusCode:  500,
 	})
 
-	flushAsyncInserts(t, ctx)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
 		GramProjectIDs: []string{projectID},
@@ -186,7 +175,7 @@ func TestGetMCPOutcomeBreakdown_AttributesHookObservedCallsToTheirClient(t *test
 		mcpServerURL: "https://api.getgram.ai/mcp/shipping",
 	})
 
-	flushAsyncInserts(t, ctx)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
 		GramProjectIDs:       []string{projectID},
@@ -228,7 +217,7 @@ func TestGetMCPOutcomeBreakdown_ExcludesCallsOutsideTheWindow(t *testing.T) {
 		statusCode:  500,
 	})
 
-	flushAsyncInserts(t, ctx)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	rows, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, telemetryRepo.GetMCPOutcomeBreakdownParams{
 		GramProjectIDs: []string{projectID},
@@ -274,7 +263,7 @@ func TestGetTelemetryWatermark_ReportsNewestObservation(t *testing.T) {
 		statusCode:  200,
 	})
 
-	flushAsyncInserts(t, ctx)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	watermark, err = ti.chClient.GetTelemetryWatermark(ctx, telemetryRepo.GetTelemetryWatermarkParams{
 		GramProjectIDs: []string{projectID},

--- a/server/internal/telemetry/overview/clickhouse.go
+++ b/server/internal/telemetry/overview/clickhouse.go
@@ -1,4 +1,10 @@
-package telemetry
+// Package overview is the neutral read path for project overview analytics.
+//
+// It exists so the management telemetry handler and Platform MCP compose the
+// same ClickHouse reads and projection rather than growing a second
+// implementation each: a summary the dashboard shows and a summary an external
+// diagnostic tool reports must not be able to disagree.
+package overview
 
 import (
 	"context"
@@ -9,7 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type projectOverviewClickHouseReader interface {
+type ClickHouseReader interface {
 	GetOverviewSummary(context.Context, repo.GetOverviewSummaryParams) (*repo.OverviewSummary, error)
 	GetActiveCounts(context.Context, repo.GetActiveCountsParams) (*repo.ActiveCounts, error)
 	GetTopServers(context.Context, repo.GetTopServersParams) ([]repo.TopServer, error)
@@ -17,43 +23,53 @@ type projectOverviewClickHouseReader interface {
 	GetLLMClientBreakdown(context.Context, repo.GetLLMClientBreakdownParams) ([]repo.LLMClientUsage, error)
 }
 
-type projectOverviewClickHouseParams struct {
-	projectID       string
-	timeStart       int64
-	timeEnd         int64
-	comparisonStart int64
-	comparisonEnd   int64
-	sessionMode     bool
+// Params bounds one project overview read: the project, the current window,
+// the equal-length comparison window preceding it, and whether session capture
+// is the organization's metrics mode.
+type Params struct {
+	ProjectID       string
+	TimeStart       int64
+	TimeEnd         int64
+	ComparisonStart int64
+	ComparisonEnd   int64
+	SessionMode     bool
 }
 
-type projectOverviewClickHouseResult struct {
-	toolMetrics           *repo.OverviewSummary
-	toolMetricsComparison *repo.OverviewSummary
-	activeCounts          *repo.ActiveCounts
-	topServers            []repo.TopServer
-	topUsers              []repo.TopUser
-	llmClients            []repo.LLMClientUsage
+// Result is the ClickHouse half of a project overview. TopUsers and LLMClients
+// stay empty in session mode, where those two lists come from PostgreSQL
+// instead; a caller that needs them reads Params.SessionMode rather than
+// treating empty as "no activity".
+type Result struct {
+	ToolMetrics           *repo.OverviewSummary
+	ToolMetricsComparison *repo.OverviewSummary
+	ActiveCounts          *repo.ActiveCounts
+	TopServers            []repo.TopServer
+	TopUsers              []repo.TopUser
+	LLMClients            []repo.LLMClientUsage
 }
 
-func fetchProjectOverviewClickHouse(
+// FetchClickHouse runs a project overview's ClickHouse lanes concurrently and
+// returns them together. It performs no authorization and no gating; a caller
+// establishes both before reading.
+func FetchClickHouse(
 	ctx context.Context,
-	reader projectOverviewClickHouseReader,
-	params projectOverviewClickHouseParams,
-) (projectOverviewClickHouseResult, error) {
-	var result projectOverviewClickHouseResult
+	reader ClickHouseReader,
+	params Params,
+) (Result, error) {
+	var result Result
 	// clickhouse.Conn is a connection pool: concurrent queries acquire separate
 	// transports and remain bounded by the pool's MaxOpenConns setting.
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
 		var queryErr error
-		result.toolMetrics, queryErr = reader.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
+		result.ToolMetrics, queryErr = reader.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
 			// Org-scope read: Gram-hosted sources stay counted, matching the
 			// summaries fast path.
 			ExcludedHookSources: nil,
-			GramProjectID:       params.projectID,
-			TimeStart:           params.timeStart,
-			TimeEnd:             params.timeEnd,
+			GramProjectID:       params.ProjectID,
+			TimeStart:           params.TimeStart,
+			TimeEnd:             params.TimeEnd,
 			User:                repo.UserIdentity{UserIDs: nil, Emails: nil},
 			CanonicalUser:       repo.CanonicalUserIdentity{OrgID: "", UserID: "", EmailLower: ""},
 			ExternalUserID:      "",
@@ -74,13 +90,13 @@ func fetchProjectOverviewClickHouse(
 
 	eg.Go(func() error {
 		var queryErr error
-		result.toolMetricsComparison, queryErr = reader.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
+		result.ToolMetricsComparison, queryErr = reader.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
 			// Org-scope read: Gram-hosted sources stay counted, matching the
 			// summaries fast path.
 			ExcludedHookSources: nil,
-			GramProjectID:       params.projectID,
-			TimeStart:           params.comparisonStart,
-			TimeEnd:             params.comparisonEnd,
+			GramProjectID:       params.ProjectID,
+			TimeStart:           params.ComparisonStart,
+			TimeEnd:             params.ComparisonEnd,
 			User:                repo.UserIdentity{UserIDs: nil, Emails: nil},
 			CanonicalUser:       repo.CanonicalUserIdentity{OrgID: "", UserID: "", EmailLower: ""},
 			ExternalUserID:      "",
@@ -101,14 +117,14 @@ func fetchProjectOverviewClickHouse(
 
 	eg.Go(func() error {
 		var queryErr error
-		result.activeCounts, queryErr = reader.GetActiveCounts(egCtx, repo.GetActiveCountsParams{
-			GramProjectID:  params.projectID,
-			TimeStart:      params.timeStart,
-			TimeEnd:        params.timeEnd,
+		result.ActiveCounts, queryErr = reader.GetActiveCounts(egCtx, repo.GetActiveCountsParams{
+			GramProjectID:  params.ProjectID,
+			TimeStart:      params.TimeStart,
+			TimeEnd:        params.TimeEnd,
 			ExternalUserID: "",
 			APIKeyID:       "",
 			ToolsetSlug:    "",
-			SessionMode:    params.sessionMode,
+			SessionMode:    params.SessionMode,
 		})
 		if queryErr != nil {
 			return oops.E(oops.CodeUnexpected, queryErr, "error retrieving active server counts")
@@ -118,10 +134,10 @@ func fetchProjectOverviewClickHouse(
 
 	eg.Go(func() error {
 		var queryErr error
-		result.topServers, queryErr = reader.GetTopServers(egCtx, repo.GetTopServersParams{
-			GramProjectID:  params.projectID,
-			TimeStart:      params.timeStart,
-			TimeEnd:        params.timeEnd,
+		result.TopServers, queryErr = reader.GetTopServers(egCtx, repo.GetTopServersParams{
+			GramProjectID:  params.ProjectID,
+			TimeStart:      params.TimeStart,
+			TimeEnd:        params.TimeEnd,
 			ExternalUserID: "",
 			APIKeyID:       "",
 			ToolsetSlug:    "",
@@ -133,13 +149,13 @@ func fetchProjectOverviewClickHouse(
 		return nil
 	})
 
-	if !params.sessionMode {
+	if !params.SessionMode {
 		eg.Go(func() error {
 			var queryErr error
-			result.topUsers, queryErr = reader.GetTopUsers(egCtx, repo.GetTopUsersParams{
-				GramProjectID:  params.projectID,
-				TimeStart:      params.timeStart,
-				TimeEnd:        params.timeEnd,
+			result.TopUsers, queryErr = reader.GetTopUsers(egCtx, repo.GetTopUsersParams{
+				GramProjectID:  params.ProjectID,
+				TimeStart:      params.TimeStart,
+				TimeEnd:        params.TimeEnd,
 				ExternalUserID: "",
 				APIKeyID:       "",
 				ToolsetSlug:    "",
@@ -154,10 +170,10 @@ func fetchProjectOverviewClickHouse(
 
 		eg.Go(func() error {
 			var queryErr error
-			result.llmClients, queryErr = reader.GetLLMClientBreakdown(egCtx, repo.GetLLMClientBreakdownParams{
-				GramProjectID:  params.projectID,
-				TimeStart:      params.timeStart,
-				TimeEnd:        params.timeEnd,
+			result.LLMClients, queryErr = reader.GetLLMClientBreakdown(egCtx, repo.GetLLMClientBreakdownParams{
+				GramProjectID:  params.ProjectID,
+				TimeStart:      params.TimeStart,
+				TimeEnd:        params.TimeEnd,
 				ExternalUserID: "",
 				APIKeyID:       "",
 				ToolsetSlug:    "",
@@ -171,7 +187,7 @@ func fetchProjectOverviewClickHouse(
 	}
 
 	if err := eg.Wait(); err != nil {
-		return projectOverviewClickHouseResult{}, fmt.Errorf("fetch project overview ClickHouse data: %w", err)
+		return Result{}, fmt.Errorf("fetch project overview ClickHouse data: %w", err)
 	}
 
 	return result, nil

--- a/server/internal/telemetry/overview/clickhouse_test.go
+++ b/server/internal/telemetry/overview/clickhouse_test.go
@@ -1,4 +1,4 @@
-package telemetry
+package overview
 
 import (
 	"context"
@@ -20,22 +20,22 @@ func TestFetchProjectOverviewClickHouseRunsSessionQueriesConcurrently(t *testing
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
 
-	result, err := fetchProjectOverviewClickHouse(ctx, reader, projectOverviewClickHouseParams{
-		projectID:       "00000000-0000-0000-0000-000000000001",
-		timeStart:       200,
-		timeEnd:         300,
-		comparisonStart: 100,
-		comparisonEnd:   200,
-		sessionMode:     true,
+	result, err := FetchClickHouse(ctx, reader, Params{
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		TimeStart:       200,
+		TimeEnd:         300,
+		ComparisonStart: 100,
+		ComparisonEnd:   200,
+		SessionMode:     true,
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint64(11), result.toolMetrics.TotalToolCalls)
-	require.Equal(t, uint64(7), result.toolMetricsComparison.TotalToolCalls)
-	require.Equal(t, uint64(3), result.activeCounts.ActiveServersCount)
-	require.Equal(t, uint64(4), result.activeCounts.ActiveUsersCount)
-	require.Equal(t, []repo.TopServer{{ServerName: "server", ToolCallCount: 5}}, result.topServers)
-	require.Empty(t, result.topUsers)
-	require.Empty(t, result.llmClients)
+	require.Equal(t, uint64(11), result.ToolMetrics.TotalToolCalls)
+	require.Equal(t, uint64(7), result.ToolMetricsComparison.TotalToolCalls)
+	require.Equal(t, uint64(3), result.ActiveCounts.ActiveServersCount)
+	require.Equal(t, uint64(4), result.ActiveCounts.ActiveUsersCount)
+	require.Equal(t, []repo.TopServer{{ServerName: "server", ToolCallCount: 5}}, result.TopServers)
+	require.Empty(t, result.TopUsers)
+	require.Empty(t, result.LLMClients)
 	require.Equal(t, int32(4), reader.started.Load())
 	require.Equal(t, int32(2), reader.overviewCalls.Load())
 	require.Equal(t, int32(1), reader.activeCountCalls.Load())
@@ -51,22 +51,22 @@ func TestFetchProjectOverviewClickHouseRunsToolCallQueriesConcurrently(t *testin
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
 
-	result, err := fetchProjectOverviewClickHouse(ctx, reader, projectOverviewClickHouseParams{
-		projectID:       "00000000-0000-0000-0000-000000000001",
-		timeStart:       200,
-		timeEnd:         300,
-		comparisonStart: 100,
-		comparisonEnd:   200,
-		sessionMode:     false,
+	result, err := FetchClickHouse(ctx, reader, Params{
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		TimeStart:       200,
+		TimeEnd:         300,
+		ComparisonStart: 100,
+		ComparisonEnd:   200,
+		SessionMode:     false,
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint64(11), result.toolMetrics.TotalToolCalls)
-	require.Equal(t, uint64(7), result.toolMetricsComparison.TotalToolCalls)
-	require.Equal(t, uint64(3), result.activeCounts.ActiveServersCount)
-	require.Equal(t, uint64(4), result.activeCounts.ActiveUsersCount)
-	require.Equal(t, []repo.TopServer{{ServerName: "server", ToolCallCount: 5}}, result.topServers)
-	require.Equal(t, []repo.TopUser{{UserID: "user", UserType: "external", ActivityCount: 6}}, result.topUsers)
-	require.Equal(t, []repo.LLMClientUsage{{ClientName: "client", ActivityCount: 8}}, result.llmClients)
+	require.Equal(t, uint64(11), result.ToolMetrics.TotalToolCalls)
+	require.Equal(t, uint64(7), result.ToolMetricsComparison.TotalToolCalls)
+	require.Equal(t, uint64(3), result.ActiveCounts.ActiveServersCount)
+	require.Equal(t, uint64(4), result.ActiveCounts.ActiveUsersCount)
+	require.Equal(t, []repo.TopServer{{ServerName: "server", ToolCallCount: 5}}, result.TopServers)
+	require.Equal(t, []repo.TopUser{{UserID: "user", UserType: "external", ActivityCount: 6}}, result.TopUsers)
+	require.Equal(t, []repo.LLMClientUsage{{ClientName: "client", ActivityCount: 8}}, result.LLMClients)
 	require.Equal(t, int32(6), reader.started.Load())
 	require.Equal(t, int32(2), reader.overviewCalls.Load())
 	require.Equal(t, int32(1), reader.activeCountCalls.Load())

--- a/server/internal/telemetry/repo/mcp_diagnostics.go
+++ b/server/internal/telemetry/repo/mcp_diagnostics.go
@@ -1,0 +1,255 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/squirrel"
+)
+
+// MCP call outcome classes. The vocabulary is closed and server-side: a
+// diagnostic caller receives these names, never a status code or an error
+// string, so nothing a provider or a client wrote can reach the result through
+// this path.
+const (
+	// MCPOutcomeSuccess is a 2xx/3xx call, or a hook-observed call that
+	// recorded a result.
+	MCPOutcomeSuccess = "success"
+	// MCPOutcomeUnauthorized is 401/403 — the call was rejected before it ran.
+	MCPOutcomeUnauthorized = "unauthorized"
+	// MCPOutcomeClientError is any other 4xx: the request itself was rejected.
+	MCPOutcomeClientError = "client_error"
+	// MCPOutcomeServerError is 5xx. It does not by itself say whether Gram or
+	// the upstream provider produced the status, which is why fault
+	// attribution weighs it against readiness rather than reading it alone.
+	MCPOutcomeServerError = "server_error"
+	// MCPOutcomeFailed is a hook-observed call that recorded an error without a
+	// status code.
+	MCPOutcomeFailed = "failed"
+	// MCPOutcomeUnknown is a call whose trace carries neither.
+	MCPOutcomeUnknown = "unknown"
+)
+
+// MCPClientUnattributed is the client label for calls that arrive straight at
+// a hosted MCP server, where nothing today records which client made them.
+// Distinct from an empty string so a reader can tell "we do not know" from a
+// client that reported no name.
+const MCPClientUnattributed = "unattributed"
+
+type GetMCPOutcomeBreakdownParams struct {
+	// GramProjectIDs scopes the read. One project answers "this server";
+	// an organization's projects answer "is this happening everywhere".
+	GramProjectIDs []string
+	// ToolsetSlugs matches hosted MCP traffic arriving directly at Gram.
+	// Empty selects every server in scope, which is how the organization-wide
+	// comparison is taken.
+	ToolsetSlugs []string
+	// MCPServerURLSuffixes matches the same servers in hook-observed traffic,
+	// where the server is identified by the URL the client called (/mcp/<slug>).
+	MCPServerURLSuffixes []string
+	TimeStart            int64
+	TimeEnd              int64
+}
+
+type MCPOutcomeBreakdownRow struct {
+	Client           string `ch:"client"`
+	Outcome          string `ch:"outcome"`
+	CallCount        uint64 `ch:"call_count"`
+	LastCallUnixNano int64  `ch:"last_call_unix_nano"`
+}
+
+// GetMCPOutcomeBreakdown counts calls by outcome class and by the client that
+// made them, over two lanes of the same traffic: calls that arrived directly at
+// a hosted MCP server (classified by HTTP status, no client attribution
+// available yet) and calls observed by an agent hook (classified by
+// result/error, attributed to the reporting client).
+//
+// It returns counts only. No status codes, URLs, arguments, results, or
+// identities leave this query.
+func (q *Queries) GetMCPOutcomeBreakdown(ctx context.Context, arg GetMCPOutcomeBreakdownParams) ([]MCPOutcomeBreakdownRow, error) {
+	if len(arg.GramProjectIDs) == 0 {
+		return []MCPOutcomeBreakdownRow{}, nil
+	}
+
+	directSQL, directArgs, err := q.mcpOutcomeDirectSource(arg)
+	if err != nil {
+		return nil, err
+	}
+	hookSQL, hookArgs, err := q.mcpOutcomeHookSource(arg)
+	if err != nil {
+		return nil, err
+	}
+
+	source := "(" + directSQL + " UNION ALL " + hookSQL + ")"
+	sourceArgs := make([]any, 0, len(directArgs)+len(hookArgs))
+	sourceArgs = append(sourceArgs, directArgs...)
+	sourceArgs = append(sourceArgs, hookArgs...)
+
+	sb := sq.Select(
+		"client",
+		"outcome",
+		"count() AS call_count",
+		"max(event_time_ns) AS last_call_unix_nano",
+	).
+		From(source).
+		GroupBy("client", "outcome").
+		OrderBy("call_count DESC", "client ASC", "outcome ASC")
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build mcp outcome breakdown query: %w", err)
+	}
+	// squirrel places the FROM subquery's placeholders after the outer
+	// builder's, and this builder contributes none, so the source arguments
+	// lead.
+	args = append(sourceArgs, args...)
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query mcp outcome breakdown: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]MCPOutcomeBreakdownRow, 0)
+	for rows.Next() {
+		var row MCPOutcomeBreakdownRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scan mcp outcome breakdown row: %w", err)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate mcp outcome breakdown rows: %w", err)
+	}
+	return result, nil
+}
+
+// mcpOutcomeDirectSource classifies calls that reached a hosted MCP server
+// directly. Aggregate aliases carry the "g_" prefix for the reason the tool
+// usage CTE documents: an alias that shadows a trace_summaries column is merged
+// into the enclosing aggregate and fails with ILLEGAL_AGGREGATION.
+func (q *Queries) mcpOutcomeDirectSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
+	grouped := sq.Select(
+		"min(start_time_unix_nano) AS event_time_ns",
+		"max(toolset_slug) AS g_toolset_slug",
+		"ifNull(anyIfMerge(http_status_code), 0) AS g_http_status_code",
+	).
+		From("trace_summaries").
+		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
+		GroupBy("trace_id").
+		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
+		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd).
+		Having("any(event_source) != 'hook'").
+		Having("g_toolset_slug != ''")
+	if len(arg.ToolsetSlugs) > 0 {
+		grouped = grouped.Having(squirrel.Eq{"g_toolset_slug": arg.ToolsetSlugs})
+	}
+	grouped = withTraceWindowScanBounds(grouped, "start_time_unix_nano", arg.TimeStart, arg.TimeEnd)
+
+	groupedSQL, groupedArgs, err := grouped.ToSql()
+	if err != nil {
+		return "", nil, fmt.Errorf("build direct mcp outcome source: %w", err)
+	}
+
+	outcome := chMultiIf(
+		"g_http_status_code = 401 OR g_http_status_code = 403", "'"+MCPOutcomeUnauthorized+"'",
+		"g_http_status_code >= 200 AND g_http_status_code < 400", "'"+MCPOutcomeSuccess+"'",
+		"g_http_status_code >= 500", "'"+MCPOutcomeServerError+"'",
+		"g_http_status_code >= 400", "'"+MCPOutcomeClientError+"'",
+		"'"+MCPOutcomeUnknown+"'",
+	)
+
+	return fmt.Sprintf(`
+SELECT
+	event_time_ns,
+	'%s' AS client,
+	%s AS outcome
+FROM (%s)`, MCPClientUnattributed, outcome, groupedSQL), groupedArgs, nil
+}
+
+// mcpOutcomeHookSource classifies the same servers' calls as an agent hook
+// observed them. This is the only lane that can name a client today, and it
+// names the reporting integration — self-reported evidence, never a metric
+// dimension a caller can filter on.
+func (q *Queries) mcpOutcomeHookSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
+	grouped := sq.Select(
+		"min(start_time_unix_nano) AS event_time_ns",
+		"any(hook_source) AS g_hook_source",
+		"max(mcp_server_url) AS g_mcp_server_url",
+		"max(has_result) AS g_has_result",
+		"max(has_error) AS g_has_error",
+	).
+		From("trace_summaries").
+		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
+		GroupBy("trace_id").
+		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
+		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd).
+		Having("any(event_source) = 'hook'").
+		Having("g_mcp_server_url != ''")
+	if len(arg.MCPServerURLSuffixes) > 0 {
+		grouped = grouped.Having("arrayExists(suffix -> endsWith(g_mcp_server_url, suffix), ?)", arg.MCPServerURLSuffixes)
+	}
+	grouped = withTraceWindowScanBounds(grouped, "start_time_unix_nano", arg.TimeStart, arg.TimeEnd)
+
+	groupedSQL, groupedArgs, err := grouped.ToSql()
+	if err != nil {
+		return "", nil, fmt.Errorf("build hook mcp outcome source: %w", err)
+	}
+
+	outcome := chMultiIf(
+		"g_has_error = 1", "'"+MCPOutcomeFailed+"'",
+		"g_has_result = 1", "'"+MCPOutcomeSuccess+"'",
+		"'"+MCPOutcomeUnknown+"'",
+	)
+
+	return fmt.Sprintf(`
+SELECT
+	event_time_ns,
+	%s AS client,
+	%s AS outcome
+FROM (%s)`, chFirstNonEmpty("g_hook_source", "'"+MCPClientUnattributed+"'"), outcome, groupedSQL), groupedArgs, nil
+}
+
+type GetTelemetryWatermarkParams struct {
+	GramProjectIDs []string
+}
+
+// GetTelemetryWatermark returns the newest event time observed for the given
+// projects, or zero when they hold no telemetry at all.
+//
+// Every external diagnostic reports this as its data_through, so a reader can
+// tell a quiet system from a stalled pipeline. A zero watermark is the absence
+// of observations, never evidence of health.
+func (q *Queries) GetTelemetryWatermark(ctx context.Context, arg GetTelemetryWatermarkParams) (int64, error) {
+	if len(arg.GramProjectIDs) == 0 {
+		return 0, nil
+	}
+
+	// gram_project_id leads telemetry_logs' sort key with time_unix_nano next,
+	// so this reads the tail of the matching ranges rather than scanning them.
+	sb := sq.Select("max(time_unix_nano) AS watermark").
+		From("telemetry_logs").
+		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs})
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("build telemetry watermark query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("query telemetry watermark: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var watermark int64
+	if rows.Next() {
+		if err := rows.Scan(&watermark); err != nil {
+			return 0, fmt.Errorf("scan telemetry watermark: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate telemetry watermark: %w", err)
+	}
+	return watermark, nil
+}


### PR DESCRIPTION
Lane D2 of Track D in the Platform MCP RFC, first slice: the shared diagnostic primitives plus the two overview-first tools. AGE-3167.

The lane names eleven tools. This PR lands the primitives and the entry points; the drill-down tools (`query_mcp_events` / `query_mcp_traces` / `query_mcp_metrics`, `get_user_mcp_status`) and the organization summaries follow as separate PRs on the same foundation.

## What this adds

**A neutral read seam.** The project overview's ClickHouse fan-out moves out of the telemetry service into `internal/telemetry/overview`, exported. The management handler and Platform MCP now compose the same reads and the same projection, so a summary the dashboard shows and a summary an external diagnostic reports cannot disagree. The handler's behaviour is unchanged — the move is mechanical and its tests moved with it.

**Two bounded ClickHouse reads** (`telemetry/repo/mcp_diagnostics.go`). `GetMCPOutcomeBreakdown` counts calls per outcome class and per client over two lanes of the same traffic: calls that reached a hosted MCP server directly, classified by HTTP status, and calls an agent hook observed, classified by result/error and attributed to the reporting client. `GetTelemetryWatermark` reports how far observations reach. Both return counts only — no status codes, URLs, arguments, results, or identities leave the query, and there is no query grammar or attribute-key discovery.

**Freshness and privacy primitives.** Every result carries `queried_at`, `data_through`, `freshness`, and the `resolved_window` it was computed over. A watermark more than five minutes behind is `stale`; an absence of observations is `no_observations` and never evidence of health. Windows come from a closed set (`1h`, `24h`, `7d`, `30d`) and anything outside it is refused rather than silently clamped. Subject counts below five serialize as `less_than_5` and cannot be recovered from what was transmitted; event counts — calls, failures — are reported exactly, since suppressing those would remove the whole diagnostic signal.

**`get_project_overview`** — the normal entry point. A project's tool calls, failures, active servers, active users, and top servers, aggregated server-side. It deliberately carries no users, no LLM clients, no tokens, and no cost.

**`get_mcp_diagnostics`** — the drill-down for one MCP that is not working, keyed by the same `mcp_id` `find_mcp` and `get_mcp` return. It returns the latest server-side readiness result, this MCP's outcomes alongside the organization's for comparison, the clients that reported failures, and an explicit fault attribution.

## Fault attribution

The diagnosis composes three independent pieces of evidence and never guesses:

- A **fresh `ready`** readiness result is a positive statement from Gram's own probe, and exonerates both Gram's configuration and the provider. A stale or missing result exonerates nothing.
- A **dominant failure class** — a majority of failures, not merely the leading one — picks between `client`, `provider`, and `gram_configuration`. An even spread names no candidate.
- A **server-computed scope check** decides whether the pattern is specific to this server or present organization-wide; an organization-wide pattern is not this server's own configuration, whatever its outcomes suggest.

`indeterminate` is a valid answer and is returned wherever the evidence does not separate the candidates — including the genuinely contradictory case where a provider answers a readiness probe but fails real calls.

## Deferred, deliberately

Client **name and version** on authorization attempts is not recorded anywhere today, and adding it needs a schema change plus auth-path wiring. That is its own PR. Until it lands, directly-arriving calls report their client as `unattributed`, and attribution returns `indeterminate` in the cases where client evidence would have decided. The hook-observed lane does name its client, so the evidence list is not empty in the meantime.

## Verification

`go build`, `go vet`, and `mise lint:server` are clean. The new ClickHouse queries are exercised against a real ClickHouse container, covering outcome classification on both lanes, project and window scoping, client attribution, and the watermark — not just compiled. Leak tests pin the exact serialized shape of both results, so a new field cannot reach a caller without being added to the allowlist in the test first. Freshness, window resolution, suppression, and every attribution branch are table-tested.

## Not included

The demo seed is untouched. These tools read telemetry the seed already produces and add no dashboard surface, so there is nothing new to show — though the demo org will report fault `none` until the seed grows some failing hosted-MCP calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Platform MCP diagnostics and consolidates the project overview into a shared, privacy‑safe read path used by both the dashboard and Platform MCP. Previously these used separate reads with no diagnostics; now both compose `internal/telemetry/overview`, and scoped drill‑downs are available with bounded windows and budgets.

- Two tools: get_project_overview (aggregate activity/failures) and get_mcp_diagnostics (per‑MCP outcomes, client evidence, explicit fault attribution). Tools register only when a telemetry reader is provided.
- Windows: overview accepts 1h/24h/7d/30d (default 24h); diagnostics accepts 1h/24h (default 1h). Requests outside each tool’s set are rejected.
- New bounded ClickHouse reads in `internal/telemetry/repo/mcp_diagnostics.go` return counts only and classify outcomes server‑side across hosted‑MCP direct and agent‑hook lanes.
- Freshness/privacy: each result carries queried_at, data_through, freshness, and resolved_window; subject counts under 5 serialize as "less_than_5"; watermark >5m marks results stale; diagnostics’ watermark is scoped to the diagnosed project.
- Fault attribution: compares the MCP’s outcomes to the rest of the organization (excluding the diagnosed server); a single‑server org reports scope unknown. Unauthorized under fresh readiness is now indeterminate (not client).
- Wiring: `cmd/gram/start.go` passes `telemetryrepo.New(chDB)` and `platformmcp.FeatureChecker(sessionCaptureEnabled)`; if Telemetry is nil, diagnostics are disabled.
- Budgets: diagnostics reads are metered at 30/connection/minute and 300/organization/minute; set limits where operation budgets are configured.
- Scope: `GetPlatformMCPDiagnosticsTarget` ensures callers diagnose only their org/project.
- Active counts in the overview now respect the resolved metrics mode; a follow‑up fix removes a no‑op session‑mode flag from the active‑count read.

<sup>Written for commit 3883454ab43bc05ca17e4881bd25ccbe8dcaba30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

