### PR TITLE
fix: bound the gating hook risk scan with an evaluation deadline

### DIFF
--- a/.changeset/gating-hook-scan-deadline.md
+++ b/.changeset/gating-hook-scan-deadline.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Risk enforcement scans on the synchronous gating hook path now run under a 3s deadline instead of being bounded only by the prompt-policy judge's 10s per-call timeout, so a slow judge can no longer hold a prompt or tool call open for up to ten seconds. The deadline is propagated into the scan rather than enforced around it, so each policy's own fail-open/fail-closed mode still decides the outcome on expiry. Override with `GRAM_HOOKS_GATING_SCAN_TIMEOUT`.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -382,6 +382,11 @@ func newStartCommand() *cli.Command {
 			Usage:   "Maximum concurrently tracked anonymous MCP sessions per tunnel (0 uses the built-in default)",
 			EnvVars: []string{"GRAM_PUBLIC_TUNNELS_LIVE_SESSION_CAP"},
 		},
+		&cli.DurationFlag{
+			Name:    "hooks-gating-scan-timeout",
+			Usage:   "Deadline for the risk enforcement scan on the synchronous gating hook path (0 uses the built-in default)",
+			EnvVars: []string{"GRAM_HOOKS_GATING_SCAN_TIMEOUT"},
+		},
 		&cli.StringFlag{
 			Name:    "openrouter-provisioning-key",
 			Usage:   "Provisioning key for OpenRouter to create new API keys for orgs - https://openrouter.ai/settings/provisioning-keys",
@@ -1350,6 +1355,7 @@ func newStartCommand() *cli.Command {
 				serverURL,
 				siteURL,
 				c.String("jwt-signing-key"),
+				c.Duration("hooks-gating-scan-timeout"),
 			)
 			hooks.Attach(mux, hooksService)
 			litellmService = litellm.NewService(logger, tracerProvider, db, chDB, sessionManager, authzEngine, hooksService, litellmCalls, litellmTraceProcessor, litellmMetricProcessor, litellmHealthProcessor, litellmInstanceResolver, auditLogger, c.String("environment"))

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -76,6 +76,11 @@ type Service struct {
 	serverURL          *url.URL
 	siteURL            *url.URL
 	jwtSecret          string
+
+	// gatingScanTimeout bounds the risk enforcement scan on the synchronous
+	// gating hook path. Zero selects defaultGatingScanTimeout, so a
+	// zero-value Service still enforces a deadline.
+	gatingScanTimeout time.Duration
 	// nowFunc supplies the event timestamp for ingest paths that stamp
 	// server-side because the client sends none (the Cursor hook, and the
 	// Codex/OTEL fallbacks). Injectable so tests can pin telemetry event time
@@ -252,6 +257,7 @@ func NewService(
 	serverURL *url.URL,
 	siteURL *url.URL,
 	jwtSecret string,
+	gatingScanTimeout time.Duration,
 ) *Service {
 	return &Service{
 		tracer:             tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/hooks"),
@@ -278,6 +284,7 @@ func NewService(
 		serverURL:          serverURL,
 		siteURL:            siteURL,
 		jwtSecret:          jwtSecret,
+		gatingScanTimeout:  gatingScanTimeout,
 		nowFunc:            time.Now,
 	}
 }

--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -4,14 +4,30 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/hookevents"
 	"github.com/speakeasy-api/gram/server/internal/message"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 )
+
+// defaultGatingScanTimeout bounds the risk enforcement scan on the synchronous
+// gating hook path (UserPromptSubmit / PreToolUse / BeforeSubmitPrompt /
+// BeforeMCPExecution), where an agent is holding a prompt or tool call open
+// waiting on the verdict. Without it the only bound is the prompt-policy
+// judge's own 10s per-call timeout, which is the latency an end user sees.
+//
+// The value sits deliberately above the judge's observed latency floor of
+// ~1.4s. A deadline at or below that floor would expire on nearly every
+// judge-backed scan, and a fail-closed policy turns each expiry into a block —
+// so a tighter deadline does not trade latency for permissiveness, it blocks
+// almost every prompt. Asynchronous batch analysis is unaffected and keeps the
+// judge's 10s bound.
+const defaultGatingScanTimeout = 3 * time.Second
 
 // riskScanTrackerKey carries a flag the transport handlers install before
 // dispatching an event, flipped when an enforcement scan actually executes
@@ -79,11 +95,28 @@ func (s *Service) scanHookEventForEnforcement(ctx context.Context, ev hookevents
 	}
 
 	markRiskScanned(ctx)
-	result, err := s.riskScanner.ScanForEnforcement(ctx, ev.Context.OrganizationID, ev.Context.ProjectID, ev.Context.User.ID, text, messageType, toolName)
+
+	timeout := s.gatingScanTimeout
+	if timeout <= 0 {
+		timeout = defaultGatingScanTimeout
+	}
+
+	// The deadline is propagated into the scan rather than enforced around it.
+	// Expiry then reaches the prompt-policy judge as a call error, and each
+	// policy's own fail-open/fail-closed mode decides the outcome: fail-open
+	// policies produce no finding (allow), fail-closed policies produce a
+	// block. Cutting the scan off from the outside would instead allow every
+	// policy uniformly, which makes a fail-closed policy bypassable by anyone
+	// who can make the judge slow.
+	scanCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	result, err := s.riskScanner.ScanForEnforcement(scanCtx, ev.Context.OrganizationID, ev.Context.ProjectID, ev.Context.User.ID, text, messageType, toolName)
 	if err != nil {
 		s.logger.WarnContext(ctx, "risk scan failed for hook event",
 			attr.SlogError(err),
 			attr.SlogEvent("risk_scan_error"),
+			attr.SlogOutcome(string(o11y.OutcomeFromErrorWithTimeout(err))),
 			attr.SlogHookSource(string(ev.Provider)),
 			attr.SlogHookEvent(ev.RawEventType),
 		)

--- a/server/internal/hooks/risk_scan_timeout_test.go
+++ b/server/internal/hooks/risk_scan_timeout_test.go
@@ -1,0 +1,174 @@
+package hooks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/hookevents"
+	"github.com/speakeasy-api/gram/server/internal/message"
+	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// deadlineRecordingScanner captures the deadline the gating path hands to
+// ScanForEnforcement, and optionally waits for that deadline before returning
+// the result the real scanner would produce.
+type deadlineRecordingScanner struct {
+	// waitForDeadline blocks the scan until the supplied context is done, so a
+	// test can observe what the gating path does with an expired scan.
+	waitForDeadline bool
+
+	// result is returned once the scan finishes. Non-nil models a policy that
+	// matched — including a fail-closed prompt policy, which turns a judge
+	// timeout into a block rather than an error.
+	result *risk.ScanResult
+
+	// err is returned once the scan finishes, alongside a nil result.
+	err error
+
+	// observedDeadline is the deadline seen on the scan context, and
+	// hasDeadline reports whether one was set at all.
+	observedDeadline time.Time
+	hasDeadline      bool
+
+	// observedCtxErr is the scan context's error at the moment the scan
+	// returned.
+	observedCtxErr error
+}
+
+func (s *deadlineRecordingScanner) ScanForEnforcement(ctx context.Context, _ string, _ uuid.UUID, _ string, _ string, _ message.Type, _ string) (*risk.ScanResult, error) {
+	s.observedDeadline, s.hasDeadline = ctx.Deadline()
+	if s.waitForDeadline {
+		<-ctx.Done()
+	}
+	s.observedCtxErr = ctx.Err()
+	return s.result, s.err
+}
+
+func (s *deadlineRecordingScanner) LookupShadowMCPBlockingPolicy(context.Context, string, uuid.UUID, string) (*risk.ShadowMCPPolicy, error) {
+	return nil, nil
+}
+
+func (s *deadlineRecordingScanner) HasEnabledShadowMCPPolicy(context.Context, uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+func (s *deadlineRecordingScanner) HasAcknowledgedChallenge(context.Context, uuid.UUID, string, string, string, string) bool {
+	return false
+}
+
+func (s *deadlineRecordingScanner) RecordPolicyChallenge(context.Context, string, uuid.UUID, string, string, string, string, string, string, string) {
+}
+
+// newGatingScanService builds the minimal Service the gating scan path needs.
+// It deliberately avoids a struct literal so the test does not have to name
+// every unrelated Service dependency.
+func newGatingScanService(t *testing.T, scanner risk.RiskScanner, timeout time.Duration) *Service {
+	t.Helper()
+
+	svc := new(Service)
+	svc.logger = testenv.NewLogger(t)
+	svc.riskScanner = scanner
+	svc.gatingScanTimeout = timeout
+	return svc
+}
+
+func newGatingScanEvent() hookevents.Event {
+	return hookevents.Event{
+		Provider:     hookevents.ProviderClaude,
+		Type:         hookevents.EventTypeUserPromptSubmit,
+		RawEventType: "UserPromptSubmit",
+		Timestamp:    time.Time{},
+		AuthContext:  nil,
+		Context: hookevents.EventContext{
+			OrganizationID: "org-1",
+			ProjectID:      uuid.New(),
+			User:           hookevents.User{ID: "user-1"},
+		},
+		ConversationID: "conv-1",
+		Raw:            nil,
+	}
+}
+
+func TestScanHookEventForEnforcementAppliesDefaultDeadline(t *testing.T) {
+	t.Parallel()
+
+	scanner := &deadlineRecordingScanner{waitForDeadline: false, result: nil, err: nil, observedDeadline: time.Time{}, hasDeadline: false, observedCtxErr: nil}
+	svc := newGatingScanService(t, scanner, 0)
+
+	start := time.Now()
+	result := svc.scanHookEventForEnforcement(t.Context(), newGatingScanEvent(), "delete prod", message.User, "")
+
+	require.Nil(t, result)
+	require.True(t, scanner.hasDeadline, "gating scan must run under a deadline")
+	remaining := scanner.observedDeadline.Sub(start)
+	require.Greater(t, remaining, defaultGatingScanTimeout-time.Second)
+	require.LessOrEqual(t, remaining, defaultGatingScanTimeout+time.Second)
+}
+
+func TestScanHookEventForEnforcementAppliesConfiguredDeadline(t *testing.T) {
+	t.Parallel()
+
+	scanner := &deadlineRecordingScanner{waitForDeadline: false, result: nil, err: nil, observedDeadline: time.Time{}, hasDeadline: false, observedCtxErr: nil}
+	svc := newGatingScanService(t, scanner, 250*time.Millisecond)
+
+	start := time.Now()
+	result := svc.scanHookEventForEnforcement(t.Context(), newGatingScanEvent(), "delete prod", message.User, "")
+
+	require.Nil(t, result)
+	require.True(t, scanner.hasDeadline)
+	remaining := scanner.observedDeadline.Sub(start)
+	require.Greater(t, remaining, time.Duration(0))
+	require.Less(t, remaining, time.Second, "the configured deadline must override the default")
+}
+
+// A scan that outlives the deadline must not take the surrounding hook request
+// down with it: the handler still has a response to write.
+func TestScanHookEventForEnforcementDeadlineLeavesCallerContextLive(t *testing.T) {
+	t.Parallel()
+
+	scanner := &deadlineRecordingScanner{waitForDeadline: true, result: nil, err: context.DeadlineExceeded, observedDeadline: time.Time{}, hasDeadline: false, observedCtxErr: nil}
+	svc := newGatingScanService(t, scanner, 50*time.Millisecond)
+
+	ctx := t.Context()
+	result := svc.scanHookEventForEnforcement(ctx, newGatingScanEvent(), "delete prod", message.User, "")
+
+	require.Nil(t, result, "a scan error allows the event through")
+	require.ErrorIs(t, scanner.observedCtxErr, context.DeadlineExceeded)
+	require.NoError(t, ctx.Err(), "the deadline must not cancel the caller's context")
+}
+
+// The deadline is propagated into the scan rather than enforced around it, so
+// a fail-closed policy that turns the expiry into a block still has its block
+// honoured. Enforcing the deadline outside the scanner would drop this result
+// and allow the prompt.
+func TestScanHookEventForEnforcementDeadlineHonoursFailClosedBlock(t *testing.T) {
+	t.Parallel()
+
+	blocked := &risk.ScanResult{
+		Action:           "block",
+		PolicyID:         uuid.New().String(),
+		PolicyName:       "no prod deletes",
+		Source:           "prompt_policy",
+		MessageType:      message.User,
+		RuleID:           "prompt_policy.match",
+		Description:      "Policy judge was unavailable; flagged by fail-closed policy.",
+		UserMessage:      nil,
+		MatchedValue:     "",
+		Entity:           "prompt_policy.match",
+		CallFingerprint:  "",
+		DeadLetterReason: "",
+	}
+	scanner := &deadlineRecordingScanner{waitForDeadline: true, result: blocked, err: nil, observedDeadline: time.Time{}, hasDeadline: false, observedCtxErr: nil}
+	svc := newGatingScanService(t, scanner, 50*time.Millisecond)
+
+	result := svc.scanHookEventForEnforcement(t.Context(), newGatingScanEvent(), "delete prod", message.User, "")
+
+	require.NotNil(t, result, "a fail-closed block produced at the deadline must still enforce")
+	require.Equal(t, "block", result.Action)
+	require.ErrorIs(t, scanner.observedCtxErr, context.DeadlineExceeded)
+}

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -235,6 +235,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 		serverURL,
 		siteURL,
 		"test-jwt-secret",
+		0,
 	)
 
 	return ctx, &testInstance{

--- a/server/internal/litellm/setup_test.go
+++ b/server/internal/litellm/setup_test.go
@@ -162,6 +162,7 @@ func newRealTestServiceWithScannerFactory(t *testing.T, scannerFactory func(*pgx
 		serverURL,
 		siteURL,
 		"test-jwt-secret",
+		0,
 	)
 	calls := callcache.New(cacheAdapter)
 	traceProcessor := NewTraceProcessor(logger, meterProvider, telemetryLogger, calls)


### PR DESCRIPTION
Closes DNO-600.

## Problem

Gating hook evaluation (`UserPromptSubmit` / `PreToolUse` / `BeforeSubmitPrompt` / `BeforeMCPExecution`) runs the prompt-policy LLM judge synchronously on the request path with no deadline on the gating path itself. The only bound is the judge's internal per-call `judgeTimeout = 10s`, so a slow judge response can hold a prompt or tool call open for up to ten seconds. Observed p95 for `risk.scanForEnforcement` on a project with several prompt-based policies is ~1.5s, with a max sitting right at the 10s judge timeout.

## Change

`scanHookEventForEnforcement` — the single call site every gating event funnels through — now wraps `ScanForEnforcement` in a 3s context timeout, configurable via `--hooks-gating-scan-timeout` / `GRAM_HOOKS_GATING_SCAN_TIMEOUT` (`0` keeps the built-in default).

Two decisions worth reviewing:

**Why 3s and not 1s.** The judge's observed latency floor is ~1.4s. A deadline at or below that floor expires on nearly every judge-backed scan, and a fail-closed policy turns each expiry into a block — so a tighter deadline does not trade latency for permissiveness, it blocks almost every prompt. Reducing the floor itself is tracked separately in DNO-601.

**Why the deadline is propagated rather than enforced around the scan.** Expiry reaches the judge as a call error, so the existing `FindingsFromEvaluation` logic still decides per policy: fail-open yields no finding (allow), fail-closed yields a block. Cutting the scan off from the outside would instead allow every policy uniformly, which would make a fail-closed policy bypassable by anyone who can make the judge slow.

The asynchronous batch analysis path is untouched and keeps the judge's 10s bound.

## Tests

Four new tests in `server/internal/hooks/risk_scan_timeout_test.go`: the default deadline is applied; a configured deadline overrides it; expiry does not cancel the caller's context (the handler still has a response to write); and a fail-closed block produced at the deadline is still enforced.

## Follow-ups (not in this PR)

- The "fail-closed blocks on timeout" property holds only for prompt-based policies. Non-judge sources (Presidio, the per-policy exclusions query) propagate `DeadlineExceeded` as an error out of `scanPolicy`, and the fan-out treats a scan error as no-match, so those fail *open*. Same for a deadline that fires before the judge starts, during the policy and grant lookups. Tightening from 10s to 3s makes that window reachable more often than it was.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the synchronous gating hook risk scan with a 3s evaluation deadline to cap user-visible latency. Previously the path had no deadline and could block until the judge’s 10s per-call timeout; now the deadline is propagated so fail-open policies allow on timeout and fail-closed policies block.

- Applies a timeout in `scanHookEventForEnforcement` around calls to `riskScanner.ScanForEnforcement`; `0` uses the built-in 3s default.
- Adds `--hooks-gating-scan-timeout` and `GRAM_HOOKS_GATING_SCAN_TIMEOUT`.
- Propagates the deadline via context (not an outer cutoff) to preserve per-policy semantics; asynchronous batch analysis is unchanged.
- Does not cancel the handler’s context on expiry; logging now includes `o11y` outcome on scan errors.
- Tests in `server/internal/hooks/risk_scan_timeout_test.go` cover default vs configured deadline, caller-context behavior, and enforcing a fail-closed block at the deadline.
- Rollout: no migration required. If you need a different cap, set the flag/env var. Update any monitors that assume a 1s evaluation deadline to reflect the 3s cap. (Aligns with Linear `DNO-600`.)

<sup>Written for commit 11ec179368679dae635b66904cd7ad4d06a390cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

