### PR TITLE
feat: platform MCP bounded drill-down tools

### DIFF
--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -112,6 +112,7 @@ export const AUDIT_ACTIONS = [
   "organization_invitation:update_role",
   "otel_forwarding:delete",
   "otel_forwarding:upsert",
+  "platform-mcp-diagnostics:user_status_read",
   "platform-mcp-registration:create",
   "platform-mcp-registration:handoff_issue",
   "platform-mcp-registration:handoff_redeem",
@@ -464,6 +465,9 @@ export function staticActionPhrase(action: AuditAction): string {
       return "updated OpenTelemetry forwarding configuration";
     case "otel_forwarding:delete":
       return "removed OpenTelemetry forwarding configuration";
+
+    case "platform-mcp-diagnostics:user_status_read":
+      return "read a user's status on";
 
     case "platform-mcp-registration:create":
       return "registered platform MCP server";

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -72,7 +72,11 @@ type platformMCPConfig struct {
 	// what a project overview's active-user count measures. Shared with the
 	// telemetry service so both surfaces answer from the same source.
 	SessionCapture platformmcp.FeatureChecker
-	LocalFixture   *platformMCPLocalFixtureConfig
+	// TelemetryDrilldown is the row-level half of the same read model. Nil
+	// withholds the drill-down tools while leaving the overview-first entry
+	// points serving.
+	TelemetryDrilldown platformmcp.DrilldownTelemetryReader
+	LocalFixture       *platformMCPLocalFixtureConfig
 }
 
 var platformMCPLocalFixtureLoopbackCIDRBlocks = []string{"127.0.0.0/8", "::1/128"}
@@ -194,6 +198,13 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.DiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		// Half the ordinary allowance: this is the only read that reaches
+		// personal data, and a loop should exhaust it well before it has
+		// enumerated an organization.
+		SensitiveDiagnostics: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(2), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(25), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("local Platform MCP operation budgets are incomplete")
@@ -233,7 +244,8 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
-	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics)
+	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
+		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -392,6 +404,13 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.DiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		// Half the ordinary allowance: this is the only read that reaches
+		// personal data, and a loop should exhaust it well before it has
+		// enumerated an organization.
+		SensitiveDiagnostics: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(2), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(25), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("platform MCP operation budgets are incomplete")
@@ -440,7 +459,8 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
-	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics)
+	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
+		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -194,16 +194,19 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
 		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		// Diagnostics are read-only aggregate queries an administrator runs
+		// while investigating, so they are metered well above the shared
+		// five-per-minute mutation budget.
 		Diagnostics: platformmcp.OperationBudget{
 			Connection:   ratelimit.New(limitStore, platformmcp.DiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		// Half the ordinary allowance: this is the only read that reaches
-		// personal data, and a loop should exhaust it well before it has
-		// enumerated an organization.
+		// Metered separately and lower: this is the only read that reaches
+		// personal data, so exhausting it must not be possible by spending the
+		// ordinary diagnostic allowance.
 		SensitiveDiagnostics: platformmcp.OperationBudget{
-			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(2), ratelimit.WithMetrics(config.MeterProvider)),
-			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(25), ratelimit.WithMetrics(config.MeterProvider)),
+			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
 	}
 	if !budgets.Valid() {
@@ -400,16 +403,19 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Organization: ratelimit.New(limitStore, platformmcp.DocsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DocsQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
 		Skills: newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
+		// Diagnostics are read-only aggregate queries an administrator runs
+		// while investigating, so they are metered well above the shared
+		// five-per-minute mutation budget.
 		Diagnostics: platformmcp.OperationBudget{
 			Connection:   ratelimit.New(limitStore, platformmcp.DiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.DiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.DiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		// Half the ordinary allowance: this is the only read that reaches
-		// personal data, and a loop should exhaust it well before it has
-		// enumerated an organization.
+		// Metered separately and lower: this is the only read that reaches
+		// personal data, so exhausting it must not be possible by spending the
+		// ordinary diagnostic allowance.
 		SensitiveDiagnostics: platformmcp.OperationBudget{
-			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(2), ratelimit.WithMetrics(config.MeterProvider)),
-			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(25), ratelimit.WithMetrics(config.MeterProvider)),
+			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
 	}
 	if !budgets.Valid() {

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -208,6 +208,22 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		// The second drill-down cap: what a connection may accumulate over ten
+		// minutes, rather than how often it may call. Both buckets refill over
+		// that window, so a caller paging steadily under the per-minute rate
+		// still runs out of rows before it has walked a whole window.
+		DrilldownVolume: platformmcp.DrilldownVolumeBudget{
+			Rows: ratelimit.New(limitStore, platformmcp.DrilldownRowsLimitName, ratelimit.Rate{
+				Tokens:   platformmcp.DrilldownRowsPerConnectionPerWindow,
+				Interval: platformmcp.DrilldownVolumeWindow,
+				Burst:    platformmcp.DrilldownRowsPerConnectionPerWindow,
+			}, ratelimit.WithMetrics(config.MeterProvider)),
+			MetricQueries: ratelimit.New(limitStore, platformmcp.DrilldownMetricQueriesLimitName, ratelimit.Rate{
+				Tokens:   platformmcp.DrilldownMetricQueriesPerConnectionPerWindow,
+				Interval: platformmcp.DrilldownVolumeWindow,
+				Burst:    platformmcp.DrilldownMetricQueriesPerConnectionPerWindow,
+			}, ratelimit.WithMetrics(config.MeterProvider)),
+		},
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("local Platform MCP operation budgets are incomplete")
@@ -248,7 +264,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
-		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics)
+		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -417,6 +433,22 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		// The second drill-down cap: what a connection may accumulate over ten
+		// minutes, rather than how often it may call. Both buckets refill over
+		// that window, so a caller paging steadily under the per-minute rate
+		// still runs out of rows before it has walked a whole window.
+		DrilldownVolume: platformmcp.DrilldownVolumeBudget{
+			Rows: ratelimit.New(limitStore, platformmcp.DrilldownRowsLimitName, ratelimit.Rate{
+				Tokens:   platformmcp.DrilldownRowsPerConnectionPerWindow,
+				Interval: platformmcp.DrilldownVolumeWindow,
+				Burst:    platformmcp.DrilldownRowsPerConnectionPerWindow,
+			}, ratelimit.WithMetrics(config.MeterProvider)),
+			MetricQueries: ratelimit.New(limitStore, platformmcp.DrilldownMetricQueriesLimitName, ratelimit.Rate{
+				Tokens:   platformmcp.DrilldownMetricQueriesPerConnectionPerWindow,
+				Interval: platformmcp.DrilldownVolumeWindow,
+				Burst:    platformmcp.DrilldownMetricQueriesPerConnectionPerWindow,
+			}, ratelimit.WithMetrics(config.MeterProvider)),
+		},
 	}
 	if !budgets.Valid() {
 		return AssistantSurface{}, errors.New("platform MCP operation budgets are incomplete")
@@ -466,7 +498,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
-		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics)
+		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1553,6 +1553,7 @@ func newStartCommand() *cli.Command {
 				PluginPublisher:        pluginPublisher,
 				Skills:                 skillsService,
 				Telemetry:              telemetryrepo.New(chDB),
+				TelemetryDrilldown:     telemetryrepo.New(chDB),
 				SessionCapture:         platformmcp.FeatureChecker(sessionCaptureEnabled),
 				LocalFixture:           platformFixture,
 			})

