### PR TITLE
chore: puts back risk events

### DIFF
--- a/.changeset/risk-events-nav.md
+++ b/.changeset/risk-events-nav.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The Risk Events page is back in the Secure navigation, directly below Watchdog (previously it was hidden whenever Watchdog was enabled).

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -208,8 +208,9 @@ export function AppSidebar({
             label="Secure"
             Icon={(p) => <Icon {...p} name="shield" />}
             items={[
-              // Watchdog supersedes Risk Overview and Risk Events: exactly one
-              // of the two sets shows, mirroring useProjectNavRoutes.
+              // Watchdog supersedes Risk Overview: exactly one of the two
+              // shows, mirroring useProjectNavRoutes. Risk Events sits below
+              // the landing surface in both modes.
               ...(isRiskWatchdogEnabled
                 ? [{ item: routes.watchdog, ...accessFor(routes.watchdog) }]
                 : [
@@ -218,15 +219,8 @@ export function AppSidebar({
                       ...accessFor(routes.riskOverview),
                     },
                   ]),
+              { item: routes.riskEvents, ...accessFor(routes.riskEvents) },
               { item: routes.policyCenter, ...accessFor(routes.policyCenter) },
-              ...(isRiskWatchdogEnabled
-                ? []
-                : [
-                    {
-                      item: routes.riskEvents,
-                      ...accessFor(routes.riskEvents),
-                    },
-                  ]),
               { item: routes.shadowMCP, ...accessFor(routes.shadowMCP) },
             ]}
           />

--- a/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
@@ -154,8 +154,9 @@ describe("useProjectNavRoutes", () => {
     expect(navRoutes).toContain(routes.assistants);
     expect(navRoutes).toContain(routes.watchdog);
     expect(navRoutes).not.toContain(routes.deployments);
-    // Watchdog supersedes the legacy risk pages in the nav.
+    // Watchdog supersedes the legacy overview in the nav; Risk Events shows
+    // in both modes.
     expect(navRoutes).not.toContain(routes.riskOverview);
-    expect(navRoutes).not.toContain(routes.riskEvents);
+    expect(navRoutes).toContain(routes.riskEvents);
   });
 });

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -89,16 +89,15 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
         ? [{ route: routes.orgMemory, scope: observe }]
         : []),
       { route: routes.logs, scope: observe },
-      // Watchdog supersedes the Risk Overview and Risk Events pages: with the
-      // flag on, it is the Secure section's landing surface and the two
-      // legacy nav items hide (their routes stay reachable by direct URL).
+      // Watchdog supersedes the Risk Overview page: with the flag on, it is
+      // the Secure section's landing surface and the legacy overview nav item
+      // hides (its route stays reachable by direct URL). Risk Events shows in
+      // both modes, directly below the landing surface.
       ...(isRiskWatchdogEnabled
         ? [{ route: routes.watchdog, scope: read }]
         : [{ route: routes.riskOverview, scope: read }]),
+      { route: routes.riskEvents, scope: ["org:admin"] as Scope[] },
       { route: routes.policyCenter, scope: readWrite },
-      ...(isRiskWatchdogEnabled
-        ? []
-        : [{ route: routes.riskEvents, scope: ["org:admin"] as Scope[] }]),
       { route: routes.shadowMCP, scope: readWrite },
       { route: routes.settings, scope: ["project:write"] },
     ];

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -414,11 +414,11 @@ export default function RiskEvents(): JSX.Element {
               selectedCount={selection.selectedCount}
               actions={[
                 {
-                  label: "Mark as false positive",
+                  label: "Suppress Once",
                   onClick: handleDismissSelected,
                 },
                 {
-                  label: "Set up exclusion rule",
+                  label: "Create Rule",
                   onClick: handleSetupExclusionSelected,
                 },
               ]}
@@ -690,8 +690,8 @@ function RiskEventsRow({
     ...(result.chatId
       ? [{ label: "Copy link", onClick: () => void handleShare() }]
       : []),
-    { label: "Mark as false positive", onClick: () => onDismiss(result) },
-    { label: "Set up exclusion rule", onClick: () => onSetupExclusion(result) },
+    { label: "Suppress Once", onClick: () => onDismiss(result) },
+    { label: "Create Rule", onClick: () => onSetupExclusion(result) },
   ];
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores Risk Events to the Secure navigation and updates action labels on the page. Previously, Risk Events was hidden when Watchdog was enabled; now it always shows directly below the Secure landing surface (Watchdog or Risk Overview).

- Secure nav logic: Watchdog still supersedes Risk Overview as the landing surface; Risk Events now shows in both modes.
- Access: Risk Events remains gated to `["org:admin"]`; the route stays directly reachable by URL.
- UI copy changes on Risk Events: “Mark as false positive” → “Suppress Once”; “Set up exclusion rule” → “Create Rule”.
- Sidebar and `useProjectNavRoutes` updated to keep nav and routing in sync; tests adjusted to expect Risk Events in both modes.
- Changeset added for a `dashboard` patch release.

<sup>Written for commit 8c37876195cc49162f6996bf86971a4810289390. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

