### PR TITLE
fix: parse the server lint task under macOS bash

### DIFF
--- a/.mise-tasks/lint/server.sh
+++ b/.mise-tasks/lint/server.sh
@@ -64,8 +64,11 @@ lint_input_fingerprint() (
     special_index=$(
         while IFS= read -r entry; do
             tag=${entry%% *}
+            # The pattern carries a leading parenthesis because bash 3.2, which
+            # is still the /bin/bash macOS ships, cannot parse a case statement
+            # inside $( ) without one and fails the whole script at parse time.
             case "$tag" in
-                [a-z]|S) printf '%s\n' "${entry#? }" ;;
+                ([a-z]|S) printf '%s\n' "${entry#? }" ;;
             esac
         done < <(git ls-files -v)
     )
@@ -78,14 +81,15 @@ lint_input_fingerprint() (
     )
     go_work=$(go env GOWORK)
     go_env_file=$(go env GOENV)
+    # Leading parentheses on the patterns for the bash 3.2 reason above.
     go_config_paths=$(
         case "$go_work" in
-            ''|off) ;;
-            *) printf '%s\n%s.sum\n' "$go_work" "$go_work" ;;
+            (''|off) ;;
+            (*) printf '%s\n%s.sum\n' "$go_work" "$go_work" ;;
         esac
         case "$go_env_file" in
-            ''|off) ;;
-            *) printf '%s\n' "$go_env_file" ;;
+            (''|off) ;;
+            (*) printf '%s\n' "$go_env_file" ;;
         esac
     )
 


### PR DESCRIPTION
`mise run lint:server` currently fails before it lints anything on a Mac:

```
.mise-tasks/lint/server.sh: line 68: syntax error near unexpected token `;;'
```

## Cause

The fingerprint helper added in #5553 puts `case` statements inside command substitutions:

```sh
special_index=$(
    while IFS= read -r entry; do
        case "$tag" in
            [a-z]|S) printf '%s\n' "${entry#? }" ;;
        esac
    done < <(git ls-files -v)
)
```

bash 3.2 cannot parse a `case` inside `$( )` unless the pattern carries a leading parenthesis. That is the `/bin/bash` macOS still ships, and the failure is at parse time, so the whole script dies before the first command runs. Linux CI has bash 5 and never saw it.

## Fix

Add the leading parenthesis to the patterns in the two affected blocks (`special_index` and `go_config_paths`). No behaviour changes anywhere the script already worked, and the other `case` statements in the file are not inside command substitutions so they are untouched.

## Verification

`bash -n` now parses the file. `mise run lint:server` builds gcl, primes the cache, and completes; a second run hits the fingerprint cache and exits silently, which is the code path the syntax error was blocking. Checked every tracked `.sh` in the repo with `bash -n` under bash 3.2: this was the only one failing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `mise run lint:server` on macOS by making the script parse under the system `/bin/bash` 3.2. Previously the task failed at parse time with “syntax error near unexpected token ';;'”; now it parses and runs with no behavior changes elsewhere.

- Adds leading parentheses to `case` patterns inside command substitutions in `special_index` and `go_config_paths` to satisfy bash 3.2 parsing; other `case` blocks are unchanged. Linux/CI (bash 5) was already fine.
- Verification: `bash -n .mise-tasks/lint/server.sh` succeeds under bash 3.2; `mise run lint:server` builds, primes cache, and completes; a subsequent run exits via the fingerprint cache.

<sup>Written for commit 2227debfc25853540ab59ca628a33c56054a322a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

