### PR TITLE
test: add E2E coverage for signup and login

### DIFF
--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -1290,11 +1290,9 @@ func TestE2E_LoginCallback_OrdinaryLogin(t *testing.T) {
 func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
 	t.Parallel()
 
-	const (
-		workosUserID = "user_01E2E_SIGNUP_NEW"
-		email        = "new-signup@example.com"
-		orgName      = "New Signup Corp"
-	)
+	const workosUserID = "user_01E2E_SIGNUP_NEW"
+	email := "new-signup@example.com"
+	orgName := "New Signup Corp"
 
 	fetcher := &mockWorkOSFetcher{
 		members:      map[string][]workos.Member{},
@@ -1359,11 +1357,9 @@ func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
 func TestE2E_LoginCallback_SignupExistingWorkOSUser(t *testing.T) {
 	t.Parallel()
 
-	const (
-		workosUserID = "user_01E2E_SIGNUP_EXISTING"
-		email        = "existing-signup@example.com"
-		orgName      = "Existing Signup Corp"
-	)
+	const workosUserID = "user_01E2E_SIGNUP_EXISTING"
+	email := "existing-signup@example.com"
+	orgName := "Existing Signup Corp"
 
 	fetcher := &mockWorkOSFetcher{
 		members: map[string][]workos.Member{},

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -2,10 +2,12 @@ package auth_test
 
 import (
 	"context"
+	"net/url"
 	"slices"
 	"testing"
 	"time"
 
+	redisCache "github.com/go-redis/cache/v9"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
@@ -195,6 +197,30 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 	ti := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	ti.trialNotifier = trialNotifier
 	return ctx, &e2eInstance{testInstance: *ti, fetcher: fetcher}
+}
+
+// loginWithNonceBinding starts Login with the cookie binding Callback needs to
+// redeem the nonce. Production sets this from the HttpOnly cookie; tests inject
+// it into context so Login → Callback is one real round trip.
+func (e *e2eInstance) loginWithNonceBinding(ctx context.Context, t *testing.T, payload *gen.LoginPayload) (context.Context, *gen.LoginResult) {
+	t.Helper()
+	ctx = auth.TestNonceBindingContext(ctx, testNonceBinding)
+	result, err := e.service.Login(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return ctx, result
+}
+
+func (e *e2eInstance) callbackFromLogin(ctx context.Context, t *testing.T, login *gen.LoginResult) *gen.CallbackResult {
+	t.Helper()
+	state := nonceStateFromLocation(t, login.Location)
+	result, err := e.service.Callback(ctx, &gen.CallbackPayload{
+		Code:  "mock_code",
+		State: &state,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
 }
 
 // setUserWorkosID stamps the WorkOS user ID on an existing Gram user so the
@@ -1198,6 +1224,203 @@ func TestE2E_Login_WithRedirect(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Contains(t, result.Location, "/authorize")
 	assert.Contains(t, result.Location, "state=")
+}
+
+// TestE2E_LoginCallback_OrdinaryLogin exercises Login → Callback with no
+// organization name. Ordinary login must not pay the signup-only WorkOS email
+// lookup and must not write a signup intent.
+func TestE2E_LoginCallback_OrdinaryLogin(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workosUserID = "user_01E2E_ORDINARY"
+		workosOrgID  = "org_01E2E_ORDINARY"
+		orgName      = "Ordinary Corp"
+	)
+
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{
+			workosUserID: {
+				{ID: "om_ORDINARY", UserID: workosUserID, OrganizationID: workosOrgID, Organization: orgName, RoleSlugs: []string{"admin"}},
+			},
+		},
+		orgs: map[string]*workos.Organization{
+			workosOrgID: {ID: workosOrgID, Name: orgName},
+		},
+	}
+
+	userInfo := &MockUserInfo{
+		UserID:        workosUserID,
+		Email:         "ordinary@example.com",
+		Organizations: []MockOrganizationEntry{},
+	}
+
+	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
+	ctx, login := inst.loginWithNonceBinding(ctx, t, &gen.LoginPayload{})
+
+	parsed, err := url.Parse(login.Location)
+	require.NoError(t, err)
+	q := parsed.Query()
+	require.False(t, q.Has("login_hint"))
+	require.False(t, q.Has("screen_hint"))
+	require.Equal(t, 0, fetcher.getUserByEmailCalls, "ordinary login must not look up WorkOS users")
+
+	nonce := nonceFromLocation(t, login.Location)
+	var intent map[string]any
+	err = inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
+	require.ErrorIs(t, err, redisCache.ErrCacheMiss, "ordinary login must not write a signup intent")
+
+	result := inst.callbackFromLogin(ctx, t, login)
+	require.NotContains(t, result.Location, "signin_error=")
+	require.NotEmpty(t, result.SessionToken)
+	require.Equal(t, 0, fetcher.getUserByEmailCalls, "callback must not perform the signup-only WorkOS email lookup")
+	require.Empty(t, fetcher.createdOrgs, "ordinary login must not provision a signup organization")
+
+	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, orgid.FromWorkOSID(workosOrgID), authCtx.ActiveOrganizationID)
+}
+
+// TestE2E_LoginCallback_SignupNewWorkOSUser exercises Login → Callback for a
+// signup whose email is unknown to WorkOS. AuthKit gets screen_hint=sign-up,
+// the company name is preserved through the IDP round trip, and callback
+// provisions the organization and creates a session.
+func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workosUserID = "user_01E2E_SIGNUP_NEW"
+		email        = "new-signup@example.com"
+		orgName      = "New Signup Corp"
+	)
+
+	fetcher := &mockWorkOSFetcher{
+		members:      map[string][]workos.Member{},
+		orgs:         map[string]*workos.Organization{},
+		usersByEmail: map[string]*workos.User{},
+	}
+
+	userInfo := &MockUserInfo{
+		UserID:        workosUserID,
+		Email:         email,
+		Organizations: []MockOrganizationEntry{},
+	}
+
+	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
+	ctx, login := inst.loginWithNonceBinding(ctx, t, &gen.LoginPayload{
+		OrgName: &orgName,
+		Email:   &email,
+	})
+
+	parsed, err := url.Parse(login.Location)
+	require.NoError(t, err)
+	q := parsed.Query()
+	require.Equal(t, email, q.Get("login_hint"))
+	require.Equal(t, "sign-up", q.Get("screen_hint"))
+	require.Equal(t, 1, fetcher.getUserByEmailCalls)
+
+	nonce := nonceFromLocation(t, login.Location)
+	var intent struct {
+		OrgName string
+	}
+	require.NoError(t, inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent))
+	require.Equal(t, orgName, intent.OrgName)
+
+	result := inst.callbackFromLogin(ctx, t, login)
+	require.NotContains(t, result.Location, "signin_error=")
+	require.NotEmpty(t, result.SessionToken)
+
+	err = inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
+	require.ErrorIs(t, err, redisCache.ErrCacheMiss, "signup intent must be consumed on callback")
+
+	require.Len(t, fetcher.createdOrgs, 1)
+	require.Equal(t, orgName, fetcher.createdOrgs[0].Name)
+	require.Len(t, fetcher.createdMemberships, 1)
+	require.Equal(t, workosUserID, fetcher.createdMemberships[0].WorkOSUserID)
+
+	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotEmpty(t, authCtx.ActiveOrganizationID)
+
+	org, err := orgRepo.New(inst.conn).GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, orgName, org.Name)
+	require.True(t, org.Whitelisted)
+}
+
+// TestE2E_LoginCallback_SignupExistingWorkOSUser exercises Login → Callback
+// for a signup whose email already has a WorkOS account. AuthKit gets
+// login_hint and no screen_hint=sign-up, but the signup intent is still
+// stored so callback can provision a Gram organization and create a session.
+func TestE2E_LoginCallback_SignupExistingWorkOSUser(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workosUserID = "user_01E2E_SIGNUP_EXISTING"
+		email        = "existing-signup@example.com"
+		orgName      = "Existing Signup Corp"
+	)
+
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{},
+		orgs:    map[string]*workos.Organization{},
+		usersByEmail: map[string]*workos.User{
+			email: {ID: workosUserID, Email: email},
+		},
+	}
+
+	userInfo := &MockUserInfo{
+		UserID:        workosUserID,
+		Email:         email,
+		Organizations: []MockOrganizationEntry{},
+	}
+
+	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
+	ctx, login := inst.loginWithNonceBinding(ctx, t, &gen.LoginPayload{
+		OrgName: &orgName,
+		Email:   &email,
+	})
+
+	parsed, err := url.Parse(login.Location)
+	require.NoError(t, err)
+	q := parsed.Query()
+	require.Equal(t, email, q.Get("login_hint"))
+	require.False(t, q.Has("screen_hint"), "existing WorkOS users must land on sign-in, not hosted sign-up")
+	require.Equal(t, 1, fetcher.getUserByEmailCalls)
+
+	nonce := nonceFromLocation(t, login.Location)
+	var intent struct {
+		OrgName string
+	}
+	require.NoError(t, inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent))
+	require.Equal(t, orgName, intent.OrgName)
+
+	result := inst.callbackFromLogin(ctx, t, login)
+	require.NotContains(t, result.Location, "signin_error=")
+	require.NotEmpty(t, result.SessionToken)
+
+	err = inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
+	require.ErrorIs(t, err, redisCache.ErrCacheMiss, "signup intent must be consumed on callback")
+
+	require.Len(t, fetcher.createdOrgs, 1)
+	require.Equal(t, orgName, fetcher.createdOrgs[0].Name)
+	require.Len(t, fetcher.createdMemberships, 1)
+	require.Equal(t, workosUserID, fetcher.createdMemberships[0].WorkOSUserID)
+
+	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotEmpty(t, authCtx.ActiveOrganizationID)
+
+	org, err := orgRepo.New(inst.conn).GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, orgName, org.Name)
+	require.True(t, org.Whitelisted)
 }
 
 // TestE2E_Logout verifies that after logging out the session is invalidated

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -256,6 +256,46 @@ func (e *e2eInstance) requireSignupProvisioned(ctx context.Context, t *testing.T
 	require.Equal(t, "enterprise", trial.Tier)
 }
 
