### PR TITLE
fix: derive the consent OAuth resource per remote session client

### DIFF
--- a/.changeset/per-client-oauth-resource.md
+++ b/.changeset/per-client-oauth-resource.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The consent page's connect and refresh actions now derive the RFC 8707 resource per remote session client instead of reusing the single endpoint-level resource. Under multi-binding the endpoint-level value belongs to at most one client, so reusing it sent the wrong resource to the wrong upstream authorization server and recorded wrong `remote_sessions.resource` values, breaking resource-matched token routing. A client with no unambiguous upstream now sends and records no resource rather than a wrong one.

--- a/.changeset/per-client-oauth-resource.md
+++ b/.changeset/per-client-oauth-resource.md
@@ -3,3 +3,5 @@
 ---
 
 The consent page's connect and refresh actions now derive the RFC 8707 resource per remote session client instead of reusing the single endpoint-level resource. Under multi-binding the endpoint-level value belongs to at most one client, so reusing it sent the wrong resource to the wrong upstream authorization server and recorded wrong `remote_sessions.resource` values, breaking resource-matched token routing. A client with no unambiguous upstream now sends and records no resource rather than a wrong one.
+
+Scope: resource-matched routing covers one credential shared across surfaces that front the same upstream. Where a user session issuer fronts two different upstream servers, nothing in the schema says which upstream a client belongs to, so derivation sees both, returns nothing, and the grant is minted without a resource — routing then fails closed rather than serving the wrong upstream. Routing that layout needs a schema addition.

--- a/server/internal/background/activities/remote_session_refresh.go
+++ b/server/internal/background/activities/remote_session_refresh.go
@@ -123,15 +123,7 @@ func (r *RemoteSessionRefresh) Do(ctx context.Context, input RefreshRemoteSessio
 	}
 	sess := candidate.RemoteSession
 