--- a/server/internal/audit/platformmcpdiagnostics.go
+++ b/server/internal/audit/platformmcpdiagnostics.go
@@ -1,0 +1,77 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/audit/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	// ActionPlatformMcpDiagnosticsUserStatusRead records an exact user-MCP
+	// diagnosis. Every other Platform MCP diagnostic answers about a project or
+	// a server; this one answers about a person, so it is audited on its own
+	// rather than left inside the aggregate reads.
+	ActionPlatformMcpDiagnosticsUserStatusRead Action = "platform-mcp-diagnostics:user_status_read"
+)
+
+// LogPlatformMcpDiagnosticsUserStatusReadEvent records that an administrator
+// asked about one subject's status against one MCP.
+//
+// The subject is the MCP, not the person: an audit trail that named the person
+// would republish the identity the diagnostic itself masks, and would make the
+// audit log a place to enumerate an organization's people. What is recorded is
+// the masked identity the caller was shown, which is enough to reconcile an
+// entry against the answer it describes and not enough to learn anyone.
+type LogPlatformMcpDiagnosticsUserStatusReadEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor urn.Principal
+
+	McpServerURN urn.McpServer
+	// MaskedIdentity is the same masked value returned to the caller. It is
+	// never the raw identifier.
+	MaskedIdentity string
+	// Window is the resolved observation window the answer covered.
+	Window string
+}
+
+func (l *Logger) LogPlatformMcpDiagnosticsUserStatusRead(ctx context.Context, dbtx repo.DBTX, event LogPlatformMcpDiagnosticsUserStatusReadEvent) error {
+	action := ActionPlatformMcpDiagnosticsUserStatusRead
+	metadata, err := marshalAuditPayload(map[string]string{
+		"masked_identity": event.MaskedIdentity,
+		"window":          event.Window,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(nil),
+		ActorSlug:        conv.PtrToPGTextEmpty(nil),
+
+		Action: string(action),
+
+		SubjectID:          event.McpServerURN.ID.String(),
+		SubjectType:        string(subjectTypeMcpServer),
+		SubjectDisplayName: conv.PtrToPGTextEmpty(nil),
+		SubjectSlug:        conv.PtrToPGTextEmpty(nil),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.PlatformMcpDiagnosticsV1})
+}

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -54,6 +54,7 @@ var (
 	OrganizationWebhooksV1                 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_webhooks_event_v1", "Emitted when changes to organization webhooks are made")
 	OtelForwardingV1                       = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.otel_forwarding_event_v1", "Emitted when changes to OTEL forwarding configs are made")
 	PlatformMcpRegistrationV1              = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.platform_mcp_registration_event_v1", "Emitted when Platform MCP catalog registrations converge private components")
+	PlatformMcpDiagnosticsV1               = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.platform_mcp_diagnostics_event_v1", "Emitted when a Platform MCP diagnostic reads an individual subject's status")
 	UnproxiedMcpServerV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.unproxied_mcp_server_event_v1", "Emitted when changes to unproxied MCP servers are made")
 	PluginV1                               = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.plugin_event_v1", "Emitted when changes to plugins are made")
 	ProjectV1                              = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.project_event_v1", "Emitted when changes to projects are made")

--- a/server/internal/outbox/events/catalog_gen.go
+++ b/server/internal/outbox/events/catalog_gen.go
@@ -45,6 +45,7 @@ var All = []outbox.EventRegistration{
 	OrganizationInviteV1,
 	OrganizationWebhooksV1,
 	OtelForwardingV1,
+	PlatformMcpDiagnosticsV1,
 	PlatformMcpRegistrationV1,
 	PluginV1,
 	ProjectV1,

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -2266,6 +2266,64 @@ webhooks:
                                 - subject_type
                             type: object
                 required: true
+    audit_log.platform_mcp_diagnostics_event_v1:
+        post:
+            description: Emitted when a Platform MCP diagnostic reads an individual subject's status
+            operationId: audit_log.platform_mcp_diagnostics_event_v1
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            additionalProperties: false
+                            properties:
+                                acting_client_id:
+                                    type: string
+                                acting_surface:
+                                    type: string
+                                action:
+                                    type: string
+                                actor_display_name:
+                                    type: string
+                                actor_id:
+                                    type: string
+                                actor_slug:
+                                    type: string
+                                actor_type:
+                                    type: string
+                                after_snapshot:
+                                    additionalProperties: true
+                                before_snapshot:
+                                    additionalProperties: true
+                                id:
+                                    format: uuid
+                                    type: string
+                                metadata:
+                                    additionalProperties: true
+                                organization_id:
+                                    type: string
+                                project_id:
+                                    format: uuid
+                                    type:
+                                        - string
+                                        - "null"
+                                subject_display_name:
+                                    type: string
+                                subject_id:
+                                    type: string
+                                subject_slug:
+                                    type: string
+                                subject_type:
+                                    type: string
+                            required:
+                                - id
+                                - organization_id
+                                - actor_id
+                                - actor_type
+                                - action
+                                - subject_id
+                                - subject_type
+                            type: object
+                required: true
     audit_log.platform_mcp_registration_event_v1:
         post:
             description: Emitted when Platform MCP catalog registrations converge private components

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -68,6 +68,8 @@ type DiagnosticsService struct {
 	drilldown       DrilldownTelemetryReader
 	references      *subjectReferenceCodec
 	sensitiveBudget OperationBudget
+	volume          DrilldownVolumeBudget
+	auditor         DrilldownAuditor
 	sessions        ProjectOverviewSessionReader
 	sessionCapture  FeatureChecker
 	reader          Reader
@@ -101,8 +103,8 @@ func NewDiagnosticsService(db *pgxpool.Pool, telemetry DiagnosticsTelemetryReade
 // is required: without it a trace or subject handle could not be bound to the
 // caller's organization and session, and the tools stay unavailable rather than
 // returning unbound identifiers.
-func (s *DiagnosticsService) WithDrilldown(drilldown DrilldownTelemetryReader, referenceKeyMaterial string, sensitiveBudget OperationBudget) *DiagnosticsService {
-	if s == nil || drilldown == nil || !sensitiveBudget.valid() {
+func (s *DiagnosticsService) WithDrilldown(drilldown DrilldownTelemetryReader, referenceKeyMaterial string, sensitiveBudget OperationBudget, volume DrilldownVolumeBudget, auditor DrilldownAuditor) *DiagnosticsService {
+	if s == nil || drilldown == nil || !sensitiveBudget.valid() || !volume.valid() || auditor == nil {
 		return s
 	}
 	codec, err := newSubjectReferenceCodec(referenceKeyMaterial)
@@ -112,12 +114,14 @@ func (s *DiagnosticsService) WithDrilldown(drilldown DrilldownTelemetryReader, r
 	s.drilldown = drilldown
 	s.references = codec
 	s.sensitiveBudget = sensitiveBudget
+	s.volume = volume
+	s.auditor = auditor
 	return s
 }
 
 // drilldownValid reports whether the bounded drill-down tools are servable.
 func (s *DiagnosticsService) drilldownValid() bool {
-	return s.valid() && s.drilldown != nil && s.references != nil && s.sensitiveBudget.valid()
+	return s.valid() && s.drilldown != nil && s.references != nil && s.sensitiveBudget.valid() && s.volume.valid() && s.auditor != nil
 }
 
 func (s *DiagnosticsService) valid() bool {

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -23,16 +23,6 @@ const (
 	DiagnosticsOrganizationLimitName = "platform-mcp-diagnostics-organization"
 )
 
-const (
-	// DiagnosticQueriesPerConnectionPerMinute and
-	// DiagnosticQueriesPerOrganizationPerMinute bound the observability reads.
-	// A diagnosis is an interactive loop — an agent asks, narrows, and asks
-	// again — so the allowance is wider than a mutation's, and what it meters
-	// is the ClickHouse scan rather than any external egress.
-	DiagnosticQueriesPerConnectionPerMinute   = 30
-	DiagnosticQueriesPerOrganizationPerMinute = 300
-)
-
 // maxDiagnosticClients bounds the per-client evidence list. Client evidence is
 // self-reported and exists to point at a suspect, not to enumerate a fleet.
 const maxDiagnosticClients = 10
@@ -179,7 +169,7 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 		return GetProjectOverviewOutput{}, err
 	}
 	now := s.now()
-	window, err := resolveWindow(input.Window, now, overviewWindowPolicy)
+	window, err := resolveWindow(input.Window, now, overviewWindowSpec)
 	if err != nil {
 		return GetProjectOverviewOutput{}, err
 	}
@@ -343,7 +333,7 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 		return GetMCPDiagnosticsOutput{}, err
 	}
 	now := s.now()
-	window, err := resolveWindow(input.Window, now, diagnosticsWindowPolicy)
+	window, err := resolveWindow(input.Window, now, diagnosticsWindowSpec)
 	if err != nil {
 		return GetMCPDiagnosticsOutput{}, err
 	}
@@ -383,12 +373,7 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 	if err != nil {
 		return GetMCPDiagnosticsOutput{}, fmt.Errorf("read organization outcome breakdown: %w", err)
 	}
-	// Scoped to the diagnosed project, not to the organization the comparison
-	// spans. An organization-wide watermark reports the freshest observation
-	// anywhere, so a busy sibling project would stamp this result fresh while
-	// the diagnosed project's own observations had stopped arriving — exactly
-	// the reading that turns an absence of evidence into evidence of health.
-	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{GramProjectIDs: []string{input.ProjectID}})
+	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{GramProjectIDs: projectIDs})
 	if err != nil {
 		return GetMCPDiagnosticsOutput{}, fmt.Errorf("read diagnostics watermark: %w", err)
 	}

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -73,16 +73,23 @@ type DiagnosticsTelemetryReader interface {
 // DiagnosticsService answers the two overview-first questions: what is this
 // project doing, and why is this one MCP not working.
 type DiagnosticsService struct {
-	db             *pgxpool.Pool
-	telemetry      DiagnosticsTelemetryReader
-	sessions       ProjectOverviewSessionReader
-	sessionCapture FeatureChecker
-	reader         Reader
-	readiness      *ReadinessService
-	budget         OperationBudget
-	now            func() time.Time
+	db              *pgxpool.Pool
+	telemetry       DiagnosticsTelemetryReader
+	drilldown       DrilldownTelemetryReader
+	references      *subjectReferenceCodec
+	sensitiveBudget OperationBudget
+	sessions        ProjectOverviewSessionReader
+	sessionCapture  FeatureChecker
+	reader          Reader
+	readiness       *ReadinessService
+	budget          OperationBudget
+	now             func() time.Time
 }
 
+// NewDiagnosticsService composes the overview-first entry points. The bounded
+// drill-down tools are attached separately by WithDrilldown, so a deployment
+// that cannot mint subject references serves the overview and withholds the
+// row-level reads rather than serving them unbound.
 func NewDiagnosticsService(db *pgxpool.Pool, telemetry DiagnosticsTelemetryReader, sessionCapture FeatureChecker, reader Reader, readiness *ReadinessService, budget OperationBudget) *DiagnosticsService {
 	var sessions ProjectOverviewSessionReader
 	if db != nil {
@@ -98,6 +105,29 @@ func NewDiagnosticsService(db *pgxpool.Pool, telemetry DiagnosticsTelemetryReade
 		budget:         budget,
 		now:            time.Now,
 	}
+}
+
+// WithDrilldown attaches the bounded drill-down reads. Reference key material
+// is required: without it a trace or subject handle could not be bound to the
+// caller's organization and session, and the tools stay unavailable rather than
+// returning unbound identifiers.
+func (s *DiagnosticsService) WithDrilldown(drilldown DrilldownTelemetryReader, referenceKeyMaterial string, sensitiveBudget OperationBudget) *DiagnosticsService {
+	if s == nil || drilldown == nil || !sensitiveBudget.valid() {
+		return s
+	}
+	codec, err := newSubjectReferenceCodec(referenceKeyMaterial)
+	if err != nil {
+		return s
+	}
+	s.drilldown = drilldown
+	s.references = codec
+	s.sensitiveBudget = sensitiveBudget
+	return s
+}
+
+// drilldownValid reports whether the bounded drill-down tools are servable.
+func (s *DiagnosticsService) drilldownValid() bool {
+	return s.valid() && s.drilldown != nil && s.references != nil && s.sensitiveBudget.valid()
 }
 
 func (s *DiagnosticsService) valid() bool {
@@ -454,24 +484,30 @@ func (s *DiagnosticsService) currentReadiness(ctx context.Context, principal Pri
 func totalsFromRows(rows []telemetryrepo.MCPOutcomeBreakdownRow) outcomeTotals {
 	var totals outcomeTotals
 	for _, row := range rows {
-		count := boundedCount(row.CallCount)
-		totals.Total += count
-		switch row.Outcome {
-		case telemetryrepo.MCPOutcomeSuccess:
-			totals.Success += count
-		case telemetryrepo.MCPOutcomeUnauthorized:
-			totals.Unauthorized += count
-		case telemetryrepo.MCPOutcomeClientError:
-			totals.ClientError += count
-		case telemetryrepo.MCPOutcomeServerError:
-			totals.ServerError += count
-		case telemetryrepo.MCPOutcomeFailed:
-			totals.Failed += count
-		default:
-			totals.Unknown += count
-		}
+		addOutcome(&totals, row.Outcome, boundedCount(row.CallCount))
 	}
 	return totals
+}
+
+// addOutcome accumulates one classified count. An outcome this build does not
+// know is counted as unknown rather than dropped, so the totals always add up
+// and a new class cannot silently shrink the denominator.
+func addOutcome(totals *outcomeTotals, outcome string, count int64) {
+	totals.Total += count
+	switch outcome {
+	case telemetryrepo.MCPOutcomeSuccess:
+		totals.Success += count
+	case telemetryrepo.MCPOutcomeUnauthorized:
+		totals.Unauthorized += count
+	case telemetryrepo.MCPOutcomeClientError:
+		totals.ClientError += count
+	case telemetryrepo.MCPOutcomeServerError:
+		totals.ServerError += count
+	case telemetryrepo.MCPOutcomeFailed:
+		totals.Failed += count
+	default:
+		totals.Unknown += count
+	}
 }
 
 // summaryFromTotals converts the internal tally into the serialized summary.

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -228,8 +228,11 @@ func (s *DiagnosticsService) GetProjectOverview(ctx context.Context, principal P
 	}
 
 	output := GetProjectOverviewOutput{
-		ProjectID:   input.ProjectID,
-		Envelope:    newDataEnvelope(now, watermarkTime(watermark), window),
+		ProjectID: input.ProjectID,
+		// A project overview is project-scoped, so the watermark and the result
+		// answer for the same scope; observation is still taken from the
+		// result rather than inferred from the watermark.
+		Envelope:    newDataEnvelope(now, watermarkTime(watermark), window, summary != nil && summary.TotalToolCalls > 0),
 		MetricsMode: metricsMode(sessionMode),
 		TopServers:  make([]ProjectOverviewServer, 0, len(servers)),
 	}
@@ -393,7 +396,7 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 	return GetMCPDiagnosticsOutput{
 		ProjectID: input.ProjectID,
 		MCPID:     input.MCPID,
-		Envelope:  newDataEnvelope(now, watermarkTime(watermark), window),
+		Envelope:  newDataEnvelope(now, watermarkTime(watermark), window, serverTotals.Total > 0),
 		Readiness: MCPDiagnosticsReadiness{
 			State:     string(normalizedReadiness(readiness, readinessFound).State),
 			Freshness: readinessFreshness(readiness, readinessFound),

--- a/server/internal/platformmcp/diagnostics_test.go
+++ b/server/internal/platformmcp/diagnostics_test.go
@@ -53,7 +53,7 @@ func TestGetProjectOverviewOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 
 	output := GetProjectOverviewOutput{
 		ProjectID:       "00000000-0000-0000-0000-000000000001",
-		Envelope:        newDataEnvelope(now, now.Add(-time.Minute), window),
+		Envelope:        newDataEnvelope(now, now.Add(-time.Minute), window, true),
 		MetricsMode:     "tool_call",
 		ToolCalls:       120,
 		FailedToolCalls: 4,
@@ -84,7 +84,7 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	output := GetMCPDiagnosticsOutput{
 		ProjectID:                   "00000000-0000-0000-0000-000000000001",
 		MCPID:                       "00000000-0000-0000-0000-000000000002",
-		Envelope:                    newDataEnvelope(now, now.Add(-time.Minute), window),
+		Envelope:                    newDataEnvelope(now, now.Add(-time.Minute), window, true),
 		Readiness:                   MCPDiagnosticsReadiness{State: string(ReadinessReady), Freshness: "fresh", CheckedAt: now.Format(time.RFC3339)},
 		Outcomes:                    MCPOutcomeSummary{Total: 10, Success: 4, Unauthorized: 6},
 		OrganizationOutcomes:        MCPOutcomeSummary{Total: 100, Success: 98, ServerError: 2},

--- a/server/internal/platformmcp/diagnostics_test.go
+++ b/server/internal/platformmcp/diagnostics_test.go
@@ -48,7 +48,7 @@ func TestGetProjectOverviewOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("24h", now, overviewWindowPolicy)
+	window, err := resolveWindow("24h", now, overviewWindowSpec)
 	require.NoError(t, err)
 
 	output := GetProjectOverviewOutput{
@@ -64,7 +64,7 @@ func TestGetProjectOverviewOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 
 	require.ElementsMatch(t, []string{
 		"project_id",
-		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
 		"metrics_mode",
 		"tool_calls", "failed_tool_calls", "active_servers", "active_users",
 		"top_servers", "name", "tool_calls",
@@ -78,7 +78,7 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("1h", now, diagnosticsWindowPolicy)
+	window, err := resolveWindow("7d", now, overviewWindowSpec)
 	require.NoError(t, err)
 
 	output := GetMCPDiagnosticsOutput{
@@ -101,7 +101,7 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
-		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
 		"readiness", "state", "freshness", "checked_at",
 		"outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
 		"organization_outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -458,11 +458,15 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 	if err != nil {
 		return GetUserMCPStatusOutput{}, ErrSubjectReferenceNotFound
 	}
+	identityKind, identifier, err := parseSubjectIdentity(subject)
+	if err != nil {
+		return GetUserMCPStatusOutput{}, ErrSubjectReferenceNotFound
+	}
 
 	output := GetUserMCPStatusOutput{
 		ProjectID:      input.ProjectID,
 		MCPID:          input.MCPID,
-		MaskedIdentity: maskSubject(subject),
+		MaskedIdentity: maskSubject(identifier),
 		Activity:       SubjectStateNoObservations,
 	}
 
@@ -483,15 +487,26 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 	// Scoped to this one subject rather than filtered out of a truncated
 	// top-user list: a subject outside that list would otherwise be reported as
 	// having no observations, which on a personal-data question is a false
-	// negative rather than a missing row. The value is whichever identity the
-	// telemetry fold resolved, so it is offered as both candidates.
-	summary, err := s.telemetry.GetOverviewSummary(ctx, telemetryrepo.GetOverviewSummaryParams{
+	// negative rather than a missing row.
+	summaryParams := telemetryrepo.GetOverviewSummaryParams{
 		GramProjectID: target.projectID,
 		TimeStart:     target.window.start.UnixNano(),
 		TimeEnd:       target.window.end.UnixNano(),
 		ToolsetSlug:   toolsetSlug,
-		User:          telemetryrepo.UserIdentity{UserIDs: []string{subject}, Emails: []string{subject}},
-	})
+	}
+	// Filtered on the column the identity actually lives in. Telemetry records
+	// a person as an email, an external user id, or a Gram user id, and these
+	// are separate columns: filtering the wrong one matches nothing and would
+	// report an active person as inactive.
+	switch identityKind {
+	case SubjectIdentityEmail:
+		summaryParams.User = telemetryrepo.UserIdentity{Emails: []string{identifier}}
+	case SubjectIdentityExternal:
+		summaryParams.ExternalUserID = identifier
+	default:
+		summaryParams.User = telemetryrepo.UserIdentity{UserIDs: []string{identifier}}
+	}
+	summary, err := s.telemetry.GetOverviewSummary(ctx, summaryParams)
 	if err != nil {
 		return GetUserMCPStatusOutput{}, fmt.Errorf("read mcp user activity: %w", err)
 	}

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -62,7 +62,7 @@ func (t drilldownTarget) hostedToolsetSlug() string {
 	return t.toolsetSlugs[0]
 }
 
-func (s *DiagnosticsService) resolveDrilldown(ctx context.Context, principal Principal, projectID, mcpID, window string, budget OperationBudget) (drilldownTarget, error) {
+func (s *DiagnosticsService) resolveDrilldown(ctx context.Context, principal Principal, projectID, mcpID, window string, budget OperationBudget, spec windowSpec) (drilldownTarget, error) {
 	if !s.valid() || s.drilldown == nil || !budget.valid() {
 		return drilldownTarget{}, ErrUnavailable
 	}
@@ -73,7 +73,7 @@ func (s *DiagnosticsService) resolveDrilldown(ctx context.Context, principal Pri
 		return drilldownTarget{}, err
 	}
 	now := s.now()
-	resolved, err := resolveWindow(window, now)
+	resolved, err := resolveWindow(window, now, spec)
 	if err != nil {
 		return drilldownTarget{}, err
 	}
@@ -123,7 +123,7 @@ func (s *DiagnosticsService) drilldownEnvelope(ctx context.Context, target drill
 type QueryMCPEventsInput struct {
 	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
 	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
-	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h or 24h (default); this tool looks back at most 24h"`
 }
 
 // MCPToolEvents is one tool's calls in the window, already summed per outcome.
@@ -141,7 +141,7 @@ type QueryMCPEventsOutput struct {
 }
 
 func (s *DiagnosticsService) QueryMCPEvents(ctx context.Context, principal Principal, input QueryMCPEventsInput) (QueryMCPEventsOutput, error) {
-	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget)
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget, drilldownWindowSpec)
 	if err != nil {
 		return QueryMCPEventsOutput{}, err
 	}
@@ -195,7 +195,7 @@ func toolEvents(rows []telemetryrepo.MCPToolOutcomeBreakdownRow) ([]MCPToolEvent
 type QueryMCPTracesInput struct {
 	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
 	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
-	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h or 24h (default); this tool looks back at most 24h"`
 	Outcome   string `json:"outcome,omitempty" jsonschema:"optional outcome class to narrow to: success, unauthorized, client_error, server_error, failed, or unknown"`
 	Cursor    string `json:"cursor,omitempty" jsonschema:"opaque cursor returned by a previous query_mcp_traces result"`
 }
@@ -226,7 +226,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	if input.Outcome != "" && !validOutcomeClass(input.Outcome) {
 		return QueryMCPTracesOutput{}, fmt.Errorf("outcome must be one of success, unauthorized, client_error, server_error, failed, unknown")
 	}
-	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget)
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget, drilldownWindowSpec)
 	if err != nil {
 		return QueryMCPTracesOutput{}, err
 	}
@@ -296,7 +296,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 type QueryMCPMetricsInput struct {
 	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
 	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
-	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), or 7d"`
 }
 
 // QueryMCPMetricsOutput is aggregated to the window it names. There is
@@ -321,7 +321,7 @@ type QueryMCPMetricsOutput struct {
 }
 
 func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Principal, input QueryMCPMetricsInput) (QueryMCPMetricsOutput, error) {
-	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget)
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget, metricsWindowSpec)
 	if err != nil {
 		return QueryMCPMetricsOutput{}, err
 	}
@@ -389,110 +389,93 @@ func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Prin
 	return output, nil
 }
 
-// GetUserMCPStatusInput asks who is using one MCP and how it is going for them.
+// GetUserMCPStatusInput names one subject and one MCP. The subject is given as
+// an opaque reference minted by a summary tool, never as an email, account id,
+// or name: the caller asks about someone it was shown, not about someone it
+// can describe.
 type GetUserMCPStatusInput struct {
 	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
 	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
-	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
-	// IncludeRows asks for per-subject rows rather than the aggregate alone.
-	// It is refused when too few subjects are involved for a row to be
-	// anything other than a person.
-	IncludeRows bool `json:"include_rows,omitempty" jsonschema:"request per-subject rows; refused when fewer than five subjects are involved"`
+	// SubjectReference is an expiring, session-bound handle returned in the
+	// optional rows of a summary tool. It cannot be searched, joined,
+	// refreshed, or constructed.
+	SubjectReference string `json:"subject_reference" jsonschema:"opaque subject reference returned by a summary tool; expires and is bound to this session"`
+	Window           string `json:"window,omitempty" jsonschema:"observation window: 1h or 24h (default); this tool looks back at most 24h"`
 }
 
-// MCPUserStatus is one subject's activity against one MCP, addressed only by an
-// expiring opaque reference. It carries no email, no external user id, and no
-// name.
-type MCPUserStatus struct {
-	SubjectReference string `json:"subject_reference"`
-	ToolCalls        int64  `json:"tool_calls"`
-}
+// Subject state categories. Closed vocabulary, assigned server-side: a category
+// is the whole answer, so there is no count to reconstruct an individual's
+// activity pattern from.
+const (
+	SubjectStateActive         = "active"
+	SubjectStateInactive       = "inactive"
+	SubjectStateNoObservations = "no_observations"
+)
 
 type GetUserMCPStatusOutput struct {
 	ProjectID string       `json:"project_id"`
 	MCPID     string       `json:"mcp_id"`
 	Envelope  DataEnvelope `json:"data"`
 
-	ActiveUsers SubjectCount `json:"active_users"`
-	// RowsSuppressed reports that per-subject rows were withheld because too
-	// few subjects were involved. It is stated rather than left to be inferred
-	// from an empty list, which would read as "nobody used this".
-	RowsSuppressed bool `json:"rows_suppressed"`
+	// MaskedIdentity is enough to recognize a subject already known to the
+	// administrator and not enough to learn one. It is never a raw identifier.
+	MaskedIdentity string `json:"masked_identity"`
+	// Activity is a state category rather than a count, so a caller cannot
+	// assemble an activity profile from repeated calls.
+	Activity string `json:"activity"`
 	// Unavailable reports that this MCP's model cannot be scoped by the reads
-	// behind this tool, so no statement is made about its users at all.
-	Unavailable bool            `json:"unavailable"`
-	Users       []MCPUserStatus `json:"users"`
+	// behind this tool, so no statement is made about the subject at all.
+	Unavailable bool `json:"unavailable"`
 }
 
 func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Principal, input GetUserMCPStatusInput) (GetUserMCPStatusOutput, error) {
 	if s == nil || s.references == nil {
 		return GetUserMCPStatusOutput{}, ErrUnavailable
 	}
+	if input.SubjectReference == "" {
+		return GetUserMCPStatusOutput{}, fmt.Errorf("subject_reference is required")
+	}
 	// Metered on its own allowance: this is the one drill-down that reaches
 	// personal data, so exhausting it must not be possible by spending the
 	// ordinary diagnostic budget.
-	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.sensitiveBudget)
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.sensitiveBudget, drilldownWindowSpec)
 	if err != nil {
 		return GetUserMCPStatusOutput{}, err
 	}
-	toolsetSlug := target.hostedToolsetSlug()
-	start, end := target.window.start.UnixNano(), target.window.end.UnixNano()
+	// Resolved only within the bound organization and connection generation.
+	// An unknown, expired, cross-generation, or cross-organization reference is
+	// a single not-found: distinguishing them would confirm that a reference
+	// once existed, which is itself information about another organization.
+	subject, err := s.references.Decode(input.SubjectReference, principal, subjectKindUser, target.now)
+	if err != nil {
+		return GetUserMCPStatusOutput{}, ErrSubjectReferenceNotFound
+	}
 
-	envelopeOnly, err := s.drilldownEnvelope(ctx, target)
+	envelope, err := s.drilldownEnvelope(ctx, target)
 	if err != nil {
 		return GetUserMCPStatusOutput{}, err
-	}
-	// A remote, tunneled, or unproxied server carries no toolset slug, and the
-	// reads below narrow by nothing else. Answering anyway would report the
-	// project's users as this MCP's — and mint a subject reference for every
-	// one of them, which is a disclosure, not just a wrong number.
-	if toolsetSlug == "" {
-		return GetUserMCPStatusOutput{
-			ProjectID:   input.ProjectID,
-			MCPID:       input.MCPID,
-			Envelope:    envelopeOnly,
-			Unavailable: true,
-			Users:       []MCPUserStatus{},
-		}, nil
-	}
-
-	counts, err := s.telemetry.GetActiveCounts(ctx, telemetryrepo.GetActiveCountsParams{
-		GramProjectID: target.projectID,
-		TimeStart:     start,
-		TimeEnd:       end,
-		ToolsetSlug:   toolsetSlug,
-	})
-	if err != nil {
-		return GetUserMCPStatusOutput{}, fmt.Errorf("read mcp user active counts: %w", err)
-	}
-	envelope := envelopeOnly
-
-	var activeUsers int64
-	if counts != nil {
-		activeUsers = boundedCount(counts.ActiveUsersCount)
 	}
 	output := GetUserMCPStatusOutput{
-		ProjectID:   input.ProjectID,
-		MCPID:       input.MCPID,
-		Envelope:    envelope,
-		ActiveUsers: NewSubjectCount(activeUsers),
-		Users:       []MCPUserStatus{},
+		ProjectID:      input.ProjectID,
+		MCPID:          input.MCPID,
+		Envelope:       envelope,
+		MaskedIdentity: maskSubject(subject),
+		Activity:       SubjectStateNoObservations,
 	}
-	if !input.IncludeRows {
-		return output, nil
-	}
-	// Refused rather than trimmed: with fewer than five subjects, a row is a
-	// person however it is labelled, and the aggregate above already answers
-	// the question rows were asked for.
-	if activeUsers < SubjectSuppressionThreshold {
-		output.RowsSuppressed = true
+
+	toolsetSlug := target.hostedToolsetSlug()
+	// A remote, tunneled, or unproxied server carries no toolset slug, and the
+	// read below narrows by nothing else. Answering anyway would report the
+	// project's activity as this MCP's.
+	if toolsetSlug == "" {
+		output.Unavailable = true
 		return output, nil
 	}
 
 	users, err := s.drilldown.GetTopUsers(ctx, telemetryrepo.GetTopUsersParams{
 		GramProjectID: target.projectID,
-		TimeStart:     start,
-		TimeEnd:       end,
+		TimeStart:     target.window.start.UnixNano(),
+		TimeEnd:       target.window.end.UnixNano(),
 		ToolsetSlug:   toolsetSlug,
 		Limit:         maxUserStatusRows,
 	})
@@ -500,19 +483,41 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 		return GetUserMCPStatusOutput{}, fmt.Errorf("read mcp user activity: %w", err)
 	}
 	for _, user := range users {
-		// user.UserID is whichever identity the telemetry fold resolved — an
-		// email in many cases. It is minted into a reference here and never
-		// projected, which is the whole reason references exist.
-		reference, err := s.references.Encode(principal, subjectKindUser, user.UserID, target.now)
-		if err != nil {
-			return GetUserMCPStatusOutput{}, fmt.Errorf("mint subject reference: %w", err)
+		if user.UserID != subject {
+			continue
 		}
-		output.Users = append(output.Users, MCPUserStatus{
-			SubjectReference: reference,
-			ToolCalls:        boundedCount(user.ActivityCount),
-		})
+		if user.ActivityCount > 0 {
+			output.Activity = SubjectStateActive
+		} else {
+			output.Activity = SubjectStateInactive
+		}
+		return output, nil
 	}
 	return output, nil
+}
+
+// maskSubject reduces an identifier to something an administrator who already
+// knows the person can recognize, and someone who does not cannot learn.
+//
+// The local part and the domain are masked separately for an email so the shape
+// stays readable; anything else keeps only its first character.
+func maskSubject(subject string) string {
+	local, domain, isEmail := strings.Cut(subject, "@")
+	if !isEmail || local == "" || domain == "" {
+		return maskToken(subject)
+	}
+	return maskToken(local) + "@" + maskToken(domain)
+}
+
+func maskToken(value string) string {
+	runes := []rune(value)
+	if len(runes) == 0 {
+		return ""
+	}
+	if len(runes) == 1 {
+		return "*"
+	}
+	return string(runes[0]) + strings.Repeat("*", min(len(runes)-1, 3))
 }
 
 func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, now time.Time) (int64, string, error) {

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -292,6 +292,27 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	return output, nil
 }
 
+// summaryIdentityParams scopes the summary read to exactly one identity filter.
+//
+// The two are recorded on different traffic: hosted calls carry
+// gram.toolset.slug and no mcp_server id, so ANDing both matches nothing and
+// silently reports zero latency. The mcp_server id is what scopes the models
+// that carry no slug, where an empty slug would otherwise read as "no filter"
+// and return the whole project under this MCP's name.
+func summaryIdentityParams(target drilldownTarget, start, end int64) telemetryrepo.GetOverviewSummaryParams {
+	params := telemetryrepo.GetOverviewSummaryParams{
+		GramProjectID: target.projectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+	}
+	if slug := target.hostedToolsetSlug(); slug != "" {
+		params.ToolsetSlug = slug
+		return params
+	}
+	params.MCPServerID = target.mcpServerID
+	return params
+}
+
 // QueryMCPMetricsInput asks for one MCP's aggregate levels over a window.
 type QueryMCPMetricsInput struct {
 	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
@@ -336,16 +357,7 @@ func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Prin
 	if err != nil {
 		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics outcomes: %w", err)
 	}
-	summary, err := s.telemetry.GetOverviewSummary(ctx, telemetryrepo.GetOverviewSummaryParams{
-		GramProjectID: target.projectID,
-		TimeStart:     start,
-		TimeEnd:       end,
-		ToolsetSlug:   toolsetSlug,
-		// Scopes the read for a remote, tunneled, or unproxied server, which
-		// carries no toolset slug. Without it an empty slug would read as "no
-		// filter" and return the whole project under this MCP's name.
-		MCPServerID: target.mcpServerID,
-	})
+	summary, err := s.telemetry.GetOverviewSummary(ctx, summaryIdentityParams(target, start, end))
 	if err != nil {
 		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics summary: %w", err)
 	}

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -334,12 +334,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 		return QueryMCPTracesOutput{}, err
 	}
 	output.Traces = fitted
-	// A page cut to fit must not advertise a cursor past the rows it dropped,
-	// or the next page would resume beyond occurrences the caller never saw.
-	if dropped {
-		more = false
-		rows = rows[:len(fitted)]
-	}
+	rows, more = resumeAfterFit(rows, len(fitted), dropped, more)
 	traversed += len(rows)
 	if more && len(rows) > 0 && traversed < maxTraceTraversal {
 		last := rows[len(rows)-1]
@@ -711,6 +706,19 @@ func parseCursorPosition(value string) (int64, string, int, error) {
 // build re-forms the whole result around a candidate row slice, because what is
 // measured has to be the response as it will actually be serialized rather than
 // the rows alone.
+// resumeAfterFit narrows the rows a cursor may resume from to the rows the
+// response actually carried. A page cut to fit still has a next page — the
+// suffix it dropped — so the cursor resumes at the last row handed over rather
+// than being withheld, which would strand those occurrences. A page cut to
+// nothing leaves no position to resume from.
+func resumeAfterFit[R any](rows []R, fitted int, dropped, more bool) ([]R, bool) {
+	if !dropped {
+		return rows, more
+	}
+	rows = rows[:fitted]
+	return rows, len(rows) > 0
+}
+
 func fitRows[R any](rows []R, build func([]R) any) ([]R, bool, error) {
 	fits, err := responseFits(build(rows))
 	if err != nil {

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -43,8 +43,23 @@ type drilldownTarget struct {
 	toolsetSlugs []string
 	urlSuffixes  []string
 	projectID    string
+	mcpServerID  string
 	window       ResolvedWindow
 	now          time.Time
+}
+
+// hostedToolsetSlug is the toolset a hosted MCP's traffic is recorded under, or
+// empty for a remote, tunneled, or unproxied server.
+//
+// Emptiness matters: the summary reads treat an empty slug as "no filter", so a
+// caller that passes it through unchecked gets the whole project's numbers back
+// under one MCP's name. Every use of this value must handle the empty case
+// rather than forwarding it.
+func (t drilldownTarget) hostedToolsetSlug() string {
+	if len(t.toolsetSlugs) == 0 {
+		return ""
+	}
+	return t.toolsetSlugs[0]
 }
 
 func (s *DiagnosticsService) resolveDrilldown(ctx context.Context, principal Principal, projectID, mcpID, window string, budget OperationBudget) (drilldownTarget, error) {
@@ -76,6 +91,7 @@ func (s *DiagnosticsService) resolveDrilldown(ctx context.Context, principal Pri
 		toolsetSlugs: nonEmpty(target.ToolsetSlug),
 		urlSuffixes:  mcpURLSuffixes(target.McpSlug),
 		projectID:    projectID,
+		mcpServerID:  mcpID,
 		window:       resolved,
 		now:          now,
 	}, nil
@@ -215,7 +231,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 		return QueryMCPTracesOutput{}, err
 	}
 
-	before, err := s.decodeTraceCursor(input.Cursor, principal, target.now)
+	before, beforeTraceID, err := s.decodeTraceCursor(input.Cursor, principal, target.now)
 	if err != nil {
 		return QueryMCPTracesOutput{}, err
 	}
@@ -223,6 +239,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	params := telemetryrepo.ListMCPTraceReferencesParams{
 		GetMCPOutcomeBreakdownParams: target.outcomeParams(),
 		BeforeUnixNano:               before,
+		BeforeTraceID:                beforeTraceID,
 		// One extra row decides whether another page exists without a second
 		// round trip, and is dropped before anything is projected.
 		Limit: maxTraceReferences + 1,
@@ -265,7 +282,8 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 		Traces:    traces,
 	}
 	if more && len(rows) > 0 {
-		cursor, err := s.references.Encode(principal, subjectKindTrace, formatCursorPosition(rows[len(rows)-1].OccurredAt), target.now)
+		last := rows[len(rows)-1]
+		cursor, err := s.references.Encode(principal, subjectKindTrace, formatCursorPosition(last.OccurredAt, last.TraceID), target.now)
 		if err != nil {
 			return QueryMCPTracesOutput{}, fmt.Errorf("mint trace cursor: %w", err)
 		}
@@ -296,6 +314,10 @@ type QueryMCPMetricsOutput struct {
 	FailureRate  float64      `json:"failure_rate"`
 	AvgLatencyMs float64      `json:"avg_latency_ms"`
 	ActiveUsers  SubjectCount `json:"active_users"`
+	// ActiveUsersUnavailable reports that this MCP's model cannot be scoped by
+	// the active-count read, so ActiveUsers is not an answer about this server.
+	// Stated rather than left as a zero, which would read as "nobody".
+	ActiveUsersUnavailable bool `json:"active_users_unavailable"`
 }
 
 func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Principal, input QueryMCPMetricsInput) (QueryMCPMetricsOutput, error) {
@@ -303,20 +325,54 @@ func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Prin
 	if err != nil {
 		return QueryMCPMetricsOutput{}, err
 	}
-	toolsetSlug := ""
-	if len(target.toolsetSlugs) > 0 {
-		toolsetSlug = target.toolsetSlugs[0]
-	}
+	toolsetSlug := target.hostedToolsetSlug()
 	start, end := target.window.start.UnixNano(), target.window.end.UnixNano()
 
+	// Call volume comes from the same correctly-scoped trace source the rest of
+	// the drill-down reads, which matches on both the toolset slug and the
+	// server URL. The summary read below can only narrow by toolset slug or
+	// mcp_server_id, so it is used for latency alone.
+	outcomeRows, err := s.telemetry.GetMCPOutcomeBreakdown(ctx, target.outcomeParams())
+	if err != nil {
+		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics outcomes: %w", err)
+	}
 	summary, err := s.telemetry.GetOverviewSummary(ctx, telemetryrepo.GetOverviewSummaryParams{
 		GramProjectID: target.projectID,
 		TimeStart:     start,
 		TimeEnd:       end,
 		ToolsetSlug:   toolsetSlug,
+		// Scopes the read for a remote, tunneled, or unproxied server, which
+		// carries no toolset slug. Without it an empty slug would read as "no
+		// filter" and return the whole project under this MCP's name.
+		MCPServerID: target.mcpServerID,
 	})
 	if err != nil {
 		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics summary: %w", err)
+	}
+	envelope, err := s.drilldownEnvelope(ctx, target)
+	if err != nil {
+		return QueryMCPMetricsOutput{}, err
+	}
+
+	totals := totalsFromRows(outcomeRows)
+	output := QueryMCPMetricsOutput{
+		ProjectID:       input.ProjectID,
+		MCPID:           input.MCPID,
+		Envelope:        envelope,
+		ToolCalls:       totals.Total,
+		FailedToolCalls: totals.failures(),
+		FailureRate:     failureRate(totals.Total, totals.failures()),
+	}
+	if summary != nil {
+		output.AvgLatencyMs = summary.AvgLatencyMs
+	}
+	// Active users are only answerable for a hosted server: the active-count
+	// read narrows by toolset slug and by nothing else, so for any other model
+	// the honest answer is that this metric is unavailable for this MCP — not
+	// the project's user count wearing its name.
+	if toolsetSlug == "" {
+		output.ActiveUsersUnavailable = true
+		return output, nil
 	}
 	counts, err := s.telemetry.GetActiveCounts(ctx, telemetryrepo.GetActiveCountsParams{
 		GramProjectID: target.projectID,
@@ -326,22 +382,6 @@ func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Prin
 	})
 	if err != nil {
 		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics active counts: %w", err)
-	}
-	envelope, err := s.drilldownEnvelope(ctx, target)
-	if err != nil {
-		return QueryMCPMetricsOutput{}, err
-	}
-
-	output := QueryMCPMetricsOutput{
-		ProjectID: input.ProjectID,
-		MCPID:     input.MCPID,
-		Envelope:  envelope,
-	}
-	if summary != nil {
-		output.ToolCalls = boundedCount(summary.TotalToolCalls)
-		output.FailedToolCalls = boundedCount(summary.FailedToolCalls)
-		output.FailureRate = failureRate(output.ToolCalls, output.FailedToolCalls)
-		output.AvgLatencyMs = summary.AvgLatencyMs
 	}
 	if counts != nil {
 		output.ActiveUsers = NewSubjectCount(boundedCount(counts.ActiveUsersCount))
@@ -377,8 +417,11 @@ type GetUserMCPStatusOutput struct {
 	// RowsSuppressed reports that per-subject rows were withheld because too
 	// few subjects were involved. It is stated rather than left to be inferred
 	// from an empty list, which would read as "nobody used this".
-	RowsSuppressed bool            `json:"rows_suppressed"`
-	Users          []MCPUserStatus `json:"users"`
+	RowsSuppressed bool `json:"rows_suppressed"`
+	// Unavailable reports that this MCP's model cannot be scoped by the reads
+	// behind this tool, so no statement is made about its users at all.
+	Unavailable bool            `json:"unavailable"`
+	Users       []MCPUserStatus `json:"users"`
 }
 
 func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Principal, input GetUserMCPStatusInput) (GetUserMCPStatusOutput, error) {
@@ -392,11 +435,26 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 	if err != nil {
 		return GetUserMCPStatusOutput{}, err
 	}
-	toolsetSlug := ""
-	if len(target.toolsetSlugs) > 0 {
-		toolsetSlug = target.toolsetSlugs[0]
-	}
+	toolsetSlug := target.hostedToolsetSlug()
 	start, end := target.window.start.UnixNano(), target.window.end.UnixNano()
+
+	envelopeOnly, err := s.drilldownEnvelope(ctx, target)
+	if err != nil {
+		return GetUserMCPStatusOutput{}, err
+	}
+	// A remote, tunneled, or unproxied server carries no toolset slug, and the
+	// reads below narrow by nothing else. Answering anyway would report the
+	// project's users as this MCP's — and mint a subject reference for every
+	// one of them, which is a disclosure, not just a wrong number.
+	if toolsetSlug == "" {
+		return GetUserMCPStatusOutput{
+			ProjectID:   input.ProjectID,
+			MCPID:       input.MCPID,
+			Envelope:    envelopeOnly,
+			Unavailable: true,
+			Users:       []MCPUserStatus{},
+		}, nil
+	}
 
 	counts, err := s.telemetry.GetActiveCounts(ctx, telemetryrepo.GetActiveCountsParams{
 		GramProjectID: target.projectID,
@@ -407,10 +465,7 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 	if err != nil {
 		return GetUserMCPStatusOutput{}, fmt.Errorf("read mcp user active counts: %w", err)
 	}
-	envelope, err := s.drilldownEnvelope(ctx, target)
-	if err != nil {
-		return GetUserMCPStatusOutput{}, err
-	}
+	envelope := envelopeOnly
 
 	var activeUsers int64
 	if counts != nil {
@@ -460,19 +515,19 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 	return output, nil
 }
 
-func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, now time.Time) (int64, error) {
+func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, now time.Time) (int64, string, error) {
 	if cursor == "" {
-		return 0, nil
+		return 0, "", nil
 	}
 	value, err := s.references.Decode(cursor, principal, subjectKindTrace, now)
 	if err != nil {
-		return 0, ErrSubjectReferenceInvalid
+		return 0, "", ErrSubjectReferenceNotFound
 	}
-	position, err := parseCursorPosition(value)
+	position, traceID, err := parseCursorPosition(value)
 	if err != nil {
-		return 0, ErrSubjectReferenceInvalid
+		return 0, "", ErrSubjectReferenceNotFound
 	}
-	return position, nil
+	return position, traceID, nil
 }
 
 // sortToolEvents puts the tool a caller should look at first at the top:
@@ -494,20 +549,27 @@ func sortToolEvents(events []MCPToolEvents) {
 
 // A trace cursor carries only a position, minted through the same bound,
 // expiring reference codec as everything else a caller holds between calls.
-func formatCursorPosition(unixNano int64) string {
-	return "t:" + strconv.FormatInt(unixNano, 10)
+func formatCursorPosition(unixNano int64, traceID string) string {
+	return "t:" + strconv.FormatInt(unixNano, 10) + ":" + traceID
 }
 
-func parseCursorPosition(value string) (int64, error) {
+// parseCursorPosition recovers the composite page key. Both halves are
+// required: the repo orders by (event_time_ns, trace_id), and a cursor carrying
+// only the timestamp would skip every trace sharing the boundary nanosecond.
+func parseCursorPosition(value string) (int64, string, error) {
 	rest, ok := strings.CutPrefix(value, "t:")
 	if !ok {
-		return 0, ErrSubjectReferenceInvalid
+		return 0, "", ErrSubjectReferenceNotFound
 	}
-	position, err := strconv.ParseInt(rest, 10, 64)
+	timestamp, traceID, ok := strings.Cut(rest, ":")
+	if !ok || traceID == "" {
+		return 0, "", ErrSubjectReferenceNotFound
+	}
+	position, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil || position <= 0 {
-		return 0, ErrSubjectReferenceInvalid
+		return 0, "", ErrSubjectReferenceNotFound
 	}
-	return position, nil
+	return position, traceID, nil
 }
 
 func validOutcomeClass(outcome string) bool {

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -1,0 +1,535 @@
+//nolint:exhaustruct // Diagnostic projections intentionally omit documented optional fields.
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+const (
+	SensitiveDiagnosticsConnectionLimitName   = "platform-mcp-sensitive-diagnostics-connection"
+	SensitiveDiagnosticsOrganizationLimitName = "platform-mcp-sensitive-diagnostics-organization"
+)
+
+const (
+	// maxDrilldownTools bounds the per-tool event breakdown.
+	maxDrilldownTools = 25
+	// maxTraceReferences bounds one page of correlation references.
+	maxTraceReferences = 20
+	// maxUserStatusRows bounds one page of per-subject rows.
+	maxUserStatusRows = 25
+)
+
+// DrilldownTelemetryReader is the additional telemetry the bounded drill-down
+// tools read. It stays separate from DiagnosticsTelemetryReader so the
+// overview-first entry points cannot accidentally acquire row-level reads.
+type DrilldownTelemetryReader interface {
+	GetMCPToolOutcomeBreakdown(ctx context.Context, arg telemetryrepo.GetMCPToolOutcomeBreakdownParams) ([]telemetryrepo.MCPToolOutcomeBreakdownRow, error)
+	ListMCPTraceReferences(ctx context.Context, arg telemetryrepo.ListMCPTraceReferencesParams) ([]telemetryrepo.MCPTraceReferenceRow, error)
+	GetTopUsers(ctx context.Context, arg telemetryrepo.GetTopUsersParams) ([]telemetryrepo.TopUser, error)
+}
+
+// drilldownTarget is one resolved MCP plus the window to read it over. Every
+// drill-down begins by resolving these together, because each of them is an
+// authorization decision: the MCP must be one this principal can already see,
+// and the window must be one of the named ones.
+type drilldownTarget struct {
+	toolsetSlugs []string
+	urlSuffixes  []string
+	projectID    string
+	window       ResolvedWindow
+	now          time.Time
+}
+
+func (s *DiagnosticsService) resolveDrilldown(ctx context.Context, principal Principal, projectID, mcpID, window string, budget OperationBudget) (drilldownTarget, error) {
+	if !s.valid() || s.drilldown == nil || !budget.valid() {
+		return drilldownTarget{}, ErrUnavailable
+	}
+	if projectID == "" || mcpID == "" {
+		return drilldownTarget{}, fmt.Errorf("project_id and mcp_id are required")
+	}
+	if err := budget.Allow(ctx, principal); err != nil {
+		return drilldownTarget{}, err
+	}
+	now := s.now()
+	resolved, err := resolveWindow(window, now)
+	if err != nil {
+		return drilldownTarget{}, err
+	}
+	// GetMCP is the authorization boundary, exactly as it is for diagnostics:
+	// it fails closed for an MCP this principal cannot see, and every read below
+	// is scoped to what it returned.
+	if _, err := s.reader.GetMCP(ctx, principal, GetMCPInput{ProjectID: projectID, MCPID: mcpID}); err != nil {
+		return drilldownTarget{}, fmt.Errorf("resolve drilldown mcp: %w", err)
+	}
+	target, err := s.diagnosticsTarget(ctx, principal.OrganizationID, projectID, mcpID)
+	if err != nil {
+		return drilldownTarget{}, err
+	}
+	return drilldownTarget{
+		toolsetSlugs: nonEmpty(target.ToolsetSlug),
+		urlSuffixes:  mcpURLSuffixes(target.McpSlug),
+		projectID:    projectID,
+		window:       resolved,
+		now:          now,
+	}, nil
+}
+
+func (t drilldownTarget) outcomeParams() telemetryrepo.GetMCPOutcomeBreakdownParams {
+	return telemetryrepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs:       []string{t.projectID},
+		ToolsetSlugs:         t.toolsetSlugs,
+		MCPServerURLSuffixes: t.urlSuffixes,
+		TimeStart:            t.window.start.UnixNano(),
+		TimeEnd:              t.window.end.UnixNano(),
+	}
+}
+
+func (s *DiagnosticsService) drilldownEnvelope(ctx context.Context, target drilldownTarget) (DataEnvelope, error) {
+	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{
+		GramProjectIDs: []string{target.projectID},
+	})
+	if err != nil {
+		return DataEnvelope{}, fmt.Errorf("read drilldown watermark: %w", err)
+	}
+	return newDataEnvelope(target.now, watermarkTime(watermark), target.window), nil
+}
+
+// QueryMCPEventsInput drills into one MCP's calls by tool. It has no free-text
+// filter and no attribute selector: the only axis is the MCP the overview
+// already named.
+type QueryMCPEventsInput struct {
+	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
+	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+}
+
+// MCPToolEvents is one tool's calls in the window, already summed per outcome.
+type MCPToolEvents struct {
+	ToolName string            `json:"tool_name"`
+	Outcomes MCPOutcomeSummary `json:"outcomes"`
+}
+
+type QueryMCPEventsOutput struct {
+	ProjectID string          `json:"project_id"`
+	MCPID     string          `json:"mcp_id"`
+	Envelope  DataEnvelope    `json:"data"`
+	Tools     []MCPToolEvents `json:"tools"`
+	Truncated bool            `json:"truncated"`
+}
+
+func (s *DiagnosticsService) QueryMCPEvents(ctx context.Context, principal Principal, input QueryMCPEventsInput) (QueryMCPEventsOutput, error) {
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget)
+	if err != nil {
+		return QueryMCPEventsOutput{}, err
+	}
+	rows, err := s.drilldown.GetMCPToolOutcomeBreakdown(ctx, telemetryrepo.GetMCPToolOutcomeBreakdownParams{
+		GetMCPOutcomeBreakdownParams: target.outcomeParams(),
+	})
+	if err != nil {
+		return QueryMCPEventsOutput{}, fmt.Errorf("read mcp tool outcome breakdown: %w", err)
+	}
+	envelope, err := s.drilldownEnvelope(ctx, target)
+	if err != nil {
+		return QueryMCPEventsOutput{}, err
+	}
+	tools, truncated := toolEvents(rows)
+	return QueryMCPEventsOutput{
+		ProjectID: input.ProjectID,
+		MCPID:     input.MCPID,
+		Envelope:  envelope,
+		Tools:     tools,
+		Truncated: truncated,
+	}, nil
+}
+
+// toolEvents folds the breakdown to one row per tool, ordered by failures then
+// calls so the broken tool leads, and caps the list with an explicit flag.
+func toolEvents(rows []telemetryrepo.MCPToolOutcomeBreakdownRow) ([]MCPToolEvents, bool) {
+	byTool := map[string]*outcomeTotals{}
+	order := []string{}
+	for _, row := range rows {
+		totals, ok := byTool[row.ToolName]
+		if !ok {
+			totals = &outcomeTotals{}
+			byTool[row.ToolName] = totals
+			order = append(order, row.ToolName)
+		}
+		addOutcome(totals, row.Outcome, boundedCount(row.CallCount))
+	}
+	events := make([]MCPToolEvents, 0, len(order))
+	for _, name := range order {
+		events = append(events, MCPToolEvents{ToolName: name, Outcomes: summaryFromTotals(*byTool[name])})
+	}
+	sortToolEvents(events)
+	if len(events) > maxDrilldownTools {
+		return events[:maxDrilldownTools], true
+	}
+	return events, false
+}
+
+// QueryMCPTracesInput asks for individual occurrences of a failure class the
+// overview or diagnostics already identified.
+type QueryMCPTracesInput struct {
+	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
+	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+	Outcome   string `json:"outcome,omitempty" jsonschema:"optional outcome class to narrow to: success, unauthorized, client_error, server_error, failed, or unknown"`
+	Cursor    string `json:"cursor,omitempty" jsonschema:"opaque cursor returned by a previous query_mcp_traces result"`
+}
+
+// MCPTraceReference is one occurrence, reduced to what an investigation needs:
+// when it happened, which tool, how it ended, and an opaque handle to quote.
+// It carries no arguments, results, bodies, headers, URLs, or identities.
+type MCPTraceReference struct {
+	Reference  string `json:"reference"`
+	OccurredAt string `json:"occurred_at"`
+	ToolName   string `json:"tool_name,omitempty"`
+	Outcome    string `json:"outcome"`
+	Client     string `json:"client"`
+}
+
+type QueryMCPTracesOutput struct {
+	ProjectID  string              `json:"project_id"`
+	MCPID      string              `json:"mcp_id"`
+	Envelope   DataEnvelope        `json:"data"`
+	Traces     []MCPTraceReference `json:"traces"`
+	NextCursor string              `json:"next_cursor,omitempty"`
+}
+
+func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Principal, input QueryMCPTracesInput) (QueryMCPTracesOutput, error) {
+	if s == nil || s.references == nil {
+		return QueryMCPTracesOutput{}, ErrUnavailable
+	}
+	if input.Outcome != "" && !validOutcomeClass(input.Outcome) {
+		return QueryMCPTracesOutput{}, fmt.Errorf("outcome must be one of success, unauthorized, client_error, server_error, failed, unknown")
+	}
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget)
+	if err != nil {
+		return QueryMCPTracesOutput{}, err
+	}
+
+	before, err := s.decodeTraceCursor(input.Cursor, principal, target.now)
+	if err != nil {
+		return QueryMCPTracesOutput{}, err
+	}
+
+	params := telemetryrepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: target.outcomeParams(),
+		BeforeUnixNano:               before,
+		// One extra row decides whether another page exists without a second
+		// round trip, and is dropped before anything is projected.
+		Limit: maxTraceReferences + 1,
+	}
+	if input.Outcome != "" {
+		params.Outcomes = []string{input.Outcome}
+	}
+	rows, err := s.drilldown.ListMCPTraceReferences(ctx, params)
+	if err != nil {
+		return QueryMCPTracesOutput{}, fmt.Errorf("read mcp trace references: %w", err)
+	}
+	envelope, err := s.drilldownEnvelope(ctx, target)
+	if err != nil {
+		return QueryMCPTracesOutput{}, err
+	}
+
+	more := len(rows) > maxTraceReferences
+	if more {
+		rows = rows[:maxTraceReferences]
+	}
+	traces := make([]MCPTraceReference, 0, len(rows))
+	for _, row := range rows {
+		reference, err := s.references.Encode(principal, subjectKindTrace, row.TraceID, target.now)
+		if err != nil {
+			return QueryMCPTracesOutput{}, fmt.Errorf("mint trace reference: %w", err)
+		}
+		traces = append(traces, MCPTraceReference{
+			Reference:  reference,
+			OccurredAt: time.Unix(0, row.OccurredAt).UTC().Format(time.RFC3339),
+			ToolName:   row.ToolName,
+			Outcome:    row.Outcome,
+			Client:     row.ClientName,
+		})
+	}
+
+	output := QueryMCPTracesOutput{
+		ProjectID: input.ProjectID,
+		MCPID:     input.MCPID,
+		Envelope:  envelope,
+		Traces:    traces,
+	}
+	if more && len(rows) > 0 {
+		cursor, err := s.references.Encode(principal, subjectKindTrace, formatCursorPosition(rows[len(rows)-1].OccurredAt), target.now)
+		if err != nil {
+			return QueryMCPTracesOutput{}, fmt.Errorf("mint trace cursor: %w", err)
+		}
+		output.NextCursor = cursor
+	}
+	return output, nil
+}
+
+// QueryMCPMetricsInput asks for one MCP's aggregate levels over a window.
+type QueryMCPMetricsInput struct {
+	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
+	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+}
+
+// QueryMCPMetricsOutput is aggregated to the window it names. There is
+// deliberately no per-bucket series: an external MCP client has no scratch
+// compute, and handing it buckets to sum would be a contract failure.
+type QueryMCPMetricsOutput struct {
+	ProjectID string       `json:"project_id"`
+	MCPID     string       `json:"mcp_id"`
+	Envelope  DataEnvelope `json:"data"`
+
+	ToolCalls       int64 `json:"tool_calls"`
+	FailedToolCalls int64 `json:"failed_tool_calls"`
+	// FailureRate is computed server-side and rounded to four decimal places.
+	// Zero calls yields zero rather than an undefined ratio.
+	FailureRate  float64      `json:"failure_rate"`
+	AvgLatencyMs float64      `json:"avg_latency_ms"`
+	ActiveUsers  SubjectCount `json:"active_users"`
+}
+
+func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Principal, input QueryMCPMetricsInput) (QueryMCPMetricsOutput, error) {
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget)
+	if err != nil {
+		return QueryMCPMetricsOutput{}, err
+	}
+	toolsetSlug := ""
+	if len(target.toolsetSlugs) > 0 {
+		toolsetSlug = target.toolsetSlugs[0]
+	}
+	start, end := target.window.start.UnixNano(), target.window.end.UnixNano()
+
+	summary, err := s.telemetry.GetOverviewSummary(ctx, telemetryrepo.GetOverviewSummaryParams{
+		GramProjectID: target.projectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+		ToolsetSlug:   toolsetSlug,
+	})
+	if err != nil {
+		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics summary: %w", err)
+	}
+	counts, err := s.telemetry.GetActiveCounts(ctx, telemetryrepo.GetActiveCountsParams{
+		GramProjectID: target.projectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+		ToolsetSlug:   toolsetSlug,
+	})
+	if err != nil {
+		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics active counts: %w", err)
+	}
+	envelope, err := s.drilldownEnvelope(ctx, target)
+	if err != nil {
+		return QueryMCPMetricsOutput{}, err
+	}
+
+	output := QueryMCPMetricsOutput{
+		ProjectID: input.ProjectID,
+		MCPID:     input.MCPID,
+		Envelope:  envelope,
+	}
+	if summary != nil {
+		output.ToolCalls = boundedCount(summary.TotalToolCalls)
+		output.FailedToolCalls = boundedCount(summary.FailedToolCalls)
+		output.FailureRate = failureRate(output.ToolCalls, output.FailedToolCalls)
+		output.AvgLatencyMs = summary.AvgLatencyMs
+	}
+	if counts != nil {
+		output.ActiveUsers = NewSubjectCount(boundedCount(counts.ActiveUsersCount))
+	}
+	return output, nil
+}
+
+// GetUserMCPStatusInput asks who is using one MCP and how it is going for them.
+type GetUserMCPStatusInput struct {
+	ProjectID string `json:"project_id" jsonschema:"AICP project ID that owns the MCP"`
+	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID as returned by find_mcp or get_mcp"`
+	Window    string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), 7d, or 30d"`
+	// IncludeRows asks for per-subject rows rather than the aggregate alone.
+	// It is refused when too few subjects are involved for a row to be
+	// anything other than a person.
+	IncludeRows bool `json:"include_rows,omitempty" jsonschema:"request per-subject rows; refused when fewer than five subjects are involved"`
+}
+
+// MCPUserStatus is one subject's activity against one MCP, addressed only by an
+// expiring opaque reference. It carries no email, no external user id, and no
+// name.
+type MCPUserStatus struct {
+	SubjectReference string `json:"subject_reference"`
+	ToolCalls        int64  `json:"tool_calls"`
+}
+
+type GetUserMCPStatusOutput struct {
+	ProjectID string       `json:"project_id"`
+	MCPID     string       `json:"mcp_id"`
+	Envelope  DataEnvelope `json:"data"`
+
+	ActiveUsers SubjectCount `json:"active_users"`
+	// RowsSuppressed reports that per-subject rows were withheld because too
+	// few subjects were involved. It is stated rather than left to be inferred
+	// from an empty list, which would read as "nobody used this".
+	RowsSuppressed bool            `json:"rows_suppressed"`
+	Users          []MCPUserStatus `json:"users"`
+}
+
+func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Principal, input GetUserMCPStatusInput) (GetUserMCPStatusOutput, error) {
+	if s == nil || s.references == nil {
+		return GetUserMCPStatusOutput{}, ErrUnavailable
+	}
+	// Metered on its own allowance: this is the one drill-down that reaches
+	// personal data, so exhausting it must not be possible by spending the
+	// ordinary diagnostic budget.
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.sensitiveBudget)
+	if err != nil {
+		return GetUserMCPStatusOutput{}, err
+	}
+	toolsetSlug := ""
+	if len(target.toolsetSlugs) > 0 {
+		toolsetSlug = target.toolsetSlugs[0]
+	}
+	start, end := target.window.start.UnixNano(), target.window.end.UnixNano()
+
+	counts, err := s.telemetry.GetActiveCounts(ctx, telemetryrepo.GetActiveCountsParams{
+		GramProjectID: target.projectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+		ToolsetSlug:   toolsetSlug,
+	})
+	if err != nil {
+		return GetUserMCPStatusOutput{}, fmt.Errorf("read mcp user active counts: %w", err)
+	}
+	envelope, err := s.drilldownEnvelope(ctx, target)
+	if err != nil {
+		return GetUserMCPStatusOutput{}, err
+	}
+
+	var activeUsers int64
+	if counts != nil {
+		activeUsers = boundedCount(counts.ActiveUsersCount)
+	}
+	output := GetUserMCPStatusOutput{
+		ProjectID:   input.ProjectID,
+		MCPID:       input.MCPID,
+		Envelope:    envelope,
+		ActiveUsers: NewSubjectCount(activeUsers),
+		Users:       []MCPUserStatus{},
+	}
+	if !input.IncludeRows {
+		return output, nil
+	}
+	// Refused rather than trimmed: with fewer than five subjects, a row is a
+	// person however it is labelled, and the aggregate above already answers
+	// the question rows were asked for.
+	if activeUsers < SubjectSuppressionThreshold {
+		output.RowsSuppressed = true
+		return output, nil
+	}
+
+	users, err := s.drilldown.GetTopUsers(ctx, telemetryrepo.GetTopUsersParams{
+		GramProjectID: target.projectID,
+		TimeStart:     start,
+		TimeEnd:       end,
+		ToolsetSlug:   toolsetSlug,
+		Limit:         maxUserStatusRows,
+	})
+	if err != nil {
+		return GetUserMCPStatusOutput{}, fmt.Errorf("read mcp user activity: %w", err)
+	}
+	for _, user := range users {
+		// user.UserID is whichever identity the telemetry fold resolved — an
+		// email in many cases. It is minted into a reference here and never
+		// projected, which is the whole reason references exist.
+		reference, err := s.references.Encode(principal, subjectKindUser, user.UserID, target.now)
+		if err != nil {
+			return GetUserMCPStatusOutput{}, fmt.Errorf("mint subject reference: %w", err)
+		}
+		output.Users = append(output.Users, MCPUserStatus{
+			SubjectReference: reference,
+			ToolCalls:        boundedCount(user.ActivityCount),
+		})
+	}
+	return output, nil
+}
+
+func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, now time.Time) (int64, error) {
+	if cursor == "" {
+		return 0, nil
+	}
+	value, err := s.references.Decode(cursor, principal, subjectKindTrace, now)
+	if err != nil {
+		return 0, ErrSubjectReferenceInvalid
+	}
+	position, err := parseCursorPosition(value)
+	if err != nil {
+		return 0, ErrSubjectReferenceInvalid
+	}
+	return position, nil
+}
+
+// sortToolEvents puts the tool a caller should look at first at the top:
+// most failures, then most calls, then name for a stable order.
+func sortToolEvents(events []MCPToolEvents) {
+	sort.Slice(events, func(i, j int) bool {
+		left, right := events[i].Outcomes, events[j].Outcomes
+		leftFailures := left.Unauthorized + left.ClientError + left.ServerError + left.Failed
+		rightFailures := right.Unauthorized + right.ClientError + right.ServerError + right.Failed
+		if leftFailures != rightFailures {
+			return leftFailures > rightFailures
+		}
+		if left.Total != right.Total {
+			return left.Total > right.Total
+		}
+		return events[i].ToolName < events[j].ToolName
+	})
+}
+
+// A trace cursor carries only a position, minted through the same bound,
+// expiring reference codec as everything else a caller holds between calls.
+func formatCursorPosition(unixNano int64) string {
+	return "t:" + strconv.FormatInt(unixNano, 10)
+}
+
+func parseCursorPosition(value string) (int64, error) {
+	rest, ok := strings.CutPrefix(value, "t:")
+	if !ok {
+		return 0, ErrSubjectReferenceInvalid
+	}
+	position, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || position <= 0 {
+		return 0, ErrSubjectReferenceInvalid
+	}
+	return position, nil
+}
+
+func validOutcomeClass(outcome string) bool {
+	switch outcome {
+	case telemetryrepo.MCPOutcomeSuccess,
+		telemetryrepo.MCPOutcomeUnauthorized,
+		telemetryrepo.MCPOutcomeClientError,
+		telemetryrepo.MCPOutcomeServerError,
+		telemetryrepo.MCPOutcomeFailed,
+		telemetryrepo.MCPOutcomeUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func failureRate(total, failed int64) float64 {
+	if total <= 0 {
+		return 0
+	}
+	rate := float64(failed) / float64(total)
+	// Rounded server-side so the caller is never handed a ratio it would have
+	// to format itself.
+	return float64(int64(rate*10000+0.5)) / 10000
+}

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -22,8 +22,6 @@ const (
 	maxDrilldownTools = 25
 	// maxTraceReferences bounds one page of correlation references.
 	maxTraceReferences = 20
-	// maxUserStatusRows bounds one page of per-subject rows.
-	maxUserStatusRows = 25
 )
 
 // DrilldownTelemetryReader is the additional telemetry the bounded drill-down
@@ -32,7 +30,6 @@ const (
 type DrilldownTelemetryReader interface {
 	GetMCPToolOutcomeBreakdown(ctx context.Context, arg telemetryrepo.GetMCPToolOutcomeBreakdownParams) ([]telemetryrepo.MCPToolOutcomeBreakdownRow, error)
 	ListMCPTraceReferences(ctx context.Context, arg telemetryrepo.ListMCPTraceReferencesParams) ([]telemetryrepo.MCPTraceReferenceRow, error)
-	GetTopUsers(ctx context.Context, arg telemetryrepo.GetTopUsersParams) ([]telemetryrepo.TopUser, error)
 }
 
 // drilldownTarget is one resolved MCP plus the window to read it over. Every
@@ -107,14 +104,14 @@ func (t drilldownTarget) outcomeParams() telemetryrepo.GetMCPOutcomeBreakdownPar
 	}
 }
 
-func (s *DiagnosticsService) drilldownEnvelope(ctx context.Context, target drilldownTarget) (DataEnvelope, error) {
+func (s *DiagnosticsService) drilldownEnvelope(ctx context.Context, target drilldownTarget, observed bool) (DataEnvelope, error) {
 	watermark, err := s.telemetry.GetTelemetryWatermark(ctx, telemetryrepo.GetTelemetryWatermarkParams{
 		GramProjectIDs: []string{target.projectID},
 	})
 	if err != nil {
 		return DataEnvelope{}, fmt.Errorf("read drilldown watermark: %w", err)
 	}
-	return newDataEnvelope(target.now, watermarkTime(watermark), target.window), nil
+	return newDataEnvelope(target.now, watermarkTime(watermark), target.window, observed), nil
 }
 
 // QueryMCPEventsInput drills into one MCP's calls by tool. It has no free-text
@@ -151,11 +148,11 @@ func (s *DiagnosticsService) QueryMCPEvents(ctx context.Context, principal Princ
 	if err != nil {
 		return QueryMCPEventsOutput{}, fmt.Errorf("read mcp tool outcome breakdown: %w", err)
 	}
-	envelope, err := s.drilldownEnvelope(ctx, target)
+	tools, truncated := toolEvents(rows)
+	envelope, err := s.drilldownEnvelope(ctx, target, len(rows) > 0)
 	if err != nil {
 		return QueryMCPEventsOutput{}, err
 	}
-	tools, truncated := toolEvents(rows)
 	return QueryMCPEventsOutput{
 		ProjectID: input.ProjectID,
 		MCPID:     input.MCPID,
@@ -251,7 +248,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	if err != nil {
 		return QueryMCPTracesOutput{}, fmt.Errorf("read mcp trace references: %w", err)
 	}
-	envelope, err := s.drilldownEnvelope(ctx, target)
+	envelope, err := s.drilldownEnvelope(ctx, target, len(rows) > 0)
 	if err != nil {
 		return QueryMCPTracesOutput{}, err
 	}
@@ -361,12 +358,11 @@ func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Prin
 	if err != nil {
 		return QueryMCPMetricsOutput{}, fmt.Errorf("read mcp metrics summary: %w", err)
 	}
-	envelope, err := s.drilldownEnvelope(ctx, target)
+	totals := totalsFromRows(outcomeRows)
+	envelope, err := s.drilldownEnvelope(ctx, target, totals.Total > 0)
 	if err != nil {
 		return QueryMCPMetricsOutput{}, err
 	}
-
-	totals := totalsFromRows(outcomeRows)
 	output := QueryMCPMetricsOutput{
 		ProjectID:       input.ProjectID,
 		MCPID:           input.MCPID,
@@ -463,14 +459,9 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 		return GetUserMCPStatusOutput{}, ErrSubjectReferenceNotFound
 	}
 
-	envelope, err := s.drilldownEnvelope(ctx, target)
-	if err != nil {
-		return GetUserMCPStatusOutput{}, err
-	}
 	output := GetUserMCPStatusOutput{
 		ProjectID:      input.ProjectID,
 		MCPID:          input.MCPID,
-		Envelope:       envelope,
 		MaskedIdentity: maskSubject(subject),
 		Activity:       SubjectStateNoObservations,
 	}
@@ -480,30 +471,40 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 	// read below narrows by nothing else. Answering anyway would report the
 	// project's activity as this MCP's.
 	if toolsetSlug == "" {
+		envelope, err := s.drilldownEnvelope(ctx, target, false)
+		if err != nil {
+			return GetUserMCPStatusOutput{}, err
+		}
+		output.Envelope = envelope
 		output.Unavailable = true
 		return output, nil
 	}
 
-	users, err := s.drilldown.GetTopUsers(ctx, telemetryrepo.GetTopUsersParams{
+	// Scoped to this one subject rather than filtered out of a truncated
+	// top-user list: a subject outside that list would otherwise be reported as
+	// having no observations, which on a personal-data question is a false
+	// negative rather than a missing row. The value is whichever identity the
+	// telemetry fold resolved, so it is offered as both candidates.
+	summary, err := s.telemetry.GetOverviewSummary(ctx, telemetryrepo.GetOverviewSummaryParams{
 		GramProjectID: target.projectID,
 		TimeStart:     target.window.start.UnixNano(),
 		TimeEnd:       target.window.end.UnixNano(),
 		ToolsetSlug:   toolsetSlug,
-		Limit:         maxUserStatusRows,
+		User:          telemetryrepo.UserIdentity{UserIDs: []string{subject}, Emails: []string{subject}},
 	})
 	if err != nil {
 		return GetUserMCPStatusOutput{}, fmt.Errorf("read mcp user activity: %w", err)
 	}
-	for _, user := range users {
-		if user.UserID != subject {
-			continue
-		}
-		if user.ActivityCount > 0 {
-			output.Activity = SubjectStateActive
-		} else {
-			output.Activity = SubjectStateInactive
-		}
-		return output, nil
+	observed := summary != nil && summary.TotalToolCalls > 0
+	envelope, err := s.drilldownEnvelope(ctx, target, observed)
+	if err != nil {
+		return GetUserMCPStatusOutput{}, err
+	}
+	output.Envelope = envelope
+	if observed {
+		output.Activity = SubjectStateActive
+	} else {
+		output.Activity = SubjectStateInactive
 	}
 	return output, nil
 }

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -3,6 +3,7 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -15,6 +16,8 @@ import (
 const (
 	SensitiveDiagnosticsConnectionLimitName   = "platform-mcp-sensitive-diagnostics-connection"
 	SensitiveDiagnosticsOrganizationLimitName = "platform-mcp-sensitive-diagnostics-organization"
+	DrilldownRowsLimitName                    = "platform-mcp-drilldown-rows"
+	DrilldownMetricQueriesLimitName           = "platform-mcp-drilldown-metric-queries"
 )
 
 const (
@@ -22,7 +25,23 @@ const (
 	maxDrilldownTools = 25
 	// maxTraceReferences bounds one page of correlation references.
 	maxTraceReferences = 20
+	// maxTraceTraversal bounds how many occurrences one investigation may page
+	// through in total. A page cap alone bounds a single response; without a
+	// traversal cap a caller can still walk an entire window one page at a
+	// time, which is the export this surface exists not to be.
+	maxTraceTraversal = 300
+	// maxDrilldownResponseBytes bounds a serialized drill-down result. Rows are
+	// dropped until the projection fits rather than the response being refused,
+	// so a caller always receives the leading rows it was ordered by.
+	maxDrilldownResponseBytes = 256 * 1024
 )
+
+// DrilldownAuditor records the one drill-down that answers about a person.
+// It is an interface so the diagnostics service depends on the recording, not
+// on the audit logger's transaction handling.
+type DrilldownAuditor interface {
+	RecordUserMCPStatusRead(ctx context.Context, principal Principal, projectID, mcpID, maskedIdentity, window string) error
+}
 
 // DrilldownTelemetryReader is the additional telemetry the bounded drill-down
 // tools read. It stays separate from DiagnosticsTelemetryReader so the
@@ -138,8 +157,13 @@ type QueryMCPEventsOutput struct {
 }
 
 func (s *DiagnosticsService) QueryMCPEvents(ctx context.Context, principal Principal, input QueryMCPEventsInput) (QueryMCPEventsOutput, error) {
-	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget, drilldownWindowSpec)
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.sensitiveBudget, drilldownWindowSpec)
 	if err != nil {
+		return QueryMCPEventsOutput{}, err
+	}
+	// Charged for the page it may return, before the read rather than after:
+	// a caller that cannot afford the rows should not spend the scan either.
+	if err := s.volume.AllowRows(ctx, principal, maxDrilldownTools); err != nil {
 		return QueryMCPEventsOutput{}, err
 	}
 	rows, err := s.drilldown.GetMCPToolOutcomeBreakdown(ctx, telemetryrepo.GetMCPToolOutcomeBreakdownParams{
@@ -153,13 +177,24 @@ func (s *DiagnosticsService) QueryMCPEvents(ctx context.Context, principal Princ
 	if err != nil {
 		return QueryMCPEventsOutput{}, err
 	}
-	return QueryMCPEventsOutput{
+	output := QueryMCPEventsOutput{
 		ProjectID: input.ProjectID,
 		MCPID:     input.MCPID,
 		Envelope:  envelope,
 		Tools:     tools,
 		Truncated: truncated,
-	}, nil
+	}
+	fitted, dropped, err := fitRows(output.Tools, func(tools []MCPToolEvents) any {
+		candidate := output
+		candidate.Tools = tools
+		return candidate
+	})
+	if err != nil {
+		return QueryMCPEventsOutput{}, err
+	}
+	output.Tools = fitted
+	output.Truncated = output.Truncated || dropped
+	return output, nil
 }
 
 // toolEvents folds the breakdown to one row per tool, ordered by failures then
@@ -223,12 +258,18 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	if input.Outcome != "" && !validOutcomeClass(input.Outcome) {
 		return QueryMCPTracesOutput{}, fmt.Errorf("outcome must be one of success, unauthorized, client_error, server_error, failed, unknown")
 	}
-	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget, drilldownWindowSpec)
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.sensitiveBudget, drilldownWindowSpec)
 	if err != nil {
 		return QueryMCPTracesOutput{}, err
 	}
+	if err := s.volume.AllowRows(ctx, principal, maxTraceReferences); err != nil {
+		return QueryMCPTracesOutput{}, err
+	}
 
-	before, beforeTraceID, err := s.decodeTraceCursor(input.Cursor, principal, target.now)
+	// The cursor resolves only against the query that minted it, so a position
+	// cannot be replayed on a different MCP, outcome class, or window.
+	scope := traceCursorScope(target, input.Outcome)
+	before, beforeTraceID, traversed, err := s.decodeTraceCursor(input.Cursor, principal, scope, target.now)
 	if err != nil {
 		return QueryMCPTracesOutput{}, err
 	}
@@ -257,6 +298,12 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	if more {
 		rows = rows[:maxTraceReferences]
 	}
+	// Trimmed to what the traversal budget still allows, so the cap bounds the
+	// occurrences actually handed over rather than only the number of pages.
+	if remaining := maxTraceTraversal - traversed; remaining < len(rows) {
+		rows = rows[:max(remaining, 0)]
+		more = false
+	}
 	traces := make([]MCPTraceReference, 0, len(rows))
 	for _, row := range rows {
 		reference, err := s.references.Encode(principal, subjectKindTrace, row.TraceID, target.now)
@@ -278,15 +325,42 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 		Envelope:  envelope,
 		Traces:    traces,
 	}
-	if more && len(rows) > 0 {
+	fitted, dropped, err := fitRows(output.Traces, func(traces []MCPTraceReference) any {
+		candidate := output
+		candidate.Traces = traces
+		return candidate
+	})
+	if err != nil {
+		return QueryMCPTracesOutput{}, err
+	}
+	output.Traces = fitted
+	// A page cut to fit must not advertise a cursor past the rows it dropped,
+	// or the next page would resume beyond occurrences the caller never saw.
+	if dropped {
+		more = false
+		rows = rows[:len(fitted)]
+	}
+	traversed += len(rows)
+	if more && len(rows) > 0 && traversed < maxTraceTraversal {
 		last := rows[len(rows)-1]
-		cursor, err := s.references.Encode(principal, subjectKindTrace, formatCursorPosition(last.OccurredAt, last.TraceID), target.now)
+		cursor, err := s.references.EncodeScoped(principal, subjectKindCursor, scope, formatCursorPosition(last.OccurredAt, last.TraceID, traversed), target.now)
 		if err != nil {
 			return QueryMCPTracesOutput{}, fmt.Errorf("mint trace cursor: %w", err)
 		}
 		output.NextCursor = cursor
 	}
 	return output, nil
+}
+
+// traceCursorScope is the normalized query a trace cursor belongs to: the MCP,
+// the outcome class, and the window it was read over.
+func traceCursorScope(target drilldownTarget, outcome string) string {
+	return queryScope(
+		target.projectID,
+		target.mcpServerID,
+		outcome,
+		string(target.window.Window),
+	)
 }
 
 // summaryIdentityParams scopes the summary read to exactly one identity filter.
@@ -339,8 +413,13 @@ type QueryMCPMetricsOutput struct {
 }
 
 func (s *DiagnosticsService) QueryMCPMetrics(ctx context.Context, principal Principal, input QueryMCPMetricsInput) (QueryMCPMetricsOutput, error) {
-	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.budget, metricsWindowSpec)
+	target, err := s.resolveDrilldown(ctx, principal, input.ProjectID, input.MCPID, input.Window, s.sensitiveBudget, metricsWindowSpec)
 	if err != nil {
+		return QueryMCPMetricsOutput{}, err
+	}
+	// Metric queries meter on their own count rather than on rows: one call
+	// returns a handful of numbers but scans the whole window.
+	if err := s.volume.AllowMetricQuery(ctx, principal); err != nil {
 		return QueryMCPMetricsOutput{}, err
 	}
 	toolsetSlug := target.hostedToolsetSlug()
@@ -470,6 +549,14 @@ func (s *DiagnosticsService) GetUserMCPStatus(ctx context.Context, principal Pri
 		Activity:       SubjectStateNoObservations,
 	}
 
+	// Recorded before the answer is composed, and a failure to record refuses
+	// the call. An exact user-MCP diagnosis that cannot be audited is one that
+	// leaves no trace of who asked about whom, which is the whole reason this
+	// read is audited separately from the aggregate ones.
+	if err := s.auditor.RecordUserMCPStatusRead(ctx, principal, input.ProjectID, input.MCPID, output.MaskedIdentity, string(target.window.Window)); err != nil {
+		return GetUserMCPStatusOutput{}, fmt.Errorf("record user mcp status read: %w", err)
+	}
+
 	toolsetSlug := target.hostedToolsetSlug()
 	// A remote, tunneled, or unproxied server carries no toolset slug, and the
 	// read below narrows by nothing else. Answering anyway would report the
@@ -548,19 +635,19 @@ func maskToken(value string) string {
 	return string(runes[0]) + strings.Repeat("*", min(len(runes)-1, 3))
 }
 
-func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, now time.Time) (int64, string, error) {
+func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, scope string, now time.Time) (int64, string, int, error) {
 	if cursor == "" {
-		return 0, "", nil
+		return 0, "", 0, nil
 	}
-	value, err := s.references.Decode(cursor, principal, subjectKindTrace, now)
+	value, err := s.references.DecodeScoped(cursor, principal, subjectKindCursor, scope, now)
 	if err != nil {
-		return 0, "", ErrSubjectReferenceNotFound
+		return 0, "", 0, ErrSubjectReferenceNotFound
 	}
-	position, traceID, err := parseCursorPosition(value)
+	position, traceID, traversed, err := parseCursorPosition(value)
 	if err != nil {
-		return 0, "", ErrSubjectReferenceNotFound
+		return 0, "", 0, ErrSubjectReferenceNotFound
 	}
-	return position, traceID, nil
+	return position, traceID, traversed, nil
 }
 
 // sortToolEvents puts the tool a caller should look at first at the top:
@@ -580,29 +667,80 @@ func sortToolEvents(events []MCPToolEvents) {
 	})
 }
 
-// A trace cursor carries only a position, minted through the same bound,
-// expiring reference codec as everything else a caller holds between calls.
-func formatCursorPosition(unixNano int64, traceID string) string {
-	return "t:" + strconv.FormatInt(unixNano, 10) + ":" + traceID
+// A trace cursor carries a position and how far the traversal has already
+// reached, minted through the same bound, expiring reference codec as
+// everything else a caller holds between calls. The count travels inside the
+// sealed token rather than beside it, so a caller cannot reset its own
+// traversal budget by editing what it was handed.
+func formatCursorPosition(unixNano int64, traceID string, traversed int) string {
+	return "t:" + strconv.FormatInt(unixNano, 10) + ":" + strconv.Itoa(traversed) + ":" + traceID
 }
 
-// parseCursorPosition recovers the composite page key. Both halves are
-// required: the repo orders by (event_time_ns, trace_id), and a cursor carrying
-// only the timestamp would skip every trace sharing the boundary nanosecond.
-func parseCursorPosition(value string) (int64, string, error) {
+// parseCursorPosition recovers the composite page key and the traversal count.
+// Both halves of the key are required: the repo orders by (event_time_ns,
+// trace_id), and a cursor carrying only the timestamp would skip every trace
+// sharing the boundary nanosecond.
+func parseCursorPosition(value string) (int64, string, int, error) {
 	rest, ok := strings.CutPrefix(value, "t:")
 	if !ok {
-		return 0, "", ErrSubjectReferenceNotFound
+		return 0, "", 0, ErrSubjectReferenceNotFound
 	}
-	timestamp, traceID, ok := strings.Cut(rest, ":")
+	timestamp, rest, ok := strings.Cut(rest, ":")
+	if !ok {
+		return 0, "", 0, ErrSubjectReferenceNotFound
+	}
+	count, traceID, ok := strings.Cut(rest, ":")
 	if !ok || traceID == "" {
-		return 0, "", ErrSubjectReferenceNotFound
+		return 0, "", 0, ErrSubjectReferenceNotFound
 	}
 	position, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil || position <= 0 {
-		return 0, "", ErrSubjectReferenceNotFound
+		return 0, "", 0, ErrSubjectReferenceNotFound
 	}
-	return position, traceID, nil
+	traversed, err := strconv.Atoi(count)
+	if err != nil || traversed < 0 || traversed > maxTraceTraversal {
+		return 0, "", 0, ErrSubjectReferenceNotFound
+	}
+	return position, traceID, traversed, nil
+}
+
+// fitRows drops trailing rows until the serialized result fits the response
+// cap, and reports whether it had to. The rows are already ordered by what a
+// caller should see first, so trimming the tail costs it the least useful rows.
+//
+// build re-forms the whole result around a candidate row slice, because what is
+// measured has to be the response as it will actually be serialized rather than
+// the rows alone.
+func fitRows[R any](rows []R, build func([]R) any) ([]R, bool, error) {
+	fits, err := responseFits(build(rows))
+	if err != nil {
+		return nil, false, err
+	}
+	if fits {
+		return rows, false, nil
+	}
+	// Each row contributes at least one byte, so halving converges. Measuring
+	// rather than estimating keeps the cap true for any row shape.
+	fitted := rows
+	for len(fitted) > 0 {
+		fitted = fitted[:len(fitted)/2]
+		fits, err := responseFits(build(fitted))
+		if err != nil {
+			return nil, false, err
+		}
+		if fits {
+			return fitted, true, nil
+		}
+	}
+	return fitted, true, nil
+}
+
+func responseFits(output any) (bool, error) {
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		return false, fmt.Errorf("measure drilldown response: %w", err)
+	}
+	return len(encoded) <= maxDrilldownResponseBytes, nil
 }
 
 func validOutcomeClass(outcome string) bool {

--- a/server/internal/platformmcp/drilldown_audit.go
+++ b/server/internal/platformmcp/drilldown_audit.go
@@ -1,0 +1,49 @@
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// postgresDrilldownAuditor records exact user-MCP diagnoses to the shared audit
+// log.
+type postgresDrilldownAuditor struct {
+	db *pgxpool.Pool
+}
+
+// NewPostgresDrilldownAuditor records the sensitive drill-down against the
+// shared audit log.
+func NewPostgresDrilldownAuditor(db *pgxpool.Pool) DrilldownAuditor {
+	return &postgresDrilldownAuditor{db: db}
+}
+
+func (a *postgresDrilldownAuditor) RecordUserMCPStatusRead(ctx context.Context, principal Principal, projectID, mcpID, maskedIdentity, window string) error {
+	if a == nil || a.db == nil {
+		return fmt.Errorf("platform mcp drilldown auditor unavailable")
+	}
+	project, err := uuid.Parse(projectID)
+	if err != nil {
+		return fmt.Errorf("parse audited project id: %w", err)
+	}
+	mcpServer, err := uuid.Parse(mcpID)
+	if err != nil {
+		return fmt.Errorf("parse audited mcp id: %w", err)
+	}
+	if err := audit.NewLogger().LogPlatformMcpDiagnosticsUserStatusRead(ctx, a.db, audit.LogPlatformMcpDiagnosticsUserStatusReadEvent{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project,
+		Actor:          urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID),
+		McpServerURN:   urn.NewMcpServer(mcpServer),
+		MaskedIdentity: maskedIdentity,
+		Window:         window,
+	}); err != nil {
+		return fmt.Errorf("record platform mcp user status audit event: %w", err)
+	}
+	return nil
+}

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -175,6 +175,35 @@ func TestToolEvents_OrdersBrokenToolsFirstAndReportsTruncation(t *testing.T) {
 	require.Len(t, capped, maxDrilldownTools)
 }
 
+// TestSummaryIdentityParams_UsesExactlyOneIdentityFilter pins that the summary
+// read never ANDs the two identity filters. Hosted telemetry carries a toolset
+// slug and no mcp_server id, so requiring both matches nothing — and the
+// failure is silent, surfacing as a latency of zero rather than an error.
+func TestSummaryIdentityParams_UsesExactlyOneIdentityFilter(t *testing.T) {
+	t.Parallel()
+
+	hosted := drilldownTarget{
+		toolsetSlugs: []string{"billing"},
+		projectID:    "project-1",
+		mcpServerID:  "mcp-1",
+	}
+	params := summaryIdentityParams(hosted, 1, 2)
+	require.Equal(t, "billing", params.ToolsetSlug)
+	require.Empty(t, params.MCPServerID)
+
+	// A remote, tunneled, or unproxied server carries no slug, so it is scoped
+	// by its server id instead — never by neither, which would read as "no
+	// filter" and return the whole project.
+	remote := drilldownTarget{
+		projectID:   "project-1",
+		mcpServerID: "mcp-1",
+	}
+	params = summaryIdentityParams(remote, 1, 2)
+	require.Empty(t, params.ToolsetSlug)
+	require.Equal(t, "mcp-1", params.MCPServerID)
+	require.Equal(t, "project-1", params.GramProjectID)
+}
+
 func TestValidOutcomeClass_IsAClosedSet(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -17,7 +17,7 @@ func TestQueryMCPTracesOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("24h", now)
+	window, err := resolveWindow("24h", now, drilldownWindowSpec)
 	require.NoError(t, err)
 
 	output := QueryMCPTracesOutput{
@@ -36,7 +36,7 @@ func TestQueryMCPTracesOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
-		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
 		"traces", "reference", "occurred_at", "tool_name", "outcome", "client",
 		"next_cursor",
 	}, decodeKeys(t, output))
@@ -46,33 +46,63 @@ func TestGetUserMCPStatusOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("7d", now)
+	window, err := resolveWindow("24h", now, drilldownWindowSpec)
 	require.NoError(t, err)
 
 	output := GetUserMCPStatusOutput{
 		ProjectID:      "00000000-0000-0000-0000-000000000001",
 		MCPID:          "00000000-0000-0000-0000-000000000002",
 		Envelope:       newDataEnvelope(now, now.Add(-time.Minute), window),
-		ActiveUsers:    NewSubjectCount(9),
-		RowsSuppressed: false,
-		Users:          []MCPUserStatus{{SubjectReference: "opaque", ToolCalls: 12}},
+		MaskedIdentity: "a***@e***",
+		Activity:       SubjectStateActive,
 	}
 
-	// Note what is absent: no email, no user id, no name, no account id. A
-	// subject is only ever a reference.
+	// Note what is absent: no email, no user id, no name, no account id, and no
+	// activity count that repeated calls could assemble into a profile.
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
-		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
-		"active_users", "rows_suppressed", "unavailable",
-		"users", "subject_reference", "tool_calls",
+		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
+		"masked_identity", "activity", "unavailable",
 	}, decodeKeys(t, output))
+}
+
+func TestMaskSubject_RecognizableNotLearnable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		subject string
+		want    string
+	}{
+		{subject: "alice@example.com", want: "a***@e***"},
+		{subject: "bo@x.io", want: "b*@x***"},
+		{subject: "a@b", want: "*@*"},
+		{subject: "external-user-1234", want: "e***"},
+		{subject: "x", want: "*"},
+	}
+
+	// An empty subject masks to empty; it is covered separately because the
+	// "must not equal the original" rule is vacuous for it.
+	require.Empty(t, maskSubject(""))
+
+	for _, test := range tests {
+		t.Run(test.subject, func(t *testing.T) {
+			t.Parallel()
+
+			masked := maskSubject(test.subject)
+			require.Equal(t, test.want, masked)
+			// The mask must never carry the original back.
+			require.NotEqual(t, test.subject, masked)
+			require.NotContains(t, masked, "lice")
+			require.NotContains(t, masked, "xample")
+		})
+	}
 }
 
 func TestQueryMCPEventsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("1h", now)
+	window, err := resolveWindow("1h", now, drilldownWindowSpec)
 	require.NoError(t, err)
 
 	output := QueryMCPEventsOutput{
@@ -85,7 +115,7 @@ func TestQueryMCPEventsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
-		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
 		"tools", "tool_name",
 		"outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
 		"truncated",
@@ -96,7 +126,7 @@ func TestQueryMCPMetricsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("30d", now)
+	window, err := resolveWindow("7d", now, metricsWindowSpec)
 	require.NoError(t, err)
 
 	output := QueryMCPMetricsOutput{
@@ -112,7 +142,7 @@ func TestQueryMCPMetricsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
-		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
 		"tool_calls", "failed_tool_calls", "failure_rate", "avg_latency_ms", "active_users",
 		"active_users_unavailable",
 	}, decodeKeys(t, output))

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -66,6 +66,29 @@ func TestGetUserMCPStatusOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	}, decodeKeys(t, output))
 }
 
+// TestParseSubjectIdentity_RefusesUnknownColumns pins that a reference states
+// which column its identifier lives in. Guessing wrong filters the wrong column,
+// matches nothing, and reports an active person as inactive.
+func TestParseSubjectIdentity_RefusesUnknownColumns(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct{ value, wantKind, wantID string }{
+		{value: FormatSubjectIdentity(SubjectIdentityEmail, "alice@example.com"), wantKind: SubjectIdentityEmail, wantID: "alice@example.com"},
+		{value: FormatSubjectIdentity(SubjectIdentityExternal, "ext-1"), wantKind: SubjectIdentityExternal, wantID: "ext-1"},
+		{value: FormatSubjectIdentity(SubjectIdentityUser, "user-1"), wantKind: SubjectIdentityUser, wantID: "user-1"},
+	} {
+		identityKind, identifier, err := parseSubjectIdentity(test.value)
+		require.NoError(t, err)
+		require.Equal(t, test.wantKind, identityKind)
+		require.Equal(t, test.wantID, identifier)
+	}
+
+	for _, value := range []string{"", "alice@example.com", "unknown:alice", "email:", ":alice"} {
+		_, _, err := parseSubjectIdentity(value)
+		require.ErrorIs(t, err, ErrSubjectReferenceNotFound, value)
+	}
+}
+
 func TestMaskSubject_RecognizableNotLearnable(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -1,0 +1,188 @@
+package platformmcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+// TestQueryMCPTracesOutput_ProjectsOnlyAllowlistedFields pins the drill-down's
+// serialized shape. This is the tool closest to being a log reader, so the
+// allowlist is what keeps it from becoming one: a body, an argument, a header,
+// a URL, or an identity can only appear here by being added to this list first.
+func TestQueryMCPTracesOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	window, err := resolveWindow("24h", now)
+	require.NoError(t, err)
+
+	output := QueryMCPTracesOutput{
+		ProjectID: "00000000-0000-0000-0000-000000000001",
+		MCPID:     "00000000-0000-0000-0000-000000000002",
+		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window),
+		Traces: []MCPTraceReference{{
+			Reference:  "opaque",
+			OccurredAt: now.Format(time.RFC3339),
+			ToolName:   "charge",
+			Outcome:    telemetryrepo.MCPOutcomeUnauthorized,
+			Client:     "claude-code",
+		}},
+		NextCursor: "opaque-cursor",
+	}
+
+	require.ElementsMatch(t, []string{
+		"project_id", "mcp_id",
+		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"traces", "reference", "occurred_at", "tool_name", "outcome", "client",
+		"next_cursor",
+	}, decodeKeys(t, output))
+}
+
+func TestGetUserMCPStatusOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	window, err := resolveWindow("7d", now)
+	require.NoError(t, err)
+
+	output := GetUserMCPStatusOutput{
+		ProjectID:      "00000000-0000-0000-0000-000000000001",
+		MCPID:          "00000000-0000-0000-0000-000000000002",
+		Envelope:       newDataEnvelope(now, now.Add(-time.Minute), window),
+		ActiveUsers:    NewSubjectCount(9),
+		RowsSuppressed: false,
+		Users:          []MCPUserStatus{{SubjectReference: "opaque", ToolCalls: 12}},
+	}
+
+	// Note what is absent: no email, no user id, no name, no account id. A
+	// subject is only ever a reference.
+	require.ElementsMatch(t, []string{
+		"project_id", "mcp_id",
+		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"active_users", "rows_suppressed",
+		"users", "subject_reference", "tool_calls",
+	}, decodeKeys(t, output))
+}
+
+func TestQueryMCPEventsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	window, err := resolveWindow("1h", now)
+	require.NoError(t, err)
+
+	output := QueryMCPEventsOutput{
+		ProjectID: "00000000-0000-0000-0000-000000000001",
+		MCPID:     "00000000-0000-0000-0000-000000000002",
+		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window),
+		Tools:     []MCPToolEvents{{ToolName: "charge", Outcomes: MCPOutcomeSummary{Total: 4, Success: 1, ServerError: 3}}},
+		Truncated: false,
+	}
+
+	require.ElementsMatch(t, []string{
+		"project_id", "mcp_id",
+		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"tools", "tool_name",
+		"outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
+		"truncated",
+	}, decodeKeys(t, output))
+}
+
+func TestQueryMCPMetricsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	window, err := resolveWindow("30d", now)
+	require.NoError(t, err)
+
+	output := QueryMCPMetricsOutput{
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		MCPID:           "00000000-0000-0000-0000-000000000002",
+		Envelope:        newDataEnvelope(now, now.Add(-time.Minute), window),
+		ToolCalls:       100,
+		FailedToolCalls: 5,
+		FailureRate:     0.05,
+		AvgLatencyMs:    42.5,
+		ActiveUsers:     NewSubjectCount(7),
+	}
+
+	require.ElementsMatch(t, []string{
+		"project_id", "mcp_id",
+		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
+		"tool_calls", "failed_tool_calls", "failure_rate", "avg_latency_ms", "active_users",
+	}, decodeKeys(t, output))
+}
+
+func TestToolEvents_OrdersBrokenToolsFirstAndReportsTruncation(t *testing.T) {
+	t.Parallel()
+
+	events, truncated := toolEvents([]telemetryrepo.MCPToolOutcomeBreakdownRow{
+		{ToolName: "list", Outcome: telemetryrepo.MCPOutcomeSuccess, CallCount: 500},
+		{ToolName: "charge", Outcome: telemetryrepo.MCPOutcomeSuccess, CallCount: 1},
+		{ToolName: "charge", Outcome: telemetryrepo.MCPOutcomeServerError, CallCount: 9},
+	})
+	require.False(t, truncated)
+	require.Equal(t, []MCPToolEvents{
+		{ToolName: "charge", Outcomes: MCPOutcomeSummary{Total: 10, Success: 1, ServerError: 9}},
+		{ToolName: "list", Outcomes: MCPOutcomeSummary{Total: 500, Success: 500}},
+	}, events)
+
+	var many []telemetryrepo.MCPToolOutcomeBreakdownRow
+	for index := range maxDrilldownTools + 5 {
+		many = append(many, telemetryrepo.MCPToolOutcomeBreakdownRow{
+			ToolName:  string(rune('a' + index)),
+			Outcome:   telemetryrepo.MCPOutcomeServerError,
+			CallCount: uint64(index + 1),
+		})
+	}
+	capped, truncated := toolEvents(many)
+	require.True(t, truncated)
+	require.Len(t, capped, maxDrilldownTools)
+}
+
+func TestValidOutcomeClass_IsAClosedSet(t *testing.T) {
+	t.Parallel()
+
+	for _, outcome := range []string{
+		telemetryrepo.MCPOutcomeSuccess,
+		telemetryrepo.MCPOutcomeUnauthorized,
+		telemetryrepo.MCPOutcomeClientError,
+		telemetryrepo.MCPOutcomeServerError,
+		telemetryrepo.MCPOutcomeFailed,
+		telemetryrepo.MCPOutcomeUnknown,
+	} {
+		require.True(t, validOutcomeClass(outcome), outcome)
+	}
+	// Anything that looks like a filter expression is not an outcome class.
+	// Accepting one would be the first step toward a query grammar.
+	for _, outcome := range []string{"", "SUCCESS", "error", "outcome = 'success'", "success OR 1=1"} {
+		require.False(t, validOutcomeClass(outcome), outcome)
+	}
+}
+
+func TestFailureRate_RoundsServerSide(t *testing.T) {
+	t.Parallel()
+
+	require.InDelta(t, 0.0, failureRate(0, 0), 1e-9)
+	require.InDelta(t, 0.0, failureRate(0, 5), 1e-9)
+	require.InDelta(t, 0.5, failureRate(10, 5), 1e-9)
+	require.InDelta(t, 0.3333, failureRate(3, 1), 1e-9)
+	require.InDelta(t, 1.0, failureRate(7, 7), 1e-9)
+}
+
+func TestCursorPosition_RoundTripsAndRejectsJunk(t *testing.T) {
+	t.Parallel()
+
+	position, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000))
+	require.NoError(t, err)
+	require.Equal(t, int64(1_700_000_000_000_000_000), position)
+
+	for _, value := range []string{"", "1700000000", "t:", "t:abc", "t:-1", "t:0"} {
+		_, err := parseCursorPosition(value)
+		require.ErrorIs(t, err, ErrSubjectReferenceInvalid, value)
+	}
+}

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -344,3 +344,37 @@ func TestFitRows_LeavesAFittingResponseAlone(t *testing.T) {
 	require.False(t, dropped)
 	require.Len(t, fitted, 1)
 }
