### PR TITLE
fix: speed up skill insight queries

### DIFF
--- a/.changeset/faster-skill-insights.md
+++ b/.changeset/faster-skill-insights.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Skill activation insights and skill-version analytics now identify mapped skill sessions before aggregating telemetry, avoiding work for unrelated sessions while preserving existing reporting semantics.

--- a/server/internal/telemetry/repo/skill_efficacy_scores.go
+++ b/server/internal/telemetry/repo/skill_efficacy_scores.go
@@ -58,6 +58,22 @@ type ListSkillEfficacyScoreSessionsParams struct {
 	Limit          uint64
 }
 
+// ListExistingSkillEfficacyScoreIDs' filters. Named rather than positional
+// because the query takes two bare strings, three string slices and two
+// timestamps: every adjacent pair is assignment-compatible, so a transposition
+// still compiles and silently reads the wrong rows — and this read is the
+// dedup guard, where a wrong answer either re-pays for inference or suppresses
+// a score that was never written.
+type ListExistingSkillEfficacyScoreIDsParams struct {
+	OrganizationID  string
+	ProjectID       string
+	SkillIDs        []string
+	SkillVersionIDs []string
+	IDs             []string
+	MinCreatedAt    time.Time
+	MaxCreatedAt    time.Time
+}
+
 type SkillEfficacyScoreSession struct {
 	ID                    string    `ch:"id"`
 	SkillID               string    `ch:"skill_id"`
@@ -72,126 +88,6 @@ type SkillEfficacyScoreSession struct {
 	ROIConfidence         *string   `ch:"roi_confidence"`
 	Flags                 []string  `ch:"flags"`
 	GramChatID            string    `ch:"gram_chat_id"`
-}
-
-type skillEfficacyScoreScope struct {
-	organizationID  string
-	projectID       string
-	skillIDs        []string
-	skillVersionIDs []string
-}
-
-// deduplicatedSkillEfficacyScores returns one coherent first-published row per
-// event ID. Physical inserts are at-least-once, so every analytical read uses
-// this scoped source before aggregating, joining, ordering, or limiting.
-func deduplicatedSkillEfficacyScores(scope skillEfficacyScoreScope) (string, []any, error) {
-	const eventTuple = "tuple(created_at, organization_id, project_id, session_id, skill_id, skill_version_id, canonical_sha256, surface, trace_id, gram_chat_id, score, rationale, est_turns_saved, est_minutes_saved, roi_confidence, flags, judge_model, judge_prompt_version)"
-
-	physical := sq.Select(
-		"id",
-		"argMin("+eventTuple+", tuple(inserted_at, created_at)) AS event",
-	).
-		From("skill_efficacy_scores").
-		Where(squirrel.Eq{"organization_id": scope.organizationID}).
-		Where(squirrel.Eq{"project_id": scope.projectID})
-	if len(scope.skillIDs) > 0 {
-		physical = physical.Where(squirrel.Eq{"toString(skill_id)": scope.skillIDs})
-	}
-	if len(scope.skillVersionIDs) > 0 {
-		physical = physical.Where(squirrel.Eq{"toString(skill_version_id)": scope.skillVersionIDs})
-	}
-	physicalSQL, args, err := physical.GroupBy("id").ToSql()
-	if err != nil {
-		return "", nil, fmt.Errorf("building deduplicated skill efficacy scores query: %w", err)
-	}
-
-	columns := []string{
-		"id",
-		"tupleElement(event, 1) AS created_at",
-		"tupleElement(event, 2) AS organization_id",
-		"tupleElement(event, 3) AS project_id",
-		"tupleElement(event, 4) AS session_id",
-		"tupleElement(event, 5) AS skill_id",
-		"tupleElement(event, 6) AS skill_version_id",
-		"tupleElement(event, 7) AS canonical_sha256",
-		"tupleElement(event, 8) AS surface",
-		"tupleElement(event, 9) AS trace_id",
-		"tupleElement(event, 10) AS gram_chat_id",
-		"tupleElement(event, 11) AS score",
-		"tupleElement(event, 12) AS rationale",
-		"tupleElement(event, 13) AS est_turns_saved",
-		"tupleElement(event, 14) AS est_minutes_saved",
-		"tupleElement(event, 15) AS roi_confidence",
-		"tupleElement(event, 16) AS flags",
-		"tupleElement(event, 17) AS judge_model",
-		"tupleElement(event, 18) AS judge_prompt_version",
-	}
-	return "SELECT " + strings.Join(columns, ", ") + " FROM (" + physicalSQL + ")", args, nil
-}
-
-func (q *Queries) ListSkillEfficacyScoreSessions(ctx context.Context, arg ListSkillEfficacyScoreSessionsParams) ([]SkillEfficacyScoreSession, error) {
-	if arg.OrganizationID == "" || arg.ProjectID == "" || len(arg.SkillIDs) == 0 || !arg.From.Before(arg.To) || arg.Limit == 0 || arg.Limit > 101 || arg.CursorScoredAt.IsZero() != (arg.CursorID == "") {
-		return nil, fmt.Errorf("list skill efficacy score sessions: invalid scope, window, or limit")
-	}
-	mappings := sq.Select(
-		"toString(project_id) AS project_id", "session_id", "surface",
-		"toString(skill_id) AS skill_id", "toString(skill_version_id) AS skill_version_id",
-		"max(seen_at) AS activated_at",
-	).
-		From("skill_session_versions").
-		Where(squirrel.Eq{"organization_id": arg.OrganizationID}).
-		Where(squirrel.Eq{"project_id": arg.ProjectID}).
-		Where(squirrel.Eq{"toString(skill_id)": arg.SkillIDs}).
-		Where("seen_at >= ?", arg.From).
-		Where("seen_at <= ?", arg.To).
-		GroupBy("project_id", "session_id", "surface", "skill_id", "skill_version_id")
-	mappingSQL, mappingArgs, err := mappings.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building scored session mappings query: %w", err)
-	}
-	scoreSQL, scoreArgs, err := deduplicatedSkillEfficacyScores(skillEfficacyScoreScope{
-		organizationID: arg.OrganizationID, projectID: arg.ProjectID, skillIDs: arg.SkillIDs, skillVersionIDs: nil,
-	})
-	if err != nil {
-		return nil, err
-	}
-	sessions := sq.Select(
-		"toString(e.id) AS id", "toString(e.skill_id) AS skill_id", "toString(e.skill_version_id) AS skill_version_id",
-		"e.surface AS surface", "m.activated_at AS activated_at", "e.created_at AS scored_at", "e.score AS score",
-		"e.rationale AS rationale", "e.est_turns_saved AS estimated_turns_saved", "e.est_minutes_saved AS estimated_minutes_saved",
-		"e.roi_confidence AS roi_confidence", "e.flags AS flags", "e.gram_chat_id AS gram_chat_id",
-	).
-		From("score_events e").
-		Join("mappings m ON m.project_id = e.project_id AND m.session_id = e.session_id AND m.surface = e.surface AND m.skill_id = toString(e.skill_id) AND m.skill_version_id = toString(e.skill_version_id)")
-	if arg.CursorID != "" {
-		sessions = sessions.Where("(e.created_at, e.id) < (?, toUUID(?))", arg.CursorScoredAt, arg.CursorID)
-	}
-	query, args, err := sessions.
-		OrderBy("e.created_at DESC", "e.id DESC").
-		Limit(arg.Limit).
-		Prefix("WITH mappings AS ("+mappingSQL+"), score_events AS ("+scoreSQL+")", append(mappingArgs, scoreArgs...)...).
-		ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building scored sessions query: %w", err)
-	}
-	rows, err := q.conn.Query(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("querying scored sessions: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-	var result []SkillEfficacyScoreSession
-	for rows.Next() {
-		var row SkillEfficacyScoreSession
-		if err := rows.ScanStruct(&row); err != nil {
-			return nil, fmt.Errorf("scanning scored session: %w", err)
-		}
-		result = append(result, row)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating scored sessions: %w", err)
-	}
-
-	return result, nil
 }
 
 // SkillInsightBucket is one activation-time bucket for a skill version. Score
@@ -228,117 +124,9 @@ func (q *Queries) QuerySkillInsights(ctx context.Context, arg QuerySkillInsights
 		return nil, fmt.Errorf("query skill insights: invalid scope, window, or interval")
 	}
 
-	sessions := sq.Select(
-		"toString(gram_project_id) AS project_id",
-		"chat_id AS session_id",
-		"if("+skillVersionAssistantUsagePredicate+", 'assistant', 'dev') AS surface",
-		"countIf("+skillVersionUsageMeasureFilter+") > 0 AS has_usage",
-		skillVersionCostExpr+" AS total_cost",
-	).
-		From("telemetry_logs").
-		Where(squirrel.Eq{"gram_project_id": []string{arg.ProjectID}}).
-		Where("time_unix_nano >= ?", arg.From.UnixNano()).
-		Where("time_unix_nano <= ?", arg.To.UnixNano()).
-		Where(skillVersionSourceRowPredicate).
-		Where("chat_id != ''").
-		GroupBy("gram_project_id", "chat_id", "surface")
-	sessionSQL, sessionArgs, err := sessions.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building skill insight sessions query: %w", err)
-	}
-
-	mappings := sq.Select(
-		"toString(project_id) AS project_id",
-		"session_id",
-		"surface",
-		"toString(skill_id) AS skill_id",
-		"toString(skill_version_id) AS skill_version_id",
-		"max(seen_at) AS observed_at",
-		"uniqExact(id) AS activation_count",
-	).
-		From("skill_session_versions").
-		Where(squirrel.Eq{"organization_id": arg.OrganizationID}).
-		Where(squirrel.Eq{"project_id": arg.ProjectID}).
-		Where("seen_at >= ?", arg.From).
-		Where("seen_at <= ?", arg.To)
-	if len(arg.SkillIDs) > 0 {
-		mappings = mappings.Where(squirrel.Eq{"toString(skill_id)": arg.SkillIDs})
-	}
-	if len(arg.SkillVersionIDs) > 0 {
-		mappings = mappings.Where(squirrel.Eq{"toString(skill_version_id)": arg.SkillVersionIDs})
-	}
-	mappings = mappings.GroupBy("project_id", "session_id", "surface", "skill_id", "skill_version_id")
-	mappingSQL, mappingArgs, err := mappings.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building skill insight mappings query: %w", err)
-	}
-
-	scoreEventSQL, scoreEventArgs, err := deduplicatedSkillEfficacyScores(skillEfficacyScoreScope{
-		organizationID: arg.OrganizationID, projectID: arg.ProjectID, skillIDs: arg.SkillIDs, skillVersionIDs: arg.SkillVersionIDs,
-	})
+	query, args, err := buildSkillInsightsQuery(arg)
 	if err != nil {
 		return nil, err
-	}
-
-	scores := sq.Select(
-		"project_id",
-		"session_id",
-		"surface",
-		"toString(skill_id) AS skill_id",
-		"toString(skill_version_id) AS skill_version_id",
-		"count() AS score_count",
-		"sum(score) AS score_sum",
-		"sum(ifNull(est_turns_saved, 0)) AS turns_sum",
-		"countIf(est_turns_saved IS NOT NULL) AS turns_count",
-		"sum(ifNull(est_minutes_saved, 0)) AS minutes_sum",
-		"countIf(est_minutes_saved IS NOT NULL) AS minutes_count",
-		"countIf(roi_confidence = 'low') AS confidence_low",
-		"countIf(roi_confidence = 'med') AS confidence_med",
-		"countIf(roi_confidence = 'high') AS confidence_high",
-		"countIf(has(flags, 'ignored')) AS ignored_count",
-		"countIf(has(flags, 'misapplied')) AS misapplied_count",
-		"countIf(has(flags, 'partially_followed')) AS partially_followed_count",
-		"countIf(has(flags, 'harmful')) AS harmful_count",
-	).
-		From("score_events")
-	scores = scores.GroupBy("project_id", "session_id", "surface", "skill_id", "skill_version_id")
-	scoreSQL, scoreArgs, err := scores.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building skill insight scores query: %w", err)
-	}
-
-	outer := sq.Select(
-		"m.skill_id AS skill_id",
-		"m.skill_version_id AS skill_version_id",
-	).
-		Column(squirrel.Expr("toInt64(toStartOfInterval(m.observed_at, toIntervalSecond(?))) * 1000000000 AS bucket_time_unix_nano", arg.IntervalSeconds)).
-		Columns(
-			"sum(m.activation_count) AS activation_count",
-			"count() AS activated_sessions",
-			"sum(if(s.has_usage, s.total_cost, 0)) AS total_session_cost",
-			"sum(ifNull(e.score_count, 0)) AS scored_sessions",
-			"sum(ifNull(e.score_sum, 0)) AS score_sum",
-			"sum(ifNull(e.turns_sum, 0)) AS estimated_turns_saved_sum",
-			"sum(ifNull(e.turns_count, 0)) AS estimated_turns_samples",
-			"sum(ifNull(e.minutes_sum, 0)) AS estimated_minutes_saved_sum",
-			"sum(ifNull(e.minutes_count, 0)) AS estimated_minutes_samples",
-			"sum(ifNull(e.confidence_low, 0)) AS roi_confidence_low",
-			"sum(ifNull(e.confidence_med, 0)) AS roi_confidence_med",
-			"sum(ifNull(e.confidence_high, 0)) AS roi_confidence_high",
-			"sum(ifNull(e.ignored_count, 0)) AS ignored_count",
-			"sum(ifNull(e.misapplied_count, 0)) AS misapplied_count",
-			"sum(ifNull(e.partially_followed_count, 0)) AS partially_followed_count",
-			"sum(ifNull(e.harmful_count, 0)) AS harmful_count",
-		).
-		From("mappings m").
-		LeftJoin("sessions s ON s.project_id = m.project_id AND s.session_id = m.session_id AND s.surface = m.surface").
-		LeftJoin("scores e ON e.project_id = m.project_id AND e.session_id = m.session_id AND e.surface = m.surface AND e.skill_id = m.skill_id AND e.skill_version_id = m.skill_version_id").
-		GroupBy("m.skill_id", "m.skill_version_id", "bucket_time_unix_nano").
-		OrderBy("bucket_time_unix_nano ASC", "m.skill_id ASC", "m.skill_version_id ASC").
-		Prefix("WITH sessions AS ("+sessionSQL+"), mappings AS ("+mappingSQL+"), score_events AS ("+scoreEventSQL+"), scores AS ("+scoreSQL+")", append(append(append(sessionArgs, mappingArgs...), scoreEventArgs...), scoreArgs...)...)
-	query, args, err := outer.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building skill insights query: %w", err)
 	}
 
 	rows, err := q.conn.Query(ctx, query, args...)