-	var fallbackResource string
-	if !sess.Resource.Valid || sess.Resource.String == "" {
-		fallbackResource, err = r.refresher.FallbackResourceForClient(ctx, sess.RemoteSessionClientID)
-		if err != nil {
-			return RefreshRemoteSessionResult{}, fmt.Errorf("derive fallback resource: %w", err)
-		}
-	}
-
-	result, err := r.refresher.RefreshNow(ctx, sess, fallbackResource)
+	result, err := r.refresher.RefreshNow(ctx, sess, "")
 	if err != nil {
 		if remotesessions.IsTokenRefreshRateLimited(err) {
 			logger.WarnContext(ctx, "scheduled remote session refresh rate limited",

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -494,7 +494,7 @@ func (s *Service) ApplyIssuerGate(
 	// user resolves by re-linking via {routeBase}/{slug}/connect.
 	var upstreamTokens map[uuid.UUID]remotesessions.UpstreamToken
 	if subject != nil {
-		tokens, rerr := s.remoteChallengeMgr.ResolveAccessTokens(newCtx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, *subject, endpoint.UpstreamResource)
+		tokens, rerr := s.remoteChallengeMgr.ResolveAccessTokens(newCtx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, *subject)
 		switch {
 		case errors.Is(rerr, remotesessions.ErrNoValidToken):
 			// The Gram user-session token is valid, but a required upstream

--- a/server/internal/mcp/authnchallenge_consent_action.go
+++ b/server/internal/mcp/authnchallenge_consent_action.go
@@ -123,6 +123,12 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 				autoRefresh = &v
 			}
 		}
+		// Not endpoint.UpstreamResource: under multi-binding that may belong
+		// to a different client's upstream; ambiguity derives "" (no resource).
+		clientResource, rerr := s.remoteChallengeMgr.FallbackResourceForClient(ctx, client.ID)
+		if rerr != nil {
+			return oops.E(oops.CodeUnexpected, rerr, "derive client upstream resource").LogError(ctx, logger)
+		}
 		challengeURL, berr := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, remotesessions.ParentChallenge{
 			ID:                  challengeState.ID,
 			ProjectID:           endpoint.ProjectID,
@@ -132,7 +138,7 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 			McpSlug:             endpoint.Slug,
 			RouteBase:           endpoint.RouteBase,
 			FinalRedirectURI:    "",
-			Resource:            endpoint.UpstreamResource,
+			Resource:            clientResource,
 			AutoRefresh:         autoRefresh,
 		}, *client)
 		if berr != nil {
@@ -164,7 +170,6 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 			endpoint.OrganizationID,
 			endpoint.UserSessionIssuerID,
 			client.ID,
-			endpoint.UpstreamResource,
 		)
 		if refreshErr != nil {
 			switch {

--- a/server/internal/mcp/authnchallenge_consent_action_test.go
+++ b/server/internal/mcp/authnchallenge_consent_action_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,22 +18,31 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	remotemcp_repo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type consentActionFixture struct {
-	ti       *testInstance
-	endpoint *mcp.ResolvedMcpEndpoint
-	stateID  string
-	// clientA/clientB derive distinct resources; clientC derives none.
+	ti        *testInstance
+	endpoint  *mcp.ResolvedMcpEndpoint
+	stateID   string
+	projectID uuid.UUID
+	orgID     string
+	shared    uuid.UUID
+	subject   urn.SessionSubject
+	// clientA/clientB derive distinct resources; clientC derives none;
+	// clientD sees both upstreams so derivation is ambiguous.
 	clientA uuid.UUID
 	clientB uuid.UUID
 	clientC uuid.UUID
+	clientD uuid.UUID
 }
 
 const (
@@ -40,18 +50,22 @@ const (
 	consentUpstreamB = "https://upstream-b.example.com"
 )
 
-// createConsentRemoteClient mints a remote_session_issuer (fake AS endpoints;
-// BuildAuthorizationUrl never contacts them) plus a client attached to every
-// given user_session_issuer.
-func createConsentRemoteClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, organizationID, slug string, userSessionIssuerIDs []uuid.UUID) uuid.UUID {
+// createConsentRemoteClient mints a remote_session_issuer plus a client
+// attached to every given user_session_issuer. asBase "" uses fake AS
+// endpoints (BuildAuthorizationUrl never contacts them); pass an httptest
+// base URL to run a real code exchange against it.
+func createConsentRemoteClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, organizationID, slug, asBase string, userSessionIssuerIDs []uuid.UUID) uuid.UUID {
 	t.Helper()
+	if asBase == "" {
+		asBase = "https://" + slug + "-as.example.com"
+	}
 	q := remotesessions_repo.New(conn)
 	rsi, err := q.CreateRemoteSessionIssuer(ctx, remotesessions_repo.CreateRemoteSessionIssuerParams{
 		ProjectID:                         uuid.NullUUID{UUID: projectID, Valid: true},
 		Slug:                              slug + "-rsi",
-		Issuer:                            "https://" + slug + "-as.example.com",
-		AuthorizationEndpoint:             conv.ToPGText("https://" + slug + "-as.example.com/authorize"),
-		TokenEndpoint:                     conv.ToPGText("https://" + slug + "-as.example.com/token"),
+		Issuer:                            asBase,
+		AuthorizationEndpoint:             conv.ToPGText(asBase + "/authorize"),
+		TokenEndpoint:                     conv.ToPGText(asBase + "/token"),
 		ScopesSupported:                   []string{},
 		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
 		ResponseTypesSupported:            []string{"code"},
@@ -100,27 +114,11 @@ func attachConsentRemoteMcpServer(t *testing.T, ctx context.Context, conn *pgxpo
 	require.NoError(t, err)
 }
 
-// seedMultiClientConsentEndpoint: one shared user_session_issuer with three
-// bound clients, two pinned to distinct upstreams via their own issuer link.
-func seedMultiClientConsentEndpoint(t *testing.T) (context.Context, consentActionFixture) {
+// mintConsentEndpointState builds the resolved endpoint (with an endpoint-
+// level UpstreamResource poison no client matches) and stores a consent
+// challenge state for a fresh subject.
+func mintConsentEndpointState(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, orgID string, shared uuid.UUID, slug string) (*mcp.ResolvedMcpEndpoint, string, urn.SessionSubject) {
 	t.Helper()
-
-	ctx, ti := newTestMCPService(t)
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx.ProjectID)
-	projectID := *authCtx.ProjectID
-	orgID := authCtx.ActiveOrganizationID
-
-	shared := createUserSessionIssuer(t, ctx, ti.conn, projectID)
-	issuerA := createUserSessionIssuer(t, ctx, ti.conn, projectID)
-	issuerB := createUserSessionIssuer(t, ctx, ti.conn, projectID)
-	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerA, "age3328-srv-a", consentUpstreamA+"/")
-	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerB, "age3328-srv-b", consentUpstreamB)
-
-	clientA := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-a", []uuid.UUID{shared, issuerA})
-	clientB := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-b", []uuid.UUID{shared, issuerB})
-	clientC := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-c", []uuid.UUID{shared})
 
 	endpoint := &mcp.ResolvedMcpEndpoint{
 		AudienceURN:          urn.NewUserSessionIssuer(shared).String(),
@@ -131,7 +129,7 @@ func seedMultiClientConsentEndpoint(t *testing.T) (context.Context, consentActio
 		OrganizationID:       orgID,
 		ProjectID:            projectID,
 		RouteBase:            "mcp",
-		Slug:                 "age3328-consent",
+		Slug:                 slug,
 		ToolsetID:            uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		// Deliberately matches no client: the action must never thread it in.
 		UpstreamResource:    "https://endpoint-level.example.com",
@@ -156,14 +154,46 @@ func seedMultiClientConsentEndpoint(t *testing.T) (context.Context, consentActio
 		Subject:             &subject,
 		CreatedAt:           time.Now(),
 	}))
+	return endpoint, stateID, subject
+}
+
+// seedMultiClientConsentEndpoint: one shared user_session_issuer with four
+// bound clients, two pinned to distinct upstreams via their own issuer link.
+func seedMultiClientConsentEndpoint(t *testing.T) (context.Context, consentActionFixture) {
+	t.Helper()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	shared := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	issuerA := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	issuerB := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerA, "age3328-srv-a", consentUpstreamA+"/")
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerB, "age3328-srv-b", consentUpstreamB)
+
+	clientA := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-a", "", []uuid.UUID{shared, issuerA})
+	clientB := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-b", "", []uuid.UUID{shared, issuerB})
+	clientC := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-c", "", []uuid.UUID{shared})
+	clientD := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-d", "", []uuid.UUID{shared, issuerA, issuerB})
+
+	endpoint, stateID, subject := mintConsentEndpointState(t, ctx, ti, projectID, orgID, shared, "age3328-consent")
 
 	return ctx, consentActionFixture{
-		ti:       ti,
-		endpoint: endpoint,
-		stateID:  stateID,
-		clientA:  clientA,
-		clientB:  clientB,
-		clientC:  clientC,
+		ti:        ti,
+		endpoint:  endpoint,
+		stateID:   stateID,
+		projectID: projectID,
+		orgID:     orgID,
+		shared:    shared,
+		subject:   subject,
+		clientA:   clientA,
+		clientB:   clientB,
+		clientC:   clientC,
+		clientD:   clientD,
 	}
 }
 
@@ -230,4 +260,163 @@ func TestServeConsentAction_ConnectWithoutDerivableResourceSendsNone(t *testing.
 	require.False(t, hasResource, "a client with no derivable resource must send none — not the endpoint-level one")
 	state := mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state"))
 	require.Empty(t, state.Resource)
+}
+
+// A client whose attached upstreams disagree on URL derives "" — no resource
+// is sent upstream and none is recorded on the login state.
+func TestServeConsentAction_ConnectAmbiguousUpstreamsSendsNoResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedMultiClientConsentEndpoint(t)
+
+	loc := postConnectAction(t, fx, fx.clientD)
+	require.Equal(t, "age3328-d-as.example.com", loc.Host)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "distinct upstream URLs make derivation ambiguous — send no resource")
+	state := mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state"))
+	require.Empty(t, state.Resource)
+}
+
+// A derivation failure must fail the connect closed: error out before any
+// upstream redirect or login state exists.
+func TestServeConsentAction_ConnectDerivationErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedMultiClientConsentEndpoint(t)
+
+	// Break only the derivation query's table; nothing earlier in the connect
+	// arm touches mcp_servers (per-test cloned DB, safe to mutate).
+	_, err := fx.ti.conn.Exec(ctx, "ALTER TABLE mcp_servers RENAME TO mcp_servers_unavailable") //nolint:glint // notestingrawsql: deliberate DDL breakage to force a derivation DB error; not expressible as an SQLc query
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("state", fx.stateID)
+	form.Set("csrf_token", "csrf-token")
+	form.Set("action", "connect")
+	form.Set("client_id", fx.clientA.String())
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+fx.endpoint.Slug+"/connect/remote-session", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	err = fx.ti.service.ServeConsentAction(w, req, fx.endpoint)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "derive client upstream resource")
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
+	require.Empty(t, w.Header().Get("Location"), "fail closed: no upstream redirect may be minted")
+}
+
+// consentExchangeCapture records the resource param of a token POST.
+type consentExchangeCapture struct {
+	HasResource bool
+	Resource    string
+}
+
+// newConsentExchangeAS is a live fake authorization server: its /token
+// endpoint captures the RFC 8707 resource and returns a token pair.
+func newConsentExchangeAS(t *testing.T, captured *atomic.Value, accessToken string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/token" || r.ParseForm() != nil || r.PostForm.Get("grant_type") != "authorization_code" {
+			http.NotFound(w, r)
+			return
+		}
+		_, has := r.PostForm["resource"]
+		captured.Store(consentExchangeCapture{HasResource: has, Resource: r.PostForm.Get("resource")})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + accessToken + `","token_type":"Bearer","expires_in":3600,"refresh_token":"rt-` + accessToken + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newConsentCallbackManager builds a ChallengeManager over the mcp test
+// instance's own db/enc/cache so it can finish flows the service started.
+func newConsentCallbackManager(t *testing.T, ti *testInstance) *remotesessions.ChallengeManager {
+	t.Helper()
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	return remotesessions.NewChallengeManager(ti.logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, ti.enc, policy, ti.cacheAdapter, ti.serverURL)
+}
+
+// completeRemoteLogin drives the code-exchange callback for one authorize
+// redirect, as the upstream AS would after the user approves.
+func completeRemoteLogin(t *testing.T, mgr *remotesessions.ChallengeManager, loc *url.URL) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/mcp/remote_login_callback?state="+url.QueryEscape(loc.Query().Get("state"))+"&code=fake-code", nil)
+	w := httptest.NewRecorder()
+	require.NoError(t, mgr.HandleRemoteLoginCallback(w, req))
+	require.Equal(t, http.StatusSeeOther, w.Code)
+}
+
+// The AGE-3328 routing-poison regression: two clients with distinct upstreams
+// connected through ONE endpoint must each exchange with, persist, and serve
+// their own resource — never a shared or endpoint-level one.
+func TestServeConsentAction_MultiBindingExchangePersistsPerClientResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	shared := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	issuerA := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	issuerB := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerA, "age3328-x-srv-a", consentUpstreamA)
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerB, "age3328-x-srv-b", consentUpstreamB)
+
+	var postedA, postedB atomic.Value
+	asA := newConsentExchangeAS(t, &postedA, "exchanged-a")
+	asB := newConsentExchangeAS(t, &postedB, "exchanged-b")
+	clientA := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-xa", asA.URL, []uuid.UUID{shared, issuerA})
+	clientB := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-xb", asB.URL, []uuid.UUID{shared, issuerB})
+
+	endpoint, stateID, subject := mintConsentEndpointState(t, ctx, ti, projectID, orgID, shared, "age3328-exchange")
+	fx := consentActionFixture{
+		ti:        ti,
+		endpoint:  endpoint,
+		stateID:   stateID,
+		projectID: projectID,
+		orgID:     orgID,
+		shared:    shared,
+		subject:   subject,
+		clientA:   clientA,
+		clientB:   clientB,
+		clientC:   uuid.Nil,
+		clientD:   uuid.Nil,
+	}
+
+	mgr := newConsentCallbackManager(t, ti)
+	completeRemoteLogin(t, mgr, postConnectAction(t, fx, clientA))
+	completeRemoteLogin(t, mgr, postConnectAction(t, fx, clientB))
+
+	// Each code exchange carried its own client's resource.
+	require.Equal(t, consentExchangeCapture{HasResource: true, Resource: consentUpstreamA}, postedA.Load())
+	require.Equal(t, consentExchangeCapture{HasResource: true, Resource: consentUpstreamB}, postedB.Load())
+
+	// Each credential row persisted its own resource.
+	q := remotesessions_repo.New(ti.conn)
+	sessA, err := q.GetActiveRemoteSession(ctx, remotesessions_repo.GetActiveRemoteSessionParams{SubjectUrn: subject, RemoteSessionClientID: clientA})
+	require.NoError(t, err)
+	require.Equal(t, consentUpstreamA, sessA.Resource.String)
+	sessB, err := q.GetActiveRemoteSession(ctx, remotesessions_repo.GetActiveRemoteSessionParams{SubjectUrn: subject, RemoteSessionClientID: clientB})
+	require.NoError(t, err)
+	require.Equal(t, consentUpstreamB, sessB.Resource.String)
+
+	// The routing layer serves both, each token qualified by its own resource.
+	tokens, err := mgr.ResolveAccessTokens(ctx, projectID, orgID, shared, subject)
+	require.NoError(t, err)
+	require.Len(t, tokens, 2)
+	byClient := map[uuid.UUID]remotesessions.UpstreamToken{}
+	for _, tok := range tokens {
+		byClient[tok.RemoteSessionClientID] = tok
+	}
+	require.Equal(t, "exchanged-a", byClient[clientA].Token)
+	require.Equal(t, consentUpstreamA, byClient[clientA].Resource)
+	require.Equal(t, "exchanged-b", byClient[clientB].Token)
+	require.Equal(t, consentUpstreamB, byClient[clientB].Resource)
 }

