### PR TITLE
feat: stub local pay-as-you-go checkout through start

### DIFF
--- a/.changeset/local-payg-checkout-stub.md
+++ b/.changeset/local-payg-checkout-stub.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The local Stripe stub now carries pay-as-you-go checkout through start: hosted Checkout completes in-process, activates the organization, and the self-serve rollout flag is on for local orgs by default.

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -435,6 +435,10 @@ func newTemporalClient(logger *slog.Logger, meterProvider metric.MeterProvider, 
 
 func newLocalFeatureFlags(ctx context.Context, logger *slog.Logger, csvPath string) *feature.InMemory {
 	inmem := &feature.InMemory{}
+	// Local dashboard telemetry enables every flag. PAYG checkout is backed by
+	// the Stripe stub when Stripe is unconfigured, so the rollout gate stays on
+	// for every local organization unless a CSV row overrides it.
+	inmem.SetFlag(feature.FlagPaygSelfServeBilling, feature.LocalWildcardDistinctID, true)
 
 	if csvPath == "" {
 		logger.DebugContext(ctx, "newLocalFeatureFlags: no csv path provided, using empty in-memory feature flag provider")
@@ -565,7 +569,7 @@ func newStripeClient(
 	if !stripeclient.IsConfigured(apiKey) {
 		if c.String("environment") == "local" {
 			logger.WarnContext(ctx, "using stub Stripe client: Stripe not configured")
-			return stripeclient.NewStubClient(logger), nil
+			return stripeclient.NewStubClient(logger, localStripePublicURL(c)), nil
 		}
 
 		logger.InfoContext(ctx, "Stripe client not configured")
@@ -588,6 +592,18 @@ func newStripeClient(
 		c.String("stripe-webhook-secret"),
 		catalog,
 	), nil
+}
+
+func localStripePublicURL(c *cli.Context) *url.URL {
+	raw := c.String("server-url")
+	if raw == "" {
+		return nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil
+	}
+	return parsed
 }
 
 // workosClientOpts builds the ClientOpts threaded into every workos.NewClient

--- a/server/cmd/gram/deps_stripe_test.go
+++ b/server/cmd/gram/deps_stripe_test.go
@@ -7,10 +7,53 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 )
+
+func TestNewLocalFeatureFlagsEnablesPaygSelfServe(t *testing.T) {
+	t.Parallel()
+
+	flags := newLocalFeatureFlags(t.Context(), testenv.NewLogger(t), "")
+	enabled, err := flags.IsFlagEnabled(t.Context(), feature.FlagPaygSelfServeBilling, "org-local", nil)
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func TestNewStripeClientLocalWithoutAPIKeyUsesServerURLForCheckout(t *testing.T) {
+	t.Parallel()
+
+	ctx := newStripeCLIContext(t, map[string]string{
+		"environment":    "local",
+		"stripe-api-key": "unset",
+		"server-url":     "https://localhost:8000",
+	})
+
+	client, err := newStripeClient(
+		t.Context(),
+		testenv.NewLogger(t),
+		guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)),
+		ctx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	local, ok := client.(stripeclient.LocalCheckout)
+	require.True(t, ok)
+
+	checkout, err := client.CreateCheckoutSession(t.Context(), stripeclient.CreateCheckoutSessionInput{
+		CustomerID:       "cus_local_org",
+		OrganizationSlug: "billing-test",
+		SuccessURL:       "https://localhost:4000/billing-test/billing",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://localhost:8000/rpc/stripe.local-checkout?session="+checkout.ID, checkout.URL)
+
+	result, err := local.CompleteCheckout(t.Context(), checkout.ID)
+	require.NoError(t, err)
+	require.Equal(t, "https://localhost:4000/billing-test/billing", result.SuccessURL)
+}
 
 func TestNewStripeClientLocalWithoutAPIKeyUsesStubBeforeCatalogValidation(t *testing.T) {
 	t.Parallel()
@@ -141,7 +184,7 @@ func TestNewBillingProviderAcceptsStripeWithoutPolar(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		stripeclient.NewStubClient(logger),
+		stripeclient.NewStubClient(logger, nil),
 		ctx,
 	)
 	require.NoError(t, err)
@@ -179,6 +222,7 @@ func newStripeCLIContext(t *testing.T, values map[string]string) *cli.Context {
 	set.String("stripe-meter-id-tum", "", "")
 	set.String("stripe-meter-event-name", "", "")
 	set.String("stripe-portal-configuration-id", "", "")
+	set.String("server-url", "", "")
 	set.String("polar-api-key", "", "")
 	for key, value := range values {
 		require.NoError(t, set.Set(key, value))

--- a/server/internal/feature/provider.go
+++ b/server/internal/feature/provider.go
@@ -27,22 +27,30 @@ type Provider interface {
 	FlagPayload(ctx context.Context, flag Flag, distinctID string, groups map[string]string) ([]byte, error)
 }
 
+// LocalWildcardDistinctID enables an in-memory flag for every distinct ID that
+// does not have its own entry. Local development uses it so rollout flags do
+// not need a row per organization.
+const LocalWildcardDistinctID = "*"
+
 type InMemory sync.Map
 
-func (imp *InMemory) IsFlagEnabled(ctx context.Context, flag Flag, distinctID string, groups map[string]string) (bool, error) {
-	key := distinctID + ":" + string(flag)
-
-	val, ok := (*sync.Map)(imp).Load(key)
+func (imp *InMemory) lookupBool(flag Flag, distinctID string) (bool, bool) {
+	val, ok := (*sync.Map)(imp).Load(distinctID + ":" + string(flag))
 	if !ok {
-		return false, nil
+		return false, false
 	}
-
 	enabled, ok := val.(bool)
-	if !ok {
-		return false, nil
-	}
+	return enabled, ok
+}
 
-	return enabled, nil
+func (imp *InMemory) IsFlagEnabled(ctx context.Context, flag Flag, distinctID string, groups map[string]string) (bool, error) {
+	if enabled, ok := imp.lookupBool(flag, distinctID); ok {
+		return enabled, nil
+	}
+	if enabled, ok := imp.lookupBool(flag, LocalWildcardDistinctID); ok {
+		return enabled, nil
+	}
+	return false, nil
 }
 
 func (imp *InMemory) IsFlagEnabledLocal(ctx context.Context, flag Flag, distinctID string, groups, personProperties map[string]string) (bool, error) {
@@ -61,18 +69,23 @@ func payloadKey(flag Flag, distinctID string) string {
 	return "payload:" + distinctID + ":" + string(flag)
 }
 
-func (imp *InMemory) FlagPayload(ctx context.Context, flag Flag, distinctID string, groups map[string]string) ([]byte, error) {
+func (imp *InMemory) lookupPayload(flag Flag, distinctID string) ([]byte, bool) {
 	val, ok := (*sync.Map)(imp).Load(payloadKey(flag, distinctID))
 	if !ok {
-		return nil, nil
+		return nil, false
 	}
-
 	payload, ok := val.([]byte)
-	if !ok {
-		return nil, nil
-	}
+	return payload, ok
+}
 
-	return payload, nil
+func (imp *InMemory) FlagPayload(ctx context.Context, flag Flag, distinctID string, groups map[string]string) ([]byte, error) {
+	if payload, ok := imp.lookupPayload(flag, distinctID); ok {
+		return payload, nil
+	}
+	if payload, ok := imp.lookupPayload(flag, LocalWildcardDistinctID); ok {
+		return payload, nil
+	}
+	return nil, nil
 }
 
 func (imp *InMemory) SetFlagPayload(flag Flag, distinctID string, payload []byte) {
@@ -85,18 +98,23 @@ func variantKey(flag Flag, distinctID string) string {
 	return "variant:" + distinctID + ":" + string(flag)
 }
 
-func (imp *InMemory) FlagVariant(ctx context.Context, flag Flag, distinctID string, groups map[string]string) (Variant, error) {
+func (imp *InMemory) lookupVariant(flag Flag, distinctID string) (Variant, bool) {
 	val, ok := (*sync.Map)(imp).Load(variantKey(flag, distinctID))
 	if !ok {
-		return "", nil
+		return "", false
 	}
-
 	variant, ok := val.(Variant)
-	if !ok {
-		return "", nil
-	}
+	return variant, ok
+}
 
-	return variant, nil
+func (imp *InMemory) FlagVariant(ctx context.Context, flag Flag, distinctID string, groups map[string]string) (Variant, error) {
+	if variant, ok := imp.lookupVariant(flag, distinctID); ok {
+		return variant, nil
+	}
+	if variant, ok := imp.lookupVariant(flag, LocalWildcardDistinctID); ok {
+		return variant, nil
+	}
+	return "", nil
 }
 
 func (imp *InMemory) SetFlagVariant(flag Flag, distinctID string, variant Variant) {
@@ -168,20 +186,21 @@ func EvaluateFlag(ctx context.Context, provider Provider, flag Flag, distinctID 
 	return EvaluationIndeterminate, nil
 }
 
-func (imp *InMemory) EvaluateFlag(_ context.Context, flag Flag, distinctID string, _ map[string]string) (Evaluation, error) {
-	key := distinctID + ":" + string(flag)
-	value, ok := (*sync.Map)(imp).Load(key)
-	if !ok {
-		return EvaluationIndeterminate, nil
-	}
-	enabled, ok := value.(bool)
-	if !ok {
-		return EvaluationIndeterminate, nil
-	}
+func evaluationFromEnabled(enabled bool) Evaluation {
 	if enabled {
-		return EvaluationEnabled, nil
+		return EvaluationEnabled
 	}
-	return EvaluationDisabled, nil
+	return EvaluationDisabled
+}
+
+func (imp *InMemory) EvaluateFlag(_ context.Context, flag Flag, distinctID string, _ map[string]string) (Evaluation, error) {
+	if enabled, ok := imp.lookupBool(flag, distinctID); ok {
+		return evaluationFromEnabled(enabled), nil
+	}
+	if enabled, ok := imp.lookupBool(flag, LocalWildcardDistinctID); ok {
+		return evaluationFromEnabled(enabled), nil
+	}
+	return EvaluationIndeterminate, nil
 }
 
 // OrgProjectGroups returns the PostHog group memberships used to evaluate

--- a/server/internal/feature/provider_test.go
+++ b/server/internal/feature/provider_test.go
@@ -31,6 +31,30 @@ func TestEvaluateFlagInMemory(t *testing.T) {
 	require.Equal(t, feature.EvaluationIndeterminate, missing)
 }
 
+func TestInMemoryWildcardDistinctID(t *testing.T) {
+	t.Parallel()
+
+	provider := &feature.InMemory{}
+	provider.SetFlag(testFeatureFlag, feature.LocalWildcardDistinctID, true)
+	provider.SetFlag(testFeatureFlag, "disabled-org", false)
+
+	enabled, err := provider.IsFlagEnabled(t.Context(), testFeatureFlag, "any-org", nil)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	disabled, err := provider.IsFlagEnabled(t.Context(), testFeatureFlag, "disabled-org", nil)
+	require.NoError(t, err)
+	require.False(t, disabled)
+
+	evaluation, err := feature.EvaluateFlag(t.Context(), provider, testFeatureFlag, "any-org", nil)
+	require.NoError(t, err)
+	require.Equal(t, feature.EvaluationEnabled, evaluation)
+
+	override, err := feature.EvaluateFlag(t.Context(), provider, testFeatureFlag, "disabled-org", nil)
+	require.NoError(t, err)
+	require.Equal(t, feature.EvaluationDisabled, override)
+}
+
 func TestEvaluateFlagLegacyProviderIsIndeterminate(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -998,94 +996,4 @@ func expandedObjectID(raw json.RawMessage) string {
 
 func (c *client) Catalog() Catalog {
 	return c.catalog
-}
-
-type stubClient struct {
-	logger *slog.Logger
-}
-
-// NewStubClient returns a local no-op Stripe client.
-func NewStubClient(logger *slog.Logger) Client {
-	return &stubClient{logger: logger}
-}
-
-func (s *stubClient) CreateCustomer(ctx context.Context, _ CreateCustomerInput) (*Customer, error) {
-	s.logger.DebugContext(ctx, "stub Stripe customer creation skipped")
-	return &Customer{ID: "cus_local_stub"}, nil
-}
-
-func (s *stubClient) CreateCheckoutSession(ctx context.Context, input CreateCheckoutSessionInput) (*CheckoutSession, error) {
-	s.logger.DebugContext(ctx, "stub Stripe Checkout session creation skipped")
-	return &CheckoutSession{ID: "cs_local_stub", URL: fmt.Sprintf("http://localhost:3000/%s/billing", url.PathEscape(input.OrganizationSlug))}, nil
-}
-
-func (s *stubClient) GetCheckoutSession(context.Context, string) (*CheckoutSessionState, error) {
-	return nil, errors.New("retrieve Stripe Checkout session is unavailable locally")
-}
-
-func (s *stubClient) GetSubscription(context.Context, string) (*SubscriptionState, error) {
-	return nil, errors.New("retrieve Stripe subscription is unavailable locally")
-}
-
-func (s *stubClient) SetSubscriptionCancelAtPeriodEnd(context.Context, SetSubscriptionCancelAtPeriodEndInput) (*SubscriptionState, error) {
-	return nil, errors.New("update Stripe subscription is unavailable locally")
-}
-
-func (s *stubClient) CreatePortalSession(context.Context, CreatePortalSessionInput) (*PortalSession, error) {
-	return nil, errors.New("create Stripe billing portal session is unavailable locally")
-}
-
-func (s *stubClient) CreateMeterEvent(ctx context.Context, _ CreateMeterEventInput) error {
-	s.logger.DebugContext(ctx, "stub Stripe meter event skipped")
-	return nil
-}
-
-func (s *stubClient) GetMeterEventSummary(ctx context.Context, _ GetMeterEventSummaryInput) (float64, error) {
-	s.logger.DebugContext(ctx, "stub Stripe meter event summary skipped")
-	return 0, nil
-}
-
-func (s *stubClient) GetInvoice(context.Context, string) (*InvoiceState, error) {
-	return nil, errors.New("retrieve Stripe invoice is unavailable locally")
-}
-
-func (s *stubClient) CreateInvoiceItem(ctx context.Context, input CreateInvoiceItemInput) (*InvoiceItem, error) {
-	s.logger.DebugContext(ctx, "stub Stripe invoice item skipped")
-	return &InvoiceItem{
-		ID:          "ii_local_stub",
-		InvoiceID:   input.InvoiceID,
-		Currency:    "usd",
-		AmountCents: input.AmountCents,
-	}, nil
-}
-
-func (s *stubClient) CreateCreditNote(ctx context.Context, input CreateCreditNoteInput) (*CreditNote, error) {
-	s.logger.DebugContext(ctx, "stub Stripe credit note skipped")
-	return &CreditNote{
-		ID:          "cn_local_stub",
-		InvoiceID:   input.InvoiceID,
-		Currency:    "usd",
-		AmountCents: input.AmountCents,
-	}, nil
-}
-
-func (s *stubClient) FindInvoiceItem(context.Context, FindInvoiceAllocationInput) (*InvoiceItem, error) {
-	return nil, nil
-}
-
-func (s *stubClient) FindCreditNote(context.Context, FindInvoiceAllocationInput) (*CreditNote, error) {
-	return nil, nil
-}
-
-func (s *stubClient) VerifyWebhook(_ []byte, _ string) (*WebhookEvent, error) {
-	return nil, fmt.Errorf("verify Stripe webhook: %w", ErrWebhookNotConfigured)
-}
-
-func (s *stubClient) Catalog() Catalog {
-	return Catalog{
-		PriceIDTUM:            "",
-		MeterIDTUM:            "",
-		MeterEventName:        "",
-		PortalConfigurationID: "",
-	}
 }

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -1132,14 +1132,16 @@ func TestVerifyWebhookAcceptsSignedEventsAcrossAPIVersions(t *testing.T) {
 func TestStubClientIsSafeToCall(t *testing.T) {
 	t.Parallel()
 
-	c := NewStubClient(testenv.NewLogger(t))
+	c := NewStubClient(testenv.NewLogger(t), nil)
 
 	customer, err := c.CreateCustomer(t.Context(), CreateCustomerInput{})
 	require.NoError(t, err)
-	require.Equal(t, "cus_local_stub", customer.ID)
-	checkout, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{OrganizationSlug: "test/org"})
+	require.Equal(t, "cus_local_1", customer.ID)
+	checkout, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
+		OrganizationSlug: "test/org",
+	})
 	require.NoError(t, err)
-	require.Equal(t, "cs_local_stub", checkout.ID)
+	require.Equal(t, "cs_local_2", checkout.ID)
 	require.Equal(t, "http://localhost:3000/test%2Forg/billing", checkout.URL)
 	require.NoError(t, c.CreateMeterEvent(t.Context(), CreateMeterEventInput{}))
 	require.Equal(t, Catalog{}, c.Catalog())

--- a/server/internal/thirdparty/stripe/stub.go
+++ b/server/internal/thirdparty/stripe/stub.go
@@ -1,0 +1,525 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"reflect"
+	"sync"
+	"time"
+)
+
+// LocalCheckoutPath is the in-process hosted Checkout stand-in used when Stripe
+// is unconfigured in local development.
+const LocalCheckoutPath = "/rpc/stripe.local-checkout"
+
+const localSessionQueryKey = "session"
+
+var (
+	// ErrLocalCheckoutSessionRequired is returned when local Checkout is completed without a session id.
+	ErrLocalCheckoutSessionRequired = errors.New("checkout session id is required")
+
+	// ErrLocalCheckoutSessionUnknown is returned when local Checkout cannot find the session.
+	ErrLocalCheckoutSessionUnknown = errors.New("checkout session not found")
+
+	// ErrLocalCheckoutSessionExpired is returned when local Checkout is completed after expiry.
+	ErrLocalCheckoutSessionExpired = errors.New("checkout session is expired")
+
+	errLocalCheckoutNotOpen        = errors.New("checkout session is not open")
+	errLocalSubscriptionRequired   = errors.New("subscription id is required")
+	errLocalSubscriptionUnknown    = errors.New("subscription not found")
+	errLocalInvoiceRequired        = errors.New("invoice id is required")
+	errLocalInvoiceUnknown         = errors.New("invoice not found")
+	errLocalPortalCustomerRequired = errors.New("customer id is required")
+	errLocalPortalReturnRequired   = errors.New("portal return URL is required")
+)
+
+// LocalCheckout is implemented by the in-process Stripe stub so local
+// development can complete hosted Checkout and start PAYG without Stripe.
+type LocalCheckout interface {
+	// CompleteCheckout finishes an open session and returns the webhook event
+	// that starts PAYG, plus the dashboard URL to send the browser to after.
+	CompleteCheckout(context.Context, string) (*LocalCheckoutCompletion, error)
+}
+
+// LocalCheckoutCompletion is the state produced when a stub Checkout session
+// is completed locally.
+type LocalCheckoutCompletion struct {
+	// Event is the checkout.session.completed envelope the webhook handler
+	// consumes after local completion.
+	Event *WebhookEvent
+
+	// SuccessURL is the dashboard destination after PAYG has started.
+	SuccessURL string
+}
+
+type stubCheckout struct {
+	id                 string
+	customerID         string
+	successURL         string
+	status             string
+	subscriptionID     string
+	billingCycleAnchor time.Time
+	trialEnd           *time.Time
+	expiresAt          time.Time
+	input              CreateCheckoutSessionInput
+}
+
+type stubInvoiceAllocation struct {
+	item      *InvoiceItem
+	note      *CreditNote
+	invoiceID string
+	key       string
+	amount    int64
+}
+
+type stubClient struct {
+	mu            sync.Mutex
+	logger        *slog.Logger
+	publicURL     *url.URL
+	seq           int
+	customers     map[string]*Customer
+	sessions      map[string]*stubCheckout
+	sessionByKey  map[string]string
+	subscriptions map[string]*SubscriptionState
+	invoices      map[string]*InvoiceState
+	allocations   []stubInvoiceAllocation
+	meterTotals   map[string]float64
+}
+
+var _ Client = (*stubClient)(nil)
+var _ LocalCheckout = (*stubClient)(nil)
+
+// NewStubClient returns the in-process Stripe stand-in used when Stripe is
+// unconfigured. publicURL is the Gram server origin used to host local
+// Checkout; when nil, Checkout returns SuccessURL so callers can complete the
+// session through LocalCheckout directly.
+func NewStubClient(logger *slog.Logger, publicURL *url.URL) Client {
+	return &stubClient{
+		mu:            sync.Mutex{},
+		logger:        logger,
+		publicURL:     cloneURL(publicURL),
+		seq:           0,
+		customers:     make(map[string]*Customer),
+		sessions:      make(map[string]*stubCheckout),
+		sessionByKey:  make(map[string]string),
+		subscriptions: make(map[string]*SubscriptionState),
+		invoices:      make(map[string]*InvoiceState),
+		allocations:   make([]stubInvoiceAllocation, 0),
+		meterTotals:   make(map[string]float64),
+	}
+}
+
+func (s *stubClient) CreateCustomer(ctx context.Context, input CreateCustomerInput) (*Customer, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if input.IdempotencyKey != "" {
+		if customer, ok := s.customers[input.IdempotencyKey]; ok {
+			copied := *customer
+			return &copied, nil
+		}
+	}
+
+	s.seq++
+	customer := &Customer{ID: fmt.Sprintf("cus_local_%d", s.seq)}
+	if input.IdempotencyKey != "" {
+		s.customers[input.IdempotencyKey] = customer
+	}
+	s.logger.DebugContext(ctx, "created local Stripe customer")
+	copied := *customer
+	return &copied, nil
+}
+
+func (s *stubClient) CreateCheckoutSession(ctx context.Context, input CreateCheckoutSessionInput) (*CheckoutSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if input.IdempotencyKey != "" {
+		if sessionID, ok := s.sessionByKey[input.IdempotencyKey]; ok {
+			session, exists := s.sessions[sessionID]
+			if !exists {
+				return nil, ErrLocalCheckoutSessionUnknown
+			}
+			if !reflect.DeepEqual(session.input, input) {
+				return nil, fmt.Errorf("idempotency key %q reused with different checkout input", input.IdempotencyKey)
+			}
+			return &CheckoutSession{ID: session.id, URL: s.checkoutURL(session.id, input)}, nil
+		}
+	}
+
+	s.seq++
+	session := &stubCheckout{
+		id:                 fmt.Sprintf("cs_local_%d", s.seq),
+		customerID:         input.CustomerID,
+		successURL:         input.SuccessURL,
+		status:             "open",
+		subscriptionID:     "",
+		billingCycleAnchor: localBillingCycleAnchor(input.BillingCycleAnchor),
+		trialEnd:           cloneTime(input.TrialEnd),
+		expiresAt:          input.ExpiresAt.UTC(),
+		input:              input,
+	}
+	s.expireSession(session, time.Now().UTC())
+	s.sessions[session.id] = session
+	if input.IdempotencyKey != "" {
+		s.sessionByKey[input.IdempotencyKey] = session.id
+	}
+	s.logger.DebugContext(ctx, "created local Stripe Checkout session")
+	return &CheckoutSession{ID: session.id, URL: s.checkoutURL(session.id, input)}, nil
+}
+
+func (s *stubClient) GetCheckoutSession(_ context.Context, id string) (*CheckoutSessionState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	session, ok := s.sessions[id]
+	if !ok {
+		return nil, ErrLocalCheckoutSessionUnknown
+	}
+	s.expireSession(session, time.Now().UTC())
+	return checkoutState(session, s.subscriptions[session.subscriptionID]), nil
+}
+
+func (s *stubClient) GetSubscription(_ context.Context, id string) (*SubscriptionState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if id == "" {
+		return nil, errLocalSubscriptionRequired
+	}
+	state, ok := s.subscriptions[id]
+	if !ok {
+		return nil, errLocalSubscriptionUnknown
+	}
+	copied := *state
+	return &copied, nil
+}
+
+func (s *stubClient) SetSubscriptionCancelAtPeriodEnd(_ context.Context, input SetSubscriptionCancelAtPeriodEndInput) (*SubscriptionState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if input.SubscriptionID == "" {
+		return nil, errLocalSubscriptionRequired
+	}
+	state, ok := s.subscriptions[input.SubscriptionID]
+	if !ok {
+		return nil, errLocalSubscriptionUnknown
+	}
+
+	now := time.Now().UTC()
+	state.CancelAtPeriodEnd = input.CancelAtPeriodEnd
+	if input.CancelAtPeriodEnd {
+		state.CancelAt = state.CurrentPeriodEnd
+		state.CanceledAt = now
+	} else {
+		state.CancelAt = time.Time{}
+		state.CanceledAt = time.Time{}
+	}
+	copied := *state
+	return &copied, nil
+}
+
+func (s *stubClient) CreatePortalSession(_ context.Context, input CreatePortalSessionInput) (*PortalSession, error) {
+	if input.CustomerID == "" {
+		return nil, errLocalPortalCustomerRequired
+	}
+	if input.ReturnURL == "" {
+		return nil, errLocalPortalReturnRequired
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.seq++
+	return &PortalSession{
+		ID:         fmt.Sprintf("bps_local_%d", s.seq),
+		CustomerID: input.CustomerID,
+		URL:        input.ReturnURL,
+	}, nil
+}
+
+func (s *stubClient) CreateMeterEvent(ctx context.Context, input CreateMeterEventInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.meterTotals[input.CustomerID] += float64(input.Value)
+	s.logger.DebugContext(ctx, "recorded local Stripe meter event")
+	return nil
+}
+
+func (s *stubClient) GetMeterEventSummary(ctx context.Context, input GetMeterEventSummaryInput) (float64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.logger.DebugContext(ctx, "read local Stripe meter event summary")
+	return s.meterTotals[input.CustomerID], nil
+}
+
+func (s *stubClient) GetInvoice(_ context.Context, id string) (*InvoiceState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if id == "" {
+		return nil, errLocalInvoiceRequired
+	}
+	state, ok := s.invoices[id]
+	if !ok {
+		return nil, errLocalInvoiceUnknown
+	}
+	copied := *state
+	return &copied, nil
+}
+
+func (s *stubClient) CreateInvoiceItem(ctx context.Context, input CreateInvoiceItemInput) (*InvoiceItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.seq++
+	item := &InvoiceItem{
+		ID:          fmt.Sprintf("ii_local_%d", s.seq),
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}
+	s.allocations = append(s.allocations, stubInvoiceAllocation{
+		item:      item,
+		note:      nil,
+		invoiceID: input.InvoiceID,
+		key:       input.AllocationKey,
+		amount:    input.AmountCents,
+	})
+	s.logger.DebugContext(ctx, "created local Stripe invoice item")
+	copied := *item
+	return &copied, nil
+}
+
+func (s *stubClient) CreateCreditNote(ctx context.Context, input CreateCreditNoteInput) (*CreditNote, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.seq++
+	note := &CreditNote{
+		ID:          fmt.Sprintf("cn_local_%d", s.seq),
+		InvoiceID:   input.InvoiceID,
+		Currency:    "usd",
+		AmountCents: input.AmountCents,
+	}
+	s.allocations = append(s.allocations, stubInvoiceAllocation{
+		item:      nil,
+		note:      note,
+		invoiceID: input.InvoiceID,
+		key:       input.AllocationKey,
+		amount:    input.AmountCents,
+	})
+	s.logger.DebugContext(ctx, "created local Stripe credit note")
+	copied := *note
+	return &copied, nil
+}
+
+func (s *stubClient) FindInvoiceItem(_ context.Context, input FindInvoiceAllocationInput) (*InvoiceItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, allocation := range s.allocations {
+		if allocation.item != nil &&
+			allocation.invoiceID == input.InvoiceID &&
+			allocation.key == input.AllocationKey &&
+			allocation.amount == input.AmountCents {
+			copied := *allocation.item
+			return &copied, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *stubClient) FindCreditNote(_ context.Context, input FindInvoiceAllocationInput) (*CreditNote, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, allocation := range s.allocations {
+		if allocation.note != nil &&
+			allocation.invoiceID == input.InvoiceID &&
+			allocation.key == input.AllocationKey &&
+			allocation.amount == input.AmountCents {
+			copied := *allocation.note
+			return &copied, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *stubClient) VerifyWebhook(_ []byte, _ string) (*WebhookEvent, error) {
+	return nil, fmt.Errorf("verify Stripe webhook: %w", ErrWebhookNotConfigured)
+}
+
+func (s *stubClient) Catalog() Catalog {
+	return Catalog{
+		PriceIDTUM:            "",
+		MeterIDTUM:            "",
+		MeterEventName:        "",
+		PortalConfigurationID: "",
+	}
+}
+
+func (s *stubClient) CompleteCheckout(ctx context.Context, sessionID string) (*LocalCheckoutCompletion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if sessionID == "" {
+		return nil, ErrLocalCheckoutSessionRequired
+	}
+	session, ok := s.sessions[sessionID]
+	if !ok {
+		return nil, ErrLocalCheckoutSessionUnknown
+	}
+
+	now := time.Now().UTC()
+	s.expireSession(session, now)
+	if session.status == "expired" {
+		return nil, ErrLocalCheckoutSessionExpired
+	}
+
+	if session.status != "complete" {
+		if session.status != "open" {
+			return nil, errLocalCheckoutNotOpen
+		}
+		s.seq++
+		subscriptionID := fmt.Sprintf("sub_local_%d", s.seq)
+		s.seq++
+		invoiceID := fmt.Sprintf("in_local_%d", s.seq)
+		subscription := newLocalSubscription(subscriptionID, session, invoiceID, now)
+		s.subscriptions[subscriptionID] = subscription
+		s.invoices[invoiceID] = &InvoiceState{
+			ID:                 invoiceID,
+			CustomerID:         session.customerID,
+			SubscriptionID:     subscriptionID,
+			Currency:           "usd",
+			BillingReason:      "subscription_create",
+			Status:             "paid",
+			ServicePeriodStart: subscription.CurrentPeriodStart,
+			ServicePeriodEnd:   subscription.CurrentPeriodEnd,
+			FinalizedAt:        now,
+			AmountRemaining:    0,
+		}
+		session.subscriptionID = subscriptionID
+		session.status = "complete"
+		s.logger.DebugContext(ctx, "completed local Stripe Checkout session")
+	}
+
+	return &LocalCheckoutCompletion{
+		Event: &WebhookEvent{
+			ID:             "evt_local_" + session.id,
+			Type:           "checkout.session.completed",
+			Created:        now,
+			ObjectID:       session.id,
+			CustomerID:     session.customerID,
+			SubscriptionID: session.subscriptionID,
+		},
+		SuccessURL: session.successURL,
+	}, nil
+}
+
+func (s *stubClient) checkoutURL(sessionID string, input CreateCheckoutSessionInput) string {
+	if s.publicURL != nil {
+		checkout := *s.publicURL
+		checkout.Path = LocalCheckoutPath
+		query := checkout.Query()
+		query.Set(localSessionQueryKey, sessionID)
+		checkout.RawQuery = query.Encode()
+		return checkout.String()
+	}
+	if input.SuccessURL != "" {
+		return input.SuccessURL
+	}
+	return fmt.Sprintf("http://localhost:3000/%s/billing", url.PathEscape(input.OrganizationSlug))
+}
+
+func (s *stubClient) expireSession(session *stubCheckout, now time.Time) {
+	if session.status == "open" && !session.expiresAt.IsZero() && !session.expiresAt.After(now) {
+		session.status = "expired"
+	}
+}
+
+func checkoutState(session *stubCheckout, subscription *SubscriptionState) *CheckoutSessionState {
+	state := &CheckoutSessionState{
+		ID:                     session.id,
+		Status:                 session.status,
+		CustomerID:             session.customerID,
+		SubscriptionID:         session.subscriptionID,
+		SubscriptionCustomerID: "",
+		SubscriptionStatus:     "",
+		BillingCycleAnchor:     session.billingCycleAnchor,
+	}
+	if subscription != nil {
+		state.SubscriptionCustomerID = subscription.CustomerID
+		state.SubscriptionStatus = subscription.Status
+		if !subscription.CurrentPeriodStart.IsZero() && session.billingCycleAnchor.IsZero() {
+			state.BillingCycleAnchor = subscription.CurrentPeriodStart
+		}
+	}
+	return state
+}
+
+func newLocalSubscription(id string, session *stubCheckout, invoiceID string, now time.Time) *SubscriptionState {
+	periodStart := now.Truncate(time.Second)
+	periodEnd := session.billingCycleAnchor
+	if periodEnd.IsZero() || !periodEnd.After(periodStart) {
+		periodEnd = periodStart.AddDate(0, 1, 0)
+	}
+
+	status := "active"
+	trialStart := time.Time{}
+	trialEnd := time.Time{}
+	if session.trialEnd != nil && session.trialEnd.After(now) {
+		status = "trialing"
+		trialStart = periodStart
+		trialEnd = session.trialEnd.UTC()
+		periodEnd = trialEnd
+	}
+
+	return &SubscriptionState{
+		ID:                           id,
+		CustomerID:                   session.customerID,
+		Status:                       status,
+		CurrentPeriodStart:           periodStart,
+		CurrentPeriodEnd:             periodEnd,
+		TrialStart:                   trialStart,
+		TrialEnd:                     trialEnd,
+		CancelAtPeriodEnd:            false,
+		CancelAt:                     time.Time{},
+		CanceledAt:                   time.Time{},
+		LatestInvoiceID:              invoiceID,
+		LatestInvoiceStatus:          "paid",
+		LatestInvoiceAmountRemaining: 0,
+		PaymentFailed:                false,
+	}
+}
+
+func localBillingCycleAnchor(value time.Time) time.Time {
+	if !value.IsZero() {
+		return value.UTC()
+	}
+	now := time.Now().UTC()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	return midnight.AddDate(0, 0, 1)
+}
+
+func cloneURL(value *url.URL) *url.URL {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copied := value.UTC()
+	return &copied
+}

--- a/server/internal/thirdparty/stripe/stub_test.go
+++ b/server/internal/thirdparty/stripe/stub_test.go
@@ -1,0 +1,207 @@
+package stripe
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestStubClientCreatesUniqueCustomersAndSessions(t *testing.T) {
+	t.Parallel()
+
+	c := NewStubClient(testenv.NewLogger(t), nil)
+	first, err := c.CreateCustomer(t.Context(), CreateCustomerInput{IdempotencyKey: "customer:one"})
+	require.NoError(t, err)
+	second, err := c.CreateCustomer(t.Context(), CreateCustomerInput{IdempotencyKey: "customer:two"})
+	require.NoError(t, err)
+	require.NotEqual(t, first.ID, second.ID)
+
+	replay, err := c.CreateCustomer(t.Context(), CreateCustomerInput{IdempotencyKey: "customer:one"})
+	require.NoError(t, err)
+	require.Equal(t, first.ID, replay.ID)
+}
+
+func TestStubClientCheckoutUsesPublicURLAndCompletesThroughStart(t *testing.T) {
+	t.Parallel()
+
+	publicURL, err := url.Parse("https://localhost:8000")
+	require.NoError(t, err)
+	c := NewStubClient(testenv.NewLogger(t), publicURL)
+	local, ok := c.(LocalCheckout)
+	require.True(t, ok)
+
+	anchor := time.Date(2026, time.August, 25, 0, 0, 0, 0, time.UTC)
+	checkout, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
+		CustomerID:         "cus_local_org",
+		OrganizationID:     "<ORG_ID>",
+		OrganizationSlug:   "billing-test",
+		SuccessURL:         "https://localhost:4000/billing-test/billing",
+		CancelURL:          "https://localhost:4000/billing-test/billing",
+		TrialEnd:           nil,
+		BillingCycleAnchor: anchor,
+		ExpiresAt:          time.Now().UTC().Add(time.Hour),
+		IdempotencyKey:     "checkout-session:<ORG_ID>",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://localhost:8000/rpc/stripe.local-checkout?session="+checkout.ID, checkout.URL)
+
+	open, err := c.GetCheckoutSession(t.Context(), checkout.ID)
+	require.NoError(t, err)
+	require.Equal(t, "open", open.Status)
+	require.Equal(t, "cus_local_org", open.CustomerID)
+	require.True(t, open.BillingCycleAnchor.Equal(anchor))
+
+	result, err := local.CompleteCheckout(t.Context(), checkout.ID)
+	require.NoError(t, err)
+	require.Equal(t, "https://localhost:4000/billing-test/billing", result.SuccessURL)
+	require.Equal(t, "checkout.session.completed", result.Event.Type)
+	require.Equal(t, checkout.ID, result.Event.ObjectID)
+	require.Equal(t, "cus_local_org", result.Event.CustomerID)
+	require.NotEmpty(t, result.Event.SubscriptionID)
+
+	complete, err := c.GetCheckoutSession(t.Context(), checkout.ID)
+	require.NoError(t, err)
+	require.Equal(t, "complete", complete.Status)
+	require.Equal(t, result.Event.SubscriptionID, complete.SubscriptionID)
+	require.Equal(t, "cus_local_org", complete.SubscriptionCustomerID)
+	require.Equal(t, "active", complete.SubscriptionStatus)
+
+	subscription, err := c.GetSubscription(t.Context(), result.Event.SubscriptionID)
+	require.NoError(t, err)
+	require.Equal(t, "cus_local_org", subscription.CustomerID)
+	require.Equal(t, "active", subscription.Status)
+	require.False(t, subscription.CancelAtPeriodEnd)
+
+	replay, err := local.CompleteCheckout(t.Context(), checkout.ID)
+	require.NoError(t, err)
+	require.Equal(t, result.Event.ID, replay.Event.ID)
+	require.Equal(t, result.Event.SubscriptionID, replay.Event.SubscriptionID)
+}
+
+func TestStubClientCheckoutIdempotencyAndExpiry(t *testing.T) {
+	t.Parallel()
+
+	c := NewStubClient(testenv.NewLogger(t), nil)
+	input := CreateCheckoutSessionInput{
+		CustomerID:         "cus_local_org",
+		OrganizationID:     "<ORG_ID>",
+		OrganizationSlug:   "billing-test",
+		SuccessURL:         "https://app.example.test/billing-test/billing",
+		CancelURL:          "https://app.example.test/billing-test/billing",
+		TrialEnd:           nil,
+		BillingCycleAnchor: time.Date(2026, time.August, 25, 0, 0, 0, 0, time.UTC),
+		ExpiresAt:          time.Now().UTC().Add(-time.Minute),
+		IdempotencyKey:     "checkout-session:<ORG_ID>:expired",
+	}
+
+	first, err := c.CreateCheckoutSession(t.Context(), input)
+	require.NoError(t, err)
+	replay, err := c.CreateCheckoutSession(t.Context(), input)
+	require.NoError(t, err)
+	require.Equal(t, first.ID, replay.ID)
+
+	input.CustomerID = "cus_other"
+	_, err = c.CreateCheckoutSession(t.Context(), input)
+	require.ErrorContains(t, err, "reused with different checkout input")
+
+	state, err := c.GetCheckoutSession(t.Context(), first.ID)
+	require.NoError(t, err)
+	require.Equal(t, "expired", state.Status)
+
+	local, ok := c.(LocalCheckout)
+	require.True(t, ok)
+	_, err = local.CompleteCheckout(t.Context(), first.ID)
+	require.ErrorIs(t, err, ErrLocalCheckoutSessionExpired)
+}
+
+func TestStubClientSubscriptionLifecycleAndPortal(t *testing.T) {
+	t.Parallel()
+
+	c := NewStubClient(testenv.NewLogger(t), nil)
+	local, ok := c.(LocalCheckout)
+	require.True(t, ok)
+
+	trialEnd := time.Now().UTC().Add(48 * time.Hour).Truncate(time.Second)
+	checkout, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
+		CustomerID:         "cus_local_org",
+		SuccessURL:         "https://app.example.test/billing-test/billing",
+		BillingCycleAnchor: trialEnd,
+		ExpiresAt:          time.Now().UTC().Add(time.Hour),
+		TrialEnd:           &trialEnd,
+		IdempotencyKey:     "checkout-session:trial",
+	})
+	require.NoError(t, err)
+
+	result, err := local.CompleteCheckout(t.Context(), checkout.ID)
+	require.NoError(t, err)
+
+	canceled, err := c.SetSubscriptionCancelAtPeriodEnd(t.Context(), SetSubscriptionCancelAtPeriodEndInput{
+		SubscriptionID:    result.Event.SubscriptionID,
+		CancelAtPeriodEnd: true,
+	})
+	require.NoError(t, err)
+	require.True(t, canceled.CancelAtPeriodEnd)
+	require.False(t, canceled.CancelAt.IsZero())
+	require.Equal(t, "trialing", canceled.Status)
+
+	resumed, err := c.SetSubscriptionCancelAtPeriodEnd(t.Context(), SetSubscriptionCancelAtPeriodEndInput{
+		SubscriptionID:    result.Event.SubscriptionID,
+		CancelAtPeriodEnd: false,
+	})
+	require.NoError(t, err)
+	require.False(t, resumed.CancelAtPeriodEnd)
+	require.True(t, resumed.CancelAt.IsZero())
+
+	portal, err := c.CreatePortalSession(t.Context(), CreatePortalSessionInput{
+		CustomerID: "cus_local_org",
+		ReturnURL:  "https://app.example.test/billing-test/billing",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "cus_local_org", portal.CustomerID)
+	require.Equal(t, "https://app.example.test/billing-test/billing", portal.URL)
+}
+
+func TestStubClientInvoiceAllocationsAndMeters(t *testing.T) {
+	t.Parallel()
+
+	c := NewStubClient(testenv.NewLogger(t), nil)
+	item, err := c.CreateInvoiceItem(t.Context(), CreateInvoiceItemInput{
+		InvoiceID:     "in_local",
+		AllocationKey: "allocation",
+		AmountCents:   1200,
+	})
+	require.NoError(t, err)
+	foundItem, err := c.FindInvoiceItem(t.Context(), FindInvoiceAllocationInput{
+		InvoiceID:     "in_local",
+		AllocationKey: "allocation",
+		AmountCents:   1200,
+	})
+	require.NoError(t, err)
+	require.Equal(t, item.ID, foundItem.ID)
+
+	note, err := c.CreateCreditNote(t.Context(), CreateCreditNoteInput{
+		InvoiceID:     "in_local",
+		AllocationKey: "credit",
+		AmountCents:   400,
+	})
+	require.NoError(t, err)
+	foundNote, err := c.FindCreditNote(t.Context(), FindInvoiceAllocationInput{
+		InvoiceID:     "in_local",
+		AllocationKey: "credit",
+		AmountCents:   400,
+	})
+	require.NoError(t, err)
+	require.Equal(t, note.ID, foundNote.ID)
+
+	require.NoError(t, c.CreateMeterEvent(t.Context(), CreateMeterEventInput{
+		CustomerID: "cus_local_org",
+		Value:      12,
+	}))
+	total, err := c.GetMeterEventSummary(t.Context(), GetMeterEventSummaryInput{CustomerID: "cus_local_org"})
+	require.NoError(t, err)
+	require.Equal(t, 12.0, total)
+}

--- a/server/internal/thirdparty/stripe/stub_test.go
+++ b/server/internal/thirdparty/stripe/stub_test.go
@@ -203,5 +203,5 @@ func TestStubClientInvoiceAllocationsAndMeters(t *testing.T) {
 	}))
 	total, err := c.GetMeterEventSummary(t.Context(), GetMeterEventSummaryInput{CustomerID: "cus_local_org"})
 	require.NoError(t, err)
-	require.Equal(t, 12.0, total)
+	require.InEpsilon(t, 12.0, total, 1e-9)
 }

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -155,6 +155,11 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		o11y.AttachHandler(mux, "POST", "/rpc/stripe.webhook", func(w http.ResponseWriter, r *http.Request) {
 			oops.ErrHandle(service.logger, service.handleStripeWebhook).ServeHTTP(w, r)
 		})
+		if _, ok := service.stripeClient.(stripeclient.LocalCheckout); ok {
+			o11y.AttachHandler(mux, "GET", stripeclient.LocalCheckoutPath, func(w http.ResponseWriter, r *http.Request) {
+				oops.ErrHandle(service.logger, service.handleLocalStripeCheckout).ServeHTTP(w, r)
+			})
+		}
 	}
 }
 

--- a/server/internal/usage/local_stripe_checkout_test.go
+++ b/server/internal/usage/local_stripe_checkout_test.go
@@ -1,0 +1,137 @@
+package usage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	gen "github.com/speakeasy-api/gram/server/gen/usage"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
+	"github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+func TestCreateStripeCheckoutUsesLocalWildcardFlag(t *testing.T) {
+	t.Parallel()
+
+	ti := newLocalStripeCheckoutTestInstance(t)
+	ti.flags = &feature.InMemory{}
+	ti.flags.SetFlag(feature.FlagPaygSelfServeBilling, feature.LocalWildcardDistinctID, true)
+	ti.service.featureFlags = ti.flags
+
+	checkoutURL, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+	parsed, err := url.Parse(checkoutURL)
+	require.NoError(t, err)
+	require.Equal(t, stripeclient.LocalCheckoutPath, parsed.Path)
+	require.NotEmpty(t, parsed.Query().Get("session"))
+}
+
+func TestLocalStripeCheckoutStartsPayg(t *testing.T) {
+	t.Parallel()
+
+	ti := newLocalStripeCheckoutTestInstance(t)
+	baseline, err := audittest.AuditLogCountByAction(t.Context(), ti.db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+
+	checkoutURL, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+	parsed, err := url.Parse(checkoutURL)
+	require.NoError(t, err)
+
+	mux := goahttp.NewMuxer()
+	Attach(mux, ti.service)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, parsed.RequestURI(), nil))
+	require.Equal(t, http.StatusSeeOther, recorder.Code)
+	require.Equal(t, "https://app.example.test/"+ti.orgSlug+"/billing", recorder.Header().Get("Location"))
+
+	metadata, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.True(t, metadata.StripeCustomerID.Valid)
+	require.True(t, metadata.StripeSubscriptionID.Valid)
+	require.True(t, metadata.StripeBillingCycleAnchor.Valid)
+
+	organization, err := orgrepo.New(ti.db).GetOrganizationMetadata(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.Equal(t, "payg", organization.GramAccountType)
+	require.True(t, organization.Whitelisted)
+
+	subscription, err := ti.service.GetStripeSubscription(ti.adminContext(t), &gen.GetStripeSubscriptionPayload{})
+	require.NoError(t, err)
+	require.Contains(t, []string{"active", "trialing"}, subscription.Status)
+
+	after, err := audittest.AuditLogCountByAction(t.Context(), ti.db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+	require.Equal(t, baseline+1, after)
+}
+
+func TestAttachLocalStripeCheckoutRoute(t *testing.T) {
+	t.Parallel()
+
+	ti := newLocalStripeCheckoutTestInstance(t)
+	mux := goahttp.NewMuxer()
+	Attach(mux, ti.service)
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, stripeclient.LocalCheckoutPath, nil))
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func TestAttachOmitsLocalStripeCheckoutRouteWithoutCompleter(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		logger:       testenv.NewLogger(t),
+		stripeClient: &fakeStripeWebhookClient{},
+	}
+	mux := goahttp.NewMuxer()
+	Attach(mux, service)
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, stripeclient.LocalCheckoutPath, nil))
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestLocalStripeCheckoutRejectsInvalidSuccessURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := localCheckoutRedirectURL("/relative")
+	require.Error(t, err)
+	_, err = localCheckoutRedirectURL("javascript:alert(1)")
+	require.Error(t, err)
+}
+
+func newLocalStripeCheckoutTestInstance(t *testing.T) *stripeCheckoutTestInstance {
+	t.Helper()
+
+	ti := newStripeCheckoutTestInstance(t)
+	publicURL, err := url.Parse("https://localhost:8000")
+	require.NoError(t, err)
+	stripe := stripeclient.NewStubClient(testenv.NewLogger(t), publicURL)
+	ti.service.stripeClient = stripe
+	ti.service.stripeHandler = ti.service.serviceStripeWebhookHandler
+	ti.service.auditLogger = audit.NewLogger()
+	ti.stripe = nil
+	return ti
+}
+
+func TestCreateStripeCheckoutStillFailsClosedForExplicitDisable(t *testing.T) {
+	t.Parallel()
+
+	ti := newLocalStripeCheckoutTestInstance(t)
+	ti.flags.SetFlag(feature.FlagPaygSelfServeBilling, ti.orgID, false)
+
+	_, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeForbidden)
+}

--- a/server/internal/usage/local_stripe_checkout_test.go
+++ b/server/internal/usage/local_stripe_checkout_test.go
@@ -12,6 +12,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/usage"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -52,7 +53,7 @@ func TestLocalStripeCheckoutStartsPayg(t *testing.T) {
 	Attach(mux, ti.service)
 	recorder := httptest.NewRecorder()
 	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, parsed.RequestURI(), nil))
-	require.Equal(t, http.StatusSeeOther, recorder.Code)
+	require.Equal(t, http.StatusSeeOther, recorder.Code, recorder.Body.String())
 	require.Equal(t, "https://app.example.test/"+ti.orgSlug+"/billing", recorder.Header().Get("Location"))
 
 	metadata, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
@@ -115,6 +116,7 @@ func newLocalStripeCheckoutTestInstance(t *testing.T) *stripeCheckoutTestInstanc
 	t.Helper()
 
 	ti := newStripeCheckoutTestInstance(t)
+	require.NoError(t, authz.SeedSystemRoleGrantsTx(t.Context(), ti.db, ti.orgID))
 	publicURL, err := url.Parse("https://localhost:8000")
 	require.NoError(t, err)
 	stripe := stripeclient.NewStubClient(testenv.NewLogger(t), publicURL)

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -63,6 +64,57 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		}
 		return oops.E(oops.CodeBadRequest, err, "invalid Stripe webhook signature").LogWarn(ctx, s.logger)
 	}
+	return s.processStripeWebhookEvent(ctx, event)
+}
+
+func (s *Service) handleLocalStripeCheckout(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	completer, ok := s.stripeClient.(stripeclient.LocalCheckout)
+	if !ok {
+		return oops.E(oops.CodeNotFound, nil, "local Stripe checkout is unavailable").LogWarn(ctx, s.logger)
+	}
+
+	sessionID := r.URL.Query().Get("session")
+	result, err := completer.CompleteCheckout(ctx, sessionID)
+	if err != nil {
+		switch {
+		case errors.Is(err, stripeclient.ErrLocalCheckoutSessionRequired):
+			return oops.E(oops.CodeBadRequest, err, "missing checkout session").LogWarn(ctx, s.logger)
+		case errors.Is(err, stripeclient.ErrLocalCheckoutSessionUnknown):
+			return oops.E(oops.CodeNotFound, err, "checkout session not found").LogWarn(ctx, s.logger)
+		case errors.Is(err, stripeclient.ErrLocalCheckoutSessionExpired):
+			return oops.E(oops.CodeConflict, err, "checkout session is expired").LogWarn(ctx, s.logger)
+		default:
+			return oops.E(oops.CodeUnexpected, err, "failed to complete local Stripe checkout").LogError(ctx, s.logger)
+		}
+	}
+	if result == nil || result.Event == nil {
+		return oops.E(oops.CodeUnexpected, nil, "local Stripe checkout did not return a completion event").LogError(ctx, s.logger)
+	}
+	if err := s.processStripeWebhookEvent(ctx, result.Event); err != nil {
+		return err
+	}
+
+	successURL, err := localCheckoutRedirectURL(result.SuccessURL)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "local Stripe checkout success URL is invalid").LogError(ctx, s.logger)
+	}
+	http.Redirect(w, r, successURL, http.StatusSeeOther)
+	return nil
+}
+
+func localCheckoutRedirectURL(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse success URL: %w", err)
+	}
+	if parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", errors.New("success URL must be an absolute HTTP URL")
+	}
+	return parsed.String(), nil
+}
+
+func (s *Service) processStripeWebhookEvent(ctx context.Context, event *stripeclient.WebhookEvent) error {
 	if event == nil || event.ID == "" || event.Type == "" {
 		return oops.E(oops.CodeBadRequest, nil, "invalid Stripe webhook event").LogWarn(ctx, s.logger)
 	}

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -412,7 +412,7 @@ func TestStripeWebhookRejectsInvalidRequests(t *testing.T) {
 		t.Parallel()
 		service := &Service{
 			logger:        testenv.NewLogger(t),
-			stripeClient:  stripeclient.NewStubClient(testenv.NewLogger(t)),
+			stripeClient:  stripeclient.NewStubClient(testenv.NewLogger(t), nil),
 			stripeHandler: testStripeWebhookHandler,
 		}
 		require.Equal(t, http.StatusServiceUnavailable, serveStripeWebhook(service, "{}").Code)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves [DNO-944](https://linear.app/speakeasy/issue/DNO-944/feat-support-local-stubbing-for-pay-as-you-go-checkout). Local development can now run the pay-as-you-go self-serve path through hosted Checkout and start without a real Stripe account.

The previous Stripe stub created a customer and a fake session, then failed on every follow-up: `GetCheckoutSession`, `GetSubscription`, portal, cancel/resume, and webhook verification all returned errors. The dashboard CTA also 403'd locally because PostHog-backed `gram-payg-self-serve-billing` is enabled in dashboard telemetry but the server's empty in-memory provider left it off.

This change:

- Replaces the no-op stub with a stateful in-process Stripe client that issues unique IDs, honors idempotency keys, expires sessions, completes Checkout, and supports subscription cancel/resume, portal return, meters, and invoice allocations.
- Hosts local Checkout at `GET /rpc/stripe.local-checkout?session=…` when `--server-url` is set. Completing the session emits `checkout.session.completed` and reuses the existing webhook activation path (`activatePaygCheckout`) rather than a local bypass.
- Enables `FlagPaygSelfServeBilling` for the in-memory `*` wildcard so every local org can start PAYG unless a CSV row overrides it. Explicit per-org `false` still fails closed.

## Test plan

- [x] `mise run test:server ./internal/thirdparty/stripe/ ./internal/feature/ ./cmd/gram/` — 112 tests
- [x] `mise run test:server ./internal/usage/` — 200 tests, including `TestLocalStripeCheckoutStartsPayg` (create session → local checkout GET → org is `payg`)
- [x] `gcl` on `cmd/gram`, `internal/feature`, `internal/thirdparty/stripe`, `internal/usage` — 0 issues
- [ ] Optional local UI: unconfigured Stripe, click **Start pay as you go**, land on `/rpc/stripe.local-checkout`, redirect to billing

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-944](https://linear.app/speakeasy/issue/DNO-944/feat-support-local-stubbing-for-pay-as-you-go-checkout)

<div><a href="https://cursor.com/agents/bc-7f5b4db6-5111-4139-8eba-d11211344f6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f5b4db6-5111-4139-8eba-d11211344f6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables end-to-end local PAYG start without a Stripe account by replacing the no-op Stripe stub with a stateful in-process client and a hosted local Checkout flow. Previously the stub returned a fake session and follow-ups failed and the dashboard CTA 403’d; now Checkout completes via the existing webhook path and redirects back to billing. Satisfies DNO-944.

- Introduces a stateful Stripe stub that issues unique IDs, honors idempotency, expires sessions, completes Checkout, and supports subscription cancel/resume, portal, meters, invoice items/credit notes, and lookups; completion emits `checkout.session.completed`.
- Serves local hosted Checkout at GET `/rpc/stripe.local-checkout` only when the Stripe client implements `stripeclient.LocalCheckout`; completion reuses the webhook activation path and redirects to an absolute HTTP(S) success URL.
- Threads `--server-url` into `stripeclient.NewStubClient` to build hosted Checkout URLs; when unset, Checkout falls back to the provided success URL.
- Enables `FlagPaygSelfServeBilling` for `feature.LocalWildcardDistinctID` (`*`) in `feature.InMemory` so local orgs see the CTA; explicit per-org `false` still fails closed. No migrations; production Stripe behavior is unchanged.

**Local usage**
- Run in `local` without a Stripe API key and pass `--server-url <http(s)://host:port>`.
- Click Start pay as you go; the app opens `/rpc/stripe.local-checkout?session=…` and redirects to billing on success.

<sup>Written for commit f7ccbaa85be79b1013ff1ba28a5223e663a59782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