@@ -358,6 +146,70 @@ func (q *Queries) QuerySkillInsights(ctx context.Context, arg QuerySkillInsights
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating skill insight buckets: %w", err)
 	}
+	return result, nil
+}
+
+func (q *Queries) ListSkillEfficacyScoreSessions(ctx context.Context, arg ListSkillEfficacyScoreSessionsParams) ([]SkillEfficacyScoreSession, error) {
+	if arg.OrganizationID == "" || arg.ProjectID == "" || len(arg.SkillIDs) == 0 || !arg.From.Before(arg.To) || arg.Limit == 0 || arg.Limit > 101 || arg.CursorScoredAt.IsZero() != (arg.CursorID == "") {
+		return nil, fmt.Errorf("list skill efficacy score sessions: invalid scope, window, or limit")
+	}
+	mappings := sq.Select(
+		"toString(project_id) AS project_id", "session_id", "surface",
+		"toString(skill_id) AS skill_id", "toString(skill_version_id) AS skill_version_id",
+		"max(seen_at) AS activated_at",
+	).
+		From("skill_session_versions").
+		Where(squirrel.Eq{"organization_id": arg.OrganizationID}).
+		Where(squirrel.Eq{"project_id": arg.ProjectID}).
+		Where(squirrel.Eq{"toString(skill_id)": arg.SkillIDs}).
+		Where("seen_at >= ?", arg.From).
+		Where("seen_at <= ?", arg.To).
+		GroupBy("project_id", "session_id", "surface", "skill_id", "skill_version_id")
+	scoreSQL, scoreArgs, err := deduplicatedSkillEfficacyScores(skillEfficacyScoreScope{
+		organizationID: arg.OrganizationID, projectID: arg.ProjectID, skillIDs: arg.SkillIDs, skillVersionIDs: nil,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sessions := sq.Select(
+		"toString(e.id) AS id", "toString(e.skill_id) AS skill_id", "toString(e.skill_version_id) AS skill_version_id",
+		"e.surface AS surface", "m.activated_at AS activated_at", "e.created_at AS scored_at", "e.score AS score",
+		"e.rationale AS rationale", "e.est_turns_saved AS estimated_turns_saved", "e.est_minutes_saved AS estimated_minutes_saved",
+		"e.roi_confidence AS roi_confidence", "e.flags AS flags", "e.gram_chat_id AS gram_chat_id",
+	).
+		From("score_events e").
+		Join("mappings m ON m.project_id = e.project_id AND m.session_id = e.session_id AND m.surface = e.surface AND m.skill_id = toString(e.skill_id) AND m.skill_version_id = toString(e.skill_version_id)")
+	if arg.CursorID != "" {
+		sessions = sessions.Where("(e.created_at, e.id) < (?, toUUID(?))", arg.CursorScoredAt, arg.CursorID)
+	}
+	query, args, err := sessions.
+		OrderBy("e.created_at DESC", "e.id DESC").
+		Limit(arg.Limit).
+		PrefixExpr(squirrel.ConcatExpr(
+			"WITH mappings AS (", mappings,
+			"), score_events AS (", squirrel.Expr(scoreSQL, scoreArgs...), ")",
+		)).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building scored sessions query: %w", err)
+	}
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying scored sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var result []SkillEfficacyScoreSession
+	for rows.Next() {
+		var row SkillEfficacyScoreSession
+		if err := rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scanning scored session: %w", err)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating scored sessions: %w", err)
+	}
+
 	return result, nil
 }
 