--- a/server/internal/mcp/authnchallenge_consent_action_test.go
+++ b/server/internal/mcp/authnchallenge_consent_action_test.go
@@ -1,0 +1,233 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	remotemcp_repo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type consentActionFixture struct {
+	ti       *testInstance
+	endpoint *mcp.ResolvedMcpEndpoint
+	stateID  string
+	// clientA/clientB derive distinct resources; clientC derives none.
+	clientA uuid.UUID
+	clientB uuid.UUID
+	clientC uuid.UUID
+}
+
+const (
+	consentUpstreamA = "https://upstream-a.example.com"
+	consentUpstreamB = "https://upstream-b.example.com"
+)
+
+// createConsentRemoteClient mints a remote_session_issuer (fake AS endpoints;
+// BuildAuthorizationUrl never contacts them) plus a client attached to every
+// given user_session_issuer.
+func createConsentRemoteClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, organizationID, slug string, userSessionIssuerIDs []uuid.UUID) uuid.UUID {
+	t.Helper()
+	q := remotesessions_repo.New(conn)
+	rsi, err := q.CreateRemoteSessionIssuer(ctx, remotesessions_repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         uuid.NullUUID{UUID: projectID, Valid: true},
+		Slug:                              slug + "-rsi",
+		Issuer:                            "https://" + slug + "-as.example.com",
+		AuthorizationEndpoint:             conv.ToPGText("https://" + slug + "-as.example.com/authorize"),
+		TokenEndpoint:                     conv.ToPGText("https://" + slug + "-as.example.com/token"),
+		ScopesSupported:                   []string{},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+	})
+	require.NoError(t, err)
+
+	rsc, err := q.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
+		ProjectID:             conv.ToNullUUID(projectID),
+		OrganizationID:        conv.ToPGTextEmpty(organizationID),
+		RemoteSessionIssuerID: rsi.ID,
+		ClientID:              slug + "-external-client",
+		ClientIDIssuedAt:      pgtype.Timestamptz{Time: time.Now(), Valid: true},
+	})
+	require.NoError(t, err)
+	for _, usi := range userSessionIssuerIDs {
+		require.NoError(t, q.AttachRemoteSessionClientToUserSessionIssuer(ctx, remotesessions_repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+			RemoteSessionClientID: rsc.ID,
+			UserSessionIssuerID:   usi,
+		}))
+	}
+	return rsc.ID
+}
+
+// attachConsentRemoteMcpServer binds a remote-backed mcp_server to issuerID
+// so clients on that issuer derive serverURL as their resource.
+func attachConsentRemoteMcpServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, issuerID uuid.UUID, slug, serverURL string) {
+	t.Helper()
+	remoteServer, err := remotemcp_repo.New(conn).CreateServer(ctx, remotemcp_repo.CreateServerParams{
+		ID:            uuid.New(),
+		ProjectID:     projectID,
+		TransportType: "sse",
+		Url:           serverURL,
+	})
+	require.NoError(t, err)
+	_, err = mcpservers_repo.New(conn).CreateMCPServer(ctx, mcpservers_repo.CreateMCPServerParams{
+		ID:                  uuid.New(),
+		ProjectID:           projectID,
+		Name:                conv.ToPGText(slug),
+		Slug:                conv.ToPGText(slug),
+		RemoteMcpServerID:   conv.ToNullUUID(remoteServer.ID),
+		Visibility:          "private",
+		UserSessionIssuerID: conv.ToNullUUID(issuerID),
+	})
+	require.NoError(t, err)
+}
+
+// seedMultiClientConsentEndpoint: one shared user_session_issuer with three
+// bound clients, two pinned to distinct upstreams via their own issuer link.
+func seedMultiClientConsentEndpoint(t *testing.T) (context.Context, consentActionFixture) {
+	t.Helper()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	shared := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	issuerA := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	issuerB := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerA, "age3328-srv-a", consentUpstreamA+"/")
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerB, "age3328-srv-b", consentUpstreamB)
+
+	clientA := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-a", []uuid.UUID{shared, issuerA})
+	clientB := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-b", []uuid.UUID{shared, issuerB})
+	clientC := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "age3328-c", []uuid.UUID{shared})
+
+	endpoint := &mcp.ResolvedMcpEndpoint{
+		AudienceURN:          urn.NewUserSessionIssuer(shared).String(),
+		CIMDAdmissionModeRaw: pgtype.Text{String: "", Valid: false},
+		CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		IsPublic:             false,
+		McpServerID:          uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		OrganizationID:       orgID,
+		ProjectID:            projectID,
+		RouteBase:            "mcp",
+		Slug:                 "age3328-consent",
+		ToolsetID:            uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		// Deliberately matches no client: the action must never thread it in.
+		UpstreamResource:    "https://endpoint-level.example.com",
+		UserSessionIssuerID: shared,
+	}
+
+	subject := urn.NewUserSubject(uuid.NewString())
+	stateID := uuid.NewString()
+	require.NoError(t, ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		UserSessionIssuerID: shared,
+		Endpoint: mcp.EndpointRef{
+			McpSlug:        endpoint.Slug,
+			RouteBase:      endpoint.RouteBase,
+			CustomDomainID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		},
+		ClientID:            "age3328-mcp-client",
+		RedirectURI:         "http://example.com/cb",
+		CodeChallenge:       "",
+		CodeChallengeMethod: "",
+		CSRFToken:           "csrf-token",
+		Subject:             &subject,
+		CreatedAt:           time.Now(),
+	}))
+
+	return ctx, consentActionFixture{
+		ti:       ti,
+		endpoint: endpoint,
+		stateID:  stateID,
+		clientA:  clientA,
+		clientB:  clientB,
+		clientC:  clientC,
+	}
+}
+
+// postConnectAction drives one client's connect action and returns the
+// upstream authorize redirect URL.
+func postConnectAction(t *testing.T, fx consentActionFixture, clientID uuid.UUID) *url.URL {
+	t.Helper()
+
+	form := url.Values{}
+	form.Set("state", fx.stateID)
+	form.Set("csrf_token", "csrf-token")
+	form.Set("action", "connect")
+	form.Set("client_id", clientID.String())
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+fx.endpoint.Slug+"/connect/remote-session", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	require.NoError(t, fx.ti.service.ServeConsentAction(w, req, fx.endpoint))
+	require.Equal(t, http.StatusSeeOther, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	return loc
+}
+
+// mintedRemoteLoginState reads back the stored RemoteLoginState — its
+// Resource is what the code exchange records onto the grant.
+func mintedRemoteLoginState(t *testing.T, ctx context.Context, fx consentActionFixture, upstreamState string) remotesessions.RemoteLoginState {
+	t.Helper()
+	loginCache := cache.NewTypedObjectCache[remotesessions.RemoteLoginState](fx.ti.logger, fx.ti.cacheAdapter, cache.SuffixNone)
+	state, err := loginCache.Get(ctx, "remoteLogin:"+upstreamState)
+	require.NoError(t, err)
+	return state
+}
+
+func TestServeConsentAction_ConnectSendsPerClientResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedMultiClientConsentEndpoint(t)
+
+	locA := postConnectAction(t, fx, fx.clientA)
+	require.Equal(t, "age3328-a-as.example.com", locA.Host)
+	require.Equal(t, consentUpstreamA, locA.Query().Get("resource"))
+	stateA := mintedRemoteLoginState(t, ctx, fx, locA.Query().Get("state"))
+	require.Equal(t, consentUpstreamA, stateA.Resource)
+	require.Equal(t, fx.clientA, stateA.RemoteSessionClientID)
+
+	locB := postConnectAction(t, fx, fx.clientB)
+	require.Equal(t, "age3328-b-as.example.com", locB.Host)
+	require.Equal(t, consentUpstreamB, locB.Query().Get("resource"))
+	stateB := mintedRemoteLoginState(t, ctx, fx, locB.Query().Get("state"))
+	require.Equal(t, consentUpstreamB, stateB.Resource)
+	require.Equal(t, fx.clientB, stateB.RemoteSessionClientID)
+}
+
+func TestServeConsentAction_ConnectWithoutDerivableResourceSendsNone(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedMultiClientConsentEndpoint(t)
+
+	loc := postConnectAction(t, fx, fx.clientC)
+	require.Equal(t, "age3328-c-as.example.com", loc.Host)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a client with no derivable resource must send none — not the endpoint-level one")
+	state := mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state"))
+	require.Empty(t, state.Resource)
+}

