### PR TITLE
feat: show inference spend history in admin billing

### DIFF
--- a/.changeset/admin-inference-spend-history.md
+++ b/.changeset/admin-inference-spend-history.md
@@ -1,0 +1,6 @@
+---
+"admin": patch
+"server": patch
+---
+
+Admin organization billing now reports complete monthly inference spend history and shows a graph once two consecutive months are available.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -60197,6 +60197,22 @@ components:
         - credits_used
         - monthly_credits
         - disabled
+    AdminInferenceSpendMonth:
+      type: object
+      properties:
+        period_end:
+          type: string
+          description: Exclusive end of the UTC calendar month.
+          format: date
+        period_start:
+          type: string
+          format: date
+        spend_usd:
+          type: string
+      required:
+        - period_start
+        - period_end
+        - spend_usd
     AdminListOrganizationMembersResult:
       type: object
       properties:

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -15,6 +15,7 @@ import {
   getOrganizationFeatures,
   getOrganizationStats,
   getInferenceKeys,
+  getInferenceSpendHistory,
   getPaygBillingSummary,
   getStripeSubscription,
   getProject,
@@ -24,6 +25,7 @@ import {
   listOrganizations,
   omitUnset,
   type AdminInferenceKey,
+  type AdminInferenceSpendMonth,
   type AdminOrganization,
   type AdminOrganizationChatAnalysisSettings,
   type AdminOrganizationFeatures,
@@ -152,6 +154,19 @@ export function inferenceKeysQuery(
   return queryOptions({
     queryKey: ["gram-admin-inference-keys", organizationID] as const,
     queryFn: () => getInferenceKeys(organizationID),
+    retry: false,
+  });
+}
+
+export function inferenceSpendHistoryQuery(
+  organizationID: string,
+): AdminQuery<
+  AdminInferenceSpendMonth[],
+  readonly ["gram-admin-inference-spend-history", string]
+> {
+  return queryOptions({
+    queryKey: ["gram-admin-inference-spend-history", organizationID] as const,
+    queryFn: () => getInferenceSpendHistory(organizationID),
     retry: false,
   });
 }

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -8,6 +8,7 @@ import {
   errorMessage,
   extendTrial,
   getInferenceKeys,
+  getInferenceSpendHistory,
   getPaygBillingSummary,
   getStripeSubscription,
   getProject,
@@ -163,6 +164,7 @@ describe("organization billing endpoints", () => {
     const fetch = stubFetch();
 
     await getInferenceKeys("org one");
+    await getInferenceSpendHistory("org one");
     await getPaygBillingSummary("org one");
     await getStripeSubscription("org one");
 
@@ -170,9 +172,12 @@ describe("organization billing endpoints", () => {
       "/admin/organization.inferenceKeys?organization_id=org+one",
     );
     expect(fetch.mock.calls[1]?.[0]).toBe(
-      "/admin/organization.paygBillingSummary?organization_id=org+one",
+      "/admin/organization.inferenceSpendHistory?organization_id=org+one",
     );
     expect(fetch.mock.calls[2]?.[0]).toBe(
+      "/admin/organization.paygBillingSummary?organization_id=org+one",
+    );
+    expect(fetch.mock.calls[3]?.[0]).toBe(
       "/admin/organization.stripeSubscription?organization_id=org+one",
     );
   });

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -616,6 +616,21 @@ export function getInferenceKeys(
   );
 }
 
+export type AdminInferenceSpendMonth = {
+  period_start: string;
+  period_end: string;
+  spend_usd: string;
+};
+
+export function getInferenceSpendHistory(
+  organizationID: string,
+): Promise<AdminInferenceSpendMonth[]> {
+  const qs = toSearchParams({ organization_id: organizationID });
+  return gramAdminFetch<AdminInferenceSpendMonth[]>(
+    `/admin/organization.inferenceSpendHistory?${qs}`,
+  );
+}
+
 export type AdminPaygBillingSummary = {
   period_start: string;
   period_end: string;

--- a/client/admin/src/pages/organization/Billing.test.tsx
+++ b/client/admin/src/pages/organization/Billing.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   getOrganization: vi.fn(),
   getInferenceKeys: vi.fn(),
+  getInferenceSpendHistory: vi.fn(),
   listOrganizationProjects: vi.fn(),
   getPaygBillingSummary: vi.fn(),
   getStripeSubscription: vi.fn(),
@@ -29,6 +30,19 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
 });
 
 const ORG = anOrganization({ account_type: "payg" });
+const HISTORY = [
+  {
+    period_start: "2026-06-01",
+    period_end: "2026-07-01",
+    spend_usd: "3.250000",
+  },
+  {
+    period_start: "2026-07-01",
+    period_end: "2026-08-01",
+    spend_usd: "4.750000",
+  },
+];
+
 const SUBSCRIPTION = {
   status: "active" as const,
   current_period_start: "2026-08-01T00:00:00Z",
@@ -74,6 +88,11 @@ beforeEach(() => {
       disabled: false,
     },
   ]);
+  mocks.getInferenceSpendHistory.mockImplementation((organizationID: string) =>
+    organizationID === ORG.id
+      ? Promise.resolve(HISTORY)
+      : Promise.reject(new Error(`unexpected organization ${organizationID}`)),
+  );
   mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
   mocks.getStripeSubscription.mockImplementation((organizationID: string) =>
     organizationID === ORG.id
@@ -131,9 +150,39 @@ describe("Billing", () => {
     expect(screen.getAllByText("Enabled")).toHaveLength(2);
     expect(screen.getByText("Disabled")).toBeTruthy();
     expect(screen.getByText(/This is an estimate, not a bill/)).toBeTruthy();
+    expect(screen.getByLabelText("Monthly inference spend graph")).toBeTruthy();
+    expect(screen.getByText("$3.25")).toBeTruthy();
+    expect(screen.getByText("$4.75")).toBeTruthy();
     expect(mocks.getInferenceKeys).toHaveBeenCalledWith(ORG.id);
+    expect(mocks.getInferenceSpendHistory).toHaveBeenCalledWith(ORG.id);
     expect(mocks.getStripeSubscription).toHaveBeenCalledWith(ORG.id);
     expect(mocks.getPaygBillingSummary).toHaveBeenCalledWith(ORG.id);
+  });
+
+  it("hides the graph until two consecutive complete months are available", async () => {
+    mocks.getInferenceSpendHistory.mockResolvedValue(HISTORY.slice(0, 1));
+
+    await renderBilling();
+
+    expect(await screen.findByText("$3.25")).toBeTruthy();
+    expect(screen.queryByLabelText("Monthly inference spend graph")).toBeNull();
+  });
+
+  it("shows the graph when the latest two months are consecutive after a gap", async () => {
+    mocks.getInferenceSpendHistory.mockResolvedValue([
+      {
+        period_start: "2026-04-01",
+        period_end: "2026-05-01",
+        spend_usd: "1.000000",
+      },
+      ...HISTORY,
+    ]);
+
+    await renderBilling();
+
+    expect(
+      await screen.findByLabelText("Monthly inference spend graph"),
+    ).toBeTruthy();
   });
 
   it.each(["incomplete", "paused"] as const)(
@@ -166,6 +215,7 @@ describe("Billing", () => {
       expect(screen.queryByText("$2.53209845")).toBeNull();
     });
     expect(screen.getByText("canceled")).toBeTruthy();
+    expect(screen.getByLabelText("Monthly inference spend graph")).toBeTruthy();
     expect(mocks.getPaygBillingSummary).toHaveBeenCalledTimes(1);
   });
 

--- a/client/admin/src/pages/organization/Billing.tsx
+++ b/client/admin/src/pages/organization/Billing.tsx
@@ -6,6 +6,7 @@ import { useConfirmDialog } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import {
   inferenceKeysQuery,
+  inferenceSpendHistoryQuery,
   invalidateOrganizationBilling,
   organizationQuery,
   paygBillingSummaryQuery,
@@ -17,6 +18,7 @@ import {
   GramAdminError,
   resumeStripeSubscription,
   type AdminInferenceKey,
+  type AdminInferenceSpendMonth,
   type AdminOrganization,
   type AdminPaygBillingSummary,
   type AdminStripeSubscription,
@@ -120,6 +122,81 @@ function InferenceKeys({ keys }: { keys: AdminInferenceKey[] }): JSX.Element {
           <Row label="State">{key.disabled ? "Disabled" : "Enabled"}</Row>
         </div>
       ))}
+    </Group>
+  );
+}
+
+function hasSufficientHistory(months: AdminInferenceSpendMonth[]): boolean {
+  const previous = months.at(-2);
+  const latest = months.at(-1);
+  return previous !== undefined && previous.period_end === latest?.period_start;
+}
+
+function InferenceSpendHistory({
+  months,
+}: {
+  months: AdminInferenceSpendMonth[];
+}): JSX.Element {
+  const showGraph = hasSufficientHistory(months);
+  const amounts = months.map((month) => Number.parseFloat(month.spend_usd));
+  const maximum = Math.max(0, ...amounts);
+
+  return (
+    <Group title="Monthly inference spend">
+      {months.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No complete monthly inference spend has been recorded yet.
+        </p>
+      ) : showGraph ? (
+        <figure
+          aria-label="Monthly inference spend graph"
+          className="space-y-2"
+        >
+          <figcaption className="sr-only">
+            Monthly inference spend by completed UTC calendar month
+          </figcaption>
+          {months.map((month, index) => {
+            const amount = amounts[index] ?? 0;
+            const width = maximum === 0 ? 0 : (amount / maximum) * 100;
+            return (
+              <div
+                key={month.period_start}
+                className="grid grid-cols-[5rem_minmax(8rem,1fr)_7rem] items-center gap-3"
+              >
+                <span className="text-muted-foreground text-xs">
+                  {formatBillingDate(month.period_start) ?? month.period_start}
+                </span>
+                <div
+                  aria-hidden="true"
+                  className="bg-muted h-3 overflow-hidden rounded-sm"
+                >
+                  <div
+                    className="bg-primary h-full rounded-sm"
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+                <span className="text-right text-sm tabular-nums">
+                  {formatExactUsd(month.spend_usd) ?? "—"}
+                </span>
+              </div>
+            );
+          })}
+        </figure>
+      ) : (
+        months.map((month) => (
+          <Row
+            key={month.period_start}
+            label={formatBillingDate(month.period_start) ?? month.period_start}
+          >
+            {formatExactUsd(month.spend_usd) ?? "—"}
+          </Row>
+        ))
+      )}
+      {months.length > 0 ? (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Complete UTC calendar months only.
+        </p>
+      ) : null}
     </Group>
   );
 }