@@ -437,22 +289,6 @@ func (q *Queries) InsertSkillEfficacyScores(ctx context.Context, rows []SkillEff
 	return nil
 }
 
-// ListExistingSkillEfficacyScoreIDs' filters. Named rather than positional
-// because the query takes two bare strings, three string slices and two
-// timestamps: every adjacent pair is assignment-compatible, so a transposition
-// still compiles and silently reads the wrong rows — and this read is the
-// dedup guard, where a wrong answer either re-pays for inference or suppresses
-// a score that was never written.
-type ListExistingSkillEfficacyScoreIDsParams struct {
-	OrganizationID  string
-	ProjectID       string
-	SkillIDs        []string
-	SkillVersionIDs []string
-	IDs             []string
-	MinCreatedAt    time.Time
-	MaxCreatedAt    time.Time
-}
-
 // ListExistingSkillEfficacyScoreIDs returns which of the given score ids are
 // already published — the publication dedup guard. The filters follow the
 // table's ORDER BY prefix — organization_id, project_id, skill_id,
@@ -509,4 +345,190 @@ func (q *Queries) ListExistingSkillEfficacyScoreIDs(ctx context.Context, arg Lis
 		return nil, fmt.Errorf("iterating existing skill efficacy score ids: %w", err)
 	}
 	return result, nil