+func runSignupLoginCallback(t *testing.T, workosUserID, email, orgName string, usersByEmail map[string]*workos.User, screenHint string) {
+	t.Helper()
+	fetcher := &mockWorkOSFetcher{
+		members:      map[string][]workos.Member{},
+		orgs:         map[string]*workos.Organization{},
+		usersByEmail: usersByEmail,
+	}
+	userInfo := &MockUserInfo{
+		UserID:        workosUserID,
+		Email:         email,
+		Organizations: []MockOrganizationEntry{},
+	}
+	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
+	ctx, login := inst.loginWithNonceBinding(ctx, t, &gen.LoginPayload{
+		OrgName: &orgName,
+		Email:   &email,
+	})
+
+	parsed, err := url.Parse(login.Location)
+	require.NoError(t, err)
+	q := parsed.Query()
+	require.Equal(t, email, q.Get("login_hint"))
+	if screenHint == "" {
+		require.False(t, q.Has("screen_hint"), "existing WorkOS users must land on sign-in, not hosted sign-up")
+	} else {
+		require.Equal(t, screenHint, q.Get("screen_hint"))
+	}
+	require.Equal(t, 1, fetcher.getUserByEmailCalls)
+
+	nonce := nonceFromLocation(t, login.Location)
+	var intent struct {
+		OrgName string
+	}
+	require.NoError(t, inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent))
+	require.Equal(t, orgName, intent.OrgName)
+
+	result := inst.callbackFromLogin(ctx, t, login)
+	inst.requireSignupProvisioned(ctx, t, nonce, orgName, workosUserID, result.SessionToken)
+}
+
 // setUserWorkosID stamps the WorkOS user ID on an existing Gram user so the
 // membership reconciliation path can run.
 func (e *e2eInstance) setUserWorkosID(ctx context.Context, t *testing.T, gramUserID, workosUserID string) {
@@ -1321,45 +1361,7 @@ func TestE2E_LoginCallback_OrdinaryLogin(t *testing.T) {
 // provisions the organization and creates a session.
 func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
 	t.Parallel()
-
-	const workosUserID = "user_01E2E_SIGNUP_NEW"
-	email := "new-signup@example.com"
-	orgName := "New Signup Corp"
-
-	fetcher := &mockWorkOSFetcher{
-		members:      map[string][]workos.Member{},
-		orgs:         map[string]*workos.Organization{},
-		usersByEmail: map[string]*workos.User{},
-	}
-
-	userInfo := &MockUserInfo{
-		UserID:        workosUserID,
-		Email:         email,
-		Organizations: []MockOrganizationEntry{},
-	}
-
-	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
-	ctx, login := inst.loginWithNonceBinding(ctx, t, &gen.LoginPayload{
-		OrgName: &orgName,
-		Email:   &email,
-	})
-
-	parsed, err := url.Parse(login.Location)
-	require.NoError(t, err)
-	q := parsed.Query()
-	require.Equal(t, email, q.Get("login_hint"))
-	require.Equal(t, "sign-up", q.Get("screen_hint"))
-	require.Equal(t, 1, fetcher.getUserByEmailCalls)
-
-	nonce := nonceFromLocation(t, login.Location)
-	var intent struct {
-		OrgName string
-	}
-	require.NoError(t, inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent))
-	require.Equal(t, orgName, intent.OrgName)
-
-	result := inst.callbackFromLogin(ctx, t, login)
-	inst.requireSignupProvisioned(ctx, t, nonce, orgName, workosUserID, result.SessionToken)
+	runSignupLoginCallback(t, "user_01E2E_SIGNUP_NEW", "new-signup@example.com", "New Signup Corp", map[string]*workos.User{}, "sign-up")
 }
 
 // TestE2E_LoginCallback_SignupExistingWorkOSUser exercises Login → Callback
