### PR TITLE
fix: suppress watchdog signals regardless of the page window

### DIFF
--- a/.changeset/watchdog-suppress-collection.md
+++ b/.changeset/watchdog-suppress-collection.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Watchdog suppression now collects a signal's findings without the page's time window, fixing the silent no-op when a signal contained findings whose messages predate the window (signals exist by scan time, the listing filters by message event time). An empty collection now shows an error toast instead of doing nothing. The signal drawer labels its window-scoped stats and unwindowed latest-evidence list so their counts can't read as contradictory, and the top-affected-users list no longer shows an "Unknown user" row for findings with no user attribution (matching the Users count).

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -560,7 +560,7 @@ export function SignalDrawer({
                           !evidenceQuery.isError &&
                           evidence.length === 0 && (
                             <Text small muted>
-                              No evidence rows in this window.
+                              No evidence rows for this rule.
                             </Text>
                           )}
                         <ExpandableList

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -195,13 +195,9 @@ function EvidenceRow({
  */
 export function SignalDrawer({
   signal,
-  window,
   onClose,
 }: {
   signal: RiskSignal | null;
-  /** The page's active time window; scopes signal-level suppression the same
-   * way the list's bulk Suppress action is scoped. */
-  window: { from?: Date; to?: Date };
   onClose: () => void;
 }): JSX.Element {
   const client = useSdkClient();
@@ -263,31 +259,28 @@ export function SignalDrawer({
 
   // Judge-backed signals get suppression as the signal-level action instead of
   // an exclusion rule. Same collect-then-confirm shape as the list's bulk
-  // action, scoped to this signal's rule and window.
+  // action, scoped to this signal's rule.
   const judgeSignal =
     signal !== null && hasJudgeSource(signal.detectionSources);
 
-  // Signal and window both live in the URL, so back/forward can swap either
-  // while the drawer stays mounted, and a dismissal belongs to the pair it was
-  // started from: surfacing one after a swap would confirm the previous
-  // selection's findings under the new one's name, or leave its action
-  // spinning. Bumping the token makes an in-flight collection drop its result —
-  // and its spinner reset — rather than land on the new selection; the request
-  // itself still runs to completion. Keyed by timestamps rather than Date
-  // identity, and by signal key rather than the signal object, so neither an
-  // equal window nor a list refetch discards a live collection.
+  // The signal lives in the URL, so back/forward can swap it while the drawer
+  // stays mounted, and a dismissal belongs to the signal it was started from:
+  // surfacing one after a swap would confirm the previous signal's findings
+  // under the new one's name, or leave its action spinning. Bumping the token
+  // makes an in-flight collection drop its result — and its spinner reset —
+  // rather than land on the new selection; the request itself still runs to
+  // completion. Keyed by signal key rather than the signal object, so a list
+  // refetch doesn't discard a live collection.
   //
   // Both resets run before paint: a passive effect would let the swap commit
   // first, painting one frame of the previous selection's dialog or editor
   // under the new signal's name.
   const collectionToken = useRef(0);
-  const windowFrom = window.from?.getTime();
-  const windowTo = window.to?.getTime();
   useLayoutEffect(() => {
     collectionToken.current += 1;
     setPendingDismiss(null);
     setCollecting(false);
-  }, [signal?.key, windowFrom, windowTo]);
+  }, [signal?.key]);
 
   // Editor state follows the signal alone: an open editor would go on targeting
   // the previous signal's rule (and keep the sheet's close affordance hidden),
@@ -305,12 +298,23 @@ export function SignalDrawer({
     const token = collectionToken.current;
     setCollecting(true);
     try {
-      const results = await collectFindingsForRules(
-        client,
-        [signal.ruleId],
-        window,
-      );
+      // Deliberately unwindowed, like the evidence query above: signals exist
+      // by scan time while the list endpoint the collector pages filters by
+      // message event time, so a windowed collection can miss — or come back
+      // empty for — findings the signal itself is displaying (scans of older
+      // messages). "Suppress all" means all of the rule's findings, and the
+      // confirm dialog names the collected count.
+      const results = await collectFindingsForRules(client, [signal.ruleId], {
+        from: undefined,
+        to: undefined,
+      });
       if (collectionToken.current !== token) return;
+      if (results.length === 0) {
+        // Without this, confirming an empty collection would silently no-op
+        // (dismiss guards empty batches) and the action would look broken.
+        toast.error("No suppressible findings found for this signal.");
+        return;
+      }
       setPendingDismiss(results);
     } catch {
       if (collectionToken.current !== token) return;
@@ -466,6 +470,13 @@ export function SignalDrawer({
                           <SignalTrend sparkline={signal.sparkline} />
                         </StatCell>
                       </div>
+                      {/* The stats above follow the page's window while the
+                          evidence below is the rule's latest regardless of
+                          it, so the two can legitimately disagree — say so
+                          instead of looking broken. */}
+                      <Text small muted>
+                        Counts reflect the page's selected time window.
+                      </Text>
 
                       {signal.topUsers.length > 0 && (
                         <>
@@ -520,7 +531,9 @@ export function SignalDrawer({
                                 matches, so the label and the reveal-all
                                 toggle (which only drives MaskedMatch rows)
                                 would both mislead there. */}
-                            {judgeSignal ? "Evidence" : "Evidence · redacted"}
+                            {judgeSignal
+                              ? "Latest evidence"
+                              : "Latest evidence · redacted"}
                           </Text>
                           {!judgeSignal && <RevealAllToggle />}
                         </div>

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -263,18 +263,11 @@ export function SignalDrawer({
   const judgeSignal =
     signal !== null && hasJudgeSource(signal.detectionSources);
 
-  // The signal lives in the URL, so back/forward can swap it while the drawer
-  // stays mounted, and a dismissal belongs to the signal it was started from:
-  // surfacing one after a swap would confirm the previous signal's findings
-  // under the new one's name, or leave its action spinning. Bumping the token
-  // makes an in-flight collection drop its result — and its spinner reset —
-  // rather than land on the new selection; the request itself still runs to
-  // completion. Keyed by signal key rather than the signal object, so a list
-  // refetch doesn't discard a live collection.
-  //
-  // Both resets run before paint: a passive effect would let the swap commit
-  // first, painting one frame of the previous selection's dialog or editor
-  // under the new signal's name.
+  // The signal lives in the URL, so back/forward can swap it mid-collection;
+  // bumping the token makes an in-flight collection drop its result instead
+  // of confirming the previous signal's findings under the new one's name.
+  // Keyed by signal key (not object identity) so refetches don't cancel;
+  // useLayoutEffect so the swap can't paint one frame of the old dialog.
   const collectionToken = useRef(0);
   useLayoutEffect(() => {
     collectionToken.current += 1;
@@ -298,20 +291,16 @@ export function SignalDrawer({
     const token = collectionToken.current;
     setCollecting(true);
     try {
-      // Deliberately unwindowed, like the evidence query above: signals exist
-      // by scan time while the list endpoint the collector pages filters by
-      // message event time, so a windowed collection can miss — or come back
-      // empty for — findings the signal itself is displaying (scans of older
-      // messages). "Suppress all" means all of the rule's findings, and the
-      // confirm dialog names the collected count.
+      // Unwindowed on purpose: the listing filters by message event time,
+      // signals exist by scan time, so a windowed collection can miss the
+      // very findings the signal displays. See the evidence query above.
       const results = await collectFindingsForRules(client, [signal.ruleId], {
         from: undefined,
         to: undefined,
       });
       if (collectionToken.current !== token) return;
       if (results.length === 0) {
-        // Without this, confirming an empty collection would silently no-op
-        // (dismiss guards empty batches) and the action would look broken.
+        // dismiss() ignores empty batches — fail loudly instead.
         toast.error("No suppressible findings found for this signal.");
         return;
       }
@@ -470,10 +459,8 @@ export function SignalDrawer({
                           <SignalTrend sparkline={signal.sparkline} />
                         </StatCell>
                       </div>
-                      {/* The stats above follow the page's window while the
-                          evidence below is the rule's latest regardless of
-                          it, so the two can legitimately disagree — say so
-                          instead of looking broken. */}
+                      {/* Windowed stats vs unwindowed evidence can disagree
+                          — say so. */}
                       <Text small muted>
                         Counts reflect the page's selected time window.
                       </Text>

--- a/client/dashboard/src/pages/security/watchdog/SuppressFindingsDialog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SuppressFindingsDialog.tsx
@@ -35,10 +35,10 @@ export function SuppressFindingsDialog({
         <Dialog.Title>Suppress findings?</Dialog.Title>
         <Dialog.Description>
           {count === 0
-            ? `No findings for ${subject} in the selected window; there is nothing to suppress.`
+            ? `No findings for ${subject}; there is nothing to suppress.`
             : `This suppresses ${count.toLocaleString()} ${
                 count === 1 ? "finding" : "findings"
-              } for ${subject} in the selected window — they drop out of the risk score and every finding count.`}
+              } for ${subject}, regardless of the selected time window — they drop out of the risk score and every finding count.`}
           {capped &&
             ` Only the first ${SIGNAL_DISMISS_CAP.toLocaleString()} findings can be suppressed at once; run this again if more remain.`}
         </Dialog.Description>

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -188,18 +188,16 @@ function WatchdogContent(): JSX.Element {
     if (selected.length === 0) return;
     setCollecting(true);
     try {
-      // Deliberately unwindowed: signals exist by scan time while the list
-      // endpoint the collector pages filters by message event time, so a
-      // windowed collection can miss findings the selected signals display
-      // (scans of older messages). The confirm dialog names the count.
+      // Unwindowed on purpose: the listing filters by message event time,
+      // signals exist by scan time — a windowed collection can miss the very
+      // findings the selected signals display.
       const results = await collectFindingsForRules(
         client,
         selected.map((signal) => signal.ruleId),
         { from: undefined, to: undefined },
       );
       if (results.length === 0) {
-        // dismiss() guards empty batches, so confirming an empty collection
-        // would silently no-op and the action would look broken.
+        // dismiss() ignores empty batches — fail loudly instead.
         toast.error("No suppressible findings found for the selection.");
         return;
       }

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -188,11 +188,21 @@ function WatchdogContent(): JSX.Element {
     if (selected.length === 0) return;
     setCollecting(true);
     try {
+      // Deliberately unwindowed: signals exist by scan time while the list
+      // endpoint the collector pages filters by message event time, so a
+      // windowed collection can miss findings the selected signals display
+      // (scans of older messages). The confirm dialog names the count.
       const results = await collectFindingsForRules(
         client,
         selected.map((signal) => signal.ruleId),
-        { from: window.from, to: window.to },
+        { from: undefined, to: undefined },
       );
+      if (results.length === 0) {
+        // dismiss() guards empty batches, so confirming an empty collection
+        // would silently no-op and the action would look broken.
+        toast.error("No suppressible findings found for the selection.");
+        return;
+      }
       setPendingDismiss({ results, signalCount: selected.length });
     } catch {
       toast.error("Failed to load the selected signals' findings.");
@@ -416,7 +426,6 @@ function WatchdogContent(): JSX.Element {
               must live under a slot to render at all. */}
           <SignalDrawer
             signal={selectedSignal}
-            window={window}
             onClose={() => setUrlParam("signal", null)}
           />
           <SuppressFindingsDialog

--- a/mise.toml
+++ b/mise.toml
@@ -379,3 +379,4 @@ GRAM_SVIX_API_KEY = { default = "unset" }
 ## from the environment. However, for local development, it can be set to a
 ## static value.
 GRAM_GCP_PROJECT_ID = "local-dev-project"
+GRAM_LOCAL_FEATURE_FLAGS_CSV = "/Users/dennis/workspace/speakeasy/gram/.claude/worktrees/watchdog-suppress-debug/server/flags.local.csv"

--- a/mise.toml
+++ b/mise.toml
@@ -379,4 +379,4 @@ GRAM_SVIX_API_KEY = { default = "unset" }
 ## from the environment. However, for local development, it can be set to a
 ## static value.
 GRAM_GCP_PROJECT_ID = "local-dev-project"
-GRAM_LOCAL_FEATURE_FLAGS_CSV = "/Users/dennis/workspace/speakeasy/gram/.claude/worktrees/watchdog-suppress-debug/server/flags.local.csv"
+GRAM_LOCAL_FEATURE_FLAGS_CSV = "{{config_root}}/server/flags.csv"

--- a/mise.toml
+++ b/mise.toml
@@ -379,4 +379,3 @@ GRAM_SVIX_API_KEY = { default = "unset" }
 ## from the environment. However, for local development, it can be set to a
 ## static value.
 GRAM_GCP_PROJECT_ID = "local-dev-project"
-GRAM_LOCAL_FEATURE_FLAGS_CSV = "{{config_root}}/server/flags.csv"

--- a/server/internal/risk/signals_ch.go
+++ b/server/internal/risk/signals_ch.go
@@ -317,11 +317,13 @@ func signalTopUsersByRule(rows []chrepo.RiskSignalUserCount) map[string][]*gen.R
 	}
 	merged := make(map[string]map[userKey]userStats)
 	for _, row := range rows {
-		// Fully unattributed findings (no user identity at all) are not an
-		// "affected user": the Users stat counts only non-empty identities
-		// (signalUserNonEmpty), so listing them here as "Unknown user" made
-		// the drawer show a user row under a Users count of zero.
-		if row.Email == "" && row.ExternalUserID == "" && row.UserID == "" {
+		// Findings the Users stat does not count are not an "affected user"
+		// here either: the stat's predicate is signalUserNonEmpty —
+		// external_user_id or user_id non-empty — so this skip mirrors it
+		// exactly. Listing skipped rows (as "Unknown user", or named via a
+		// stray stamped email) made the drawer show user rows under a Users
+		// count that excluded them.
+		if row.ExternalUserID == "" && row.UserID == "" {
 			continue
 		}
 		email := row.Email

--- a/server/internal/risk/signals_ch.go
+++ b/server/internal/risk/signals_ch.go
@@ -317,6 +317,13 @@ func signalTopUsersByRule(rows []chrepo.RiskSignalUserCount) map[string][]*gen.R
 	}
 	merged := make(map[string]map[userKey]userStats)
 	for _, row := range rows {
+		// Fully unattributed findings (no user identity at all) are not an
+		// "affected user": the Users stat counts only non-empty identities
+		// (signalUserNonEmpty), so listing them here as "Unknown user" made
+		// the drawer show a user row under a Users count of zero.
+		if row.Email == "" && row.ExternalUserID == "" && row.UserID == "" {
+			continue
+		}
 		email := row.Email
 		if email == "" && strings.Contains(row.ExternalUserID, "@") {
 			email = row.ExternalUserID

--- a/server/internal/risk/signals_ch.go
+++ b/server/internal/risk/signals_ch.go
@@ -317,12 +317,8 @@ func signalTopUsersByRule(rows []chrepo.RiskSignalUserCount) map[string][]*gen.R
 	}
 	merged := make(map[string]map[userKey]userStats)
 	for _, row := range rows {
-		// Findings the Users stat does not count are not an "affected user"
-		// here either: the stat's predicate is signalUserNonEmpty —
-		// external_user_id or user_id non-empty — so this skip mirrors it
-		// exactly. Listing skipped rows (as "Unknown user", or named via a
-		// stray stamped email) made the drawer show user rows under a Users
-		// count that excluded them.
+		// Mirror the Users stat's predicate (signalUserNonEmpty): rows it
+		// doesn't count must not appear here as "Unknown user" rows either.
 		if row.ExternalUserID == "" && row.UserID == "" {
 			continue
 		}

--- a/server/internal/risk/signals_internal_test.go
+++ b/server/internal/risk/signals_internal_test.go
@@ -70,17 +70,14 @@ func TestTopScoresDescending(t *testing.T) {
 	require.Equal(t, []float64{8}, topScoresDescending([]float64{8, 8, 8}, 1))
 }
 
-// TestSignalTopUsersByRule_SkipsUnattributed pins the drawer-consistency rule:
-// findings with no user identity at all are not "affected users" — the Users
-// stat counts only non-empty identities, so listing them as "Unknown user"
-// showed a user row under a Users count of zero.
+// TestSignalTopUsersByRule_SkipsUnattributed pins top users to the Users
+// stat's id-based predicate: rows it doesn't count never render as rows.
 func TestSignalTopUsersByRule_SkipsUnattributed(t *testing.T) {
 	t.Parallel()
 
 	rows := []chrepo.RiskSignalUserCount{
 		{RuleID: "r1", UserID: "", ExternalUserID: "", Email: "", Team: "", Findings: 3},
-		// A stray stamped email without any user id is skipped too: the Users
-		// stat's predicate is id-based, and this list mirrors it exactly.
+		// Stamped email without ids: skipped too, the predicate is id-based.
 		{RuleID: "r1", UserID: "", ExternalUserID: "", Email: "ghost@example.com", Team: "", Findings: 2},
 		{RuleID: "r1", UserID: "u1", ExternalUserID: "", Email: "alice@example.com", Team: "", Findings: 1},
 	}

--- a/server/internal/risk/signals_internal_test.go
+++ b/server/internal/risk/signals_internal_test.go
@@ -79,6 +79,9 @@ func TestSignalTopUsersByRule_SkipsUnattributed(t *testing.T) {
 
 	rows := []chrepo.RiskSignalUserCount{
 		{RuleID: "r1", UserID: "", ExternalUserID: "", Email: "", Team: "", Findings: 3},
+		// A stray stamped email without any user id is skipped too: the Users
+		// stat's predicate is id-based, and this list mirrors it exactly.
+		{RuleID: "r1", UserID: "", ExternalUserID: "", Email: "ghost@example.com", Team: "", Findings: 2},
 		{RuleID: "r1", UserID: "u1", ExternalUserID: "", Email: "alice@example.com", Team: "", Findings: 1},
 	}
 

--- a/server/internal/risk/signals_internal_test.go
+++ b/server/internal/risk/signals_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 )
 
 func TestSignalScore_GoldenValues(t *testing.T) {
@@ -66,4 +68,27 @@ func TestTopScoresDescending(t *testing.T) {
 	require.Equal(t, []float64{9, 7, 5}, topScoresDescending([]float64{5, 9, 1, 7, 3}, 3))
 	require.Equal(t, []float64{4, 2}, topScoresDescending([]float64{2, 4}, 3))
 	require.Equal(t, []float64{8}, topScoresDescending([]float64{8, 8, 8}, 1))
+}
+
+// TestSignalTopUsersByRule_SkipsUnattributed pins the drawer-consistency rule:
+// findings with no user identity at all are not "affected users" — the Users
+// stat counts only non-empty identities, so listing them as "Unknown user"
+// showed a user row under a Users count of zero.
+func TestSignalTopUsersByRule_SkipsUnattributed(t *testing.T) {
+	t.Parallel()
+
+	rows := []chrepo.RiskSignalUserCount{
+		{RuleID: "r1", UserID: "", ExternalUserID: "", Email: "", Team: "", Findings: 3},
+		{RuleID: "r1", UserID: "u1", ExternalUserID: "", Email: "alice@example.com", Team: "", Findings: 1},
+	}
+
+	out := signalTopUsersByRule(rows)
+	require.Len(t, out["r1"], 1)
+	require.Equal(t, "alice@example.com", out["r1"][0].Email)
+
+	// A rule with only unattributed findings yields no top users at all.
+	onlyUnattributed := signalTopUsersByRule([]chrepo.RiskSignalUserCount{
+		{RuleID: "r2", UserID: "", ExternalUserID: "", Email: "", Team: "", Findings: 2},
+	})
+	require.Empty(t, onlyUnattributed["r2"])
 }


### PR DESCRIPTION
## What

Fixes two Watchdog bugs around signal suppression.

**Silent suppress no-op.** Signals exist by scan time (`created_at`) while the listing that "Suppress all" and the bulk action collect finding ids from filters by message event time (`message_created_at`). A signal whose findings were scans of older messages (e.g. after a policy-edit rescan) displayed findings its own suppress action couldn't collect — zero ids, and `dismiss()` silently returns on empty batches. Collection is now unwindowed at both call sites ("Suppress all" means all of the rule; the confirm dialog names the count), an empty collection shows an error toast, and the drawer's now-unused `window` prop is gone.

**Contradictory drawer counts.** The stats grid is window-scoped while the evidence list is deliberately unwindowed — now labeled ("Latest evidence", plus a note that counts follow the selected window) instead of reading as broken. Server-side, top-affected-users no longer emits an "Unknown user" row for findings with no user attribution, matching the Users stat that only counts real identities (previously: "Users 0" above "Unknown user · 1 findings").

## Testing

New unit test pins the unattributed-row exclusion. Full dashboard suite (2,570) and server risk package (352) green; type-check, oxlint, `go vet` clean.

Note: `mise run lint:server` is currently broken on macOS bash at origin/main (syntax error in the lint-cache wrapper from #5553) — unrelated to this change; golangci runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses Watchdog signals regardless of the page time window to prevent silent no-ops. Previously, suppression collected by the page’s message-time window while signals exist by scan time, so it could collect zero ids and do nothing.

- Bulk “Suppress all” and per-signal suppression now collect unwindowed findings for the selected rules; the confirm dialog states it ignores the page window, and empty selections show an error toast.
- Drawer/UI: label that counts follow the page’s selected window, rename the evidence section to “Latest evidence,” update the empty state to “for this rule,” and remove the unused `window` prop from `SignalDrawer`.
- Server: top-affected-users excludes fully unattributed findings to match the Users stat; adds a unit test to pin this behavior.
- Dev config: drops an accidental local flags override in `mise.toml`.

<sup>Written for commit 1ea0269c97432e08b43e0936e946c380ef52aee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

