### PR TITLE
chore: replace rsync with rclone

### DIFF
--- a/.github/workflows/sync-docs-to-marketing.yaml
+++ b/.github/workflows/sync-docs-to-marketing.yaml
@@ -40,11 +40,13 @@ jobs:
             mkdir -p "$dest_path"
             # Exclude the root docs index.mdx from being copied and protect any existing
             # destination file from deletion/overwrites.
-            rsync -a --delete \
+            tools/rclone sync \
+              --metadata \
+              --links \
+              --create-empty-src-dirs \
               --exclude='.DS_Store' \
               --exclude='/index.mdx' \
-              --filter='P /index.mdx' \
-              "$src_path/" "$dest_path/"
+              "$src_path" "$dest_path"
           else
             echo "Warning: $src_path does not exist; nothing to sync."
           fi
@@ -64,9 +66,12 @@ jobs:
               'favicon.ico'
               'favicon.png'
             )
-            rsync -a --delete \
+            tools/rclone sync \
+              --metadata \
+              --links \
+              --create-empty-src-dirs \
               "${EXCLUDES[@]/#/--exclude=}" \
-              "$src_assets/" "$dest_assets/"
+              "$src_assets" "$dest_assets"
           else
             echo "Warning: $src_assets does not exist; no assets to sync."
           fi

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -33,16 +33,21 @@ copy_from_main=(
 
 for item in "${copy_from_main[@]}"; do
   src="${main_worktree}/${item}"
-  [ -e "$src" ] && rsync -a "$src" .
+  [ -e "$src" ] || continue
+  if [ -d "$src" ]; then
+    tools/rclone copy --metadata --links --create-empty-src-dirs "$src" "$item"
+  else
+    tools/rclone copyto --metadata --links "$src" "$item"
+  fi
 done
 
 # Seed the custom linter so lint:server can reuse it when build inputs match.
 gcl="${main_worktree}/server/bin/gcl"
 if [ -x "$gcl" ]; then
   mkdir -p "${current_worktree}/server/bin"
-  rsync -a "$gcl" "${current_worktree}/server/bin/"
+  tools/rclone copyto --metadata "$gcl" "${current_worktree}/server/bin/gcl"
   if [ -f "${gcl}.fingerprint" ]; then
-    rsync -a "${gcl}.fingerprint" "${current_worktree}/server/bin/"
+    tools/rclone copyto --metadata "${gcl}.fingerprint" "${current_worktree}/server/bin/gcl.fingerprint"
   fi
 fi
 

--- a/.mise-tasks/skills/recommended.sh
+++ b/.mise-tasks/skills/recommended.sh
@@ -75,7 +75,7 @@ for name in $names; do
 
   rm -rf "$dest"
   mkdir -p "$dest"
-  rsync -a "$tmp/$path/" "$dest/"
+  tools/rclone copy --metadata --links --create-empty-src-dirs "$tmp/$path" "$dest"
   echo "$ref" > "$marker"
   rm -rf "$tmp"
   trap - EXIT

--- a/tools/rclone
+++ b/tools/rclone
@@ -1,0 +1,37 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "1.75.0"
+tool = "rclone"
+bin = "rclone"
+
+[lock]
+
+[lock.platforms]
+
+[lock.platforms.linux-arm64]
+url = "https://github.com/rclone/rclone/releases/download/v1.75.0/rclone-v1.75.0-linux-arm64.zip"
+checksum = "sha256:d0ad88ba4c8e285b7c9efa591e0ab643280a91741e13c27f3a9c0957ccfa5203"
+
+[lock.platforms.linux-arm64-musl]
+url = "https://github.com/rclone/rclone/releases/download/v1.75.0/rclone-v1.75.0-linux-arm64.zip"
+checksum = "sha256:d0ad88ba4c8e285b7c9efa591e0ab643280a91741e13c27f3a9c0957ccfa5203"
+
+[lock.platforms.linux-x64]
+url = "https://github.com/rclone/rclone/releases/download/v1.75.0/rclone-v1.75.0-linux-amd64.zip"
+checksum = "sha256:aa2804e08f48250e71009c727124b6341cd0288465804a9a09d14663cabafbaa"
+
+[lock.platforms.linux-x64-musl]
+url = "https://github.com/rclone/rclone/releases/download/v1.75.0/rclone-v1.75.0-linux-amd64.zip"
+checksum = "sha256:aa2804e08f48250e71009c727124b6341cd0288465804a9a09d14663cabafbaa"
+
+[lock.platforms.macos-arm64]
+url = "https://github.com/rclone/rclone/releases/download/v1.75.0/rclone-v1.75.0-osx-arm64.zip"
+checksum = "sha256:35e8f2a666ce789b29111db0dd843ddabc0d59c6b609d07bcaae5d1a07cba6f8"
+
+[lock.platforms.macos-x64]
+url = "https://github.com/rclone/rclone/releases/download/v1.75.0/rclone-v1.75.0-osx-amd64.zip"
+checksum = "sha256:19edbb8e5e73096eb66e92a42abbc5c34bfa8981ea3986a53872c7eef85a22f4"
+
+[lock.platforms.windows-x64]
+url = "https://github.com/rclone/rclone/releases/download/v1.75.0/rclone-v1.75.0-windows-amd64.zip"
+checksum = "sha256:203581f0a7baeae873f2347483a798c79e2eaf5c384a4e9d866aa374f1c89ac0"


### PR DESCRIPTION
## Summary

The usage of `rsync` created a requirement that development environments have that tool installed system wide breaking the contract that the gram monorepo only requires docker and mise as pre-requisites. This change fixes that issue by moving to `rclone` which can be managed by mise and is equivalent.

- add a pinned `rclone` tool stub for supported development and CI platforms
- replace repository `rsync` calls with equivalent `rclone sync`, `copy`, and `copyto` operations
- preserve exclusions, deletion behavior, metadata, symlinks, empty directories, and executable modes

## Verification

- `bash -n .mise-tasks/git/workinit.sh .mise-tasks/skills/recommended.sh`
- parsed `.github/workflows/sync-docs-to-marketing.yaml` with `yq`
- exercised local sync and copy scenarios covering exclusions, protected files, stale-file deletion, overlays, symlinks, empty directories, and executable permissions
- confirmed no `rsync` usages remain


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `rsync` with a pinned `rclone` across CI and dev scripts to standardize sync/copy behavior. This removes the system `rsync` dependency while preserving exclusions, deletion semantics, metadata, symlinks, empty directories, and executable modes.

- Adds `tools/rclone` as a `mise` tool stub (v1.75.0) for Linux/macOS/Windows.
- Updates .github/workflows/sync-docs-to-marketing.yaml to use `tools/rclone sync` with `--metadata --links --create-empty-src-dirs` and `--exclude '/index.mdx'` (keeps the destination index protected from deletion).
- Replaces `rsync` in .mise-tasks scripts with `rclone copy`/`copyto`, handling directories vs files explicitly.
- Removes all remaining `rsync` invocations; developers and CI should call `tools/rclone` (no system `rsync` required).

<sup>Written for commit 2263dcba1aa68b535fc0722bd1bb806c27363c18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

