### PR TITLE
feat: rename platform MCP plugin to platform-mcp

### DIFF
--- a/.agents/skills/authoring-platform-mcp-skills/SKILL.md
+++ b/.agents/skills/authoring-platform-mcp-skills/SKILL.md
@@ -23,7 +23,7 @@ Use product language in every distributed skill: **Speakeasy AI Control Plane**,
 | Generator and validation          | `server/internal/plugins/generate.go` (`loadPlatformMCPSkills`, `emitPlatformMCPSkills`) |
 | Package tests                     | `server/internal/plugins/generate_test.go`                                               |
 | Claude package output             | `platform-mcp/skills/<skill-name>/SKILL.md`                                              |
-| Portable Agent Plugin output      | `agent-plugins/platform-mcp/skills/<skill-name>/SKILL.md`                                 |
+| Portable Agent Plugin output      | `agent-plugins/platform-mcp/skills/<skill-name>/SKILL.md`                                |
 | Contributor guidance only         | `.agents/skills/authoring-platform-mcp-skills/SKILL.md` (this file)                      |
 
 Do not put a user-facing Platform workflow under `.agents/skills/`: that directory teaches contributors and coding agents how to work on this repository. It is not copied into the customer Platform Plugin.

--- a/.agents/skills/authoring-platform-mcp-skills/SKILL.md
+++ b/.agents/skills/authoring-platform-mcp-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring-platform-mcp-skills
-description: Use when adding, editing, reviewing, testing, or locating a reviewed skill distributed with the Speakeasy AICP Platform MCP plugin; triggers include "Platform MCP skill", "platform_mcp_skills", "add a catalog workflow", "bundle a skill with Platform MCP", and "where should this Platform skill live?".
+description: Use when adding, editing, reviewing, testing, or locating a reviewed skill distributed with the Platform MCP plugin; triggers include "Platform MCP skill", "platform_mcp_skills", "add a catalog workflow", "bundle a skill with Platform MCP", and "where should this Platform skill live?".
 ---
 
 # Authoring Platform MCP skills
@@ -23,7 +23,7 @@ Use product language in every distributed skill: **Speakeasy AI Control Plane**,
 | Generator and validation          | `server/internal/plugins/generate.go` (`loadPlatformMCPSkills`, `emitPlatformMCPSkills`) |
 | Package tests                     | `server/internal/plugins/generate_test.go`                                               |
 | Claude package output             | `platform-mcp/skills/<skill-name>/SKILL.md`                                              |
-| Portable Agent Plugin output      | `agent-plugins/speakeasy-aicp-platform-mcp/skills/<skill-name>/SKILL.md`                 |
+| Portable Agent Plugin output      | `agent-plugins/platform-mcp/skills/<skill-name>/SKILL.md`                                 |
 | Contributor guidance only         | `.agents/skills/authoring-platform-mcp-skills/SKILL.md` (this file)                      |
 
 Do not put a user-facing Platform workflow under `.agents/skills/`: that directory teaches contributors and coding agents how to work on this repository. It is not copied into the customer Platform Plugin.