@@ -234,6 +311,9 @@ export function Billing({ org }: { org: AdminOrganization }): JSX.Element {
   const restoreFocus = useRef(false);
 
   const inferenceKeysResult = useQuery(inferenceKeysQuery(org.id));
+  const inferenceSpendHistoryResult = useQuery(
+    inferenceSpendHistoryQuery(org.id),
+  );
   const subscriptionQuery = useQuery(stripeSubscriptionQuery(org.id));
   const subscription = subscriptionQuery.data;
   const state = subscription ? billingState(subscription) : null;
@@ -342,6 +422,21 @@ export function Billing({ org }: { org: AdminOrganization }): JSX.Element {
           {errorMessage(summaryQuery.error)}
         </p>
       )}
+
+      {inferenceSpendHistoryResult.data ? (
+        <InferenceSpendHistory months={inferenceSpendHistoryResult.data} />
+      ) : null}
+      {inferenceSpendHistoryResult.isPending ? (
+        <p className="text-muted-foreground mt-5 text-sm">
+          Loading inference spend history…
+        </p>
+      ) : null}
+      {inferenceSpendHistoryResult.isError ? (
+        <p role="alert" className="text-destructive mt-5 text-sm">
+          Could not load inference spend history:{" "}
+          {errorMessage(inferenceSpendHistoryResult.error)}
+        </p>
+      ) : null}
 
       {state &&
         (state.kind === "active" ||

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -181,6 +181,13 @@ var AdminInferenceKey = Type("AdminInferenceKey", func() {
 	Required("key_type", "credits_used", "monthly_credits", "disabled")
 })
 
+var AdminInferenceSpendMonth = Type("AdminInferenceSpendMonth", func() {
+	Attribute("period_start", String, func() { Format(FormatDate) })
+	Attribute("period_end", String, "Exclusive end of the UTC calendar month.", func() { Format(FormatDate) })
+	Attribute("spend_usd", String)
+	Required("period_start", "period_end", "spend_usd")
+})
+
 var AdminPaygBillingSummary = Type("AdminPaygBillingSummary", func() {
 	Attribute("period_start", String, func() { Format(FormatDateTime) })
 	Attribute("period_end", String, func() { Format(FormatDateTime) })
@@ -648,6 +655,14 @@ var _ = Service("admin", func() {
 		Result(ArrayOf(AdminInferenceKey))
 		HTTP(func() { GET("/admin/organization.inferenceKeys"); Param("organization_id"); Response(StatusOK) })
 		Meta("openapi:operationId", "adminGetInferenceKeys")
+	})
+
+	Method("getInferenceSpendHistory", func() {
+		Description("Returns up to twelve complete UTC calendar months of recorded inference spend for an organization.")
+		Payload(func() { security.AdminAuthPayload(); Required("organization_id"); Attribute("organization_id", String) })
+		Result(ArrayOf(AdminInferenceSpendMonth))
+		HTTP(func() { GET("/admin/organization.inferenceSpendHistory"); Param("organization_id"); Response(StatusOK) })
+		Meta("openapi:operationId", "adminGetInferenceSpendHistory")
 	})
 
 	Method("getPaygBillingSummary", func() {

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -32,6 +32,7 @@ type Client struct {
 	RearmTrialEndpoint               goa.Endpoint
 	GetOrganizationStatsEndpoint     goa.Endpoint
 	GetInferenceKeysEndpoint         goa.Endpoint
+	GetInferenceSpendHistoryEndpoint goa.Endpoint
 	GetPaygBillingSummaryEndpoint    goa.Endpoint
 	GetStripeSubscriptionEndpoint    goa.Endpoint
 	CancelStripeSubscriptionEndpoint goa.Endpoint
@@ -39,7 +40,7 @@ type Client struct {
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, getInferenceSpendHistory, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
@@ -58,6 +59,7 @@ func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpda
 		RearmTrialEndpoint:               rearmTrial,
 		GetOrganizationStatsEndpoint:     getOrganizationStats,
 		GetInferenceKeysEndpoint:         getInferenceKeys,
+		GetInferenceSpendHistoryEndpoint: getInferenceSpendHistory,
 		GetPaygBillingSummaryEndpoint:    getPaygBillingSummary,
 		GetStripeSubscriptionEndpoint:    getStripeSubscription,
 		CancelStripeSubscriptionEndpoint: cancelStripeSubscription,
@@ -443,6 +445,29 @@ func (c *Client) GetInferenceKeys(ctx context.Context, p *GetInferenceKeysPayloa
 		return
 	}
 	return ires.([]*AdminInferenceKey), nil
+}
+
+// GetInferenceSpendHistory calls the "getInferenceSpendHistory" endpoint of
+// the "admin" service.
+// GetInferenceSpendHistory may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) GetInferenceSpendHistory(ctx context.Context, p *GetInferenceSpendHistoryPayload) (res []*AdminInferenceSpendMonth, err error) {
+	var ires any
+	ires, err = c.GetInferenceSpendHistoryEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.([]*AdminInferenceSpendMonth), nil
 }
 
 // GetPaygBillingSummary calls the "getPaygBillingSummary" endpoint of the

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -33,6 +33,7 @@ type Endpoints struct {
 	RearmTrial               goa.Endpoint
 	GetOrganizationStats     goa.Endpoint
 	GetInferenceKeys         goa.Endpoint
+	GetInferenceSpendHistory goa.Endpoint
 	GetPaygBillingSummary    goa.Endpoint
 	GetStripeSubscription    goa.Endpoint
 	CancelStripeSubscription goa.Endpoint
@@ -61,6 +62,7 @@ func NewEndpoints(s Service) *Endpoints {
 		RearmTrial:               NewRearmTrialEndpoint(s, a.APIKeyAuth),
 		GetOrganizationStats:     NewGetOrganizationStatsEndpoint(s, a.APIKeyAuth),
 		GetInferenceKeys:         NewGetInferenceKeysEndpoint(s, a.APIKeyAuth),
+		GetInferenceSpendHistory: NewGetInferenceSpendHistoryEndpoint(s, a.APIKeyAuth),
 		GetPaygBillingSummary:    NewGetPaygBillingSummaryEndpoint(s, a.APIKeyAuth),
 		GetStripeSubscription:    NewGetStripeSubscriptionEndpoint(s, a.APIKeyAuth),
 		CancelStripeSubscription: NewCancelStripeSubscriptionEndpoint(s, a.APIKeyAuth),
@@ -87,6 +89,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.RearmTrial = m(e.RearmTrial)
 	e.GetOrganizationStats = m(e.GetOrganizationStats)
 	e.GetInferenceKeys = m(e.GetInferenceKeys)
+	e.GetInferenceSpendHistory = m(e.GetInferenceSpendHistory)
 	e.GetPaygBillingSummary = m(e.GetPaygBillingSummary)
 	e.GetStripeSubscription = m(e.GetStripeSubscription)
 	e.CancelStripeSubscription = m(e.CancelStripeSubscription)
@@ -439,6 +442,29 @@ func NewGetInferenceKeysEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc
 			return nil, err
 		}
 		return s.GetInferenceKeys(ctx, p)
+	}
+}
+
+// NewGetInferenceSpendHistoryEndpoint returns an endpoint function that calls
+// the method "getInferenceSpendHistory" of service "admin".
+func NewGetInferenceSpendHistoryEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*GetInferenceSpendHistoryPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.GetInferenceSpendHistory(ctx, p)
 	}
 }
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -70,6 +70,9 @@ type Service interface {
 	// Returns the configured state of every materialized platform-managed
 	// OpenRouter key for an organization.
 	GetInferenceKeys(context.Context, *GetInferenceKeysPayload) (res []*AdminInferenceKey, err error)
+	// Returns up to twelve complete UTC calendar months of recorded inference
+	// spend for an organization.
+	GetInferenceSpendHistory(context.Context, *GetInferenceSpendHistoryPayload) (res []*AdminInferenceSpendMonth, err error)
 	// Returns current PAYG usage and estimated cost for an organization.
 	GetPaygBillingSummary(context.Context, *GetPaygBillingSummaryPayload) (res *AdminPaygBillingSummary, err error)
 	// Returns the live Stripe subscription and payment state for an organization.
@@ -101,7 +104,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [21]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription"}
+var MethodNames = [22]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "getInferenceSpendHistory", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription"}
 
 // AdminBulkUpdateAccountTypeResult is the result type of the admin service
 // bulkUpdateAccountType method.
@@ -122,6 +125,13 @@ type AdminInferenceKey struct {
 	CreditsUsed    float64
 	MonthlyCredits int64
 	Disabled       bool
+}
+
+type AdminInferenceSpendMonth struct {
+	PeriodStart string
+	// Exclusive end of the UTC calendar month.
+	PeriodEnd string
+	SpendUsd  string
 }
 
 // AdminListOrganizationMembersResult is the result type of the admin service
@@ -364,6 +374,13 @@ type ExtendTrialPayload struct {
 // GetInferenceKeysPayload is the payload type of the admin service
 // getInferenceKeys method.
 type GetInferenceKeysPayload struct {
+	AdminSessionToken *string
+	OrganizationID    string
+}
+
+// GetInferenceSpendHistoryPayload is the payload type of the admin service
+// getInferenceSpendHistory method.
+type GetInferenceSpendHistoryPayload struct {
 	AdminSessionToken *string
 	OrganizationID    string
 }

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -593,6 +593,26 @@ func BuildGetInferenceKeysPayload(adminGetInferenceKeysOrganizationID string, ad
 	return v, nil
 }
 
+// BuildGetInferenceSpendHistoryPayload builds the payload for the admin
+// getInferenceSpendHistory endpoint from CLI flags.
+func BuildGetInferenceSpendHistoryPayload(adminGetInferenceSpendHistoryOrganizationID string, adminGetInferenceSpendHistoryAdminSessionToken string) (*admin.GetInferenceSpendHistoryPayload, error) {
+	var organizationID string
+	{
+		organizationID = adminGetInferenceSpendHistoryOrganizationID
+	}
+	var adminSessionToken *string
+	{
+		if adminGetInferenceSpendHistoryAdminSessionToken != "" {
+			adminSessionToken = &adminGetInferenceSpendHistoryAdminSessionToken
+		}
+	}
+	v := &admin.GetInferenceSpendHistoryPayload{}
+	v.OrganizationID = organizationID
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}
+
 // BuildGetPaygBillingSummaryPayload builds the payload for the admin
 // getPaygBillingSummary endpoint from CLI flags.
 func BuildGetPaygBillingSummaryPayload(adminGetPaygBillingSummaryOrganizationID string, adminGetPaygBillingSummaryAdminSessionToken string) (*admin.GetPaygBillingSummaryPayload, error) {

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -83,6 +83,10 @@ type Client struct {
 	// getInferenceKeys endpoint.
 	GetInferenceKeysDoer goahttp.Doer
 
+	// GetInferenceSpendHistory Doer is the HTTP client used to make requests to
+	// the getInferenceSpendHistory endpoint.
+	GetInferenceSpendHistoryDoer goahttp.Doer
+
 	// GetPaygBillingSummary Doer is the HTTP client used to make requests to the
 	// getPaygBillingSummary endpoint.
 	GetPaygBillingSummaryDoer goahttp.Doer
@@ -136,6 +140,7 @@ func NewClient(
 		RearmTrialDoer:               doer,
 		GetOrganizationStatsDoer:     doer,
 		GetInferenceKeysDoer:         doer,
+		GetInferenceSpendHistoryDoer: doer,
 		GetPaygBillingSummaryDoer:    doer,
 		GetStripeSubscriptionDoer:    doer,
 		CancelStripeSubscriptionDoer: doer,
@@ -551,6 +556,30 @@ func (c *Client) GetInferenceKeys() goa.Endpoint {
 		resp, err := c.GetInferenceKeysDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "getInferenceKeys", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// GetInferenceSpendHistory returns an endpoint that makes HTTP requests to the
+// admin service getInferenceSpendHistory server.
+func (c *Client) GetInferenceSpendHistory() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeGetInferenceSpendHistoryRequest(c.encoder)
+		decodeResponse = DecodeGetInferenceSpendHistoryResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildGetInferenceSpendHistoryRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.GetInferenceSpendHistoryDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "getInferenceSpendHistory", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -4063,6 +4063,246 @@ func DecodeGetInferenceKeysResponse(decoder func(*http.Response) goahttp.Decoder
 	}
 }
 
+// BuildGetInferenceSpendHistoryRequest instantiates a HTTP request object with
+// method and path set to call the "admin" service "getInferenceSpendHistory"
+// endpoint
+func (c *Client) BuildGetInferenceSpendHistoryRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: GetInferenceSpendHistoryAdminPath()}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "getInferenceSpendHistory", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeGetInferenceSpendHistoryRequest returns an encoder for requests sent
+// to the admin getInferenceSpendHistory server.
+func EncodeGetInferenceSpendHistoryRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.GetInferenceSpendHistoryPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "getInferenceSpendHistory", "*admin.GetInferenceSpendHistoryPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		values := req.URL.Query()
+		values.Add("organization_id", p.OrganizationID)
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+
+// DecodeGetInferenceSpendHistoryResponse returns a decoder for responses
+// returned by the admin getInferenceSpendHistory endpoint. restoreBody
+// controls whether the response body should be restored after having been read.
+// DecodeGetInferenceSpendHistoryResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeGetInferenceSpendHistoryResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body []*AdminInferenceSpendMonthResponse
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			for _, e := range body {
+				if e != nil {
+					if err2 := ValidateAdminInferenceSpendMonthResponse(e); err2 != nil {
+						err = goa.MergeErrors(err, err2)
+					}
+				}
+			}
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			res := NewGetInferenceSpendHistoryAdminInferenceSpendMonthOK(body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body GetInferenceSpendHistoryUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body GetInferenceSpendHistoryForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body GetInferenceSpendHistoryBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body GetInferenceSpendHistoryNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body GetInferenceSpendHistoryConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body GetInferenceSpendHistoryUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body GetInferenceSpendHistoryInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body GetInferenceSpendHistoryInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+				}
+				err = ValidateGetInferenceSpendHistoryInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+				}
+				return nil, NewGetInferenceSpendHistoryInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body GetInferenceSpendHistoryUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+				}
+				err = ValidateGetInferenceSpendHistoryUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+				}
+				return nil, NewGetInferenceSpendHistoryUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "getInferenceSpendHistory", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body GetInferenceSpendHistoryGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "getInferenceSpendHistory", err)
+			}
+			err = ValidateGetInferenceSpendHistoryGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "getInferenceSpendHistory", err)
+			}
+			return nil, NewGetInferenceSpendHistoryGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "getInferenceSpendHistory", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // BuildGetPaygBillingSummaryRequest instantiates a HTTP request object with
 // method and path set to call the "admin" service "getPaygBillingSummary"
 // endpoint