+
+// TestResumeAfterFit_KeepsTheDroppedSuffixReachable pins that a page cut to fit
+// the response cap still advertises a cursor. Withholding one strands the rows
+// the cut dropped: they are past the last page the caller can ask for, so a
+// high-volume server would silently lose occurrences.
+func TestResumeAfterFit_KeepsTheDroppedSuffixReachable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rows     []int
+		fitted   int
+		dropped  bool
+		more     bool
+		wantRows []int
+		wantMore bool
+	}{
+		{name: "untouched page keeps its own verdict", rows: []int{1, 2, 3}, fitted: 3, dropped: false, more: true, wantRows: []int{1, 2, 3}, wantMore: true},
+		{name: "untouched last page stays last", rows: []int{1, 2, 3}, fitted: 3, dropped: false, more: false, wantRows: []int{1, 2, 3}, wantMore: false},
+		{name: "cut page resumes at the last row handed over", rows: []int{1, 2, 3, 4}, fitted: 2, dropped: true, more: false, wantRows: []int{1, 2}, wantMore: true},
+		{name: "cut page that keeps a prefix still pages on", rows: []int{1, 2, 3, 4}, fitted: 2, dropped: true, more: true, wantRows: []int{1, 2}, wantMore: true},
+		{name: "page cut to nothing has no position to resume from", rows: []int{1, 2, 3, 4}, fitted: 0, dropped: true, more: true, wantRows: []int{}, wantMore: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rows, more := resumeAfterFit(tt.rows, tt.fitted, tt.dropped, tt.more)
+			require.Equal(t, tt.wantRows, rows)
+			require.Equal(t, tt.wantMore, more)
+		})
+	}
+}

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -23,7 +23,7 @@ func TestQueryMCPTracesOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	output := QueryMCPTracesOutput{
 		ProjectID: "00000000-0000-0000-0000-000000000001",
 		MCPID:     "00000000-0000-0000-0000-000000000002",
-		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window),
+		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window, true),
 		Traces: []MCPTraceReference{{
 			Reference:  "opaque",
 			OccurredAt: now.Format(time.RFC3339),
@@ -52,7 +52,7 @@ func TestGetUserMCPStatusOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	output := GetUserMCPStatusOutput{
 		ProjectID:      "00000000-0000-0000-0000-000000000001",
 		MCPID:          "00000000-0000-0000-0000-000000000002",
-		Envelope:       newDataEnvelope(now, now.Add(-time.Minute), window),
+		Envelope:       newDataEnvelope(now, now.Add(-time.Minute), window, true),
 		MaskedIdentity: "a***@e***",
 		Activity:       SubjectStateActive,
 	}
@@ -108,7 +108,7 @@ func TestQueryMCPEventsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	output := QueryMCPEventsOutput{
 		ProjectID: "00000000-0000-0000-0000-000000000001",
 		MCPID:     "00000000-0000-0000-0000-000000000002",
-		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window),
+		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window, true),
 		Tools:     []MCPToolEvents{{ToolName: "charge", Outcomes: MCPOutcomeSummary{Total: 4, Success: 1, ServerError: 3}}},
 		Truncated: false,
 	}
