### PR TITLE
feat: Device Agent Windows Installation - stable MSI endpoint + MSI-first dashboard instructions

### DIFF
--- a/.changeset/windows-msi-install-instructions.md
+++ b/.changeset/windows-msi-install-instructions.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The Windows device-agent setup walkthrough now installs from the signed MSI instead of raw binaries. The install step downloads the installer from a stable link that always resolves to the current signed version, and `msiexec` registers the machine-wide service itself — no separate service-registration step. The raw-binary PowerShell script remains available as an alternative for scripted installs, an Intune Win32/LOB note covers fleet deployment, and the enroll/verify commands now invoke the CLI by its install path (the MSI does not add it to PATH).

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -1004,7 +1004,19 @@ function WinInstallStep() {
   const msiUrl = version
     ? `${RELEASES_BASE}/v${version}/speakeasy-agent_${version}.msi`
     : null;
-  const stableMsiUrl = `${getServerURL()}/v1/install/device-agent-windows.msi`;
+  // The snippet lands in an elevated shell, so never emit a plaintext
+  // download: if the server URL is somehow non-HTTPS, skip the stable link
+  // and build the snippet against the (always-HTTPS) release bucket instead.
+  const serverURL = getServerURL();
+  const stableMsiUrl = serverURL.startsWith("https:")
+    ? `${serverURL}/v1/install/device-agent-windows.msi`
+    : null;
+  const downloadScript = stableMsiUrl
+    ? `Invoke-WebRequest "${stableMsiUrl}" -OutFile speakeasy-agent.msi
+msiexec /i speakeasy-agent.msi`
+    : `${psVersionAssign(version)}
+Invoke-WebRequest "${RELEASES_BASE}/v$VERSION/speakeasy-agent_\${VERSION}.msi" -OutFile speakeasy-agent.msi
+msiexec /i speakeasy-agent.msi`;
 
   return (
     <div className="flex flex-col gap-6">
@@ -1015,11 +1027,10 @@ function WinInstallStep() {
       <div className="flex flex-col gap-2">
         <SubLabel>Run the download + install script</SubLabel>
         <StepNote>
-          Run from an elevated (Administrator) PowerShell. The stable URL always
-          redirects to the latest signed installer.
+          Run from an elevated (Administrator) PowerShell. The download URL
+          always resolves to the latest signed installer.
         </StepNote>
-        <CodeBlock language="powershell">{`Invoke-WebRequest "${stableMsiUrl}" -OutFile speakeasy-agent.msi
-msiexec /i speakeasy-agent.msi`}</CodeBlock>
+        <CodeBlock language="powershell">{downloadScript}</CodeBlock>
       </div>
       <OrDivider />
       <div className="flex flex-col gap-2">
@@ -1036,10 +1047,20 @@ msiexec /i speakeasy-agent.msi`}</CodeBlock>
             {isError
               ? "Couldn't load the latest release — use the "
               : "Loading the latest release… or use the "}
-            <ExternalLink href={stableMsiUrl} iconSuffixName="external-link">
-              stable installer link
-            </ExternalLink>
-            , which always serves the current version.
+            {stableMsiUrl ? (
+              <ExternalLink href={stableMsiUrl} iconSuffixName="external-link">
+                stable installer link
+              </ExternalLink>
+            ) : (
+              <ExternalLink
+                href={MANIFEST_URL}
+                target="_blank"
+                iconSuffixName="external-link"
+              >
+                release manifest
+              </ExternalLink>
+            )}
+            , which always points at the current version.
           </Text>
         )}
       </div>
@@ -1063,8 +1084,8 @@ Invoke-WebRequest "$BASE/speakeasy_\${VERSION}_windows_amd64.exe"  -OutFile spea
         <Text small muted>
           Upload the msi to Intune (or your MDM) as a{" "}
           <strong className="font-medium">Win32 / line-of-business app</strong>{" "}
-          and assign it per machine — no script needed. Get it from the stable
-          link above, and pair it with a <code>managed.json</code> pushed to{" "}
+          and assign it per machine — no script needed. Get it with the script
+          or link above, and pair it with a <code>managed.json</code> pushed to{" "}
           <code>%ProgramData%\Speakeasy\</code> (see the identity step) so
           enrollment is set centrally.
         </Text>

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -1028,7 +1028,7 @@ msiexec /i speakeasy-agent.msi`;
         <SubLabel>Run the download + install script</SubLabel>
         <StepNote>
           Run from an elevated (Administrator) PowerShell. The download URL
-          always resolves to the latest signed installer.
+          resolves to the latest signed installer.
         </StepNote>
         <CodeBlock language="powershell">{downloadScript}</CodeBlock>
       </div>

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -14,7 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
 import { Text } from "@/components/ui/Text";
 import { useOrganization } from "@/contexts/Auth";
 import { useAgentToken } from "@/hooks/useAgentToken";
-import { cn } from "@/lib/utils";
+import { cn, getServerURL } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
 import { Button } from "@/components/ui/Button";
 import { Icon } from "@/components/ui/Icon";
@@ -140,11 +140,12 @@ type BaseOsSpec = {
   invertLogoInDark?: boolean;
 };
 
-// Windows and Linux still ship as raw binaries registered via a manual
-// service-install script; only macOS moved to a signed, notarized .pkg.
+// Linux still ships as raw binaries registered via a manual service-install
+// script; macOS moved to a signed, notarized .pkg and Windows to a signed
+// .msi (their install steps are bespoke components, not script fields).
 // Keeping this as its own type (instead of leaving these fields optional on
-// a single OsSpec) means macOS can't silently carry stale script fields that
-// nothing renders anymore.
+// a single OsSpec) means macOS/Windows can't silently carry stale script
+// fields that nothing renders anymore.
 type ScriptOsSpec = BaseOsSpec & {
   lang: "bash" | "powershell";
   archNote?: React.ReactNode;
@@ -163,7 +164,7 @@ type ScriptOsSpec = BaseOsSpec & {
 
 const OS_CONFIG: {
   macos: BaseOsSpec;
-  windows: ScriptOsSpec;
+  windows: BaseOsSpec;
   linux: ScriptOsSpec;
 } = {
   macos: {
@@ -178,20 +179,6 @@ const OS_CONFIG: {
     tileDesc: "x64",
     logo: "/icons/platforms/windows.svg",
     logoSize: "h-7 w-7",
-    lang: "powershell",
-    download: (version) => `${psVersionAssign(version)}
-$BASE = "${RELEASES_BASE}/v$VERSION"
-Invoke-WebRequest "$BASE/speakeasyd_\${VERSION}_windows_amd64.exe" -OutFile speakeasyd.exe
-Invoke-WebRequest "$BASE/speakeasy_\${VERSION}_windows_amd64.exe"  -OutFile speakeasy.exe`,
-    serviceNote: (
-      <>
-        Installs <code>speakeasyd</code> as a Windows service.
-      </>
-    ),
-    serviceRegister: `.\\speakeasyd.exe -service install
-.\\speakeasyd.exe -service start`,
-    verify: `.\\speakeasy.exe status`,
-    downloadKeys: ["windows/amd64"],
   },
   linux: {
     label: "Linux",
@@ -334,10 +321,10 @@ function BinaryDownloadButton({
 }
 
 // ManualDownload lists the direct binary links for the selected OS only (the
-// alternative to the curl/PowerShell download script). Degrades to a manifest
-// link if the fetch fails. Windows/Linux only — macOS installs from the pkg
-// (MacInstallStep), not the raw-binary manifest.
-function ManualDownload({ os }: { os: "windows" | "linux" }) {
+// alternative to the curl download script). Degrades to a manifest link if
+// the fetch fails. Linux only — macOS installs from the pkg (MacInstallStep)
+// and Windows from the msi (WinInstallStep), not the raw-binary manifest.
+function ManualDownload({ os }: { os: "linux" }) {
   const { data, isLoading, isError } = useAgentReleases();
 
   if (isLoading) {
@@ -428,10 +415,11 @@ function ManualDownload({ os }: { os: "windows" | "linux" }) {
   );
 }
 
-// DownloadStep is the first setup step on Windows/Linux: two ways to get the
+// DownloadStep is the first setup step on Linux: two ways to get the
 // binaries (script or direct download), separated by an OR so it's clear
-// they're alternatives. macOS uses MacInstallStep instead.
-function DownloadStep({ os }: { os: "windows" | "linux" }) {
+// they're alternatives. macOS uses MacInstallStep and Windows WinInstallStep
+// instead.
+function DownloadStep({ os }: { os: "linux" }) {
   const { data } = useAgentReleases();
   const version = safeVersion(data?.latest?.["speakeasyd"]?.version);
   const cfg = OS_CONFIG[os];
@@ -551,13 +539,16 @@ curl -fsSL "$BASE/checksums.txt" | grep " $PKG$" | sha256sum -c - &&
 
 // ManualIdentity is the personal/PoC identity path: sign in once with the CLI.
 function ManualIdentity({ os }: { os: OsKey }) {
-  // macOS: bare `speakeasy` is command-not-found (see MacVerifyStep for why
-  // the CLI isn't on PATH there). Windows/Linux keep the bare command: their
-  // raw binaries land in the shell's cwd/PATH per the download step above.
-  const command =
-    os === "macos"
-      ? `"$HOME/Library/Application Support/Speakeasy/bin/speakeasy" enroll`
-      : "speakeasy enroll";
+  // macOS and Windows: bare `speakeasy` is command-not-found — neither the
+  // pkg nor the msi puts the CLI on PATH (see MacVerifyStep for the macOS
+  // rationale), so invoke it by its install path. Linux keeps the bare
+  // command: the raw binaries move into /usr/local/bin per the install steps.
+  const commands: Record<OsKey, string> = {
+    macos: `"$HOME/Library/Application Support/Speakeasy/bin/speakeasy" enroll`,
+    windows: `& "C:\\Program Files\\Speakeasy\\speakeasy.exe" enroll`,
+    linux: "speakeasy enroll",
+  };
+  const command = commands[os];
 
   return (
     <div className="flex flex-col gap-4">
@@ -998,6 +989,107 @@ launchctl print "gui/$(id -u)/com.speakeasy.daemon"
   );
 }
 
+// WinInstallStep is the first (and only pre-verify) setup step on Windows:
+// install from the signed .msi, which lays down the daemon, CLI, and UI under
+// C:\Program Files\Speakeasy\ and registers the machine-wide LocalSystem
+// service itself — no separate service-registration step. The primary snippet
+// uses this Gram server's stable /v1/install URL, which 302-redirects to the
+// current version's signed msi, so the copy never goes stale. Like the macOS
+// pkg, the msi is deliberately not listed in releases.json (it's the
+// manual/MDM on-ramp), so the direct-download URL is built from the resolved
+// version rather than read off the manifest artifacts.
+function WinInstallStep() {
+  const { data, isError } = useAgentReleases();
+  const version = safeVersion(data?.latest?.["speakeasyd"]?.version);
+  const msiUrl = version
+    ? `${RELEASES_BASE}/v${version}/speakeasy-agent_${version}.msi`
+    : null;
+  const stableMsiUrl = `${getServerURL()}/v1/install/device-agent-windows.msi`;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <SubLabel>Tooling breakdown</SubLabel>
+        <BinaryLegend />
+      </div>
+      <div className="flex flex-col gap-2">
+        <SubLabel>Run the download + install script</SubLabel>
+        <StepNote>
+          Run from an elevated (Administrator) PowerShell. The stable URL always
+          redirects to the latest signed installer.
+        </StepNote>
+        <CodeBlock language="powershell">{`Invoke-WebRequest "${stableMsiUrl}" -OutFile speakeasy-agent.msi
+msiexec /i speakeasy-agent.msi`}</CodeBlock>
+      </div>
+      <OrDivider />
+      <div className="flex flex-col gap-2">
+        <SubLabel>Download the installer directly</SubLabel>
+        {msiUrl ? (
+          <BinaryDownloadButton
+            href={msiUrl}
+            role="Installer"
+            name="speakeasy-agent.msi"
+            version={version ?? ""}
+          />
+        ) : (
+          <Text small muted>
+            {isError
+              ? "Couldn't load the latest release — use the "
+              : "Loading the latest release… or use the "}
+            <ExternalLink href={stableMsiUrl} iconSuffixName="external-link">
+              stable installer link
+            </ExternalLink>
+            , which always serves the current version.
+          </Text>
+        )}
+      </div>
+      <OrDivider />
+      <div className="flex flex-col gap-2">
+        <SubLabel>Scripted install with raw binaries</SubLabel>
+        <StepNote>
+          Raw binaries remain supported for scripted installs. Unlike the
+          MSI&apos;s machine-wide LocalSystem service, this registers the
+          service for the current user only.
+        </StepNote>
+        <CodeBlock language="powershell">{`${psVersionAssign(version)}
+$BASE = "${RELEASES_BASE}/v$VERSION"
+Invoke-WebRequest "$BASE/speakeasyd_\${VERSION}_windows_amd64.exe" -OutFile speakeasyd.exe
+Invoke-WebRequest "$BASE/speakeasy_\${VERSION}_windows_amd64.exe"  -OutFile speakeasy.exe
+.\\speakeasyd.exe -service install
+.\\speakeasyd.exe -service start`}</CodeBlock>
+      </div>
+      <div className="flex flex-col gap-2">
+        <SubLabel>Or push it as a fleet via MDM</SubLabel>
+        <Text small muted>
+          Upload the msi to Intune (or your MDM) as a{" "}
+          <strong className="font-medium">Win32 / line-of-business app</strong>{" "}
+          and assign it per machine — no script needed. Get it from the stable
+          link above, and pair it with a <code>managed.json</code> pushed to{" "}
+          <code>%ProgramData%\Speakeasy\</code> (see the identity step) so
+          enrollment is set centrally.
+        </Text>
+        <Text small muted>
+          Keep <code>auto_update: "notify"</code> on Windows fleets: the agent
+          can&apos;t replace its own running binaries on Windows, so version
+          bumps ship as MSI re-pushes from your MDM.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+// The MSI registers a machine-wide SCM service, so status comes from the SCM
+// rather than a per-user unit. sc.exe is deliberate — bare `sc` is
+// PowerShell's Set-Content alias. The CLI isn't on PATH (see ManualIdentity),
+// so it's invoked by its install path; the daemon's named pipe grants
+// interactive users client access, so no elevation is needed here.
+function WinVerifyStep() {
+  return (
+    <CodeBlock language="powershell">{`sc.exe query com.speakeasy.daemon
+& "C:\\Program Files\\Speakeasy\\speakeasy.exe" status`}</CodeBlock>
+  );
+}
+
 // IdentityStep is the final sheet step: pick how the agent learns who's on the
 // device (fleet MDM vs personal enrollment). Takes os because ManualIdentity's
 // enroll command differs on macOS (see there).
@@ -1064,9 +1156,9 @@ type SetupStep = { title: string; body: React.ReactNode };
 
 // buildSteps assembles the ordered setup steps for a platform. Remote sessions
 // have their own cloud-environment flow; local platforms follow the OS-specific
-// installation path below. macOS installs from
-// a signed .pkg (one combined install step, no chmod/move or separate service
-// registration); Windows/Linux still ship raw binaries via a download script,
+// installation path below. macOS installs from a signed .pkg and Windows from
+// a signed .msi (one combined install step each, no chmod/move or separate
+// service registration); Linux still ships raw binaries via a download script,
 // so the list length (and numbering) varies by OS.
 function buildSteps(platform: PlatformKey): SetupStep[] {
   if (platform === "remote") {
@@ -1090,6 +1182,17 @@ function buildSteps(platform: PlatformKey): SetupStep[] {
     return [
       { title: "Download and install the agent", body: <MacInstallStep /> },
       { title: "Verify it's running", body: <MacVerifyStep /> },
+      {
+        title: "Set the user's identity",
+        body: <IdentityStep os={platform} />,
+      },
+    ];
+  }
+
+  if (platform === "windows") {
+    return [
+      { title: "Download and install the agent", body: <WinInstallStep /> },
+      { title: "Verify it's running", body: <WinVerifyStep /> },
       {
         title: "Set the user's identity",
         body: <IdentityStep os={platform} />,

--- a/server/internal/about/impl.go
+++ b/server/internal/about/impl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
 // deviceAgentReleasesBaseURL is the public, unauthenticated bucket the
@@ -33,6 +34,7 @@ import (
 const deviceAgentReleasesBaseURL = "https://storage.googleapis.com/speakeasy-device-agent-releases-prod"
 
 const installDeviceAgentMacOSPath = "/v1/install/device-agent-macos.pkg"
+const installDeviceAgentWindowsPath = "/v1/install/device-agent-windows.msi"
 
 // maxManifestSize bounds how much of the releases manifest response we will
 // read; releases.json is tiny, so this is generous headroom against a large
@@ -83,10 +85,11 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		srv.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, nil, nil),
 	)
 
-	// Raw HTTP handler: a stable, version-agnostic link to the current signed
-	// macOS device-agent pkg, for docs/IT-admin instructions that can't run
-	// the dashboard's own version-resolution logic.
+	// Raw HTTP handlers: stable, version-agnostic links to the current signed
+	// macOS device-agent pkg and Windows msi, for docs/IT-admin instructions
+	// that can't run the dashboard's own version-resolution logic.
 	mux.Handle("GET", installDeviceAgentMacOSPath, service.handleInstallDeviceAgentMacOS)
+	mux.Handle("GET", installDeviceAgentWindowsPath, service.handleInstallDeviceAgentWindows)
 }
 
 // Openapi implements about.Service.
@@ -102,7 +105,23 @@ func (s *Service) Openapi(context.Context) (res *gen.OpenapiResult, body io.Read
 // pkg. Never hardcode the pkg URL elsewhere; link here instead so every
 // consumer stays current without a docs edit on every release.
 func (s *Service) handleInstallDeviceAgentMacOS(w http.ResponseWriter, r *http.Request) {
-	ctx, span := s.tracer.Start(r.Context(), "about.handleInstallDeviceAgentMacOS")
+	s.redirectToDeviceAgentArtifact(w, r, "about.handleInstallDeviceAgentMacOS", "speakeasy-agent_%s.pkg")
+}
+
+// handleInstallDeviceAgentWindows is the Windows analog of
+// handleInstallDeviceAgentMacOS: a stable link that 302-redirects to the
+// current version's signed msi.
+func (s *Service) handleInstallDeviceAgentWindows(w http.ResponseWriter, r *http.Request) {
+	s.redirectToDeviceAgentArtifact(w, r, "about.handleInstallDeviceAgentWindows", "speakeasy-agent_%s.msi")
+}
+
+// redirectToDeviceAgentArtifact resolves the current device-agent version from
+// the public releases manifest and 302-redirects to that version's copy of the
+// artifact named by artifactPattern (a fmt pattern with one %s for the
+// version). Installer artifacts follow the same on-ramp rule: published under
+// v<version>/ in the bucket but deliberately absent from releases.json.
+func (s *Service) redirectToDeviceAgentArtifact(w http.ResponseWriter, r *http.Request, spanName string, artifactPattern string) {
+	ctx, span := s.tracer.Start(r.Context(), spanName)
 	defer span.End()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.deviceAgentManifestURL, nil)
@@ -122,7 +141,7 @@ func (s *Service) handleInstallDeviceAgentMacOS(w http.ResponseWriter, r *http.R
 		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
 		span.SetStatus(codes.Error, "manifest non-200")
@@ -159,6 +178,6 @@ func (s *Service) handleInstallDeviceAgentMacOS(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	pkgURL := fmt.Sprintf("%s/v%s/speakeasy-agent_%s.pkg", s.deviceAgentReleasesURL, version, version)
-	http.Redirect(w, r, pkgURL, http.StatusFound)
+	artifactURL := fmt.Sprintf("%s/v%s/%s", s.deviceAgentReleasesURL, version, fmt.Sprintf(artifactPattern, version))
+	http.Redirect(w, r, artifactURL, http.StatusFound)
 }

--- a/server/internal/about/impl_test.go
+++ b/server/internal/about/impl_test.go
@@ -69,6 +69,30 @@ func TestHandleInstallDeviceAgentMacOS_RedirectsToVersionedPkg(t *testing.T) {
 	)
 }
 
+func TestHandleInstallDeviceAgentWindows_RedirectsToVersionedMsi(t *testing.T) {
+	t.Parallel()
+
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schema_version":1,"latest":{"speakeasyd":{"version":"0.1.31"}}}`))
+	}))
+	defer manifest.Close()
+
+	svc := newTestService(t, manifest.URL)
+
+	req := httptest.NewRequest(http.MethodGet, installDeviceAgentWindowsPath, nil)
+	rec := httptest.NewRecorder()
+	req.URL, _ = url.Parse("https://app.getgram.ai" + installDeviceAgentWindowsPath)
+
+	svc.handleInstallDeviceAgentWindows(rec, req)
+
+	require.Equal(t, http.StatusFound, rec.Code)
+	require.Equal(t,
+		fmt.Sprintf("%s/v0.1.31/speakeasy-agent_0.1.31.msi", deviceAgentReleasesBaseURL),
+		rec.Header().Get("Location"),
+	)
+}
+
 func TestHandleInstallDeviceAgentMacOS_ManifestUnreachable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Now that the signed device-agent MSI publishes fail-closed to the release bucket, Gram should point Windows users at it instead of the raw-binary PowerShell flow. Fixes DNO-942.

## Server

Adds `GET /v1/install/device-agent-windows.msi` alongside the existing `GET /v1/install/device-agent-macos.pkg`: same pattern — resolve the current version from the public `releases.json`, validate the version shape, 302-redirect to `v<version>/speakeasy-agent_<version>.msi` in the release bucket. The manifest-resolution logic is now shared between both handlers, parameterized by artifact filename.

A sibling path was chosen over a `?os=` query param: the macOS URL is already shipped and must survive regardless (so a query param consolidates nothing), and the extension-in-path is what Intune LOB configs and browsers want.

## Dashboard

Reworks the Windows setup sheet to be MSI-first, mirroring the macOS structure:

- **Install step:** download the signed MSI via the new stable endpoint (`Invoke-WebRequest` follows the 302 natively) and install via `msiexec /i`. The MSI lays down all three binaries in `C:\Program Files\Speakeasy\` and registers the LocalSystem SCM service itself, so the manual service-registration step disappears.
- **Fleet note:** Intune deploys the one MSI as a Win32/LOB app instead of the multi-step script.
- **Verify step:** `sc.exe query com.speakeasy.daemon` + the CLI by its install path (machine-level service now, not per-user). `sc.exe` is deliberate — bare `sc` is PowerShell's `Set-Content` alias.
- **Raw-binary PowerShell script** demoted to an "or" alternative rather than removed (raw binaries remain supported for scripted installs).
- **Caveat surfaced:** MSI fleets should stay on `auto_update: "notify"` — Windows has no self-update apply path; upgrades are MSI re-pushes.

Also fixes a latent bug in the Windows identity step: bare `speakeasy enroll` assumed the CLI was in the shell's cwd, but the MSI doesn't put `C:\Program Files\Speakeasy` on PATH — the enroll/verify commands now invoke the CLI by its install path, like macOS does.

## Non-goals

- No change to the macOS endpoint URL.
- No Linux endpoint (helper packages install via checksummed root scripts by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFPMpADydN1tKUVJ5sivfR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable Windows MSI installer endpoint and makes the dashboard Windows setup MSI-first, replacing the raw-binary flow, to enable signed, fail-closed installs and simpler MDM deployment (DNO-942). Previously: PowerShell + manual service registration; now: `msiexec` from a stable URL that redirects to the current signed MSI. The CLI is invoked by its install path.

- Server: Adds GET `/v1/install/device-agent-windows.msi` alongside macOS; shared manifest-resolution redirects to `v<version>/speakeasy-agent_<version>.msi`. Adds a redirect test; macOS URL unchanged.
- Dashboard: Windows flow installs via `msiexec` from the stable endpoint, with a direct-download button; the raw-binary script remains as an alternative. Verify uses `sc.exe`, and enroll/verify call the CLI by its install path (MSI doesn’t add it to PATH).
- Safety: The install snippet only uses the stable endpoint when the server URL is HTTPS; otherwise it builds against the always-HTTPS release bucket. The fallback link degrades to the release manifest.

**Rollout**
- Point docs and MDM profiles to `/v1/install/device-agent-windows.msi`.
- Intune: upload the MSI as a Win32/LOB app and push `managed.json` to `%ProgramData%\Speakeasy\` for enrollment.
- Keep `auto_update: "notify"` on Windows fleets; upgrades ship as MSI re-pushes.

<sup>Written for commit b66eb173789baacab965973430071605eb517d6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

