### PR TITLE
fix: accept cross-origin CIMD redirect_uris with observability

### DIFF
--- a/.changeset/cimd-cross-origin-redirects.md
+++ b/.changeset/cimd-cross-origin-redirects.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Client ID Metadata Documents may now register `redirect_uris` on a different origin than the `client_id` URL: the validator's same-origin binding is removed in favor of a `cimd.redirect_uris.cross_origin` counter and a log line naming the cross-origin redirect origins, while exact-match validation of the authorization request's `redirect_uri` against the document remains the enforced control. Non-loopback redirect URIs in a document must now use https explicitly; previously custom schemes were rejected only as a side effect of the origin binding, and RFC 8252 http loopback redirects are unchanged.

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.test.tsx
@@ -153,11 +153,11 @@ describe("CimdAdmissionModeField", () => {
   it("warns about origin reach when Open is selected", () => {
     render(<CimdAdmissionModeField userSessionIssuer={issuer("presets")} />);
 
-    expect(screen.queryByText(/only guardrails/)).toBeNull();
+    expect(screen.queryByText(/any valid CIMD client/i)).toBeNull();
 
     fireEvent.click(screen.getByRole("radio", { name: "Open" }));
 
-    expect(screen.getByText(/only guardrails/)).toBeDefined();
+    expect(screen.getByText(/any valid CIMD client/i)).toBeDefined();
   });
 
   it("saves a mode change directly for an already-configured issuer", () => {

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
@@ -154,8 +154,8 @@ export function CimdAdmissionModeField({
       {selectedMode === WritableMode.Open && (
         <Alert variant="warning" dismissible={false}>
           Open admission accepts client metadata documents from any origin on
-          the internet. The consent screen and redirect origin-binding become
-          the only guardrails on who can start an authorization flow.
+          the internet. The consent screen becomes the only guardrail on who can
+          start an authorization flow.
         </Alert>
       )}
 

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
@@ -154,8 +154,8 @@ export function CimdAdmissionModeField({
       {selectedMode === WritableMode.Open && (
         <Alert variant="warning" dismissible={false}>
           Open admission accepts client metadata documents from any origin on
-          the internet. The consent screen becomes the only guardrail on who can
-          start an authorization flow.
+          the internet. Any valid CIMD client can reach the consent screen, so
+          users must review it before approving an authorization flow.
         </Alert>
       )}
 

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -184,6 +184,14 @@ const (
 	// per-reason dimension on cimd.validation.failures.
 	CIMDValidationReasonKey = attribute.Key("gram.cimd.validation_reason")
 
+	// CIMDCrossOriginRedirectOriginsKey lists the origins of a validated
+	// Client ID Metadata Document's non-loopback redirect_uris that differ
+	// from the client_id URL's origin. Log-only: the origins are
+	// attacker-chosen on the unauthenticated OAuth surface, so they never
+	// become metric labels — the cimd.redirect_uris.cross_origin counter
+	// carries only the bounded client_id origin.
+	CIMDCrossOriginRedirectOriginsKey = attribute.Key("gram.cimd.cross_origin_redirect_origins")
+
 	// CIMDAdmissionModeKey is the effective per-issuer CIMD admission policy
 	// ("disabled", "presets", "open") — the low-cardinality dimension on
 	// cimd.admission.decisions. Operator-chosen, never attacker-influenced.
@@ -1078,6 +1086,10 @@ func CIMDValidationReason[V ~string](v V) attribute.KeyValue {
 
 func SlogCIMDValidationReason[V ~string](v V) slog.Attr {
 	return slog.String(string(CIMDValidationReasonKey), string(v))
+}
+
+func SlogCIMDCrossOriginRedirectOrigins(v []string) slog.Attr {
+	return slog.Any(string(CIMDCrossOriginRedirectOriginsKey), v)
 }
 
 func CIMDAdmissionMode[V ~string](v V) attribute.KeyValue {

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -341,14 +341,18 @@ func TestOAuthCIMD_DocumentClientIDMismatchRejected(t *testing.T) {
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_client_metadata")
 }
 
-func TestOAuthCIMD_CrossOriginRedirectURIRejected(t *testing.T) {
+// TestOAuthCIMD_CrossOriginRedirectURIAccepted: a document may register
+// redirect_uris on a different origin than the client_id URL (AIS-597
+// removed the same-origin binding); the authorization request matching the
+// registered URI exactly proceeds to consent.
+func TestOAuthCIMD_CrossOriginRedirectURIAccepted(t *testing.T) {
 	t.Parallel()
 
 	_, ti, ds, toolset := newTestCIMDService(t)
 	ds.set(t, func(ds *cimdDocServer) { ds.doc["redirect_uris"] = []any{"https://elsewhere.example.com/callback"} })
 
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "https://elsewhere.example.com/callback", pkceChallenge(pkceVerifier(t)))
-	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_redirect_uri")
+	require.Equal(t, http.StatusFound, w.Code, "cross-origin registered redirect_uris must be accepted: %s", w.Body.String())
 }
 
 func TestOAuthCIMD_UnregisteredRedirectURIRejected(t *testing.T) {

--- a/server/internal/usersessions/cimd/admission/pattern.go
+++ b/server/internal/usersessions/cimd/admission/pattern.go
@@ -24,9 +24,9 @@ import (
 //   - The scheme and host must be entirely literal. A wildcard that could
 //     widen the host is the classic redirect-URI wildcard vulnerability:
 //     "https://claude.ai*" matches https://claude.ai.evil.example.com, and
-//     "https://*/x" matches anything at all. Host-literal also keeps Gram's
-//     same-origin redirect_uri binding meaningful, since the origin a
-//     pattern admits is fixed.
+//     "https://*/x" matches anything at all. Host-literal also keeps the
+//     origin a pattern admits fixed, so an entry is a statement about one
+//     vendor's host rather than an open set of hosts.
 //
 //   - A `*` stands for exactly one COMPLETE path segment and never matches
 //     across "/". So /oauth/*/client.json admits /oauth/abc/client.json but

--- a/server/internal/usersessions/cimd/cimd.go
+++ b/server/internal/usersessions/cimd/cimd.go
@@ -2,7 +2,7 @@
 // Documents (draft-ietf-oauth-client-id-metadata-document-02): resolving a
 // URL-shaped client_id presented to the user-session authorization server by
 // fetching the document it names, parsing it, and validating it against the
-// spec's rules plus Gram's own origin-binding policy.
+// spec's rules plus this server's own policy rules.
 //
 // The Resolver owns the fetch lifecycle, its cache policy, and its telemetry
 // (metrics + logs) but deliberately not persistence: the caller passes in the
@@ -153,8 +153,9 @@ type Document struct {
 	LogoURI string `json:"logo_uri"`
 
 	// RedirectURIs is the registered redirect set. Required; each entry
-	// must pass the standard redirect-URI scheme rules plus Gram's
-	// same-origin binding with the loopback exception.
+	// must be an https URL or an RFC 8252 loopback http URL. Entries on a
+	// different origin than the client_id URL are accepted but observed
+	// through the cimd.redirect_uris.cross_origin counter.
 	RedirectURIs []string `json:"redirect_uris"`
 
 	// ResponseTypes is parsed but not enforced, for the same reason as
@@ -239,11 +240,12 @@ func newFetchClientFrom(base *guardian.HTTPClient) *guardian.HTTPClient {
 // AS imposes: -02 §3 URL syntax, §4 triple client_id equality (the fetch never
 // follows redirects, so the fetched URL is the presented URL by
 // construction), required client_name + redirect_uris, public-client-only
-// auth method, secret/private-key bans, and Gram's same-origin redirect-URI
-// binding. Those checks run against the document as fetched, so a cached row
-// carries the verdict of the validation code that was deployed when it was
-// last refreshed: tightening a rule in validate.go does not re-reject a
-// cached client until its TTL lapses, up to maxCacheTTL later. Callers that
+// auth method, secret/private-key bans, and the https-or-loopback
+// redirect-URI scheme rule. Those checks run against the document as
+// fetched, so a cached row carries the verdict of the validation code that
+// was deployed when it was last refreshed: tightening a rule in validate.go
+// does not re-reject a cached client until its TTL lapses, up to maxCacheTTL
+// later. Callers that
 // need a rule applied sooner must purge their stored cache state, which
 // forces the next resolve to fetch and re-validate a full document.
 func (r *Resolver) Resolve(ctx context.Context, clientID string, cache CacheState) (*CacheResult, error) {
@@ -280,15 +282,16 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 		// not parse or failed syntax rules), so the origin attribute and the
 		// duration histogram are both deliberately omitted.
 		r.observe(ctx, resolveObservation{
-			clientID:      clientID,
-			origin:        "",
-			result:        fetchResultValidationError,
-			reason:        validationReasonOf(err),
-			status:        0,
-			duration:      0,
-			fetched:       false,
-			responseBytes: 0,
-			err:           err,
+			clientID:                   clientID,
+			origin:                     "",
+			result:                     fetchResultValidationError,
+			reason:                     validationReasonOf(err),
+			status:                     0,
+			duration:                   0,
+			fetched:                    false,
+			responseBytes:              0,
+			crossOriginRedirectOrigins: nil,
+			err:                        err,
 		})
 		return inspection{
 			Document:        nil,
@@ -310,15 +313,16 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 	// reject.
 	if !cache.ExpiresAt.IsZero() && cache.ExpiresAt.After(time.Now()) {
 		r.observe(ctx, resolveObservation{
-			clientID:      clientID,
-			origin:        origin,
-			result:        fetchResultCached,
-			reason:        "",
-			status:        0,
-			duration:      0,
-			fetched:       false,
-			responseBytes: 0,
-			err:           nil,
+			clientID:                   clientID,
+			origin:                     origin,
+			result:                     fetchResultCached,
+			reason:                     "",
+			status:                     0,
+			duration:                   0,
+			fetched:                    false,
+			responseBytes:              0,
+			crossOriginRedirectOrigins: nil,
+			err:                        nil,
 		})
 		return inspection{
 			Document:        nil,
@@ -342,15 +346,16 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 	fetched, err := r.fetchDocument(ctx, origin, clientID, cache.ETag)
 	if err != nil {
 		r.observe(ctx, resolveObservation{
-			clientID:      clientID,
-			origin:        origin,
-			result:        fetchResultFetchError,
-			reason:        "",
-			status:        fetched.status,
-			duration:      time.Since(start),
-			fetched:       true,
-			responseBytes: 0,
-			err:           err,
+			clientID:                   clientID,
+			origin:                     origin,
+			result:                     fetchResultFetchError,
+			reason:                     "",
+			status:                     fetched.status,
+			duration:                   time.Since(start),
+			fetched:                    true,
+			responseBytes:              0,
+			crossOriginRedirectOrigins: nil,
+			err:                        err,
 		})
 		return inspection{
 			Document:        nil,
@@ -368,15 +373,16 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 
 	if fetched.notModified {
 		r.observe(ctx, resolveObservation{
-			clientID:      clientID,
-			origin:        origin,
-			result:        fetchResultConditionalNotModified,
-			reason:        "",
-			status:        fetched.status,
-			duration:      time.Since(start),
-			fetched:       true,
-			responseBytes: 0,
-			err:           nil,
+			clientID:                   clientID,
+			origin:                     origin,
+			result:                     fetchResultConditionalNotModified,
+			reason:                     "",
+			status:                     fetched.status,
+			duration:                   time.Since(start),
+			fetched:                    true,
+			responseBytes:              0,
+			crossOriginRedirectOrigins: nil,
+			err:                        nil,
 		})
 		// RFC 9110 §15.4.5 lets a 304 carry a new validator, and a cache
 		// that ignores one revalidates against a superseded ETag forever.
@@ -418,15 +424,16 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 	var doc Document
 	if err := json.Unmarshal(body, &doc); err != nil {
 		r.observe(ctx, resolveObservation{
-			clientID:      clientID,
-			origin:        origin,
-			result:        fetchResultParseError,
-			reason:        "",
-			status:        status,
-			duration:      time.Since(start),
-			fetched:       true,
-			responseBytes: len(body),
-			err:           err,
+			clientID:                   clientID,
+			origin:                     origin,
+			result:                     fetchResultParseError,
+			reason:                     "",
+			status:                     status,
+			duration:                   time.Since(start),
+			fetched:                    true,
+			responseBytes:              len(body),
+			crossOriginRedirectOrigins: nil,
+			err:                        err,
 		})
 		return inspection{
 			Document:        nil,
@@ -442,17 +449,19 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 		}
 	}
 
-	if err := validateDocument(&doc, clientID, clientIDURL); err != nil {
+	findings, err := validateDocument(&doc, clientID, clientIDURL)
+	if err != nil {
 		r.observe(ctx, resolveObservation{
-			clientID:      clientID,
-			origin:        origin,
-			result:        fetchResultValidationError,
-			reason:        validationReasonOf(err),
-			status:        status,
-			duration:      time.Since(start),
-			fetched:       true,
-			responseBytes: len(body),
-			err:           err,
+			clientID:                   clientID,
+			origin:                     origin,
+			result:                     fetchResultValidationError,
+			reason:                     validationReasonOf(err),
+			status:                     status,
+			duration:                   time.Since(start),
+			fetched:                    true,
+			responseBytes:              len(body),
+			crossOriginRedirectOrigins: nil,
+			err:                        err,
 		})
 		return inspection{
 			Document:        nil,
@@ -469,15 +478,16 @@ func (r *Resolver) inspect(ctx context.Context, clientID string, cache CacheStat
 	}
 
 	r.observe(ctx, resolveObservation{
-		clientID:      clientID,
-		origin:        origin,
-		result:        fetchResultSuccess,
-		reason:        "",
-		status:        status,
-		duration:      time.Since(start),
-		fetched:       true,
-		responseBytes: len(body),
-		err:           nil,
+		clientID:                   clientID,
+		origin:                     origin,
+		result:                     fetchResultSuccess,
+		reason:                     "",
+		status:                     status,
+		duration:                   time.Since(start),
+		fetched:                    true,
+		responseBytes:              len(body),
+		crossOriginRedirectOrigins: findings.crossOriginRedirectOrigins,
+		err:                        nil,
 	})
 	return inspection{
 		Document:        &doc,
@@ -507,7 +517,14 @@ type resolveObservation struct {
 	// read; log-only (the cimd.fetch.response_size histogram is recorded
 	// inside fetchDocument, where the cap-hit case is also visible).
 	responseBytes int
-	err           error
+
+	// crossOriginRedirectOrigins is the validator's cross-origin finding for
+	// a document that passed validation; nil on every other result. The
+	// origins go to the log line only — the counter they trigger carries
+	// just the bounded client_id origin.
+	crossOriginRedirectOrigins []string
+
+	err error
 }
 
 func (r *Resolver) observe(ctx context.Context, o resolveObservation) {
@@ -517,6 +534,9 @@ func (r *Resolver) observe(ctx context.Context, o resolveObservation) {
 	}
 	if o.result == fetchResultValidationError {
 		r.metrics.RecordValidationFailure(ctx, o.reason)
+	}
+	if len(o.crossOriginRedirectOrigins) > 0 {
+		r.metrics.RecordCrossOriginRedirects(ctx, o.origin)
 	}
 
 	// The client_id is attacker-chosen on an unauthenticated surface and, on
@@ -545,6 +565,9 @@ func (r *Resolver) observe(ctx context.Context, o resolveObservation) {
 	}
 	if o.reason != "" {
 		logAttrs = append(logAttrs, attr.SlogCIMDValidationReason(o.reason))
+	}
+	if len(o.crossOriginRedirectOrigins) > 0 {
+		logAttrs = append(logAttrs, attr.SlogCIMDCrossOriginRedirectOrigins(o.crossOriginRedirectOrigins))
 	}
 	if o.err != nil {
 		logAttrs = append(logAttrs, attr.SlogError(o.err))

--- a/server/internal/usersessions/cimd/metrics.go
+++ b/server/internal/usersessions/cimd/metrics.go
@@ -17,11 +17,14 @@ const (
 	meterFetchResponseSize    = "cimd.fetch.response_size"
 	meterValidationFailures   = "cimd.validation.failures"
 
-	// meterCrossOriginRedirects observes validated documents whose
-	// redirect_uris leave the client_id origin. Such redirects are accepted;
+	// meterCrossOriginRedirects observes validated documents carrying a
+	// non-loopback redirect_uri that leaves the client_id origin. RFC 8252
+	// http loopback redirects are exempt, so a client whose only off-origin
+	// redirect is a loopback URL never counts. Such redirects are accepted;
 	// the counter only makes the shift visible. Emitted wherever validation
 	// runs (cached resolutions skip it), so treat it as a presence signal
-	// rather than a rate. The origins themselves go to logs, never labels.
+	// rather than a rate. Its one label is the bounded client_id origin; the
+	// redirect origins themselves go to logs, never labels.
 	meterCrossOriginRedirects = "cimd.redirect_uris.cross_origin"
 )
 

--- a/server/internal/usersessions/cimd/metrics.go
+++ b/server/internal/usersessions/cimd/metrics.go
@@ -17,16 +17,11 @@ const (
 	meterFetchResponseSize    = "cimd.fetch.response_size"
 	meterValidationFailures   = "cimd.validation.failures"
 
-	// meterCrossOriginRedirects counts validated documents carrying at least
-	// one non-loopback redirect_uri whose origin differs from the client_id
-	// URL. Cross-origin redirects are accepted; this instrument exists so a
-	// monitor can flag a catalog preset vendor moving to cross-origin
-	// redirects, not to block anything. One point per document per validating
-	// resolution: fresh fetches only (cached resolutions skip validation),
-	// and the authenticated verifyURL preflight shares the emission path, so
-	// operator-driven inspections count too — treat it as a presence signal,
-	// not a precise rate. The redirect origins themselves go to logs, never
-	// labels; the only attribute is the bounded client_id origin.
+	// meterCrossOriginRedirects observes validated documents whose
+	// redirect_uris leave the client_id origin. Such redirects are accepted;
+	// the counter only makes the shift visible. Emitted wherever validation
+	// runs (cached resolutions skip it), so treat it as a presence signal
+	// rather than a rate. The origins themselves go to logs, never labels.
 	meterCrossOriginRedirects = "cimd.redirect_uris.cross_origin"
 )
 

--- a/server/internal/usersessions/cimd/metrics.go
+++ b/server/internal/usersessions/cimd/metrics.go
@@ -16,6 +16,18 @@ const (
 	meterFetchDurationSeconds = "cimd.fetch.duration_seconds"
 	meterFetchResponseSize    = "cimd.fetch.response_size"
 	meterValidationFailures   = "cimd.validation.failures"
+
+	// meterCrossOriginRedirects counts validated documents carrying at least
+	// one non-loopback redirect_uri whose origin differs from the client_id
+	// URL. Cross-origin redirects are accepted; this instrument exists so a
+	// monitor can flag a catalog preset vendor moving to cross-origin
+	// redirects, not to block anything. One point per document per validating
+	// resolution: fresh fetches only (cached resolutions skip validation),
+	// and the authenticated verifyURL preflight shares the emission path, so
+	// operator-driven inspections count too — treat it as a presence signal,
+	// not a precise rate. The redirect origins themselves go to logs, never
+	// labels; the only attribute is the bounded client_id origin.
+	meterCrossOriginRedirects = "cimd.redirect_uris.cross_origin"
 )
 
 // fetchResult labels the outcome of one Resolve attempt on the cimd.fetch.*
@@ -52,34 +64,35 @@ const (
 type validationReason string
 
 const (
-	reasonClientIDTooLong        validationReason = "client_id_too_long"
-	reasonClientIDScheme         validationReason = "client_id_scheme"
-	reasonClientIDFragment       validationReason = "client_id_fragment"
-	reasonClientIDUnparseable    validationReason = "client_id_unparseable"
-	reasonClientIDUserinfo       validationReason = "client_id_userinfo"
-	reasonClientIDMissingHost    validationReason = "client_id_missing_host"
-	reasonClientIDMissingPath    validationReason = "client_id_missing_path"
-	reasonClientIDDotSegments    validationReason = "client_id_dot_segments"
-	reasonClientIDMismatch       validationReason = "client_id_mismatch"
-	reasonMissingClientName      validationReason = "missing_client_name"
-	reasonClientNameTooLong      validationReason = "client_name_too_long"
-	reasonInvalidAuthMethod      validationReason = "invalid_auth_method"
-	reasonContainsSecret         validationReason = "contains_secret"
-	reasonJWKSInvalid            validationReason = "jwks_invalid"
-	reasonJWKSPrivateKey         validationReason = "jwks_private_key"
-	reasonJWKSSymmetricKey       validationReason = "jwks_symmetric_key"
-	reasonMissingRedirectURIs    validationReason = "missing_redirect_uris"
-	reasonTooManyRedirectURIs    validationReason = "too_many_redirect_uris"
-	reasonRedirectURITooLong     validationReason = "redirect_uri_too_long"
-	reasonRedirectURIInvalid     validationReason = "redirect_uri_invalid"
-	reasonRedirectOriginMismatch validationReason = "redirect_origin_mismatch"
+	reasonClientIDTooLong     validationReason = "client_id_too_long"
+	reasonClientIDScheme      validationReason = "client_id_scheme"
+	reasonClientIDFragment    validationReason = "client_id_fragment"
+	reasonClientIDUnparseable validationReason = "client_id_unparseable"
+	reasonClientIDUserinfo    validationReason = "client_id_userinfo"
+	reasonClientIDMissingHost validationReason = "client_id_missing_host"
+	reasonClientIDMissingPath validationReason = "client_id_missing_path"
+	reasonClientIDDotSegments validationReason = "client_id_dot_segments"
+	reasonClientIDMismatch    validationReason = "client_id_mismatch"
+	reasonMissingClientName   validationReason = "missing_client_name"
+	reasonClientNameTooLong   validationReason = "client_name_too_long"
+	reasonInvalidAuthMethod   validationReason = "invalid_auth_method"
+	reasonContainsSecret      validationReason = "contains_secret"
+	reasonJWKSInvalid         validationReason = "jwks_invalid"
+	reasonJWKSPrivateKey      validationReason = "jwks_private_key"
+	reasonJWKSSymmetricKey    validationReason = "jwks_symmetric_key"
+	reasonMissingRedirectURIs validationReason = "missing_redirect_uris"
+	reasonTooManyRedirectURIs validationReason = "too_many_redirect_uris"
+	reasonRedirectURITooLong  validationReason = "redirect_uri_too_long"
+	reasonRedirectURIInvalid  validationReason = "redirect_uri_invalid"
+	reasonRedirectURIScheme   validationReason = "redirect_uri_scheme"
 )
 
 type metrics struct {
-	fetchAttempts      metric.Int64Counter
-	fetchDuration      metric.Float64Histogram
-	fetchResponseSize  metric.Int64Histogram
-	validationFailures metric.Int64Counter
+	fetchAttempts        metric.Int64Counter
+	fetchDuration        metric.Float64Histogram
+	fetchResponseSize    metric.Int64Histogram
+	validationFailures   metric.Int64Counter
+	crossOriginRedirects metric.Int64Counter
 }
 
 func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metrics {
@@ -124,11 +137,21 @@ func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metric
 		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterValidationFailures), attr.SlogError(err))
 	}
 
+	crossOriginRedirects, err := meter.Int64Counter(
+		meterCrossOriginRedirects,
+		metric.WithDescription("Count of validated CIMD metadata documents carrying at least one non-loopback redirect_uri not same-origin with the client_id URL, by client_id origin"),
+		metric.WithUnit("{document}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterCrossOriginRedirects), attr.SlogError(err))
+	}
+
 	return &metrics{
-		fetchAttempts:      fetchAttempts,
-		fetchDuration:      fetchDuration,
-		fetchResponseSize:  fetchResponseSize,
-		validationFailures: validationFailures,
+		fetchAttempts:        fetchAttempts,
+		fetchDuration:        fetchDuration,
+		fetchResponseSize:    fetchResponseSize,
+		validationFailures:   validationFailures,
+		crossOriginRedirects: crossOriginRedirects,
 	}
 }
 
@@ -154,6 +177,13 @@ func (m *metrics) RecordResponseSize(ctx context.Context, origin string, bytes i
 		return
 	}
 	m.fetchResponseSize.Record(ctx, bytes, metric.WithAttributes(attr.CIMDOrigin(origin)))
+}
+
+func (m *metrics) RecordCrossOriginRedirects(ctx context.Context, origin string) {
+	if m == nil || m.crossOriginRedirects == nil {
+		return
+	}
+	m.crossOriginRedirects.Add(ctx, 1, metric.WithAttributes(attr.CIMDOrigin(origin)))
 }
 
 func (m *metrics) RecordValidationFailure(ctx context.Context, reason validationReason) {

--- a/server/internal/usersessions/cimd/metrics_test.go
+++ b/server/internal/usersessions/cimd/metrics_test.go
@@ -345,6 +345,67 @@ func TestMetrics_NamesPinned(t *testing.T) {
 	require.Equal(t, "cimd.fetch.duration_seconds", meterFetchDurationSeconds)
 	require.Equal(t, "cimd.fetch.response_size", meterFetchResponseSize)
 	require.Equal(t, "cimd.validation.failures", meterValidationFailures)
+	require.Equal(t, "cimd.redirect_uris.cross_origin", meterCrossOriginRedirects)
+}
+
+// TestResolverMetrics_CrossOriginRedirects pins the observability that
+// replaced the redirect-URI same-origin binding (AIS-597): a document that
+// validates with a cross-origin redirect_uri resolves successfully and
+// records one cimd.redirect_uris.cross_origin point carrying only the
+// bounded client_id origin — the redirect origins themselves stay out of
+// metric labels.
+func TestResolverMetrics_CrossOriginRedirects(t *testing.T) {
+	t.Parallel()
+
+	var clientID string
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		doc := validDocumentJSON(clientID)
+		doc["redirect_uris"] = []string{"https://api.other.example/callback"}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(doc); err != nil {
+			t.Errorf("encode document: %v", err)
+		}
+	})
+	clientID = srv.URL + "/client.json"
+	srvURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	result, err := resolver.Resolve(t.Context(), clientID, noCache)
+	require.NoError(t, err)
+	require.NotNil(t, result.Document)
+
+	rm := collectMetrics(t, reader)
+
+	crossOrigin := counterPoints(t, rm, meterCrossOriginRedirects)
+	require.Len(t, crossOrigin, 1)
+	require.Equal(t, int64(1), crossOrigin[0].Value)
+	requireAttr(t, crossOrigin[0].Attributes, attr.CIMDOriginKey, srvURL.Host)
+	require.Equal(t, 1, crossOrigin[0].Attributes.Len(), "only the client_id origin may label this counter")
+}
+
+// TestResolverMetrics_SameOriginRecordsNoCrossOrigin pins the counter's
+// absence on the ordinary case: a document whose redirect_uris are loopback
+// or same-origin records no cimd.redirect_uris.cross_origin point at all, so
+// the instrument stays silent until the event it watches for occurs.
+func TestResolverMetrics_SameOriginRecordsNoCrossOrigin(t *testing.T) {
+	t.Parallel()
+
+	var clientID string
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(validDocumentJSON(clientID)); err != nil {
+			t.Errorf("encode document: %v", err)
+		}
+	})
+	clientID = srv.URL + "/client.json"
+
+	_, err := resolver.Resolve(t.Context(), clientID, noCache)
+	require.NoError(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	_, ok := findMetric(rm, meterCrossOriginRedirects)
+	require.False(t, ok)
 }
 
 // TestMetrics_CacheResultLabelsPinned pins the wire spellings of the two

--- a/server/internal/usersessions/cimd/outcome.go
+++ b/server/internal/usersessions/cimd/outcome.go
@@ -25,7 +25,7 @@ const (
 	OutcomeUnparseable Outcome = "unparseable"
 
 	// OutcomeInvalidDocument means the body parsed as JSON but the document
-	// violates the spec or Gram's origin-binding policy. Reason carries the
+	// violates the spec or this server's policy rules. Reason carries the
 	// specific rule.
 	OutcomeInvalidDocument Outcome = "invalid_document"
 )

--- a/server/internal/usersessions/cimd/validate.go
+++ b/server/internal/usersessions/cimd/validate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/usersessions/oauthwire"
@@ -93,21 +94,36 @@ func ValidateClientIDURL(clientID string) (*url.URL, error) {
 	return parsed, nil
 }
 
-// validateDocument applies the -02 §4 document rules plus Gram policy to a
+// validationFindings carries the non-blocking observations validateDocument
+// made about a document it accepted. Only meaningful alongside a nil error;
+// every rejection returns the zero value.
+type validationFindings struct {
+	// crossOriginRedirectOrigins lists the distinct origins (scheme://host,
+	// compared without normalization) of non-loopback redirect_uris that do
+	// not share the client_id URL's origin, in first-seen order. Cross-origin
+	// redirects are accepted — the load-bearing control is exact-match
+	// validation of the authorization request's redirect_uri against the
+	// document at authorize time — so this exists purely to feed the
+	// cimd.redirect_uris.cross_origin counter and its log line.
+	crossOriginRedirectOrigins []string
+}
+
+// validateDocument applies the -02 §4 document rules plus local policy to a
 // parsed document. clientID is both the client_id the OAuth client presented
 // and the URL that was fetched (the fetcher never follows redirects), so the
 // single equality check here completes the §4 triple equality requirement.
-func validateDocument(doc *Document, clientID string, clientIDURL *url.URL) error {
+func validateDocument(doc *Document, clientID string, clientIDURL *url.URL) (validationFindings, error) {
+	var none validationFindings
 	if doc.ClientID != clientID {
-		return oauthValidationError(reasonClientIDMismatch, "invalid_client_metadata", "document client_id does not match the client identifier URL")
+		return none, oauthValidationError(reasonClientIDMismatch, "invalid_client_metadata", "document client_id does not match the client identifier URL")
 	}
 	// MCP requires client_name, and the user_session_clients.client_name
 	// column is NOT NULL — requiring it here avoids fallback logic.
 	if doc.ClientName == "" {
-		return oauthValidationError(reasonMissingClientName, "invalid_client_metadata", "client_name is required")
+		return none, oauthValidationError(reasonMissingClientName, "invalid_client_metadata", "client_name is required")
 	}
 	if len(doc.ClientName) > maxClientNameLength {
-		return oauthValidationError(reasonClientNameTooLong, "invalid_client_metadata", fmt.Sprintf("client_name exceeds the %d byte limit", maxClientNameLength))
+		return none, oauthValidationError(reasonClientNameTooLong, "invalid_client_metadata", fmt.Sprintf("client_name exceeds the %d byte limit", maxClientNameLength))
 	}
 	// Only public clients are accepted. -02 §8.2's direction of travel is
 	// that capable clients SHOULD authenticate (MCP clients MAY use
@@ -128,63 +144,71 @@ func validateDocument(doc *Document, clientID string, clientIDURL *url.URL) erro
 	// entirely while being plain public clients, and rejecting them here
 	// would make any preset for them dead on arrival.
 	if doc.TokenEndpointAuthMethod != "" && doc.TokenEndpointAuthMethod != "none" {
-		return oauthValidationError(reasonInvalidAuthMethod, "invalid_client_metadata", `token_endpoint_auth_method must be "none" or absent`)
+		return none, oauthValidationError(reasonInvalidAuthMethod, "invalid_client_metadata", `token_endpoint_auth_method must be "none" or absent`)
 	}
 	// -02 §4.1: a metadata document is public, so it must never carry a
 	// client secret in any form. Presence alone invalidates the document.
 	if doc.ClientSecret != nil || doc.ClientSecretExpiresAt != nil {
-		return oauthValidationError(reasonContainsSecret, "invalid_client_metadata", "document must not contain client_secret or client_secret_expires_at")
+		return none, oauthValidationError(reasonContainsSecret, "invalid_client_metadata", "document must not contain client_secret or client_secret_expires_at")
 	}
 	if err := validateJWKSPublicOnly(doc.JWKS); err != nil {
-		return err
+		return none, err
 	}
 
 	if len(doc.RedirectURIs) == 0 {
-		return oauthValidationError(reasonMissingRedirectURIs, "invalid_redirect_uri", "redirect_uris is required")
+		return none, oauthValidationError(reasonMissingRedirectURIs, "invalid_redirect_uri", "redirect_uris is required")
 	}
 	if len(doc.RedirectURIs) > maxRedirectURIs {
-		return oauthValidationError(reasonTooManyRedirectURIs, "invalid_redirect_uri", fmt.Sprintf("redirect_uris exceeds the limit of %d entries", maxRedirectURIs))
+		return none, oauthValidationError(reasonTooManyRedirectURIs, "invalid_redirect_uri", fmt.Sprintf("redirect_uris exceeds the limit of %d entries", maxRedirectURIs))
 	}
+	var crossOrigins []string
 	for _, uri := range doc.RedirectURIs {
 		if len(uri) > maxRedirectURILength {
-			return oauthValidationError(reasonRedirectURITooLong, "invalid_redirect_uri", fmt.Sprintf("redirect_uri exceeds the %d byte limit", maxRedirectURILength))
+			return none, oauthValidationError(reasonRedirectURITooLong, "invalid_redirect_uri", fmt.Sprintf("redirect_uri exceeds the %d byte limit", maxRedirectURILength))
 		}
 		// ValidateRedirectURI returns *oauthwire.Error values of its
 		// own, so the wrap preserves the client-safe wire mapping while the
 		// annotation adds the shared metric reason.
 		if err := oauthwire.ValidateRedirectURI(uri); err != nil {
-			return &validationError{reason: reasonRedirectURIInvalid, err: fmt.Errorf("validate redirect_uri: %w", err)}
+			return none, &validationError{reason: reasonRedirectURIInvalid, err: fmt.Errorf("validate redirect_uri: %w", err)}
 		}
-		if err := validateOriginBinding(clientIDURL, uri); err != nil {
-			return err
+		parsed, err := url.Parse(uri)
+		if err != nil {
+			// Unreachable in practice: ValidateRedirectURI parses the same
+			// string above. Kept so a divergence between the two parses
+			// fails closed instead of skipping the scheme rule.
+			return none, oauthValidationError(reasonRedirectURIInvalid, "invalid_redirect_uri", "redirect_uri must be an absolute URL")
+		}
+		if IsLoopbackRedirectURI(parsed) {
+			continue
+		}
+		// Non-loopback redirect URIs must use https. This is stricter than
+		// oauthwire.ValidateRedirectURI, which deliberately tolerates
+		// native-app custom schemes for DCR clients (AIS-434): a CIMD
+		// document is fetched from an https URL and self-asserts its
+		// registration, so the redirect set is held to web-grade schemes
+		// until a concrete client needs otherwise.
+		if parsed.Scheme != "https" {
+			return none, oauthValidationError(reasonRedirectURIScheme, "invalid_redirect_uri", fmt.Sprintf("redirect_uri %q must use the https scheme or be an RFC 8252 loopback http URL", uri))
+		}
+		// Cross-origin redirect URIs are accepted (no surveyed CIMD
+		// implementation binds redirect origins to the client_id origin, and
+		// -02 §8.1 leaves it optional) but observed: the origins feed a
+		// counter and log line so a preset vendor moving to cross-origin
+		// redirects is visible. Both URLs are https by this point, so the
+		// origin comparison reduces to the host — compared without
+		// normalization, so an explicit :443 is a different origin, and an
+		// https URL on a loopback host counts as cross-origin too
+		// (IsLoopbackRedirectURI exempts only http, per RFC 8252 §7.3).
+		if parsed.Host != clientIDURL.Host {
+			origin := parsed.Scheme + "://" + parsed.Host
+			if !slices.Contains(crossOrigins, origin) {
+				crossOrigins = append(crossOrigins, origin)
+			}
 		}
 	}
 
-	return nil
-}
-
-// validateOriginBinding enforces Gram's CIMD redirect-URI origin-binding
-// policy: every redirect_uri in the document must share the client_id URL's
-// origin (scheme + host + port, compared without normalization), except
-// loopback redirects, which are always allowed on any port. This is
-// deliberate Gram policy expressly permitted by -02 §8.1, not a spec
-// requirement — under open admission the client_id origin is the only
-// identity anchor, and binding ensures authorization codes are only ever
-// delivered to that origin (or to loopback). All known vendor CIMD documents
-// pass this rule (verified 2026-07); a legitimate cross-origin client would
-// need a per-URL exemption on the admission allowlist (follow-up work).
-func validateOriginBinding(clientIDURL *url.URL, redirectURI string) error {
-	parsed, err := url.Parse(redirectURI)
-	if err != nil {
-		return oauthValidationError(reasonRedirectURIInvalid, "invalid_redirect_uri", "redirect_uri must be an absolute URL")
-	}
-	if IsLoopbackRedirectURI(parsed) {
-		return nil
-	}
-	if parsed.Scheme != clientIDURL.Scheme || parsed.Host != clientIDURL.Host {
-		return oauthValidationError(reasonRedirectOriginMismatch, "invalid_redirect_uri", fmt.Sprintf("redirect_uri %q is not same-origin with the client_id URL", redirectURI))
-	}
-	return nil
+	return validationFindings{crossOriginRedirectOrigins: crossOrigins}, nil
 }
 
 // IsLoopbackRedirectURI reports whether a parsed redirect URI is an RFC 8252

--- a/server/internal/usersessions/cimd/validate_test.go
+++ b/server/internal/usersessions/cimd/validate_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // testDocument returns a document that passes every validateDocument check
-// for the given client_id URL: same-origin plus loopback redirect URIs,
-// public auth method, required client_name.
+// for the given client_id URL: https plus loopback redirect URIs, public
+// auth method, required client_name.
 func testDocument(clientID string) *Document {
 	return &Document{
 		ClientID:                clientID,
@@ -118,7 +118,9 @@ func TestValidateDocument_Valid(t *testing.T) {
 
 	parsed, err := ValidateClientIDURL(testClientID)
 	require.NoError(t, err)
-	require.NoError(t, validateDocument(testDocument(testClientID), testClientID, parsed))
+	findings, err := validateDocument(testDocument(testClientID), testClientID, parsed)
+	require.NoError(t, err)
+	require.Empty(t, findings.crossOriginRedirectOrigins)
 }
 
 func TestValidateDocument_ClientIDMismatchRejected(t *testing.T) {
@@ -129,7 +131,8 @@ func TestValidateDocument_ClientIDMismatchRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientID = "https://client.example.com/oauth/other.json"
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonClientIDMismatch)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonClientIDMismatch)
 }
 
 func TestValidateDocument_MissingClientNameRejected(t *testing.T) {
@@ -140,7 +143,8 @@ func TestValidateDocument_MissingClientNameRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientName = ""
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonMissingClientName)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonMissingClientName)
 }
 
 // TestValidateDocument_MissingAuthMethodAccepted: an absent
@@ -162,7 +166,8 @@ func TestValidateDocument_MissingAuthMethodAccepted(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.TokenEndpointAuthMethod = ""
-	require.NoError(t, validateDocument(doc, testClientID, parsed))
+	_, err = validateDocument(doc, testClientID, parsed)
+	require.NoError(t, err)
 }
 
 // TestValidateDocument_AsymmetricAuthMethodRejected pins that dropping the
@@ -177,7 +182,8 @@ func TestValidateDocument_AsymmetricAuthMethodRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.TokenEndpointAuthMethod = "private_key_jwt"
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonInvalidAuthMethod)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonInvalidAuthMethod)
 }
 
 func TestValidateDocument_SymmetricAuthMethodRejected(t *testing.T) {
@@ -188,7 +194,8 @@ func TestValidateDocument_SymmetricAuthMethodRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.TokenEndpointAuthMethod = "client_secret_basic"
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonInvalidAuthMethod)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonInvalidAuthMethod)
 }
 
 func TestValidateDocument_ClientSecretRejected(t *testing.T) {
@@ -199,7 +206,8 @@ func TestValidateDocument_ClientSecretRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientSecret = json.RawMessage(`"s3cret"`)
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonContainsSecret)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonContainsSecret)
 }
 
 func TestValidateDocument_ClientSecretExpiresAtRejected(t *testing.T) {
@@ -210,7 +218,8 @@ func TestValidateDocument_ClientSecretExpiresAtRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientSecretExpiresAt = json.RawMessage(`0`)
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonContainsSecret)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonContainsSecret)
 }
 
 func TestValidateDocument_JWKSNotAJWKSetRejected(t *testing.T) {
@@ -221,7 +230,8 @@ func TestValidateDocument_JWKSNotAJWKSetRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.JWKS = json.RawMessage(`[]`)
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonJWKSInvalid)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonJWKSInvalid)
 }
 
 func TestValidateDocument_JWKSPrivateKeyRejected(t *testing.T) {
@@ -232,7 +242,8 @@ func TestValidateDocument_JWKSPrivateKeyRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"EC","crv":"P-256","x":"a","y":"b","d":"private"}]}`)
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonJWKSPrivateKey)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonJWKSPrivateKey)
 }
 
 func TestValidateDocument_JWKSSymmetricKeyRejected(t *testing.T) {
@@ -243,7 +254,8 @@ func TestValidateDocument_JWKSSymmetricKeyRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"oct","k":"c2VjcmV0"}]}`)
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonJWKSSymmetricKey)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonJWKSSymmetricKey)
 }
 
 func TestValidateDocument_JWKSPublicKeyAccepted(t *testing.T) {
@@ -254,7 +266,8 @@ func TestValidateDocument_JWKSPublicKeyAccepted(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"EC","crv":"P-256","x":"a","y":"b"}]}`)
-	require.NoError(t, validateDocument(doc, testClientID, parsed))
+	_, err = validateDocument(doc, testClientID, parsed)
+	require.NoError(t, err)
 }
 
 func TestValidateDocument_OversizedClientNameRejected(t *testing.T) {
@@ -265,7 +278,8 @@ func TestValidateDocument_OversizedClientNameRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientName = strings.Repeat("a", maxClientNameLength+1)
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonClientNameTooLong)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_client_metadata", reasonClientNameTooLong)
 }
 
 func TestValidateDocument_TooManyRedirectURIsRejected(t *testing.T) {
@@ -279,7 +293,8 @@ func TestValidateDocument_TooManyRedirectURIsRejected(t *testing.T) {
 	for range maxRedirectURIs + 1 {
 		doc.RedirectURIs = append(doc.RedirectURIs, "https://client.example.com/callback")
 	}
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonTooManyRedirectURIs)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_redirect_uri", reasonTooManyRedirectURIs)
 }
 
 func TestValidateDocument_OversizedRedirectURIRejected(t *testing.T) {
@@ -290,7 +305,8 @@ func TestValidateDocument_OversizedRedirectURIRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"https://client.example.com/" + strings.Repeat("a", maxRedirectURILength)}
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectURITooLong)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_redirect_uri", reasonRedirectURITooLong)
 }
 
 func TestValidateDocument_MissingRedirectURIsRejected(t *testing.T) {
@@ -301,7 +317,8 @@ func TestValidateDocument_MissingRedirectURIsRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = nil
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonMissingRedirectURIs)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_redirect_uri", reasonMissingRedirectURIs)
 }
 
 // TestValidateDocument_NonLoopbackHTTPRedirectURIRejected exercises the
@@ -316,47 +333,82 @@ func TestValidateDocument_NonLoopbackHTTPRedirectURIRejected(t *testing.T) {
 	require.NoError(t, err)
 
 	// An http redirect on a non-loopback host fails ValidateRedirectURI's
-	// RFC 8252 §7.3 rule before origin binding is consulted.
+	// RFC 8252 §7.3 rule before the CIMD-specific https scheme rule runs.
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"http://client.example.com/callback"}
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectURIInvalid)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_redirect_uri", reasonRedirectURIInvalid)
 }
 
-func TestValidateDocument_CrossOriginHostRejected(t *testing.T) {
+// TestValidateDocument_CrossOriginHostAccepted pins the removal of the
+// redirect-URI same-origin binding (AIS-597): https redirect_uris on a
+// different host than the client_id URL are valid, and their distinct
+// origins come back as findings in first-seen order for the observability
+// emission. Same-origin entries produce no finding.
+func TestValidateDocument_CrossOriginHostAccepted(t *testing.T) {
 	t.Parallel()
 
 	parsed, err := ValidateClientIDURL(testClientID)
 	require.NoError(t, err)
 
 	doc := testDocument(testClientID)
-	doc.RedirectURIs = []string{"https://evil.example.com/callback"}
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectOriginMismatch)
+	doc.RedirectURIs = []string{
+		"https://api.other.example/callback",
+		"https://api.other.example/second",
+		"https://client.example.com/callback",
+	}
+	findings, err := validateDocument(doc, testClientID, parsed)
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://api.other.example"}, findings.crossOriginRedirectOrigins)
 }
 
-func TestValidateDocument_CrossOriginPortRejected(t *testing.T) {
+func TestValidateDocument_CrossOriginPortAccepted(t *testing.T) {
 	t.Parallel()
 
 	parsed, err := ValidateClientIDURL(testClientID)
 	require.NoError(t, err)
 
 	// No normalization: an explicit :443 is a different origin string than
-	// the client_id URL's implicit port.
+	// the client_id URL's implicit port, so the entry is accepted but
+	// reported as cross-origin.
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"https://client.example.com:443/callback"}
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectOriginMismatch)
+	findings, err := validateDocument(doc, testClientID, parsed)
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://client.example.com:443"}, findings.crossOriginRedirectOrigins)
 }
 
-func TestValidateDocument_CustomSchemeRejectedByOriginBinding(t *testing.T) {
+// TestValidateDocument_HTTPSLoopbackCountedCrossOrigin pins the boundary of
+// the loopback exemption: IsLoopbackRedirectURI exempts only http loopback
+// URLs (RFC 8252 §7.3), so an https URL on a loopback host passes the scheme
+// rule as a regular https redirect and counts as cross-origin.
+func TestValidateDocument_HTTPSLoopbackCountedCrossOrigin(t *testing.T) {
 	t.Parallel()
 
 	parsed, err := ValidateClientIDURL(testClientID)
 	require.NoError(t, err)
 
-	// Passes the RFC 8252 scheme rules but cannot be same-origin with an
-	// https client_id, so Gram's origin binding rejects it.
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = []string{"https://localhost:8080/callback"}
+	findings, err := validateDocument(doc, testClientID, parsed)
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://localhost:8080"}, findings.crossOriginRedirectOrigins)
+}
+
+// TestValidateDocument_CustomSchemeRedirectRejected pins the CIMD-specific
+// scheme rule: oauthwire.ValidateRedirectURI tolerates native-app custom
+// schemes (kept for DCR clients, AIS-434), but a document's non-loopback
+// redirect_uris must use https.
+func TestValidateDocument_CustomSchemeRedirectRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := ValidateClientIDURL(testClientID)
+	require.NoError(t, err)
+
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"com.example.app://callback"}
-	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectOriginMismatch)
+	_, err = validateDocument(doc, testClientID, parsed)
+	requireValidationError(t, err, "invalid_redirect_uri", reasonRedirectURIScheme)
 }
 
 func TestValidateDocument_LoopbackAnyPortAccepted(t *testing.T) {
@@ -371,7 +423,9 @@ func TestValidateDocument_LoopbackAnyPortAccepted(t *testing.T) {
 		"http://localhost:9999/cb",
 		"http://[::1]:1234/callback",
 	}
-	require.NoError(t, validateDocument(doc, testClientID, parsed))
+	findings, err := validateDocument(doc, testClientID, parsed)
+	require.NoError(t, err)
+	require.Empty(t, findings.crossOriginRedirectOrigins, "http loopback redirects are exempt from cross-origin reporting")
 }
 
 func TestValidateDocument_UnknownExtensionFieldsAccepted(t *testing.T) {
@@ -391,5 +445,6 @@ func TestValidateDocument_UnknownExtensionFieldsAccepted(t *testing.T) {
 
 	parsed, err := ValidateClientIDURL(testClientID)
 	require.NoError(t, err)
-	require.NoError(t, validateDocument(&doc, testClientID, parsed))
+	_, err = validateDocument(&doc, testClientID, parsed)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-597/remove-the-cimd-redirect-uri-same-origin-binding-and-add-cross-origin

Remove the CIMD validator's `redirect_uri` same-origin binding, which was rejecting otherwise valid documents whose `redirect_uris` live on a different origin than the `client_id` URL. No surveyed CIMD implementation enforces such a binding, and exact-match validation of the authorization request's `redirect_uri` against the fetched document remains the enforced control. In its place, validated documents carrying cross-origin `redirect_uris` record a `cimd.redirect_uris.cross_origin` counter (labeled only with the `client_id` origin) and a log line naming the cross-origin redirect origins.

Non-loopback redirect URIs in a document must now use the https scheme explicitly, with its own reason in the validation failure metric. Custom schemes were previously rejected only as a side effect of the origin binding. RFC 8252 http loopback redirects are unchanged.

Failed validations are never cached, so affected clients recover on their next authorization attempt after deploy with no operator action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts cross-origin CIMD redirect_uris and adds observability, while requiring https for non-loopback redirects. Previously we rejected redirect_uris not same-origin with the client_id; now we accept them, emit `cimd.redirect_uris.cross_origin`, and log the redirect origins. Exact-match redirect_uri checking at authorize time is unchanged. Addresses Linear AIS-597.

- Removes origin binding in server-side validation; validator returns findings used to record `cimd.redirect_uris.cross_origin` and log origins via `gram.cimd.cross_origin_redirect_origins`.
- Adds metric wiring and pins names in tests; updates the auth flow test to accept cross-origin registered redirects.
- Introduces explicit scheme rule: non-loopback redirect_uris must use https; adds validation reason `redirect_uri_scheme` and removes `redirect_origin_mismatch`.
- Emits the cross-origin counter only on successful validations from fresh fetches; the authenticated verifyURL preflight shares this path; cached resolutions skip validation.
- UI: rewords Open admission warning to “Any valid CIMD client can reach the consent screen, so users must review it before approving,” and updates its test.

- No schema or API changes; failed validations are never cached, so affected clients recover on their next authorization attempt.
- Optional: add a Datadog monitor on `cimd.redirect_uris.cross_origin` (labels include only the client_id origin; redirect origins appear in logs).

<sup>Written for commit 4b5bb7ce0e6cdf6737454d43ca05325fff9a5690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