--- a/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
+++ b/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
@@ -317,7 +317,7 @@ func (s *Service) serveConsentProxiedMCP(
 	if serverRow.Visibility == mcpservers.VisibilityPrivate && subject.Kind == urn.SessionSubjectKindAnonymous {
 		return oops.E(oops.CodeUnauthorized, nil, "anonymous subject cannot enumerate a private MCP server").LogWarn(ctx, logger)
 	}
-	tokens, err := s.remoteChallengeMgr.ResolveAccessTokens(ctx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, subject, endpoint.UpstreamResource)
+	tokens, err := s.remoteChallengeMgr.ResolveAccessTokens(ctx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, subject)
 	if err != nil {
 		if errors.Is(err, remotesessions.ErrNoValidToken) {
 			return oops.E(oops.CodeConflict, err, "connect the upstream service before choosing tools").LogWarn(ctx, logger)

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -407,9 +407,10 @@ func (m *ChallengeManager) RefreshRemoteSession(
 		return zero, ErrRemoteSessionNotRefreshable
 	}
 
-	// Only legacy rows without a persisted resource need the derived fallback.
+	// Only legacy NULL-resource rows need the derived fallback, matching
+	// validateAndRefresh: a valid-but-empty binding keeps omitting resource.
 	fallbackResource := ""
-	if !session.Resource.Valid || session.Resource.String == "" {
+	if !session.Resource.Valid {
 		fallbackResource, err = m.refresher.FallbackResourceForClient(ctx, clientID)
 		if err != nil {
 			return zero, fmt.Errorf("derive fallback resource: %w", err)

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -407,17 +407,7 @@ func (m *ChallengeManager) RefreshRemoteSession(
 		return zero, ErrRemoteSessionNotRefreshable
 	}
 
-	// Only legacy NULL-resource rows need the derived fallback, matching
-	// validateAndRefresh: a valid-but-empty binding keeps omitting resource.
-	fallbackResource := ""
-	if !session.Resource.Valid {
-		fallbackResource, err = m.refresher.FallbackResourceForClient(ctx, clientID)
-		if err != nil {
-			return zero, fmt.Errorf("derive fallback resource: %w", err)
-		}
-	}
-
-	return m.refresher.RefreshNow(ctx, session, fallbackResource)
+	return m.refresher.RefreshNow(ctx, session, "")
 }
 
 // FallbackResourceForClient derives one client's RFC 8707 resource from its

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -377,7 +377,6 @@ func (m *ChallengeManager) RefreshRemoteSession(
 	organizationID string,
 	userSessionIssuerID uuid.UUID,
 	clientID uuid.UUID,
-	fallbackResource string,
 ) (RefreshResult, error) {
 	var zero RefreshResult
 
@@ -408,7 +407,22 @@ func (m *ChallengeManager) RefreshRemoteSession(
 		return zero, ErrRemoteSessionNotRefreshable
 	}
 
+	// Only legacy rows without a persisted resource need the derived fallback.
+	fallbackResource := ""
+	if !session.Resource.Valid || session.Resource.String == "" {
+		fallbackResource, err = m.refresher.FallbackResourceForClient(ctx, clientID)
+		if err != nil {
+			return zero, fmt.Errorf("derive fallback resource: %w", err)
+		}
+	}
+
 	return m.refresher.RefreshNow(ctx, session, fallbackResource)
+}
+
+// FallbackResourceForClient derives one client's RFC 8707 resource from its
+// attached MCP servers; ambiguous or absent upstreams derive "".
+func (m *ChallengeManager) FallbackResourceForClient(ctx context.Context, clientID uuid.UUID) (string, error) {
+	return m.refresher.FallbackResourceForClient(ctx, clientID)
 }
 
 // DisconnectRemoteSession soft-deletes the subject's remote_session for one

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -685,6 +685,140 @@ func TestResolveAccessTokens_DerivesPerClientFallbackResource(t *testing.T) {
 	require.Equal(t, "https://upstream-lazy.example.com", capturedResource.Load())
 }
 
+// tokenPostCapture is the resource param of the last refresh POST; presence
+// matters separately from value (RFC 8707 omits the param when absent).
+type tokenPostCapture struct {
+	HasResource bool
+	Resource    string
+}
+
+// newResourceCapturingRefreshHandler wraps newSharedGrantRefreshHandler and
+// records whether/what `resource` the refresh POST carried.
+func newResourceCapturingRefreshHandler(refreshCount *atomic.Int64, captured *atomic.Value, accessToken string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/token" && r.ParseForm() == nil {
+			_, has := r.PostForm["resource"]
+			captured.Store(tokenPostCapture{HasResource: has, Resource: r.PostForm.Get("resource")})
+		}
+		newSharedGrantRefreshHandler(refreshCount, accessToken)(w, r)
+	}
+}
+
+// setStoredSessionResource stamps a persisted RFC 8707 resource onto the
+// fixture's session via the same upsert the code-exchange callback uses.
+func setStoredSessionResource(t *testing.T, ctx context.Context, fx sharedGrantFixture, resource string) {
+	t.Helper()
+	_, err := repo.New(fx.ti.conn).UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+		SubjectUrn:             fx.subject,
+		UserSessionIssuerID:    fx.session.UserSessionIssuerID,
+		RemoteSessionClientID:  fx.clientID,
+		AccessTokenEncrypted:   fx.session.AccessTokenEncrypted,
+		AccessExpiresAt:        fx.session.AccessExpiresAt,
+		RefreshTokenEncrypted:  fx.session.RefreshTokenEncrypted,
+		AuthorizationExpiresAt: fx.session.AuthorizationExpiresAt,
+		RefreshExpiresAt:       fx.session.RefreshExpiresAt,
+		Scopes:                 fx.session.Scopes,
+		Resource:               conv.ToPGText(resource),
+		AutoRefresh:            fx.session.AutoRefresh,
+	})
+	require.NoError(t, err)
+}
+
+// A persisted resource wins on explicit refresh: no derivation replaces it,
+// even when the client's attached MCP server would derive something else.
+func TestRefreshRemoteSession_StoredResourceWinsOverDerivation(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	var captured atomic.Value
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-stored-res", newResourceCapturingRefreshHandler(&refreshCount, &captured, "rotated-stored"))
+
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-stored-res", "https://derived-loser.example.com/")
+	setStoredSessionResource(t, ctx, fx, "https://stored-winner.example.com")
+
+	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, tokenPostCapture{HasResource: true, Resource: "https://stored-winner.example.com"}, captured.Load())
+}
+
+// NULL stored resource + ambiguous derivation (two attached upstreams with
+// distinct URLs) must POST no resource param at all on explicit refresh.
+func TestRefreshRemoteSession_AmbiguousDerivationSendsNoResource(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	var captured atomic.Value
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-amb-refresh", newResourceCapturingRefreshHandler(&refreshCount, &captured, "rotated-ambiguous"))
+
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-amb-refresh-1", "https://amb-one.example.com")
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerB, "age-3328-amb-refresh-2", "https://amb-two.example.com")
+
+	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, tokenPostCapture{HasResource: false, Resource: ""}, captured.Load())
+}
+
+// The lazy request-time path uses a persisted resource as-is: derivation
+// never overrides it and the resolved entry reports the stored value.
+func TestResolveAccessTokens_StoredResourceWinsOverDerivation(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	var captured atomic.Value
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-lazy-stored", newResourceCapturingRefreshHandler(&refreshCount, &captured, "rotated-lazy-stored"))
+
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-lazy-stored", "https://derived-loser.example.com/")
+	setStoredSessionResource(t, ctx, fx, "https://stored-lazy.example.com")
+	require.NoError(t, testrepo.New(fx.ti.conn).ExpireRemoteSessionAccessTokenFixture(ctx, fx.session.ID))
+
+	tokens, err := fx.mgr.ResolveAccessTokens(ctx, fx.projectID, fx.organizationID, fx.issuerB, fx.subject)
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	require.Equal(t, tokenPostCapture{HasResource: true, Resource: "https://stored-lazy.example.com"}, captured.Load())
+	for _, tok := range tokens {
+		require.Equal(t, "https://stored-lazy.example.com", tok.Resource)
+	}
+}
+
+// Lazy path, NULL stored resource, ambiguous derivation: the refresh POST
+// must carry no resource param.
+func TestResolveAccessTokens_AmbiguousDerivationSendsNoResource(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	var captured atomic.Value
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-lazy-amb", newResourceCapturingRefreshHandler(&refreshCount, &captured, "rotated-lazy-ambiguous"))
+
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-lazy-amb-1", "https://amb-one.example.com")
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerB, "age-3328-lazy-amb-2", "https://amb-two.example.com")
+	require.NoError(t, testrepo.New(fx.ti.conn).ExpireRemoteSessionAccessTokenFixture(ctx, fx.session.ID))
+
+	tokens, err := fx.mgr.ResolveAccessTokens(ctx, fx.projectID, fx.organizationID, fx.issuerB, fx.subject)
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	require.Equal(t, tokenPostCapture{HasResource: false, Resource: ""}, captured.Load())
+}
+
+// A caller-supplied non-empty fallback (the platform ResolveAccessToken /
+// ResolveAuthorization path) wins over derivation on a NULL-resource row.
+func TestResolveAccessToken_ExplicitFallbackSkipsDerivation(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	var captured atomic.Value
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-explicit-fb", newResourceCapturingRefreshHandler(&refreshCount, &captured, "rotated-explicit-fb"))
+
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-explicit-fb", "https://derived-unused.example.com/")
+	require.NoError(t, testrepo.New(fx.ti.conn).ExpireRemoteSessionAccessTokenFixture(ctx, fx.session.ID))
+
+	token, err := fx.mgr.ResolveAccessToken(ctx, fx.clientID, fx.subject, "https://caller-fallback.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "rotated-explicit-fb", token)
+	require.Equal(t, tokenPostCapture{HasResource: true, Resource: "https://caller-fallback.example.com"}, captured.Load())
+}
+
 func TestRefreshRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -634,6 +634,57 @@ func seedRefreshableSharedGrant(t *testing.T, slug string, handler http.HandlerF
 	}
 }
 