@@ -1368,47 +1370,11 @@ func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
 // stored so callback can provision a Gram organization and create a session.
 func TestE2E_LoginCallback_SignupExistingWorkOSUser(t *testing.T) {
 	t.Parallel()
-
-	const workosUserID = "user_01E2E_SIGNUP_EXISTING"
 	email := "existing-signup@example.com"
-	orgName := "Existing Signup Corp"
-
-	fetcher := &mockWorkOSFetcher{
-		members: map[string][]workos.Member{},
-		orgs:    map[string]*workos.Organization{},
-		usersByEmail: map[string]*workos.User{
-			email: {ID: workosUserID, Email: email},
-		},
-	}
-
-	userInfo := &MockUserInfo{
-		UserID:        workosUserID,
-		Email:         email,
-		Organizations: []MockOrganizationEntry{},
-	}
-
-	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
-	ctx, login := inst.loginWithNonceBinding(ctx, t, &gen.LoginPayload{
-		OrgName: &orgName,
-		Email:   &email,
-	})
-
-	parsed, err := url.Parse(login.Location)
-	require.NoError(t, err)
-	q := parsed.Query()
-	require.Equal(t, email, q.Get("login_hint"))
-	require.False(t, q.Has("screen_hint"), "existing WorkOS users must land on sign-in, not hosted sign-up")
-	require.Equal(t, 1, fetcher.getUserByEmailCalls)
-
-	nonce := nonceFromLocation(t, login.Location)
-	var intent struct {
-		OrgName string
-	}
-	require.NoError(t, inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent))
-	require.Equal(t, orgName, intent.OrgName)
-
-	result := inst.callbackFromLogin(ctx, t, login)
-	inst.requireSignupProvisioned(ctx, t, nonce, orgName, workosUserID, result.SessionToken)
+	workosUserID := "user_01E2E_SIGNUP_EXISTING"
+	runSignupLoginCallback(t, workosUserID, email, "Existing Signup Corp", map[string]*workos.User{
+		email: {ID: workosUserID, Email: email},
+	}, "")
 }
 
 // TestE2E_Logout verifies that after logging out the session is invalidated

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -211,6 +211,10 @@ func (e *e2eInstance) loginWithNonceBinding(ctx context.Context, t *testing.T, p
 	return ctx, result
 }
 