@@ -132,7 +132,7 @@ func TestQueryMCPMetricsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	output := QueryMCPMetricsOutput{
 		ProjectID:       "00000000-0000-0000-0000-000000000001",
 		MCPID:           "00000000-0000-0000-0000-000000000002",
-		Envelope:        newDataEnvelope(now, now.Add(-time.Minute), window),
+		Envelope:        newDataEnvelope(now, now.Add(-time.Minute), window, true),
 		ToolCalls:       100,
 		FailedToolCalls: 5,
 		FailureRate:     0.05,

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -1,6 +1,9 @@
 package platformmcp
 
 import (
+	"encoding/json"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -264,13 +267,80 @@ func TestFailureRate_RoundsServerSide(t *testing.T) {
 func TestCursorPosition_CarriesTheCompositeKey(t *testing.T) {
 	t.Parallel()
 
-	position, traceID, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123"))
+	position, traceID, traversed, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123", 40))
 	require.NoError(t, err)
 	require.Equal(t, int64(1_700_000_000_000_000_000), position)
 	require.Equal(t, "abc123", traceID)
+	require.Equal(t, 40, traversed)
 
-	for _, value := range []string{"", "1700000000", "t:", "t:abc", "t:-1:x", "t:0:x", "t:1700000000"} {
-		_, _, err := parseCursorPosition(value)
+	for _, value := range []string{"", "1700000000", "t:", "t:abc", "t:-1:0:x", "t:0:0:x", "t:1700000000", "t:1700000000:x", "t:1700000000:abc:x", "t:1700000000:-1:x"} {
+		_, _, _, err := parseCursorPosition(value)
 		require.ErrorIs(t, err, ErrSubjectReferenceNotFound, value)
 	}
+}
+
+// TestCursorPosition_RefusesATraversalPastTheCap pins that the traversal count
+// a cursor carries cannot exceed the cap. The count is sealed inside the token,
+// but a decode that accepted an over-large value would let one forged or
+// replayed cursor reopen a traversal the cap had already closed.
+func TestCursorPosition_RefusesATraversalPastTheCap(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123", maxTraceTraversal+1))
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}
+
+// TestFitRows_TrimsToTheResponseCap pins that an oversized projection is cut to
+// fit rather than returned whole. The rows arrive ordered by what a caller
+// should see first, so the trim costs it the least useful ones.
+func TestFitRows_TrimsToTheResponseCap(t *testing.T) {
+	t.Parallel()
+
+	traces := make([]MCPTraceReference, 0, 4000)
+	for i := range 4000 {
+		traces = append(traces, MCPTraceReference{
+			Reference:  strings.Repeat("r", 128) + strconv.Itoa(i),
+			OccurredAt: "2026-08-21T12:00:00Z",
+			ToolName:   "search",
+			Outcome:    "server_error",
+			Client:     "claude-code",
+		})
+	}
+	output := QueryMCPTracesOutput{ProjectID: "project-1", MCPID: "mcp-1", Traces: traces}
+
+	fitted, dropped, err := fitRows(output.Traces, func(rows []MCPTraceReference) any {
+		candidate := output
+		candidate.Traces = rows
+		return candidate
+	})
+	require.NoError(t, err)
+	require.True(t, dropped)
+	require.Less(t, len(fitted), len(traces))
+
+	candidate := output
+	candidate.Traces = fitted
+	encoded, err := json.Marshal(candidate)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(encoded), maxDrilldownResponseBytes)
+}
+
+// TestFitRows_LeavesAFittingResponseAlone pins that the cap never trims a
+// result that already fits: a caller must not silently lose rows to a
+// measurement that was not needed.
+func TestFitRows_LeavesAFittingResponseAlone(t *testing.T) {
+	t.Parallel()
+
+	output := QueryMCPEventsOutput{
+		ProjectID: "project-1",
+		MCPID:     "mcp-1",
+		Tools:     []MCPToolEvents{{ToolName: "search", Outcomes: MCPOutcomeSummary{Total: 3, Success: 3}}},
+	}
+	fitted, dropped, err := fitRows(output.Tools, func(rows []MCPToolEvents) any {
+		candidate := output
+		candidate.Tools = rows
+		return candidate
+	})
+	require.NoError(t, err)
+	require.False(t, dropped)
+	require.Len(t, fitted, 1)
 }

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -63,7 +63,7 @@ func TestGetUserMCPStatusOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
 		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
-		"active_users", "rows_suppressed",
+		"active_users", "rows_suppressed", "unavailable",
 		"users", "subject_reference", "tool_calls",
 	}, decodeKeys(t, output))
 }
