### PR TITLE
fix: backfill missing grant resources during refresh

### DIFF
--- a/.changeset/refresh-backfills-legacy-resource.md
+++ b/.changeset/refresh-backfills-legacy-resource.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Successful remote-session refreshes now backfill the RFC 8707 resource binding onto legacy rows that predate the resource column. The refresh CAS write stamps the resource the refresh grant actually used, but only when the stored value is NULL and the derivation is unambiguous — a stored binding is never overwritten, and an empty derivation leaves NULL in place. All refresh entry points (lazy MCP resolution, org-admin manual refresh, and the scheduled background sweep) converge through this write, so pre-column credentials now pick up a persisted routing key on their next refresh.

--- a/server/internal/remotesessions/cimd_test.go
+++ b/server/internal/remotesessions/cimd_test.go
@@ -8,7 +8,6 @@ package remotesessions_test
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -353,24 +352,7 @@ func TestCIMD_RefreshUsesMetadataURLAsClientIDWithoutBasicAuth(t *testing.T) {
 	require.NotNil(t, authCtx.ProjectID)
 
 	var spy upstreamSpy
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			spy.handlerErr = err
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		form, err := url.ParseQuery(string(body))
-		if err != nil {
-			spy.handlerErr = err
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		spy.form = form
-		spy.authHdr = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"refreshed-access","token_type":"Bearer","expires_in":3600,"refresh_token":"refreshed-refresh"}`))
-	}))
+	tokenServer := httptest.NewServer(spyRefreshHandler(&spy))
 	t.Cleanup(tokenServer.Close)
 
 	// One encryption client shared between the manager (which decrypts the

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -700,6 +700,7 @@ RETURNING *;
 -- another writer won or the session was revoked; both end in a re-auth challenge.
 -- Keyed by (subject, client) + CAS only: the session's user_session_issuer_id
 -- is provenance, never part of the credential's identity.
+-- backfill_resource stamps the refresh's RFC 8707 resource onto legacy NULL rows; COALESCE never overwrites a stored binding.
 UPDATE remote_sessions
 SET
     access_token_encrypted = @access_token_encrypted,
@@ -708,6 +709,7 @@ SET
     authorization_expires_at = @authorization_expires_at,
     refresh_expires_at = @refresh_expires_at,
     scopes = @scopes,
+    resource = COALESCE(resource, sqlc.narg('backfill_resource')),
     updated_at = clock_timestamp()
 WHERE subject_urn = @subject_urn
   AND remote_session_client_id = @remote_session_client_id

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -700,7 +700,8 @@ RETURNING *;
 -- another writer won or the session was revoked; both end in a re-auth challenge.
 -- Keyed by (subject, client) + CAS only: the session's user_session_issuer_id
 -- is provenance, never part of the credential's identity.
--- backfill_resource stamps the refresh's RFC 8707 resource onto legacy NULL rows; COALESCE never overwrites a stored binding.
+-- backfill_resource stamps the refresh's RFC 8707 resource onto legacy NULL rows;
+-- COALESCE never overwrites a stored binding and NULLIF keeps an empty backfill NULL.
 UPDATE remote_sessions
 SET
     access_token_encrypted = @access_token_encrypted,
@@ -709,7 +710,7 @@ SET
     authorization_expires_at = @authorization_expires_at,
     refresh_expires_at = @refresh_expires_at,
     scopes = @scopes,
-    resource = COALESCE(resource, sqlc.narg('backfill_resource')),
+    resource = COALESCE(resource, NULLIF(sqlc.narg('backfill_resource')::text, '')),
     updated_at = clock_timestamp()
 WHERE subject_urn = @subject_urn
   AND remote_session_client_id = @remote_session_client_id

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -222,6 +222,15 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 
 	updated, accessToken, refreshErr := refreshSessionTokens(ctx, q, s.enc, s.policy, sess, resource)
 	if refreshErr == nil {
+		// The stamp is permanent, so record which rows the backfill wrote and
+		// what it wrote — the only way to find them again if a value is wrong.
+		if !sess.Resource.Valid && updated.Resource.Valid {
+			s.logger.InfoContext(ctx, "backfilled the remote session resource binding during refresh",
+				attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
+				attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
+				attr.SlogOAuthResource(updated.Resource.String),
+			)
+		}
 		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: RefreshOutcomeRefreshed}, nil
 	}
 

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -5450,7 +5450,7 @@ SET
     authorization_expires_at = $4,
     refresh_expires_at = $5,
     scopes = $6,
-    resource = COALESCE(resource, $7),
+    resource = COALESCE(resource, NULLIF($7::text, '')),
     updated_at = clock_timestamp()
 WHERE subject_urn = $8
   AND remote_session_client_id = $9
@@ -5477,7 +5477,8 @@ type UpdateRemoteSessionTokensIfUnchangedParams struct {
 // another writer won or the session was revoked; both end in a re-auth challenge.
 // Keyed by (subject, client) + CAS only: the session's user_session_issuer_id
 // is provenance, never part of the credential's identity.
-// backfill_resource stamps the refresh's RFC 8707 resource onto legacy NULL rows; COALESCE never overwrites a stored binding.
+// backfill_resource stamps the refresh's RFC 8707 resource onto legacy NULL rows;
+// COALESCE never overwrites a stored binding and NULLIF keeps an empty backfill NULL.
 func (q *Queries) UpdateRemoteSessionTokensIfUnchanged(ctx context.Context, arg UpdateRemoteSessionTokensIfUnchangedParams) (RemoteSession, error) {
 	row := q.db.QueryRow(ctx, updateRemoteSessionTokensIfUnchanged,
 		arg.AccessTokenEncrypted,

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -5450,11 +5450,12 @@ SET
     authorization_expires_at = $4,
     refresh_expires_at = $5,
     scopes = $6,
+    resource = COALESCE(resource, $7),
     updated_at = clock_timestamp()
-WHERE subject_urn = $7
-  AND remote_session_client_id = $8
+WHERE subject_urn = $8
+  AND remote_session_client_id = $9
   AND deleted IS FALSE
-  AND updated_at = $9
+  AND updated_at = $10
 RETURNING id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, access_expires_at, refresh_token_encrypted, authorization_expires_at, refresh_expires_at, scopes, resource, auto_refresh, last_refresh_attempt_at, last_used_at, created_at, updated_at, deleted_at, deleted
 `
 
@@ -5465,6 +5466,7 @@ type UpdateRemoteSessionTokensIfUnchangedParams struct {
 	AuthorizationExpiresAt pgtype.Timestamptz
 	RefreshExpiresAt       pgtype.Timestamptz
 	Scopes                 []string
+	BackfillResource       pgtype.Text
 	SubjectUrn             urn.SessionSubject
 	RemoteSessionClientID  uuid.UUID
 	ExpectedUpdatedAt      pgtype.Timestamptz
@@ -5475,6 +5477,7 @@ type UpdateRemoteSessionTokensIfUnchangedParams struct {
 // another writer won or the session was revoked; both end in a re-auth challenge.
 // Keyed by (subject, client) + CAS only: the session's user_session_issuer_id
 // is provenance, never part of the credential's identity.
+// backfill_resource stamps the refresh's RFC 8707 resource onto legacy NULL rows; COALESCE never overwrites a stored binding.
 func (q *Queries) UpdateRemoteSessionTokensIfUnchanged(ctx context.Context, arg UpdateRemoteSessionTokensIfUnchangedParams) (RemoteSession, error) {
 	row := q.db.QueryRow(ctx, updateRemoteSessionTokensIfUnchanged,
 		arg.AccessTokenEncrypted,
@@ -5483,6 +5486,7 @@ func (q *Queries) UpdateRemoteSessionTokensIfUnchanged(ctx context.Context, arg 
 		arg.AuthorizationExpiresAt,
 		arg.RefreshExpiresAt,
 		arg.Scopes,
+		arg.BackfillResource,
 		arg.SubjectUrn,
 		arg.RemoteSessionClientID,
 		arg.ExpectedUpdatedAt,

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -168,7 +168,9 @@ func (m *ChallengeManager) resolveUpstreamToken(
 		return zero, fmt.Errorf("get active remote_session: %w", err)
 	}
 
-	tok, refreshed, err := m.validateAndRefresh(ctx, sess, resource)
+	// Rebinds sess to the row the token came from, so a refresh that backfilled
+	// a legacy NULL resource routes on this same request.
+	tok, sess, err := m.validateAndRefresh(ctx, sess, resource)
 	if err != nil {
 		// A known-expired access token with no usable refresh grant is the
 		// ordinary reconnect path. The downstream 401 carries the challenge;
@@ -197,17 +199,6 @@ func (m *ChallengeManager) resolveUpstreamToken(
 			attr.SlogError(err),
 		)
 		return zero, nil
-	}
-
-	// A refresh rewrote the row this request loaded — most notably it may have
-	// backfilled a legacy NULL resource. Read the returned metadata from the
-	// post-refresh row so the request that heals the row routes with the
-	// backfilled resource instead of failing closed on the pre-refresh value
-	// (the next request would see the stored binding; this one must too). On a
-	// lost refresh race the refreshed row is the winner's re-read row, pairing
-	// the adopted token with the resource that token was actually minted for.
-	if refreshed != nil {
-		sess = *refreshed
 	}
 
 	// Stamped only on the success path: a resolved token is one that is about
@@ -403,12 +394,11 @@ func (m *ChallengeManager) ResolveAccessTokens(
 // via the upstream /token endpoint when the token is past its usable window
 // and a refresh_token is present.
 //
-// When a refresh ran, the returned *RemoteSession is the post-refresh row the
-// token came from (the CAS write's RETURNING row, or the concurrent winner's
-// re-read row when this caller lost the race) so the caller reads grant-time
-// metadata — the possibly just-backfilled RFC 8707 resource — from the same
-// row as the token. It is nil when the still-valid stored token was served
-// as-is (sess is already the token's row) or when there is no usable token.
+// The returned row is the one the token came from — sess when the stored token
+// was served as-is, and the post-refresh row otherwise (the CAS write's
+// RETURNING row, or the concurrent winner's re-read row when this caller lost
+// the race) — so the caller reads grant-time metadata, notably the possibly
+// just-backfilled RFC 8707 resource, from the same row as the token.
 //
 // The usable window depends on what the upstream told us:
 //   - access_expires_at set: the upstream-stated expiry governs.
@@ -421,10 +411,10 @@ func (m *ChallengeManager) validateAndRefresh(
 	ctx context.Context,
 	sess remotesessions_repo.RemoteSession,
 	resource string,
-) (string, *remotesessions_repo.RemoteSession, error) {
+) (string, remotesessions_repo.RemoteSession, error) {
 	now := time.Now()
 	if sess.AuthorizationExpiresAt.Valid && !sess.AuthorizationExpiresAt.Time.After(now) {
-		return "", nil, ErrNoValidToken
+		return "", sess, ErrNoValidToken
 	}
 
 	hasRefresh := sess.RefreshTokenEncrypted.Valid && sess.RefreshTokenEncrypted.String != ""
@@ -432,26 +422,22 @@ func (m *ChallengeManager) validateAndRefresh(
 	if !sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now) {
 		plain, err := m.enc.Decrypt(sess.AccessTokenEncrypted)
 		if err != nil {
-			return "", nil, fmt.Errorf("decrypt access token: %w", err)
+			return "", sess, fmt.Errorf("decrypt access token: %w", err)
 		}
-		return plain, nil, nil
+		return plain, sess, nil
 	}
 
 	if !hasRefresh {
-		return "", nil, ErrNoValidToken
+		return "", sess, ErrNoValidToken
 	}
 
 	res, err := m.refresher.RefreshNow(ctx, sess, resource)
 	if err != nil {
-		return "", nil, err
+		return "", sess, err
 	}
 	// RefreshOutcomeSessionInactive lands here as an empty token, which the
-	// caller treats the same as "never linked". Its zero-valued Session is not
-	// a row to read metadata from, so it is not surfaced.
-	if res.Outcome == RefreshOutcomeSessionInactive {
-		return "", nil, nil
-	}
-	return res.AccessToken, &res.Session, nil
+	// caller treats the same as "never linked".
+	return res.AccessToken, res.Session, nil
 }
 
 // refreshSessionTokens POSTs grant_type=refresh_token to the upstream token
@@ -594,7 +580,7 @@ func refreshSessionTokens(
 		AuthorizationExpiresAt: authorizationExpires,
 		RefreshExpiresAt:       refreshExpires,
 		Scopes:                 scopes,
-		BackfillResource:       conv.ToPGTextEmpty(resource), // query's COALESCE keeps a stored binding; "" maps to NULL
+		BackfillResource:       conv.ToPGTextEmpty(resource), // the query's COALESCE/NULLIF keeps a stored binding and rejects an empty stamp
 		ExpectedUpdatedAt:      sess.UpdatedAt,
 	})
 	if err != nil {

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -168,7 +168,7 @@ func (m *ChallengeManager) resolveUpstreamToken(
 		return zero, fmt.Errorf("get active remote_session: %w", err)
 	}
 
-	tok, err := m.validateAndRefresh(ctx, sess, resource)
+	tok, refreshed, err := m.validateAndRefresh(ctx, sess, resource)
 	if err != nil {
 		// A known-expired access token with no usable refresh grant is the
 		// ordinary reconnect path. The downstream 401 carries the challenge;
@@ -197,6 +197,17 @@ func (m *ChallengeManager) resolveUpstreamToken(
 			attr.SlogError(err),
 		)
 		return zero, nil
+	}
+
+	// A refresh rewrote the row this request loaded — most notably it may have
+	// backfilled a legacy NULL resource. Read the returned metadata from the
+	// post-refresh row so the request that heals the row routes with the
+	// backfilled resource instead of failing closed on the pre-refresh value
+	// (the next request would see the stored binding; this one must too). On a
+	// lost refresh race the refreshed row is the winner's re-read row, pairing
+	// the adopted token with the resource that token was actually minted for.
+	if refreshed != nil {
+		sess = *refreshed
 	}
 
 	// Stamped only on the success path: a resolved token is one that is about
@@ -392,6 +403,13 @@ func (m *ChallengeManager) ResolveAccessTokens(
 // via the upstream /token endpoint when the token is past its usable window
 // and a refresh_token is present.
 //
+// When a refresh ran, the returned *RemoteSession is the post-refresh row the
+// token came from (the CAS write's RETURNING row, or the concurrent winner's
+// re-read row when this caller lost the race) so the caller reads grant-time
+// metadata — the possibly just-backfilled RFC 8707 resource — from the same
+// row as the token. It is nil when the still-valid stored token was served
+// as-is (sess is already the token's row) or when there is no usable token.
+//
 // The usable window depends on what the upstream told us:
 //   - access_expires_at set: the upstream-stated expiry governs.
 //   - access_expires_at NULL: no expiry was reported, so the stored access
@@ -403,10 +421,10 @@ func (m *ChallengeManager) validateAndRefresh(
 	ctx context.Context,
 	sess remotesessions_repo.RemoteSession,
 	resource string,
-) (string, error) {
+) (string, *remotesessions_repo.RemoteSession, error) {
 	now := time.Now()
 	if sess.AuthorizationExpiresAt.Valid && !sess.AuthorizationExpiresAt.Time.After(now) {
-		return "", ErrNoValidToken
+		return "", nil, ErrNoValidToken
 	}
 
 	hasRefresh := sess.RefreshTokenEncrypted.Valid && sess.RefreshTokenEncrypted.String != ""
@@ -414,22 +432,26 @@ func (m *ChallengeManager) validateAndRefresh(
 	if !sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now) {
 		plain, err := m.enc.Decrypt(sess.AccessTokenEncrypted)
 		if err != nil {
-			return "", fmt.Errorf("decrypt access token: %w", err)
+			return "", nil, fmt.Errorf("decrypt access token: %w", err)
 		}
-		return plain, nil
+		return plain, nil, nil
 	}
 
 	if !hasRefresh {
-		return "", ErrNoValidToken
+		return "", nil, ErrNoValidToken
 	}
 
 	res, err := m.refresher.RefreshNow(ctx, sess, resource)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	// RefreshOutcomeSessionInactive lands here as an empty token, which the
-	// caller treats the same as "never linked".
-	return res.AccessToken, nil
+	// caller treats the same as "never linked". Its zero-valued Session is not
+	// a row to read metadata from, so it is not surfaced.
+	if res.Outcome == RefreshOutcomeSessionInactive {
+		return "", nil, nil
+	}
+	return res.AccessToken, &res.Session, nil
 }
 
 // refreshSessionTokens POSTs grant_type=refresh_token to the upstream token

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -572,6 +572,7 @@ func refreshSessionTokens(
 		AuthorizationExpiresAt: authorizationExpires,
 		RefreshExpiresAt:       refreshExpires,
 		Scopes:                 scopes,
+		BackfillResource:       conv.ToPGTextEmpty(resource), // query's COALESCE keeps a stored binding; "" maps to NULL
 		ExpectedUpdatedAt:      sess.UpdatedAt,
 	})
 	if err != nil {

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -28,15 +28,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *upstreamSpy) (context.Context, *remotesessions.ChallengeManager, *testInstance, uuid.UUID, urn.SessionSubject) {
-	t.Helper()
-
-	ctx, ti := newTestService(t)
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx.ProjectID)
-
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// spyRefreshHandler is the standard success token endpoint: it captures the
+// inbound form + Authorization header into spy and returns a rotated pair.
+func spyRefreshHandler(spy *upstreamSpy) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			spy.handlerErr = err
@@ -54,7 +49,30 @@ func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *up
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"refreshed-access","token_type":"Bearer","expires_in":3600,"refresh_token":"refreshed-refresh"}`))
-	}))
+	}
+}
+
+func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *upstreamSpy) (context.Context, *remotesessions.ChallengeManager, *testInstance, uuid.UUID, urn.SessionSubject) {
+	t.Helper()
+
+	slugSuffix := "aud-set"
+	if !audience.Valid {
+		slugSuffix = "aud-unset"
+	}
+	return setupRefreshFixtureWithHandler(t, slugSuffix, audience, spyRefreshHandler(spy))
+}
+
+// setupRefreshFixtureWithHandler seeds issuer + client + expired NULL-resource
+// session rows against a custom token endpoint handler, with per-test slugs.
+func setupRefreshFixtureWithHandler(t *testing.T, slugSuffix string, audience pgtype.Text, handler http.HandlerFunc) (context.Context, *remotesessions.ChallengeManager, *testInstance, uuid.UUID, urn.SessionSubject) {
+	t.Helper()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	tokenServer := httptest.NewServer(handler)
 	t.Cleanup(tokenServer.Close)
 
 	enc := testenv.NewEncryptionClient(t)
@@ -74,10 +92,6 @@ func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *up
 	)
 
 	q := repo.New(ti.conn)
-	slugSuffix := "aud-set"
-	if !audience.Valid {
-		slugSuffix = "aud-unset"
-	}
 	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
 		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Slug:                              "refresh-" + slugSuffix,

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *upstreamSpy) (context.Context, *remotesessions.ChallengeManager, uuid.UUID, urn.SessionSubject) {
+func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *upstreamSpy) (context.Context, *remotesessions.ChallengeManager, *testInstance, uuid.UUID, urn.SessionSubject) {
 	t.Helper()
 
 	ctx, ti := newTestService(t)
@@ -122,14 +122,14 @@ func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *up
 	subject := urn.NewUserSubject("refresh-subject-" + slugSuffix)
 	seedExpiredRemoteSession(t, ctx, ti, enc, subject, userIssuer, client.ID)
 
-	return ctx, mgr, client.ID, subject
+	return ctx, mgr, ti, client.ID, subject
 }
 
 func TestResolveAccessToken_RefreshIncludesAudience(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
+	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestResolveAccessToken_RefreshOmitsAudienceWhenUnset(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -30,6 +30,8 @@ import (
 
 // spyRefreshHandler is the standard success token endpoint: it captures the
 // inbound form + Authorization header into spy and returns a rotated pair.
+// Handler errors can't fail the test directly (testifylint go-require), so
+// they land in spy.handlerErr for the test goroutine to assert.
 func spyRefreshHandler(spy *upstreamSpy) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -52,14 +54,15 @@ func spyRefreshHandler(spy *upstreamSpy) http.HandlerFunc {
 	}
 }
 
-func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *upstreamSpy) (context.Context, *remotesessions.ChallengeManager, *testInstance, uuid.UUID, urn.SessionSubject) {
+func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *upstreamSpy) (context.Context, *remotesessions.ChallengeManager, uuid.UUID, urn.SessionSubject) {
 	t.Helper()
 
 	slugSuffix := "aud-set"
 	if !audience.Valid {
 		slugSuffix = "aud-unset"
 	}
-	return setupRefreshFixtureWithHandler(t, slugSuffix, audience, spyRefreshHandler(spy))
+	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithHandler(t, slugSuffix, audience, spyRefreshHandler(spy))
+	return ctx, mgr, clientID, subject
 }
 
 // setupRefreshFixtureWithHandler seeds issuer + client + expired NULL-resource
@@ -143,7 +146,7 @@ func TestResolveAccessToken_RefreshIncludesAudience(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
+	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)
@@ -157,7 +160,7 @@ func TestResolveAccessToken_RefreshOmitsAudienceWhenUnset(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)

--- a/server/internal/remotesessions/tokenservice_authmethod_test.go
+++ b/server/internal/remotesessions/tokenservice_authmethod_test.go
@@ -7,8 +7,6 @@ package remotesessions_test
 
 import (
 	"context"
-	"io"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -53,28 +51,7 @@ func setupRefreshFixture(t *testing.T, authMethod string, clientSecret string, s
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Errors inside this handler can't fail the test directly
-		// (testifylint go-require) — capture them and let the
-		// surrounding test goroutine assert after the round-trip.
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			spy.handlerErr = err
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		form, err := url.ParseQuery(string(body))
-		if err != nil {
-			spy.handlerErr = err
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		spy.form = form
-		spy.authHdr = r.Header.Get("Authorization")
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"refreshed-access","token_type":"Bearer","expires_in":3600,"refresh_token":"refreshed-refresh"}`))
-	}))
+	tokenServer := httptest.NewServer(spyRefreshHandler(spy))
 	t.Cleanup(tokenServer.Close)
 
 	// Build deps for ChallengeManager. Each must share state with the

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -1,0 +1,85 @@
+// A successful refresh stamps the resource it actually used onto legacy NULL
+// rows, never overwrites a stored binding, and leaves NULL when underivable.
+
+package remotesessions_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func getRemoteSessionRow(t *testing.T, ctx context.Context, ti *testInstance, clientID uuid.UUID, subject urn.SessionSubject) repo.RemoteSession {
+	t.Helper()
+
+	sess, err := repo.New(ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            subject,
+		RemoteSessionClientID: clientID,
+	})
+	require.NoError(t, err)
+	return sess
+}
+
+func TestResolveAccessToken_RefreshBackfillsNullResource(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+
+	require.False(t, getRemoteSessionRow(t, ctx, ti, clientID, subject).Resource.Valid, "fixture must seed a legacy NULL-resource row")
+
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "https://mcp.example.com/mcp")
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.Equal(t, "https://mcp.example.com/mcp", conv.FromPGTextOrEmpty[string](sess.Resource), "refresh must stamp the resource it used onto a legacy NULL row")
+}
+
+func TestResolveAccessToken_RefreshNeverOverwritesStoredResource(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+
+	const stored = "https://stored.example.com/mcp"
+	err := testrepo.New(ti.conn).SetRemoteSessionResourceFixture(ctx, testrepo.SetRemoteSessionResourceFixtureParams{
+		Resource:              conv.ToPGText(stored),
+		SubjectUrn:            subject,
+		RemoteSessionClientID: clientID,
+	})
+	require.NoError(t, err)
+
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "https://drifted.example.com/mcp")
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	require.Equal(t, stored, spy.form.Get("resource"), "refresh grant must replay the stored binding, not the caller's fallback")
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.Equal(t, stored, conv.FromPGTextOrEmpty[string](sess.Resource), "a stored resource binding must never be overwritten")
+}
+
+func TestResolveAccessToken_RefreshLeavesResourceNullWhenUnderivable(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.False(t, sess.Resource.Valid, "an empty derivation must leave the legacy row's resource NULL")
+}

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -216,6 +216,58 @@ func TestResolveAccessToken_RefreshBackfillIsIdempotent(t *testing.T) {
 	require.Equal(t, used, spy.form.Get("resource"), "the second grant must replay the stamped binding")
 }
 