+}
+
+type skillEfficacyScoreScope struct {
+	organizationID  string
+	projectID       string
+	skillIDs        []string
+	skillVersionIDs []string
+}
+
+// deduplicatedSkillEfficacyScores returns one coherent first-published row per
+// event ID. Physical inserts are at-least-once, so every analytical read uses
+// this scoped source before aggregating, joining, ordering, or limiting.
+func deduplicatedSkillEfficacyScores(scope skillEfficacyScoreScope) (string, []any, error) {
+	const eventTuple = "tuple(created_at, organization_id, project_id, session_id, skill_id, skill_version_id, canonical_sha256, surface, trace_id, gram_chat_id, score, rationale, est_turns_saved, est_minutes_saved, roi_confidence, flags, judge_model, judge_prompt_version)"
+
+	physical := sq.Select(
+		"id",
+		"argMin("+eventTuple+", tuple(inserted_at, created_at)) AS event",
+	).
+		From("skill_efficacy_scores").
+		Where(squirrel.Eq{"organization_id": scope.organizationID}).
+		Where(squirrel.Eq{"project_id": scope.projectID})
+	if len(scope.skillIDs) > 0 {
+		physical = physical.Where(squirrel.Eq{"toString(skill_id)": scope.skillIDs})
+	}
+	if len(scope.skillVersionIDs) > 0 {
+		physical = physical.Where(squirrel.Eq{"toString(skill_version_id)": scope.skillVersionIDs})
+	}
+	physicalSQL, args, err := physical.GroupBy("id").ToSql()
+	if err != nil {
+		return "", nil, fmt.Errorf("building deduplicated skill efficacy scores query: %w", err)
+	}
+
+	columns := []string{
+		"id",
+		"tupleElement(event, 1) AS created_at",
+		"tupleElement(event, 2) AS organization_id",
+		"tupleElement(event, 3) AS project_id",
+		"tupleElement(event, 4) AS session_id",
+		"tupleElement(event, 5) AS skill_id",
+		"tupleElement(event, 6) AS skill_version_id",
+		"tupleElement(event, 7) AS canonical_sha256",
+		"tupleElement(event, 8) AS surface",
+		"tupleElement(event, 9) AS trace_id",
+		"tupleElement(event, 10) AS gram_chat_id",
+		"tupleElement(event, 11) AS score",
+		"tupleElement(event, 12) AS rationale",
+		"tupleElement(event, 13) AS est_turns_saved",
+		"tupleElement(event, 14) AS est_minutes_saved",
+		"tupleElement(event, 15) AS roi_confidence",
+		"tupleElement(event, 16) AS flags",
+		"tupleElement(event, 17) AS judge_model",
+		"tupleElement(event, 18) AS judge_prompt_version",
+	}
+	return "SELECT " + strings.Join(columns, ", ") + " FROM (" + physicalSQL + ")", args, nil
+}
+
+func skillInsightMappingRows(arg QuerySkillInsightsParams) squirrel.SelectBuilder {
+	rows := sq.Select().
+		From("skill_session_versions").
+		Where(squirrel.Eq{"organization_id": arg.OrganizationID}).
+		Where(squirrel.Eq{"project_id": arg.ProjectID}).
+		Where("seen_at >= ?", arg.From).
+		Where("seen_at <= ?", arg.To)
+	if len(arg.SkillIDs) > 0 {
+		rows = rows.Where(squirrel.Eq{"toString(skill_id)": arg.SkillIDs})
+	}
+	if len(arg.SkillVersionIDs) > 0 {
+		rows = rows.Where(squirrel.Eq{"toString(skill_version_id)": arg.SkillVersionIDs})
+	}
+	return rows
+}
+
+func skillInsightMappings(rows squirrel.SelectBuilder) squirrel.SelectBuilder {
+	return rows.Columns(
+		"toString(project_id) AS project_id",
+		"session_id",
+		"surface",
+		"toString(skill_id) AS skill_id",
+		"toString(skill_version_id) AS skill_version_id",
+		"max(seen_at) AS observed_at",
+		"uniqExact(id) AS activation_count",
+	).
+		GroupBy("project_id", "session_id", "surface", "skill_id", "skill_version_id")
+}
+
+func skillInsightSessionUsage(arg QuerySkillInsightsParams, mappingRows squirrel.SelectBuilder) squirrel.SelectBuilder {
+	return mappedSkillTelemetryQuery(
+		[]string{arg.ProjectID},
+		arg.From.UnixNano(),
+		arg.To.UnixNano(),
+		mappingRows.Column("session_id").Distinct(),
+	).
+		Columns(
+			"toString(gram_project_id) AS project_id",
+			"chat_id AS session_id",
+			"if("+skillVersionAssistantUsagePredicate+", 'assistant', 'dev') AS surface",
+			"countIf("+skillVersionUsageMeasureFilter+") > 0 AS has_usage",
+			skillVersionCostExpr+" AS total_cost",
+		).
+		GroupBy("gram_project_id", "chat_id", "surface")
+}
+
+func skillInsightScores() squirrel.SelectBuilder {
+	return sq.Select(
+		"project_id",
+		"session_id",
+		"surface",
+		"toString(skill_id) AS skill_id",
+		"toString(skill_version_id) AS skill_version_id",
+		"count() AS score_count",
+		"sum(score) AS score_sum",
+		"sum(ifNull(est_turns_saved, 0)) AS turns_sum",
+		"countIf(est_turns_saved IS NOT NULL) AS turns_count",
+		"sum(ifNull(est_minutes_saved, 0)) AS minutes_sum",
+		"countIf(est_minutes_saved IS NOT NULL) AS minutes_count",
+		"countIf(roi_confidence = 'low') AS confidence_low",
+		"countIf(roi_confidence = 'med') AS confidence_med",
+		"countIf(roi_confidence = 'high') AS confidence_high",
+		"countIf(has(flags, 'ignored')) AS ignored_count",
+		"countIf(has(flags, 'misapplied')) AS misapplied_count",
+		"countIf(has(flags, 'partially_followed')) AS partially_followed_count",
+		"countIf(has(flags, 'harmful')) AS harmful_count",
+	).
+		From("score_events").
+		GroupBy("project_id", "session_id", "surface", "skill_id", "skill_version_id")
+}
+
+func skillInsightResult(intervalSeconds int64) squirrel.SelectBuilder {
+	return sq.Select(
+		"m.skill_id AS skill_id",
+		"m.skill_version_id AS skill_version_id",
+	).
+		Column(squirrel.Expr("toInt64(toStartOfInterval(m.observed_at, toIntervalSecond(?))) * 1000000000 AS bucket_time_unix_nano", intervalSeconds)).
+		Columns(
+			"sum(m.activation_count) AS activation_count",
+			"count() AS activated_sessions",
+			"sum(if(s.has_usage, s.total_cost, 0)) AS total_session_cost",
+			"sum(ifNull(e.score_count, 0)) AS scored_sessions",
+			"sum(ifNull(e.score_sum, 0)) AS score_sum",
+			"sum(ifNull(e.turns_sum, 0)) AS estimated_turns_saved_sum",
+			"sum(ifNull(e.turns_count, 0)) AS estimated_turns_samples",
+			"sum(ifNull(e.minutes_sum, 0)) AS estimated_minutes_saved_sum",
+			"sum(ifNull(e.minutes_count, 0)) AS estimated_minutes_samples",
+			"sum(ifNull(e.confidence_low, 0)) AS roi_confidence_low",
+			"sum(ifNull(e.confidence_med, 0)) AS roi_confidence_med",
+			"sum(ifNull(e.confidence_high, 0)) AS roi_confidence_high",
+			"sum(ifNull(e.ignored_count, 0)) AS ignored_count",
+			"sum(ifNull(e.misapplied_count, 0)) AS misapplied_count",
+			"sum(ifNull(e.partially_followed_count, 0)) AS partially_followed_count",
+			"sum(ifNull(e.harmful_count, 0)) AS harmful_count",
+		).
+		From("mappings m").
+		LeftJoin("sessions s ON s.project_id = m.project_id AND s.session_id = m.session_id AND s.surface = m.surface").
+		LeftJoin("scores e ON e.project_id = m.project_id AND e.session_id = m.session_id AND e.surface = m.surface AND e.skill_id = m.skill_id AND e.skill_version_id = m.skill_version_id").
+		GroupBy("m.skill_id", "m.skill_version_id", "bucket_time_unix_nano").
+		OrderBy("bucket_time_unix_nano ASC", "m.skill_id ASC", "m.skill_version_id ASC")
+}
+
+func buildSkillInsightsQuery(arg QuerySkillInsightsParams) (string, []any, error) {
+	mappingRows := skillInsightMappingRows(arg)
+	mappings := skillInsightMappings(mappingRows)
+	sessions := skillInsightSessionUsage(arg, mappingRows)
+
+	scoreEventSQL, scoreEventArgs, err := deduplicatedSkillEfficacyScores(skillEfficacyScoreScope{
+		organizationID:  arg.OrganizationID,
+		projectID:       arg.ProjectID,
+		skillIDs:        arg.SkillIDs,
+		skillVersionIDs: arg.SkillVersionIDs,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	query, args, err := skillInsightResult(arg.IntervalSeconds).
+		PrefixExpr(squirrel.ConcatExpr(
+			"WITH mappings AS (", mappings,
+			"), sessions AS (", sessions,
+			"), score_events AS (", squirrel.Expr(scoreEventSQL, scoreEventArgs...),
+			"), scores AS (", skillInsightScores(), ")",
+		)).
+		ToSql()
+	if err != nil {
+		return "", nil, fmt.Errorf("building skill insights query: %w", err)
+	}
+	return query, args, nil
 }

--- a/server/internal/telemetry/repo/skill_efficacy_scores_test.go
+++ b/server/internal/telemetry/repo/skill_efficacy_scores_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -123,6 +124,53 @@ func TestInsertSkillEfficacyScores_EmptyInputIsNoop(t *testing.T) {
 
 	require.NoError(t, queries.InsertSkillEfficacyScores(ctx, nil))
 	require.NoError(t, queries.InsertSkillEfficacyScores(ctx, []repo.SkillEfficacyScore{}))
+}
+
+func TestMappedSessionFilterUsesChatIDSkippingIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	sessionID := uuid.NewString()
+	now := time.Now().UTC()
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, 'INFO', '', NULL, NULL, ?, '{}', ?, 'claude-code:otel:logs', 'claude-code')
+	`, uuid.NewString(), now.UnixNano(), now.UnixNano(), `{"gen_ai.conversation.id":"`+sessionID+`"}`, projectID)
+	require.NoError(t, err)
+
+	rows, err := conn.Query(ctx, `
+		EXPLAIN indexes = 1
+		WITH mappings AS (
+			SELECT project_id, session_id
+			FROM skill_session_versions
+			WHERE project_id = toUUID(?)
+			GROUP BY project_id, session_id
+		)
+		SELECT count()
+		FROM telemetry_logs
+		WHERE gram_project_id = toUUID(?)
+		  AND time_unix_nano >= ?
+		  AND time_unix_nano <= ?
+		  AND chat_id IN (SELECT session_id FROM mappings)
+	`, projectID.String(), projectID.String(), now.Add(-time.Hour).UnixNano(), now.Add(time.Hour).UnixNano())
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var planLines []string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		planLines = append(planLines, line)
+	}
+	require.NoError(t, rows.Err())
+	require.Contains(t, strings.Join(planLines, "\n"), "idx_telemetry_logs_mat_chat_id")
 }
 
 func TestQuerySkillInsightsAggregatesMappingsAndScoresWithoutUsage(t *testing.T) {

--- a/server/internal/telemetry/repo/skill_mapped_sessions.go
+++ b/server/internal/telemetry/repo/skill_mapped_sessions.go
@@ -1,0 +1,16 @@
+package repo
+
+import "github.com/Masterminds/squirrel"
+
+func mappedSkillTelemetryQuery(projectIDs []string, timeStart, timeEnd int64, mappedSessions squirrel.SelectBuilder) squirrel.SelectBuilder {
+	return sq.Select().
+		From("telemetry_logs").
+		Where(squirrel.Eq{"gram_project_id": projectIDs}).
+		Where("time_unix_nano >= ?", timeStart).
+		Where("time_unix_nano <= ?", timeEnd).
+		Where(skillVersionSourceRowPredicate).
+		Where("chat_id != ''").
+		// Keep chat_id as a standalone predicate so ClickHouse can use its
+		// skipping index. The project and surface join still decides attribution.
+		Where(squirrel.Expr("chat_id IN (?)", mappedSessions))
+}

--- a/server/internal/telemetry/repo/skill_version_metrics.go
+++ b/server/internal/telemetry/repo/skill_version_metrics.go
@@ -157,6 +157,50 @@ func skillVersionDimensionValuesExpr(groupBy string) string {
 	return "map(" + strings.Join(parts, ", ") + ") AS dimension_values"
 }
 
+func partitionSkillVersionFilters(filters []AttributeMetricsFilter) ([][]string, []AttributeMetricsFilter) {
+	versionFilters := make([][]string, 0, len(filters))
+	sessionFilters := make([]AttributeMetricsFilter, 0, len(filters))
+	for _, filter := range filters {
+		if filter.Dimension != skillVersionDimension {
+			sessionFilters = append(sessionFilters, filter)
+			continue
+		}
+		if len(filter.Values) > 0 {
+			versionFilters = append(versionFilters, filter.Values)
+		}
+	}
+	return versionFilters, sessionFilters
+}
+
+func skillVersionMappingRows(projectIDs []string, versionFilters [][]string) squirrel.SelectBuilder {
+	rows := sq.Select().
+		From("skill_session_versions").
+		Where(squirrel.Eq{"project_id": projectIDs})
+	if len(versionFilters) == 0 {
+		return rows
+	}
+
+	relevantValues := make(map[string]struct{})
+	for _, values := range versionFilters {
+		for _, value := range values {
+			relevantValues[value] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(relevantValues))
+	for value := range relevantValues {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return rows.Where(squirrel.Eq{"toString(skill_version_id)": values})
+}
+
+func requireSkillVersionFilters(builder squirrel.SelectBuilder, versionFilters [][]string) squirrel.SelectBuilder {
+	for _, values := range versionFilters {
+		builder = builder.Having("hasAny(groupUniqArray(toString(skill_version_id)), ?)", values)
+	}
+	return builder
+}
+
 func buildSkillVersionMetricsQuery(arg AttributeMetricsQueryParams, timeseries bool) (string, []any, error) {
 	if !attributeMeasureSet[arg.SortBy] {
 		return "", nil, fmt.Errorf("unknown sort_by measure %q", arg.SortBy)
@@ -165,84 +209,52 @@ func buildSkillVersionMetricsQuery(arg AttributeMetricsQueryParams, timeseries b
 		return "", nil, fmt.Errorf("sort_by measure %q is not supported for skill version grouping", arg.SortBy)
 	}
 
-	sessionBuilder := sq.Select(
-		"gram_project_id AS project_id",
-		"chat_id AS session_id",
-		// Surface stays in the join key: assistant completion URNs map to
-		// assistant, while every admitted dev-agent telemetry row maps to dev.
-		"if("+skillVersionAssistantUsagePredicate+", 'assistant', 'dev') AS surface",
-		"min(time_unix_nano) AS session_time_unix_nano",
-		"countIf("+skillVersionUsageMeasureFilter+") > 0 AS s_has_usage",
-	).
-		Columns(skillVersionSessionMeasureSelects...).
-		Columns(skillVersionSessionSelects()...).
-		From("telemetry_logs").
-		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
-		Where("time_unix_nano >= ?", arg.TimeStart).
-		Where("time_unix_nano <= ?", arg.TimeEnd).
-		Where(skillVersionSourceRowPredicate).
-		Where("chat_id != ''")
-
-	var skillVersionFilterSets [][]string
-	existingFilters := make([]AttributeMetricsFilter, 0, len(arg.Filters))
-	for _, filter := range arg.Filters {
-		if filter.Dimension == skillVersionDimension {
-			if len(filter.Values) > 0 {
-				skillVersionFilterSets = append(skillVersionFilterSets, filter.Values)
-			}
-			continue
-		}
-		existingFilters = append(existingFilters, filter)
-	}
-	var err error
-	sessionBuilder, err = applySessionFilters(sessionBuilder, existingFilters, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
-	if err != nil {
-		return "", nil, err
-	}
-	sessionBuilder = sessionBuilder.GroupBy("gram_project_id", "chat_id", "surface")
-	sessionSQL, sessionArgs, err := sessionBuilder.ToSql()
-	if err != nil {
-		return "", nil, fmt.Errorf("building skill version session query: %w", err)
-	}
-
-	mappingBuilder := sq.Select(
+	versionFilters, sessionFilters := partitionSkillVersionFilters(arg.Filters)
+	mappingRows := skillVersionMappingRows(arg.ProjectIDs, versionFilters)
+	mappings := mappingRows.Columns(
 		"project_id",
 		"session_id",
 		"surface",
 		"groupUniqArray(toString(skill_version_id)) AS skill_versions",
 	).
-		From("skill_session_versions").
-		Where(squirrel.Eq{"project_id": arg.ProjectIDs})
-	if len(skillVersionFilterSets) > 0 {
-		relevantValues := make(map[string]struct{})
-		for _, values := range skillVersionFilterSets {
-			for _, value := range values {
-				relevantValues[value] = struct{}{}
-			}
-			mappingBuilder = mappingBuilder.Having("hasAny(groupUniqArray(toString(skill_version_id)), ?)", values)
-		}
-		values := make([]string, 0, len(relevantValues))
-		for value := range relevantValues {
-			values = append(values, value)
-		}
-		sort.Strings(values)
-		mappingBuilder = mappingBuilder.Where(squirrel.Eq{"toString(skill_version_id)": values})
-	}
-	mappingBuilder = mappingBuilder.GroupBy("project_id", "session_id", "surface")
-	mappingSQL, mappingArgs, err := mappingBuilder.ToSql()
+		GroupBy("project_id", "session_id", "surface")
+	mappings = requireSkillVersionFilters(mappings, versionFilters)
+
+	mappedSessions := mappingRows.
+		Column("session_id").
+		GroupBy("project_id", "session_id", "surface")
+	mappedSessions = requireSkillVersionFilters(mappedSessions, versionFilters)
+
+	sessions := mappedSkillTelemetryQuery(arg.ProjectIDs, arg.TimeStart, arg.TimeEnd, mappedSessions).
+		Columns(
+			"gram_project_id AS project_id",
+			"chat_id AS session_id",
+			// Surface stays in the join key: assistant completion URNs map to
+			// assistant, while every admitted dev-agent telemetry row maps to dev.
+			"if("+skillVersionAssistantUsagePredicate+", 'assistant', 'dev') AS surface",
+			"min(time_unix_nano) AS session_time_unix_nano",
+			"countIf("+skillVersionUsageMeasureFilter+") > 0 AS s_has_usage",
+		).
+		Columns(skillVersionSessionMeasureSelects...).
+		Columns(skillVersionSessionSelects()...).
+		GroupBy("gram_project_id", "chat_id", "surface")
+	var err error
+	sessions, err = applySessionFilters(sessions, sessionFilters, canonicalIdentityOrgLiteral(arg.CanonicalIdentityOrg))
 	if err != nil {
-		return "", nil, fmt.Errorf("building skill version mapping query: %w", err)
+		return "", nil, err
 	}
 
 	groupExpr, grouped, err := skillVersionGroupExpr(arg.GroupBy)
 	if err != nil {
 		return "", nil, err
 	}
-	outer := sq.Select(groupExpr+" AS group_value").
+	outer := sq.Select(groupExpr + " AS group_value").
 		Columns(skillVersionMeasureSelects...).
 		From("sessions").
 		Join("mappings USING (project_id, session_id, surface)").
-		Prefix("WITH sessions AS ("+sessionSQL+"), mappings AS ("+mappingSQL+")", append(sessionArgs, mappingArgs...)...)
+		PrefixExpr(squirrel.ConcatExpr(
+			"WITH mappings AS (", mappings, "), sessions AS (", sessions, ")",
+		))
 
 	groupColumns := make([]string, 0, 2)
 	if timeseries {

--- a/server/internal/telemetry/repo/skill_version_metrics_test.go
+++ b/server/internal/telemetry/repo/skill_version_metrics_test.go
@@ -1,0 +1,44 @@
+package repo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSkillVersionMetricsQueryRestrictsTelemetryToMappedSessions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	query, _, err := buildSkillVersionMetricsQuery(AttributeMetricsQueryParams{
+		ProjectIDs:           []string{"00000000-0000-0000-0000-000000000001"},
+		TimeStart:            now.Add(-24 * time.Hour).UnixNano(),
+		TimeEnd:              now.UnixNano(),
+		GroupBy:              skillVersionDimension,
+		SortBy:               "total_cost",
+		Filters:              nil,
+		CanonicalIdentityOrg: "",
+		IntervalSeconds:      int64(time.Hour.Seconds()),
+	}, false)
+	require.NoError(t, err)
+
+	require.Contains(t, query, "chat_id IN (SELECT session_id FROM skill_session_versions")
+}
+
+func TestBuildSkillInsightsQueryRestrictsTelemetryToMappedSessions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	query, _, err := buildSkillInsightsQuery(QuerySkillInsightsParams{
+		OrganizationID:  "test-organization",
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		SkillIDs:        []string{"00000000-0000-0000-0000-000000000002"},
+		SkillVersionIDs: nil,
+		From:            now.Add(-24 * time.Hour),
+		To:              now,
+		IntervalSeconds: int64(time.Hour.Seconds()),
+	})
+	require.NoError(t, err)
+	require.Contains(t, query, "chat_id IN (SELECT DISTINCT session_id FROM skill_session_versions")
+}


### PR DESCRIPTION
## Why?

Skill activation counts and skill-version analytics aggregate raw telemetry for every session in a project before joining against the much smaller set of sessions that activated skills. On larger reporting windows, that makes the endpoints slow even when only a few sessions are relevant.

Relates to [DNO-811](https://linear.app/speakeasy/issue/DNO-811/skill-activation-counts-take-1-minute-to-load).

## What?

- Build the relevant skill-session mapping scope before reading telemetry.
- Restrict telemetry aggregation to mapped session IDs, allowing ClickHouse to use the existing `chat_id` skipping index.
- Share the mapped-session query builder across skill insights and `skill_version` analytics.
- Compose query CTEs from Squirrel builders to keep SQL and arguments aligned.

## Notes

No database migration is required. Existing cost, token, filtering, and attribution semantics remain unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up skill activation insights and skill-version analytics by restricting telemetry aggregation to mapped skill sessions. Previously, queries scanned `telemetry_logs` across the full window; now they precompute session mappings and use the `chat_id` skipping index, preserving existing results.

- Build session mappings from `skill_session_versions` and reuse them across insights and `skill_version` metrics; compose CTEs with `squirrel` to keep SQL and args aligned.
- Add `mappedSkillTelemetryQuery` to keep a standalone `chat_id IN (...)` predicate; tests assert the index is used and that queries are restricted to mapped sessions.
- No API changes or database migration; cost attribution, filters, and reporting semantics are unchanged.
- Addresses Linear DNO-811 (slow activation counts in the Skills list).

<sup>Written for commit a9a1e095250780546b8692336d21a201493306d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

