### PR TITLE
fix: preserve OTEL forwarding header values

### DIFF
--- a/.changeset/preserve-otel-forwarding-headers.md
+++ b/.changeset/preserve-otel-forwarding-headers.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+OTEL forwarding updates now preserve encrypted values for unchanged headers while still treating the submitted header list as the complete desired set. Adding or removing one header no longer clears the values of retained headers.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -70242,11 +70242,10 @@ components:
           description: Header name.
         value:
           type: string
-          description: Header value. Stored encrypted at rest; never returned on reads.
-      description: HTTP header value provided when upserting a forwarding config.
+          description: Header value. Omit to preserve an existing value; provide to create, replace, or clear it. Stored encrypted at rest and never returned on reads.
+      description: HTTP header provided when upserting a forwarding config. Omit the value to preserve the existing encrypted value for the same name.
       required:
         - name
-        - value
     Package:
       type: object
       properties:
@@ -81324,7 +81323,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OtelForwardingHeaderInput'
-          description: Full set of headers to attach. Replaces any existing headers.
+          description: Complete desired header set. Omitted entries are removed; entries with an omitted value preserve the existing encrypted value for the same name.
       required:
         - endpoint_url
         - enabled

--- a/client/dashboard/src/components/ui/Switch/index.tsx
+++ b/client/dashboard/src/components/ui/Switch/index.tsx
@@ -21,6 +21,7 @@ export function Switch({
 }: SwitchProps): JSX.Element {
   return (
     <button
+      type="button"
       onClick={() => onCheckedChange(!checked)}
       disabled={disabled}
       aria-label={ariaLabel}

--- a/client/dashboard/src/pages/org/OtelForwardingSection.test.tsx
+++ b/client/dashboard/src/pages/org/OtelForwardingSection.test.tsx
@@ -18,6 +18,7 @@ const testState = vi.hoisted(() => ({
     endpointUrl: "https://collector.example.com",
     headers: [] as Array<{ name: string; hasValue: boolean }>,
   },
+  returnData: true,
   upsert: vi.fn(),
   deleteConfig: vi.fn(),
 }));
@@ -29,8 +30,8 @@ vi.mock("@/components/require-scope", () => ({
 vi.mock("@gram/client/react-query/otelForwardingConfig", () => ({
   invalidateAllOtelForwardingConfig: vi.fn(),
   useOtelForwardingConfig: () => ({
-    data: testState.data,
-    isLoading: false,
+    data: testState.returnData ? testState.data : undefined,
+    isLoading: !testState.returnData,
   }),
 }));
 
@@ -63,6 +64,7 @@ beforeEach(() => {
     endpointUrl: "https://collector.example.com",
     headers: [],
   };
+  testState.returnData = true;
   testState.upsert.mockReset();
   testState.deleteConfig.mockReset();
   testState.upsert.mockImplementation(async () => testState.data);
@@ -72,6 +74,57 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("OtelForwardingSection", () => {
+  it("hydrates untouched defaults when the query resolves", () => {
+    testState.data.headers = [{ name: "Authorization", hasValue: true }];
+    testState.returnData = false;
+    const { rerender } = render(<OtelForwardingSection />);
+
+    expect(
+      (screen.getByLabelText("Endpoint URL") as HTMLInputElement).value,
+    ).toBe("");
+
+    testState.returnData = true;
+    rerender(<OtelForwardingSection />);
+
+    expect(
+      (screen.getByLabelText("Endpoint URL") as HTMLInputElement).value,
+    ).toBe(testState.data.endpointUrl);
+    expect(screen.getByPlaceholderText("••••")).not.toBeNull();
+  });
+
+  it("requires a replacement value when a stored header is renamed", async () => {
+    testState.data.headers = [{ name: "foo", hasValue: true }];
+    render(<OtelForwardingSection />);
+
+    fireEvent.change(screen.getByPlaceholderText("Header name"), {
+      target: { value: "renamed" },
+    });
+
+    const saveButton = screen.getByRole("button", {
+      name: "Save",
+    }) as HTMLButtonElement;
+    expect(screen.getByPlaceholderText("Header value")).not.toBeNull();
+    expect(saveButton.disabled).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Header value"), {
+      target: { value: "replacement" },
+    });
+    await waitFor(() => expect(saveButton.disabled).toBe(false));
+    fireEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(testState.upsert).toHaveBeenCalledWith({
+        request: {
+          upsertConfigRequestBody3: {
+            endpointUrl: testState.data.endpointUrl,
+            enabled: testState.data.enabled,
+            headers: [{ name: "renamed", value: "replacement" }],
+          },
+        },
+      }),
+    );
+  });
+
   it("preserves unsaved headers across a background config refresh", () => {
     const { rerender } = render(<OtelForwardingSection />);
 

--- a/client/dashboard/src/pages/org/OtelForwardingSection.test.tsx
+++ b/client/dashboard/src/pages/org/OtelForwardingSection.test.tsx
@@ -1,0 +1,198 @@
+import type * as ReactQuery from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  data: {
+    id: "config-id",
+    organizationId: "org-id",
+    enabled: true,
+    endpointUrl: "https://collector.example.com",
+    headers: [] as Array<{ name: string; hasValue: boolean }>,
+  },
+  upsert: vi.fn(),
+  deleteConfig: vi.fn(),
+}));
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@gram/client/react-query/otelForwardingConfig", () => ({
+  invalidateAllOtelForwardingConfig: vi.fn(),
+  useOtelForwardingConfig: () => ({
+    data: testState.data,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/upsertOtelForwardingConfig", () => ({
+  useUpsertOtelForwardingConfigMutation: () => ({
+    mutateAsync: testState.upsert,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/deleteOtelForwardingConfig", () => ({
+  useDeleteOtelForwardingConfigMutation: () => ({
+    mutateAsync: testState.deleteConfig,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactQuery>()),
+  useQueryClient: () => ({}),
+}));
+
+import { OtelForwardingSection } from "./OtelForwardingSection";
+
+beforeEach(() => {
+  testState.data = {
+    id: "config-id",
+    organizationId: "org-id",
+    enabled: true,
+    endpointUrl: "https://collector.example.com",
+    headers: [],
+  };
+  testState.upsert.mockReset();
+  testState.deleteConfig.mockReset();
+  testState.upsert.mockImplementation(async () => testState.data);
+  testState.deleteConfig.mockResolvedValue(undefined);
+});
+
+afterEach(cleanup);
+
+describe("OtelForwardingSection", () => {
+  it("preserves unsaved headers across a background config refresh", () => {
+    const { rerender } = render(<OtelForwardingSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add header" }));
+    fireEvent.change(screen.getAllByPlaceholderText("Header name")[0]!, {
+      target: { value: "Authorization" },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText("Header value")[0]!, {
+      target: { value: "Bearer first" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add header" }));
+    fireEvent.change(screen.getAllByPlaceholderText("Header name")[1]!, {
+      target: { value: "X-Tenant" },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText("Header value")[1]!, {
+      target: { value: "second" },
+    });
+
+    testState.data = { ...testState.data, headers: [] };
+    rerender(<OtelForwardingSection />);
+
+    expect(screen.getAllByPlaceholderText("Header name")).toHaveLength(2);
+    expect(
+      (screen.getAllByPlaceholderText("Header name")[0] as HTMLInputElement)
+        .value,
+    ).toBe("Authorization");
+    expect(
+      (screen.getAllByPlaceholderText("Header value")[0] as HTMLInputElement)
+        .value,
+    ).toBe("Bearer first");
+    expect(
+      (screen.getAllByPlaceholderText("Header name")[1] as HTMLInputElement)
+        .value,
+    ).toBe("X-Tenant");
+    expect(
+      (screen.getAllByPlaceholderText("Header value")[1] as HTMLInputElement)
+        .value,
+    ).toBe("second");
+  });
+
+  it("shows four bullets for a stored header value", () => {
+    testState.data.headers = [{ name: "Authorization", hasValue: true }];
+
+    render(<OtelForwardingSection />);
+
+    const valueInput = screen.getByPlaceholderText("••••") as HTMLInputElement;
+    expect(valueInput.value).toBe("");
+  });
+
+  it("uses native form submission and explicit button types", () => {
+    const { container } = render(<OtelForwardingSection />);
+
+    const formElement = container.querySelector("form");
+    expect(formElement).not.toBeNull();
+    expect(
+      (screen.getByRole("button", { name: "Save" }) as HTMLButtonElement).type,
+    ).toBe("submit");
+    expect(
+      (screen.getByRole("button", { name: "Add header" }) as HTMLButtonElement)
+        .type,
+    ).toBe("button");
+    expect(
+      (screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement)
+        .type,
+    ).toBe("button");
+    expect((screen.getByRole("switch") as HTMLButtonElement).type).toBe(
+      "button",
+    );
+    expect(
+      (screen.getByLabelText("Endpoint URL") as HTMLInputElement).value,
+    ).toBe(testState.data.endpointUrl);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add header" }));
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Remove header row",
+        }) as HTMLButtonElement
+      ).type,
+    ).toBe("button");
+  });
+
+  it("preserves a stored header while adding and saving another", async () => {
+    testState.data.headers = [{ name: "foo", hasValue: true }];
+    const upsert = Promise.withResolvers<typeof testState.data>();
+    testState.upsert.mockReturnValue(upsert.promise);
+    render(<OtelForwardingSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add header" }));
+    fireEvent.change(screen.getAllByPlaceholderText("Header name")[1]!, {
+      target: { value: "another" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Header value"), {
+      target: { value: "happy days" },
+    });
+
+    const saveButton = screen.getByRole("button", {
+      name: "Save",
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(saveButton.disabled).toBe(false));
+    fireEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(testState.upsert).toHaveBeenCalledWith({
+        request: {
+          upsertConfigRequestBody3: {
+            endpointUrl: testState.data.endpointUrl,
+            enabled: testState.data.enabled,
+            headers: [
+              { name: "foo" },
+              { name: "another", value: "happy days" },
+            ],
+          },
+        },
+      }),
+    );
+    await waitFor(() => expect(saveButton.disabled).toBe(true));
+
+    await act(async () => {
+      upsert.resolve(testState.data);
+    });
+  });
+});

--- a/client/dashboard/src/pages/org/OtelForwardingSection.tsx
+++ b/client/dashboard/src/pages/org/OtelForwardingSection.tsx
@@ -11,11 +11,14 @@ import {
 } from "@gram/client/react-query/otelForwardingConfig";
 import { useUpsertOtelForwardingConfigMutation } from "@gram/client/react-query/upsertOtelForwardingConfig";
 import { useDeleteOtelForwardingConfigMutation } from "@gram/client/react-query/deleteOtelForwardingConfig";
+import type { OtelForwardingConfig } from "@gram/client/models/components/otelforwardingconfig.js";
+import type { OtelForwardingHeaderInput } from "@gram/client/models/components/otelforwardingheaderinput.js";
 import type { OtelForwardingHeader } from "@gram/client/models/components/otelforwardingheader.js";
 import { Stack } from "@/components/ui/Stack";
 import { useQueryClient } from "@tanstack/react-query";
+import { useForm } from "@tanstack/react-form";
 import { Plus, Send, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { toast } from "sonner";
 
 type EditableHeader = {
@@ -50,87 +53,91 @@ function blankRow(): EditableHeader {
   };
 }
 
+type OtelForwardingFormValues = {
+  enabled: boolean;
+  endpointUrl: string;
+  headers: EditableHeader[];
+};
+
+function formValuesFromConfig(
+  config: OtelForwardingConfig | undefined,
+): OtelForwardingFormValues {
+  return {
+    enabled: config?.enabled ?? false,
+    endpointUrl: config?.endpointUrl ?? "",
+    headers: config?.headers.map(rowFromServer) ?? [],
+  };
+}
+
+function hasValidHeaders(headers: EditableHeader[]): boolean {
+  return headers.every((header) => {
+    if (header.name.trim() === "") return false;
+    return header.value !== "" || header.hasStoredValue;
+  });
+}
+
+function headerInputFromForm(
+  header: EditableHeader,
+): OtelForwardingHeaderInput {
+  const name = header.name.trim();
+  if (header.hasStoredValue && header.value === "") return { name };
+  return { name, value: header.value };
+}
+
 export function OtelForwardingSection(): JSX.Element {
   const { data, isLoading } = useOtelForwardingConfig();
   const queryClient = useQueryClient();
-  const { mutate: upsert, status: upsertStatus } =
-    useUpsertOtelForwardingConfigMutation({
-      onSuccess: () => {
-        toast.success("Forwarding config saved");
-        void invalidateAllOtelForwardingConfig(queryClient);
-      },
-      onError: (err) => {
-        toast.error(`Failed to save forwarding config: ${err.message}`);
-      },
-    });
-  const { mutate: deleteConfig, status: deleteStatus } =
-    useDeleteOtelForwardingConfigMutation({
-      onSuccess: () => {
-        toast.success("Forwarding config deleted");
-        void invalidateAllOtelForwardingConfig(queryClient);
-      },
-      onError: (err) => {
-        toast.error(`Failed to delete forwarding config: ${err.message}`);
-      },
-    });
-
-  const [enabled, setEnabled] = useState(false);
-  const [url, setUrl] = useState("");
-  const [headers, setHeaders] = useState<EditableHeader[]>([]);
+  const defaultValues = useMemo(() => formValuesFromConfig(data), [data]);
+  const upsertMutation = useUpsertOtelForwardingConfigMutation({
+    onSuccess: async () => {
+      toast.success("Forwarding config saved");
+      await invalidateAllOtelForwardingConfig(queryClient);
+    },
+    onError: (err) => {
+      toast.error(`Failed to save forwarding config: ${err.message}`);
+    },
+  });
+  const deleteMutation = useDeleteOtelForwardingConfigMutation({
+    onSuccess: async () => {
+      toast.success("Forwarding config deleted");
+      await invalidateAllOtelForwardingConfig(queryClient);
+    },
+    onError: (err) => {
+      toast.error(`Failed to delete forwarding config: ${err.message}`);
+    },
+  });
+  const form = useForm({
+    defaultValues,
+    onSubmit: async ({ value }) => {
+      try {
+        const saved = await upsertMutation.mutateAsync({
+          request: {
+            upsertConfigRequestBody3: {
+              endpointUrl: value.endpointUrl.trim(),
+              enabled: value.enabled,
+              headers: value.headers.map(headerInputFromForm),
+            },
+          },
+        });
+        form.reset(formValuesFromConfig(saved));
+      } catch {
+        return;
+      }
+    },
+  });
 
   const isConfigured = Boolean(data?.id);
+  const isMutating = upsertMutation.isPending || deleteMutation.isPending;
 
-  // Pull server values into the form on first load and whenever the server
-  // copy changes (e.g. after another tab edits the config).
-  useEffect(() => {
-    if (!data) return;
-    setEnabled(data.enabled);
-    setUrl(data.endpointUrl);
-    setHeaders(data.headers.map(rowFromServer));
-  }, [data]);
-
-  const isMutating = upsertStatus === "pending" || deleteStatus === "pending";
-
-  const trimmedUrl = url.trim();
-  const hasValidHeaders = useMemo(
-    () =>
-      headers.every((h) => {
-        const name = h.name.trim();
-        if (name === "") return false;
-        // Allow keeping an existing value (hasStoredValue + empty input).
-        if (h.value === "" && !h.hasStoredValue) return false;
-        return true;
-      }),
-    [headers],
-  );
-  const canSave = trimmedUrl !== "" && hasValidHeaders && !isMutating;
-
-  const handleSave = () => {
-    upsert({
-      request: {
-        upsertConfigRequestBody3: {
-          endpointUrl: trimmedUrl,
-          enabled,
-          headers: headers
-            .filter((h) => h.name.trim() !== "")
-            .map((h) => ({
-              name: h.name.trim(),
-              // Server treats empty + previously-stored as a no-op: it will
-              // re-encrypt the existing value. Sending the new value when
-              // the user typed one in.
-              value: h.value,
-            })),
-        },
-      },
-    });
-  };
-
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!isConfigured) return;
-    deleteConfig({ request: {} });
-    setEnabled(false);
-    setUrl("");
-    setHeaders([]);
+
+    try {
+      await deleteMutation.mutateAsync({ request: {} });
+      form.reset(formValuesFromConfig(undefined));
+    } catch {
+      return;
+    }
   };
 
   return (
@@ -146,148 +153,239 @@ export function OtelForwardingSection(): JSX.Element {
         </Text>
       </div>
 
-      <div className="border-border bg-card flex flex-col gap-4 border p-4">
-        <Stack direction="horizontal" justify="space-between" align="center">
-          <Stack gap={1}>
-            <Stack direction="horizontal" align="center" gap={2}>
-              <Send className="text-muted-foreground h-4 w-4" />
-              <Text variant="body" className="font-medium">
-                Enable forwarding
-              </Text>
-            </Stack>
-            <Text variant="body" className="text-muted-foreground ml-6 text-sm">
-              Send each inbound OTEL payload to the endpoint below.
-            </Text>
-          </Stack>
-          <RequireScope scope="org:admin" level="component">
-            <Switch
-              checked={enabled}
-              onCheckedChange={setEnabled}
-              disabled={isLoading || isMutating}
-              aria-label="Enable OTEL forwarding"
-            />
-          </RequireScope>
-        </Stack>
+      <form
+        className="border-border bg-card flex flex-col gap-4 border p-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void form.handleSubmit();
+        }}
+      >
+        <form.Subscribe
+          selector={(state) => [state.values, state.isSubmitting] as const}
+        >
+          {([values, isSubmitting]) => {
+            const formDisabled = isLoading || isMutating || isSubmitting;
+            const canSave =
+              values.endpointUrl.trim() !== "" &&
+              hasValidHeaders(values.headers) &&
+              !formDisabled;
 
-        <div className="border-border border-t" />
+            return (
+              <fieldset disabled={formDisabled} className="contents">
+                <Stack
+                  direction="horizontal"
+                  justify="space-between"
+                  align="center"
+                >
+                  <Stack gap={1}>
+                    <Stack direction="horizontal" align="center" gap={2}>
+                      <Send className="text-muted-foreground h-4 w-4" />
+                      <Text variant="body" className="font-medium">
+                        Enable forwarding
+                      </Text>
+                    </Stack>
+                    <Text
+                      variant="body"
+                      className="text-muted-foreground ml-6 text-sm"
+                    >
+                      Send each inbound OTEL payload to the endpoint below.
+                    </Text>
+                  </Stack>
+                  <RequireScope scope="org:admin" level="component">
+                    <form.Field name="enabled">
+                      {(field) => (
+                        <Switch
+                          checked={field.state.value}
+                          onCheckedChange={field.handleChange}
+                          disabled={formDisabled}
+                          aria-label="Enable OTEL forwarding"
+                        />
+                      )}
+                    </form.Field>
+                  </RequireScope>
+                </Stack>
 
-        <Stack gap={2}>
-          <Label htmlFor="otel-forwarding-url">Endpoint URL</Label>
-          <Input
-            id="otel-forwarding-url"
-            placeholder="https://collector.example.com"
-            value={url}
-            onChange={setUrl}
-            disabled={isLoading || isMutating}
-          />
-        </Stack>
+                <div className="border-border border-t" />
 
-        <div className="border-border border-t" />
+                <form.Field name="endpointUrl">
+                  {(field) => (
+                    <Stack gap={2}>
+                      <Label htmlFor={field.name}>Endpoint URL</Label>
+                      <Input
+                        id={field.name}
+                        name={field.name}
+                        placeholder="https://collector.example.com"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onBlur={field.handleBlur}
+                        disabled={formDisabled}
+                      />
+                    </Stack>
+                  )}
+                </form.Field>
 
-        <Stack gap={2}>
-          <Stack direction="horizontal" justify="space-between" align="center">
-            <Label>Headers</Label>
-            <RequireScope scope="org:admin" level="component">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setHeaders((prev) => [...prev, blankRow()])}
-                disabled={isLoading || isMutating}
-              >
-                <Plus className="mr-1 h-3.5 w-3.5" />
-                Add header
-              </Button>
-            </RequireScope>
-          </Stack>
+                <div className="border-border border-t" />
 
-          {headers.length === 0 ? (
-            <Text variant="body" className="text-muted-foreground text-sm">
-              No headers. Add any required authorization headers (e.g.
-              <code className="bg-muted ml-1 px-1">Authorization</code>
-              ).
-            </Text>
-          ) : (
-            <Stack gap={2}>
-              {headers.map((header, idx) => (
-                <HeaderRow
-                  key={header.rowID}
-                  header={header}
-                  disabled={isLoading || isMutating}
-                  onChange={(next) =>
-                    setHeaders((prev) => {
-                      const copy = prev.slice();
-                      copy[idx] = next;
-                      return copy;
-                    })
-                  }
-                  onRemove={() =>
-                    setHeaders((prev) => prev.filter((_, i) => i !== idx))
-                  }
-                />
-              ))}
-            </Stack>
-          )}
-        </Stack>
+                <form.Field name="headers" mode="array">
+                  {(headersField) => (
+                    <Stack gap={2}>
+                      <Stack
+                        direction="horizontal"
+                        justify="space-between"
+                        align="center"
+                      >
+                        <Label>Headers</Label>
+                        <RequireScope scope="org:admin" level="component">
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => headersField.pushValue(blankRow())}
+                            disabled={formDisabled}
+                          >
+                            <Plus className="mr-1 h-3.5 w-3.5" />
+                            Add header
+                          </Button>
+                        </RequireScope>
+                      </Stack>
 
-        <div className="border-border border-t" />
+                      {headersField.state.value.length === 0 ? (
+                        <Text
+                          variant="body"
+                          className="text-muted-foreground text-sm"
+                        >
+                          No headers. Add any required authorization headers
+                          (e.g.
+                          <code className="bg-muted ml-1 px-1">
+                            Authorization
+                          </code>
+                          ).
+                        </Text>
+                      ) : (
+                        <Stack gap={2}>
+                          {headersField.state.value.map((header, idx) => (
+                            <form.Field
+                              key={header.rowID}
+                              name={`headers[${idx}].name` as const}
+                            >
+                              {(nameField) => (
+                                <form.Field
+                                  name={`headers[${idx}].value` as const}
+                                >
+                                  {(valueField) => (
+                                    <HeaderRow
+                                      name={nameField.state.value}
+                                      value={valueField.state.value}
+                                      hasStoredValue={header.hasStoredValue}
+                                      nameInputName={nameField.name}
+                                      valueInputName={valueField.name}
+                                      disabled={formDisabled}
+                                      onNameChange={nameField.handleChange}
+                                      onNameBlur={nameField.handleBlur}
+                                      onValueChange={valueField.handleChange}
+                                      onValueBlur={valueField.handleBlur}
+                                      onRemove={() =>
+                                        headersField.removeValue(idx)
+                                      }
+                                    />
+                                  )}
+                                </form.Field>
+                              )}
+                            </form.Field>
+                          ))}
+                        </Stack>
+                      )}
+                    </Stack>
+                  )}
+                </form.Field>
 
-        <Stack direction="horizontal" justify="space-between" align="center">
-          <RequireScope scope="org:admin" level="component">
-            <Button
-              variant="destructive-secondary"
-              size="sm"
-              onClick={handleDelete}
-              disabled={!isConfigured || isMutating}
-            >
-              <Trash2 className="mr-1 h-3.5 w-3.5" />
-              Delete
-            </Button>
-          </RequireScope>
-          <RequireScope scope="org:admin" level="component">
-            <Button onClick={handleSave} disabled={!canSave}>
-              Save
-            </Button>
-          </RequireScope>
-        </Stack>
-      </div>
+                <div className="border-border border-t" />
+
+                <Stack
+                  direction="horizontal"
+                  justify="space-between"
+                  align="center"
+                >
+                  <RequireScope scope="org:admin" level="component">
+                    <Button
+                      type="button"
+                      variant="destructive-secondary"
+                      size="sm"
+                      onClick={() => void handleDelete()}
+                      disabled={!isConfigured || formDisabled}
+                    >
+                      <Trash2 className="mr-1 h-3.5 w-3.5" />
+                      Delete
+                    </Button>
+                  </RequireScope>
+                  <RequireScope scope="org:admin" level="component">
+                    <Button type="submit" disabled={!canSave}>
+                      Save
+                    </Button>
+                  </RequireScope>
+                </Stack>
+              </fieldset>
+            );
+          }}
+        </form.Subscribe>
+      </form>
     </Stack>
   );
 }
 
 function HeaderRow({
-  header,
+  name,
+  value,
+  hasStoredValue,
+  nameInputName,
+  valueInputName,
   disabled,
-  onChange,
+  onNameChange,
+  onNameBlur,
+  onValueChange,
+  onValueBlur,
   onRemove,
 }: {
-  header: EditableHeader;
+  name: string;
+  value: string;
+  hasStoredValue: boolean;
+  nameInputName: string;
+  valueInputName: string;
   disabled: boolean;
-  onChange: (next: EditableHeader) => void;
+  onNameChange: (value: string) => void;
+  onNameBlur: () => void;
+  onValueChange: (value: string) => void;
+  onValueBlur: () => void;
   onRemove: () => void;
 }) {
   return (
     <Stack direction="horizontal" gap={2} align="center">
       <Input
+        name={nameInputName}
         placeholder="Header name"
-        value={header.name}
-        onChange={(value) => onChange({ ...header, name: value })}
+        value={name}
+        onChange={onNameChange}
+        onBlur={onNameBlur}
         disabled={disabled}
         className="flex-1"
       />
       <Input
-        placeholder={header.hasStoredValue ? "•••••• (saved)" : "Header value"}
-        value={header.value}
-        onChange={(value) => onChange({ ...header, value })}
+        name={valueInputName}
+        placeholder={hasStoredValue ? "••••" : "Header value"}
+        value={value}
+        onChange={onValueChange}
+        onBlur={onValueBlur}
         type="password"
         disabled={disabled}
         className="flex-1"
       />
       <Button
+        type="button"
         variant="tertiary"
         size="sm"
         onClick={onRemove}
         disabled={disabled}
-        aria-label={`Remove header ${header.name || "row"}`}
+        aria-label={`Remove header ${name || "row"}`}
       >
         <Trash2 className="h-3.5 w-3.5" />
       </Button>

--- a/client/dashboard/src/pages/org/OtelForwardingSection.tsx
+++ b/client/dashboard/src/pages/org/OtelForwardingSection.tsx
@@ -26,11 +26,10 @@ type EditableHeader = {
   // place without unmounting the row.
   rowID: string;
   name: string;
-  // Empty string with hasStoredValue=true means "keep existing encrypted
-  // value." A non-empty string overwrites it. A row whose hasStoredValue is
-  // false and value is empty is a brand-new blank row.
+  // Original server name for a write-only value this row may preserve.
+  // Renaming the row requires a replacement value.
+  storedName: string | null;
   value: string;
-  hasStoredValue: boolean;
 };
 
 function rowFromServer(h: OtelForwardingHeader, idx: number): EditableHeader {
@@ -38,7 +37,7 @@ function rowFromServer(h: OtelForwardingHeader, idx: number): EditableHeader {
     rowID: `existing-${idx}-${h.name}`,
     name: h.name,
     value: "",
-    hasStoredValue: h.hasValue,
+    storedName: h.hasValue ? h.name : null,
   };
 }
 
@@ -49,7 +48,7 @@ function blankRow(): EditableHeader {
     rowID: `new-${newRowCounter}`,
     name: "",
     value: "",
-    hasStoredValue: false,
+    storedName: null,
   };
 }
 
@@ -69,10 +68,18 @@ function formValuesFromConfig(
   };
 }
 
+function preservesStoredValue(header: EditableHeader): boolean {
+  return (
+    header.storedName !== null &&
+    header.value === "" &&
+    header.name.trim().toLowerCase() === header.storedName.toLowerCase()
+  );
+}
+
 function hasValidHeaders(headers: EditableHeader[]): boolean {
   return headers.every((header) => {
     if (header.name.trim() === "") return false;
-    return header.value !== "" || header.hasStoredValue;
+    return header.value !== "" || preservesStoredValue(header);
   });
 }
 
@@ -80,7 +87,7 @@ function headerInputFromForm(
   header: EditableHeader,
 ): OtelForwardingHeaderInput {
   const name = header.name.trim();
-  if (header.hasStoredValue && header.value === "") return { name };
+  if (preservesStoredValue(header)) return { name };
   return { name, value: header.value };
 }
 
@@ -276,7 +283,9 @@ export function OtelForwardingSection(): JSX.Element {
                                     <HeaderRow
                                       name={nameField.state.value}
                                       value={valueField.state.value}
-                                      hasStoredValue={header.hasStoredValue}
+                                      hasStoredValue={preservesStoredValue(
+                                        header,
+                                      )}
                                       nameInputName={nameField.name}
                                       valueInputName={valueField.name}
                                       disabled={formDisabled}

--- a/client/dashboard/src/sdk/src/models/components/otelforwardingheaderinput.ts
+++ b/client/dashboard/src/sdk/src/models/components/otelforwardingheaderinput.ts
@@ -5,7 +5,7 @@
 import * as z from "zod/v4-mini";
 
 /**
- * HTTP header value provided when upserting a forwarding config.
+ * HTTP header provided when upserting a forwarding config. Omit the value to preserve the existing encrypted value for the same name.
  */
 export type OtelForwardingHeaderInput = {
   /**
@@ -13,15 +13,15 @@ export type OtelForwardingHeaderInput = {
    */
   name: string;
   /**
-   * Header value. Stored encrypted at rest; never returned on reads.
+   * Header value. Omit to preserve an existing value; provide to create, replace, or clear it. Stored encrypted at rest and never returned on reads.
    */
-  value: string;
+  value?: string | undefined;
 };
 
 /** @internal */
 export type OtelForwardingHeaderInput$Outbound = {
   name: string;
-  value: string;
+  value?: string | undefined;
 };
 
 /** @internal */
@@ -30,7 +30,7 @@ export const OtelForwardingHeaderInput$outboundSchema: z.ZodMiniType<
   OtelForwardingHeaderInput
 > = z.object({
   name: z.string(),
-  value: z.string(),
+  value: z.optional(z.string()),
 });
 
 export function otelForwardingHeaderInputToJSON(

--- a/client/dashboard/src/sdk/src/models/components/upsertconfigrequestbody3.ts
+++ b/client/dashboard/src/sdk/src/models/components/upsertconfigrequestbody3.ts
@@ -20,7 +20,7 @@ export type UpsertConfigRequestBody3 = {
    */
   endpointUrl: string;
   /**
-   * Full set of headers to attach. Replaces any existing headers.
+   * Complete desired header set. Omitted entries are removed; entries with an omitted value preserve the existing encrypted value for the same name.
    */
   headers?: Array<OtelForwardingHeaderInput> | undefined;
 };

--- a/server/design/otelforwarding/design.go
+++ b/server/design/otelforwarding/design.go
@@ -19,10 +19,10 @@ var HeaderModel = Type("OtelForwardingHeader", func() {
 })
 
 var HeaderInput = Type("OtelForwardingHeaderInput", func() {
-	Description("HTTP header value provided when upserting a forwarding config.")
-	Required("name", "value")
+	Description("HTTP header provided when upserting a forwarding config. Omit the value to preserve the existing encrypted value for the same name.")
+	Required("name")
 	Attribute("name", String, "Header name.")
-	Attribute("value", String, "Header value. Stored encrypted at rest; never returned on reads.")
+	Attribute("value", String, "Header value. Omit to preserve an existing value; provide to create, replace, or clear it. Stored encrypted at rest and never returned on reads.")
 })
 
 var Config = Type("OtelForwardingConfig", func() {
@@ -86,7 +86,7 @@ var _ = Service("otelForwarding", func() {
 			security.SessionPayload()
 			Attribute("endpoint_url", String, "URL to forward OTEL payloads to.")
 			Attribute("enabled", Boolean, "Whether forwarding should be active.")
-			Attribute("headers", ArrayOf(HeaderInput), "Full set of headers to attach. Replaces any existing headers.")
+			Attribute("headers", ArrayOf(HeaderInput), "Complete desired header set. Omitted entries are removed; entries with an omitted value preserve the existing encrypted value for the same name.")
 			Required("endpoint_url", "enabled")
 		})
 

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -71400,11 +71400,10 @@ components:
                     description: Header name.
                 value:
                     type: string
-                    description: Header value. Stored encrypted at rest; never returned on reads.
-            description: HTTP header value provided when upserting a forwarding config.
+                    description: Header value. Omit to preserve an existing value; provide to create, replace, or clear it. Stored encrypted at rest and never returned on reads.
+            description: HTTP header provided when upserting a forwarding config. Omit the value to preserve the existing encrypted value for the same name.
             required:
                 - name
-                - value
         Package:
             type: object
             properties:
@@ -82480,7 +82479,7 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/OtelForwardingHeaderInput'
-                    description: Full set of headers to attach. Replaces any existing headers.
+                    description: Complete desired header set. Omitted entries are removed; entries with an omitted value preserve the existing encrypted value for the same name.
             required:
                 - endpoint_url
                 - enabled

--- a/server/gen/http/otel_forwarding/client/types.go
+++ b/server/gen/http/otel_forwarding/client/types.go
@@ -19,7 +19,8 @@ type UpsertConfigRequestBody struct {
 	EndpointURL string `form:"endpoint_url" json:"endpoint_url" xml:"endpoint_url"`
 	// Whether forwarding should be active.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
-	// Full set of headers to attach. Replaces any existing headers.
+	// Complete desired header set. Omitted entries are removed; entries with an
+	// omitted value preserve the existing encrypted value for the same name.
 	Headers []*OtelForwardingHeaderInputRequestBody `form:"headers,omitempty" json:"headers,omitempty" xml:"headers,omitempty"`
 }
 
@@ -633,8 +634,9 @@ type OtelForwardingHeaderResponseBody struct {
 type OtelForwardingHeaderInputRequestBody struct {
 	// Header name.
 	Name string `form:"name" json:"name" xml:"name"`
-	// Header value. Stored encrypted at rest; never returned on reads.
-	Value string `form:"value" json:"value" xml:"value"`
+	// Header value. Omit to preserve an existing value; provide to create,
+	// replace, or clear it. Stored encrypted at rest and never returned on reads.
+	Value *string `form:"value,omitempty" json:"value,omitempty" xml:"value,omitempty"`
 }
 
 // NewUpsertConfigRequestBody builds the HTTP request body from the payload of

--- a/server/gen/http/otel_forwarding/server/encode_decode.go
+++ b/server/gen/http/otel_forwarding/server/encode_decode.go
@@ -672,7 +672,7 @@ func unmarshalOtelForwardingHeaderInputRequestBodyToOtelforwardingOtelForwarding
 	}
 	res := &otelforwarding.OtelForwardingHeaderInput{
 		Name:  *v.Name,
-		Value: *v.Value,
+		Value: v.Value,
 	}
 
 	return res

--- a/server/gen/http/otel_forwarding/server/types.go
+++ b/server/gen/http/otel_forwarding/server/types.go
@@ -19,7 +19,8 @@ type UpsertConfigRequestBody struct {
 	EndpointURL *string `form:"endpoint_url,omitempty" json:"endpoint_url,omitempty" xml:"endpoint_url,omitempty"`
 	// Whether forwarding should be active.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
-	// Full set of headers to attach. Replaces any existing headers.
+	// Complete desired header set. Omitted entries are removed; entries with an
+	// omitted value preserve the existing encrypted value for the same name.
 	Headers []*OtelForwardingHeaderInputRequestBody `form:"headers,omitempty" json:"headers,omitempty" xml:"headers,omitempty"`
 }
 
@@ -633,7 +634,8 @@ type OtelForwardingHeaderResponseBody struct {
 type OtelForwardingHeaderInputRequestBody struct {
 	// Header name.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// Header value. Stored encrypted at rest; never returned on reads.
+	// Header value. Omit to preserve an existing value; provide to create,
+	// replace, or clear it. Stored encrypted at rest and never returned on reads.
 	Value *string `form:"value,omitempty" json:"value,omitempty" xml:"value,omitempty"`
 }
 
@@ -1180,9 +1182,6 @@ func ValidateUpsertConfigRequestBody(body *UpsertConfigRequestBody) (err error) 
 func ValidateOtelForwardingHeaderInputRequestBody(body *OtelForwardingHeaderInputRequestBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
-	}
-	if body.Value == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("value", "body"))
 	}
 	return
 }

--- a/server/gen/otel_forwarding/service.go
+++ b/server/gen/otel_forwarding/service.go
@@ -92,12 +92,14 @@ type OtelForwardingHeader struct {
 	HasValue bool
 }
 
-// HTTP header value provided when upserting a forwarding config.
+// HTTP header provided when upserting a forwarding config. Omit the value to
+// preserve the existing encrypted value for the same name.
 type OtelForwardingHeaderInput struct {
 	// Header name.
 	Name string
-	// Header value. Stored encrypted at rest; never returned on reads.
-	Value string
+	// Header value. Omit to preserve an existing value; provide to create,
+	// replace, or clear it. Stored encrypted at rest and never returned on reads.
+	Value *string
 }
 
 // UpsertConfigPayload is the payload type of the otelForwarding service
@@ -109,7 +111,8 @@ type UpsertConfigPayload struct {
 	EndpointURL string
 	// Whether forwarding should be active.
 	Enabled bool
-	// Full set of headers to attach. Replaces any existing headers.
+	// Complete desired header set. Omitted entries are removed; entries with an
+	// omitted value preserve the existing encrypted value for the same name.
 	Headers []*OtelForwardingHeaderInput
 }
 

--- a/server/internal/otelforwarding/impl.go
+++ b/server/internal/otelforwarding/impl.go
@@ -108,16 +108,16 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 		return nil, err
 	}
 
-	headers, err := normalizeHeaderInputs(payload.Headers)
+	logger := s.logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID), attr.SlogUserID(authCtx.UserID))
+
+	// Load the current values from the database before resolving omitted
+	// write-only header values and building the audit before-snapshot.
+	before, beforeRow, err := s.client.LoadForOrgRow(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, err
 	}
 
-	logger := s.logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID), attr.SlogUserID(authCtx.UserID))
-
-	// Load the pre-state for the audit before-snapshot. Stale cache here is
-	// fine — the snapshot is for human review, not for write decisions.
-	before, beforeRow, err := s.client.LoadForOrgRow(ctx, authCtx.ActiveOrganizationID)
+	headers, err := normalizeHeaderInputs(payload.Headers, before.Headers)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func validateForwardingURL(raw string) error {
 	return nil
 }
 
-func normalizeHeaderInputs(in []*gen.OtelForwardingHeaderInput) (map[string]string, error) {
+func normalizeHeaderInputs(in []*gen.OtelForwardingHeaderInput, existing map[string]string) (map[string]string, error) {
 	if len(in) == 0 {
 		return nil, nil
 	}
@@ -248,7 +248,15 @@ func normalizeHeaderInputs(in []*gen.OtelForwardingHeaderInput) (map[string]stri
 		if _, exists := out[name]; exists {
 			return nil, oops.E(oops.CodeInvalid, nil, "duplicate header name: %q", name)
 		}
-		out[name] = h.Value
+		if h.Value != nil {
+			out[name] = *h.Value
+			continue
+		}
+		value, exists := existing[name]
+		if !exists {
+			return nil, oops.E(oops.CodeInvalid, nil, "header value is required for new header: %q", name)
+		}
+		out[name] = value
 	}
 	return out, nil
 }

--- a/server/internal/otelforwarding/impl.go
+++ b/server/internal/otelforwarding/impl.go
@@ -2,12 +2,14 @@ package otelforwarding
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/url"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -110,23 +112,31 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 
 	logger := s.logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID), attr.SlogUserID(authCtx.UserID))
 
-	// Load the current values from the database before resolving omitted
-	// write-only header values and building the audit before-snapshot.
-	before, beforeRow, err := s.client.LoadForOrgRow(ctx, authCtx.ActiveOrganizationID)
+	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, err
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	before := emptyCachedConfig(authCtx.ActiveOrganizationID)
+	var beforeRow *repo.OtelForwardingConfig
+	lockedRow, err := repo.New(dbtx).GetOrgOTELForwardingConfigForUpdate(ctx, authCtx.ActiveOrganizationID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "lock otel forwarding config").LogError(ctx, logger)
+	default:
+		beforeRow = &lockedRow
+		before, err = s.client.rowToConfig(authCtx.ActiveOrganizationID, lockedRow)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	headers, err := normalizeHeaderInputs(payload.Headers, before.Headers)
 	if err != nil {
 		return nil, err
 	}
-
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	cfg, row, err := s.client.UpsertWithTx(ctx, dbtx, authCtx.ActiveOrganizationID, payload.EndpointURL, headers, payload.Enabled)
 	if err != nil {
@@ -231,6 +241,7 @@ func normalizeHeaderInputs(in []*gen.OtelForwardingHeaderInput, existing map[str
 		return nil, nil
 	}
 	out := make(map[string]string, len(in))
+	seenNames := make(map[string]struct{}, len(in))
 	for _, h := range in {
 		if h == nil {
 			continue
@@ -245,14 +256,25 @@ func normalizeHeaderInputs(in []*gen.OtelForwardingHeaderInput, existing map[str
 		if strings.ContainsAny(name, " \t\r\n") {
 			return nil, oops.E(oops.CodeInvalid, nil, "header name contains invalid whitespace: %q", name)
 		}
-		if _, exists := out[name]; exists {
+		foldedName := strings.ToLower(name)
+		if _, exists := seenNames[foldedName]; exists {
 			return nil, oops.E(oops.CodeInvalid, nil, "duplicate header name: %q", name)
 		}
+		seenNames[foldedName] = struct{}{}
 		if h.Value != nil {
 			out[name] = *h.Value
 			continue
 		}
 		value, exists := existing[name]
+		if !exists {
+			for existingName, existingValue := range existing {
+				if strings.EqualFold(existingName, name) {
+					value = existingValue
+					exists = true
+					break
+				}
+			}
+		}
 		if !exists {
 			return nil, oops.E(oops.CodeInvalid, nil, "header value is required for new header: %q", name)
 		}

--- a/server/internal/otelforwarding/impl_test.go
+++ b/server/internal/otelforwarding/impl_test.go
@@ -28,6 +28,18 @@ func TestNormalizeHeaderInputsPreservesOmittedExistingValue(t *testing.T) {
 	}, headers)
 }
 
+func TestNormalizeHeaderInputsPreservesValueAcrossNameCasing(t *testing.T) {
+	t.Parallel()
+
+	headers, err := normalizeHeaderInputs(
+		[]*gen.OtelForwardingHeaderInput{{Name: "authorization", Value: nil}},
+		map[string]string{"Authorization": "original secret"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"authorization": "original secret"}, headers)
+}
+
 func TestNormalizeHeaderInputsRemovesOmittedHeaderEntry(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/otelforwarding/impl_test.go
+++ b/server/internal/otelforwarding/impl_test.go
@@ -1,0 +1,70 @@
+package otelforwarding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/otel_forwarding"
+)
+
+func TestNormalizeHeaderInputsPreservesOmittedExistingValue(t *testing.T) {
+	t.Parallel()
+
+	newValue := "happy days"
+
+	headers, err := normalizeHeaderInputs(
+		[]*gen.OtelForwardingHeaderInput{
+			{Name: "foo", Value: nil},
+			{Name: "another", Value: &newValue},
+		},
+		map[string]string{"foo": "original secret"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"another": "happy days",
+		"foo":     "original secret",
+	}, headers)
+}
+
+func TestNormalizeHeaderInputsRemovesOmittedHeaderEntry(t *testing.T) {
+	t.Parallel()
+
+	headers, err := normalizeHeaderInputs(
+		[]*gen.OtelForwardingHeaderInput{{Name: "kept", Value: nil}},
+		map[string]string{
+			"kept":    "kept secret",
+			"removed": "removed secret",
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"kept": "kept secret"}, headers)
+}
+
+func TestNormalizeHeaderInputsRejectsOmittedNewValue(t *testing.T) {
+	t.Parallel()
+
+	headers, err := normalizeHeaderInputs(
+		[]*gen.OtelForwardingHeaderInput{{Name: "new", Value: nil}},
+		nil,
+	)
+
+	require.Nil(t, headers)
+	require.ErrorContains(t, err, `header value is required for new header: "new"`)
+}
+
+func TestNormalizeHeaderInputsAcceptsExplicitEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	emptyValue := ""
+
+	headers, err := normalizeHeaderInputs(
+		[]*gen.OtelForwardingHeaderInput{{Name: "existing", Value: &emptyValue}},
+		map[string]string{"existing": "original secret"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"existing": ""}, headers)
+}

--- a/server/internal/otelforwarding/queries.sql
+++ b/server/internal/otelforwarding/queries.sql
@@ -5,6 +5,14 @@ WHERE organization_id = @organization_id
   AND project_id IS NULL
   AND deleted IS FALSE;
 
+-- name: GetOrgOTELForwardingConfigForUpdate :one
+SELECT *
+FROM otel_forwarding_configs
+WHERE organization_id = @organization_id
+  AND project_id IS NULL
+  AND deleted IS FALSE
+FOR UPDATE;
+
 -- name: UpsertOrgOTELForwardingConfig :one
 INSERT INTO otel_forwarding_configs (
     organization_id

--- a/server/internal/otelforwarding/repo/queries.sql.go
+++ b/server/internal/otelforwarding/repo/queries.sql.go
@@ -53,6 +53,33 @@ func (q *Queries) GetOrgOTELForwardingConfig(ctx context.Context, organizationID
 	return i, err
 }
 
+const getOrgOTELForwardingConfigForUpdate = `-- name: GetOrgOTELForwardingConfigForUpdate :one
+SELECT created_at, deleted_at, updated_at, endpoint_url, headers_encrypted, organization_id, project_id, enabled, id, deleted
+FROM otel_forwarding_configs
+WHERE organization_id = $1
+  AND project_id IS NULL
+  AND deleted IS FALSE
+FOR UPDATE
+`
+
+func (q *Queries) GetOrgOTELForwardingConfigForUpdate(ctx context.Context, organizationID string) (OtelForwardingConfig, error) {
+	row := q.db.QueryRow(ctx, getOrgOTELForwardingConfigForUpdate, organizationID)
+	var i OtelForwardingConfig
+	err := row.Scan(
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.UpdatedAt,
+		&i.EndpointUrl,
+		&i.HeadersEncrypted,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.Enabled,
+		&i.ID,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const softDeleteOrgOTELForwardingConfig = `-- name: SoftDeleteOrgOTELForwardingConfig :exec
 UPDATE otel_forwarding_configs
 SET deleted_at = clock_timestamp()


### PR DESCRIPTION
## Summary

- preserve encrypted values for unchanged OTEL forwarding headers while retaining full-list removal semantics
- submit unchanged write-only values by omission and reject omitted values for new headers
- migrate the dashboard editor to semantic TanStack Form submission with query-backed defaults
- regenerate the management API and dashboard SDK contracts
- add server and dashboard patch changesets

## Verification

- `mise run test:server ./internal/otelforwarding/`
- `aube run -F dashboard test -- OtelForwardingSection.test.tsx`
- `aube run -F dashboard type-check`
- browser-verified form submission payloads and stored-header editing behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves encrypted values for unchanged OTEL forwarding headers while keeping complete-list semantics. Previously, editing headers required resending every secret and risked clearing values; now omitted values on existing names keep the stored value, omitted entries remove headers, and new headers must provide a value.

- Server: loads and locks the existing config row before upsert and normalizes headers case-insensitively. Omitted value on an existing name preserves the encrypted value; omitted value on a new name is rejected; an explicit empty string clears the value; duplicate names (case-insensitive) are rejected.
- API/SDK: `OtelForwardingHeaderInput.value` is now optional across OpenAPI, server types, and the dashboard SDK; headers are documented as the “complete desired set.”
- Dashboard: form rebuilt with `@tanstack/react-form` and native submit; all buttons have explicit types (including the `Switch`). Stored-value rows show a “••••” placeholder and submit without a value to preserve; renaming a stored header requires a replacement value; unsaved edits survive background refreshes.
- Tests/changesets: server tests cover normalization (case-insensitive matching, omissions, empty clears). Dashboard tests cover hydration, rename validation, submission, and form semantics. Patch changesets added for `server` and `dashboard`.

**Rollout/migration**
- Existing clients can continue sending all values. To preserve an existing secret, send only the header name; to clear a value, send an empty string; to remove a header, omit it from the submitted list.

<sup>Written for commit ede256a1ffd6476c1133339cd2d647c5f4612cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