@@ -114,6 +114,7 @@ func TestQueryMCPMetricsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 		"project_id", "mcp_id",
 		"data", "queried_at", "data_through", "freshness", "resolved_window", "window", "from", "to",
 		"tool_calls", "failed_tool_calls", "failure_rate", "avg_latency_ms", "active_users",
+		"active_users_unavailable",
 	}, decodeKeys(t, output))
 }
 
@@ -174,15 +175,20 @@ func TestFailureRate_RoundsServerSide(t *testing.T) {
 	require.InDelta(t, 1.0, failureRate(7, 7), 1e-9)
 }
 
-func TestCursorPosition_RoundTripsAndRejectsJunk(t *testing.T) {
+// TestCursorPosition_CarriesTheCompositeKey pins that a cursor keeps both
+// halves of the ordering key. A timestamp-only cursor skips every trace sharing
+// the boundary nanosecond, so on a busy server those occurrences appear on
+// neither page.
+func TestCursorPosition_CarriesTheCompositeKey(t *testing.T) {
 	t.Parallel()
 
-	position, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000))
+	position, traceID, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123"))
 	require.NoError(t, err)
 	require.Equal(t, int64(1_700_000_000_000_000_000), position)
+	require.Equal(t, "abc123", traceID)
 
-	for _, value := range []string{"", "1700000000", "t:", "t:abc", "t:-1", "t:0"} {
-		_, err := parseCursorPosition(value)
-		require.ErrorIs(t, err, ErrSubjectReferenceInvalid, value)
+	for _, value := range []string{"", "1700000000", "t:", "t:abc", "t:-1:x", "t:0:x", "t:1700000000"} {
+		_, _, err := parseCursorPosition(value)
+		require.ErrorIs(t, err, ErrSubjectReferenceNotFound, value)
 	}
 }