+// callbackFromLogin redeems the state Login put on the authorization URL.
+// It does not seed a nonce; that would skip the Login-written binding and
+// signup-intent keys this helper exists to exercise. Callback reports auth
+// failures as a redirect with signin_error=, not as a Go error.
 func (e *e2eInstance) callbackFromLogin(ctx context.Context, t *testing.T, login *gen.LoginResult) *gen.CallbackResult {
 	t.Helper()
 	state := nonceStateFromLocation(t, login.Location)
@@ -220,6 +224,7 @@ func (e *e2eInstance) callbackFromLogin(ctx context.Context, t *testing.T, login
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
+	require.NotContains(t, result.Location, "signin_error=")
 	return result
 }
 
@@ -1271,7 +1276,6 @@ func TestE2E_LoginCallback_OrdinaryLogin(t *testing.T) {
 	require.ErrorIs(t, err, redisCache.ErrCacheMiss, "ordinary login must not write a signup intent")
 
 	result := inst.callbackFromLogin(ctx, t, login)
-	require.NotContains(t, result.Location, "signin_error=")
 	require.NotEmpty(t, result.SessionToken)
 	require.Equal(t, 0, fetcher.getUserByEmailCalls, "callback must not perform the signup-only WorkOS email lookup")
 	require.Empty(t, fetcher.createdOrgs, "ordinary login must not provision a signup organization")
@@ -1327,7 +1331,6 @@ func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
 	require.Equal(t, orgName, intent.OrgName)
 
 	result := inst.callbackFromLogin(ctx, t, login)
-	require.NotContains(t, result.Location, "signin_error=")
 	require.NotEmpty(t, result.SessionToken)
 
 	err = inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
@@ -1348,6 +1351,11 @@ func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, orgName, org.Name)
 	require.True(t, org.Whitelisted)
+	require.Equal(t, "enterprise", org.GramAccountType)
+
+	trial, err := trialsRepo.New(inst.conn).GetTrial(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", trial.Tier)
 }
 
 // TestE2E_LoginCallback_SignupExistingWorkOSUser exercises Login → Callback
@@ -1396,7 +1404,6 @@ func TestE2E_LoginCallback_SignupExistingWorkOSUser(t *testing.T) {
 	require.Equal(t, orgName, intent.OrgName)
 
 	result := inst.callbackFromLogin(ctx, t, login)
-	require.NotContains(t, result.Location, "signin_error=")
 	require.NotEmpty(t, result.SessionToken)
 
 	err = inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
@@ -1417,6 +1424,11 @@ func TestE2E_LoginCallback_SignupExistingWorkOSUser(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, orgName, org.Name)
 	require.True(t, org.Whitelisted)
+	require.Equal(t, "enterprise", org.GramAccountType)
+
+	trial, err := trialsRepo.New(inst.conn).GetTrial(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", trial.Tier)
 }
 
 // TestE2E_Logout verifies that after logging out the session is invalidated

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -199,9 +199,7 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 	return ctx, &e2eInstance{testInstance: *ti, fetcher: fetcher}
 }
 
-// loginWithNonceBinding starts Login with the cookie binding Callback needs to
-// redeem the nonce. Production sets this from the HttpOnly cookie; tests inject
-// it into context so Login → Callback is one real round trip.
+// loginWithNonceBinding injects the cookie binding so Callback can redeem Login's nonce.
 func (e *e2eInstance) loginWithNonceBinding(ctx context.Context, t *testing.T, payload *gen.LoginPayload) (context.Context, *gen.LoginResult) {
 	t.Helper()
 	ctx = auth.TestNonceBindingContext(ctx, testNonceBinding)
@@ -211,10 +209,7 @@ func (e *e2eInstance) loginWithNonceBinding(ctx context.Context, t *testing.T, p
 	return ctx, result
 }
 
-// callbackFromLogin redeems the state Login put on the authorization URL.
-// It does not seed a nonce; that would skip the Login-written binding and
-// signup-intent keys this helper exists to exercise. Callback reports auth
-// failures as a redirect with signin_error=, not as a Go error.
+// callbackFromLogin redeems Login's state and fails on signin_error= redirects.
 func (e *e2eInstance) callbackFromLogin(ctx context.Context, t *testing.T, login *gen.LoginResult) *gen.CallbackResult {
 	t.Helper()
 	state := nonceStateFromLocation(t, login.Location)
@@ -226,6 +221,39 @@ func (e *e2eInstance) callbackFromLogin(ctx context.Context, t *testing.T, login
 	require.NotNil(t, result)
 	require.NotContains(t, result.Location, "signin_error=")
 	return result
+}
+
+// requireSignupProvisioned asserts callback consumed the intent and provisioned an enterprise org.
+func (e *e2eInstance) requireSignupProvisioned(ctx context.Context, t *testing.T, nonce, orgName, workosUserID, sessionToken string) {
+	t.Helper()
+	require.NotEmpty(t, sessionToken)
+
+	var intent struct {
+		OrgName string
+	}
+	err := e.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
+	require.ErrorIs(t, err, redisCache.ErrCacheMiss, "signup intent must be consumed on callback")
+
+	require.Len(t, e.fetcher.createdOrgs, 1)
+	require.Equal(t, orgName, e.fetcher.createdOrgs[0].Name)
+	require.Len(t, e.fetcher.createdMemberships, 1)
+	require.Equal(t, workosUserID, e.fetcher.createdMemberships[0].WorkOSUserID)
+
+	ctx, err = e.sessionManager.Authenticate(ctx, sessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotEmpty(t, authCtx.ActiveOrganizationID)
+
+	org, err := orgRepo.New(e.conn).GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, orgName, org.Name)
+	require.True(t, org.Whitelisted)
+	require.Equal(t, "enterprise", org.GramAccountType)
+
+	trial, err := trialsRepo.New(e.conn).GetTrial(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", trial.Tier)
 }
 
 // setUserWorkosID stamps the WorkOS user ID on an existing Gram user so the
@@ -1331,31 +1359,7 @@ func TestE2E_LoginCallback_SignupNewWorkOSUser(t *testing.T) {
 	require.Equal(t, orgName, intent.OrgName)
 
 	result := inst.callbackFromLogin(ctx, t, login)
-	require.NotEmpty(t, result.SessionToken)
-
-	err = inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
-	require.ErrorIs(t, err, redisCache.ErrCacheMiss, "signup intent must be consumed on callback")
-
-	require.Len(t, fetcher.createdOrgs, 1)
-	require.Equal(t, orgName, fetcher.createdOrgs[0].Name)
-	require.Len(t, fetcher.createdMemberships, 1)
-	require.Equal(t, workosUserID, fetcher.createdMemberships[0].WorkOSUserID)
-
-	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
-	require.NoError(t, err)
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotEmpty(t, authCtx.ActiveOrganizationID)
-
-	org, err := orgRepo.New(inst.conn).GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
-	require.NoError(t, err)
-	require.Equal(t, orgName, org.Name)
-	require.True(t, org.Whitelisted)
-	require.Equal(t, "enterprise", org.GramAccountType)
-
-	trial, err := trialsRepo.New(inst.conn).GetTrial(ctx, authCtx.ActiveOrganizationID)
-	require.NoError(t, err)
-	require.Equal(t, "enterprise", trial.Tier)
+	inst.requireSignupProvisioned(ctx, t, nonce, orgName, workosUserID, result.SessionToken)
 }
 
 // TestE2E_LoginCallback_SignupExistingWorkOSUser exercises Login → Callback
@@ -1404,31 +1408,7 @@ func TestE2E_LoginCallback_SignupExistingWorkOSUser(t *testing.T) {
 	require.Equal(t, orgName, intent.OrgName)
 
 	result := inst.callbackFromLogin(ctx, t, login)
-	require.NotEmpty(t, result.SessionToken)
-
-	err = inst.nonceStore.Get(ctx, "auth:signup_intent:"+nonce, &intent)
-	require.ErrorIs(t, err, redisCache.ErrCacheMiss, "signup intent must be consumed on callback")
-
-	require.Len(t, fetcher.createdOrgs, 1)
-	require.Equal(t, orgName, fetcher.createdOrgs[0].Name)
-	require.Len(t, fetcher.createdMemberships, 1)
-	require.Equal(t, workosUserID, fetcher.createdMemberships[0].WorkOSUserID)
-
-	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
-	require.NoError(t, err)
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotEmpty(t, authCtx.ActiveOrganizationID)
-
-	org, err := orgRepo.New(inst.conn).GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
-	require.NoError(t, err)
-	require.Equal(t, orgName, org.Name)
-	require.True(t, org.Whitelisted)
-	require.Equal(t, "enterprise", org.GramAccountType)
-
-	trial, err := trialsRepo.New(inst.conn).GetTrial(ctx, authCtx.ActiveOrganizationID)
-	require.NoError(t, err)
-	require.Equal(t, "enterprise", trial.Tier)
+	inst.requireSignupProvisioned(ctx, t, nonce, orgName, workosUserID, result.SessionToken)
 }
 
 // TestE2E_Logout verifies that after logging out the session is invalidated


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [AGE-3326](https://linear.app/speakeasy/issue/AGE-3326/test-add-e2e-coverage-for-signup-and-login).

Adds three Login → Callback E2E tests on the existing `server/internal/auth/e2e_test.go` harness. The hosted AuthKit screen itself is out of scope; these cover the server-side authorization URL, signup-intent cache, org provisioning, and session creation.

* **Ordinary login** (no organization name): no signup-only WorkOS email lookup, no signup intent, session created from existing WorkOS memberships.
* **New-user signup** (org name + email unknown to WorkOS): `screen_hint=sign-up`, signup intent preserved through the IDP round trip, organization provisioned, session created.
* **Existing-user signup** (org name + email already in WorkOS): `login_hint` present, `screen_hint=sign-up` omitted, signup intent still preserved, organization provisioned, session created.

The two signup cases share `runSignupLoginCallback` (usersByEmail + expected screen_hint).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3326](https://linear.app/speakeasy/issue/AGE-3326/test-add-e2e-coverage-for-signup-and-login)

<div><a href="https://cursor.com/agents/bc-9357f6ba-cba1-4bb4-b78b-6b0fdd883cb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9357f6ba-cba1-4bb4-b78b-6b0fdd883cb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds E2E tests for Login → Callback covering ordinary login and two signup paths, meeting AGE-3326. Tightens the test harness to redeem Login state, fail on signin_error redirects, and assert enterprise trial provisioning.

- Test-only change in `server/internal/auth/e2e_test.go`; adds `loginWithNonceBinding`, `callbackFromLogin` (redeems Login state; fails on `signin_error=`), shared `requireSignupProvisioned` assertions, and consolidates signup setup in `runSignupLoginCallback`.
- Ordinary login: no `login_hint` or `screen_hint`; no WorkOS email lookup; no signup intent; session from existing memberships.
- Signup (new WorkOS user): sets `login_hint` and `screen_hint=sign-up`; caches org name in signup intent; provisions org and membership; consumes intent; whitelists org with enterprise account type; arms enterprise trial; creates session.
- Signup (existing WorkOS user): sets `login_hint` only; caches and consumes signup intent; provisions org and membership; whitelists org with enterprise account type; arms enterprise trial; creates session.
- Fixes pointer usage for `LoginPayload` string fields. No production behavior changes or migrations.

<sup>Written for commit be71f2dff6a45f6014e218049b6e9ab13bb8e235. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