--- a/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.tsx
+++ b/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.tsx
@@ -52,13 +52,15 @@ const PLATFORM_MCP_INSTALL_CLIENTS: PlatformMCPInstallClient[] = [
 export type PlatformMCPInstallMethod = "marketplace" | "download" | "manual";
 type PackagePlatform = "claude" | "cursor" | "codex" | "opencode";
 
+const PLATFORM_MCP_PLUGIN_NAME = "platform-mcp";
+
 function packagePlatform(client: ClientFamily): PackagePlatform {
   if (client === "claude_code" || client === "claude_cowork") return "claude";
   return client;
 }
 
 function packageFilename(client: ClientFamily): string {
-  return `speakeasy-aicp-platform-mcp-${packagePlatform(client)}.zip`;
+  return `${PLATFORM_MCP_PLUGIN_NAME}-${packagePlatform(client)}.zip`;
 }
 
 type PlatformMCPInstallWalkthroughProps = {
@@ -72,13 +74,13 @@ type PlatformMCPInstallWalkthroughProps = {
 
 function manualConfig(client: ClientFamily, mcpUrl: string): string {
   if (client === "codex") {
-    return `[mcp_servers.speakeasy-aicp-platform-mcp]\nurl = "${mcpUrl}"`;
+    return `[mcp_servers.${PLATFORM_MCP_PLUGIN_NAME}]\nurl = "${mcpUrl}"`;
   }
   if (client === "opencode") {
     return JSON.stringify(
       {
         mcp: {
-          "speakeasy-aicp-platform-mcp": {
+          [PLATFORM_MCP_PLUGIN_NAME]: {
             type: "remote",
             url: mcpUrl,
             enabled: true,
@@ -92,7 +94,7 @@ function manualConfig(client: ClientFamily, mcpUrl: string): string {
   return JSON.stringify(
     {
       mcpServers: {
-        "speakeasy-aicp-platform-mcp": {
+        [PLATFORM_MCP_PLUGIN_NAME]: {
           type: "http",
           url: mcpUrl,
         },
@@ -206,14 +208,14 @@ function marketplaceSteps(
       {
         title: "Make the plugin available to your account",
         description:
-          "Find Speakeasy AICP Platform MCP and choose an availability policy that lets your admin account install it. Do not mark it Required unless your organization has separately decided to deploy it more broadly.",
-        code: "speakeasy-aicp-platform-mcp",
+          "Find Platform MCP and choose an availability policy that lets your admin account install it. Do not mark it Required unless your organization has separately decided to deploy it more broadly.",
+        code: PLATFORM_MCP_PLUGIN_NAME,
         language: "text",
       },
       {
         title: "Install it for yourself and complete OAuth",
         description:
-          "Install Speakeasy AICP Platform MCP for your own Claude account, open a new Cowork session, and complete AI Control Plane browser authorization when you first use the MCP.",
+          "Install Platform MCP for your own Claude account, open a new Cowork session, and complete AI Control Plane browser authorization when you first use the MCP.",
       },
     ];
   }
@@ -230,7 +232,7 @@ function marketplaceSteps(
       {
         title: "Install Platform MCP for your account",
         description:
-          "Find Speakeasy AICP Platform MCP in the imported marketplace and install it for your Cursor account. Do not require it for the whole team unless your organization has made that separate rollout decision.",
+          "Find Platform MCP in the imported marketplace and install it for your Cursor account. Do not require it for the whole team unless your organization has made that separate rollout decision.",
         code: "platform-mcp-cursor",
         language: "text",
       },
@@ -275,7 +277,7 @@ function marketplaceSteps(
       title: "Install Platform MCP for your profile",
       description:
         "Install only the Platform MCP package into your Claude Code profile. This does not install it for other organization members.",
-      code: `/plugin install speakeasy-aicp-platform-mcp@${marketplaceName}`,
+      code: `/plugin install ${PLATFORM_MCP_PLUGIN_NAME}@${marketplaceName}`,
     },
     {
       title: "Restart your Claude Code session and complete OAuth",

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -677,7 +677,7 @@ function PlatformMCPPluginCard(): JSX.Element {
       if (!response.ok) throw new Error("download failed");
       await downloadResponse(
         response,
-        `speakeasy-aicp-platform-mcp-${platform}.zip`,
+        `platform-mcp-${platform}.zip`,
       );
     } catch (error) {
       toast.error("Could not download the Platform MCP package");

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -675,10 +675,7 @@ function PlatformMCPPluginCard(): JSX.Element {
         {},
       );
       if (!response.ok) throw new Error("download failed");
-      await downloadResponse(
-        response,
-        `platform-mcp-${platform}.zip`,
-      );
+      await downloadResponse(response, `platform-mcp-${platform}.zip`);
     } catch (error) {
       toast.error("Could not download the Platform MCP package");
       console.error("Platform MCP plugin download failed", error);

--- a/server/internal/platformmcp/catalog_readiness.go
+++ b/server/internal/platformmcp/catalog_readiness.go
@@ -164,7 +164,7 @@ func (p *RemoteMCPReadinessProber) probe(ctx context.Context, remoteURL string, 
 	}
 	httpClient.Transport = roundTripper
 
-	client := mcp.NewClient(&mcp.Implementation{Name: "speakeasy-aicp-platform-mcp-readiness", Version: "1.0.0"}, nil)
+	client := mcp.NewClient(&mcp.Implementation{Name: "platform-mcp-readiness", Version: "1.0.0"}, nil)
 	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: remoteURL, HTTPClient: httpClient, MaxRetries: 0, DisableStandaloneSSE: true}, nil)
 	if err != nil {
 		return catalogProbeFailure(err, roundTripper)

--- a/server/internal/platformmcp/localfixture/config.go
+++ b/server/internal/platformmcp/localfixture/config.go
@@ -17,7 +17,7 @@ const (
 	ProviderKey           = "local-fixture"
 	CanonicalRef          = "local-fixture/reviewed-mcp"
 	SetupIntent           = "provider_setup"
-	OAuthClientName       = "Speakeasy AICP Platform MCP local fixture"
+	OAuthClientName       = "Platform MCP local fixture"
 	SetupGuideVersion     = "local-fixture-v1"
 	fixtureOAuthPath      = "platform-mcp/local-fixture"
 	fixtureIssuerSlug     = "platform-mcp-local-fixture"
@@ -185,7 +185,7 @@ func (c *Config) SetupResources() []platformmcp.SetupResource {
 		// same citation a real guide carries, rather than a shape that only
 		// exists in the fixture.
 		Text: "# Local fixture provider setup\n\n" +
-			"- Owner: Speakeasy AICP Platform MCP\n" +
+			"- Owner: Platform MCP\n" +
 			"- Source: " + SetupGuideVersion + " (synthetic local fixture; never fetched at request time)\n" +
 			"- Observed: " + observedAt.Format(time.DateOnly) + "\n" +
 			"- Revalidate by: " + observedAt.AddDate(0, 0, 90).Format(time.DateOnly) + "\n" +
@@ -194,7 +194,7 @@ func (c *Config) SetupResources() []platformmcp.SetupResource {
 
 		Provider:     ProviderKey,
 		Intent:       SetupIntent,
-		Owner:        "Speakeasy AICP Platform MCP",
+		Owner:        "Platform MCP",
 		Source:       SetupGuideVersion,
 		ObservedAt:   observedAt,
 		RevalidateBy: observedAt.AddDate(0, 0, 90),

--- a/server/internal/platformmcp/oauth_page.html
+++ b/server/internal/platformmcp/oauth_page.html
@@ -231,8 +231,7 @@
         <header class="header">
           <h1 id="page-title">Choose an organization</h1>
           <p>
-            <strong>{{.ClientName}}</strong> requests access to Speakeasy AICP
-            Platform MCP.
+            <strong>{{.ClientName}}</strong> requests access to Platform MCP.
           </p>
         </header>
         <dl class="info">
@@ -257,8 +256,7 @@
           <h1 id="page-title">Connect Platform MCP</h1>
           <p>
             Allow <strong>{{.ClientName}}</strong> to administer
-            <strong>{{.OrganizationName}}</strong> through Speakeasy AICP
-            Platform MCP.
+            <strong>{{.OrganizationName}}</strong> through Platform MCP.
           </p>
         </header>
         <dl class="info">
@@ -301,7 +299,7 @@
           <h1 id="page-title">Provider connected</h1>
           <p>
             Provider authorization is complete. Return to your agent to continue
-            setting up Speakeasy AICP Platform MCP.
+            setting up Platform MCP.
           </p>
         </header>
         <p class="info">You can close this window.</p>

--- a/server/internal/platformmcp/oauthhttp.go
+++ b/server/internal/platformmcp/oauthhttp.go
@@ -370,7 +370,7 @@ func (s *OAuthHTTP) organizationSelectionGet(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	s.renderOAuthPage(w, oauthPageData{
-		Title:         "Choose an organization · Speakeasy AICP Platform MCP",
+		Title:         "Choose an organization · Platform MCP",
 		Kind:          "organization",
 		ClientName:    client.Name,
 		Organizations: organizations,
@@ -443,7 +443,7 @@ func (s *OAuthHTTP) selectedOrganization(ctx context.Context, challenge oauthCha
 func (s *OAuthHTTP) ProviderSetupCompleteHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		s.renderOAuthPage(w, oauthPageData{
-			Title:     "Provider connected · Speakeasy AICP Platform MCP",
+			Title:     "Provider connected · Platform MCP",
 			Kind:      "provider-complete",
 			AutoClose: true,
 		})
@@ -481,7 +481,7 @@ func (s *OAuthHTTP) connectGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.renderOAuthPage(w, oauthPageData{
-		Title:            "Connect Platform MCP · Speakeasy AICP Platform MCP",
+		Title:            "Connect Platform MCP",
 		Kind:             "connect",
 		ClientName:       client.Name,
 		OrganizationName: organization.Name,

--- a/server/internal/platformmcp/oauthhttp_test.go
+++ b/server/internal/platformmcp/oauthhttp_test.go
@@ -135,6 +135,8 @@ func TestOAuthHTTPProviderSetupCompletionDoesNotExposeState(t *testing.T) {
 	require.Equal(t, http.StatusOK, response.Code)
 	require.Equal(t, "no-store", response.Header().Get("Cache-Control"))
 	require.NotContains(t, response.Body.String(), "secret")
+	require.Contains(t, response.Body.String(), "setting up Platform MCP")
+	require.NotContains(t, response.Body.String(), "AICP")
 }
 
 func TestOAuthHTTPMetadataAndClientRegistration(t *testing.T) {
@@ -222,6 +224,8 @@ func TestOAuthHTTPSelectsOrganizationAfterIDPCallback(t *testing.T) {
 	require.Equal(t, http.StatusOK, selection.Code)
 	require.Contains(t, selection.Body.String(), "Organization one")
 	require.Contains(t, selection.Body.String(), "Choose an organization")
+	require.Contains(t, selection.Body.String(), "requests access to Platform MCP")
+	require.NotContains(t, selection.Body.String(), "AICP")
 	require.Contains(t, selection.Body.String(), "auth-consent-container")
 	require.Contains(t, selection.Body.String(), "font-diatype-mono")
 	require.NotContains(t, selection.Body.String(), "fonts.googleapis.com")

--- a/server/internal/platformmcp/remotesessionprovider/adapter.go
+++ b/server/internal/platformmcp/remotesessionprovider/adapter.go
@@ -232,7 +232,7 @@ func (a *Adapter) probe(ctx context.Context, descriptor Descriptor, token string
 	httpClient.Transport = authRT
 
 	client := mcp.NewClient(&mcp.Implementation{
-		Name:       "speakeasy-aicp-platform-mcp-readiness",
+		Name:       "platform-mcp-readiness",
 		Title:      "",
 		Version:    "1.0.0",
 		WebsiteURL: "",

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -135,8 +135,8 @@ type operationBudgetResult struct {
 // a second list that would drift.
 func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "speakeasy-aicp-platform-mcp",
-		Title:   "Speakeasy AICP Platform MCP",
+		Name:    "platform-mcp",
+		Title:   "Platform MCP",
 		Version: "0.1.0",
 	}, &mcp.ServerOptions{
 		Instructions: "Use this server to inspect the selected organization and help distribute reviewed MCP servers to an explicit project. List reviewed catalogue options and eligible projects, then ask the user to choose one of each before mutating. Inspect the chosen candidate and collect only its declared non-secret configuration values. Normal non-secret URLs may be discussed and returned. Register it privately. If readiness says an upstream identity provider is missing, ask the user to explicitly confirm and then call attach_platform_mcp_identity_provider; the server derives the provider from the persisted reviewed MCP source and returns its non-secret provider_url plus an Inspect authorization_url for the user to use Connect or Authorize. Immediately present authorization_url as the exact clickable link—never say a link is above or ask the user to confirm an unspecified authorization action. Never request or accept OAuth codes, tokens, client secrets, passwords, API keys, or secret headers in chat. The registration dashboard_setup_url is the Authentication settings fallback, not the authorization page. Force a fresh readiness check after user authorization and add the ready server to the project's existing Default plugin. For the guided flow, use register_platform_mcp_for_project, get_platform_mcp_onboarding_status, attach_platform_mcp_identity_provider when confirmed, and add_platform_mcp_to_default_plugin.",

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -414,6 +414,16 @@ const (
 	platformMCPCodexPluginRoot    = "platform-mcp-codex"
 	platformMCPOpenCodePluginRoot = opencodePluginRoot + "/platform-mcp"
 	platformMCPAgentPluginRoot    = agentPluginRoot + "/" + platformMCPPluginName
+
+	// platformMCPLegacyPluginName is the Agent Plugin and OpenCode identifier
+	// carry still recognizes in already-published repositories. Indeterminate
+	// admission preserves those bytes; a confirmed decision migrates them to
+	// platformMCPPluginName.
+	platformMCPLegacyPluginName = "speakeasy-aicp-platform-mcp"
+
+	// platformMCPLegacyAgentPluginRoot is the Agent Plugin directory that
+	// already-published repositories may still contain.
+	platformMCPLegacyAgentPluginRoot = agentPluginRoot + "/" + platformMCPLegacyPluginName
 )
 
 func platformMCPPackageFilename(platform string) string {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -405,7 +405,8 @@ const mcpSharedFingerprintKey = "__shared__"
 const mcpPlatformFingerprintKey = "__platform_mcp__"
 
 const (
-	platformMCPPluginName         = "speakeasy-aicp-platform-mcp"
+	platformMCPPluginName         = "platform-mcp"
+	platformMCPDisplayName        = "Platform MCP"
 	platformMCPServerName         = "platform-mcp"
 	platformMCPPluginRoot         = "platform-mcp"
 	platformMCPDescription        = "Manage MCPs, Risk Policies and explore logs in your favorite agent."
@@ -414,6 +415,10 @@ const (
 	platformMCPOpenCodePluginRoot = opencodePluginRoot + "/platform-mcp"
 	platformMCPAgentPluginRoot    = agentPluginRoot + "/" + platformMCPPluginName
 )
+
+func platformMCPPackageFilename(platform string) string {
+	return platformMCPPluginName + "-" + platform + ".zip"
+}
 
 // platformMCPSkillsFS is the single source for reviewed skills distributed with
 // every Platform MCP package. Add skills as
@@ -748,7 +753,7 @@ func generateSharedFilesWithPlatformClients(plugins []PluginInfo, cfg GenerateCo
 	if cfg.PlatformMCPEnabled {
 		claudePlugins = append(claudePlugins, marketplaceEntry{
 			Name:        platformMCPPluginName,
-			DisplayName: "Speakeasy AICP Platform MCP",
+			DisplayName: platformMCPDisplayName,
 			Source:      "./" + platformMCPPluginRoot,
 			Description: platformMCPDescription,
 		})
@@ -871,8 +876,8 @@ func generateReadme(plugins []PluginInfo, cfg GenerateConfig) []byte {
 	}
 
 	if cfg.PlatformMCPEnabled {
-		b.WriteString("## Speakeasy AICP Platform MCP\n\n")
-		b.WriteString("The `speakeasy-aicp-platform-mcp` plugin connects supported agents to Speakeasy through OAuth and includes a reviewed workflow for adding an MCP Catalogue server to an explicit project. Installing the package grants no organization access until OAuth and live authorization succeed.\n\n")
+		b.WriteString("## " + platformMCPDisplayName + "\n\n")
+		fmt.Fprintf(&b, "The `%s` plugin connects supported agents to Speakeasy through OAuth and includes a reviewed workflow for adding an MCP catalog server to an explicit project. Installing the package grants no organization access until OAuth and live authorization succeed.\n\n", platformMCPPluginName)
 	}
 
 	if len(plugins) > 0 {
@@ -2117,7 +2122,7 @@ func generatePlatformMCPPackage(cfg GenerateConfig, platformURL string) (map[str
 	files := make(map[string][]byte)
 	meta, err := marshalJSON(claudePluginMeta{
 		Name:        platformMCPPluginName,
-		DisplayName: "Speakeasy AICP Platform MCP",
+		DisplayName: platformMCPDisplayName,
 		Description: platformMCPDescription,
 		Version:     platformMCPManifestVersion(cfg),
 		Author:      pluginAuthor{Name: "Speakeasy", URL: "https://www.speakeasy.com/"},
@@ -2150,7 +2155,7 @@ func generatePlatformMCPPackage(cfg GenerateConfig, platformURL string) (map[str
 
 func platformMCPPluginInfo(platformURL string) PluginInfo {
 	return PluginInfo{
-		Name:        "Speakeasy AICP Platform MCP",
+		Name:        platformMCPDisplayName,
 		Slug:        platformMCPPluginName,
 		Description: platformMCPDescription,
 		Servers: []PluginServerInfo{{

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -148,6 +148,9 @@ func TestGeneratePluginPackagesIncludesPlatformMCPOnlyWhenEnabled(t *testing.T) 
 	require.Contains(t, string(files["README.md"]), "## "+platformMCPDisplayName)
 	require.Contains(t, string(files["README.md"]), "`"+platformMCPPluginName+"`")
 	require.NotContains(t, strings.ToLower(string(files["README.md"])), "aicp")
+
+	var claude marketplaceManifest
+	require.NoError(t, json.Unmarshal(files[".claude-plugin/marketplace.json"], &claude))
 	require.Len(t, claude.Plugins, len(fingerprintTestPlugins())+2)
 	require.Equal(t, "acme-corp-observability", claude.Plugins[0].Name)
 	require.Equal(t, marketplaceEntry{

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -80,7 +80,7 @@ func TestGeneratePluginPackagesIncludesPlatformMCPOnlyWhenEnabled(t *testing.T) 
 	var meta claudePluginMeta
 	require.NoError(t, json.Unmarshal(files["platform-mcp/.claude-plugin/plugin.json"], &meta))
 	require.Equal(t, platformMCPPluginName, meta.Name)
-	require.Equal(t, "Speakeasy AICP Platform MCP", meta.DisplayName)
+	require.Equal(t, platformMCPDisplayName, meta.DisplayName)
 	require.Equal(t, platformMCPDescription, meta.Description)
 	require.Equal(t, "Speakeasy", meta.Author.Name)
 	require.Nil(t, meta.UserConfig, "Platform MCP must not request tenant credentials")
@@ -102,8 +102,8 @@ func TestGeneratePluginPackagesIncludesPlatformMCPOnlyWhenEnabled(t *testing.T) 
 			"platform-mcp/skills/" + name + "/SKILL.md",
 			"cursor-plugins/platform-mcp-cursor/skills/" + name + "/SKILL.md",
 			"platform-mcp-codex/skills/" + name + "/SKILL.md",
-			"opencode-plugins/platform-mcp/speakeasy-aicp-platform-mcp/skills/" + name + "/SKILL.md",
-			"agent-plugins/speakeasy-aicp-platform-mcp/skills/" + name + "/SKILL.md",
+			"opencode-plugins/platform-mcp/" + platformMCPPluginName + "/skills/" + name + "/SKILL.md",
+			platformMCPAgentPluginRoot + "/skills/" + name + "/SKILL.md",
 		}
 		for _, packagePath := range paths {
 			require.Equal(t, skill, files[packagePath], "missing or changed Platform MCP skill %q at %s", name, packagePath)
@@ -118,20 +118,20 @@ func TestGeneratePluginPackagesIncludesPlatformMCPOnlyWhenEnabled(t *testing.T) 
 	require.Contains(t, string(claudeSkill), "send_platform_mcp_feedback")
 
 	var agentManifest agentPluginManifest
-	require.NoError(t, json.Unmarshal(files["agent-plugins/speakeasy-aicp-platform-mcp/plugin.json"], &agentManifest))
+	require.NoError(t, json.Unmarshal(files[platformMCPAgentPluginRoot+"/plugin.json"], &agentManifest))
 	require.Equal(t, platformMCPPluginName, agentManifest.Name)
 	require.Equal(t, "Speakeasy", agentManifest.Author.Name)
 	var agentMCP agentMCPConfig
-	require.NoError(t, json.Unmarshal(files["agent-plugins/speakeasy-aicp-platform-mcp/mcp.json"], &agentMCP))
+	require.NoError(t, json.Unmarshal(files[platformMCPAgentPluginRoot+"/mcp.json"], &agentMCP))
 	require.Equal(t, "https://app.getgram.ai/platform-mcp", agentMCP.MCPServers[platformMCPServerName].URL)
-	require.Equal(t, claudeSkill, files["agent-plugins/speakeasy-aicp-platform-mcp/skills/add-mcp-from-catalog/SKILL.md"])
+	require.Equal(t, claudeSkill, files[platformMCPAgentPluginRoot+"/skills/add-mcp-from-catalog/SKILL.md"])
 
 	platformPrefixes := []string{
 		"platform-mcp/",
 		"cursor-plugins/platform-mcp-cursor/",
 		"platform-mcp-codex/",
 		"opencode-plugins/platform-mcp/",
-		"agent-plugins/speakeasy-aicp-platform-mcp/",
+		"agent-plugins/" + platformMCPPluginName + "/",
 	}
 	for path, content := range files {
 		if slices.ContainsFunc(platformPrefixes, func(prefix string) bool { return strings.HasPrefix(path, prefix) }) {
@@ -145,13 +145,14 @@ func TestGeneratePluginPackagesIncludesPlatformMCPOnlyWhenEnabled(t *testing.T) 
 		}
 	}
 
-	var claude marketplaceManifest
-	require.NoError(t, json.Unmarshal(files[".claude-plugin/marketplace.json"], &claude))
+	require.Contains(t, string(files["README.md"]), "## "+platformMCPDisplayName)
+	require.Contains(t, string(files["README.md"]), "`"+platformMCPPluginName+"`")
+	require.NotContains(t, strings.ToLower(string(files["README.md"])), "aicp")
 	require.Len(t, claude.Plugins, len(fingerprintTestPlugins())+2)
 	require.Equal(t, "acme-corp-observability", claude.Plugins[0].Name)
 	require.Equal(t, marketplaceEntry{
 		Name:        platformMCPPluginName,
-		DisplayName: "Speakeasy AICP Platform MCP",
+		DisplayName: platformMCPDisplayName,
 		Source:      "./platform-mcp",
 		Description: platformMCPDescription,
 	}, claude.Plugins[1])

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -223,6 +223,76 @@ func TestCarryPlatformMCPSubtreeAcceptsB1AndFullNativeLayouts(t *testing.T) {
 	require.NotContains(t, carried, platformMCPOpenCodePluginRoot+"/plugin/"+platformMCPPluginName+".ts")
 }
 
+func TestCarryPlatformMCPSubtreeAcceptsLegacyAgentPluginLayout(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{ServerURL: "https://app.getgram.ai", Version: "42"}
+	current, err := generatePlatformMCPFiles(cfg)
+	require.NoError(t, err)
+
+	legacy := remapPlatformMCPFilesToLegacyLayout(current)
+	require.NotContains(t, legacy, platformMCPAgentPluginRoot+"/plugin.json")
+	require.Contains(t, legacy, platformMCPLegacyAgentPluginRoot+"/plugin.json")
+	require.Contains(t, legacy, platformMCPOpenCodePluginRoot+"/plugin/"+platformMCPLegacyPluginName+".ts")
+
+	carried := make(map[string][]byte)
+	intact, nativeClientsAvailable := carryPlatformMCPSubtree(carried, legacy)
+	require.True(t, intact)
+	require.True(t, nativeClientsAvailable)
+	require.Equal(t, legacy, carried)
+
+	b1Legacy := make(map[string][]byte)
+	for filePath, content := range legacy {
+		if strings.HasPrefix(filePath, platformMCPPluginRoot+"/") || strings.HasPrefix(filePath, platformMCPLegacyAgentPluginRoot+"/") {
+			b1Legacy[filePath] = content
+		}
+	}
+	carried = make(map[string][]byte)
+	intact, nativeClientsAvailable = carryPlatformMCPSubtree(carried, b1Legacy)
+	require.True(t, intact)
+	require.False(t, nativeClientsAvailable)
+	require.Equal(t, b1Legacy, carried)
+
+	// A B1-only repair of this layout must hash the Agent Plugin bytes that
+	// were actually preserved, not only the Claude package.
+	withAgent := platformMCPFingerprintFromFiles(b1Legacy)
+	withoutAgent := maps.Clone(b1Legacy)
+	delete(withoutAgent, platformMCPLegacyAgentPluginRoot+"/plugin.json")
+	require.NotEqual(t, withAgent, platformMCPFingerprintFromFiles(withoutAgent))
+}
+
+// remapPlatformMCPFilesToLegacyLayout rewrites only the Agent Plugin directory
+// and the OpenCode identifier so already-published repositories can be
+// reconstructed in tests. Claude, Cursor, Codex, and the OpenCode package root
+// stay on their current paths.
+func remapPlatformMCPFilesToLegacyLayout(files map[string][]byte) map[string][]byte {
+	legacy := make(map[string][]byte, len(files))
+	for filePath, content := range files {
+		legacy[remapPlatformMCPPathToLegacyLayout(filePath)] = content
+	}
+	return legacy
+}
+
+func remapPlatformMCPPathToLegacyLayout(filePath string) string {
+	currentAgentPrefix := platformMCPAgentPluginRoot + "/"
+	legacyAgentPrefix := platformMCPLegacyAgentPluginRoot + "/"
+	if rest, ok := strings.CutPrefix(filePath, currentAgentPrefix); ok {
+		return legacyAgentPrefix + rest
+	}
+
+	currentOpenCodePlugin := platformMCPOpenCodePluginRoot + "/plugin/" + platformMCPPluginName + ".ts"
+	if filePath == currentOpenCodePlugin {
+		return platformMCPOpenCodePluginRoot + "/plugin/" + platformMCPLegacyPluginName + ".ts"
+	}
+
+	currentOpenCodeIDPrefix := platformMCPOpenCodePluginRoot + "/" + platformMCPPluginName + "/"
+	legacyOpenCodeIDPrefix := platformMCPOpenCodePluginRoot + "/" + platformMCPLegacyPluginName + "/"
+	if rest, ok := strings.CutPrefix(filePath, currentOpenCodeIDPrefix); ok {
+		return legacyOpenCodeIDPrefix + rest
+	}
+	return filePath
+}
+
 func TestGeneratePlatformMCPPluginPackageDirectDownloadsShareDefinition(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -2690,11 +2690,10 @@ func platformMCPOnlyFingerprintChange(current, published map[string]string) bool
 	return maps.Equal(current, published)
 }
 
-// carryPlatformMCPSubtree preserves a complete currently-published Platform
-// package. B1 repositories contain Claude plus portable Agent Plugins; B2/B3
-// add Cursor, Codex, and OpenCode as one native-client set. During indeterminate
-// admission, preserving B1 is valid, but partial native sets are never copied or
-// advertised. The second result reports whether the complete B2/B3 set exists.
+// platformMCPFingerprintFromFiles hashes the Platform MCP files present in
+// files. It includes both the current Agent Plugin root and the identifier
+// still present in already-published repositories so a B1-only repair of
+// either layout records the bytes that were actually pushed.
 func platformMCPFingerprintFromFiles(files map[string][]byte) string {
 	platformRoots := []string{
 		platformMCPPluginRoot,
@@ -2702,6 +2701,7 @@ func platformMCPFingerprintFromFiles(files map[string][]byte) string {
 		platformMCPCodexPluginRoot,
 		platformMCPOpenCodePluginRoot,
 		platformMCPAgentPluginRoot,
+		platformMCPLegacyAgentPluginRoot,
 	}
 	platformFiles := make(map[string][]byte)
 	for filePath, content := range files {
@@ -2712,6 +2712,14 @@ func platformMCPFingerprintFromFiles(files map[string][]byte) string {
 	return hashFiles(platformMCPGeneratorVersion, platformFiles)
 }
 
+// carryPlatformMCPSubtree preserves a complete currently-published Platform
+// package. B1 repositories contain Claude plus portable Agent Plugins; B2/B3
+// add Cursor, Codex, and OpenCode as one native-client set. Carry accepts
+// either the current Agent Plugin/OpenCode identifier or the identifier still
+// present in already-published repositories, so an unavailable admission
+// decision cannot regenerate those bytes. During indeterminate admission,
+// preserving B1 is valid, but partial native sets are never copied or
+// advertised. The second result reports whether the complete B2/B3 set exists.
 func carryPlatformMCPSubtree(dst, existing map[string][]byte) (bool, bool) {
 	if len(existing) == 0 {
 		return false, false
@@ -2719,32 +2727,6 @@ func carryPlatformMCPSubtree(dst, existing map[string][]byte) (bool, bool) {
 	skills, err := loadPlatformMCPSkills()
 	if err != nil {
 		return false, false
-	}
-
-	b1Required := []string{
-		platformMCPPluginRoot + "/.claude-plugin/plugin.json",
-		platformMCPPluginRoot + "/.mcp.json",
-		platformMCPAgentPluginRoot + "/plugin.json",
-		platformMCPAgentPluginRoot + "/mcp.json",
-	}
-	nativeRequired := []string{
-		platformMCPCursorPluginRoot + "/.cursor-plugin/plugin.json",
-		platformMCPCursorPluginRoot + "/mcp.json",
-		platformMCPCodexPluginRoot + "/.codex-plugin/plugin.json",
-		platformMCPCodexPluginRoot + "/.mcp.json",
-		platformMCPOpenCodePluginRoot + "/plugin/" + platformMCPPluginName + ".ts",
-		platformMCPOpenCodePluginRoot + "/" + platformMCPPluginName + "/mcp.json",
-	}
-	for name := range skills {
-		b1Required = append(b1Required,
-			platformMCPPluginRoot+"/skills/"+name+"/SKILL.md",
-			platformMCPAgentPluginRoot+"/skills/"+name+"/SKILL.md",
-		)
-		nativeRequired = append(nativeRequired,
-			platformMCPCursorPluginRoot+"/skills/"+name+"/SKILL.md",
-			platformMCPCodexPluginRoot+"/skills/"+name+"/SKILL.md",
-			platformMCPOpenCodePluginRoot+"/"+platformMCPPluginName+"/skills/"+name+"/SKILL.md",
-		)
 	}
 
 	stageRoots := func(roots []string, required []string) (map[string][]byte, bool) {
@@ -2762,20 +2744,55 @@ func carryPlatformMCPSubtree(dst, existing map[string][]byte) (bool, bool) {
 		return staged, true
 	}
 
-	b1, ok := stageRoots([]string{platformMCPPluginRoot, platformMCPAgentPluginRoot}, b1Required)
-	if !ok {
-		return false, false
-	}
-	maps.Copy(dst, b1)
+	for _, layout := range []struct {
+		pluginName string
+		agentRoot  string
+	}{
+		{platformMCPPluginName, platformMCPAgentPluginRoot},
+		{platformMCPLegacyPluginName, platformMCPLegacyAgentPluginRoot},
+	} {
+		b1Required := []string{
+			platformMCPPluginRoot + "/.claude-plugin/plugin.json",
+			platformMCPPluginRoot + "/.mcp.json",
+			layout.agentRoot + "/plugin.json",
+			layout.agentRoot + "/mcp.json",
+		}
+		nativeRequired := []string{
+			platformMCPCursorPluginRoot + "/.cursor-plugin/plugin.json",
+			platformMCPCursorPluginRoot + "/mcp.json",
+			platformMCPCodexPluginRoot + "/.codex-plugin/plugin.json",
+			platformMCPCodexPluginRoot + "/.mcp.json",
+			platformMCPOpenCodePluginRoot + "/plugin/" + layout.pluginName + ".ts",
+			platformMCPOpenCodePluginRoot + "/" + layout.pluginName + "/mcp.json",
+		}
+		for name := range skills {
+			b1Required = append(b1Required,
+				platformMCPPluginRoot+"/skills/"+name+"/SKILL.md",
+				layout.agentRoot+"/skills/"+name+"/SKILL.md",
+			)
+			nativeRequired = append(nativeRequired,
+				platformMCPCursorPluginRoot+"/skills/"+name+"/SKILL.md",
+				platformMCPCodexPluginRoot+"/skills/"+name+"/SKILL.md",
+				platformMCPOpenCodePluginRoot+"/"+layout.pluginName+"/skills/"+name+"/SKILL.md",
+			)
+		}
 
-	native, nativeOK := stageRoots(
-		[]string{platformMCPCursorPluginRoot, platformMCPCodexPluginRoot, platformMCPOpenCodePluginRoot},
-		nativeRequired,
-	)
-	if nativeOK {
-		maps.Copy(dst, native)
+		b1, ok := stageRoots([]string{platformMCPPluginRoot, layout.agentRoot}, b1Required)
+		if !ok {
+			continue
+		}
+		maps.Copy(dst, b1)
+
+		native, nativeOK := stageRoots(
+			[]string{platformMCPCursorPluginRoot, platformMCPCodexPluginRoot, platformMCPOpenCodePluginRoot},
+			nativeRequired,
+		)
+		if nativeOK {
+			maps.Copy(dst, native)
+		}
+		return true, nativeOK
 	}
-	return true, nativeOK
+	return false, false
 }
 
 // carryHooksSubtree copies the published hooks (observability) subtree

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1388,7 +1388,7 @@ func (s *Service) DownloadPlatformMCPPlugin(ctx context.Context, payload *gen.Do
 		return nil, nil, oops.E(oops.CodeUnexpected, err, "build Platform MCP plugin zip").LogError(ctx, s.logger)
 	}
 
-	filename := fmt.Sprintf("speakeasy-aicp-platform-mcp-%s.zip", payload.Platform)
+	filename := platformMCPPackageFilename(payload.Platform)
 	return &gen.DownloadPlatformMCPPluginResult{
 		ContentType:        "application/zip",
 		ContentDisposition: fmt.Sprintf(`attachment; filename="%s"`, filename),
@@ -1627,8 +1627,8 @@ func (s *Service) platformMCPPackageStatusWithProject(ctx context.Context, ac *c
 		Admission:               "indeterminate",
 		Available:               false,
 		PackageName:             platformMCPPluginName,
-		ClaudeFilename:          "speakeasy-aicp-platform-mcp-claude.zip",
-		AgentPluginFilename:     "speakeasy-aicp-platform-mcp-agent-plugin.zip",
+		ClaudeFilename:          platformMCPPackageFilename("claude"),
+		AgentPluginFilename:     platformMCPPackageFilename("agent-plugin"),
 		CanonicalProjectSlug:    nil,
 		MarketplaceName:         nil,
 		MarketplaceConnected:    false,

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -2579,8 +2579,8 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 		"platform-mcp/.claude-plugin/plugin.json":                 mock.lastPushedFiles["platform-mcp/.claude-plugin/plugin.json"],
 		"platform-mcp/.mcp.json":                                  mock.lastPushedFiles["platform-mcp/.mcp.json"],
 		"platform-mcp/skills/add-mcp-from-catalog/SKILL.md":       mock.lastPushedFiles["platform-mcp/skills/add-mcp-from-catalog/SKILL.md"],
-		"agent-plugins/" + platformMCPPluginName + "/plugin.json": mock.lastPushedFiles["agent-plugins/"+platformMCPPluginName+"/plugin.json"],
-		"agent-plugins/" + platformMCPPluginName + "/mcp.json":    mock.lastPushedFiles["agent-plugins/"+platformMCPPluginName+"/mcp.json"],
+		"agent-plugins/platform-mcp/plugin.json": mock.lastPushedFiles["agent-plugins/platform-mcp/plugin.json"],
+		"agent-plugins/platform-mcp/mcp.json":    mock.lastPushedFiles["agent-plugins/platform-mcp/mcp.json"],
 	}
 
 	// An indeterminate result preserves the prior package and fingerprint. It
@@ -2625,7 +2625,7 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 	require.Contains(t, mock.lastPushedFiles, "platform-mcp/.mcp.json")
 	require.NotContains(t, mock.lastPushedFiles, "cursor-plugins/platform-mcp-cursor/.cursor-plugin/plugin.json")
 	require.NotContains(t, mock.lastPushedFiles, "platform-mcp-codex/.codex-plugin/plugin.json")
-	require.NotContains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/"+platformMCPPluginName+".ts")
+	require.NotContains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/platform-mcp.ts")
 
 	connection, err = pluginsrepo.New(ti.conn).GetGitHubConnection(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
@@ -2651,7 +2651,7 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 	require.True(t, mock.pushFilesCalled)
 	require.Contains(t, mock.lastPushedFiles, "cursor-plugins/platform-mcp-cursor/mcp.json")
 	require.Contains(t, mock.lastPushedFiles, "platform-mcp-codex/.mcp.json")
-	require.Contains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/"+platformMCPPluginName+".ts")
+	require.Contains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/platform-mcp.ts")
 
 	connection, err = pluginsrepo.New(ti.conn).GetGitHubConnection(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
@@ -2772,8 +2772,8 @@ func TestPluginsService_PlatformMCPPackageStatusAndDownloadBeforeConnection(t *t
 	require.Equal(t, "missing", status.Freshness)
 	require.True(t, status.RepairAllowed)
 	require.True(t, status.DirectDownloadAvailable)
-	require.Equal(t, platformMCPPackageFilename("claude"), status.ClaudeFilename)
-	require.Equal(t, platformMCPPackageFilename("agent-plugin"), status.AgentPluginFilename)
+	require.Equal(t, "platform-mcp-claude.zip", status.ClaudeFilename)
+	require.Equal(t, "platform-mcp-agent-plugin.zip", status.AgentPluginFilename)
 
 	// Repair intentionally bootstraps the canonical default-project marketplace
 	// when none exists, without requiring a prior Platform MCP connection.
@@ -2802,13 +2802,13 @@ func TestPluginsService_PlatformMCPPackageStatusAndDownloadBeforeConnection(t *t
 		"claude":       {".claude-plugin/plugin.json", ".mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
 		"cursor":       {".cursor-plugin/plugin.json", "mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
 		"codex":        {".codex-plugin/plugin.json", ".mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
-		"opencode":     {"plugin/" + platformMCPPluginName + ".ts", platformMCPPluginName + "/mcp.json", platformMCPPluginName + "/skills/add-mcp-from-catalog/SKILL.md"},
+		"opencode":     {"plugin/platform-mcp.ts", "platform-mcp/mcp.json", "platform-mcp/skills/add-mcp-from-catalog/SKILL.md"},
 		"agent-plugin": {"plugin.json", "mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
 	}
 	for platform, expectedFiles := range packageAssertions {
 		result, body, err := ti.service.DownloadPlatformMCPPlugin(ctx, &gen.DownloadPlatformMCPPluginPayload{Platform: platform})
 		require.NoError(t, err, platform)
-		require.Equal(t, fmt.Sprintf(`attachment; filename="%s"`, platformMCPPackageFilename(platform)), result.ContentDisposition)
+		require.Equal(t, fmt.Sprintf(`attachment; filename="platform-mcp-%s.zip"`, platform), result.ContentDisposition)
 		archive, err := io.ReadAll(body)
 		require.NoError(t, err, platform)
 		require.NoError(t, body.Close())

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -2576,11 +2576,11 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 	require.NoError(t, json.Unmarshal(connection.PublishedMcpFingerprints, &fingerprints))
 	require.Contains(t, fingerprints, "__platform_mcp__")
 	platformFilesBefore := map[string][]byte{
-		"platform-mcp/.claude-plugin/plugin.json":                 mock.lastPushedFiles["platform-mcp/.claude-plugin/plugin.json"],
-		"platform-mcp/.mcp.json":                                  mock.lastPushedFiles["platform-mcp/.mcp.json"],
-		"platform-mcp/skills/add-mcp-from-catalog/SKILL.md":       mock.lastPushedFiles["platform-mcp/skills/add-mcp-from-catalog/SKILL.md"],
-		"agent-plugins/platform-mcp/plugin.json": mock.lastPushedFiles["agent-plugins/platform-mcp/plugin.json"],
-		"agent-plugins/platform-mcp/mcp.json":    mock.lastPushedFiles["agent-plugins/platform-mcp/mcp.json"],
+		"platform-mcp/.claude-plugin/plugin.json":           mock.lastPushedFiles["platform-mcp/.claude-plugin/plugin.json"],
+		"platform-mcp/.mcp.json":                            mock.lastPushedFiles["platform-mcp/.mcp.json"],
+		"platform-mcp/skills/add-mcp-from-catalog/SKILL.md": mock.lastPushedFiles["platform-mcp/skills/add-mcp-from-catalog/SKILL.md"],
+		"agent-plugins/platform-mcp/plugin.json":            mock.lastPushedFiles["agent-plugins/platform-mcp/plugin.json"],
+		"agent-plugins/platform-mcp/mcp.json":               mock.lastPushedFiles["agent-plugins/platform-mcp/mcp.json"],
 	}
 
 	// An indeterminate result preserves the prior package and fingerprint. It

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -2576,11 +2576,11 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 	require.NoError(t, json.Unmarshal(connection.PublishedMcpFingerprints, &fingerprints))
 	require.Contains(t, fingerprints, "__platform_mcp__")
 	platformFilesBefore := map[string][]byte{
-		"platform-mcp/.claude-plugin/plugin.json":               mock.lastPushedFiles["platform-mcp/.claude-plugin/plugin.json"],
-		"platform-mcp/.mcp.json":                                mock.lastPushedFiles["platform-mcp/.mcp.json"],
-		"platform-mcp/skills/add-mcp-from-catalog/SKILL.md":     mock.lastPushedFiles["platform-mcp/skills/add-mcp-from-catalog/SKILL.md"],
-		"agent-plugins/speakeasy-aicp-platform-mcp/plugin.json": mock.lastPushedFiles["agent-plugins/speakeasy-aicp-platform-mcp/plugin.json"],
-		"agent-plugins/speakeasy-aicp-platform-mcp/mcp.json":    mock.lastPushedFiles["agent-plugins/speakeasy-aicp-platform-mcp/mcp.json"],
+		"platform-mcp/.claude-plugin/plugin.json":                 mock.lastPushedFiles["platform-mcp/.claude-plugin/plugin.json"],
+		"platform-mcp/.mcp.json":                                  mock.lastPushedFiles["platform-mcp/.mcp.json"],
+		"platform-mcp/skills/add-mcp-from-catalog/SKILL.md":       mock.lastPushedFiles["platform-mcp/skills/add-mcp-from-catalog/SKILL.md"],
+		"agent-plugins/" + platformMCPPluginName + "/plugin.json": mock.lastPushedFiles["agent-plugins/"+platformMCPPluginName+"/plugin.json"],
+		"agent-plugins/" + platformMCPPluginName + "/mcp.json":    mock.lastPushedFiles["agent-plugins/"+platformMCPPluginName+"/mcp.json"],
 	}
 
 	// An indeterminate result preserves the prior package and fingerprint. It
@@ -2625,7 +2625,7 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 	require.Contains(t, mock.lastPushedFiles, "platform-mcp/.mcp.json")
 	require.NotContains(t, mock.lastPushedFiles, "cursor-plugins/platform-mcp-cursor/.cursor-plugin/plugin.json")
 	require.NotContains(t, mock.lastPushedFiles, "platform-mcp-codex/.codex-plugin/plugin.json")
-	require.NotContains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/speakeasy-aicp-platform-mcp.ts")
+	require.NotContains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/"+platformMCPPluginName+".ts")
 
 	connection, err = pluginsrepo.New(ti.conn).GetGitHubConnection(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
@@ -2651,7 +2651,7 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 	require.True(t, mock.pushFilesCalled)
 	require.Contains(t, mock.lastPushedFiles, "cursor-plugins/platform-mcp-cursor/mcp.json")
 	require.Contains(t, mock.lastPushedFiles, "platform-mcp-codex/.mcp.json")
-	require.Contains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/speakeasy-aicp-platform-mcp.ts")
+	require.Contains(t, mock.lastPushedFiles, "opencode-plugins/platform-mcp/plugin/"+platformMCPPluginName+".ts")
 
 	connection, err = pluginsrepo.New(ti.conn).GetGitHubConnection(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
@@ -2772,8 +2772,8 @@ func TestPluginsService_PlatformMCPPackageStatusAndDownloadBeforeConnection(t *t
 	require.Equal(t, "missing", status.Freshness)
 	require.True(t, status.RepairAllowed)
 	require.True(t, status.DirectDownloadAvailable)
-	require.Equal(t, "speakeasy-aicp-platform-mcp-claude.zip", status.ClaudeFilename)
-	require.Equal(t, "speakeasy-aicp-platform-mcp-agent-plugin.zip", status.AgentPluginFilename)
+	require.Equal(t, platformMCPPackageFilename("claude"), status.ClaudeFilename)
+	require.Equal(t, platformMCPPackageFilename("agent-plugin"), status.AgentPluginFilename)
 
 	// Repair intentionally bootstraps the canonical default-project marketplace
 	// when none exists, without requiring a prior Platform MCP connection.
@@ -2802,13 +2802,13 @@ func TestPluginsService_PlatformMCPPackageStatusAndDownloadBeforeConnection(t *t
 		"claude":       {".claude-plugin/plugin.json", ".mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
 		"cursor":       {".cursor-plugin/plugin.json", "mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
 		"codex":        {".codex-plugin/plugin.json", ".mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
-		"opencode":     {"plugin/speakeasy-aicp-platform-mcp.ts", "speakeasy-aicp-platform-mcp/mcp.json", "speakeasy-aicp-platform-mcp/skills/add-mcp-from-catalog/SKILL.md"},
+		"opencode":     {"plugin/" + platformMCPPluginName + ".ts", platformMCPPluginName + "/mcp.json", platformMCPPluginName + "/skills/add-mcp-from-catalog/SKILL.md"},
 		"agent-plugin": {"plugin.json", "mcp.json", "skills/add-mcp-from-catalog/SKILL.md"},
 	}
 	for platform, expectedFiles := range packageAssertions {
 		result, body, err := ti.service.DownloadPlatformMCPPlugin(ctx, &gen.DownloadPlatformMCPPluginPayload{Platform: platform})
 		require.NoError(t, err, platform)
-		require.Equal(t, fmt.Sprintf(`attachment; filename="speakeasy-aicp-platform-mcp-%s.zip"`, platform), result.ContentDisposition)
+		require.Equal(t, fmt.Sprintf(`attachment; filename="%s"`, platformMCPPackageFilename(platform)), result.ContentDisposition)
 		archive, err := io.ReadAll(body)
 		require.NoError(t, err, platform)
 		require.NoError(t, body.Close())

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -2612,6 +2612,22 @@ func TestPluginsService_PublishProject_PlatformMCPAdmissionTransitions(t *testin
 		require.Equal(t, content, mock.lastPushedFiles[filePath], filePath)
 	}
 
+	// An already-published repository may still use the previously published
+	// Agent Plugin identifier. Indeterminate admission must carry that tree
+	// as-is and skip, not regenerate a new package.
+	legacyRepo := remapPublishedFilesToLegacyPlatformMCPLayout(mock.lastPushedFiles)
+	require.Contains(t, legacyRepo, "agent-plugins/speakeasy-aicp-platform-mcp/plugin.json")
+	require.NotContains(t, legacyRepo, "agent-plugins/platform-mcp/plugin.json")
+	mock.repoFiles = legacyRepo
+	mock.getRepoFilesCalled = false
+	mock.pushFilesCalled = false
+	result, err = publisher.PublishProject(ctx, input)
+	require.NoError(t, err)
+	require.True(t, result.Skipped)
+	require.True(t, mock.getRepoFilesCalled)
+	require.False(t, mock.pushFilesCalled)
+	mock.repoFiles = nil
+
 	// A current full B2/B3 fingerprint cannot hide a missing native package.
 	// Indeterminate admission repairs the repository to an internally consistent
 	// B1-only state, then confirmed admission restores the complete native set.
@@ -2967,6 +2983,34 @@ func hooksFilesOf(files map[string][]byte) map[string]string {
 		}
 	}
 	return out
+}
+
+// remapPublishedFilesToLegacyPlatformMCPLayout rewrites only the Agent Plugin
+// directory and the OpenCode identifier so a live repository that still uses
+// that published layout can be reconstructed in tests.
+func remapPublishedFilesToLegacyPlatformMCPLayout(files map[string][]byte) map[string][]byte {
+	legacy := make(map[string][]byte, len(files))
+	for filePath, content := range files {
+		legacy[remapPublishedPathToLegacyPlatformMCP(filePath)] = content
+	}
+	return legacy
+}
+
+func remapPublishedPathToLegacyPlatformMCP(filePath string) string {
+	const currentAgentPrefix = "agent-plugins/platform-mcp/"
+	const legacyAgentPrefix = "agent-plugins/speakeasy-aicp-platform-mcp/"
+	if rest, ok := strings.CutPrefix(filePath, currentAgentPrefix); ok {
+		return legacyAgentPrefix + rest
+	}
+	if filePath == "opencode-plugins/platform-mcp/plugin/platform-mcp.ts" {
+		return "opencode-plugins/platform-mcp/plugin/speakeasy-aicp-platform-mcp.ts"
+	}
+	const currentOpenCodeIDPrefix = "opencode-plugins/platform-mcp/platform-mcp/"
+	const legacyOpenCodeIDPrefix = "opencode-plugins/platform-mcp/speakeasy-aicp-platform-mcp/"
+	if rest, ok := strings.CutPrefix(filePath, currentOpenCodeIDPrefix); ok {
+		return legacyOpenCodeIDPrefix + rest
+	}
+	return filePath
 }
 
 func filesWithPrefix(files map[string][]byte, prefix string) map[string]string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [GRW-9](https://linear.app/speakeasy/issue/GRW-9/feat-rename-platform-mcp-plugin-for-customer-organizations).

The published plugin identifier is now `platform-mcp` instead of `speakeasy-aicp-platform-mcp`. Harness install commands become `platform-mcp@<marketplace>` — for Speakeasy that is `platform-mcp@speakeasy-speakeasy`, and for other orgs the existing `speakeasy-<company>` marketplace suffix is unchanged.

## Changes

- Generator and marketplace manifests emit `platform-mcp` with display name **Platform MCP**
- Direct-download zip names, OpenCode/Agent Plugin paths, and MCP server implementation name follow the new identifier
- Setup-flow install walkthrough, Plugins page downloads, and OAuth consent copy use the updated name
- Indeterminate Platform MCP admission still carries the previously published Agent Plugin and OpenCode identifier so an unavailable admission decision cannot regenerate a live package; confirmed admission migrates to `platform-mcp`

Marketplace names are not changed. Cursor (`platform-mcp-cursor`) and Codex (`platform-mcp-codex`) package slugs were already without the `aicp` prefix.

## Testing

- `mise run test:server ./internal/plugins/ -run 'TestGeneratePluginPackagesIncludesPlatformMCP|TestGeneratePlatformMCPPluginPackageDirectDownloads|TestCarryPlatformMCPSubtree|TestPluginsService_PlatformMCP|TestPluginsService_PublishProject_PlatformMCP|TestMCPFingerprintsIsolatesPlatformMCP'`
- `mise run test:server ./internal/platformmcp/ -run 'TestOAuthHTTPSelectsOrganizationAfterIDPCallback|TestOAuthHTTPProviderSetupCompletionDoesNotExposeState|TestOAuthHTTPCompletesChallengeStateHandoff'`
- `mise run test:server ./internal/platformmcp/localfixture/ -run 'TestOAuthHTTPPublishesSyntheticMetadataAndRegistersOnlyReviewedClient|TestOAuthHTTPRestoresValidatedPersistedClient'`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-9](https://linear.app/speakeasy/issue/GRW-9/feat-rename-platform-mcp-plugin-for-customer-organizations)

<div><a href="https://cursor.com/agents/bc-db1eeb0b-1c17-4130-875a-8c5dbfa10085?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db1eeb0b-1c17-4130-875a-8c5dbfa10085&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the published Platform MCP plugin from `speakeasy-aicp-platform-mcp` to `platform-mcp` and removes “AICP” from user-facing copy to standardize installs and artifacts. Carry now preserves already-published repositories that still use the legacy identifier during indeterminate admission; confirmed admission migrates to `platform-mcp`. Implements GRW-9.

- Install and artifacts: use `/plugin install platform-mcp@<marketplace>`; direct-download zips are `platform-mcp-<platform>.zip`. Required: update any scripts, CI, or docs that referenced the old identifier or filenames. Cursor/Codex slugs remain `platform-mcp-cursor` and `platform-mcp-codex`.
- Config and paths: use `platform-mcp` keys and paths (e.g., `[mcp_servers.platform-mcp]`, `agent-plugins/platform-mcp/...`, `opencode-plugins/platform-mcp/plugin/platform-mcp.ts`). Required: rename any existing configs and file paths using the old value.
- Publishing/carry: carry recognizes legacy `speakeasy-aicp-platform-mcp` Agent Plugin and OpenCode identifiers in already-published repos and preserves them during indeterminate admission; confirmed admission migrates to the new identifier. No action needed until you confirm.
- Server identifiers: MCP server is `platform-mcp`; readiness client is `platform-mcp-readiness`.
- Copy/README/tests: OAuth and UI say “Platform MCP”; README references `platform-mcp`; tests assert new names and no “AICP”.

<sup>Written for commit 332deb38890d9964bc6f4bba42007fd335ff6533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

