### PR TITLE
feat: exclude in-dashboard assistant conversations from risk analysis

### DIFF
--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
@@ -11,8 +11,15 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
+
+// dashboardAssistantSourceKind is assistant_threads.source_kind for
+// conversations that arrived through the Gram dashboard assistant sidebar.
+// Those chats are core dashboard functionality rather than a sold artifact,
+// so they are out of scope for risk analysis.
+const dashboardAssistantSourceKind = triggers.DefinitionSlugDashboard
 
 // FetchUnanalyzed retrieves all active policies for a project and the batch
 // of chat message IDs that have not yet been marked as analyzed
@@ -81,18 +88,39 @@ func (a *FetchUnanalyzed) Do(ctx context.Context, args FetchUnanalyzedArgs) (_ *
 		}, nil
 	}
 
+	skippedMessages, err := queries.MarkDashboardAssistantMessagesRiskAnalyzed(ctx, repo.MarkDashboardAssistantMessagesRiskAnalyzedParams{
+		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:        args.IDLowerBound,
+		DashboardSourceKind: dashboardAssistantSourceKind,
+		BatchLimit:          args.BatchLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mark dashboard assistant messages analyzed: %w", err)
+	}
+	skippedContentParts, err := queries.MarkDashboardAssistantContentPartsRiskAnalyzed(ctx, repo.MarkDashboardAssistantContentPartsRiskAnalyzedParams{
+		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:        args.IDLowerBound,
+		DashboardSourceKind: dashboardAssistantSourceKind,
+		BatchLimit:          args.BatchLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mark dashboard assistant content parts analyzed: %w", err)
+	}
+
 	messageIDs, err := queries.FetchUnanalyzedMessageIDs(ctx, repo.FetchUnanalyzedMessageIDsParams{
-		ProjectID:    uuid.NullUUID{UUID: args.ProjectID, Valid: true},
-		IDLowerBound: args.IDLowerBound,
-		BatchLimit:   args.BatchLimit,
+		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:        args.IDLowerBound,
+		DashboardSourceKind: dashboardAssistantSourceKind,
+		BatchLimit:          args.BatchLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fetch unanalyzed message IDs: %w", err)
 	}
 	contentPartIDs, err := queries.FetchUnanalyzedContentPartIDs(ctx, repo.FetchUnanalyzedContentPartIDsParams{
-		ProjectID:    uuid.NullUUID{UUID: args.ProjectID, Valid: true},
-		IDLowerBound: args.IDLowerBound,
-		BatchLimit:   args.BatchLimit,
+		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:        args.IDLowerBound,
+		DashboardSourceKind: dashboardAssistantSourceKind,
+		BatchLimit:          args.BatchLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fetch unanalyzed content part IDs: %w", err)
@@ -102,6 +130,8 @@ func (a *FetchUnanalyzed) Do(ctx context.Context, args FetchUnanalyzedArgs) (_ *
 		attribute.Int("risk.unanalyzed_count", len(messageIDs)+len(contentPartIDs)),
 		attribute.Int("risk.unanalyzed_message_count", len(messageIDs)),
 		attribute.Int("risk.unanalyzed_content_part_count", len(contentPartIDs)),
+		attribute.Int("risk.dashboard_messages_skipped", int(skippedMessages)),
+		attribute.Int("risk.dashboard_content_parts_skipped", int(skippedContentParts)),
 		attribute.Int("risk.active_policies", len(policies)),
 	)
 

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
@@ -88,39 +88,47 @@ func (a *FetchUnanalyzed) Do(ctx context.Context, args FetchUnanalyzedArgs) (_ *
 		}, nil
 	}
 
-	skippedMessages, err := queries.MarkDashboardAssistantMessagesRiskAnalyzed(ctx, repo.MarkDashboardAssistantMessagesRiskAnalyzedParams{
-		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
-		IDLowerBound:        args.IDLowerBound,
+	dashboardChatIDs, err := queries.ListDashboardAssistantChatIDs(ctx, repo.ListDashboardAssistantChatIDsParams{
 		DashboardSourceKind: dashboardAssistantSourceKind,
-		BatchLimit:          args.BatchLimit,
+		ProjectID:           args.ProjectID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list dashboard assistant chat IDs: %w", err)
+	}
+
+	skippedMessages, err := queries.MarkDashboardAssistantMessagesRiskAnalyzed(ctx, repo.MarkDashboardAssistantMessagesRiskAnalyzedParams{
+		ProjectID:        uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:     args.IDLowerBound,
+		DashboardChatIds: dashboardChatIDs,
+		BatchLimit:       args.BatchLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("mark dashboard assistant messages analyzed: %w", err)
 	}
 	skippedContentParts, err := queries.MarkDashboardAssistantContentPartsRiskAnalyzed(ctx, repo.MarkDashboardAssistantContentPartsRiskAnalyzedParams{
-		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
-		IDLowerBound:        args.IDLowerBound,
-		DashboardSourceKind: dashboardAssistantSourceKind,
-		BatchLimit:          args.BatchLimit,
+		ProjectID:        uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:     args.IDLowerBound,
+		DashboardChatIds: dashboardChatIDs,
+		BatchLimit:       args.BatchLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("mark dashboard assistant content parts analyzed: %w", err)
 	}
 
 	messageIDs, err := queries.FetchUnanalyzedMessageIDs(ctx, repo.FetchUnanalyzedMessageIDsParams{
-		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
-		IDLowerBound:        args.IDLowerBound,
-		DashboardSourceKind: dashboardAssistantSourceKind,
-		BatchLimit:          args.BatchLimit,
+		ProjectID:        uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:     args.IDLowerBound,
+		DashboardChatIds: dashboardChatIDs,
+		BatchLimit:       args.BatchLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fetch unanalyzed message IDs: %w", err)
 	}
 	contentPartIDs, err := queries.FetchUnanalyzedContentPartIDs(ctx, repo.FetchUnanalyzedContentPartIDsParams{
-		ProjectID:           uuid.NullUUID{UUID: args.ProjectID, Valid: true},
-		IDLowerBound:        args.IDLowerBound,
-		DashboardSourceKind: dashboardAssistantSourceKind,
-		BatchLimit:          args.BatchLimit,
+		ProjectID:        uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		IDLowerBound:     args.IDLowerBound,
+		DashboardChatIds: dashboardChatIDs,
+		BatchLimit:       args.BatchLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fetch unanalyzed content part IDs: %w", err)

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed_test.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed_test.go
@@ -91,3 +91,83 @@ func TestFetchUnanalyzed_RespectsBatchLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.MessageIDs, 2)
 }
+
+func TestFetchUnanalyzed_ExcludesDashboardAssistantMessages(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+	inScope := seedMessages(t, conn, td, 1)
+
+	dashboardChat := seedAssistantLinkedChat(t, conn, td, "dashboard")
+	dashboardMsgs := seedMessagesInChat(t, conn, td, dashboardChat, 2)
+
+	activity := risk_analysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn)
+	result, err := activity.Do(t.Context(), risk_analysis.FetchUnanalyzedArgs{
+		ProjectID:    td.projectID,
+		IDLowerBound: zeroLowerBound,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, inScope, result.MessageIDs)
+
+	queries := riskrepo.New(conn)
+	for _, id := range dashboardMsgs {
+		analyzedAt, err := queries.GetChatMessageRiskAnalyzedAtForTest(t.Context(), riskrepo.GetChatMessageRiskAnalyzedAtForTestParams{
+			ID:        id,
+			ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
+		})
+		require.NoError(t, err)
+		require.True(t, analyzedAt.Valid, "dashboard assistant message %s must be marked analyzed without scanning", id)
+	}
+}
+
+func TestFetchUnanalyzed_KeepsSlackAssistantMessages(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	slackChat := seedAssistantLinkedChat(t, conn, td, "slack")
+	slackMsgs := seedMessagesInChat(t, conn, td, slackChat, 1)
+
+	activity := risk_analysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn)
+	result, err := activity.Do(t.Context(), risk_analysis.FetchUnanalyzedArgs{
+		ProjectID:    td.projectID,
+		IDLowerBound: zeroLowerBound,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, slackMsgs, result.MessageIDs)
+
+	analyzedAt, err := riskrepo.New(conn).GetChatMessageRiskAnalyzedAtForTest(t.Context(), riskrepo.GetChatMessageRiskAnalyzedAtForTestParams{
+		ID:        slackMsgs[0],
+		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
+	})
+	require.NoError(t, err)
+	require.False(t, analyzedAt.Valid, "slack assistant messages stay in the unanalyzed sweep")
+}
+
+func TestFetchUnanalyzed_ExcludesDashboardAssistantContentParts(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+	inScopePart := seedContentPartInChat(t, conn, td, td.chatID)
+
+	dashboardChat := seedAssistantLinkedChat(t, conn, td, "dashboard")
+	dashboardPart := seedContentPartInChat(t, conn, td, dashboardChat)
+
+	activity := risk_analysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn)
+	result, err := activity.Do(t.Context(), risk_analysis.FetchUnanalyzedArgs{
+		ProjectID:    td.projectID,
+		IDLowerBound: zeroLowerBound,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{inScopePart}, result.ContentPartIDs)
+
+	analyzedAt, err := riskrepo.New(conn).GetContentPartRiskAnalyzedAtForTest(t.Context(), riskrepo.GetContentPartRiskAnalyzedAtForTestParams{
+		ID:        dashboardPart,
+		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
+	})
+	require.NoError(t, err)
+	require.True(t, analyzedAt.Valid, "dashboard assistant content part must be marked analyzed without scanning")
+}

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed_test.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed_test.go
@@ -146,6 +146,58 @@ func TestFetchUnanalyzed_KeepsSlackAssistantMessages(t *testing.T) {
 	require.False(t, analyzedAt.Valid, "slack assistant messages stay in the unanalyzed sweep")
 }
 
+func TestFetchUnanalyzed_LaterSlackThreadKeepsChatInSweep(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	chatID := seedAssistantLinkedChat(t, conn, td, "dashboard")
+	msgs := seedMessagesInChat(t, conn, td, chatID, 1)
+	seedAssistantThreadOnChat(t, conn, td, chatID, "slack")
+
+	activity := risk_analysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn)
+	result, err := activity.Do(t.Context(), risk_analysis.FetchUnanalyzedArgs{
+		ProjectID:    td.projectID,
+		IDLowerBound: zeroLowerBound,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, msgs, result.MessageIDs)
+
+	analyzedAt, err := riskrepo.New(conn).GetChatMessageRiskAnalyzedAtForTest(t.Context(), riskrepo.GetChatMessageRiskAnalyzedAtForTestParams{
+		ID:        msgs[0],
+		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
+	})
+	require.NoError(t, err)
+	require.False(t, analyzedAt.Valid, "latest slack thread must keep the chat in the unanalyzed sweep")
+}
+
+func TestFetchUnanalyzed_LaterDashboardThreadExcludesChat(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	chatID := seedAssistantLinkedChat(t, conn, td, "slack")
+	msgs := seedMessagesInChat(t, conn, td, chatID, 1)
+	seedAssistantThreadOnChat(t, conn, td, chatID, "dashboard")
+
+	activity := risk_analysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn)
+	result, err := activity.Do(t.Context(), risk_analysis.FetchUnanalyzedArgs{
+		ProjectID:    td.projectID,
+		IDLowerBound: zeroLowerBound,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.MessageIDs)
+
+	analyzedAt, err := riskrepo.New(conn).GetChatMessageRiskAnalyzedAtForTest(t.Context(), riskrepo.GetChatMessageRiskAnalyzedAtForTestParams{
+		ID:        msgs[0],
+		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
+	})
+	require.NoError(t, err)
+	require.True(t, analyzedAt.Valid, "latest dashboard thread must mark the chat analyzed without scanning")
+}
+
 func TestFetchUnanalyzed_ExcludesDashboardAssistantContentParts(t *testing.T) {
 	t.Parallel()
 	conn := cloneDB(t)

--- a/server/internal/background/activities/risk_analysis/setup_test.go
+++ b/server/internal/background/activities/risk_analysis/setup_test.go
@@ -169,6 +169,28 @@ func seedAssistantLinkedChat(t *testing.T, conn *pgxpool.Pool, td testData, sour
 	return chatID
 }
 
+func seedAssistantThreadOnChat(t *testing.T, conn *pgxpool.Pool, td testData, chatID uuid.UUID, sourceKind string) {
+	t.Helper()
+	ctx := t.Context()
+	queries := riskrepo.New(conn)
+
+	assistantID, err := queries.CreateAssistantForTest(ctx, riskrepo.CreateAssistantForTestParams{
+		ProjectID:      td.projectID,
+		OrganizationID: td.orgID,
+		Name:           "assistant-" + sourceKind + "-" + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateAssistantThreadForTest(ctx, riskrepo.CreateAssistantThreadForTestParams{
+		AssistantID:   assistantID,
+		ProjectID:     td.projectID,
+		CorrelationID: "corr-" + uuid.NewString()[:8],
+		ChatID:        chatID,
+		SourceKind:    sourceKind,
+	})
+	require.NoError(t, err)
+}
+
 func seedContentPartInChat(t *testing.T, conn *pgxpool.Pool, td testData, chatID uuid.UUID) uuid.UUID {
 	t.Helper()
 	partID, err := riskrepo.New(conn).CreateChatContentPartForTest(t.Context(), riskrepo.CreateChatContentPartForTestParams{

--- a/server/internal/background/activities/risk_analysis/setup_test.go
+++ b/server/internal/background/activities/risk_analysis/setup_test.go
@@ -115,13 +115,18 @@ func seedTestData(t *testing.T, conn *pgxpool.Pool, enabled bool) testData {
 
 func seedMessages(t *testing.T, conn *pgxpool.Pool, td testData, count int) []uuid.UUID {
 	t.Helper()
+	return seedMessagesInChat(t, conn, td, td.chatID, count)
+}
+
+func seedMessagesInChat(t *testing.T, conn *pgxpool.Pool, td testData, chatID uuid.UUID, count int) []uuid.UUID {
+	t.Helper()
 	ctx := t.Context()
 
 	testQueries := testrepo.New(conn)
 	var ids []uuid.UUID
 	for range count {
 		msgID, err := testQueries.InsertChatMessage(ctx, testrepo.InsertChatMessageParams{
-			ChatID:    td.chatID,
+			ChatID:    chatID,
 			ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
 			Role:      "user",
 			Content:   "test message",
@@ -130,4 +135,49 @@ func seedMessages(t *testing.T, conn *pgxpool.Pool, td testData, count int) []uu
 		ids = append(ids, msgID)
 	}
 	return ids
+}
+
+func seedAssistantLinkedChat(t *testing.T, conn *pgxpool.Pool, td testData, sourceKind string) uuid.UUID {
+	t.Helper()
+	ctx := t.Context()
+	queries := riskrepo.New(conn)
+
+	chatID, err := queries.CreateChatForTest(ctx, riskrepo.CreateChatForTestParams{
+		ProjectID:      td.projectID,
+		OrganizationID: td.orgID,
+		UserID:         pgtype.Text{},
+		ExternalUserID: pgtype.Text{},
+	})
+	require.NoError(t, err)
+
+	assistantID, err := queries.CreateAssistantForTest(ctx, riskrepo.CreateAssistantForTestParams{
+		ProjectID:      td.projectID,
+		OrganizationID: td.orgID,
+		Name:           "assistant-" + sourceKind + "-" + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+
+	_, err = queries.CreateAssistantThreadForTest(ctx, riskrepo.CreateAssistantThreadForTestParams{
+		AssistantID:   assistantID,
+		ProjectID:     td.projectID,
+		CorrelationID: "corr-" + uuid.NewString()[:8],
+		ChatID:        chatID,
+		SourceKind:    sourceKind,
+	})
+	require.NoError(t, err)
+
+	return chatID
+}
+
+func seedContentPartInChat(t *testing.T, conn *pgxpool.Pool, td testData, chatID uuid.UUID) uuid.UUID {
+	t.Helper()
+	partID, err := riskrepo.New(conn).CreateChatContentPartForTest(t.Context(), riskrepo.CreateChatContentPartForTestParams{
+		ChatID:              chatID,
+		ProjectID:           uuid.NullUUID{UUID: td.projectID, Valid: true},
+		Kind:                "user",
+		ContentAssetUrl:     "asset://test",
+		ParentChatMessageID: uuid.NullUUID{},
+	})
+	require.NoError(t, err)
+	return partID
 }

--- a/server/internal/risk/finding_ch_test.go
+++ b/server/internal/risk/finding_ch_test.go
@@ -559,6 +559,7 @@ func TestFindingCHWriter_HandleBatch_ResolvesAttribution(t *testing.T) {
 		ProjectID:     *authCtx.ProjectID,
 		CorrelationID: "attribution-thread",
 		ChatID:        chatID,
+		SourceKind:    "test",
 	})
 	require.NoError(t, err)
 

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -857,13 +857,52 @@ ORDER BY buckets.bucket_start ASC, categories.category ASC;
 -- zero at steady state. The id >= @id_lower_bound bound (a UUIDv7 lower
 -- bound computed from the configured lookback) further limits the scan to
 -- recent messages, reusing the same partial index ordering.
+--
+-- In-dashboard assistant conversations (assistant_threads.source_kind =
+-- @dashboard_source_kind) are out of scope: the project assistant is core
+-- dashboard functionality, not a sold artifact, and scanning it produces
+-- meta-findings when it is used to investigate other risk results. Sold
+-- surfaces (Slack, Teams, ...) stay in the sweep.
 SELECT cm.id
 FROM chat_messages cm
 WHERE cm.project_id = @project_id
   AND cm.risk_analyzed_at IS NULL
   AND cm.id >= @id_lower_bound
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_threads at
+    WHERE at.chat_id = cm.chat_id
+      AND at.project_id = @project_id
+      AND at.deleted IS FALSE
+      AND at.source_kind = @dashboard_source_kind
+  )
 ORDER BY cm.id DESC
 LIMIT @batch_limit;
+
+-- name: MarkDashboardAssistantMessagesRiskAnalyzed :execrows
+-- Stamp risk_analyzed_at on in-dashboard assistant messages so they leave
+-- the unanalyzed partial index without being scanned. Bounded by the same
+-- lookback and batch limit as FetchUnanalyzedMessageIDs.
+UPDATE chat_messages
+SET risk_analyzed_at = clock_timestamp()
+WHERE chat_messages.project_id = @project_id
+  AND chat_messages.id IN (
+    SELECT cm.id
+    FROM chat_messages cm
+    WHERE cm.project_id = @project_id
+      AND cm.risk_analyzed_at IS NULL
+      AND cm.id >= @id_lower_bound
+      AND EXISTS (
+        SELECT 1
+        FROM assistant_threads at
+        WHERE at.chat_id = cm.chat_id
+          AND at.project_id = @project_id
+          AND at.deleted IS FALSE
+          AND at.source_kind = @dashboard_source_kind
+      )
+    ORDER BY cm.id DESC
+    LIMIT @batch_limit
+  );
 
 -- name: MarkMessagesRiskAnalyzed :exec
 UPDATE chat_messages
@@ -874,14 +913,46 @@ WHERE id = ANY(@message_ids::uuid[])
 -- name: FetchUnanalyzedContentPartIDs :many
 -- Scans the partial index chat_content_parts_risk_analyzed_at_null_idx
 -- (project_id, id WHERE risk_analyzed_at IS NULL), mirroring the chat_messages
--- unanalyzed sweep for non-turn content.
+-- unanalyzed sweep for non-turn content. In-dashboard assistant conversations
+-- (assistant_threads.source_kind = @dashboard_source_kind) are out of scope:
+-- the project assistant is core dashboard functionality, not a sold artifact.
 SELECT ccp.id
 FROM chat_content_parts ccp
 WHERE ccp.project_id = @project_id
   AND ccp.risk_analyzed_at IS NULL
   AND ccp.id >= @id_lower_bound
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_threads at
+    WHERE at.chat_id = ccp.chat_id
+      AND at.project_id = @project_id
+      AND at.deleted IS FALSE
+      AND at.source_kind = @dashboard_source_kind
+  )
 ORDER BY ccp.id DESC
 LIMIT @batch_limit;
+
+-- name: MarkDashboardAssistantContentPartsRiskAnalyzed :execrows
+UPDATE chat_content_parts
+SET risk_analyzed_at = clock_timestamp()
+WHERE chat_content_parts.project_id = @project_id
+  AND chat_content_parts.id IN (
+    SELECT ccp.id
+    FROM chat_content_parts ccp
+    WHERE ccp.project_id = @project_id
+      AND ccp.risk_analyzed_at IS NULL
+      AND ccp.id >= @id_lower_bound
+      AND EXISTS (
+        SELECT 1
+        FROM assistant_threads at
+        WHERE at.chat_id = ccp.chat_id
+          AND at.project_id = @project_id
+          AND at.deleted IS FALSE
+          AND at.source_kind = @dashboard_source_kind
+      )
+    ORDER BY ccp.id DESC
+    LIMIT @batch_limit
+  );
 
 -- name: MarkContentPartsRiskAnalyzed :exec
 UPDATE chat_content_parts
@@ -2003,7 +2074,7 @@ RETURNING id;
 
 -- name: CreateAssistantThreadForTest :one
 INSERT INTO assistant_threads (assistant_id, project_id, correlation_id, chat_id, source_kind)
-VALUES (@assistant_id, @project_id, @correlation_id, @chat_id, 'test')
+VALUES (@assistant_id, @project_id, @correlation_id, @chat_id, @source_kind)
 RETURNING id;
 
 -- name: CreateChatMessageForTest :one
@@ -2040,3 +2111,15 @@ WHERE id = @id;
 UPDATE risk_results
 SET false_positive_at = clock_timestamp()
 WHERE id = @id;
+
+-- name: GetChatMessageRiskAnalyzedAtForTest :one
+SELECT risk_analyzed_at
+FROM chat_messages
+WHERE id = @id
+  AND project_id = @project_id;
+
+-- name: GetContentPartRiskAnalyzedAtForTest :one
+SELECT risk_analyzed_at
+FROM chat_content_parts
+WHERE id = @id
+  AND project_id = @project_id;

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -851,6 +851,25 @@ CROSS JOIN categories
 LEFT JOIN findings_by_bucket ON findings_by_bucket.bucket_start = buckets.bucket_start AND findings_by_bucket.category = categories.category
 ORDER BY buckets.bucket_start ASC, categories.category ASC;
 
+-- name: ListDashboardAssistantChatIDs :many
+-- Chats whose current assistant thread is the in-dashboard project assistant.
+-- One project-scoped scan of live assistant_threads (project_id is the leading
+-- column of assistant_threads_project_id_assistant_id_correlation_id_key).
+-- DISTINCT ON keeps the latest live thread per chat so an older dashboard
+-- link cannot hide a later Slack/Teams thread, matching GetChatMessageAttribution.
+WITH latest_thread AS (
+  SELECT DISTINCT ON (at.chat_id)
+    at.chat_id,
+    at.source_kind
+  FROM assistant_threads at
+  WHERE at.project_id = @project_id
+    AND at.deleted IS FALSE
+  ORDER BY at.chat_id, at.created_at DESC, at.id DESC
+)
+SELECT chat_id
+FROM latest_thread
+WHERE source_kind = @dashboard_source_kind;
+
 -- name: FetchUnanalyzedMessageIDs :many
 -- Scans the partial index chat_messages_risk_analyzed_at_null_idx
 -- (project_id, id WHERE risk_analyzed_at IS NULL), which shrinks toward
@@ -858,23 +877,19 @@ ORDER BY buckets.bucket_start ASC, categories.category ASC;
 -- bound computed from the configured lookback) further limits the scan to
 -- recent messages, reusing the same partial index ordering.
 --
--- In-dashboard assistant conversations (assistant_threads.source_kind =
--- @dashboard_source_kind) are out of scope: the project assistant is core
--- dashboard functionality, not a sold artifact, and scanning it produces
--- meta-findings when it is used to investigate other risk results. Sold
--- surfaces (Slack, Teams, ...) stay in the sweep.
+-- @dashboard_chat_ids are chats whose latest live assistant thread has
+-- source_kind dashboard. Those conversations are out of scope: the project
+-- assistant is core dashboard functionality, not a sold artifact, and
+-- scanning it produces meta-findings when it is used to investigate other
+-- risk results. Sold surfaces (Slack, Teams, ...) stay in the sweep.
 SELECT cm.id
 FROM chat_messages cm
 WHERE cm.project_id = @project_id
   AND cm.risk_analyzed_at IS NULL
   AND cm.id >= @id_lower_bound
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_threads at
-    WHERE at.chat_id = cm.chat_id
-      AND at.project_id = @project_id
-      AND at.deleted IS FALSE
-      AND at.source_kind = @dashboard_source_kind
+  AND (
+    COALESCE(cardinality(@dashboard_chat_ids::uuid[]), 0) = 0
+    OR cm.chat_id <> ALL(@dashboard_chat_ids::uuid[])
   )
 ORDER BY cm.id DESC
 LIMIT @batch_limit;
@@ -892,14 +907,7 @@ WHERE chat_messages.project_id = @project_id
     WHERE cm.project_id = @project_id
       AND cm.risk_analyzed_at IS NULL
       AND cm.id >= @id_lower_bound
-      AND EXISTS (
-        SELECT 1
-        FROM assistant_threads at
-        WHERE at.chat_id = cm.chat_id
-          AND at.project_id = @project_id
-          AND at.deleted IS FALSE
-          AND at.source_kind = @dashboard_source_kind
-      )
+      AND cm.chat_id = ANY(@dashboard_chat_ids::uuid[])
     ORDER BY cm.id DESC
     LIMIT @batch_limit
   );
@@ -913,21 +921,17 @@ WHERE id = ANY(@message_ids::uuid[])
 -- name: FetchUnanalyzedContentPartIDs :many
 -- Scans the partial index chat_content_parts_risk_analyzed_at_null_idx
 -- (project_id, id WHERE risk_analyzed_at IS NULL), mirroring the chat_messages
--- unanalyzed sweep for non-turn content. In-dashboard assistant conversations
--- (assistant_threads.source_kind = @dashboard_source_kind) are out of scope:
--- the project assistant is core dashboard functionality, not a sold artifact.
+-- unanalyzed sweep for non-turn content. @dashboard_chat_ids are chats whose
+-- latest live assistant thread has source_kind dashboard, which is out of
+-- scope: core dashboard functionality, not a sold artifact.
 SELECT ccp.id
 FROM chat_content_parts ccp
 WHERE ccp.project_id = @project_id
   AND ccp.risk_analyzed_at IS NULL
   AND ccp.id >= @id_lower_bound
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_threads at
-    WHERE at.chat_id = ccp.chat_id
-      AND at.project_id = @project_id
-      AND at.deleted IS FALSE
-      AND at.source_kind = @dashboard_source_kind
+  AND (
+    COALESCE(cardinality(@dashboard_chat_ids::uuid[]), 0) = 0
+    OR ccp.chat_id <> ALL(@dashboard_chat_ids::uuid[])
   )
 ORDER BY ccp.id DESC
 LIMIT @batch_limit;
@@ -942,14 +946,7 @@ WHERE chat_content_parts.project_id = @project_id
     WHERE ccp.project_id = @project_id
       AND ccp.risk_analyzed_at IS NULL
       AND ccp.id >= @id_lower_bound
-      AND EXISTS (
-        SELECT 1
-        FROM assistant_threads at
-        WHERE at.chat_id = ccp.chat_id
-          AND at.project_id = @project_id
-          AND at.deleted IS FALSE
-          AND at.source_kind = @dashboard_source_kind
-      )
+      AND ccp.chat_id = ANY(@dashboard_chat_ids::uuid[])
     ORDER BY ccp.id DESC
     LIMIT @batch_limit
   );

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -1065,35 +1065,31 @@ FROM chat_content_parts ccp
 WHERE ccp.project_id = $1
   AND ccp.risk_analyzed_at IS NULL
   AND ccp.id >= $2
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_threads at
-    WHERE at.chat_id = ccp.chat_id
-      AND at.project_id = $1
-      AND at.deleted IS FALSE
-      AND at.source_kind = $3
+  AND (
+    COALESCE(cardinality($3::uuid[]), 0) = 0
+    OR ccp.chat_id <> ALL($3::uuid[])
   )
 ORDER BY ccp.id DESC
 LIMIT $4
 `
 
 type FetchUnanalyzedContentPartIDsParams struct {
-	ProjectID           uuid.NullUUID
-	IDLowerBound        uuid.UUID
-	DashboardSourceKind string
-	BatchLimit          int32
+	ProjectID        uuid.NullUUID
+	IDLowerBound     uuid.UUID
+	DashboardChatIds []uuid.UUID
+	BatchLimit       int32
 }
 
 // Scans the partial index chat_content_parts_risk_analyzed_at_null_idx
 // (project_id, id WHERE risk_analyzed_at IS NULL), mirroring the chat_messages
-// unanalyzed sweep for non-turn content. In-dashboard assistant conversations
-// (assistant_threads.source_kind = @dashboard_source_kind) are out of scope:
-// the project assistant is core dashboard functionality, not a sold artifact.
+// unanalyzed sweep for non-turn content. @dashboard_chat_ids are chats whose
+// latest live assistant thread has source_kind dashboard, which is out of
+// scope: core dashboard functionality, not a sold artifact.
 func (q *Queries) FetchUnanalyzedContentPartIDs(ctx context.Context, arg FetchUnanalyzedContentPartIDsParams) ([]uuid.UUID, error) {
 	rows, err := q.db.Query(ctx, fetchUnanalyzedContentPartIDs,
 		arg.ProjectID,
 		arg.IDLowerBound,
-		arg.DashboardSourceKind,
+		arg.DashboardChatIds,
 		arg.BatchLimit,
 	)
 	if err != nil {
@@ -1120,23 +1116,19 @@ FROM chat_messages cm
 WHERE cm.project_id = $1
   AND cm.risk_analyzed_at IS NULL
   AND cm.id >= $2
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_threads at
-    WHERE at.chat_id = cm.chat_id
-      AND at.project_id = $1
-      AND at.deleted IS FALSE
-      AND at.source_kind = $3
+  AND (
+    COALESCE(cardinality($3::uuid[]), 0) = 0
+    OR cm.chat_id <> ALL($3::uuid[])
   )
 ORDER BY cm.id DESC
 LIMIT $4
 `
 
 type FetchUnanalyzedMessageIDsParams struct {
-	ProjectID           uuid.NullUUID
-	IDLowerBound        uuid.UUID
-	DashboardSourceKind string
-	BatchLimit          int32
+	ProjectID        uuid.NullUUID
+	IDLowerBound     uuid.UUID
+	DashboardChatIds []uuid.UUID
+	BatchLimit       int32
 }
 
 // Scans the partial index chat_messages_risk_analyzed_at_null_idx
@@ -1145,16 +1137,16 @@ type FetchUnanalyzedMessageIDsParams struct {
 // bound computed from the configured lookback) further limits the scan to
 // recent messages, reusing the same partial index ordering.
 //
-// In-dashboard assistant conversations (assistant_threads.source_kind =
-// @dashboard_source_kind) are out of scope: the project assistant is core
-// dashboard functionality, not a sold artifact, and scanning it produces
-// meta-findings when it is used to investigate other risk results. Sold
-// surfaces (Slack, Teams, ...) stay in the sweep.
+// @dashboard_chat_ids are chats whose latest live assistant thread has
+// source_kind dashboard. Those conversations are out of scope: the project
+// assistant is core dashboard functionality, not a sold artifact, and
+// scanning it produces meta-findings when it is used to investigate other
+// risk results. Sold surfaces (Slack, Teams, ...) stay in the sweep.
 func (q *Queries) FetchUnanalyzedMessageIDs(ctx context.Context, arg FetchUnanalyzedMessageIDsParams) ([]uuid.UUID, error) {
 	rows, err := q.db.Query(ctx, fetchUnanalyzedMessageIDs,
 		arg.ProjectID,
 		arg.IDLowerBound,
-		arg.DashboardSourceKind,
+		arg.DashboardChatIds,
 		arg.BatchLimit,
 	)
 	if err != nil {
@@ -2492,6 +2484,51 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDashboardAssistantChatIDs = `-- name: ListDashboardAssistantChatIDs :many
+WITH latest_thread AS (
+  SELECT DISTINCT ON (at.chat_id)
+    at.chat_id,
+    at.source_kind
+  FROM assistant_threads at
+  WHERE at.project_id = $2
+    AND at.deleted IS FALSE
+  ORDER BY at.chat_id, at.created_at DESC, at.id DESC
+)
+SELECT chat_id
+FROM latest_thread
+WHERE source_kind = $1
+`
+
+type ListDashboardAssistantChatIDsParams struct {
+	DashboardSourceKind string
+	ProjectID           uuid.UUID
+}
+
+// Chats whose current assistant thread is the in-dashboard project assistant.
+// One project-scoped scan of live assistant_threads (project_id is the leading
+// column of assistant_threads_project_id_assistant_id_correlation_id_key).
+// DISTINCT ON keeps the latest live thread per chat so an older dashboard
+// link cannot hide a later Slack/Teams thread, matching GetChatMessageAttribution.
+func (q *Queries) ListDashboardAssistantChatIDs(ctx context.Context, arg ListDashboardAssistantChatIDsParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listDashboardAssistantChatIDs, arg.DashboardSourceKind, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var chat_id uuid.UUID
+		if err := rows.Scan(&chat_id); err != nil {
+			return nil, err
+		}
+		items = append(items, chat_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -4282,31 +4319,24 @@ WHERE chat_content_parts.project_id = $1
     WHERE ccp.project_id = $1
       AND ccp.risk_analyzed_at IS NULL
       AND ccp.id >= $2
-      AND EXISTS (
-        SELECT 1
-        FROM assistant_threads at
-        WHERE at.chat_id = ccp.chat_id
-          AND at.project_id = $1
-          AND at.deleted IS FALSE
-          AND at.source_kind = $3
-      )
+      AND ccp.chat_id = ANY($3::uuid[])
     ORDER BY ccp.id DESC
     LIMIT $4
   )
 `
 
 type MarkDashboardAssistantContentPartsRiskAnalyzedParams struct {
-	ProjectID           uuid.NullUUID
-	IDLowerBound        uuid.UUID
-	DashboardSourceKind string
-	BatchLimit          int32
+	ProjectID        uuid.NullUUID
+	IDLowerBound     uuid.UUID
+	DashboardChatIds []uuid.UUID
+	BatchLimit       int32
 }
 
 func (q *Queries) MarkDashboardAssistantContentPartsRiskAnalyzed(ctx context.Context, arg MarkDashboardAssistantContentPartsRiskAnalyzedParams) (int64, error) {
 	result, err := q.db.Exec(ctx, markDashboardAssistantContentPartsRiskAnalyzed,
 		arg.ProjectID,
 		arg.IDLowerBound,
-		arg.DashboardSourceKind,
+		arg.DashboardChatIds,
 		arg.BatchLimit,
 	)
 	if err != nil {
@@ -4325,24 +4355,17 @@ WHERE chat_messages.project_id = $1
     WHERE cm.project_id = $1
       AND cm.risk_analyzed_at IS NULL
       AND cm.id >= $2
-      AND EXISTS (
-        SELECT 1
-        FROM assistant_threads at
-        WHERE at.chat_id = cm.chat_id
-          AND at.project_id = $1
-          AND at.deleted IS FALSE
-          AND at.source_kind = $3
-      )
+      AND cm.chat_id = ANY($3::uuid[])
     ORDER BY cm.id DESC
     LIMIT $4
   )
 `
 
 type MarkDashboardAssistantMessagesRiskAnalyzedParams struct {
-	ProjectID           uuid.NullUUID
-	IDLowerBound        uuid.UUID
-	DashboardSourceKind string
-	BatchLimit          int32
+	ProjectID        uuid.NullUUID
+	IDLowerBound     uuid.UUID
+	DashboardChatIds []uuid.UUID
+	BatchLimit       int32
 }
 
 // Stamp risk_analyzed_at on in-dashboard assistant messages so they leave
@@ -4352,7 +4375,7 @@ func (q *Queries) MarkDashboardAssistantMessagesRiskAnalyzed(ctx context.Context
 	result, err := q.db.Exec(ctx, markDashboardAssistantMessagesRiskAnalyzed,
 		arg.ProjectID,
 		arg.IDLowerBound,
-		arg.DashboardSourceKind,
+		arg.DashboardChatIds,
 		arg.BatchLimit,
 	)
 	if err != nil {

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -486,7 +486,7 @@ func (q *Queries) CreateAssistantForTest(ctx context.Context, arg CreateAssistan
 
 const createAssistantThreadForTest = `-- name: CreateAssistantThreadForTest :one
 INSERT INTO assistant_threads (assistant_id, project_id, correlation_id, chat_id, source_kind)
-VALUES ($1, $2, $3, $4, 'test')
+VALUES ($1, $2, $3, $4, $5)
 RETURNING id
 `
 
@@ -495,6 +495,7 @@ type CreateAssistantThreadForTestParams struct {
 	ProjectID     uuid.UUID
 	CorrelationID string
 	ChatID        uuid.UUID
+	SourceKind    string
 }
 
 func (q *Queries) CreateAssistantThreadForTest(ctx context.Context, arg CreateAssistantThreadForTestParams) (uuid.UUID, error) {
@@ -503,6 +504,7 @@ func (q *Queries) CreateAssistantThreadForTest(ctx context.Context, arg CreateAs
 		arg.ProjectID,
 		arg.CorrelationID,
 		arg.ChatID,
+		arg.SourceKind,
 	)
 	var id uuid.UUID
 	err := row.Scan(&id)
@@ -1063,21 +1065,37 @@ FROM chat_content_parts ccp
 WHERE ccp.project_id = $1
   AND ccp.risk_analyzed_at IS NULL
   AND ccp.id >= $2
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_threads at
+    WHERE at.chat_id = ccp.chat_id
+      AND at.project_id = $1
+      AND at.deleted IS FALSE
+      AND at.source_kind = $3
+  )
 ORDER BY ccp.id DESC
-LIMIT $3
+LIMIT $4
 `
 
 type FetchUnanalyzedContentPartIDsParams struct {
-	ProjectID    uuid.NullUUID
-	IDLowerBound uuid.UUID
-	BatchLimit   int32
+	ProjectID           uuid.NullUUID
+	IDLowerBound        uuid.UUID
+	DashboardSourceKind string
+	BatchLimit          int32
 }
 
 // Scans the partial index chat_content_parts_risk_analyzed_at_null_idx
 // (project_id, id WHERE risk_analyzed_at IS NULL), mirroring the chat_messages
-// unanalyzed sweep for non-turn content.
+// unanalyzed sweep for non-turn content. In-dashboard assistant conversations
+// (assistant_threads.source_kind = @dashboard_source_kind) are out of scope:
+// the project assistant is core dashboard functionality, not a sold artifact.
 func (q *Queries) FetchUnanalyzedContentPartIDs(ctx context.Context, arg FetchUnanalyzedContentPartIDsParams) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, fetchUnanalyzedContentPartIDs, arg.ProjectID, arg.IDLowerBound, arg.BatchLimit)
+	rows, err := q.db.Query(ctx, fetchUnanalyzedContentPartIDs,
+		arg.ProjectID,
+		arg.IDLowerBound,
+		arg.DashboardSourceKind,
+		arg.BatchLimit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1102,14 +1120,23 @@ FROM chat_messages cm
 WHERE cm.project_id = $1
   AND cm.risk_analyzed_at IS NULL
   AND cm.id >= $2
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_threads at
+    WHERE at.chat_id = cm.chat_id
+      AND at.project_id = $1
+      AND at.deleted IS FALSE
+      AND at.source_kind = $3
+  )
 ORDER BY cm.id DESC
-LIMIT $3
+LIMIT $4
 `
 
 type FetchUnanalyzedMessageIDsParams struct {
-	ProjectID    uuid.NullUUID
-	IDLowerBound uuid.UUID
-	BatchLimit   int32
+	ProjectID           uuid.NullUUID
+	IDLowerBound        uuid.UUID
+	DashboardSourceKind string
+	BatchLimit          int32
 }
 
 // Scans the partial index chat_messages_risk_analyzed_at_null_idx
@@ -1117,8 +1144,19 @@ type FetchUnanalyzedMessageIDsParams struct {
 // zero at steady state. The id >= @id_lower_bound bound (a UUIDv7 lower
 // bound computed from the configured lookback) further limits the scan to
 // recent messages, reusing the same partial index ordering.
+//
+// In-dashboard assistant conversations (assistant_threads.source_kind =
+// @dashboard_source_kind) are out of scope: the project assistant is core
+// dashboard functionality, not a sold artifact, and scanning it produces
+// meta-findings when it is used to investigate other risk results. Sold
+// surfaces (Slack, Teams, ...) stay in the sweep.
 func (q *Queries) FetchUnanalyzedMessageIDs(ctx context.Context, arg FetchUnanalyzedMessageIDsParams) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, fetchUnanalyzedMessageIDs, arg.ProjectID, arg.IDLowerBound, arg.BatchLimit)
+	rows, err := q.db.Query(ctx, fetchUnanalyzedMessageIDs,
+		arg.ProjectID,
+		arg.IDLowerBound,
+		arg.DashboardSourceKind,
+		arg.BatchLimit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1601,6 +1639,25 @@ func (q *Queries) GetChatMessageForUnmask(ctx context.Context, arg GetChatMessag
 	return i, err
 }
 
+const getChatMessageRiskAnalyzedAtForTest = `-- name: GetChatMessageRiskAnalyzedAtForTest :one
+SELECT risk_analyzed_at
+FROM chat_messages
+WHERE id = $1
+  AND project_id = $2
+`
+
+type GetChatMessageRiskAnalyzedAtForTestParams struct {
+	ID        uuid.UUID
+	ProjectID uuid.NullUUID
+}
+
+func (q *Queries) GetChatMessageRiskAnalyzedAtForTest(ctx context.Context, arg GetChatMessageRiskAnalyzedAtForTestParams) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, getChatMessageRiskAnalyzedAtForTest, arg.ID, arg.ProjectID)
+	var risk_analyzed_at pgtype.Timestamptz
+	err := row.Scan(&risk_analyzed_at)
+	return risk_analyzed_at, err
+}
+
 const getChatUserAccountEmailForUnmask = `-- name: GetChatUserAccountEmailForUnmask :one
 SELECT ua.email
 FROM chats c
@@ -1676,6 +1733,25 @@ func (q *Queries) GetContentPartBatch(ctx context.Context, arg GetContentPartBat
 		return nil, err
 	}
 	return items, nil
+}
+
+const getContentPartRiskAnalyzedAtForTest = `-- name: GetContentPartRiskAnalyzedAtForTest :one
+SELECT risk_analyzed_at
+FROM chat_content_parts
+WHERE id = $1
+  AND project_id = $2
+`
+
+type GetContentPartRiskAnalyzedAtForTestParams struct {
+	ID        uuid.UUID
+	ProjectID uuid.NullUUID
+}
+
+func (q *Queries) GetContentPartRiskAnalyzedAtForTest(ctx context.Context, arg GetContentPartRiskAnalyzedAtForTestParams) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, getContentPartRiskAnalyzedAtForTest, arg.ID, arg.ProjectID)
+	var risk_analyzed_at pgtype.Timestamptz
+	err := row.Scan(&risk_analyzed_at)
+	return risk_analyzed_at, err
 }
 
 const getCustomDetectionRule = `-- name: GetCustomDetectionRule :one
@@ -4194,6 +4270,95 @@ type MarkContentPartsRiskAnalyzedParams struct {
 func (q *Queries) MarkContentPartsRiskAnalyzed(ctx context.Context, arg MarkContentPartsRiskAnalyzedParams) error {
 	_, err := q.db.Exec(ctx, markContentPartsRiskAnalyzed, arg.ContentPartIds, arg.ProjectID)
 	return err
+}
+
+const markDashboardAssistantContentPartsRiskAnalyzed = `-- name: MarkDashboardAssistantContentPartsRiskAnalyzed :execrows
+UPDATE chat_content_parts
+SET risk_analyzed_at = clock_timestamp()
+WHERE chat_content_parts.project_id = $1
+  AND chat_content_parts.id IN (
+    SELECT ccp.id
+    FROM chat_content_parts ccp
+    WHERE ccp.project_id = $1
+      AND ccp.risk_analyzed_at IS NULL
+      AND ccp.id >= $2
+      AND EXISTS (
+        SELECT 1
+        FROM assistant_threads at
+        WHERE at.chat_id = ccp.chat_id
+          AND at.project_id = $1
+          AND at.deleted IS FALSE
+          AND at.source_kind = $3
+      )
+    ORDER BY ccp.id DESC
+    LIMIT $4
+  )
+`
+
+type MarkDashboardAssistantContentPartsRiskAnalyzedParams struct {
+	ProjectID           uuid.NullUUID
+	IDLowerBound        uuid.UUID
+	DashboardSourceKind string
+	BatchLimit          int32
+}
+
+func (q *Queries) MarkDashboardAssistantContentPartsRiskAnalyzed(ctx context.Context, arg MarkDashboardAssistantContentPartsRiskAnalyzedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markDashboardAssistantContentPartsRiskAnalyzed,
+		arg.ProjectID,
+		arg.IDLowerBound,
+		arg.DashboardSourceKind,
+		arg.BatchLimit,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const markDashboardAssistantMessagesRiskAnalyzed = `-- name: MarkDashboardAssistantMessagesRiskAnalyzed :execrows
+UPDATE chat_messages
+SET risk_analyzed_at = clock_timestamp()
+WHERE chat_messages.project_id = $1
+  AND chat_messages.id IN (
+    SELECT cm.id
+    FROM chat_messages cm
+    WHERE cm.project_id = $1
+      AND cm.risk_analyzed_at IS NULL
+      AND cm.id >= $2
+      AND EXISTS (
+        SELECT 1
+        FROM assistant_threads at
+        WHERE at.chat_id = cm.chat_id
+          AND at.project_id = $1
+          AND at.deleted IS FALSE
+          AND at.source_kind = $3
+      )
+    ORDER BY cm.id DESC
+    LIMIT $4
+  )
+`
+
+type MarkDashboardAssistantMessagesRiskAnalyzedParams struct {
+	ProjectID           uuid.NullUUID
+	IDLowerBound        uuid.UUID
+	DashboardSourceKind string
+	BatchLimit          int32
+}
+
+// Stamp risk_analyzed_at on in-dashboard assistant messages so they leave
+// the unanalyzed partial index without being scanned. Bounded by the same
+// lookback and batch limit as FetchUnanalyzedMessageIDs.
+func (q *Queries) MarkDashboardAssistantMessagesRiskAnalyzed(ctx context.Context, arg MarkDashboardAssistantMessagesRiskAnalyzedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markDashboardAssistantMessagesRiskAnalyzed,
+		arg.ProjectID,
+		arg.IDLowerBound,
+		arg.DashboardSourceKind,
+		arg.BatchLimit,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const markMessagesRiskAnalyzed = `-- name: MarkMessagesRiskAnalyzed :exec


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Stop scanning in-dashboard project assistant conversations for risk findings. Those chats are core dashboard UI (including investigating other findings), not a sold artifact, so they produced noisy meta-results.
- FetchUnanalyzed loads chats whose **latest live** `assistant_threads` row is `source_kind = dashboard`, skips those messages and content parts, and stamps `risk_analyzed_at` so they leave the unanalyzed index without going through scanners.
- A later Slack/Teams thread on the same chat stays in the sweep; an older dashboard link does not hide it. Slack, Teams, and other sold assistant surfaces stay in scope.

Fixes AIS-598.

## Test plan

- FetchUnanalyzed coverage that dashboard-linked messages/content parts are omitted and marked analyzed.
- Coverage that Slack-linked assistant messages remain in the unanalyzed batch.
- Coverage that a later Slack thread on a previously dashboard-linked chat stays in the sweep, and that a later dashboard thread excludes the chat.
- `mise run test:server ./internal/background/activities/risk_analysis/ ./internal/risk/`
- `mise lint:server`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-598](https://linear.app/speakeasy/issue/AIS-598/feat-exclude-in-dashboard-assistant-conversations-from-risk-analysis)

<div><a href="https://cursor.com/agents/bc-3cb75cb6-7b32-476b-bcb4-08db4ca4a0e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb75cb6-7b32-476b-bcb4-08db4ca4a0e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude in-dashboard project-assistant conversations from risk analysis to remove noisy meta-findings. Previously all assistant-linked chats were scanned; now we skip and stamp `risk_analyzed_at` only for chats whose latest live assistant thread is `source_kind = dashboard`, while Slack/Teams and other sold surfaces remain in scope.

- Compute dashboard chat IDs once per project and pass them to queries: fetch queries exclude those chats; new mark queries stamp messages and content parts. Emits `risk.dashboard_messages_skipped` and `risk.dashboard_content_parts_skipped`.
- Behavior: a later Slack/Teams thread keeps a chat in scope; a later dashboard thread excludes it.
- Tests cover dashboard exclusion, Slack inclusion, latest-thread precedence, and stamping; `CreateAssistantThreadForTest` now accepts `source_kind`.
- No migration. Ensure production `assistant_threads.source_kind` matches `triggers.DefinitionSlugDashboard`. Addresses Linear AIS-598.

<sup>Written for commit f1001d75cb05dde4689f83cec8ace17764ba2ae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