+// A session with no persisted resource must refresh with the client's own
+// derived RFC 8707 resource, never an endpoint-level one.
+func TestRefreshRemoteSession_DerivesPerClientFallbackResource(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	var capturedResource atomic.Value
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/token" && r.ParseForm() == nil {
+			capturedResource.Store(r.PostForm.Get("resource"))
+		}
+		newSharedGrantRefreshHandler(&refreshCount, "rotated-with-resource")(w, r)
+	}
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-refresh-res", handler)
+
+	// The client's sole attached MCP server pins its derived resource.
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-refresh-res", "https://upstream-refresh.example.com/")
+
+	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, int64(1), refreshCount.Load())
+	require.Equal(t, "https://upstream-refresh.example.com", capturedResource.Load())
+}
+
+// The lazy request-time path must also derive per client, never an
+// endpoint-level fallback (AGE-3328): a NULL-resource row refreshed via
+// ResolveAccessTokens sends the client's own derived resource upstream.
+func TestResolveAccessTokens_DerivesPerClientFallbackResource(t *testing.T) {
+	t.Parallel()
+
+	var refreshCount atomic.Int64
+	var capturedResource atomic.Value
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/token" && r.ParseForm() == nil {
+			capturedResource.Store(r.PostForm.Get("resource"))
+		}
+		newSharedGrantRefreshHandler(&refreshCount, "rotated-lazy-resource")(w, r)
+	}
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-lazy-res", handler)
+
+	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-lazy-res", "https://upstream-lazy.example.com/")
+	require.NoError(t, testrepo.New(fx.ti.conn).ExpireRemoteSessionAccessTokenFixture(ctx, fx.session.ID))
+
+	tokens, err := fx.mgr.ResolveAccessTokens(ctx, fx.projectID, fx.organizationID, fx.issuerB, fx.subject)
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	require.Equal(t, int64(1), refreshCount.Load())
+	require.Equal(t, "https://upstream-lazy.example.com", capturedResource.Load())
+}
+
 func TestRefreshRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	t.Parallel()
 
@@ -643,7 +694,7 @@ func TestRefreshRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
 	requireBoundClient(t, bound, fx.clientID)
 
-	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID, "")
+	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "rotated-access", result.AccessToken)
@@ -665,7 +716,7 @@ func TestRefreshRemoteSession_FindsGrantAfterMintingIssuerSoftDeleted(t *testing
 	bound := listBoundClientIDs(t, ctx, fx, fx.issuerB)
 	requireBoundClient(t, bound, fx.clientID)
 
-	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID, "")
+	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "rotated-after-delete", result.AccessToken)

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -640,14 +640,8 @@ func TestRefreshRemoteSession_DerivesPerClientFallbackResource(t *testing.T) {
 	t.Parallel()
 
 	var refreshCount atomic.Int64
-	var capturedResource atomic.Value
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost && r.URL.Path == "/token" && r.ParseForm() == nil {
-			capturedResource.Store(r.PostForm.Get("resource"))
-		}
-		newSharedGrantRefreshHandler(&refreshCount, "rotated-with-resource")(w, r)
-	}
-	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-refresh-res", handler)
+	var captured atomic.Value
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-refresh-res", newResourceCapturingRefreshHandler(&refreshCount, &captured, "rotated-with-resource"))
 
 	// The client's sole attached MCP server pins its derived resource.
 	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-refresh-res", "https://upstream-refresh.example.com/")
@@ -656,7 +650,7 @@ func TestRefreshRemoteSession_DerivesPerClientFallbackResource(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, int64(1), refreshCount.Load())
-	require.Equal(t, "https://upstream-refresh.example.com", capturedResource.Load())
+	require.Equal(t, tokenPostCapture{HasResource: true, Resource: "https://upstream-refresh.example.com"}, captured.Load())
 }
 
 // The lazy request-time path must also derive per client, never an
@@ -666,14 +660,8 @@ func TestResolveAccessTokens_DerivesPerClientFallbackResource(t *testing.T) {
 	t.Parallel()
 
 	var refreshCount atomic.Int64
-	var capturedResource atomic.Value
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost && r.URL.Path == "/token" && r.ParseForm() == nil {
-			capturedResource.Store(r.PostForm.Get("resource"))
-		}
-		newSharedGrantRefreshHandler(&refreshCount, "rotated-lazy-resource")(w, r)
-	}
-	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-lazy-res", handler)
+	var captured atomic.Value
+	ctx, fx := seedRefreshableSharedGrant(t, "age-3328-lazy-res", newResourceCapturingRefreshHandler(&refreshCount, &captured, "rotated-lazy-resource"))
 
 	attachRemoteMcpServerToIssuer(t, ctx, fx.ti.conn, fx.projectID, fx.issuerA, "age-3328-lazy-res", "https://upstream-lazy.example.com/")
 	require.NoError(t, testrepo.New(fx.ti.conn).ExpireRemoteSessionAccessTokenFixture(ctx, fx.session.ID))