+// The live-E2E blip: with a second bound credential present, per-upstream
+// routing depends on each entry's Resource, so the request whose refresh
+// backfills a legacy NULL resource must itself return the backfilled value.
+// Returning the pre-refresh empty resource fails routing closed
+// (legacy_null_resource) on exactly the request that healed the row, leaving
+// only the NEXT request to succeed.
+func TestResolveAccessTokens_RefreshingRequestCarriesBackfilledResource(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-same-request", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	row := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.False(t, row.Resource.Valid, "fixture must seed a legacy NULL-resource row")
+
+	refreshedClient, err := repo.New(ti.conn).GetRemoteSessionClientWithIssuerByID(ctx, clientID)
+	require.NoError(t, err)
+
+	// Second bound credential on a distinct remote issuer with a still-valid
+	// token — the multi-upstream shape that makes routing depend on Resource.
+	enc := testenv.NewEncryptionClient(t)
+	secondClient, secondIssuer := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, row.UserSessionIssuerID, authCtx.ActiveOrganizationID, "rsi-backfill-same-request")
+	secondAccess, err := enc.Encrypt([]byte("second-token"))
+	require.NoError(t, err)
+	_, err = repo.New(ti.conn).UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+		SubjectUrn:            subject,
+		UserSessionIssuerID:   row.UserSessionIssuerID,
+		RemoteSessionClientID: secondClient,
+		AccessTokenEncrypted:  secondAccess,
+		AccessExpiresAt:       conv.ToPGTimestamptz(time.Now().Add(time.Hour)),
+		Scopes:                []string{},
+		Resource:              conv.ToPGText("https://second.example.com/mcp"),
+	})
+	require.NoError(t, err)
+
+	const derived = "https://mcp.example.com/mcp"
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, row.UserSessionIssuerID, subject, derived)
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, derived, spy.form.Get("resource"), "the refresh grant must have carried the derived resource")
+
+	require.Equal(t, remotesessions.UpstreamToken{Token: "refreshed-access", Resource: derived, RemoteSessionClientID: clientID}, tokens[refreshedClient.RemoteSessionIssuerID],
+		"the request that backfills the resource must itself carry it, not the pre-refresh empty value")
+	require.Equal(t, remotesessions.UpstreamToken{Token: "second-token", Resource: "https://second.example.com/mcp", RemoteSessionClientID: secondClient}, tokens[secondIssuer])
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.Equal(t, derived, conv.FromPGTextOrEmpty[string](sess.Resource), "the backfill must also have been persisted")
+}
+
 // seedRemoteMCPServerForIssuer binds one remote MCP server at mcpURL to the
 // user session issuer so FallbackResourceForClient derives it unambiguously.
 func seedRemoteMCPServerForIssuer(t *testing.T, ctx context.Context, ti *testInstance, userIssuerID uuid.UUID, slug, mcpURL string) {

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -255,11 +255,11 @@ func TestResolveAccessTokens_RefreshingRequestCarriesBackfilledResource(t *testi
 	require.NoError(t, err)
 
 	const derived = "https://mcp.example.com/mcp"
-	// Attach the upstream the resource names, so the value under test is one
-	// the client derivation resolves rather than only a caller-supplied string.
+	// The refreshing client's sole attached upstream, so RefreshNow derives
+	// this resource: the value under test is never a caller-supplied string.
 	seedRemoteMCPServerForIssuer(t, ctx, ti, row.UserSessionIssuerID, "backfill-same-request-mcp", derived)
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, row.UserSessionIssuerID, subject, derived)
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, row.UserSessionIssuerID, subject)
 	require.NoError(t, err)
 	require.NoError(t, spy.handlerErr)
 	require.Equal(t, derived, spy.form.Get("resource"), "the refresh grant must have carried the derived resource")

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -301,6 +301,81 @@ func seedRemoteMCPServerForIssuer(t *testing.T, ctx context.Context, ti *testIns
 	require.NoError(t, err)
 }
 
