### PR TITLE
fix(plugins): return skill count from GetPlugin endpoint

### DIFF
--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -85,6 +85,7 @@ import { PluginSkillsSection } from "./PluginSkillsSection";
 import { PluginAssignmentsList } from "./PluginAssignmentsList";
 import {
   activePluginSection,
+  pluginSectionHref,
   PLUGIN_ASSIGNMENTS_SECTION_ID,
   PLUGIN_OVERVIEW_SECTION_ID,
   PLUGIN_SERVERS_SECTION_ID,
@@ -604,6 +605,11 @@ export default function PluginDetail(): JSX.Element | null {
                   tone="information"
                   format="number"
                   icon="network"
+                  link={pluginSectionHref(
+                    routes,
+                    pluginId!,
+                    PLUGIN_SERVERS_SECTION_ID,
+                  )}
                 />
                 <StatTile
                   title="Skills"
@@ -611,6 +617,11 @@ export default function PluginDetail(): JSX.Element | null {
                   tone="information"
                   format="number"
                   icon="sparkles"
+                  link={pluginSectionHref(
+                    routes,
+                    pluginId!,
+                    PLUGIN_SKILLS_SECTION_ID,
+                  )}
                 />
                 {showAssignments && (
                   <>
@@ -621,6 +632,11 @@ export default function PluginDetail(): JSX.Element | null {
                       format="number"
                       icon="users"
                       subtext="Roles, users, and emails"
+                      link={pluginSectionHref(
+                        routes,
+                        pluginId!,
+                        PLUGIN_ASSIGNMENTS_SECTION_ID,
+                      )}
                     />
                     <StatTile
                       title="Installs"

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -424,7 +424,7 @@ func (s *Service) GetPlugin(ctx context.Context, payload *gen.GetPluginPayload) 
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
-	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{
+	pluginRow, err := s.repo.GetPluginWithCounts(ctx, repo.GetPluginWithCountsParams{
 		ID:             pluginID,
 		OrganizationID: ac.ActiveOrganizationID,
 		ProjectID:      *ac.ProjectID,
@@ -450,7 +450,25 @@ func (s *Service) GetPlugin(ctx context.Context, payload *gen.GetPluginPayload) 
 	if err != nil {
 		return nil, err
 	}
-	return pluginToGen(plugin, servers, assignments, compatibility[plugin.Slug]), nil
+
+	plugin := repo.Plugin{
+		ID:             pluginRow.ID,
+		OrganizationID: pluginRow.OrganizationID,
+		ProjectID:      pluginRow.ProjectID,
+		Name:           pluginRow.Name,
+		Slug:           pluginRow.Slug,
+		Description:    pluginRow.Description,
+		IsDefault:      pluginRow.IsDefault,
+		CreatedAt:      pluginRow.CreatedAt,
+		UpdatedAt:      pluginRow.UpdatedAt,
+		DeletedAt:      pluginRow.DeletedAt,
+		Deleted:        pluginRow.Deleted,
+	}
+	result := pluginToGen(plugin, servers, assignments, compatibility[plugin.Slug])
+	result.ServerCount = &pluginRow.ServerCount
+	result.SkillCount = &pluginRow.SkillCount
+	result.AssignmentCount = &pluginRow.AssignmentCount
+	return result, nil
 }
 
 func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPayload) (*gen.Plugin, error) {

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -76,6 +76,37 @@ WHERE id = @id
   AND project_id = @project_id
   AND deleted IS FALSE;
 
+-- name: GetPluginWithCounts :one
+SELECT
+  p.*,
+  (SELECT count(*) FROM plugin_servers ps WHERE ps.plugin_id = p.id AND ps.deleted IS FALSE) AS server_count,
+  (
+    SELECT count(*)
+    FROM skill_distributions sd
+    JOIN skills s
+      ON s.id = sd.skill_id
+      AND s.project_id = sd.project_id
+      AND s.archived_at IS NULL
+    WHERE sd.plugin_id = p.id
+      AND sd.project_id = p.project_id
+      AND sd.channel = 'plugin'
+      AND sd.assistant_id IS NULL
+      AND sd.revoked_at IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM skill_versions sv
+        WHERE sv.skill_id = sd.skill_id
+          AND sv.spec_valid IS TRUE
+          AND (sd.pinned_version_id IS NULL OR sv.id = sd.pinned_version_id)
+      )
+  ) AS skill_count,
+  (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id) AS assignment_count
+FROM plugins p
+WHERE p.id = @id
+  AND p.organization_id = @organization_id
+  AND p.project_id = @project_id
+  AND p.deleted IS FALSE;
+
 -- name: ListPlugins :many
 SELECT
   p.*,

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -521,6 +521,83 @@ func (q *Queries) GetPluginServerByBackend(ctx context.Context, arg GetPluginSer
 	return i, err
 }
 
+const getPluginWithCounts = `-- name: GetPluginWithCounts :one
+SELECT
+  p.id, p.organization_id, p.project_id, p.name, p.slug, p.description, p.is_default, p.created_at, p.updated_at, p.deleted_at, p.deleted,
+  (SELECT count(*) FROM plugin_servers ps WHERE ps.plugin_id = p.id AND ps.deleted IS FALSE) AS server_count,
+  (
+    SELECT count(*)
+    FROM skill_distributions sd
+    JOIN skills s
+      ON s.id = sd.skill_id
+      AND s.project_id = sd.project_id
+      AND s.archived_at IS NULL
+    WHERE sd.plugin_id = p.id
+      AND sd.project_id = p.project_id
+      AND sd.channel = 'plugin'
+      AND sd.assistant_id IS NULL
+      AND sd.revoked_at IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM skill_versions sv
+        WHERE sv.skill_id = sd.skill_id
+          AND sv.spec_valid IS TRUE
+          AND (sd.pinned_version_id IS NULL OR sv.id = sd.pinned_version_id)
+      )
+  ) AS skill_count,
+  (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id) AS assignment_count
+FROM plugins p
+WHERE p.id = $1
+  AND p.organization_id = $2
+  AND p.project_id = $3
+  AND p.deleted IS FALSE
+`
+
+type GetPluginWithCountsParams struct {
+	ID             uuid.UUID
+	OrganizationID string
+	ProjectID      uuid.UUID
+}
+
+type GetPluginWithCountsRow struct {
+	ID              uuid.UUID
+	OrganizationID  string
+	ProjectID       uuid.UUID
+	Name            string
+	Slug            string
+	Description     pgtype.Text
+	IsDefault       pgtype.Bool
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+	DeletedAt       pgtype.Timestamptz
+	Deleted         bool
+	ServerCount     int64
+	SkillCount      int64
+	AssignmentCount int64
+}
+
+func (q *Queries) GetPluginWithCounts(ctx context.Context, arg GetPluginWithCountsParams) (GetPluginWithCountsRow, error) {
+	row := q.db.QueryRow(ctx, getPluginWithCounts, arg.ID, arg.OrganizationID, arg.ProjectID)
+	var i GetPluginWithCountsRow
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.IsDefault,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+		&i.ServerCount,
+		&i.SkillCount,
+		&i.AssignmentCount,
+	)
+	return i, err
+}
+
 const getProjectMarketplaceNameContext = `-- name: GetProjectMarketplaceNameContext :one
 SELECT
   pr.slug AS project_slug,

--- a/server/internal/plugins/skill_distributions_test.go
+++ b/server/internal/plugins/skill_distributions_test.go
@@ -184,4 +184,10 @@ func TestListPluginSkillsForProjectResolvesContent(t *testing.T) {
 	}
 	require.NotNil(t, skillCount)
 	require.EqualValues(t, 2, *skillCount)
+
+	// GetPlugin also returns the correct skill count (AGE-3333)
+	gotPlugin, err := ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: plugin.ID})
+	require.NoError(t, err)
+	require.NotNil(t, gotPlugin.SkillCount)
+	require.EqualValues(t, 2, *gotPlugin.SkillCount)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes AGE-3333: The plugin detail page was showing 0 skills while the list page showed the correct count (e.g., 10 skills).

## Problem

The `GetPlugin` endpoint used a simple query that only returned the base plugin fields, while `ListPlugins` included subqueries for `server_count`, `skill_count`, and `assignment_count`. This caused a mismatch where:
- Plugin list showed "10 SKILLS" (correct)
- Plugin detail page showed "0" skills (incorrect)

## Solution

1. **Backend**: Added a new `GetPluginWithCounts` SQL query that includes the same count subqueries as `ListPlugins`. Updated the `GetPlugin` service function to use this new query and populate the counts on the response.

2. **Frontend**: Added navigation links to the StatTile components (MCP servers, Skills, Assignments) on the plugin overview page, so clicking them navigates to their respective detail sections.

## Changes

- `server/internal/plugins/queries.sql`: Add `GetPluginWithCounts` query with server_count, skill_count, and assignment_count subqueries
- `server/internal/plugins/repo/queries.sql.go`: Generated code from the new query
- `server/internal/plugins/impl.go`: Update `GetPlugin` to use the new query and populate counts
- `server/internal/plugins/skill_distributions_test.go`: Add test case verifying `GetPlugin` returns correct skill count
- `client/dashboard/src/pages/plugins/PluginDetail.tsx`: Add `link` props to StatTile components for navigation

## Testing

- All existing tests pass
- Added new test case that verifies `GetPlugin` returns the correct skill count (matching `ListPlugins`)
- Server builds successfully
- Dashboard type-checks successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3333](https://linear.app/speakeasy/issue/AGE-3333/bug-fix-plugin-detail-skill-count-and-navigation)

<div><a href="https://cursor.com/agents/bc-d05b16cb-eff1-45e7-bc41-1c66d5f4f935?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d05b16cb-eff1-45e7-bc41-1c66d5f4f935&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return server, skill, and assignment counts from GetPlugin so the plugin detail page shows the same numbers as the list. Also make StatTile cards on the overview link to their sections. Addresses AGE-3333.

- Backend: Add GetPluginWithCounts query with the same count subqueries as ListPlugins and update GetPlugin to use it. Populate ServerCount, SkillCount, and AssignmentCount on the response; previously SkillCount was 0 on detail.
- Frontend: Add link props to StatTile cards (MCP servers, Skills, Assignments) using pluginSectionHref to navigate within PluginDetail. No route changes.
- Tests: Add assertion that GetPlugin returns the correct SkillCount.

<sup>Written for commit 5b4b63446354547866697cf8ea76d3b153217bbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