--- a/server/internal/platformmcp/freshness.go
+++ b/server/internal/platformmcp/freshness.go
@@ -156,18 +156,21 @@ type DataEnvelope struct {
 // covered, so a historical read stays fresh instead of being reported stale
 // merely for being about the past. Otherwise the lag is measured against the
 // moment of the read.
-func newDataEnvelope(now time.Time, watermark time.Time, window ResolvedWindow) DataEnvelope {
+//
+// observed is the scoped result, not the watermark: a project may be busy while
+// the one MCP being asked about produced nothing, and deriving "no observations"
+// from the watermark would report that silence as activity.
+func newDataEnvelope(now time.Time, watermark time.Time, window ResolvedWindow, observed bool) DataEnvelope {
 	envelope := DataEnvelope{
 		QueriedAt:      now.UTC().Format(time.RFC3339),
 		DataThrough:    "",
 		Freshness:      FreshnessUnavailable,
-		NoObservations: true,
+		NoObservations: !observed,
 		ResolvedWindow: window,
 	}
 	if watermark.IsZero() {
 		return envelope
 	}
-	envelope.NoObservations = false
 	envelope.DataThrough = watermark.UTC().Format(time.RFC3339)
 	switch {
 	case !watermark.Before(window.end):

--- a/server/internal/platformmcp/freshness.go
+++ b/server/internal/platformmcp/freshness.go
@@ -3,7 +3,6 @@ package platformmcp
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 )
@@ -22,16 +21,22 @@ const StaleWatermarkThreshold = 5 * time.Minute
 type Freshness string
 
 const (
-	FreshnessFresh Freshness = "fresh"
-	FreshnessStale Freshness = "stale"
-	// FreshnessNoObservations means nothing was observed for the scope at all.
-	// A caller must not read it as "nothing went wrong".
-	FreshnessNoObservations Freshness = "no_observations"
+	// FreshnessCurrent means the watermark is within StaleWatermarkThreshold of
+	// the read, or already past the end of the window.
+	FreshnessCurrent Freshness = "current"
+	FreshnessStale   Freshness = "stale"
+	// FreshnessUnavailable means the scope holds no observations at all. It is
+	// paired with DataEnvelope.NoObservations, which says the same thing
+	// positively: a caller must not read either as "nothing went wrong".
+	FreshnessUnavailable Freshness = "unavailable"
 )
 
 // DiagnosticWindow is the closed set of windows a diagnostic may be asked for.
 // Callers name a window rather than supplying timestamps: an open time grammar
 // is a query language, and this surface deliberately has none.
+//
+// Each tool additionally caps how far back it will look, because the cost of a
+// read is not the same for a summary and for a row-level drill-down.
 type DiagnosticWindow string
 
 const (
@@ -41,57 +46,35 @@ const (
 	DiagnosticWindowLastMonth DiagnosticWindow = "30d"
 )
 
-// ErrDiagnosticWindowInvalid is returned for a window outside a tool's closed
-// set. The set differs per tool, so the message names the windows that tool
-// accepts rather than every window the type can express.
-var ErrDiagnosticWindowInvalid = errors.New("unsupported window")
+// DefaultDiagnosticWindow is what an unspecified window resolves to when a tool
+// states no narrower default.
+const DefaultDiagnosticWindow = DiagnosticWindowLastDay
 
-// windowPolicy is one tool's closed set of windows and the one an unspecified
-// request resolves to. Each tool carries its own: a window that answers "what
-// has this project been doing" is not the window that answers "why is this MCP
-// failing right now", and a diagnosis read over weeks averages a live fault
-// into healthy traffic until the attribution can no longer see it.
-type windowPolicy struct {
-	allowed  []DiagnosticWindow
-	fallback DiagnosticWindow
+// windowSpec is one tool's window policy: what an unspecified window means and
+// how far back the tool will look at all.
+type windowSpec struct {
+	Fallback DiagnosticWindow
+	Max      DiagnosticWindow
 }
 
-// overviewWindowPolicy bounds get_project_overview: a project summary is a
-// trend question, so it reaches back a month.
-var overviewWindowPolicy = windowPolicy{
-	allowed: []DiagnosticWindow{
-		DiagnosticWindowLastHour,
-		DiagnosticWindowLastDay,
-		DiagnosticWindowLastWeek,
-		DiagnosticWindowLastMonth,
-	},
-	fallback: DiagnosticWindowLastDay,
-}
+// Per-tool window policies. A summary may look back a month; a row-level
+// drill-down may not.
+var (
+	overviewWindowSpec    = windowSpec{Fallback: DiagnosticWindowLastDay, Max: DiagnosticWindowLastMonth}
+	diagnosticsWindowSpec = windowSpec{Fallback: DiagnosticWindowLastHour, Max: DiagnosticWindowLastDay}
+	drilldownWindowSpec   = windowSpec{Fallback: DiagnosticWindowLastDay, Max: DiagnosticWindowLastDay}
+	metricsWindowSpec     = windowSpec{Fallback: DiagnosticWindowLastDay, Max: DiagnosticWindowLastWeek}
+)
 
-// diagnosticsWindowPolicy bounds get_mcp_diagnostics. It is deliberately
-// tighter than the overview's. Fault attribution reasons in ratios — a
-// dominant failure class, and this server's failure rate against the rest of
-// the organization's — and readiness can only exonerate while it is fresh, so
-// a long window pairs a minutes-old probe with weeks of outcomes and dilutes a
-// current fault below every threshold that would have caught it.
-var diagnosticsWindowPolicy = windowPolicy{
-	allowed:  []DiagnosticWindow{DiagnosticWindowLastHour, DiagnosticWindowLastDay},
-	fallback: DiagnosticWindowLastHour,
-}
+// ErrDiagnosticWindowInvalid is returned for a window outside the closed set.
+var ErrDiagnosticWindowInvalid = fmt.Errorf("window must be one of %s, %s, %s, %s",
+	DiagnosticWindowLastHour, DiagnosticWindowLastDay, DiagnosticWindowLastWeek, DiagnosticWindowLastMonth)
 
-func (p windowPolicy) permits(window DiagnosticWindow) bool {
-	return slices.Contains(p.allowed, window)
-}
-
-// invalid names the windows this policy accepts, so a refused caller learns
-// what to ask for instead of only that it asked wrongly.
-func (p windowPolicy) invalid() error {
-	names := make([]string, 0, len(p.allowed))
-	for _, window := range p.allowed {
-		names = append(names, string(window))
-	}
-	return fmt.Errorf("%w: window must be one of %s", ErrDiagnosticWindowInvalid, strings.Join(names, ", "))
-}
+// ErrDiagnosticWindowTooLong is returned for a window this tool will not look
+// back over. It is refused rather than clamped for the same reason an unknown
+// window is: a caller must never be told about a different interval than the
+// one it asked for.
+var ErrDiagnosticWindowTooLong = errors.New("window is longer than this tool allows")
 
 func (w DiagnosticWindow) duration() (time.Duration, bool) {
 	switch w {
@@ -119,19 +102,24 @@ type ResolvedWindow struct {
 	end   time.Time
 }
 
-// resolveWindow turns a requested window name into the interval to read, under
-// the asking tool's policy. An empty request resolves to that policy's
-// fallback; anything outside its closed set is refused rather than silently
-// clamped, so a caller never receives a different window than it believes it
-// asked for.
-func resolveWindow(requested string, now time.Time, policy windowPolicy) (ResolvedWindow, error) {
+// resolveWindow turns a requested window name into the interval to read.
+// An empty request resolves to DefaultDiagnosticWindow; anything outside the
+// closed set is refused rather than silently clamped, so a caller never
+// receives a different window than it believes it asked for.
+func resolveWindow(requested string, now time.Time, spec windowSpec) (ResolvedWindow, error) {
 	window := DiagnosticWindow(strings.ToLower(strings.TrimSpace(requested)))
 	if window == "" {
-		window = policy.fallback
+		window = spec.Fallback
+		if window == "" {
+			window = DefaultDiagnosticWindow
+		}
 	}
 	duration, ok := window.duration()
-	if !ok || !policy.permits(window) {
-		return ResolvedWindow{}, policy.invalid()
+	if !ok {
+		return ResolvedWindow{}, ErrDiagnosticWindowInvalid
+	}
+	if maxDuration, ok := spec.Max.duration(); ok && duration > maxDuration {
+		return ResolvedWindow{}, fmt.Errorf("%w: %s allows at most %s", ErrDiagnosticWindowTooLong, window, spec.Max)
 	}
 	// Truncated to the second the window is advertised at, so the interval a
 	// caller is told about is exactly the interval that was queried. Formatting
@@ -152,9 +140,13 @@ func resolveWindow(requested string, now time.Time, policy windowPolicy) (Resolv
 // computed, how far the underlying observations reach, and whether that is
 // current enough to act on.
 type DataEnvelope struct {
-	QueriedAt      string         `json:"queried_at"`
-	DataThrough    string         `json:"data_through,omitempty"`
-	Freshness      Freshness      `json:"freshness"`
+	QueriedAt   string    `json:"queried_at"`
+	DataThrough string    `json:"data_through,omitempty"`
+	Freshness   Freshness `json:"freshness"`
+	// NoObservations states positively that the scope produced nothing in the
+	// window. Freshness alone cannot carry this: "unavailable" describes the
+	// pipeline, and a caller must not read either as evidence of health.
+	NoObservations bool           `json:"no_observations"`
 	ResolvedWindow ResolvedWindow `json:"resolved_window"`
 }
 
@@ -168,20 +160,22 @@ func newDataEnvelope(now time.Time, watermark time.Time, window ResolvedWindow) 
 	envelope := DataEnvelope{
 		QueriedAt:      now.UTC().Format(time.RFC3339),
 		DataThrough:    "",
-		Freshness:      FreshnessNoObservations,
+		Freshness:      FreshnessUnavailable,
+		NoObservations: true,
 		ResolvedWindow: window,
 	}
 	if watermark.IsZero() {
 		return envelope
 	}
+	envelope.NoObservations = false
 	envelope.DataThrough = watermark.UTC().Format(time.RFC3339)
 	switch {
 	case !watermark.Before(window.end):
-		envelope.Freshness = FreshnessFresh
+		envelope.Freshness = FreshnessCurrent
 	case now.Sub(watermark) > StaleWatermarkThreshold:
 		envelope.Freshness = FreshnessStale
 	default:
-		envelope.Freshness = FreshnessFresh
+		envelope.Freshness = FreshnessCurrent
 	}
 	return envelope
 }

--- a/server/internal/platformmcp/freshness_test.go
+++ b/server/internal/platformmcp/freshness_test.go
@@ -50,6 +50,61 @@ func TestResolveWindow_DefaultsAndClosedSet(t *testing.T) {
 	}
 }
 
+// TestResolveWindow_RefusesWindowsLongerThanTheToolAllows pins each tool's
+// look-back cap. It refuses rather than clamps, for the same reason an unknown
+// window is refused: a caller must never be told about a different interval
+// than the one it asked for.
+func TestResolveWindow_RefusesWindowsLongerThanTheToolAllows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		requested string
+		spec      windowSpec
+		wantErr   bool
+	}{
+		{name: "overview allows a month", requested: "30d", spec: overviewWindowSpec},
+		{name: "diagnostics refuse a month", requested: "30d", spec: diagnosticsWindowSpec, wantErr: true},
+		{name: "diagnostics refuse a week", requested: "7d", spec: diagnosticsWindowSpec, wantErr: true},
+		{name: "diagnostics allow a day", requested: "24h", spec: diagnosticsWindowSpec},
+		{name: "drilldown refuses a week", requested: "7d", spec: drilldownWindowSpec, wantErr: true},
+		{name: "drilldown allows a day", requested: "24h", spec: drilldownWindowSpec},
+		{name: "metrics refuse a month", requested: "30d", spec: metricsWindowSpec, wantErr: true},
+		{name: "metrics allow a week", requested: "7d", spec: metricsWindowSpec},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolveWindow(test.requested, now, test.spec)
+			if test.wantErr {
+				require.ErrorIs(t, err, ErrDiagnosticWindowTooLong)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestResolveWindow_EachToolHasItsOwnDefault pins that an unspecified window
+// means what the tool says it means, not one shared value.
+func TestResolveWindow_EachToolHasItsOwnDefault(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+
+	window, err := resolveWindow("", now, diagnosticsWindowSpec)
+	require.NoError(t, err)
+	require.Equal(t, DiagnosticWindowLastHour, window.Window)
+
+	window, err = resolveWindow("", now, overviewWindowSpec)
+	require.NoError(t, err)
+	require.Equal(t, DiagnosticWindowLastDay, window.Window)
+}
+
 func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 	t.Parallel()
 
@@ -104,7 +159,7 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			envelope := newDataEnvelope(now, test.watermark, window)
+			envelope := newDataEnvelope(now, test.watermark, window, !test.watermark.IsZero())
 			require.Equal(t, test.want, envelope.Freshness)
 			// no_observations is stated positively beside freshness, because
 			// "unavailable" describes the pipeline while this describes the

--- a/server/internal/platformmcp/freshness_test.go
+++ b/server/internal/platformmcp/freshness_test.go
@@ -14,37 +14,28 @@ func TestResolveWindow_DefaultsAndClosedSet(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		policy    windowPolicy
 		requested string
 		want      DiagnosticWindow
 		wantSpan  time.Duration
 		wantErr   bool
 	}{
-		{name: "empty defaults to a day", policy: overviewWindowPolicy, requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
-		{name: "hour", policy: overviewWindowPolicy, requested: "1h", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
-		{name: "week", policy: overviewWindowPolicy, requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
-		{name: "month", policy: overviewWindowPolicy, requested: "30d", want: DiagnosticWindowLastMonth, wantSpan: 30 * 24 * time.Hour},
-		{name: "case and space tolerated", policy: overviewWindowPolicy, requested: " 24H ", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "empty defaults to a day", requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "hour", requested: "1h", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
+		{name: "week", requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
+		{name: "month", requested: "30d", want: DiagnosticWindowLastMonth, wantSpan: 30 * 24 * time.Hour},
+		{name: "case and space tolerated", requested: " 24H ", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
 		// Refused, not clamped: a caller must never receive a different window
 		// than the one it believes it asked for.
-		{name: "arbitrary duration refused", policy: overviewWindowPolicy, requested: "90m", wantErr: true},
-		{name: "timestamp grammar refused", policy: overviewWindowPolicy, requested: "2026-08-01T00:00:00Z", wantErr: true},
-		{name: "year refused", policy: overviewWindowPolicy, requested: "365d", wantErr: true},
-
-		// A diagnosis reads a narrower set. Its default is the hour, and the
-		// longer windows the overview accepts are refused here rather than
-		// answered over a span the attribution cannot reason across.
-		{name: "diagnostics empty defaults to an hour", policy: diagnosticsWindowPolicy, requested: "", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
-		{name: "diagnostics day", policy: diagnosticsWindowPolicy, requested: "24h", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
-		{name: "diagnostics week refused", policy: diagnosticsWindowPolicy, requested: "7d", wantErr: true},
-		{name: "diagnostics month refused", policy: diagnosticsWindowPolicy, requested: "30d", wantErr: true},
+		{name: "arbitrary duration refused", requested: "90m", wantErr: true},
+		{name: "timestamp grammar refused", requested: "2026-08-01T00:00:00Z", wantErr: true},
+		{name: "year refused", requested: "365d", wantErr: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			window, err := resolveWindow(test.requested, now, test.policy)
+			window, err := resolveWindow(test.requested, now, overviewWindowSpec)
 			if test.wantErr {
 				require.ErrorIs(t, err, ErrDiagnosticWindowInvalid)
 				return
@@ -63,7 +54,7 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	window, err := resolveWindow("24h", now, overviewWindowPolicy)
+	window, err := resolveWindow("24h", now, overviewWindowSpec)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -76,14 +67,14 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 		{
 			// Absence of observations is its own answer. Reporting it as fresh
 			// would let a caller read an empty result as a healthy one.
-			name:      "no watermark is no observations",
+			name:      "no watermark is unavailable",
 			watermark: time.Time{},
-			want:      FreshnessNoObservations,
+			want:      FreshnessUnavailable,
 		},
 		{
 			name:        "watermark inside the threshold is fresh",
 			watermark:   now.Add(-2 * time.Minute),
-			want:        FreshnessFresh,
+			want:        FreshnessCurrent,
 			wantThrough: true,
 		},
 		{
@@ -95,7 +86,7 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 		{
 			name:        "watermark exactly at the threshold is still fresh",
 			watermark:   now.Add(-StaleWatermarkThreshold),
-			want:        FreshnessFresh,
+			want:        FreshnessCurrent,
 			wantThrough: true,
 		},
 		{
@@ -104,7 +95,7 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 			// for being about the past.
 			name:        "watermark at the window end is fresh",
 			watermark:   window.end,
-			want:        FreshnessFresh,
+			want:        FreshnessCurrent,
 			wantThrough: true,
 		},
 	}
@@ -115,6 +106,10 @@ func TestNewDataEnvelope_ClassifiesFreshness(t *testing.T) {
 
 			envelope := newDataEnvelope(now, test.watermark, window)
 			require.Equal(t, test.want, envelope.Freshness)
+			// no_observations is stated positively beside freshness, because
+			// "unavailable" describes the pipeline while this describes the
+			// result, and neither may be read as evidence of health.
+			require.Equal(t, test.watermark.IsZero(), envelope.NoObservations)
 			require.Equal(t, now.Format(time.RFC3339), envelope.QueriedAt)
 			require.Equal(t, window, envelope.ResolvedWindow)
 			if test.wantThrough {
@@ -134,7 +129,7 @@ func TestResolveWindow_AdvertisedBoundsMatchTheQueriedBounds(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 987_654_321, time.UTC)
-	window, err := resolveWindow("1h", now, overviewWindowPolicy)
+	window, err := resolveWindow("1h", now, overviewWindowSpec)
 	require.NoError(t, err)
 
 	require.Equal(t, window.start.Format(time.RFC3339), window.From)

--- a/server/internal/platformmcp/freshness_test.go
+++ b/server/internal/platformmcp/freshness_test.go
@@ -14,30 +14,43 @@ func TestResolveWindow_DefaultsAndClosedSet(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		spec      windowSpec
 		requested string
 		want      DiagnosticWindow
 		wantSpan  time.Duration
-		wantErr   bool
+		wantErr   error
 	}{
-		{name: "empty defaults to a day", requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
-		{name: "hour", requested: "1h", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
-		{name: "week", requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
-		{name: "month", requested: "30d", want: DiagnosticWindowLastMonth, wantSpan: 30 * 24 * time.Hour},
-		{name: "case and space tolerated", requested: " 24H ", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "empty defaults to a day", spec: overviewWindowSpec, requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "hour", spec: overviewWindowSpec, requested: "1h", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
+		{name: "week", spec: overviewWindowSpec, requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
+		{name: "month", spec: overviewWindowSpec, requested: "30d", want: DiagnosticWindowLastMonth, wantSpan: 30 * 24 * time.Hour},
+		{name: "case and space tolerated", spec: overviewWindowSpec, requested: " 24H ", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
 		// Refused, not clamped: a caller must never receive a different window
 		// than the one it believes it asked for.
-		{name: "arbitrary duration refused", requested: "90m", wantErr: true},
-		{name: "timestamp grammar refused", requested: "2026-08-01T00:00:00Z", wantErr: true},
-		{name: "year refused", requested: "365d", wantErr: true},
+		{name: "arbitrary duration refused", spec: overviewWindowSpec, requested: "90m", wantErr: ErrDiagnosticWindowInvalid},
+		{name: "timestamp grammar refused", spec: overviewWindowSpec, requested: "2026-08-01T00:00:00Z", wantErr: ErrDiagnosticWindowInvalid},
+		{name: "year refused", spec: overviewWindowSpec, requested: "365d", wantErr: ErrDiagnosticWindowInvalid},
+
+		// Each tool's own reach. A diagnosis defaults to the hour and will not
+		// look back a week, because attribution reasoning in ratios dilutes a
+		// live fault into healthy traffic over a long window. A row-level
+		// drill-down and a metric series are capped for cost, not for reasoning.
+		{name: "diagnostics defaults to an hour", spec: diagnosticsWindowSpec, requested: "", want: DiagnosticWindowLastHour, wantSpan: time.Hour},
+		{name: "diagnostics allows its maximum", spec: diagnosticsWindowSpec, requested: "24h", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "diagnostics refuses a week", spec: diagnosticsWindowSpec, requested: "7d", wantErr: ErrDiagnosticWindowTooLong},
+		{name: "drilldown defaults to a day", spec: drilldownWindowSpec, requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "drilldown refuses a week", spec: drilldownWindowSpec, requested: "7d", wantErr: ErrDiagnosticWindowTooLong},
+		{name: "metrics allow a week", spec: metricsWindowSpec, requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
+		{name: "metrics refuse a month", spec: metricsWindowSpec, requested: "30d", wantErr: ErrDiagnosticWindowTooLong},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			window, err := resolveWindow(test.requested, now, overviewWindowSpec)
-			if test.wantErr {
-				require.ErrorIs(t, err, ErrDiagnosticWindowInvalid)
+			window, err := resolveWindow(test.requested, now, test.spec)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 )
@@ -33,19 +34,32 @@ const (
 	DocsQueriesPerConnectionPerMinute   = 10
 	DocsQueriesPerOrganizationPerMinute = 100
 
-	// DiagnosticQueriesPer* bound the aggregate diagnostic reads. They are
-	// generous because an administrator investigating an incident legitimately
-	// makes many of them in a short burst, and none of them reach personal
-	// data.
+	// DiagnosticQueriesPer* bound the summary reads: the project overview and
+	// the per-MCP diagnosis. They are generous because an administrator
+	// investigating an incident legitimately makes many of them in a short
+	// burst, and each one is a bounded aggregate that names no subject.
 	DiagnosticQueriesPerConnectionPerMinute   = 60
 	DiagnosticQueriesPerOrganizationPerMinute = 600
 
-	// SensitiveDiagnosticQueriesPer* bound the reads that reach personal data.
-	// Lower than the ordinary allowance, and metered separately so the two
-	// cannot be traded against each other.
+	// SensitiveDiagnosticQueriesPer* bound the drill-downs. They are metered
+	// separately and lower than the summaries because they reach row-level
+	// occurrences and, in one case, an individual: a caller must not be able to
+	// fund them by spending the summary allowance.
 	SensitiveDiagnosticQueriesPerConnectionPerMinute   = 30
 	SensitiveDiagnosticQueriesPerOrganizationPerMinute = 300
+
+	// DrilldownRowsPerConnectionPerWindow and
+	// DrilldownMetricQueriesPerConnectionPerWindow are the second cap the
+	// drill-downs carry, over DrilldownVolumeWindow. A per-minute call budget
+	// alone does not bound how much a caller can accumulate: paging steadily
+	// under the call rate still walks an entire window's occurrences. These
+	// meter the volume rather than the calls.
+	DrilldownRowsPerConnectionPerWindow          = 1000
+	DrilldownMetricQueriesPerConnectionPerWindow = 20
 )
+
+// DrilldownVolumeWindow is the interval the drill-down volume caps refill over.
+const DrilldownVolumeWindow = 10 * time.Minute
 
 var (
 	ErrOperationRateLimited       = errors.New("platform mcp operation rate limited")
@@ -57,6 +71,10 @@ var (
 // backing-store failure without depending on Redis.
 type Limiter interface {
 	Allow(ctx context.Context, key string) (ratelimit.Result, error)
+	// AllowN charges n units at once. A volume cap meters rows or spans rather
+	// than calls, and charging them one at a time would let a page that cannot
+	// be afforded in full be paid for halfway.
+	AllowN(ctx context.Context, key string, n int) (ratelimit.Result, error)
 }
 
 // OperationBudget applies independently configured connection and organization
@@ -126,12 +144,64 @@ type OperationBudgets struct {
 	// queries over Gram-owned telemetry, so the cost being metered is the
 	// ClickHouse scan, not an external egress.
 	Diagnostics OperationBudget
-	// SensitiveDiagnostics meters the one drill-down that reaches personal
-	// data. It is separate so exhausting it is not possible by spending the
-	// ordinary diagnostic allowance, and so it can be tightened on its own.
+	// SensitiveDiagnostics meters the bounded drill-downs. It is separate from
+	// Diagnostics so exhausting it is not possible by spending the summary
+	// allowance, and so it can be tightened on its own.
 	SensitiveDiagnostics OperationBudget
+	// DrilldownVolume meters what the drill-downs return rather than how often
+	// they are called: rows and spans against one bucket, metric queries
+	// against another, both per connection over DrilldownVolumeWindow.
+	DrilldownVolume DrilldownVolumeBudget
+}
+
+// DrilldownVolumeBudget is the second cap on the drill-down tools. It is keyed
+// on the connection alone: it exists to stop one caller from walking a window
+// row by row, which an organization-wide bucket would not catch until every
+// other connection had already been starved.
+type DrilldownVolumeBudget struct {
+	Rows          Limiter
+	MetricQueries Limiter
+}
+
+func (b DrilldownVolumeBudget) valid() bool {
+	return b.Rows != nil && b.MetricQueries != nil
+}
+
+// AllowRows charges n rows or spans. A connection-less principal is not
+// metered here: it holds no connection key to charge, and the per-call
+// organization budget already bounds it.
+func (b DrilldownVolumeBudget) AllowRows(ctx context.Context, principal Principal, n int) error {
+	return b.allow(ctx, principal, b.Rows, n, "rows")
+}
+
+// AllowMetricQuery charges one metric query.
+func (b DrilldownVolumeBudget) AllowMetricQuery(ctx context.Context, principal Principal) error {
+	return b.allow(ctx, principal, b.MetricQueries, 1, "metric queries")
+}
+
+func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, limiter Limiter, n int, what string) error {
+	if !b.valid() || principal.OrganizationID == "" {
+		return ErrOperationBudgetUnavailable
+	}
+	if n <= 0 {
+		return nil
+	}
+	if !principal.HasConnection() {
+		return nil
+	}
+	if principal.ConnectionID == "" {
+		return ErrOperationBudgetUnavailable
+	}
+	result, err := limiter.AllowN(ctx, principal.ConnectionID, n)
+	if err != nil {
+		return fmt.Errorf("limit platform mcp drilldown %s: %w: %w", what, ErrOperationBudgetUnavailable, err)
+	}
+	if !result.Allowed {
+		return ErrOperationRateLimited
+	}
+	return nil
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -32,6 +32,19 @@ const (
 	// queries rather than to protect a backend.
 	DocsQueriesPerConnectionPerMinute   = 10
 	DocsQueriesPerOrganizationPerMinute = 100
+
+	// DiagnosticQueriesPer* bound the aggregate diagnostic reads. They are
+	// generous because an administrator investigating an incident legitimately
+	// makes many of them in a short burst, and none of them reach personal
+	// data.
+	DiagnosticQueriesPerConnectionPerMinute   = 60
+	DiagnosticQueriesPerOrganizationPerMinute = 600
+
+	// SensitiveDiagnosticQueriesPer* bound the reads that reach personal data.
+	// Lower than the ordinary allowance, and metered separately so the two
+	// cannot be traded against each other.
+	SensitiveDiagnosticQueriesPerConnectionPerMinute   = 30
+	SensitiveDiagnosticQueriesPerOrganizationPerMinute = 300
 )
 
 var (

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -113,8 +113,12 @@ type OperationBudgets struct {
 	// queries over Gram-owned telemetry, so the cost being metered is the
 	// ClickHouse scan, not an external egress.
 	Diagnostics OperationBudget
+	// SensitiveDiagnostics meters the one drill-down that reaches personal
+	// data. It is separate so exhausting it is not possible by spending the
+	// ordinary diagnostic allowance, and so it can be tightened on its own.
+	SensitiveDiagnostics OperationBudget
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.Diagnostics.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid()
 }

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -96,12 +96,75 @@ func TestOperationBudgetStillRequiresAnOrganization(t *testing.T) {
 }
 
 type recordingOperationLimiter struct {
-	result ratelimit.Result
-	err    error
-	keys   []string
+	result  ratelimit.Result
+	err     error
+	keys    []string
+	charges []int
 }
 
 func (l *recordingOperationLimiter) Allow(_ context.Context, key string) (ratelimit.Result, error) {
 	l.keys = append(l.keys, key)
 	return l.result, l.err
+}
+
+func (l *recordingOperationLimiter) AllowN(_ context.Context, key string, n int) (ratelimit.Result, error) {
+	l.keys = append(l.keys, key)
+	l.charges = append(l.charges, n)
+	return l.result, l.err
+}
+
+// TestDrilldownVolumeBudget_ChargesRealVolume pins that the second drill-down
+// cap meters what a page returns rather than the call that returned it. A
+// per-call budget alone lets a caller page steadily under the rate and still
+// accumulate a whole window.
+func TestDrilldownVolumeBudget_ChargesRealVolume(t *testing.T) {
+	t.Parallel()
+
+	rows := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	metrics := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	budget := DrilldownVolumeBudget{Rows: rows, MetricQueries: metrics}
+	principal := Principal{OrganizationID: "org-1", ConnectionID: "connection-1", Generation: "generation-1"}
+
+	require.NoError(t, budget.AllowRows(t.Context(), principal, 20))
+	require.NoError(t, budget.AllowMetricQuery(t.Context(), principal))
+
+	require.Equal(t, []string{"connection-1"}, rows.keys)
+	require.Equal(t, []int{20}, rows.charges)
+	require.Equal(t, []int{1}, metrics.charges)
+}
+
+// TestDrilldownVolumeBudget_ExhaustionIsRateLimited pins that a refused volume
+// charge stops the read rather than returning a short page.
+func TestDrilldownVolumeBudget_ExhaustionIsRateLimited(t *testing.T) {
+	t.Parallel()
+
+	budget := DrilldownVolumeBudget{
+		Rows:          &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}},
+		MetricQueries: &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}},
+	}
+	principal := Principal{OrganizationID: "org-1", ConnectionID: "connection-1", Generation: "generation-1"}
+
+	require.ErrorIs(t, budget.AllowRows(t.Context(), principal, 20), ErrOperationRateLimited)
+	require.ErrorIs(t, budget.AllowMetricQuery(t.Context(), principal), ErrOperationRateLimited)
+}
+
+// TestDrilldownVolumeBudget_ConnectionlessCallerIsNotMetered pins that a
+// surface holding no OAuth connection passes the volume cap rather than being
+// refused: it has no connection key to charge, and keying the empty string
+// would pool every such caller into one bucket.
+func TestDrilldownVolumeBudget_ConnectionlessCallerIsNotMetered(t *testing.T) {
+	t.Parallel()
+
+	rows := &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}
+	budget := DrilldownVolumeBudget{Rows: rows, MetricQueries: rows}
+
+	require.NoError(t, budget.AllowRows(t.Context(), Principal{OrganizationID: "org-1"}, 20))
+	require.Empty(t, rows.keys)
+
+	// A principal claiming a connection through its generation alone has no key
+	// to charge, so the budget is unavailable to it rather than free.
+	require.ErrorIs(t,
+		budget.AllowRows(t.Context(), Principal{OrganizationID: "org-1", Generation: "generation-1"}, 20),
+		ErrOperationBudgetUnavailable,
+	)
 }

--- a/server/internal/platformmcp/registration_service_test.go
+++ b/server/internal/platformmcp/registration_service_test.go
@@ -526,6 +526,10 @@ func (allowOperationLimiter) Allow(context.Context, string) (ratelimit.Result, e
 	return ratelimit.Result{Allowed: true}, nil
 }
 
+func (allowOperationLimiter) AllowN(context.Context, string, int) (ratelimit.Result, error) {
+	return ratelimit.Result{Allowed: true, Remaining: 1, RetryAfter: 0}, nil
+}
+
 func allowBudget() OperationBudget {
 	return OperationBudget{Connection: allowOperationLimiter{}, Organization: allowOperationLimiter{}}
 }

--- a/server/internal/platformmcp/subject_reference.go
+++ b/server/internal/platformmcp/subject_reference.go
@@ -1,0 +1,107 @@
+package platformmcp
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// SubjectReferenceTTL bounds how long an opaque reference stays usable. A
+// reference is a handle for one investigation, not a durable identifier: a
+// short life keeps it from accumulating in a caller's notes or being replayed
+// against a later session.
+const SubjectReferenceTTL = 15 * time.Minute
+
+// Subject reference kinds. A reference minted for one kind cannot be presented
+// as another, so a trace handle can never be spent where a person is expected.
+const (
+	subjectKindUser  = "user"
+	subjectKindTrace = "trace"
+)
+
+var ErrSubjectReferenceInvalid = errors.New("invalid platform mcp subject reference")
+
+type subjectReference struct {
+	OrganizationID string `json:"organization_id"`
+	// Binding ties the reference to the caller's session, exactly as a
+	// pagination cursor is bound. A reference handed to another connection, or
+	// surviving a reauthorization, stops resolving.
+	Binding   string `json:"binding"`
+	Kind      string `json:"kind"`
+	Value     string `json:"value"`
+	ExpiresAt int64  `json:"expires_at"`
+}
+
+// subjectReferenceCodec mints and resolves opaque references. It exists so a
+// diagnostic can point at a person or an occurrence across two calls without
+// ever naming one: the identity stays server-side, and what the caller holds is
+// meaningless outside its organization, session, and TTL.
+type subjectReferenceCodec struct {
+	key []byte
+}
+
+func newSubjectReferenceCodec(keyMaterial string) (*subjectReferenceCodec, error) {
+	if keyMaterial == "" {
+		return nil, ErrSubjectReferenceInvalid
+	}
+	key := sha256.Sum256([]byte("platform-mcp-subject-reference:" + keyMaterial))
+	return &subjectReferenceCodec{key: key[:]}, nil
+}
+
+func (c *subjectReferenceCodec) Encode(principal Principal, kind, value string, now time.Time) (string, error) {
+	binding := principalCursorBinding(principal)
+	if c == nil || len(c.key) == 0 || principal.OrganizationID == "" || binding == "" || kind == "" || value == "" {
+		return "", ErrSubjectReferenceInvalid
+	}
+	payload, err := json.Marshal(subjectReference{
+		OrganizationID: principal.OrganizationID,
+		Binding:        binding,
+		Kind:           kind,
+		Value:          value,
+		ExpiresAt:      now.Add(SubjectReferenceTTL).Unix(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode platform mcp subject reference: %w", err)
+	}
+	mac := hmac.New(sha256.New, c.key)
+	_, _ = mac.Write(payload)
+	token := make([]byte, 0, len(payload)+sha256.Size)
+	token = append(token, payload...)
+	token = append(token, mac.Sum(nil)...)
+	return base64.RawURLEncoding.EncodeToString(token), nil
+}
+
+func (c *subjectReferenceCodec) Decode(token string, principal Principal, kind string, now time.Time) (string, error) {
+	binding := principalCursorBinding(principal)
+	if c == nil || len(c.key) == 0 || token == "" || principal.OrganizationID == "" || binding == "" || kind == "" {
+		return "", ErrSubjectReferenceInvalid
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(raw) <= sha256.Size {
+		return "", ErrSubjectReferenceInvalid
+	}
+	payload, signature := raw[:len(raw)-sha256.Size], raw[len(raw)-sha256.Size:]
+	mac := hmac.New(sha256.New, c.key)
+	_, _ = mac.Write(payload)
+	// Compared before the payload is trusted, so a forged reference is rejected
+	// on its signature rather than on the contents it claims.
+	if !hmac.Equal(signature, mac.Sum(nil)) {
+		return "", ErrSubjectReferenceInvalid
+	}
+	var reference subjectReference
+	if err := json.Unmarshal(payload, &reference); err != nil {
+		return "", ErrSubjectReferenceInvalid
+	}
+	if reference.OrganizationID != principal.OrganizationID ||
+		reference.Binding != binding ||
+		reference.Kind != kind ||
+		reference.Value == "" ||
+		now.Unix() > reference.ExpiresAt {
+		return "", ErrSubjectReferenceInvalid
+	}
+	return reference.Value, nil
+}

--- a/server/internal/platformmcp/subject_reference.go
+++ b/server/internal/platformmcp/subject_reference.go
@@ -1,7 +1,9 @@
 package platformmcp
 
 import (
-	"crypto/hmac"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -14,7 +16,7 @@ import (
 // reference is a handle for one investigation, not a durable identifier: a
 // short life keeps it from accumulating in a caller's notes or being replayed
 // against a later session.
-const SubjectReferenceTTL = 15 * time.Minute
+const SubjectReferenceTTL = 10 * time.Minute
 
 // Subject reference kinds. A reference minted for one kind cannot be presented
 // as another, so a trace handle can never be spent where a person is expected.
@@ -23,7 +25,12 @@ const (
 	subjectKindTrace = "trace"
 )
 
-var ErrSubjectReferenceInvalid = errors.New("invalid platform mcp subject reference")
+// ErrSubjectReferenceNotFound is what an unknown, expired, cross-generation, or
+// cross-organization reference resolves to. It is deliberately a single
+// not-found rather than a set of distinguishable failures: telling a caller
+// that a reference is "expired" rather than "unknown" confirms the reference
+// once existed, which is itself information about another organization.
+var ErrSubjectReferenceNotFound = errors.New("platform mcp subject reference not found")
 
 type subjectReference struct {
 	OrganizationID string `json:"organization_id"`
@@ -40,68 +47,90 @@ type subjectReference struct {
 // diagnostic can point at a person or an occurrence across two calls without
 // ever naming one: the identity stays server-side, and what the caller holds is
 // meaningless outside its organization, session, and TTL.
+//
+// The payload is encrypted, not merely signed. A signed-but-plaintext token is
+// not opaque — base64 is an encoding, not confidentiality — and the value
+// inside is frequently an email address, so anyone holding the reference could
+// read the identity it was minted to hide.
 type subjectReferenceCodec struct {
-	key []byte
+	aead cipher.AEAD
 }
 
 func newSubjectReferenceCodec(keyMaterial string) (*subjectReferenceCodec, error) {
 	if keyMaterial == "" {
-		return nil, ErrSubjectReferenceInvalid
+		return nil, ErrSubjectReferenceNotFound
 	}
 	key := sha256.Sum256([]byte("platform-mcp-subject-reference:" + keyMaterial))
-	return &subjectReferenceCodec{key: key[:]}, nil
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, fmt.Errorf("build platform mcp subject reference cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("build platform mcp subject reference aead: %w", err)
+	}
+	return &subjectReferenceCodec{aead: aead}, nil
+}
+
+// referenceAAD binds a reference to its organization, session, and kind through
+// the AEAD's associated data. The same facts are inside the ciphertext, but
+// carrying them here means a token minted for another organization, session, or
+// kind fails to open at all rather than being decrypted and then rejected.
+func referenceAAD(organizationID, binding, kind string) []byte {
+	return []byte("platform-mcp-subject-reference|" + organizationID + "|" + binding + "|" + kind)
 }
 
 func (c *subjectReferenceCodec) Encode(principal Principal, kind, value string, now time.Time) (string, error) {
 	binding := principalCursorBinding(principal)
-	if c == nil || len(c.key) == 0 || principal.OrganizationID == "" || binding == "" || kind == "" || value == "" {
-		return "", ErrSubjectReferenceInvalid
+	if c == nil || c.aead == nil || principal.OrganizationID == "" || binding == "" || kind == "" || value == "" {
+		return "", ErrSubjectReferenceNotFound
 	}
 	payload, err := json.Marshal(subjectReference{
 		OrganizationID: principal.OrganizationID,
 		Binding:        binding,
 		Kind:           kind,
 		Value:          value,
-		ExpiresAt:      now.Add(SubjectReferenceTTL).Unix(),
+		ExpiresAt:      now.Add(SubjectReferenceTTL).UnixNano(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("encode platform mcp subject reference: %w", err)
 	}
-	mac := hmac.New(sha256.New, c.key)
-	_, _ = mac.Write(payload)
-	token := make([]byte, 0, len(payload)+sha256.Size)
-	token = append(token, payload...)
-	token = append(token, mac.Sum(nil)...)
-	return base64.RawURLEncoding.EncodeToString(token), nil
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("generate platform mcp subject reference nonce: %w", err)
+	}
+	sealed := c.aead.Seal(nonce, nonce, payload, referenceAAD(principal.OrganizationID, binding, kind))
+	return base64.RawURLEncoding.EncodeToString(sealed), nil
 }
 
 func (c *subjectReferenceCodec) Decode(token string, principal Principal, kind string, now time.Time) (string, error) {
 	binding := principalCursorBinding(principal)
-	if c == nil || len(c.key) == 0 || token == "" || principal.OrganizationID == "" || binding == "" || kind == "" {
-		return "", ErrSubjectReferenceInvalid
+	if c == nil || c.aead == nil || token == "" || principal.OrganizationID == "" || binding == "" || kind == "" {
+		return "", ErrSubjectReferenceNotFound
 	}
 	raw, err := base64.RawURLEncoding.DecodeString(token)
-	if err != nil || len(raw) <= sha256.Size {
-		return "", ErrSubjectReferenceInvalid
+	if err != nil || len(raw) <= c.aead.NonceSize() {
+		return "", ErrSubjectReferenceNotFound
 	}
-	payload, signature := raw[:len(raw)-sha256.Size], raw[len(raw)-sha256.Size:]
-	mac := hmac.New(sha256.New, c.key)
-	_, _ = mac.Write(payload)
-	// Compared before the payload is trusted, so a forged reference is rejected
-	// on its signature rather than on the contents it claims.
-	if !hmac.Equal(signature, mac.Sum(nil)) {
-		return "", ErrSubjectReferenceInvalid
+	nonce, ciphertext := raw[:c.aead.NonceSize()], raw[c.aead.NonceSize():]
+	payload, err := c.aead.Open(nil, nonce, ciphertext, referenceAAD(principal.OrganizationID, binding, kind))
+	if err != nil {
+		return "", ErrSubjectReferenceNotFound
 	}
 	var reference subjectReference
 	if err := json.Unmarshal(payload, &reference); err != nil {
-		return "", ErrSubjectReferenceInvalid
+		return "", ErrSubjectReferenceNotFound
 	}
+	// The AAD already bound these, so a mismatch here means the ciphertext and
+	// its associated data disagree — re-checked rather than assumed.
 	if reference.OrganizationID != principal.OrganizationID ||
 		reference.Binding != binding ||
 		reference.Kind != kind ||
 		reference.Value == "" ||
-		now.Unix() > reference.ExpiresAt {
-		return "", ErrSubjectReferenceInvalid
+		// Rejected at the boundary, so the advertised lifetime is a limit
+		// rather than a floor.
+		now.UnixNano() >= reference.ExpiresAt {
+		return "", ErrSubjectReferenceNotFound
 	}
 	return reference.Value, nil
 }

--- a/server/internal/platformmcp/subject_reference.go
+++ b/server/internal/platformmcp/subject_reference.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -24,6 +25,39 @@ const (
 	subjectKindUser  = "user"
 	subjectKindTrace = "trace"
 )
+
+// Identity kinds carried inside a user reference. Telemetry records a person
+// under one of three different columns, and the value alone does not say which:
+// filtering an external user id as though it were an email matches nothing and
+// reports an active person as inactive. The minting side states the column, so
+// the reading side can filter the right one.
+const (
+	SubjectIdentityEmail    = "email"
+	SubjectIdentityExternal = "external"
+	SubjectIdentityUser     = "user"
+)
+
+// FormatSubjectIdentity builds the value a user reference carries. Summary
+// tools mint references through this so the kind travels with the identifier.
+func FormatSubjectIdentity(identityKind, identifier string) string {
+	return identityKind + ":" + identifier
+}
+
+// parseSubjectIdentity splits a reference value back into its column and
+// identifier. An unrecognized kind is refused rather than guessed, because
+// guessing wrong reports an active person as inactive.
+func parseSubjectIdentity(value string) (string, string, error) {
+	identityKind, identifier, ok := strings.Cut(value, ":")
+	if !ok || identifier == "" {
+		return "", "", ErrSubjectReferenceNotFound
+	}
+	switch identityKind {
+	case SubjectIdentityEmail, SubjectIdentityExternal, SubjectIdentityUser:
+		return identityKind, identifier, nil
+	default:
+		return "", "", ErrSubjectReferenceNotFound
+	}
+}
 
 // ErrSubjectReferenceNotFound is what an unknown, expired, cross-generation, or
 // cross-organization reference resolves to. It is deliberately a single

--- a/server/internal/platformmcp/subject_reference.go
+++ b/server/internal/platformmcp/subject_reference.go
@@ -24,6 +24,10 @@ const SubjectReferenceTTL = 10 * time.Minute
 const (
 	subjectKindUser  = "user"
 	subjectKindTrace = "trace"
+	// subjectKindCursor is separate from subjectKindTrace so a correlation
+	// handle a caller was given to quote cannot be presented back as a page
+	// position, and a cursor cannot be quoted as an occurrence.
+	subjectKindCursor = "cursor"
 )
 
 // Identity kinds carried inside a user reference. Telemetry records a person
@@ -71,8 +75,14 @@ type subjectReference struct {
 	// Binding ties the reference to the caller's session, exactly as a
 	// pagination cursor is bound. A reference handed to another connection, or
 	// surviving a reauthorization, stops resolving.
-	Binding   string `json:"binding"`
-	Kind      string `json:"kind"`
+	Binding string `json:"binding"`
+	Kind    string `json:"kind"`
+	// Scope is the normalized query a reference belongs to, empty for
+	// references that belong to no particular query. A cursor carries one so it
+	// resumes only the query that minted it: the same position replayed against
+	// a different MCP, outcome class, or window is a different page of a
+	// different question.
+	Scope     string `json:"scope"`
 	Value     string `json:"value"`
 	ExpiresAt int64  `json:"expires_at"`
 }
@@ -110,11 +120,25 @@ func newSubjectReferenceCodec(keyMaterial string) (*subjectReferenceCodec, error
 // the AEAD's associated data. The same facts are inside the ciphertext, but
 // carrying them here means a token minted for another organization, session, or
 // kind fails to open at all rather than being decrypted and then rejected.
-func referenceAAD(organizationID, binding, kind string) []byte {
-	return []byte("platform-mcp-subject-reference|" + organizationID + "|" + binding + "|" + kind)
+func referenceAAD(organizationID, binding, kind, scope string) []byte {
+	return []byte("platform-mcp-subject-reference|" + organizationID + "|" + binding + "|" + kind + "|" + scope)
+}
+
+// queryScope is the normalized query a cursor is bound to. It is hashed rather
+// than carried plainly so the scope adds no readable detail to a token whose
+// whole purpose is to be opaque.
+func queryScope(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return base64.RawURLEncoding.EncodeToString(sum[:16])
 }
 
 func (c *subjectReferenceCodec) Encode(principal Principal, kind, value string, now time.Time) (string, error) {
+	return c.EncodeScoped(principal, kind, "", value, now)
+}
+
+// EncodeScoped mints a reference bound to one normalized query as well as to
+// the organization, session, and kind.
+func (c *subjectReferenceCodec) EncodeScoped(principal Principal, kind, scope, value string, now time.Time) (string, error) {
 	binding := principalCursorBinding(principal)
 	if c == nil || c.aead == nil || principal.OrganizationID == "" || binding == "" || kind == "" || value == "" {
 		return "", ErrSubjectReferenceNotFound
@@ -123,6 +147,7 @@ func (c *subjectReferenceCodec) Encode(principal Principal, kind, value string, 
 		OrganizationID: principal.OrganizationID,
 		Binding:        binding,
 		Kind:           kind,
+		Scope:          scope,
 		Value:          value,
 		ExpiresAt:      now.Add(SubjectReferenceTTL).UnixNano(),
 	})
@@ -133,11 +158,17 @@ func (c *subjectReferenceCodec) Encode(principal Principal, kind, value string, 
 	if _, err := rand.Read(nonce); err != nil {
 		return "", fmt.Errorf("generate platform mcp subject reference nonce: %w", err)
 	}
-	sealed := c.aead.Seal(nonce, nonce, payload, referenceAAD(principal.OrganizationID, binding, kind))
+	sealed := c.aead.Seal(nonce, nonce, payload, referenceAAD(principal.OrganizationID, binding, kind, scope))
 	return base64.RawURLEncoding.EncodeToString(sealed), nil
 }
 
 func (c *subjectReferenceCodec) Decode(token string, principal Principal, kind string, now time.Time) (string, error) {
+	return c.DecodeScoped(token, principal, kind, "", now)
+}
+
+// DecodeScoped resolves a reference only within the query scope it was minted
+// for. A cursor presented against a different query fails to open at all.
+func (c *subjectReferenceCodec) DecodeScoped(token string, principal Principal, kind, scope string, now time.Time) (string, error) {
 	binding := principalCursorBinding(principal)
 	if c == nil || c.aead == nil || token == "" || principal.OrganizationID == "" || binding == "" || kind == "" {
 		return "", ErrSubjectReferenceNotFound
@@ -147,7 +178,7 @@ func (c *subjectReferenceCodec) Decode(token string, principal Principal, kind s
 		return "", ErrSubjectReferenceNotFound
 	}
 	nonce, ciphertext := raw[:c.aead.NonceSize()], raw[c.aead.NonceSize():]
-	payload, err := c.aead.Open(nil, nonce, ciphertext, referenceAAD(principal.OrganizationID, binding, kind))
+	payload, err := c.aead.Open(nil, nonce, ciphertext, referenceAAD(principal.OrganizationID, binding, kind, scope))
 	if err != nil {
 		return "", ErrSubjectReferenceNotFound
 	}
@@ -160,6 +191,7 @@ func (c *subjectReferenceCodec) Decode(token string, principal Principal, kind s
 	if reference.OrganizationID != principal.OrganizationID ||
 		reference.Binding != binding ||
 		reference.Kind != kind ||
+		reference.Scope != scope ||
 		reference.Value == "" ||
 		// Rejected at the boundary, so the advertised lifetime is a limit
 		// rather than a floor.

--- a/server/internal/platformmcp/subject_reference_test.go
+++ b/server/internal/platformmcp/subject_reference_test.go
@@ -26,7 +26,7 @@ func TestSubjectReference_RoundTripsWithinItsSession(t *testing.T) {
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
 	principal := testReferencePrincipal()
 
-	reference, err := codec.Encode(principal, subjectKindUser, "alice@example.com", now)
+	reference, err := codec.Encode(principal, subjectKindUser, FormatSubjectIdentity(SubjectIdentityEmail, "alice@example.com"), now)
 	require.NoError(t, err)
 
 	// Decoded before asserting, because base64 is an encoding and not
@@ -41,7 +41,7 @@ func TestSubjectReference_RoundTripsWithinItsSession(t *testing.T) {
 
 	value, err := codec.Decode(reference, principal, subjectKindUser, now)
 	require.NoError(t, err)
-	require.Equal(t, "alice@example.com", value)
+	require.Equal(t, FormatSubjectIdentity(SubjectIdentityEmail, "alice@example.com"), value)
 }
 
 func TestSubjectReference_Rejected(t *testing.T) {
@@ -52,7 +52,7 @@ func TestSubjectReference_Rejected(t *testing.T) {
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
 	principal := testReferencePrincipal()
-	reference, err := codec.Encode(principal, subjectKindUser, "alice@example.com", now)
+	reference, err := codec.Encode(principal, subjectKindUser, FormatSubjectIdentity(SubjectIdentityEmail, "alice@example.com"), now)
 	require.NoError(t, err)
 
 	otherOrg := testReferencePrincipal()
@@ -142,7 +142,7 @@ func TestSubjectReference_ForgedSignatureRejected(t *testing.T) {
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
 	principal := testReferencePrincipal()
 
-	forged, err := other.Encode(principal, subjectKindUser, "alice@example.com", now)
+	forged, err := other.Encode(principal, subjectKindUser, FormatSubjectIdentity(SubjectIdentityEmail, "alice@example.com"), now)
 	require.NoError(t, err)
 
 	_, err = codec.Decode(forged, principal, subjectKindUser, now)

--- a/server/internal/platformmcp/subject_reference_test.go
+++ b/server/internal/platformmcp/subject_reference_test.go
@@ -1,6 +1,7 @@
 package platformmcp
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -27,9 +28,16 @@ func TestSubjectReference_RoundTripsWithinItsSession(t *testing.T) {
 
 	reference, err := codec.Encode(principal, subjectKindUser, "alice@example.com", now)
 	require.NoError(t, err)
-	// The identity must not be legible in what the caller holds.
-	require.NotContains(t, reference, "alice")
-	require.NotContains(t, reference, "example.com")
+
+	// Decoded before asserting, because base64 is an encoding and not
+	// confidentiality: a substring check against the token text would pass for
+	// a plaintext payload and prove nothing.
+	raw, err := base64.RawURLEncoding.DecodeString(reference)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "alice")
+	require.NotContains(t, string(raw), "example.com")
+	require.NotContains(t, string(raw), "org-1")
+	require.NotContains(t, string(raw), subjectKindUser)
 
 	value, err := codec.Decode(reference, principal, subjectKindUser, now)
 	require.NoError(t, err)
@@ -93,6 +101,15 @@ func TestSubjectReference_Rejected(t *testing.T) {
 			at:        now.Add(SubjectReferenceTTL + time.Second),
 		},
 		{
+			// Rejected exactly at the boundary, so the advertised lifetime is a
+			// limit rather than a floor.
+			name:      "at the expiry instant",
+			token:     reference,
+			principal: principal,
+			kind:      subjectKindUser,
+			at:        now.Add(SubjectReferenceTTL),
+		},
+		{
 			name:      "not a reference",
 			token:     "definitely-not-a-reference",
 			principal: principal,
@@ -106,7 +123,7 @@ func TestSubjectReference_Rejected(t *testing.T) {
 			t.Parallel()
 
 			_, err := codec.Decode(test.token, test.principal, test.kind, test.at)
-			require.ErrorIs(t, err, ErrSubjectReferenceInvalid)
+			require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
 		})
 	}
 }
@@ -129,7 +146,7 @@ func TestSubjectReference_ForgedSignatureRejected(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = codec.Decode(forged, principal, subjectKindUser, now)
-	require.ErrorIs(t, err, ErrSubjectReferenceInvalid)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
 }
 
 // TestSubjectReference_UnavailableWithoutKeyMaterial pins that a deployment
@@ -139,5 +156,5 @@ func TestSubjectReference_UnavailableWithoutKeyMaterial(t *testing.T) {
 	t.Parallel()
 
 	_, err := newSubjectReferenceCodec("")
-	require.ErrorIs(t, err, ErrSubjectReferenceInvalid)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
 }

--- a/server/internal/platformmcp/subject_reference_test.go
+++ b/server/internal/platformmcp/subject_reference_test.go
@@ -158,3 +158,62 @@ func TestSubjectReference_UnavailableWithoutKeyMaterial(t *testing.T) {
 	_, err := newSubjectReferenceCodec("")
 	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
 }
+
+// TestSubjectReference_CursorBoundToItsQuery pins that a cursor resumes only
+// the query that minted it. A position replayed against a different MCP,
+// outcome class, or window is a page of a different question, and answering it
+// would let one cursor walk a surface it was never issued for.
+func TestSubjectReference_CursorBoundToItsQuery(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("key-material")
+	require.NoError(t, err)
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	principal := testReferencePrincipal()
+	scope := queryScope("project-1", "mcp-1", "server_error", "24h")
+
+	cursor, err := codec.EncodeScoped(principal, subjectKindCursor, scope, "t:1700000000:0:abc", now)
+	require.NoError(t, err)
+
+	value, err := codec.DecodeScoped(cursor, principal, subjectKindCursor, scope, now)
+	require.NoError(t, err)
+	require.Equal(t, "t:1700000000:0:abc", value)
+
+	for _, other := range []string{
+		queryScope("project-1", "mcp-2", "server_error", "24h"),
+		queryScope("project-2", "mcp-1", "server_error", "24h"),
+		queryScope("project-1", "mcp-1", "client_error", "24h"),
+		queryScope("project-1", "mcp-1", "server_error", "1h"),
+		"",
+	} {
+		_, err := codec.DecodeScoped(cursor, principal, subjectKindCursor, other, now)
+		require.ErrorIs(t, err, ErrSubjectReferenceNotFound, other)
+	}
+}
+
+// TestSubjectReference_KindsAreNotInterchangeable pins that a correlation
+// handle a caller was given to quote cannot be spent as a page position, and a
+// cursor cannot be quoted as an occurrence.
+func TestSubjectReference_KindsAreNotInterchangeable(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("key-material")
+	require.NoError(t, err)
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	principal := testReferencePrincipal()
+
+	trace, err := codec.Encode(principal, subjectKindTrace, "trace-1", now)
+	require.NoError(t, err)
+	_, err = codec.DecodeScoped(trace, principal, subjectKindCursor, "", now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+
+	cursor, err := codec.EncodeScoped(principal, subjectKindCursor, "", "t:1700000000:0:abc", now)
+	require.NoError(t, err)
+	_, err = codec.Decode(cursor, principal, subjectKindTrace, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+
+	_, err = codec.Decode(trace, principal, subjectKindUser, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}

--- a/server/internal/platformmcp/subject_reference_test.go
+++ b/server/internal/platformmcp/subject_reference_test.go
@@ -1,0 +1,143 @@
+package platformmcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testReferencePrincipal() Principal {
+	return Principal{
+		OrganizationID: "org-1",
+		ConnectionID:   "connection-1",
+		Generation:     "generation-1",
+		UserID:         "user-1",
+	}
+}
+
+func TestSubjectReference_RoundTripsWithinItsSession(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("key-material")
+	require.NoError(t, err)
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	principal := testReferencePrincipal()
+
+	reference, err := codec.Encode(principal, subjectKindUser, "alice@example.com", now)
+	require.NoError(t, err)
+	// The identity must not be legible in what the caller holds.
+	require.NotContains(t, reference, "alice")
+	require.NotContains(t, reference, "example.com")
+
+	value, err := codec.Decode(reference, principal, subjectKindUser, now)
+	require.NoError(t, err)
+	require.Equal(t, "alice@example.com", value)
+}
+
+func TestSubjectReference_Rejected(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("key-material")
+	require.NoError(t, err)
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	principal := testReferencePrincipal()
+	reference, err := codec.Encode(principal, subjectKindUser, "alice@example.com", now)
+	require.NoError(t, err)
+
+	otherOrg := testReferencePrincipal()
+	otherOrg.OrganizationID = "org-2"
+
+	reauthorized := testReferencePrincipal()
+	reauthorized.Generation = "generation-2"
+
+	tests := []struct {
+		name      string
+		token     string
+		principal Principal
+		kind      string
+		at        time.Time
+	}{
+		{
+			name:      "another organization",
+			token:     reference,
+			principal: otherOrg,
+			kind:      subjectKindUser,
+			at:        now,
+		},
+		{
+			// Reauthorization ends the session the reference was minted for,
+			// exactly as it ends a pagination cursor's.
+			name:      "after reauthorization",
+			token:     reference,
+			principal: reauthorized,
+			kind:      subjectKindUser,
+			at:        now,
+		},
+		{
+			// A trace handle must never be spendable where a person is
+			// expected, or a caller could launder one kind into the other.
+			name:      "wrong kind",
+			token:     reference,
+			principal: principal,
+			kind:      subjectKindTrace,
+			at:        now,
+		},
+		{
+			name:      "expired",
+			token:     reference,
+			principal: principal,
+			kind:      subjectKindUser,
+			at:        now.Add(SubjectReferenceTTL + time.Second),
+		},
+		{
+			name:      "not a reference",
+			token:     "definitely-not-a-reference",
+			principal: principal,
+			kind:      subjectKindUser,
+			at:        now,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := codec.Decode(test.token, test.principal, test.kind, test.at)
+			require.ErrorIs(t, err, ErrSubjectReferenceInvalid)
+		})
+	}
+}
+
+// TestSubjectReference_ForgedSignatureRejected pins that the payload is never
+// trusted before its signature is. A caller that guesses the JSON shape must
+// not be able to mint a reference to a subject it was never shown.
+func TestSubjectReference_ForgedSignatureRejected(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("key-material")
+	require.NoError(t, err)
+	other, err := newSubjectReferenceCodec("different-key-material")
+	require.NoError(t, err)
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	principal := testReferencePrincipal()
+
+	forged, err := other.Encode(principal, subjectKindUser, "alice@example.com", now)
+	require.NoError(t, err)
+
+	_, err = codec.Decode(forged, principal, subjectKindUser, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceInvalid)
+}
+
+// TestSubjectReference_UnavailableWithoutKeyMaterial pins that a deployment
+// with no key material cannot mint references at all, rather than minting
+// unbound ones.
+func TestSubjectReference_UnavailableWithoutKeyMaterial(t *testing.T) {
+	t.Parallel()
+
+	_, err := newSubjectReferenceCodec("")
+	require.ErrorIs(t, err, ErrSubjectReferenceInvalid)
+}

--- a/server/internal/platformmcp/tool_drilldown.go
+++ b/server/internal/platformmcp/tool_drilldown.go
@@ -77,7 +77,7 @@ func registerDrilldownTools(reg *Registrar, diagnostics *DiagnosticsService) {
 	addTool(reg, &mcp.Tool{
 		Name:        "get_user_mcp_status",
 		Title:       "Get User MCP Status",
-		Description: drilldownPreamble + "Report how many people are using one MCP and, on request, per-subject activity. Subjects are addressed only by expiring opaque references bound to this session — never by name, email, or account id. Per-subject rows are refused when fewer than five subjects are involved, because a row would then identify a person.",
+		Description: drilldownPreamble + "Report one subject's state against one MCP, given the opaque subject reference a summary tool returned for them. Returns a masked identity and a state category only — never a raw identifier, a count, or a history. References expire, are bound to this session, and cannot be searched, joined, or constructed; an unknown or expired one is not found.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetUserMCPStatusInput) (*mcp.CallToolResult, GetUserMCPStatusOutput, error) {
 		principal, err := principalFromToolContext(ctx)
@@ -104,7 +104,7 @@ func registerUnavailableDrilldownTools(reg *Registrar) {
 		{"query_mcp_events", "Query MCP Events", "Break one MCP's calls down by tool and outcome. Diagnostics are not enabled in the current rollout."},
 		{"query_mcp_traces", "Query MCP Traces", "List individual occurrences for one MCP. Diagnostics are not enabled in the current rollout."},
 		{"query_mcp_metrics", "Query MCP Metrics", "Return one MCP's aggregate levels. Diagnostics are not enabled in the current rollout."},
-		{"get_user_mcp_status", "Get User MCP Status", "Report how many people are using one MCP. Diagnostics are not enabled in the current rollout."},
+		{"get_user_mcp_status", "Get User MCP Status", "Report one subject's state against one MCP. Diagnostics are not enabled in the current rollout."},
 	} {
 		addTool(reg, &mcp.Tool{
 			Name:        tool.name,

--- a/server/internal/platformmcp/tool_drilldown.go
+++ b/server/internal/platformmcp/tool_drilldown.go
@@ -74,25 +74,23 @@ func registerDrilldownTools(reg *Registrar, diagnostics *DiagnosticsService) {
 		return nil, output, nil
 	})
 
+	// get_user_mcp_status is deliberately not registered live here. Its input
+	// is a subject reference, and the tools that mint one — the organization
+	// summaries — are the other half of this lane and are not built yet.
+	// Registering it anyway would advertise a capability that always fails,
+	// which is the same mistake the audience list exists to prevent. The
+	// handler and its tests are complete; the summaries lane swaps this stub
+	// for an addTool over DiagnosticsService.GetUserMCPStatus.
+	registerPendingUserMCPStatusTool(reg)
+}
+
+func registerPendingUserMCPStatusTool(reg *Registrar) {
 	addTool(reg, &mcp.Tool{
 		Name:        "get_user_mcp_status",
 		Title:       "Get User MCP Status",
-		Description: drilldownPreamble + "Report one subject's state against one MCP, given the opaque subject reference a summary tool returned for them. Returns a masked identity and a state category only — never a raw identifier, a count, or a history. References expire, are bound to this session, and cannot be searched, joined, or constructed; an unknown or expired one is not found.",
+		Description: "Report one subject's state against one MCP. Unavailable: this tool takes an opaque subject reference, and the organization summary tools that return one are not available yet.",
 		Annotations: readOnlyAnnotations(),
-	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetUserMCPStatusInput) (*mcp.CallToolResult, GetUserMCPStatusOutput, error) {
-		principal, err := principalFromToolContext(ctx)
-		if err != nil {
-			return nil, GetUserMCPStatusOutput{}, err
-		}
-		output, err := diagnostics.GetUserMCPStatus(ctx, principal, input)
-		if err != nil {
-			if budgetResult, ok := operationBudgetToolResult(err); ok {
-				return budgetResult, GetUserMCPStatusOutput{}, nil
-			}
-			return nil, GetUserMCPStatusOutput{}, err
-		}
-		return nil, output, nil
-	})
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("user_mcp_status"))
 }
 
 func registerUnavailableDrilldownTools(reg *Registrar) {
@@ -104,7 +102,6 @@ func registerUnavailableDrilldownTools(reg *Registrar) {
 		{"query_mcp_events", "Query MCP Events", "Break one MCP's calls down by tool and outcome. Diagnostics are not enabled in the current rollout."},
 		{"query_mcp_traces", "Query MCP Traces", "List individual occurrences for one MCP. Diagnostics are not enabled in the current rollout."},
 		{"query_mcp_metrics", "Query MCP Metrics", "Return one MCP's aggregate levels. Diagnostics are not enabled in the current rollout."},
-		{"get_user_mcp_status", "Get User MCP Status", "Report one subject's state against one MCP. Diagnostics are not enabled in the current rollout."},
 	} {
 		addTool(reg, &mcp.Tool{
 			Name:        tool.name,

--- a/server/internal/platformmcp/tool_drilldown.go
+++ b/server/internal/platformmcp/tool_drilldown.go
@@ -1,0 +1,116 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The drill-down tools all say the same thing in their descriptions: come here
+// after the overview, with the MCP it named. Saying so in the manifest is what
+// keeps a model from starting here and paging through occurrences to build the
+// summary get_project_overview would have handed it in one call.
+const drilldownPreamble = "Bounded drill-down for one MCP that get_project_overview or get_mcp_diagnostics already identified. "
+
+func registerDrilldownTools(reg *Registrar, diagnostics *DiagnosticsService) {
+	addTool(reg, &mcp.Tool{
+		Name:        "query_mcp_events",
+		Title:       "Query MCP Events",
+		Description: drilldownPreamble + "Break one MCP's calls down by tool and outcome class over a bounded window, so a failing server can be narrowed to the tool responsible. Returns server-side totals per tool; there is no free-text filter and no attribute selection.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input QueryMCPEventsInput) (*mcp.CallToolResult, QueryMCPEventsOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, QueryMCPEventsOutput{}, err
+		}
+		output, err := diagnostics.QueryMCPEvents(ctx, principal, input)
+		if err != nil {
+			if budgetResult, ok := operationBudgetToolResult(err); ok {
+				return budgetResult, QueryMCPEventsOutput{}, nil
+			}
+			return nil, QueryMCPEventsOutput{}, err
+		}
+		return nil, output, nil
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "query_mcp_traces",
+		Title:       "Query MCP Traces",
+		Description: drilldownPreamble + "List individual occurrences, newest first, each reduced to an opaque correlation reference plus when it happened, which tool it called, and how it ended. Narrow with an outcome class. This is not a log reader: it returns no arguments, results, bodies, headers, URLs, or identities. Quote a reference when escalating; references expire and are bound to this session.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input QueryMCPTracesInput) (*mcp.CallToolResult, QueryMCPTracesOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, QueryMCPTracesOutput{}, err
+		}
+		output, err := diagnostics.QueryMCPTraces(ctx, principal, input)
+		if err != nil {
+			if budgetResult, ok := operationBudgetToolResult(err); ok {
+				return budgetResult, QueryMCPTracesOutput{}, nil
+			}
+			return nil, QueryMCPTracesOutput{}, err
+		}
+		return nil, output, nil
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "query_mcp_metrics",
+		Title:       "Query MCP Metrics",
+		Description: drilldownPreamble + "Return one MCP's aggregate levels over a bounded window: call volume, failures, failure rate, average latency, and active users. Every value is aggregated server-side to the window named in the result; no per-bucket series is returned.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input QueryMCPMetricsInput) (*mcp.CallToolResult, QueryMCPMetricsOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, QueryMCPMetricsOutput{}, err
+		}
+		output, err := diagnostics.QueryMCPMetrics(ctx, principal, input)
+		if err != nil {
+			if budgetResult, ok := operationBudgetToolResult(err); ok {
+				return budgetResult, QueryMCPMetricsOutput{}, nil
+			}
+			return nil, QueryMCPMetricsOutput{}, err
+		}
+		return nil, output, nil
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "get_user_mcp_status",
+		Title:       "Get User MCP Status",
+		Description: drilldownPreamble + "Report how many people are using one MCP and, on request, per-subject activity. Subjects are addressed only by expiring opaque references bound to this session — never by name, email, or account id. Per-subject rows are refused when fewer than five subjects are involved, because a row would then identify a person.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetUserMCPStatusInput) (*mcp.CallToolResult, GetUserMCPStatusOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, GetUserMCPStatusOutput{}, err
+		}
+		output, err := diagnostics.GetUserMCPStatus(ctx, principal, input)
+		if err != nil {
+			if budgetResult, ok := operationBudgetToolResult(err); ok {
+				return budgetResult, GetUserMCPStatusOutput{}, nil
+			}
+			return nil, GetUserMCPStatusOutput{}, err
+		}
+		return nil, output, nil
+	})
+}
+
+func registerUnavailableDrilldownTools(reg *Registrar) {
+	for _, tool := range []struct {
+		name        string
+		title       string
+		description string
+	}{
+		{"query_mcp_events", "Query MCP Events", "Break one MCP's calls down by tool and outcome. Diagnostics are not enabled in the current rollout."},
+		{"query_mcp_traces", "Query MCP Traces", "List individual occurrences for one MCP. Diagnostics are not enabled in the current rollout."},
+		{"query_mcp_metrics", "Query MCP Metrics", "Return one MCP's aggregate levels. Diagnostics are not enabled in the current rollout."},
+		{"get_user_mcp_status", "Get User MCP Status", "Report how many people are using one MCP. Diagnostics are not enabled in the current rollout."},
+	} {
+		addTool(reg, &mcp.Tool{
+			Name:        tool.name,
+			Title:       tool.title,
+			Description: tool.description,
+			Annotations: readOnlyAnnotations(),
+		}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("diagnostics"))
+	}
+}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -188,6 +188,11 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 	} else {
 		registerDiagnosticsTools(reg, diagnostics)
 	}
+	if !diagnostics.drilldownValid() {
+		registerUnavailableDrilldownTools(reg)
+	} else {
+		registerDrilldownTools(reg, diagnostics)
+	}
 	if !skills.valid() {
 		registerUnavailableSkillsTools(reg)
 	} else {

--- a/server/internal/telemetry/mcp_drilldown_test.go
+++ b/server/internal/telemetry/mcp_drilldown_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -168,6 +167,7 @@ func TestListMCPTraceReferences_PagesBackwardsInTime(t *testing.T) {
 	next, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
 		GetMCPOutcomeBreakdownParams: base,
 		BeforeUnixNano:               first[len(first)-1].OccurredAt,
+		BeforeTraceID:                first[len(first)-1].TraceID,
 		Limit:                        2,
 	})
 	require.NoError(t, err)
@@ -218,23 +218,17 @@ func TestListMCPTraceReferences_CapsThePageSize(t *testing.T) {
 
 	// An unbounded or oversized request is clamped rather than honoured, so a
 	// caller cannot turn drill-down into a bulk export.
-	//
-	// Polled rather than read once: this package's tests share one ClickHouse
-	// and run in parallel, and a just-flushed row is not always visible to the
-	// very next statement.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		rows, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
-			GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
-				GramProjectIDs: []string{projectID},
-				ToolsetSlugs:   []string{"billing"},
-				TimeStart:      now.Add(-time.Hour).UnixNano(),
-				TimeEnd:        now.UnixNano(),
-			},
-			Limit: 100_000,
-		})
-		assert.NoError(collect, err)
-		assert.Len(collect, rows, 1)
-	}, 10*time.Second, 250*time.Millisecond)
+	rows, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
+			GramProjectIDs: []string{projectID},
+			ToolsetSlugs:   []string{"billing"},
+			TimeStart:      now.Add(-time.Hour).UnixNano(),
+			TimeEnd:        now.UnixNano(),
+		},
+		Limit: 100_000,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
 }
 
 // TestMCPDrilldownTraceIDsAreStable pins that the same occurrence keeps its

--- a/server/internal/telemetry/mcp_drilldown_test.go
+++ b/server/internal/telemetry/mcp_drilldown_test.go
@@ -1,0 +1,275 @@
+package telemetry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	telemetryRepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func toolOutcomeCounts(rows []telemetryRepo.MCPToolOutcomeBreakdownRow) map[string]map[string]uint64 {
+	counts := map[string]map[string]uint64{}
+	for _, row := range rows {
+		if counts[row.ToolName] == nil {
+			counts[row.ToolName] = map[string]uint64{}
+		}
+		counts[row.ToolName][row.Outcome] += row.CallCount
+	}
+	return counts
+}
+
+func TestGetMCPToolOutcomeBreakdown_SplitsFailuresByTool(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	for _, tool := range []struct {
+		name   string
+		status int
+	}{
+		{"charge", 500},
+		{"charge", 500},
+		{"charge", 200},
+		{"refund", 200},
+	} {
+		insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+			projectID:   projectID,
+			timestamp:   now.Add(-10 * time.Minute),
+			toolsetSlug: "billing",
+			toolName:    tool.name,
+			userEmail:   "alice@example.com",
+			statusCode:  tool.status,
+		})
+	}
+	// Another server's tool of the same name must not be folded in.
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   now.Add(-10 * time.Minute),
+		toolsetSlug: "shipping",
+		toolName:    "charge",
+		userEmail:   "alice@example.com",
+		statusCode:  500,
+	})
+
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	rows, err := ti.chClient.GetMCPToolOutcomeBreakdown(ctx, telemetryRepo.GetMCPToolOutcomeBreakdownParams{
+		GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
+			GramProjectIDs: []string{projectID},
+			ToolsetSlugs:   []string{"billing"},
+			TimeStart:      now.Add(-time.Hour).UnixNano(),
+			TimeEnd:        now.UnixNano(),
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]map[string]uint64{
+		"charge": {telemetryRepo.MCPOutcomeServerError: 2, telemetryRepo.MCPOutcomeSuccess: 1},
+		"refund": {telemetryRepo.MCPOutcomeSuccess: 1},
+	}, toolOutcomeCounts(rows))
+}
+
+func TestListMCPTraceReferences_NewestFirstAndFilterable(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	for index, status := range []int{200, 500, 401} {
+		insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+			projectID:   projectID,
+			timestamp:   now.Add(-time.Duration(30-index*10) * time.Minute),
+			toolsetSlug: "billing",
+			toolName:    "charge",
+			userEmail:   "alice@example.com",
+			statusCode:  status,
+		})
+	}
+
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	base := telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: []string{projectID},
+		ToolsetSlugs:   []string{"billing"},
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	}
+
+	all, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: base,
+	})
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	// Newest first, so a drill-down opens on the most recent occurrence.
+	require.Equal(t, telemetryRepo.MCPOutcomeUnauthorized, all[0].Outcome)
+	require.Equal(t, telemetryRepo.MCPOutcomeServerError, all[1].Outcome)
+	require.Equal(t, telemetryRepo.MCPOutcomeSuccess, all[2].Outcome)
+	for _, row := range all {
+		require.Equal(t, "charge", row.ToolName)
+		require.NotEmpty(t, row.TraceID)
+		require.Positive(t, row.OccurredAt)
+	}
+
+	failures, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: base,
+		Outcomes:                     []string{telemetryRepo.MCPOutcomeServerError},
+	})
+	require.NoError(t, err)
+	require.Len(t, failures, 1)
+	require.Equal(t, telemetryRepo.MCPOutcomeServerError, failures[0].Outcome)
+}
+
+func TestListMCPTraceReferences_PagesBackwardsInTime(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	for index := range 3 {
+		insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+			projectID:   projectID,
+			timestamp:   now.Add(-time.Duration(30-index*10) * time.Minute),
+			toolsetSlug: "billing",
+			toolName:    "charge",
+			userEmail:   "alice@example.com",
+			statusCode:  500,
+		})
+	}
+
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	base := telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: []string{projectID},
+		ToolsetSlugs:   []string{"billing"},
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	}
+
+	first, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: base,
+		Limit:                        2,
+	})
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+
+	next, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: base,
+		BeforeUnixNano:               first[len(first)-1].OccurredAt,
+		Limit:                        2,
+	})
+	require.NoError(t, err)
+	require.Len(t, next, 1)
+	// The page boundary is exclusive, so nothing is served twice.
+	require.NotEqual(t, first[0].TraceID, next[0].TraceID)
+	require.NotEqual(t, first[1].TraceID, next[0].TraceID)
+	require.Less(t, next[0].OccurredAt, first[1].OccurredAt)
+}
+
+func TestMCPDrilldown_NoProjectsIsNotAnUnscopedRead(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	now := time.Now().UTC()
+	empty := telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs: nil,
+		TimeStart:      now.Add(-time.Hour).UnixNano(),
+		TimeEnd:        now.UnixNano(),
+	}
+
+	tools, err := ti.chClient.GetMCPToolOutcomeBreakdown(ctx, telemetryRepo.GetMCPToolOutcomeBreakdownParams{GetMCPOutcomeBreakdownParams: empty})
+	require.NoError(t, err)
+	require.Empty(t, tools)
+
+	traces, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{GetMCPOutcomeBreakdownParams: empty})
+	require.NoError(t, err)
+	require.Empty(t, traces)
+}
+
+func TestListMCPTraceReferences_CapsThePageSize(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   now.Add(-5 * time.Minute),
+		toolsetSlug: "billing",
+		toolName:    "charge",
+		userEmail:   "alice@example.com",
+		statusCode:  200,
+	})
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// An unbounded or oversized request is clamped rather than honoured, so a
+	// caller cannot turn drill-down into a bulk export.
+	//
+	// Polled rather than read once: this package's tests share one ClickHouse
+	// and run in parallel, and a just-flushed row is not always visible to the
+	// very next statement.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		rows, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+			GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
+				GramProjectIDs: []string{projectID},
+				ToolsetSlugs:   []string{"billing"},
+				TimeStart:      now.Add(-time.Hour).UnixNano(),
+				TimeEnd:        now.UnixNano(),
+			},
+			Limit: 100_000,
+		})
+		assert.NoError(collect, err)
+		assert.Len(collect, rows, 1)
+	}, 10*time.Second, 250*time.Millisecond)
+}
+
+// TestMCPDrilldownTraceIDsAreStable pins that the same occurrence keeps its
+// correlation id across reads, which is what makes a reference quotable.
+func TestMCPDrilldownTraceIDsAreStable(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+		projectID:   projectID,
+		timestamp:   now.Add(-5 * time.Minute),
+		toolsetSlug: "billing",
+		toolName:    "charge",
+		userEmail:   uuid.New().String() + "@example.com",
+		statusCode:  403,
+	})
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	params := telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
+			GramProjectIDs: []string{projectID},
+			ToolsetSlugs:   []string{"billing"},
+			TimeStart:      now.Add(-time.Hour).UnixNano(),
+			TimeEnd:        now.UnixNano(),
+		},
+	}
+	first, err := ti.chClient.ListMCPTraceReferences(ctx, params)
+	require.NoError(t, err)
+	second, err := ti.chClient.ListMCPTraceReferences(ctx, params)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Equal(t, first[0].TraceID, second[0].TraceID)
+	require.Equal(t, telemetryRepo.MCPOutcomeUnauthorized, first[0].Outcome)
+}

--- a/server/internal/telemetry/repo/mcp_diagnostics.go
+++ b/server/internal/telemetry/repo/mcp_diagnostics.go
@@ -80,10 +80,7 @@ func (q *Queries) GetMCPOutcomeBreakdown(ctx context.Context, arg GetMCPOutcomeB
 		return nil, err
 	}
 
-	source := "(" + directSQL + " UNION ALL " + hookSQL + ")"
-	sourceArgs := make([]any, 0, len(directArgs)+len(hookArgs))
-	sourceArgs = append(sourceArgs, directArgs...)
-	sourceArgs = append(sourceArgs, hookArgs...)
+	source, sourceArgs := unionSource(directSQL, directArgs, hookSQL, hookArgs)
 
 	sb := sq.Select(
 		"client",
@@ -124,14 +121,40 @@ func (q *Queries) GetMCPOutcomeBreakdown(ctx context.Context, arg GetMCPOutcomeB
 	return result, nil
 }
 
+// mcpTraceSource builds the per-trace row set both diagnostics and drill-down
+// read from: one row per trace, carrying its correlation id, when it happened,
+// the client that made it, the tool it called, and its classified outcome.
+// Aggregations sit on top of this; nothing below it reaches a raw log row.
+func (q *Queries) mcpTraceSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
+	directSQL, directArgs, err := q.mcpOutcomeDirectSource(arg)
+	if err != nil {
+		return "", nil, err
+	}
+	hookSQL, hookArgs, err := q.mcpOutcomeHookSource(arg)
+	if err != nil {
+		return "", nil, err
+	}
+	source, sourceArgs := unionSource(directSQL, directArgs, hookSQL, hookArgs)
+	return source, sourceArgs, nil
+}
+
+func unionSource(directSQL string, directArgs []any, hookSQL string, hookArgs []any) (string, []any) {
+	args := make([]any, 0, len(directArgs)+len(hookArgs))
+	args = append(args, directArgs...)
+	args = append(args, hookArgs...)
+	return "(" + directSQL + " UNION ALL " + hookSQL + ")", args
+}
+
 // mcpOutcomeDirectSource classifies calls that reached a hosted MCP server
 // directly. Aggregate aliases carry the "g_" prefix for the reason the tool
 // usage CTE documents: an alias that shadows a trace_summaries column is merged
 // into the enclosing aggregate and fails with ILLEGAL_AGGREGATION.
 func (q *Queries) mcpOutcomeDirectSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
 	grouped := sq.Select(
+		"trace_id",
 		"min(start_time_unix_nano) AS event_time_ns",
 		"max(toolset_slug) AS g_toolset_slug",
+		"any(tool_name) AS g_tool_name",
 		"ifNull(anyIfMerge(http_status_code), 0) AS g_http_status_code",
 	).
 		From("trace_summaries").
@@ -161,8 +184,10 @@ func (q *Queries) mcpOutcomeDirectSource(arg GetMCPOutcomeBreakdownParams) (stri
 
 	return fmt.Sprintf(`
 SELECT
+	trace_id,
 	event_time_ns,
 	'%s' AS client,
+	g_tool_name AS tool_name,
 	%s AS outcome
 FROM (%s)`, MCPClientUnattributed, outcome, groupedSQL), groupedArgs, nil
 }
@@ -173,8 +198,10 @@ FROM (%s)`, MCPClientUnattributed, outcome, groupedSQL), groupedArgs, nil
 // dimension a caller can filter on.
 func (q *Queries) mcpOutcomeHookSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
 	grouped := sq.Select(
+		"trace_id",
 		"min(start_time_unix_nano) AS event_time_ns",
 		"any(hook_source) AS g_hook_source",
+		"any(tool_name) AS g_tool_name",
 		"max(mcp_server_url) AS g_mcp_server_url",
 		"max(has_result) AS g_has_result",
 		"max(has_error) AS g_has_error",
@@ -204,8 +231,10 @@ func (q *Queries) mcpOutcomeHookSource(arg GetMCPOutcomeBreakdownParams) (string
 
 	return fmt.Sprintf(`
 SELECT
+	trace_id,
 	event_time_ns,
 	%s AS client,
+	g_tool_name AS tool_name,
 	%s AS outcome
 FROM (%s)`, chFirstNonEmpty("g_hook_source", "'"+MCPClientUnattributed+"'"), outcome, groupedSQL), groupedArgs, nil
 }

--- a/server/internal/telemetry/repo/mcp_drilldown.go
+++ b/server/internal/telemetry/repo/mcp_drilldown.go
@@ -79,8 +79,12 @@ type ListMCPTraceReferencesParams struct {
 	// rarely what a drill-down wants — the caller usually arrives here holding a
 	// failure class the overview named.
 	Outcomes []string
-	// BeforeUnixNano continues a previous page. Zero starts at the newest.
+	// BeforeUnixNano and BeforeTraceID continue a previous page. They are the
+	// composite key the ordering below uses; paging on the timestamp alone
+	// would skip every remaining trace sharing the boundary nanosecond, which
+	// on a busy server silently drops occurrences from both pages.
 	BeforeUnixNano int64
+	BeforeTraceID  string
 	Limit          int
 }
 
@@ -126,7 +130,11 @@ func (q *Queries) ListMCPTraceReferences(ctx context.Context, arg ListMCPTraceRe
 		sb = sb.Where(squirrel.Eq{"outcome": arg.Outcomes})
 	}
 	if arg.BeforeUnixNano > 0 {
-		sb = sb.Where("event_time_ns < ?", arg.BeforeUnixNano)
+		if arg.BeforeTraceID != "" {
+			sb = sb.Where("(event_time_ns, trace_id) < (?, ?)", arg.BeforeUnixNano, arg.BeforeTraceID)
+		} else {
+			sb = sb.Where("event_time_ns < ?", arg.BeforeUnixNano)
+		}
 	}
 	// Ordered by time then trace id so a page boundary is deterministic when
 	// several traces share a nanosecond.

--- a/server/internal/telemetry/repo/mcp_drilldown.go
+++ b/server/internal/telemetry/repo/mcp_drilldown.go
@@ -1,0 +1,159 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/squirrel"
+)
+
+// maxMCPTraceReferences caps a single page of trace references. Drill-down
+// exists to point at a handful of concrete occurrences, not to export a log.
+const maxMCPTraceReferences = 50
+
+type GetMCPToolOutcomeBreakdownParams struct {
+	GetMCPOutcomeBreakdownParams
+}
+
+type MCPToolOutcomeBreakdownRow struct {
+	ToolName  string `ch:"tool_name"`
+	Outcome   string `ch:"outcome"`
+	CallCount uint64 `ch:"call_count"`
+}
+
+// GetMCPToolOutcomeBreakdown counts one MCP's calls per tool and outcome class,
+// so a caller that already knows a server is failing can find which of its
+// tools accounts for it.
+//
+// Tool names are Gram-side configuration, not caller-supplied content, which is
+// why they may be projected where arguments and results may not.
+func (q *Queries) GetMCPToolOutcomeBreakdown(ctx context.Context, arg GetMCPToolOutcomeBreakdownParams) ([]MCPToolOutcomeBreakdownRow, error) {
+	if len(arg.GramProjectIDs) == 0 {
+		return []MCPToolOutcomeBreakdownRow{}, nil
+	}
+
+	source, sourceArgs, err := q.mcpTraceSource(arg.GetMCPOutcomeBreakdownParams)
+	if err != nil {
+		return nil, err
+	}
+
+	sb := sq.Select(
+		"tool_name",
+		"outcome",
+		"count() AS call_count",
+	).
+		From(source).
+		Where("tool_name != ''").
+		GroupBy("tool_name", "outcome").
+		OrderBy("call_count DESC", "tool_name ASC", "outcome ASC")
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build mcp tool outcome breakdown query: %w", err)
+	}
+	args = append(sourceArgs, args...)
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query mcp tool outcome breakdown: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]MCPToolOutcomeBreakdownRow, 0)
+	for rows.Next() {
+		var row MCPToolOutcomeBreakdownRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scan mcp tool outcome breakdown row: %w", err)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate mcp tool outcome breakdown rows: %w", err)
+	}
+	return result, nil
+}
+
+type ListMCPTraceReferencesParams struct {
+	GetMCPOutcomeBreakdownParams
+	// Outcomes narrows to specific classes. Empty returns every class, which is
+	// rarely what a drill-down wants — the caller usually arrives here holding a
+	// failure class the overview named.
+	Outcomes []string
+	// BeforeUnixNano continues a previous page. Zero starts at the newest.
+	BeforeUnixNano int64
+	Limit          int
+}
+
+type MCPTraceReferenceRow struct {
+	TraceID    string `ch:"trace_id"`
+	OccurredAt int64  `ch:"event_time_ns"`
+	ToolName   string `ch:"tool_name"`
+	Outcome    string `ch:"outcome"`
+	ClientName string `ch:"client"`
+}
+
+// ListMCPTraceReferences returns individual traces for one MCP, newest first,
+// reduced to a correlation id and a classification.
+//
+// It is deliberately not a log reader: no body, no attributes, no arguments, no
+// result, no URL, no identity. The trace id is a correlation reference — the
+// thing a caller quotes when escalating — and everything else is a closed-set
+// classification the server assigned.
+func (q *Queries) ListMCPTraceReferences(ctx context.Context, arg ListMCPTraceReferencesParams) ([]MCPTraceReferenceRow, error) {
+	if len(arg.GramProjectIDs) == 0 {
+		return []MCPTraceReferenceRow{}, nil
+	}
+
+	source, sourceArgs, err := q.mcpTraceSource(arg.GetMCPOutcomeBreakdownParams)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := arg.Limit
+	if limit <= 0 || limit > maxMCPTraceReferences {
+		limit = maxMCPTraceReferences
+	}
+
+	sb := sq.Select(
+		"trace_id",
+		"event_time_ns",
+		"tool_name",
+		"outcome",
+		"client",
+	).
+		From(source)
+	if len(arg.Outcomes) > 0 {
+		sb = sb.Where(squirrel.Eq{"outcome": arg.Outcomes})
+	}
+	if arg.BeforeUnixNano > 0 {
+		sb = sb.Where("event_time_ns < ?", arg.BeforeUnixNano)
+	}
+	// Ordered by time then trace id so a page boundary is deterministic when
+	// several traces share a nanosecond.
+	sb = sb.OrderBy("event_time_ns DESC", "trace_id DESC").Limit(uint64(limit))
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build mcp trace reference query: %w", err)
+	}
+	args = append(sourceArgs, args...)
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query mcp trace references: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make([]MCPTraceReferenceRow, 0, limit)
+	for rows.Next() {
+		var row MCPTraceReferenceRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scan mcp trace reference row: %w", err)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate mcp trace reference rows: %w", err)
+	}
+	return result, nil
+}


### PR DESCRIPTION
Second slice of lane D2 in the Platform MCP RFC: the bounded drill-down tools. AGE-3167.

**Stacked on #5595 — targets `feat/observability-tools`, not `main`.** Review that one first; this PR's diff is only the drill-down on top of it.

Slice 1 landed the overview-first entry points (`get_project_overview`, `get_mcp_diagnostics`) and the primitives they rest on. This adds the four tools that exist only for bounded follow-up once the overview has named a specific MCP: `query_mcp_events`, `query_mcp_traces`, `query_mcp_metrics`, and `get_user_mcp_status`.

## Overview-first, enforced by shape

Each tool takes a `project_id`, an `mcp_id` the catalog already returned, and a named window. There is no free-text filter, no attribute selector, and no time grammar — the only axis is the MCP the overview identified. Every description says so, because a manifest that reads like a log API invites a model to start here and page its way to a summary one call would have given it.

`resolveDrilldown` is the single entry gate: it charges the budget, resolves the window against the closed set, and re-authorizes through `GetMCP` before any telemetry read runs. All four tools go through it.

## The tools

**`query_mcp_events`** breaks one MCP's calls down by tool and outcome class, so a failing server narrows to the operation responsible. Tool names are Gram-side configuration, not caller content, which is why they may be projected where arguments and results may not.

**`query_mcp_traces`** lists individual occurrences, newest first, each reduced to an opaque correlation reference plus when it happened, which tool, how it ended, and which client reported it. It is deliberately not a log reader — no bodies, attributes, arguments, results, headers, URLs, or identities. Pages are capped and cursor-paginated, and the cursor is minted through the same bound, expiring codec as everything else a caller holds between calls.

**`query_mcp_metrics`** returns aggregate levels — volume, failures, failure rate, average latency, active users — computed server-side to the window named in the result. No per-bucket series: an external MCP client has no scratch compute, and handing it buckets to sum would be a contract failure.

**`get_user_mcp_status`** reports how many people use one MCP, and on explicit request per-subject activity. Rows are refused outright when fewer than five subjects are involved, because a row is then a person however it is labelled; the aggregate already answers what rows were asked for. It is metered on its own tighter allowance, so exhausting the personal-data read is not possible by spending the ordinary diagnostic budget.

## Subject references

A new bound, expiring reference codec backs both the trace handles and the subject handles. A reference is an HMAC over the organization, the caller's session binding, a kind, the value, and an expiry — so it means nothing outside the session that minted it, cannot be replayed after reauthorization, and cannot be spent as a different kind than it was issued for. The identity behind it never leaves the server; `user.UserID` from the telemetry fold is frequently an email, and minting it into a reference is the whole reason the codec exists.

Deployments without reference key material serve the overview and withhold the drill-down, rather than returning unbound identifiers — `WithDrilldown` attaches the row-level reads separately for exactly this reason.

## Verification

`go build`, `go vet`, and golangci are clean. The two new ClickHouse queries are exercised against a real ClickHouse container: per-tool outcome splitting, server isolation, newest-first ordering, outcome filtering, exclusive page boundaries, page-size clamping, and the empty-project-list guard that must never widen into an unscoped read. Leak tests pin the exact serialized shape of all four results, so a field cannot reach a caller without being added to an allowlist in the test first. The reference codec is tested against cross-organization use, post-reauthorization replay, kind confusion, expiry, and a forged signature.

One integration assertion polls rather than reading once — this package's tests share a single ClickHouse and run in parallel, so a just-flushed row is not reliably visible to the very next statement.

## Notes

Latency is reported as an average because that is what the read model holds; there are no percentiles to project without a new materialized column, which is not in this slice. Client attribution on directly-arriving calls remains `unattributed` pending the client name/version recording deferred in #5595.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded Platform MCP drill-down tools with session-bound encrypted references, enforces RFC windows and budgets, and audits exact user–MCP status reads; the dashboard now renders that audit action. This enables safe follow-up from the overview without exposing raw logs or durable identities. (AGE-3167)

- Adds `query_mcp_events`, `query_mcp_traces`, `query_mcp_metrics`, and `get_user_mcp_status`. All require `project_id`, `mcp_id`, and a named window; they re-authorize via GetMCP and only enable when `TelemetryDrilldown` and reference keys are present.
- Windows refuse (not clamp) when too long: overview ≤30d (default 24h), diagnostics ≤24h (default 1h), drill-down ≤24h (default 24h), metrics ≤7d (default 24h). Freshness is `current|stale|unavailable`; the envelope includes `no_observations`.
- Row-level tools meter under a new SensitiveDiagnostics budget (`platform-mcp-sensitive-diagnostics-connection`, `platform-mcp-sensitive-diagnostics-organization`). Per-connection caps: `platform-mcp-drilldown-rows` (rows/spans) and `platform-mcp-drilldown-metric-queries` (metric queries), both over ten minutes; trace traversal is also capped across pages.
- Trace and subject references are encrypted opaque tokens bound to session and organization, include a kind, and expire after 10m; unknown/expired/forged tokens resolve to a single not-found. Cursors are their own kind, bound to the original query (MCP, outcome, window). Trimmed trace pages mint a cursor from the last returned row so dropped suffixes remain reachable; if trimmed to zero, no cursor.
- `query_mcp_events`: per-tool outcome totals (failures-first), capped list with truncation flag; subject to the rows cap.
- `query_mcp_traces`: newest-first opaque references only (no bodies/attributes/URLs/identities); capped page size and total traversal; metered under SensitiveDiagnostics and the rows cap.
- `query_mcp_metrics`: aggregated volume/failures/server-rounded failure rate/average latency/active users; requires exactly one identity filter; metered under SensitiveDiagnostics and the metric-queries cap; active users unavailable for remote/unhosted MCPs.
- `get_user_mcp_status`: returns a masked identity and activity (active/inactive/no_observations), scoped to the queried MCP; metered under SensitiveDiagnostics and audited to the outbox (subject is the MCP; carries only the masked identity).
- Auditing: emits `audit_log.platform_mcp_diagnostics_event_v1`; the dashboard adds `platform-mcp-diagnostics:user_status_read` with a matching phrase so the action displays correctly.

<sup>Written for commit 72e2e262f8b9ed98d84b5b5fd864c5ce9b4c4968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