+// attachClientUpstream gives one client a private user session issuer carrying
+// a single remote MCP server, so the client derives mcpURL and its siblings on
+// the shared issuer derive nothing from it.
+func attachClientUpstream(t *testing.T, ctx context.Context, ti *testInstance, clientID uuid.UUID, slug, mcpURL string) {
+	t.Helper()
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-"+slug)
+	require.NoError(t, repo.New(ti.conn).AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: clientID,
+		UserSessionIssuerID:   issuerID,
+	}))
+	seedRemoteMCPServerForIssuer(t, ctx, ti, issuerID, slug+"-mcp", mcpURL)
+}
+
+// Two clients bound to one issuer, each fronting a different upstream: the
+// backfill must stamp the refreshed client's own derived resource. Before the
+// derivation was per-client one endpoint-level resource reached every client,
+// so refreshing one could stamp a sibling's upstream onto its row — a
+// permanent wrong-audience binding that then routes every later request.
+func TestResolveAccessTokens_BackfillStampsTheRefreshedClientsOwnResource(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-wrong-client", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	row := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.False(t, row.Resource.Valid, "fixture must seed a legacy NULL-resource row")
+
+	q := repo.New(ti.conn)
+	refreshedClient, err := q.GetRemoteSessionClientWithIssuerByID(ctx, clientID)
+	require.NoError(t, err)
+
+	// The sibling holds a still-valid token minted for its own upstream, so
+	// nothing but a misattribution can put its resource on the refreshed row.
+	const siblingResource = "https://sibling.example.com/mcp"
+	enc := testenv.NewEncryptionClient(t)
+	siblingClient, siblingIssuer := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, row.UserSessionIssuerID, authCtx.ActiveOrganizationID, "rsi-backfill-wrong-client")
+	siblingAccess, err := enc.Encrypt([]byte("sibling-token"))
+	require.NoError(t, err)
+	_, err = q.UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+		SubjectUrn:            subject,
+		UserSessionIssuerID:   row.UserSessionIssuerID,
+		RemoteSessionClientID: siblingClient,
+		AccessTokenEncrypted:  siblingAccess,
+		AccessExpiresAt:       conv.ToPGTimestamptz(time.Now().Add(time.Hour)),
+		Scopes:                []string{},
+		Resource:              conv.ToPGText(siblingResource),
+	})
+	require.NoError(t, err)
+
+	// Each client reaches its upstream through its own issuer, so the two
+	// derivations differ and the shared issuer derives nothing: any resource
+	// that is not the refreshed client's own is visibly the wrong one.
+	const derived = "https://own.example.com/mcp"
+	attachClientUpstream(t, ctx, ti, clientID, "backfill-wrong-client-own", derived)
+	attachClientUpstream(t, ctx, ti, siblingClient, "backfill-wrong-client-sibling", siblingResource)
+
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, row.UserSessionIssuerID, subject)
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, derived, spy.form.Get("resource"), "the refresh grant must carry the refreshed client's own derived resource")
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.Equal(t, derived, conv.FromPGTextOrEmpty[string](sess.Resource), "the backfill must stamp the refreshed client's own resource, never a sibling's")
+
+	require.Equal(t, remotesessions.UpstreamToken{Token: "refreshed-access", Resource: derived, RemoteSessionClientID: clientID}, tokens[refreshedClient.RemoteSessionIssuerID])
+	require.Equal(t, remotesessions.UpstreamToken{Token: "sibling-token", Resource: siblingResource, RemoteSessionClientID: siblingClient}, tokens[siblingIssuer])
+
+	siblingSess := getRemoteSessionRow(t, ctx, ti, siblingClient, subject)
+	require.Equal(t, siblingResource, conv.FromPGTextOrEmpty[string](siblingSess.Resource), "the sibling's own binding must survive a neighbour's backfill")
+}
+
 // The scheduled sweep converges through the same CAS write: refreshing a
 // NULL-resource row stamps the client-derived fallback it sent upstream.
 func TestRemoteSessionRefreshActivity_SweepBackfillsNullResource(t *testing.T) {

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -255,6 +255,10 @@ func TestResolveAccessTokens_RefreshingRequestCarriesBackfilledResource(t *testi
 	require.NoError(t, err)
 
 	const derived = "https://mcp.example.com/mcp"
+	// Attach the upstream the resource names, so the value under test is one
+	// the client derivation resolves rather than only a caller-supplied string.
+	seedRemoteMCPServerForIssuer(t, ctx, ti, row.UserSessionIssuerID, "backfill-same-request-mcp", derived)
+
 	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, row.UserSessionIssuerID, subject, derived)
 	require.NoError(t, err)
 	require.NoError(t, spy.handlerErr)

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -5,14 +5,26 @@ package remotesessions_test
 
 import (
 	"context"
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -32,7 +44,7 @@ func TestResolveAccessToken_RefreshBackfillsNullResource(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-stamp", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
 
 	require.False(t, getRemoteSessionRow(t, ctx, ti, clientID, subject).Resource.Valid, "fixture must seed a legacy NULL-resource row")
 
@@ -43,13 +55,15 @@ func TestResolveAccessToken_RefreshBackfillsNullResource(t *testing.T) {
 
 	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
 	require.Equal(t, "https://mcp.example.com/mcp", conv.FromPGTextOrEmpty[string](sess.Resource), "refresh must stamp the resource it used onto a legacy NULL row")
+	// The stamped value is exactly the wire value the refresh grant carried.
+	require.Equal(t, spy.form.Get("resource"), conv.FromPGTextOrEmpty[string](sess.Resource), "the stored binding must equal the form resource the grant used")
 }
 
 func TestResolveAccessToken_RefreshNeverOverwritesStoredResource(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-keep-stored", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
 
 	const stored = "https://stored.example.com/mcp"
 	err := testrepo.New(ti.conn).SetRemoteSessionResourceFixture(ctx, testrepo.SetRemoteSessionResourceFixtureParams{
@@ -73,7 +87,7 @@ func TestResolveAccessToken_RefreshLeavesResourceNullWhenUnderivable(t *testing.
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-underivable", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)
@@ -82,4 +96,196 @@ func TestResolveAccessToken_RefreshLeavesResourceNullWhenUnderivable(t *testing.
 
 	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
 	require.False(t, sess.Resource.Valid, "an empty derivation must leave the legacy row's resource NULL")
+}
+
+// A refresh that loses the CAS (the row rotated mid-POST) must be a full
+// no-op: no resource stamped, no token overwritten, winner's token adopted.
+func TestResolveAccessToken_RefreshCASLossStampsNothing(t *testing.T) {
+	t.Parallel()
+
+	refreshArrived := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRefresh) }) }
+	t.Cleanup(release)
+
+	// Block mid-refresh so the test can rotate the row before the CAS write.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		close(refreshArrived)
+		<-releaseRefresh
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed-access","token_type":"Bearer","expires_in":3600,"refresh_token":"refreshed-refresh"}`))
+	}
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-cas-loss", pgtype.Text{String: "", Valid: false}, handler)
+	before := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+
+	type resolveResult struct {
+		token string
+		err   error
+	}
+	resolved := make(chan resolveResult, 1)
+	go func() {
+		tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "https://mcp.example.com/mcp")
+		resolved <- resolveResult{token: tok, err: err}
+	}()
+
+	<-refreshArrived
+
+	// Concurrent winner rotates tokens + updated_at, leaving resource NULL.
+	enc := testenv.NewEncryptionClient(t)
+	winnerAccess, err := enc.Encrypt([]byte("winner-access"))
+	require.NoError(t, err)
+	winnerRefresh, err := enc.Encrypt([]byte("winner-refresh"))
+	require.NoError(t, err)
+	winner, err := repo.New(ti.conn).UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+		SubjectUrn:            subject,
+		UserSessionIssuerID:   before.UserSessionIssuerID,
+		RemoteSessionClientID: clientID,
+		AccessTokenEncrypted:  winnerAccess,
+		AccessExpiresAt:       conv.ToPGTimestamptz(time.Now().Add(time.Hour)),
+		RefreshTokenEncrypted: conv.ToPGText(winnerRefresh),
+		RefreshExpiresAt:      pgtype.Timestamptz{},
+		Scopes:                before.Scopes,
+		Resource:              pgtype.Text{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, before.ID, winner.ID, "the winner rotates the row in place")
+
+	release()
+
+	got := <-resolved
+	require.NoError(t, got.err)
+	require.Equal(t, "winner-access", got.token, "a CAS loss adopts the concurrent winner's token")
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.False(t, sess.Resource.Valid, "a losing refresh write must not stamp its resource")
+	require.Equal(t, winner.UpdatedAt.Time, sess.UpdatedAt.Time, "the losing CAS write must not touch the row")
+	require.Equal(t, winner.AccessTokenEncrypted, sess.AccessTokenEncrypted, "the winner's access token must survive")
+	require.Equal(t, winner.RefreshTokenEncrypted.String, sess.RefreshTokenEncrypted.String, "the winner's refresh token must survive")
+}
+
+// A refresh rejected with invalid_grant clears only the refresh grant; the
+// failed refresh must not stamp the fallback resource it attempted with.
+func TestResolveAccessToken_InvalidGrantLeavesResourceNull(t *testing.T) {
+	t.Parallel()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}`))
+	}
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-invalid-grant", pgtype.Text{String: "", Valid: false}, handler)
+
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "https://mcp.example.com/mcp")
+	require.NoError(t, err)
+	require.Empty(t, tok)
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.False(t, sess.Resource.Valid, "a failed refresh must not stamp a resource")
+	require.False(t, sess.RefreshTokenEncrypted.Valid, "invalid_grant must clear the dead refresh grant")
+	require.False(t, sess.RefreshExpiresAt.Valid)
+}
+
+// A second refresh after the stamp keeps the same value: COALESCE is a no-op
+// and the grant replays the now-stored binding.
+func TestResolveAccessToken_RefreshBackfillIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-idempotent", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
+
+	const used = "https://mcp.example.com/mcp"
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, used)
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	stamped := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.Equal(t, used, conv.FromPGTextOrEmpty[string](stamped.Resource))
+
+	// Age the fresh access token out so the next resolve refreshes again.
+	require.NoError(t, testrepo.New(ti.conn).ExpireRemoteSessionAccessTokenFixture(ctx, stamped.ID))
+
+	tok, err = mgr.ResolveAccessToken(ctx, clientID, subject, used)
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.Equal(t, used, conv.FromPGTextOrEmpty[string](sess.Resource), "a second refresh must keep the stamped value")
+	require.Equal(t, used, spy.form.Get("resource"), "the second grant must replay the stamped binding")
+}
+
+// seedRemoteMCPServerForIssuer binds one remote MCP server at mcpURL to the
+// user session issuer so FallbackResourceForClient derives it unambiguously.
+func seedRemoteMCPServerForIssuer(t *testing.T, ctx context.Context, ti *testInstance, userIssuerID uuid.UUID, slug, mcpURL string) {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	remoteServer, err := remotemcprepo.New(ti.conn).CreateServer(ctx, remotemcprepo.CreateServerParams{
+		ID:            uuid.New(),
+		ProjectID:     *authCtx.ProjectID,
+		TransportType: "sse",
+		Url:           mcpURL,
+	})
+	require.NoError(t, err)
+
+	_, err = mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:                  uuid.New(),
+		ProjectID:           *authCtx.ProjectID,
+		Name:                conv.ToPGText(slug),
+		Slug:                conv.ToPGText(slug),
+		RemoteMcpServerID:   conv.ToNullUUID(remoteServer.ID),
+		Visibility:          "private",
+		UserSessionIssuerID: conv.ToNullUUID(userIssuerID),
+	})
+	require.NoError(t, err)
+}
+
+// The scheduled sweep converges through the same CAS write: refreshing a
+// NULL-resource row stamps the client-derived fallback it sent upstream.
+func TestRemoteSessionRefreshActivity_SweepBackfillsNullResource(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, _, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "backfill-sweep", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	row := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.False(t, row.Resource.Valid)
+
+	const mcpURL = "https://mcp.example.com/mcp"
+	seedRemoteMCPServerForIssuer(t, ctx, ti, row.UserSessionIssuerID, "backfill-sweep-mcp", mcpURL)
+
+	// Make the row a due keepalive candidate: stale, org-enforced, live Gram session.
+	require.NoError(t, repo.New(ti.conn).SetRemoteSessionUpdatedAt(ctx, repo.SetRemoteSessionUpdatedAtParams{
+		ID:        row.ID,
+		ProjectID: conv.ToNullUUID(*authCtx.ProjectID),
+		UpdatedAt: conv.ToPGTimestamptz(time.Now().Add(-25 * time.Hour)),
+	}))
+	seedGramSession(t, ctx, ti, subject, row.UserSessionIssuerID, "backfill-sweep", 24*time.Hour)
+	enableOrgAutoRefreshFeature(t, ctx, ti, authCtx.ActiveOrganizationID, productfeatures.FeatureRemoteSessionAutoRefreshEnforced)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	refresher := remotesessions.NewRefreshService(testenv.NewLogger(t), ti.conn, testenv.NewEncryptionClient(t), policy, cache.NoopCache)
+	activity := activities.NewRemoteSessionRefresh(testenv.NewLogger(t), ti.conn, refresher)
+
+	res, err := activity.Do(ctx, activities.RefreshRemoteSessionInput{
+		SessionID:      row.ID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+	require.False(t, res.RateLimited)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refresh_token", spy.form.Get("grant_type"), "the sweep must have executed the refresh grant")
+
+	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.Equal(t, mcpURL, conv.FromPGTextOrEmpty[string](sess.Resource), "the sweep must stamp the client-derived fallback")
+	require.Equal(t, spy.form.Get("resource"), conv.FromPGTextOrEmpty[string](sess.Resource), "the stored binding must equal the form resource the grant used")
 }

--- a/server/internal/remotesessions/tokenservice_resource_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_test.go
@@ -18,7 +18,7 @@ func TestResolveAccessToken_RefreshIncludesResource(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "https://mcp.example.com/mcp")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestResolveAccessToken_RefreshOmitsResourceWhenEmpty(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
+	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)

--- a/server/internal/remotesessions/tokenservice_resource_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_test.go
@@ -18,7 +18,7 @@ func TestResolveAccessToken_RefreshIncludesResource(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "https://mcp.example.com/mcp")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestResolveAccessToken_RefreshOmitsResourceWhenEmpty(t *testing.T) {
 	t.Parallel()
 
 	var spy upstreamSpy
-	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
+	ctx, mgr, _, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
 
 	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -419,6 +419,13 @@ UPDATE remote_sessions
 SET access_expires_at = clock_timestamp() - interval '1 minute'
 WHERE id = @id;
 
+-- name: SetRemoteSessionResourceFixture :exec
+-- Test-only fixture stamping a stored RFC 8707 resource binding on a row.
+UPDATE remote_sessions
+SET resource = @resource
+WHERE subject_urn = @subject_urn
+  AND remote_session_client_id = @remote_session_client_id;
+
 -- name: GetToolCallBlockLinksFixture :one
 -- Test-only. The block page query deliberately does not expose the optional
 -- foreign keys, but asserting that the salvage cleared exactly the link the

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1571,6 +1571,25 @@ func (q *Queries) SetProjectSlugFixture(ctx context.Context, arg SetProjectSlugF
 	return err
 }
 
+const setRemoteSessionResourceFixture = `-- name: SetRemoteSessionResourceFixture :exec
+UPDATE remote_sessions
+SET resource = $1
+WHERE subject_urn = $2
+  AND remote_session_client_id = $3
+`
+
+type SetRemoteSessionResourceFixtureParams struct {
+	Resource              pgtype.Text
+	SubjectUrn            urn.SessionSubject
+	RemoteSessionClientID uuid.UUID
+}
+
+// Test-only fixture stamping a stored RFC 8707 resource binding on a row.
+func (q *Queries) SetRemoteSessionResourceFixture(ctx context.Context, arg SetRemoteSessionResourceFixtureParams) error {
+	_, err := q.db.Exec(ctx, setRemoteSessionResourceFixture, arg.Resource, arg.SubjectUrn, arg.RemoteSessionClientID)
+	return err
+}
+
 const setUserSessionIssuerCIMDAdmissionMode = `-- name: SetUserSessionIssuerCIMDAdmissionMode :exec
 UPDATE user_session_issuers
 SET client_id_metadata_admission_mode = $1


### PR DESCRIPTION
Backfills `remote_sessions.resource` during refresh for rows minted before the column existed (AGE-3329).

Fits #5572's resource-matched routing: legacy NULL-resource credentials can never be routed in the multi-credential case; every refresh path (sweep, org-admin, lazy MCP) funnels through one CAS write, which now converges them without user re-auth.

Critical lines:
- `server/internal/remotesessions/queries.sql` (`UpdateRemoteSessionTokensIfUnchanged`) — `resource = COALESCE(resource, @backfill_resource)`: the query is the single enforcement point; a stored binding can never be overwritten.
- `server/internal/remotesessions/tokenservice.go` (`refreshSessionTokens`) — passes exactly the resource the refresh grant sent upstream.

Stacked on #5572; pairs with the per-client derivation fix (AGE-3328) so only per-client values are ever persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills the RFC 8707 resource onto legacy `remote_sessions` during refresh and returns the backfilled value on the same request, restoring resource-matched routing for pre-column rows. Previously refresh never persisted or surfaced the resource; now it stamps the grant’s resource only when stored NULL and derivation is unambiguous.

- Single enforcement in `UpdateRemoteSessionTokensIfUnchanged`: `resource = COALESCE(resource, @backfill_resource)` with a new `BackfillResource` param under the existing CAS, so a stored binding cannot be changed.
- `refreshSessionTokens` passes the derived resource (empty maps to NULL); `validateAndRefresh` returns the post-refresh row and `resolveUpstreamToken` re-reads it so the request that heals the row routes with the backfilled resource; on a CAS loss we adopt the winner’s row and token.
- All refresh entry points (lazy MCP resolution, org-admin refresh, scheduled sweep) converge through this write without user re-auth.
- Tests cover NULL stamp, never overwrite, underivable stays NULL, CAS-loss stamps nothing, invalid_grant clears only the refresh grant, idempotent second refresh, sweep backfill, and same-request routing. No migrations or config changes. Aligns with Linear AGE-3329.

<sup>Written for commit 70e656fc4a289f2ddaa1732e8effeb290632071e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