@@ -682,7 +670,7 @@ func TestResolveAccessTokens_DerivesPerClientFallbackResource(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, tokens, 1)
 	require.Equal(t, int64(1), refreshCount.Load())
-	require.Equal(t, "https://upstream-lazy.example.com", capturedResource.Load())
+	require.Equal(t, tokenPostCapture{HasResource: true, Resource: "https://upstream-lazy.example.com"}, captured.Load())
 }
 
 // tokenPostCapture is the resource param of the last refresh POST; presence

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -31,11 +31,9 @@ import (
 // active remote_session_client is bound to a given (user_session_issuer,
 // remote_session_issuer) pair through the join table. It scopes the
 // constraint per remote_session_issuer, so a user_session_issuer can bind
-// distinct clients across distinct remote issuers; the
-// remote_session_client_user_session_issuers one_per_issuer index applies a
-// stricter cap (one client per user_session_issuer regardless of remote
-// issuer) until AIS-137 removes it, after which this guard is the sole
-// attach-time enforcement.
+// distinct clients across distinct remote issuers. The old one_per_issuer
+// index (one client per user_session_issuer regardless of remote issuer) was
+// dropped by AIS-137; this guard is the sole attach-time enforcement.
 //
 // excludeClientID skips a row so an update of the same client passes; pass
 // uuid.Nil to exclude nothing (the create paths). Must run inside the attach

--- a/server/internal/remotesessions/migrateissuer_test.go
+++ b/server/internal/remotesessions/migrateissuer_test.go
@@ -136,7 +136,7 @@ func TestMigrateIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T) {
 	require.NoError(t, err)
 
 	// Before: the token resolves under the source issuer's id.
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{sourceUUID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
 
@@ -151,7 +151,7 @@ func TestMigrateIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T) {
 
 	// After: the same token value resolves, now keyed by the target issuer.
 	// Nothing re-authenticated; only the client's foreign key moved.
-	tokens, err = mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err = mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{targetID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
 

--- a/server/internal/remotesessions/organizationsessionhandlers.go
+++ b/server/internal/remotesessions/organizationsessionhandlers.go
@@ -199,17 +199,6 @@ func (s *Service) RefreshSession(ctx context.Context, payload *orgsessionsgen.Re
 		return nil, oops.E(oops.CodeBadRequest, nil, "remote session has no refresh token").LogError(ctx, logger)
 	}
 
-	// Sessions minted since the resource column exists carry their RFC 8707
-	// binding; RefreshNow replays it. Only legacy NULL rows need the
-	// derived-from-attached-MCP-servers fallback.
-	var fallbackResource string
-	if !row.RemoteSession.Resource.Valid || row.RemoteSession.Resource.String == "" {
-		fallbackResource, err = s.refresher.FallbackResourceForClient(ctx, row.RemoteSession.RemoteSessionClientID)
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "derive fallback resource").LogError(ctx, logger)
-		}
-	}
-
 	// Refresh through the shared single-flighted primitive — the same lock the
 	// lazy MCP path and the scheduled sweep hold, so an admin click can never
 	// replay a refresh token a concurrent refresh already consumed. Two
@@ -217,7 +206,7 @@ func (s *Service) RefreshSession(ctx context.Context, payload *orgsessionsgen.Re
 	// are adopted instead of double-POSTing, and a definitive upstream
 	// invalid_grant clears only the dead refresh grant so a still-working
 	// access token remains connected.
-	result, err := s.refresher.RefreshNow(ctx, row.RemoteSession, fallbackResource)
+	result, err := s.refresher.RefreshNow(ctx, row.RemoteSession, "")
 	if err != nil {
 		// Operator-actionable failures carry a public-safe reason; surface it so
 		// the admin sees why the refresh failed instead of a generic error.

--- a/server/internal/remotesessions/platformmigrateissuer_test.go
+++ b/server/internal/remotesessions/platformmigrateissuer_test.go
@@ -131,7 +131,7 @@ func TestMigrateToGlobalIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{sourceUUID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
 
@@ -143,7 +143,7 @@ func TestMigrateToGlobalIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T)
 
 	// The same token value resolves, now keyed by the platform issuer. Only the
 	// client's foreign key moved.
-	tokens, err = mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err = mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{targetID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
 

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -1647,6 +1647,9 @@ RETURNING c.*;
 -- MCP servers attached to a client through its user_session_issuer(s). Callers
 -- establish the client belongs to the org upstream
 -- (GetOrganizationRemoteSessionClientByID).
+--
+-- A soft-deleted upstream must not contribute its URL: the derived RFC 8707
+-- resource is sent to the authorization server and recorded on new grants.
 SELECT DISTINCT
     m.id,
     m.project_id,
@@ -1656,7 +1659,7 @@ SELECT DISTINCT
     COALESCE(rms.url, '')::text AS url
 FROM mcp_servers AS m
 JOIN projects AS p ON p.id = m.project_id
-LEFT JOIN remote_mcp_servers AS rms ON rms.id = m.remote_mcp_server_id
+LEFT JOIN remote_mcp_servers AS rms ON rms.id = m.remote_mcp_server_id AND rms.deleted IS FALSE
 WHERE m.deleted IS FALSE
   AND m.user_session_issuer_id IN (
       SELECT link.user_session_issuer_id

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -77,9 +77,9 @@ func NewRefreshService(logger *slog.Logger, db *pgxpool.Pool, enc *encryption.Cl
 }
 
 // FallbackResourceForClient derives the RFC 8707 resource for a client from
-// its attached MCP servers — the same derivation the org-admin refresh handler
-// uses. Callers reach for it only when a session predates the persisted
-// resource column (remote_sessions.resource IS NULL).
+// its attached MCP servers. RefreshNow applies it to rows that carry no
+// persisted resource; the consent connect arm applies it to the grant it is
+// about to mint.
 func (s *RefreshService) FallbackResourceForClient(ctx context.Context, clientID uuid.UUID) (string, error) {
 	rows, err := remotesessions_repo.New(s.db).ListOrganizationMcpServersForClient(ctx, clientID)
 	if err != nil {
@@ -118,15 +118,15 @@ func refreshLockKey(subject urn.SessionSubject, clientID uuid.UUID) string {
 // that finished while this caller was still acquiring.
 //
 // The refresh_token grant replays the session's persisted RFC 8707 resource
-// binding when one was captured at code exchange; fallbackResource covers rows
-// minted before the resource column existed (callers derive it from the
-// client's attached MCP servers, or pass "").
+// binding when one was captured at code exchange. Rows minted before the
+// resource column existed fall back to callerResource, and then to the
+// client's own derivation — one derivation rule for every refresh path.
 //
 // A non-nil error is either an operator-actionable *TokenRefreshError or an
 // internal infrastructure failure. A definitive invalid_grant clears only the
 // refresh grant: the existing access token remains usable until its own known
 // expiry. This keeps proactive refresh failure from forcing a reconnect.
-func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_repo.RemoteSession, fallbackResource string) (RefreshResult, error) {
+func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_repo.RemoteSession, callerResource string) (RefreshResult, error) {
 	var zero RefreshResult
 	q := remotesessions_repo.New(s.db)
 
@@ -217,7 +217,17 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 	// request-derived value can drift from it (e.g. after MCP server moves).
 	resource := conv.FromPGTextOrEmpty[string](sess.Resource)
 	if resource == "" {
-		resource = fallbackResource
+		resource = callerResource
+	}
+	if resource == "" {
+		// Legacy row minted before the resource column, with no caller value:
+		// derive the client's own so it is never replayed against another
+		// upstream's audience.
+		var err error
+		resource, err = s.FallbackResourceForClient(ctx, sess.RemoteSessionClientID)
+		if err != nil {
+			return zero, fmt.Errorf("derive fallback resource: %w", err)
+		}
 	}
 
 	updated, accessToken, refreshErr := refreshSessionTokens(ctx, q, s.enc, s.policy, sess, resource)

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -2780,7 +2780,7 @@ SELECT DISTINCT
     COALESCE(rms.url, '')::text AS url
 FROM mcp_servers AS m
 JOIN projects AS p ON p.id = m.project_id
-LEFT JOIN remote_mcp_servers AS rms ON rms.id = m.remote_mcp_server_id
+LEFT JOIN remote_mcp_servers AS rms ON rms.id = m.remote_mcp_server_id AND rms.deleted IS FALSE
 WHERE m.deleted IS FALSE
   AND m.user_session_issuer_id IN (
       SELECT link.user_session_issuer_id
@@ -2802,6 +2802,9 @@ type ListOrganizationMcpServersForClientRow struct {
 // MCP servers attached to a client through its user_session_issuer(s). Callers
 // establish the client belongs to the org upstream
 // (GetOrganizationRemoteSessionClientByID).
+//
+// A soft-deleted upstream must not contribute its URL: the derived RFC 8707
+// resource is sent to the authorization server and recorded on new grants.
 func (q *Queries) ListOrganizationMcpServersForClient(ctx context.Context, remoteSessionClientID uuid.UUID) ([]ListOrganizationMcpServersForClientRow, error) {
 	rows, err := q.db.Query(ctx, listOrganizationMcpServersForClient, remoteSessionClientID)
 	if err != nil {

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -425,6 +425,29 @@ func seedOrgLevelRemoteClient(t *testing.T, ctx context.Context, conn *pgxpool.P
 	return created.ID
 }
 
+// attachRemoteMcpServerToIssuer binds a remote-backed MCP server to issuerID
+// so clients on that issuer derive serverURL as their resource.
+func attachRemoteMcpServerToIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, issuerID uuid.UUID, slug, serverURL string) {
+	t.Helper()
+	remoteServer, err := remotemcprepo.New(conn).CreateServer(ctx, remotemcprepo.CreateServerParams{
+		ID:            uuid.New(),
+		ProjectID:     projectID,
+		TransportType: "sse",
+		Url:           serverURL,
+	})
+	require.NoError(t, err)
+	_, err = mcpserversrepo.New(conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:                  uuid.New(),
+		ProjectID:           projectID,
+		Name:                conv.ToPGText(slug),
+		Slug:                conv.ToPGText(slug),
+		RemoteMcpServerID:   conv.ToNullUUID(remoteServer.ID),
+		Visibility:          "private",
+		UserSessionIssuerID: conv.ToNullUUID(issuerID),
+	})
+	require.NoError(t, err)
+}
+
 // seedMCPServerInOrg creates a project in the supplied organization and an MCP
 // server within it, returning the MCP server id. Used to exercise cross-org
 // isolation on org-admin MCP server lookups.

--- a/server/internal/remotesessions/sharedcredential_test.go
+++ b/server/internal/remotesessions/sharedcredential_test.go
@@ -219,7 +219,7 @@ func TestRefreshRemoteSession_SiblingIssuerRefreshesSharedCredential(t *testing.
 	subject := seedRefreshableSharedSession(t, ctx, ti, provenance, clientID, "shared-refresh-sibling")
 	sibling := bindSiblingIssuer(t, ctx, ti, clientID, "usi-shared-refresh-sibling-b")
 
-	result, err := newDisconnectChallengeManager(t, ti).RefreshRemoteSession(ctx, subject, *authCtx.ProjectID, authCtx.ActiveOrganizationID, sibling, clientID, "")
+	result, err := newDisconnectChallengeManager(t, ti).RefreshRemoteSession(ctx, subject, *authCtx.ProjectID, authCtx.ActiveOrganizationID, sibling, clientID)
 	require.NoError(t, err, "a sibling issuer bound to the same client must be able to refresh the shared credential")
 	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "sibling-refreshed-access", result.AccessToken)
@@ -255,7 +255,7 @@ func TestRefreshRemoteSession_OrgLevelClientBindingAuthorizes(t *testing.T) {
 
 	mgr := newDisconnectChallengeManager(t, ti)
 
-	result, err := mgr.RefreshRemoteSession(ctx, subject, *authCtx.ProjectID, authCtx.ActiveOrganizationID, usi, clientID, "")
+	result, err := mgr.RefreshRemoteSession(ctx, subject, *authCtx.ProjectID, authCtx.ActiveOrganizationID, usi, clientID)
 	require.NoError(t, err, "the org-level client arm of the binding probe must authorize the refresh")
 	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "org-refreshed-access", result.AccessToken)
@@ -291,7 +291,7 @@ func TestSharedCredentialLifecycle_WrongProjectRejected(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, n, "a foreign project must not disconnect the credential")
 
-	_, err = mgr.RefreshRemoteSession(ctx, fx.subject, foreignProject, fx.organizationID, fx.userIssuerID, fx.clientID, "")
+	_, err = mgr.RefreshRemoteSession(ctx, fx.subject, foreignProject, fx.organizationID, fx.userIssuerID, fx.clientID)
 	require.ErrorIs(t, err, remotesessions.ErrRemoteSessionNotRefreshable, "a foreign project must not spend the refresh grant")
 
 	_, err = repo.New(ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
@@ -311,7 +311,7 @@ func TestRefreshRemoteSession_UnboundIssuerFailsClosed(t *testing.T) {
 	fx := seedRevocableSession(t, ctx, ti, "shared-refresh-unbound", "", "s3cret", true)
 	unbound := createUserSessionIssuer(t, ctx, ti.conn, "usi-x-shared-refresh-unbound")
 
-	_, err := newDisconnectChallengeManager(t, ti).RefreshRemoteSession(ctx, fx.subject, fx.projectID, authCtx.ActiveOrganizationID, unbound, fx.clientID, "")
+	_, err := newDisconnectChallengeManager(t, ti).RefreshRemoteSession(ctx, fx.subject, fx.projectID, authCtx.ActiveOrganizationID, unbound, fx.clientID)
 	require.ErrorIs(t, err, remotesessions.ErrRemoteSessionNotRefreshable, "an unbound issuer must not be able to spend the shared refresh grant")
 }
 

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -345,7 +345,6 @@ func (m *ChallengeManager) ResolveAccessTokens(
 	organizationID string,
 	userSessionIssuerID uuid.UUID,
 	subject urn.SessionSubject,
-	resource string,
 ) (map[uuid.UUID]UpstreamToken, error) {
 	clients, err := m.listRemoteSessionClientRowsForUserSessionIssuer(ctx, projectID, organizationID, userSessionIssuerID)
 	if err != nil {
@@ -376,7 +375,9 @@ func (m *ChallengeManager) ResolveAccessTokens(
 		// the same row load that produced the token, so a disconnect+reconnect
 		// between two reads can never pair an old token with a new row's
 		// resource.
-		resolved, err := m.resolveUpstreamToken(ctx, c.ClientID, subject, resource)
+		// No endpoint-level fallback: a refresh of a legacy NULL-resource row
+		// derives the client's own resource in validateAndRefresh.
+		resolved, err := m.resolveUpstreamToken(ctx, c.ClientID, subject, "")
 		if err != nil {
 			return nil, fmt.Errorf("resolve access token: %w", err)
 		}
@@ -421,6 +422,16 @@ func (m *ChallengeManager) validateAndRefresh(
 
 	if !hasRefresh {
 		return "", ErrNoValidToken
+	}
+
+	// Legacy NULL-resource row with no caller fallback: derive the client's
+	// own resource so the grant is never replayed against another upstream's.
+	if resource == "" && !sess.Resource.Valid {
+		derived, err := m.refresher.FallbackResourceForClient(ctx, sess.RemoteSessionClientID)
+		if err != nil {
+			return "", fmt.Errorf("derive fallback resource: %w", err)
+		}
+		resource = derived
 	}
 
 	res, err := m.refresher.RefreshNow(ctx, sess, resource)

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -376,7 +376,7 @@ func (m *ChallengeManager) ResolveAccessTokens(
 		// between two reads can never pair an old token with a new row's
 		// resource.
 		// No endpoint-level fallback: a refresh of a legacy NULL-resource row
-		// derives the client's own resource in validateAndRefresh.
+		// derives the client's own resource in RefreshNow.
 		resolved, err := m.resolveUpstreamToken(ctx, c.ClientID, subject, "")
 		if err != nil {
 			return nil, fmt.Errorf("resolve access token: %w", err)
@@ -422,16 +422,6 @@ func (m *ChallengeManager) validateAndRefresh(
 
 	if !hasRefresh {
 		return "", ErrNoValidToken
-	}
-
-	// Legacy NULL-resource row with no caller fallback: derive the client's
-	// own resource so the grant is never replayed against another upstream's.
-	if resource == "" && !sess.Resource.Valid {
-		derived, err := m.refresher.FallbackResourceForClient(ctx, sess.RemoteSessionClientID)
-		if err != nil {
-			return "", fmt.Errorf("derive fallback resource: %w", err)
-		}
-		resource = derived
 	}
 
 	res, err := m.refresher.RefreshNow(ctx, sess, resource)

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -124,7 +124,7 @@ func TestResolveAccessTokens_SingleClientHappyPath(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{remoteIssuerID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientID}}, tokens)
 }
@@ -209,7 +209,7 @@ func TestResolveAccessTokens_NoClientsReturnsNil(t *testing.T) {
 	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-resolve-empty")
 	subject := urn.NewUserSubject("resolve-empty-subject")
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Nil(t, tokens)
 }
@@ -229,7 +229,7 @@ func TestResolveAccessTokens_MissingSessionReturnsErrNoValidToken(t *testing.T) 
 	seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, authCtx.ActiveOrganizationID, "rsi-resolve-missing")
 
 	subject := urn.NewUserSubject("resolve-missing-subject")
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.ErrorIs(t, err, remotesessions.ErrNoValidToken)
 	require.Nil(t, tokens)
 }
@@ -261,7 +261,7 @@ func TestResolveAccessTokens_ExpiredAuthorizationRejectsUnexpiredAccessToken(t *
 	})
 	require.NoError(t, err)
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.ErrorIs(t, err, remotesessions.ErrNoValidToken)
 	require.Nil(t, tokens)
 }
@@ -297,7 +297,7 @@ func TestResolveAccessTokens_TenantClientOnPlatformIssuer(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{platformID: {Token: "platform-upstream-token", Resource: "", RemoteSessionClientID: uuid.MustParse(clientID)}}, tokens)
 }
@@ -344,7 +344,7 @@ func TestResolveAccessTokens_MultipleUpstreamsCarryQualifiedResources(t *testing
 		require.NoError(t, err)
 	}
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{
 		remoteIssuerA: {Token: "token-a", Resource: "https://a.example.com/mcp", RemoteSessionClientID: clientA},

--- a/server/internal/remotesessions/upstreamrevoke.go
+++ b/server/internal/remotesessions/upstreamrevoke.go
@@ -82,11 +82,12 @@ type UpstreamRevoker struct {
 
 	// client is built once and shared by every revocation. Guardian's pooled
 	// transport is meant for exactly this — a long-lived client making repeated
-	// requests to the same hosts — and a bulk revoke is the case it pays off on,
-	// since every session in a batch shares one issuer. Constructing one per
-	// call instead would open a connection per session and hold each idle until
-	// it timed out, which is the file-descriptor leak PooledClient's own
-	// documentation warns against.
+	// requests to the same hosts — and a bulk revoke is the case it pays off
+	// on: even a batch spanning several clients' issuers repeats each host, and
+	// the pool amortizes every repeat. Constructing one per call instead would
+	// open a connection per session and hold each idle until it timed out,
+	// which is the file-descriptor leak PooledClient's own documentation warns
+	// against.
 	client *guardian.HTTPClient
 
 	metrics *remotesessionmetrics.Revoke

--- a/server/internal/remotesessions/upstreamrevoke.go
+++ b/server/internal/remotesessions/upstreamrevoke.go
@@ -62,10 +62,9 @@ const (
 	// when it expires are counted and logged rather than silently dropped.
 	bulkRevokeTimeout = 30 * time.Second
 
-	// bulkRevokeConcurrency caps in-flight POSTs within one batch. Every session
-	// on a client shares that client's issuer, so the whole batch lands on a
-	// single upstream host and an unbounded fan-out would read as a burst from
-	// Gram against one customer's identity provider.
+	// bulkRevokeConcurrency caps in-flight POSTs within one batch. A batch can
+	// span several clients' upstream hosts, but an unbounded fan-out would
+	// still read as a burst from Gram against a customer's identity provider.
 	bulkRevokeConcurrency = 8
 )
 
@@ -222,8 +221,8 @@ func (r *UpstreamRevoker) RevokeDetached(ctx context.Context, cred RevokedCreden
 // RevokeDetached. Two bounds on top of that, because a batch is unbounded in a
 // way a single revoke is not:
 //
-//   - bulkRevokeConcurrency in flight at once. The batch shares one issuer, so
-//     the fan-out is aimed at a single upstream host.
+//   - bulkRevokeConcurrency in flight at once. A batch can span multiple
+//     clients' hosts, so the cap bounds the total fan-out, not one host's.
 //   - bulkRevokeTimeout across the whole batch, with each session still holding
 //     its own upstreamRevokeTimeout inside it. Without the per-session bound one
 //     unresponsive upstream would hold a concurrency slot for the entire batch
@@ -278,6 +277,7 @@ func (r *UpstreamRevoker) RevokeAllDetached(ctx context.Context, creds []Revoked
 		return
 	}
 
+	// Attribution is best-effort: a batch can span clients, log the first.
 	r.logger.WarnContext(ctx, "upstream revoke: batch budget exhausted before every session was attempted",
 		attr.SlogRemoteSessionClientID(creds[0].RemoteSessionClientID.String()),
 		attr.SlogRemoteSessionRevokeDroppedCount(dropped),


### PR DESCRIPTION
Derives the RFC 8707 resource per remote-session client instead of threading the endpoint-level `UpstreamResource` into every bound client's OAuth flow (AGE-3328).

Fits the shared-credential routing layer from #5572: `routeUpstreamToken` matches credentials by their grant-time resource, so the mint/refresh arms must record each client's own resource or multi-binding endpoints record duplicates and fail closed.

Critical lines:
- `server/internal/mcp/authnchallenge_consent_action.go` — connect arm derives via `FallbackResourceForClient(client.ID)`; empty derivation sends/records none.
- `server/internal/remotesessions/challenge.go` — `RefreshRemoteSession` drops its `fallbackResource` param and derives internally, NULL-stored-resource only.
- `server/internal/remotesessions/tokenservice.go` (`validateAndRefresh`) — the lazy request-time refresh derives per client too; `ResolveAccessTokens` no longer accepts an endpoint-level resource, so no caller can replay one client's grant against another's upstream.

The platform-MCP adapter's explicit per-provider resource is untouched and stays authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the RFC 8707 resource per remote-session client across connect, explicit refresh, and lazy refresh so multi-binding endpoints route correctly. Previously we threaded the endpoint-level resource into all clients; now each client derives its own and, on ambiguity, sends none. This prevents wrong-audience grants and duplicate remote_sessions.resource values.

- Connect/consent: derive via FallbackResourceForClient(clientID); ambiguity → no resource; derivation errors fail closed before redirect. The platform MCP adapter’s explicit per-provider resource remains authoritative.
- Refresh: RefreshRemoteSession drops the fallbackResource argument and derives a fallback only when the stored resource is NULL; a valid-but-empty stored resource continues to omit the param. The lazy path (ResolveAccessTokens) removed the resource argument and derives per client during validateAndRefresh; an explicit caller fallback still wins.
- Exposes ChallengeManager.FallbackResourceForClient for callers that need the derived value.
- Tightens tests to cover ambiguous/none/stored-resource cases; updates bulk-revoke comments (no behavior change).

Must land before enabling multi-binding endpoints in production.

- Migration
  - Update call sites:
    - ResolveAccessTokens(ctx, projectID, orgID, userSessionIssuerID, subject) (remove the resource argument).
    - RefreshRemoteSession(ctx, subject, projectID, orgID, userSessionIssuerID, clientID) (remove the fallbackResource argument).
  - Stop threading endpoint-level resources into OAuth flows; rely on per-client derivation.

<sup>Written for commit 638be5190fc4d52670c9683998467f37c604fe64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