@@ -5065,6 +5305,19 @@ func unmarshalAdminInferenceKeyResponseToAdminAdminInferenceKey(v *AdminInferenc
 		CreditsUsed:    *v.CreditsUsed,
 		MonthlyCredits: *v.MonthlyCredits,
 		Disabled:       *v.Disabled,
+	}
+
+	return res
+}
+
+// unmarshalAdminInferenceSpendMonthResponseToAdminAdminInferenceSpendMonth
+// builds a value of type *admin.AdminInferenceSpendMonth from a value of type
+// *AdminInferenceSpendMonthResponse.
+func unmarshalAdminInferenceSpendMonthResponseToAdminAdminInferenceSpendMonth(v *AdminInferenceSpendMonthResponse) *admin.AdminInferenceSpendMonth {
+	res := &admin.AdminInferenceSpendMonth{
+		PeriodStart: *v.PeriodStart,
+		PeriodEnd:   *v.PeriodEnd,
+		SpendUsd:    *v.SpendUsd,
 	}
 
 	return res

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -92,6 +92,11 @@ func GetInferenceKeysAdminPath() string {
 	return "/admin/organization.inferenceKeys"
 }
 
+// GetInferenceSpendHistoryAdminPath returns the URL path to the admin service getInferenceSpendHistory HTTP endpoint.
+func GetInferenceSpendHistoryAdminPath() string {
+	return "/admin/organization.inferenceSpendHistory"
+}
+
 // GetPaygBillingSummaryAdminPath returns the URL path to the admin service getPaygBillingSummary HTTP endpoint.
 func GetPaygBillingSummaryAdminPath() string {
 	return "/admin/organization.paygBillingSummary"

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -3577,6 +3577,196 @@ type GetInferenceKeysGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// GetInferenceSpendHistoryUnauthorizedResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "unauthorized" error.
+type GetInferenceSpendHistoryUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryForbiddenResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "forbidden" error.
+type GetInferenceSpendHistoryForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryBadRequestResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "bad_request" error.
+type GetInferenceSpendHistoryBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryNotFoundResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "not_found" error.
+type GetInferenceSpendHistoryNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryConflictResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "conflict" error.
+type GetInferenceSpendHistoryConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryUnsupportedMediaResponseBody is the type of the
+// "admin" service "getInferenceSpendHistory" endpoint HTTP response body for
+// the "unsupported_media" error.
+type GetInferenceSpendHistoryUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryInvalidResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "invalid" error.
+type GetInferenceSpendHistoryInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryInvariantViolationResponseBody is the type of the
+// "admin" service "getInferenceSpendHistory" endpoint HTTP response body for
+// the "invariant_violation" error.
+type GetInferenceSpendHistoryInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryUnexpectedResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "unexpected" error.
+type GetInferenceSpendHistoryUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// GetInferenceSpendHistoryGatewayErrorResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "gateway_error" error.
+type GetInferenceSpendHistoryGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // GetPaygBillingSummaryUnauthorizedResponseBody is the type of the "admin"
 // service "getPaygBillingSummary" endpoint HTTP response body for the
 // "unauthorized" error.
@@ -4406,6 +4596,15 @@ type AdminInferenceKeyResponse struct {
 	CreditsUsed    *float64 `form:"credits_used,omitempty" json:"credits_used,omitempty" xml:"credits_used,omitempty"`
 	MonthlyCredits *int64   `form:"monthly_credits,omitempty" json:"monthly_credits,omitempty" xml:"monthly_credits,omitempty"`
 	Disabled       *bool    `form:"disabled,omitempty" json:"disabled,omitempty" xml:"disabled,omitempty"`
+}
+
+// AdminInferenceSpendMonthResponse is used to define fields on response body
+// types.
+type AdminInferenceSpendMonthResponse struct {
+	PeriodStart *string `form:"period_start,omitempty" json:"period_start,omitempty" xml:"period_start,omitempty"`
+	// Exclusive end of the UTC calendar month.
+	PeriodEnd *string `form:"period_end,omitempty" json:"period_end,omitempty" xml:"period_end,omitempty"`
+	SpendUsd  *string `form:"spend_usd,omitempty" json:"spend_usd,omitempty" xml:"spend_usd,omitempty"`
 }
 
 // NewUpdateOrganizationRequestBody builds the HTTP request body from the
@@ -7326,6 +7525,171 @@ func NewGetInferenceKeysUnexpected(body *GetInferenceKeysUnexpectedResponseBody)
 // NewGetInferenceKeysGatewayError builds a admin service getInferenceKeys
 // endpoint gateway_error error.
 func NewGetInferenceKeysGatewayError(body *GetInferenceKeysGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryAdminInferenceSpendMonthOK builds a "admin"
+// service "getInferenceSpendHistory" endpoint result from a HTTP "OK" response.
+func NewGetInferenceSpendHistoryAdminInferenceSpendMonthOK(body []*AdminInferenceSpendMonthResponse) []*admin.AdminInferenceSpendMonth {
+	v := make([]*admin.AdminInferenceSpendMonth, len(body))
+	for i, val := range body {
+		if val == nil {
+			v[i] = nil
+			continue
+		}
+		v[i] = unmarshalAdminInferenceSpendMonthResponseToAdminAdminInferenceSpendMonth(val)
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryUnauthorized builds a admin service
+// getInferenceSpendHistory endpoint unauthorized error.
+func NewGetInferenceSpendHistoryUnauthorized(body *GetInferenceSpendHistoryUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryForbidden builds a admin service
+// getInferenceSpendHistory endpoint forbidden error.
+func NewGetInferenceSpendHistoryForbidden(body *GetInferenceSpendHistoryForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryBadRequest builds a admin service
+// getInferenceSpendHistory endpoint bad_request error.
+func NewGetInferenceSpendHistoryBadRequest(body *GetInferenceSpendHistoryBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryNotFound builds a admin service
+// getInferenceSpendHistory endpoint not_found error.
+func NewGetInferenceSpendHistoryNotFound(body *GetInferenceSpendHistoryNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryConflict builds a admin service
+// getInferenceSpendHistory endpoint conflict error.
+func NewGetInferenceSpendHistoryConflict(body *GetInferenceSpendHistoryConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryUnsupportedMedia builds a admin service
+// getInferenceSpendHistory endpoint unsupported_media error.
+func NewGetInferenceSpendHistoryUnsupportedMedia(body *GetInferenceSpendHistoryUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryInvalid builds a admin service
+// getInferenceSpendHistory endpoint invalid error.
+func NewGetInferenceSpendHistoryInvalid(body *GetInferenceSpendHistoryInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryInvariantViolation builds a admin service
+// getInferenceSpendHistory endpoint invariant_violation error.
+func NewGetInferenceSpendHistoryInvariantViolation(body *GetInferenceSpendHistoryInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryUnexpected builds a admin service
+// getInferenceSpendHistory endpoint unexpected error.
+func NewGetInferenceSpendHistoryUnexpected(body *GetInferenceSpendHistoryUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryGatewayError builds a admin service
+// getInferenceSpendHistory endpoint gateway_error error.
+func NewGetInferenceSpendHistoryGatewayError(body *GetInferenceSpendHistoryGatewayErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -12765,6 +13129,248 @@ func ValidateGetInferenceKeysGatewayErrorResponseBody(body *GetInferenceKeysGate
 	return
 }
 
+// ValidateGetInferenceSpendHistoryUnauthorizedResponseBody runs the
+// validations defined on getInferenceSpendHistory_unauthorized_response_body
+func ValidateGetInferenceSpendHistoryUnauthorizedResponseBody(body *GetInferenceSpendHistoryUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryForbiddenResponseBody runs the validations
+// defined on getInferenceSpendHistory_forbidden_response_body
+func ValidateGetInferenceSpendHistoryForbiddenResponseBody(body *GetInferenceSpendHistoryForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryBadRequestResponseBody runs the validations
+// defined on getInferenceSpendHistory_bad_request_response_body
+func ValidateGetInferenceSpendHistoryBadRequestResponseBody(body *GetInferenceSpendHistoryBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryNotFoundResponseBody runs the validations
+// defined on getInferenceSpendHistory_not_found_response_body
+func ValidateGetInferenceSpendHistoryNotFoundResponseBody(body *GetInferenceSpendHistoryNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryConflictResponseBody runs the validations
+// defined on getInferenceSpendHistory_conflict_response_body
+func ValidateGetInferenceSpendHistoryConflictResponseBody(body *GetInferenceSpendHistoryConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryUnsupportedMediaResponseBody runs the
+// validations defined on
+// getInferenceSpendHistory_unsupported_media_response_body
+func ValidateGetInferenceSpendHistoryUnsupportedMediaResponseBody(body *GetInferenceSpendHistoryUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryInvalidResponseBody runs the validations
+// defined on getInferenceSpendHistory_invalid_response_body
+func ValidateGetInferenceSpendHistoryInvalidResponseBody(body *GetInferenceSpendHistoryInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryInvariantViolationResponseBody runs the
+// validations defined on
+// getInferenceSpendHistory_invariant_violation_response_body
+func ValidateGetInferenceSpendHistoryInvariantViolationResponseBody(body *GetInferenceSpendHistoryInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryUnexpectedResponseBody runs the validations
+// defined on getInferenceSpendHistory_unexpected_response_body
+func ValidateGetInferenceSpendHistoryUnexpectedResponseBody(body *GetInferenceSpendHistoryUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateGetInferenceSpendHistoryGatewayErrorResponseBody runs the
+// validations defined on getInferenceSpendHistory_gateway_error_response_body
+func ValidateGetInferenceSpendHistoryGatewayErrorResponseBody(body *GetInferenceSpendHistoryGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
 // ValidateGetPaygBillingSummaryUnauthorizedResponseBody runs the validations
 // defined on getPaygBillingSummary_unauthorized_response_body
 func ValidateGetPaygBillingSummaryUnauthorizedResponseBody(body *GetPaygBillingSummaryUnauthorizedResponseBody) (err error) {
@@ -13858,6 +14464,27 @@ func ValidateAdminInferenceKeyResponse(body *AdminInferenceKeyResponse) (err err
 	}
 	if body.Disabled == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("disabled", "body"))
+	}
+	return
+}
+
+// ValidateAdminInferenceSpendMonthResponse runs the validations defined on
+// AdminInferenceSpendMonthResponse
+func ValidateAdminInferenceSpendMonthResponse(body *AdminInferenceSpendMonthResponse) (err error) {
+	if body.PeriodStart == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("period_start", "body"))
+	}
+	if body.PeriodEnd == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("period_end", "body"))
+	}
+	if body.SpendUsd == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("spend_usd", "body"))
+	}
+	if body.PeriodStart != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.period_start", *body.PeriodStart, goa.FormatDate))
+	}
+	if body.PeriodEnd != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.period_end", *body.PeriodEnd, goa.FormatDate))
 	}
 	return
 }

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -3595,6 +3595,208 @@ func EncodeGetInferenceKeysError(encoder func(context.Context, http.ResponseWrit
 	}
 }
 
+// EncodeGetInferenceSpendHistoryResponse returns an encoder for responses
+// returned by the admin getInferenceSpendHistory endpoint.
+func EncodeGetInferenceSpendHistoryResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.([]*admin.AdminInferenceSpendMonth)
+		enc := encoder(ctx, w)
+		body := NewGetInferenceSpendHistoryResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeGetInferenceSpendHistoryRequest returns a decoder for requests sent to
+// the admin getInferenceSpendHistory endpoint.
+func DecodeGetInferenceSpendHistoryRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.GetInferenceSpendHistoryPayload, error) {
+	return func(r *http.Request) (*admin.GetInferenceSpendHistoryPayload, error) {
+		var payload *admin.GetInferenceSpendHistoryPayload
+		var (
+			organizationID    string
+			adminSessionToken *string
+			err               error
+		)
+		organizationID = r.URL.Query().Get("organization_id")
+		if organizationID == "" {
+			err = goa.MergeErrors(err, goa.MissingFieldError("organization_id", "query string"))
+		}
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		if err != nil {
+			return payload, err
+		}
+		payload = NewGetInferenceSpendHistoryPayload(organizationID, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeGetInferenceSpendHistoryError returns an encoder for errors returned
+// by the getInferenceSpendHistory admin endpoint.
+func EncodeGetInferenceSpendHistoryError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewGetInferenceSpendHistoryGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // EncodeGetPaygBillingSummaryResponse returns an encoder for responses
 // returned by the admin getPaygBillingSummary endpoint.
 func EncodeGetPaygBillingSummaryResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
@@ -4489,6 +4691,19 @@ func marshalAdminAdminInferenceKeyToAdminInferenceKeyResponse(v *admin.AdminInfe
 		CreditsUsed:    v.CreditsUsed,
 		MonthlyCredits: v.MonthlyCredits,
 		Disabled:       v.Disabled,
+	}
+
+	return res
+}
+
+// marshalAdminAdminInferenceSpendMonthToAdminInferenceSpendMonthResponse
+// builds a value of type *AdminInferenceSpendMonthResponse from a value of
+// type *admin.AdminInferenceSpendMonth.
+func marshalAdminAdminInferenceSpendMonthToAdminInferenceSpendMonthResponse(v *admin.AdminInferenceSpendMonth) *AdminInferenceSpendMonthResponse {
+	res := &AdminInferenceSpendMonthResponse{
+		PeriodStart: v.PeriodStart,
+		PeriodEnd:   v.PeriodEnd,
+		SpendUsd:    v.SpendUsd,
 	}
 
 	return res

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -92,6 +92,11 @@ func GetInferenceKeysAdminPath() string {
 	return "/admin/organization.inferenceKeys"
 }
 
+// GetInferenceSpendHistoryAdminPath returns the URL path to the admin service getInferenceSpendHistory HTTP endpoint.
+func GetInferenceSpendHistoryAdminPath() string {
+	return "/admin/organization.inferenceSpendHistory"
+}
+
 // GetPaygBillingSummaryAdminPath returns the URL path to the admin service getPaygBillingSummary HTTP endpoint.
 func GetPaygBillingSummaryAdminPath() string {
 	return "/admin/organization.paygBillingSummary"

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	RearmTrial               http.Handler
 	GetOrganizationStats     http.Handler
 	GetInferenceKeys         http.Handler
+	GetInferenceSpendHistory http.Handler
 	GetPaygBillingSummary    http.Handler
 	GetStripeSubscription    http.Handler
 	CancelStripeSubscription http.Handler
@@ -86,6 +87,7 @@ func New(
 			{"RearmTrial", "POST", "/admin/trial.rearm"},
 			{"GetOrganizationStats", "GET", "/admin/organizations.stats"},
 			{"GetInferenceKeys", "GET", "/admin/organization.inferenceKeys"},
+			{"GetInferenceSpendHistory", "GET", "/admin/organization.inferenceSpendHistory"},
 			{"GetPaygBillingSummary", "GET", "/admin/organization.paygBillingSummary"},
 			{"GetStripeSubscription", "GET", "/admin/organization.stripeSubscription"},
 			{"CancelStripeSubscription", "POST", "/admin/organization.cancelStripeSubscription"},
@@ -108,6 +110,7 @@ func New(
 		RearmTrial:               NewRearmTrialHandler(e.RearmTrial, mux, decoder, encoder, errhandler, formatter),
 		GetOrganizationStats:     NewGetOrganizationStatsHandler(e.GetOrganizationStats, mux, decoder, encoder, errhandler, formatter),
 		GetInferenceKeys:         NewGetInferenceKeysHandler(e.GetInferenceKeys, mux, decoder, encoder, errhandler, formatter),
+		GetInferenceSpendHistory: NewGetInferenceSpendHistoryHandler(e.GetInferenceSpendHistory, mux, decoder, encoder, errhandler, formatter),
 		GetPaygBillingSummary:    NewGetPaygBillingSummaryHandler(e.GetPaygBillingSummary, mux, decoder, encoder, errhandler, formatter),
 		GetStripeSubscription:    NewGetStripeSubscriptionHandler(e.GetStripeSubscription, mux, decoder, encoder, errhandler, formatter),
 		CancelStripeSubscription: NewCancelStripeSubscriptionHandler(e.CancelStripeSubscription, mux, decoder, encoder, errhandler, formatter),
@@ -137,6 +140,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.RearmTrial = m(s.RearmTrial)
 	s.GetOrganizationStats = m(s.GetOrganizationStats)
 	s.GetInferenceKeys = m(s.GetInferenceKeys)
+	s.GetInferenceSpendHistory = m(s.GetInferenceSpendHistory)
 	s.GetPaygBillingSummary = m(s.GetPaygBillingSummary)
 	s.GetStripeSubscription = m(s.GetStripeSubscription)
 	s.CancelStripeSubscription = m(s.CancelStripeSubscription)
@@ -165,6 +169,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountRearmTrialHandler(mux, h.RearmTrial)
 	MountGetOrganizationStatsHandler(mux, h.GetOrganizationStats)
 	MountGetInferenceKeysHandler(mux, h.GetInferenceKeys)
+	MountGetInferenceSpendHistoryHandler(mux, h.GetInferenceSpendHistory)
 	MountGetPaygBillingSummaryHandler(mux, h.GetPaygBillingSummary)
 	MountGetStripeSubscriptionHandler(mux, h.GetStripeSubscription)
 	MountCancelStripeSubscriptionHandler(mux, h.CancelStripeSubscription)
@@ -1056,6 +1061,60 @@ func NewGetInferenceKeysHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "getInferenceKeys")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountGetInferenceSpendHistoryHandler configures the mux to serve the "admin"
+// service "getInferenceSpendHistory" endpoint.
+func MountGetInferenceSpendHistoryHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("GET", "/admin/organization.inferenceSpendHistory", f)
+}
+
+// NewGetInferenceSpendHistoryHandler creates a HTTP handler which loads the
+// HTTP request and calls the "admin" service "getInferenceSpendHistory"
+// endpoint.
+func NewGetInferenceSpendHistoryHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeGetInferenceSpendHistoryRequest(mux, decoder)
+		encodeResponse = EncodeGetInferenceSpendHistoryResponse(encoder)
+		encodeError    = EncodeGetInferenceSpendHistoryError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "getInferenceSpendHistory")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -409,6 +409,10 @@ type GetOrganizationStatsResponseBody struct {
 // "getInferenceKeys" endpoint HTTP response body.
 type GetInferenceKeysResponseBody []*AdminInferenceKeyResponse
 
+// GetInferenceSpendHistoryResponseBody is the type of the "admin" service
+// "getInferenceSpendHistory" endpoint HTTP response body.
+type GetInferenceSpendHistoryResponseBody []*AdminInferenceSpendMonthResponse
+
 // GetPaygBillingSummaryResponseBody is the type of the "admin" service
 // "getPaygBillingSummary" endpoint HTTP response body.
 type GetPaygBillingSummaryResponseBody struct {
@@ -3583,6 +3587,196 @@ type GetInferenceKeysGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// GetInferenceSpendHistoryUnauthorizedResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "unauthorized" error.
+type GetInferenceSpendHistoryUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryForbiddenResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "forbidden" error.
+type GetInferenceSpendHistoryForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryBadRequestResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "bad_request" error.
+type GetInferenceSpendHistoryBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryNotFoundResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "not_found" error.
+type GetInferenceSpendHistoryNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryConflictResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "conflict" error.
+type GetInferenceSpendHistoryConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryUnsupportedMediaResponseBody is the type of the
+// "admin" service "getInferenceSpendHistory" endpoint HTTP response body for
+// the "unsupported_media" error.
+type GetInferenceSpendHistoryUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryInvalidResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "invalid" error.
+type GetInferenceSpendHistoryInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryInvariantViolationResponseBody is the type of the
+// "admin" service "getInferenceSpendHistory" endpoint HTTP response body for
+// the "invariant_violation" error.
+type GetInferenceSpendHistoryInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryUnexpectedResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "unexpected" error.
+type GetInferenceSpendHistoryUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// GetInferenceSpendHistoryGatewayErrorResponseBody is the type of the "admin"
+// service "getInferenceSpendHistory" endpoint HTTP response body for the
+// "gateway_error" error.
+type GetInferenceSpendHistoryGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // GetPaygBillingSummaryUnauthorizedResponseBody is the type of the "admin"
 // service "getPaygBillingSummary" endpoint HTTP response body for the
 // "unauthorized" error.
@@ -4414,6 +4608,15 @@ type AdminInferenceKeyResponse struct {
 	Disabled       bool    `form:"disabled" json:"disabled" xml:"disabled"`
 }
 
+// AdminInferenceSpendMonthResponse is used to define fields on response body
+// types.
+type AdminInferenceSpendMonthResponse struct {
+	PeriodStart string `form:"period_start" json:"period_start" xml:"period_start"`
+	// Exclusive end of the UTC calendar month.
+	PeriodEnd string `form:"period_end" json:"period_end" xml:"period_end"`
+	SpendUsd  string `form:"spend_usd" json:"spend_usd" xml:"spend_usd"`
+}
+
 // NewGetProjectResponseBody builds the HTTP response body from the result of
 // the "getProject" endpoint of the "admin" service.
 func NewGetProjectResponseBody(res *admin.AdminProjectDetail) *GetProjectResponseBody {
@@ -4696,6 +4899,20 @@ func NewGetInferenceKeysResponseBody(res []*admin.AdminInferenceKey) GetInferenc
 			continue
 		}
 		body[i] = marshalAdminAdminInferenceKeyToAdminInferenceKeyResponse(val)
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryResponseBody builds the HTTP response body from
+// the result of the "getInferenceSpendHistory" endpoint of the "admin" service.
+func NewGetInferenceSpendHistoryResponseBody(res []*admin.AdminInferenceSpendMonth) GetInferenceSpendHistoryResponseBody {
+	body := make([]*AdminInferenceSpendMonthResponse, len(res))
+	for i, val := range res {
+		if val == nil {
+			body[i] = nil
+			continue
+		}
+		body[i] = marshalAdminAdminInferenceSpendMonthToAdminInferenceSpendMonthResponse(val)
 	}
 	return body
 }
@@ -7200,6 +7417,156 @@ func NewGetInferenceKeysGatewayErrorResponseBody(res *goa.ServiceError) *GetInfe
 	return body
 }
 
+// NewGetInferenceSpendHistoryUnauthorizedResponseBody builds the HTTP response
+// body from the result of the "getInferenceSpendHistory" endpoint of the
+// "admin" service.
+func NewGetInferenceSpendHistoryUnauthorizedResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryUnauthorizedResponseBody {
+	body := &GetInferenceSpendHistoryUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryForbiddenResponseBody builds the HTTP response
+// body from the result of the "getInferenceSpendHistory" endpoint of the
+// "admin" service.
+func NewGetInferenceSpendHistoryForbiddenResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryForbiddenResponseBody {
+	body := &GetInferenceSpendHistoryForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryBadRequestResponseBody builds the HTTP response
+// body from the result of the "getInferenceSpendHistory" endpoint of the
+// "admin" service.
+func NewGetInferenceSpendHistoryBadRequestResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryBadRequestResponseBody {
+	body := &GetInferenceSpendHistoryBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryNotFoundResponseBody builds the HTTP response
+// body from the result of the "getInferenceSpendHistory" endpoint of the
+// "admin" service.
+func NewGetInferenceSpendHistoryNotFoundResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryNotFoundResponseBody {
+	body := &GetInferenceSpendHistoryNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryConflictResponseBody builds the HTTP response
+// body from the result of the "getInferenceSpendHistory" endpoint of the
+// "admin" service.
+func NewGetInferenceSpendHistoryConflictResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryConflictResponseBody {
+	body := &GetInferenceSpendHistoryConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryUnsupportedMediaResponseBody builds the HTTP
+// response body from the result of the "getInferenceSpendHistory" endpoint of
+// the "admin" service.
+func NewGetInferenceSpendHistoryUnsupportedMediaResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryUnsupportedMediaResponseBody {
+	body := &GetInferenceSpendHistoryUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryInvalidResponseBody builds the HTTP response body
+// from the result of the "getInferenceSpendHistory" endpoint of the "admin"
+// service.
+func NewGetInferenceSpendHistoryInvalidResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryInvalidResponseBody {
+	body := &GetInferenceSpendHistoryInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryInvariantViolationResponseBody builds the HTTP
+// response body from the result of the "getInferenceSpendHistory" endpoint of
+// the "admin" service.
+func NewGetInferenceSpendHistoryInvariantViolationResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryInvariantViolationResponseBody {
+	body := &GetInferenceSpendHistoryInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryUnexpectedResponseBody builds the HTTP response
+// body from the result of the "getInferenceSpendHistory" endpoint of the
+// "admin" service.
+func NewGetInferenceSpendHistoryUnexpectedResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryUnexpectedResponseBody {
+	body := &GetInferenceSpendHistoryUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewGetInferenceSpendHistoryGatewayErrorResponseBody builds the HTTP response
+// body from the result of the "getInferenceSpendHistory" endpoint of the
+// "admin" service.
+func NewGetInferenceSpendHistoryGatewayErrorResponseBody(res *goa.ServiceError) *GetInferenceSpendHistoryGatewayErrorResponseBody {
+	body := &GetInferenceSpendHistoryGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewGetPaygBillingSummaryUnauthorizedResponseBody builds the HTTP response
 // body from the result of the "getPaygBillingSummary" endpoint of the "admin"
 // service.
@@ -7985,6 +8352,16 @@ func NewGetOrganizationStatsPayload(adminSessionToken *string) *admin.GetOrganiz
 // payload.
 func NewGetInferenceKeysPayload(organizationID string, adminSessionToken *string) *admin.GetInferenceKeysPayload {
 	v := &admin.GetInferenceKeysPayload{}
+	v.OrganizationID = organizationID
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
+// NewGetInferenceSpendHistoryPayload builds a admin service
+// getInferenceSpendHistory endpoint payload.
+func NewGetInferenceSpendHistoryPayload(organizationID string, adminSessionToken *string) *admin.GetInferenceSpendHistoryPayload {
+	v := &admin.GetInferenceSpendHistoryPayload{}
 	v.OrganizationID = organizationID
 	v.AdminSessionToken = adminSessionToken
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -103,7 +103,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|list-shadow-mcp-inventory-servers-for-user|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription)",
+		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|get-inference-spend-history|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration|get-session-meta|report-session-moved|create-session-handoff)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-image-from-url|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -400,6 +400,10 @@ func ParseEndpoint(
 		adminGetInferenceKeysFlags                 = flag.NewFlagSet("get-inference-keys", flag.ExitOnError)
 		adminGetInferenceKeysOrganizationIDFlag    = adminGetInferenceKeysFlags.String("organization-id", "REQUIRED", "")
 		adminGetInferenceKeysAdminSessionTokenFlag = adminGetInferenceKeysFlags.String("admin-session-token", "", "")
+
+		adminGetInferenceSpendHistoryFlags                 = flag.NewFlagSet("get-inference-spend-history", flag.ExitOnError)
+		adminGetInferenceSpendHistoryOrganizationIDFlag    = adminGetInferenceSpendHistoryFlags.String("organization-id", "REQUIRED", "")
+		adminGetInferenceSpendHistoryAdminSessionTokenFlag = adminGetInferenceSpendHistoryFlags.String("admin-session-token", "", "")
 
 		adminGetPaygBillingSummaryFlags                 = flag.NewFlagSet("get-payg-billing-summary", flag.ExitOnError)
 		adminGetPaygBillingSummaryOrganizationIDFlag    = adminGetPaygBillingSummaryFlags.String("organization-id", "REQUIRED", "")
@@ -3707,6 +3711,7 @@ func ParseEndpoint(
 	adminRearmTrialFlags.Usage = adminRearmTrialUsage
 	adminGetOrganizationStatsFlags.Usage = adminGetOrganizationStatsUsage
 	adminGetInferenceKeysFlags.Usage = adminGetInferenceKeysUsage
+	adminGetInferenceSpendHistoryFlags.Usage = adminGetInferenceSpendHistoryUsage
 	adminGetPaygBillingSummaryFlags.Usage = adminGetPaygBillingSummaryUsage
 	adminGetStripeSubscriptionFlags.Usage = adminGetStripeSubscriptionUsage
 	adminCancelStripeSubscriptionFlags.Usage = adminCancelStripeSubscriptionUsage
@@ -4745,6 +4750,9 @@ func ParseEndpoint(
 
 			case "get-inference-keys":
 				epf = adminGetInferenceKeysFlags
+
+			case "get-inference-spend-history":
+				epf = adminGetInferenceSpendHistoryFlags
 
 			case "get-payg-billing-summary":
 				epf = adminGetPaygBillingSummaryFlags
@@ -6923,6 +6931,9 @@ func ParseEndpoint(
 			case "get-inference-keys":
 				endpoint = c.GetInferenceKeys()
 				data, err = adminc.BuildGetInferenceKeysPayload(*adminGetInferenceKeysOrganizationIDFlag, *adminGetInferenceKeysAdminSessionTokenFlag)
+			case "get-inference-spend-history":
+				endpoint = c.GetInferenceSpendHistory()
+				data, err = adminc.BuildGetInferenceSpendHistoryPayload(*adminGetInferenceSpendHistoryOrganizationIDFlag, *adminGetInferenceSpendHistoryAdminSessionTokenFlag)
 			case "get-payg-billing-summary":
 				endpoint = c.GetPaygBillingSummary()
 				data, err = adminc.BuildGetPaygBillingSummaryPayload(*adminGetPaygBillingSummaryOrganizationIDFlag, *adminGetPaygBillingSummaryAdminSessionTokenFlag)
@@ -9526,6 +9537,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
 	fmt.Fprintln(os.Stderr, `    get-organization-stats: Returns platform-wide organization counts for the strip above the organizations list. Every figure counts the whole platform: none of them narrows to the caller's list filters, so the strip does not move when an operator filters.`)
 	fmt.Fprintln(os.Stderr, `    get-inference-keys: Returns the configured state of every materialized platform-managed OpenRouter key for an organization.`)
+	fmt.Fprintln(os.Stderr, `    get-inference-spend-history: Returns up to twelve complete UTC calendar months of recorded inference spend for an organization.`)
 	fmt.Fprintln(os.Stderr, `    get-payg-billing-summary: Returns current PAYG usage and estimated cost for an organization.`)
 	fmt.Fprintln(os.Stderr, `    get-stripe-subscription: Returns the live Stripe subscription and payment state for an organization.`)
 	fmt.Fprintln(os.Stderr, `    cancel-stripe-subscription: Schedules an organization's PAYG subscription to cancel at period end.`)
@@ -9896,6 +9908,26 @@ func adminGetInferenceKeysUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin get-inference-keys --organization-id \"abc123\" --admin-session-token \"abc123\"")
+}
+
+func adminGetInferenceSpendHistoryUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin get-inference-spend-history", os.Args[0])
+	fmt.Fprint(os.Stderr, " -organization-id STRING")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Returns up to twelve complete UTC calendar months of recorded inference spend for an organization.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -organization-id STRING: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin get-inference-spend-history --organization-id \"abc123\" --admin-session-token \"abc123\"")
 }
 
 func adminGetPaygBillingSummaryUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -739,6 +739,85 @@ paths:
                                 $ref: '#/components/schemas/Error'
             security:
                 - admin_auth_header_Authorization: []
+    /admin/organization.inferenceSpendHistory:
+        get:
+            tags:
+                - admin
+            summary: getInferenceSpendHistory admin
+            description: Returns up to twelve complete UTC calendar months of recorded inference spend for an organization.
+            operationId: adminGetInferenceSpendHistory
+            parameters:
+                - name: organization_id
+                  in: query
+                  allowEmptyValue: true
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/AdminInferenceSpendMonth'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/organization.members:
         get:
             tags:
@@ -61341,6 +61420,22 @@ components:
                 - credits_used
                 - monthly_credits
                 - disabled
+        AdminInferenceSpendMonth:
+            type: object
+            properties:
+                period_end:
+                    type: string
+                    description: Exclusive end of the UTC calendar month.
+                    format: date
+                period_start:
+                    type: string
+                    format: date
+                spend_usd:
+                    type: string
+            required:
+                - period_start
+                - period_end
+                - spend_usd
         AdminListOrganizationMembersResult:
             type: object
             properties:

--- a/server/internal/admin/billing.go
+++ b/server/internal/admin/billing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"golang.org/x/sync/errgroup"
@@ -71,6 +72,32 @@ func (s *Service) GetInferenceKeys(ctx context.Context, payload *gen.GetInferenc
 		return nil, oops.E(oops.CodeUnexpected, err, "read OpenRouter inference key usage").LogError(ctx, s.logger)
 	}
 
+	return result, nil
+}
+
+func (s *Service) GetInferenceSpendHistory(ctx context.Context, payload *gen.GetInferenceSpendHistoryPayload) ([]*gen.AdminInferenceSpendMonth, error) {
+	organizationID, err := s.canonicalAdminOrganizationID(ctx, payload.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	months, err := usagerepo.New(s.db).ListOpenRouterInferenceSpendByMonth(ctx, usagerepo.ListOpenRouterInferenceSpendByMonthParams{
+		OrganizationID:   organizationID,
+		BillableKeyTypes: openrouter.BillableKeyTypeStrings(),
+		CompletedBefore:  conv.ToPGTimestamptz(time.Now().UTC()),
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list inference spend history").LogError(ctx, s.logger)
+	}
+
+	result := make([]*gen.AdminInferenceSpendMonth, len(months))
+	for index, month := range months {
+		result[index] = &gen.AdminInferenceSpendMonth{
+			PeriodStart: month.PeriodStart,
+			PeriodEnd:   month.PeriodEnd,
+			SpendUsd:    month.SpendUsd,
+		}
+	}
 	return result, nil
 }
 

--- a/server/internal/admin/billing_test.go
+++ b/server/internal/admin/billing_test.go
@@ -3,7 +3,9 @@ package admin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
@@ -12,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	"github.com/speakeasy-api/gram/server/internal/usage"
@@ -151,6 +154,71 @@ func TestGetInferenceKeysFailsWhenOpenRouterUsageCannotBeRead(t *testing.T) {
 
 	_, err = svc.GetInferenceKeys(ctx, &gen.GetInferenceKeysPayload{OrganizationID: "org_inference_usage_error"})
 	requireOopsCode(t, err, oops.CodeUnexpected)
+}
+
+func TestGetInferenceSpendHistoryReturnsCompleteMonths(t *testing.T) {
+	t.Parallel()
+	ctx, svc, db := newTestAdminService(t)
+	const organizationID = "org_inference_history"
+	seedOrg(t, ctx, db, orgFixture{id: organizationID, name: "Inference History", slug: "inference-history"})
+
+	now := time.Now().UTC()
+	currentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	firstMonth := currentMonth.AddDate(0, -2, 0)
+	openRouterRepo := orrepo.New(db)
+	for _, keyType := range []string{"chat", "internal"} {
+		_, err := openRouterRepo.CreateOpenRouterAPIKey(ctx, orrepo.CreateOpenRouterAPIKeyParams{
+			OrganizationID: organizationID, KeyType: keyType, KeyEncrypted: pgtype.Text{}, KeyHash: "hash-" + keyType, MonthlyCredits: 100,
+		})
+		require.NoError(t, err)
+	}
+	fixtures := testrepo.New(db)
+	err := fixtures.SetOpenRouterAPIKeyCreatedAtFixture(ctx, testrepo.SetOpenRouterAPIKeyCreatedAtFixtureParams{
+		CreatedAt:      pgtype.Timestamptz{Time: firstMonth, Valid: true},
+		OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
+	for keyType, spendUSD := range map[string]string{"chat": "1.0", "internal": "0.5"} {
+		err = fixtures.SeedOpenRouterSpendRangeFixture(ctx, testrepo.SeedOpenRouterSpendRangeFixtureParams{
+			OrganizationID: organizationID,
+			KeyType:        keyType,
+			SpendUsd:       spendUSD,
+			StartDay:       pgtype.Date{Time: firstMonth, Valid: true},
+			EndDay:         pgtype.Date{Time: currentMonth.AddDate(0, 0, -1), Valid: true},
+		})
+		require.NoError(t, err)
+	}
+	err = fixtures.SeedOpenRouterSpendRangeFixture(ctx, testrepo.SeedOpenRouterSpendRangeFixtureParams{
+		OrganizationID: organizationID,
+		KeyType:        "unsupported",
+		SpendUsd:       "999.0",
+		StartDay:       pgtype.Date{Time: firstMonth, Valid: true},
+		EndDay:         pgtype.Date{Time: firstMonth, Valid: true},
+	})
+	require.NoError(t, err)
+
+	result, err := svc.GetInferenceSpendHistory(ctx, &gen.GetInferenceSpendHistoryPayload{OrganizationID: organizationID})
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	for index, month := range result {
+		periodStart := firstMonth.AddDate(0, index, 0)
+		periodEnd := periodStart.AddDate(0, 1, 0)
+		days := periodEnd.Sub(periodStart).Hours() / 24
+		require.Equal(t, periodStart.Format(time.DateOnly), month.PeriodStart)
+		require.Equal(t, periodEnd.Format(time.DateOnly), month.PeriodEnd)
+		require.Equal(t, fmt.Sprintf("%.6f", days*1.5), month.SpendUsd)
+	}
+
+	err = fixtures.DeleteOpenRouterSpendDayFixture(ctx, testrepo.DeleteOpenRouterSpendDayFixtureParams{
+		OrganizationID: organizationID,
+		KeyType:        "internal",
+		Day:            pgtype.Date{Time: firstMonth, Valid: true},
+	})
+	require.NoError(t, err)
+	result, err = svc.GetInferenceSpendHistory(ctx, &gen.GetInferenceSpendHistoryPayload{OrganizationID: organizationID})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, firstMonth.AddDate(0, 1, 0).Format(time.DateOnly), result[0].PeriodStart)
 }
 
 func TestGetPaygBillingSummaryUsesCanonicalOrganizationID(t *testing.T) {

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -481,6 +481,31 @@ SELECT
     (now() - INTERVAL '7 days')::timestamptz AS seven_days_ago,
     (now() + INTERVAL '7 days')::timestamptz AS in_seven_days;
 
+-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
+-- Test-only fixture: places a platform-managed key before a historical spend
+-- range so completeness checks expect every day in that range.
+UPDATE openrouter_api_keys
+SET created_at = @created_at
+WHERE organization_id = @organization_id;
+
+-- name: SeedOpenRouterSpendRangeFixture :exec
+-- Test-only fixture: records one exact daily spend amount across an inclusive
+-- UTC date range.
+INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
+SELECT
+    sqlc.arg(organization_id)::text
+  , sqlc.arg(key_type)::text
+  , day::date
+  , sqlc.arg(spend_usd)::text::numeric(14, 6)
+FROM GENERATE_SERIES(sqlc.arg(start_day)::date, sqlc.arg(end_day)::date, INTERVAL '1 day') AS day;
+
+-- name: DeleteOpenRouterSpendDayFixture :exec
+-- Test-only fixture: creates an incomplete historical month.
+DELETE FROM openrouter_spend_daily
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND day = @day;
+
 -- name: GetSessionHandoffLinkFixture :one
 -- Test-only inspection of a minted session-handoff link, so tests can assert a
 -- consumed link keeps its burn bookkeeping without keeping the blob pointer.

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -265,6 +265,25 @@ func (q *Queries) DeferDeviceIntegrationSyncsFixture(ctx context.Context, device
 	return err
 }
 
+const deleteOpenRouterSpendDayFixture = `-- name: DeleteOpenRouterSpendDayFixture :exec
+DELETE FROM openrouter_spend_daily
+WHERE organization_id = $1
+  AND key_type = $2
+  AND day = $3
+`
+
+type DeleteOpenRouterSpendDayFixtureParams struct {
+	OrganizationID string
+	KeyType        string
+	Day            pgtype.Date
+}
+
+// Test-only fixture: creates an incomplete historical month.
+func (q *Queries) DeleteOpenRouterSpendDayFixture(ctx context.Context, arg DeleteOpenRouterSpendDayFixtureParams) error {
+	_, err := q.db.Exec(ctx, deleteOpenRouterSpendDayFixture, arg.OrganizationID, arg.KeyType, arg.Day)
+	return err
+}
+
 const disableDeviceIntegrationSchedulesFixture = `-- name: DisableDeviceIntegrationSchedulesFixture :exec
 UPDATE device_integration_schedules
 SET disabled_at = clock_timestamp()
@@ -1348,6 +1367,37 @@ func (q *Queries) ScrubDeploymentFunctionMachineSpecs(ctx context.Context, deplo
 	return err
 }
 
+const seedOpenRouterSpendRangeFixture = `-- name: SeedOpenRouterSpendRangeFixture :exec
+INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
+SELECT
+    $1::text
+  , $2::text
+  , day::date
+  , $3::text::numeric(14, 6)
+FROM GENERATE_SERIES($4::date, $5::date, INTERVAL '1 day') AS day
+`
+
+type SeedOpenRouterSpendRangeFixtureParams struct {
+	OrganizationID string
+	KeyType        string
+	SpendUsd       string
+	StartDay       pgtype.Date
+	EndDay         pgtype.Date
+}
+
+// Test-only fixture: records one exact daily spend amount across an inclusive
+// UTC date range.
+func (q *Queries) SeedOpenRouterSpendRangeFixture(ctx context.Context, arg SeedOpenRouterSpendRangeFixtureParams) error {
+	_, err := q.db.Exec(ctx, seedOpenRouterSpendRangeFixture,
+		arg.OrganizationID,
+		arg.KeyType,
+		arg.SpendUsd,
+		arg.StartDay,
+		arg.EndDay,
+	)
+	return err
+}
+
 const seedOutboxEntry = `-- name: SeedOutboxEntry :one
 INSERT INTO outbox (organization_id, event_type, payload)
 VALUES ($1, $2, $3)
@@ -1464,6 +1514,24 @@ type SetFunctionToolVariablesParams struct {
 
 func (q *Queries) SetFunctionToolVariables(ctx context.Context, arg SetFunctionToolVariablesParams) error {
 	_, err := q.db.Exec(ctx, setFunctionToolVariables, arg.Variables, arg.ID, arg.ProjectID)
+	return err
+}
+
+const setOpenRouterAPIKeyCreatedAtFixture = `-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
+UPDATE openrouter_api_keys
+SET created_at = $1
+WHERE organization_id = $2
+`
+
+type SetOpenRouterAPIKeyCreatedAtFixtureParams struct {
+	CreatedAt      pgtype.Timestamptz
+	OrganizationID string
+}
+
+// Test-only fixture: places a platform-managed key before a historical spend
+// range so completeness checks expect every day in that range.
+func (q *Queries) SetOpenRouterAPIKeyCreatedAtFixture(ctx context.Context, arg SetOpenRouterAPIKeyCreatedAtFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyCreatedAtFixture, arg.CreatedAt, arg.OrganizationID)
 	return err
 }
 

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -59,6 +59,59 @@ SELECT
 FROM inputs
 CROSS JOIN completed_spend;
 
+-- name: ListOpenRouterInferenceSpendByMonth :many
+WITH candidate_months AS (
+  SELECT
+      DATE_TRUNC('month', day)::date AS period_start
+    , (DATE_TRUNC('month', day) + INTERVAL '1 month')::date AS period_end
+    , SUM(spend_usd)::numeric(30, 6) AS spend_usd
+  FROM openrouter_spend_daily
+  WHERE organization_id = sqlc.arg(organization_id)::text
+    AND key_type = ANY(sqlc.arg(billable_key_types)::text[])
+    AND day < DATE_TRUNC('month', sqlc.arg(completed_before)::timestamptz AT TIME ZONE 'UTC')::date
+  GROUP BY DATE_TRUNC('month', day)
+), complete_months AS (
+  SELECT candidate_months.*
+  FROM candidate_months
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM openrouter_api_keys AS inference_key
+    CROSS JOIN LATERAL GENERATE_SERIES(
+      GREATEST(candidate_months.period_start, (inference_key.created_at AT TIME ZONE 'UTC')::date),
+      LEAST(
+        candidate_months.period_end,
+        COALESCE((inference_key.deleted_at AT TIME ZONE 'UTC')::date, candidate_months.period_end)
+      ) - 1,
+      INTERVAL '1 day'
+    ) AS expected_day(day)
+    WHERE inference_key.organization_id = sqlc.arg(organization_id)::text
+      AND inference_key.key_type = ANY(sqlc.arg(billable_key_types)::text[])
+      AND (inference_key.created_at AT TIME ZONE 'UTC')::date < candidate_months.period_end
+      AND (
+        inference_key.deleted_at IS NULL
+        OR (inference_key.deleted_at AT TIME ZONE 'UTC')::date > candidate_months.period_start
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM openrouter_spend_daily AS daily_spend
+        WHERE daily_spend.organization_id = inference_key.organization_id
+          AND daily_spend.key_type = inference_key.key_type
+          AND daily_spend.day = expected_day.day::date
+      )
+  )
+), latest_months AS (
+  SELECT *
+  FROM complete_months
+  ORDER BY period_start DESC
+  LIMIT 12
+)
+SELECT
+    period_start::text AS period_start
+  , period_end::text AS period_end
+  , spend_usd::text AS spend_usd
+FROM latest_months
+ORDER BY period_start;
+
 -- name: ListMaterializedOpenRouterInferenceKeys :many
 SELECT key_type, monthly_credits, disabled
 FROM openrouter_api_keys

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -1146,6 +1146,92 @@ func (q *Queries) ListMaterializedOpenRouterInferenceKeys(ctx context.Context, a
 	return items, nil
 }
 
+const listOpenRouterInferenceSpendByMonth = `-- name: ListOpenRouterInferenceSpendByMonth :many
+WITH candidate_months AS (
+  SELECT
+      DATE_TRUNC('month', day)::date AS period_start
+    , (DATE_TRUNC('month', day) + INTERVAL '1 month')::date AS period_end
+    , SUM(spend_usd)::numeric(30, 6) AS spend_usd
+  FROM openrouter_spend_daily
+  WHERE organization_id = $1::text
+    AND key_type = ANY($2::text[])
+    AND day < DATE_TRUNC('month', $3::timestamptz AT TIME ZONE 'UTC')::date
+  GROUP BY DATE_TRUNC('month', day)
+), complete_months AS (
+  SELECT candidate_months.period_start, candidate_months.period_end, candidate_months.spend_usd
+  FROM candidate_months
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM openrouter_api_keys AS inference_key
+    CROSS JOIN LATERAL GENERATE_SERIES(
+      GREATEST(candidate_months.period_start, (inference_key.created_at AT TIME ZONE 'UTC')::date),
+      LEAST(
+        candidate_months.period_end,
+        COALESCE((inference_key.deleted_at AT TIME ZONE 'UTC')::date, candidate_months.period_end)
+      ) - 1,
+      INTERVAL '1 day'
+    ) AS expected_day(day)
+    WHERE inference_key.organization_id = $1::text
+      AND inference_key.key_type = ANY($2::text[])
+      AND (inference_key.created_at AT TIME ZONE 'UTC')::date < candidate_months.period_end
+      AND (
+        inference_key.deleted_at IS NULL
+        OR (inference_key.deleted_at AT TIME ZONE 'UTC')::date > candidate_months.period_start
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM openrouter_spend_daily AS daily_spend
+        WHERE daily_spend.organization_id = inference_key.organization_id
+          AND daily_spend.key_type = inference_key.key_type
+          AND daily_spend.day = expected_day.day::date
+      )
+  )
+), latest_months AS (
+  SELECT period_start, period_end, spend_usd
+  FROM complete_months
+  ORDER BY period_start DESC
+  LIMIT 12
+)
+SELECT
+    period_start::text AS period_start
+  , period_end::text AS period_end
+  , spend_usd::text AS spend_usd
+FROM latest_months
+ORDER BY period_start
+`
+
+type ListOpenRouterInferenceSpendByMonthParams struct {
+	OrganizationID   string
+	BillableKeyTypes []string
+	CompletedBefore  pgtype.Timestamptz
+}
+
+type ListOpenRouterInferenceSpendByMonthRow struct {
+	PeriodStart string
+	PeriodEnd   string
+	SpendUsd    string
+}
+
+func (q *Queries) ListOpenRouterInferenceSpendByMonth(ctx context.Context, arg ListOpenRouterInferenceSpendByMonthParams) ([]ListOpenRouterInferenceSpendByMonthRow, error) {
+	rows, err := q.db.Query(ctx, listOpenRouterInferenceSpendByMonth, arg.OrganizationID, arg.BillableKeyTypes, arg.CompletedBefore)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOpenRouterInferenceSpendByMonthRow
+	for rows.Next() {
+		var i ListOpenRouterInferenceSpendByMonthRow
+		if err := rows.Scan(&i.PeriodStart, &i.PeriodEnd, &i.SpendUsd); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listStaleTUMMeterReportCycles = `-- name: ListStaleTUMMeterReportCycles :many
 SELECT
     stripe_meter_reports.billing_cycle_usage_id


### PR DESCRIPTION
## Summary

- expose up to 12 complete UTC calendar months of exact inference spend through an admin-only endpoint
- keep history available independently of Stripe subscription state and exclude incomplete collection months
- show exact monthly values on organization billing, adding a compact bar graph once the latest two months are consecutive

## Testing

- `mise run test:server ./internal/admin -count=1`
- `aube run -F admin test -- src/pages/organization/Billing.test.tsx src/lib/gramAdminApi.test.ts`
- `aube run -F admin lint`
- targeted `gcl` for changed server packages
- local admin billing page verified with two complete months

Linear-issue: Fixes DNO-941

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows monthly inference spend history on the admin organization billing page so admins can track prior usage (DNO-941). Previously only the current period was visible; now admins can view up to 12 complete UTC months, independent of Stripe, with a compact bar graph when the latest two months are consecutive.

- API: Adds GET `/admin/organization.inferenceSpendHistory?organization_id=...` returning `[ { period_start, period_end, spend_usd } ]`. OpenAPI and generated clients/types updated.
- Data: Aggregates from daily `openrouter_spend_daily`; includes a month only if every day since any billable OpenRouter key’s creation within that month is present; limited to billable key types; excludes the current partial month.
- Admin UI: Billing page fetches and lists monthly values; shows a compact bar graph when the last two months are consecutive.
- Tests: Server, repo SQL, and admin UI tests cover completeness, gaps, and ordering; fixtures seed spend ranges and missing days.
- Rollout: No schema or config changes; no migrations. Changeset adds patch bumps for `admin` and `server`.

<sup>Written for commit b9711623900f552052a1cd0543209796772e918b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

