### PR TITLE
feat: add sign-up link to the login page

### DIFF
--- a/.changeset/login-signup-link.md
+++ b/.changeset/login-signup-link.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The login page now links to sign-up so visitors can start a 14-day trial.

--- a/client/dashboard/src/pages/login/components/login-panel.test.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.test.tsx
@@ -1,0 +1,27 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { LoginPanel } from "./login-panel";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderPanel(initialEntry = "/login") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <LoginPanel redirectTo={null} />
+    </MemoryRouter>,
+  );
+}
+
+describe("LoginPanel", () => {
+  it("links to the sign-up page", () => {
+    renderPanel();
+
+    const link = screen.getByRole("link", { name: /sign up/i });
+    expect(link.getAttribute("href")).toBe("/sign-up");
+    expect(screen.getByText(/don't have an account/i)).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/pages/login/components/login-panel.test.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.test.tsx
@@ -20,8 +20,10 @@ describe("LoginPanel", () => {
   it("links to the sign-up page", () => {
     renderPanel();
 
-    const link = screen.getByRole("link", { name: /sign up/i });
+    const link = screen.getByRole("link", {
+      name: /sign-up for a 14-day trial/i,
+    });
     expect(link.getAttribute("href")).toBe("/sign-up");
-    expect(screen.getByText(/don't have an account/i)).toBeTruthy();
+    expect(screen.getByText(/no account/i)).toBeTruthy();
   });
 });

--- a/client/dashboard/src/pages/login/components/login-panel.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.tsx
@@ -1,4 +1,5 @@
 import { buildLoginRedirectURL, cn } from "@/lib/utils";
+import { Link } from "react-router";
 import { AUTH_BUTTON_CLASSES, AUTH_PILLARS } from "./auth-constants";
 import { SigninErrorNotice } from "./auth-errors";
 
@@ -44,6 +45,16 @@ export function LoginPanel({
 
       <p className="auth-mono-text text-center text-[11px] leading-relaxed tracking-[0.02em] text-[var(--muted)]">
         Single sign-on through your identity provider.
+      </p>
+
+      <p className="mt-2 text-[14px] text-(--muted-strong)">
+        Don't have an account?{" "}
+        <Link
+          to="/sign-up"
+          className="text-(--link) underline hover:text-(--focus)"
+        >
+          Sign up
+        </Link>
       </p>
     </>
   );

--- a/client/dashboard/src/pages/login/components/login-panel.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.tsx
@@ -1,4 +1,5 @@
 import { buildLoginRedirectURL, cn } from "@/lib/utils";
+import { useRoutes } from "@/routes";
 import { Link } from "react-router";
 import { AUTH_BUTTON_CLASSES, AUTH_PILLARS } from "./auth-constants";
 import { SigninErrorNotice } from "./auth-errors";
@@ -8,6 +9,7 @@ export function LoginPanel({
 }: {
   redirectTo: string | null;
 }): JSX.Element {
+  const routes = useRoutes();
   const handleLogin = () => {
     window.location.href = buildLoginRedirectURL(redirectTo);
   };
@@ -50,7 +52,7 @@ export function LoginPanel({
       <p className="mt-2 text-[14px] text-(--muted-strong)">
         No account?{" "}
         <Link
-          to="/sign-up"
+          to={routes.signUp.href()}
           className="text-(--link) underline hover:text-(--focus)"
         >
           Sign-up for a 14-day trial.

--- a/client/dashboard/src/pages/login/components/login-panel.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.tsx
@@ -48,12 +48,12 @@ export function LoginPanel({
       </p>
 
       <p className="mt-2 text-[14px] text-(--muted-strong)">
-        Don't have an account?{" "}
+        No account?{" "}
         <Link
           to="/sign-up"
           className="text-(--link) underline hover:text-(--focus)"
         >
-          Sign up
+          Sign-up for a 14-day trial.
         </Link>
       </p>
     </>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes AGE-3331.

The sign-up page already links back to login. This adds the reciprocal link on `/login` so visitors who land there can start a trial.

- Copy: “No account? **Sign-up for a 14-day trial.**”
- Clicking the link navigates to `/sign-up`
- Unit test covers the `/sign-up` href

### Demo

![Login page with No account? Sign-up for a 14-day trial link](https://cursor.com/artifacts/c/art-76bc0033-68cd-42b9-a592-4e64f7255111)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3331](https://linear.app/speakeasy/issue/AGE-3331/feat-add-sign-up-link-to-login-page)

<div><a href="https://cursor.com/agents/bc-9a410728-2297-419c-a17d-1c0582051ac6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a410728-2297-419c-a17d-1c0582051ac6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Sign-up” link on the login page so visitors can start a trial. Previously `/login` had no path to sign-up; now it shows “No account? Sign-up for a 14-day trial.” linking to `/sign-up`, matching the reciprocal link on `/sign-up`.

- Uses `react-router` `Link` with `routes.signUp.href()` for SPA navigation; no backend or auth flow changes.
- Copy and hover/focus styling match the `/sign-up` treatment.
- Unit test with `@testing-library/react` and `vitest` asserts the `/sign-up` href and the trial copy.
- Adds a changeset marking a patch release for `dashboard`.
- Satisfies Linear AGE-3331 (login page links to sign-up).

<sup>Written for commit bdedb27ac502b60a32233f2eec40405d0785ea17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



