### PR TITLE
feat: add Codex log dialect

### DIFF
--- a/server/internal/otel/dialect/log.go
+++ b/server/internal/otel/dialect/log.go
@@ -17,6 +17,7 @@ type LogDialect interface {
 
 var logDialects = []LogDialect{
 	ClaudeCodeLog{},
+	CodexLog{},
 }
 
 func ForLog(record *otelv1.InboundLogRecord) LogDialect {

--- a/server/internal/otel/dialect/log_codex.go
+++ b/server/internal/otel/dialect/log_codex.go
@@ -1,0 +1,62 @@
+package dialect
+
+import (
+	otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
+	"github.com/speakeasy-api/gram/server/internal/genaiconv"
+)
+
+const (
+	codexLogScopeName       = "codex_otel.log_only"
+	codexUserPromptEvent    = "codex.user_prompt"
+	codexRedactedUserPrompt = "[REDACTED]"
+)
+
+type CodexLog struct{}
+
+func (CodexLog) AppliesTo(record *otelv1.InboundLogRecord) bool {
+	return record.GetScope().GetName() == codexLogScopeName
+}
+
+func (CodexLog) InputContent(record *otelv1.InboundLogRecord) (string, genaiconv.InputMessages, error) {
+	switch record.GetEventName() {
+	case codexUserPromptEvent:
+		key, prompt := getOneLogAttr(record, "prompt")
+		if key == "" || prompt == "" || prompt == codexRedactedUserPrompt {
+			return "", nil, nil
+		}
+
+		return key, genaiconv.InputMessages{{
+			Role: genaiconv.RoleUser,
+			Parts: []genaiconv.Part{&genaiconv.TextPart{
+				Type:    genaiconv.PartTypeText,
+				Content: prompt,
+			}},
+			Name: nil,
+		}}, nil
+	default:
+		return "", nil, nil
+	}
+}
+
+func (CodexLog) OutputContent(*otelv1.InboundLogRecord) (string, genaiconv.OutputMessages, error) {
+	return "", nil, nil
+}
+
+func (CodexLog) SessionID(record *otelv1.InboundLogRecord) (string, string, error) {
+	key, value := getOneLogAttr(record, "conversation.id")
+	return key, value, nil
+}
+
+func (CodexLog) ExternalUserEmail(record *otelv1.InboundLogRecord) (string, string, error) {
+	key, value := getOneLogAttr(record, "user.email")
+	return key, value, nil
+}
+
+func (CodexLog) ExternalUserID(record *otelv1.InboundLogRecord) (string, string, error) {
+	key, value := getOneLogAttr(record, "user.account_id")
+	return key, value, nil
+}
+
+func (CodexLog) ResponseID(*otelv1.InboundLogRecord) (string, string, error) {
+	return "", "", nil
+}

--- a/server/internal/otel/dialect/log_codex_test.go
+++ b/server/internal/otel/dialect/log_codex_test.go
@@ -1,0 +1,109 @@
+package dialect
+
+import (
+	"testing"
+
+	otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
+	"github.com/speakeasy-api/gram/server/internal/genaiconv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexLogPrompt(t *testing.T) {
+	t.Parallel()
+
+	record := codexLogRecord(codexLogScopeName, codexUserPromptEvent,
+		logDialectStringAttribute("prompt", "explain this trace"),
+		logDialectStringAttribute("conversation.id", "conversation-id"),
+		logDialectStringAttribute("user.email", "user@example.invalid"),
+		logDialectStringAttribute("user.account_id", "external-user-id"),
+		logDialectStringAttribute("gen_ai.response.id", "response-id"),
+	)
+
+	selected := ForLog(record)
+	fallback, ok := selected.(LogFallback)
+	require.True(t, ok)
+	require.Equal(t, []LogDialect{CodexLog{}, SemconvLog{}}, fallback.Candidates)
+
+	inputKey, input, err := selected.InputContent(record)
+	require.NoError(t, err)
+	require.Equal(t, "prompt", inputKey)
+	require.Equal(t, genaiconv.InputMessages{{
+		Role: genaiconv.RoleUser,
+		Parts: []genaiconv.Part{&genaiconv.TextPart{
+			Type:    genaiconv.PartTypeText,
+			Content: "explain this trace",
+		}},
+		Name: nil,
+	}}, input)
+
+	outputKey, output, err := selected.OutputContent(record)
+	require.NoError(t, err)
+	require.Empty(t, outputKey)
+	require.Nil(t, output)
+
+	key, value, err := selected.SessionID(record)
+	require.NoError(t, err)
+	require.Equal(t, "conversation.id", key)
+	require.Equal(t, "conversation-id", value)
+
+	key, value, err = selected.ExternalUserEmail(record)
+	require.NoError(t, err)
+	require.Equal(t, "user.email", key)
+	require.Equal(t, "user@example.invalid", value)
+
+	key, value, err = selected.ExternalUserID(record)
+	require.NoError(t, err)
+	require.Equal(t, "user.account_id", key)
+	require.Equal(t, "external-user-id", value)
+
+	key, value, err = selected.ResponseID(record)
+	require.NoError(t, err)
+	require.Equal(t, "gen_ai.response.id", key)
+	require.Equal(t, "response-id", value)
+}
+
+func TestCodexLogSkipsRedactedPrompt(t *testing.T) {
+	t.Parallel()
+
+	record := codexLogRecord(codexLogScopeName, codexUserPromptEvent,
+		logDialectStringAttribute("prompt", codexRedactedUserPrompt),
+	)
+
+	key, input, err := ForLog(record).InputContent(record)
+	require.NoError(t, err)
+	require.Empty(t, key)
+	require.Nil(t, input)
+}
+
+func TestCodexLogSkipsEmptyPrompt(t *testing.T) {
+	t.Parallel()
+
+	record := codexLogRecord(codexLogScopeName, codexUserPromptEvent,
+		logDialectStringAttribute("prompt", ""),
+	)
+
+	key, input, err := ForLog(record).InputContent(record)
+	require.NoError(t, err)
+	require.Empty(t, key)
+	require.Nil(t, input)
+}
+
+func TestCodexLogDoesNotApplyToTraceSafeScope(t *testing.T) {
+	t.Parallel()
+
+	record := codexLogRecord("codex_otel.trace_safe", codexUserPromptEvent,
+		logDialectStringAttribute("prompt", "explain this trace"),
+	)
+
+	require.IsType(t, SemconvLog{}, ForLog(record))
+}
+
+func codexLogRecord(scopeName, eventName string, attributes ...*otelv1.InboundLogRecord_KeyValue) *otelv1.InboundLogRecord {
+	return (&otelv1.InboundLogRecord_builder{
+		EventName: &eventName,
+		Scope: (&otelv1.InboundLogRecord_InstrumentationScope_builder{
+			Name: &scopeName,
+		}).Build(),
+		Attributes: attributes,
+	}).Build()
+}

--- a/server/internal/otel/dialect/log_codex_test.go
+++ b/server/internal/otel/dialect/log_codex_test.go
@@ -88,6 +88,35 @@ func TestCodexLogSkipsEmptyPrompt(t *testing.T) {
 	require.Nil(t, input)
 }
 
+func TestCodexLogEmptyIdentifiersUseSemconvFallback(t *testing.T) {
+	t.Parallel()
+
+	record := codexLogRecord(codexLogScopeName, codexUserPromptEvent,
+		logDialectStringAttribute("conversation.id", ""),
+		logDialectStringAttribute("gen_ai.conversation.id", "semconv-conversation-id"),
+		logDialectStringAttribute("user.email", ""),
+		logDialectStringAttribute("user.account_id", ""),
+		logDialectStringAttribute("user.id", "semconv-user-id"),
+	)
+
+	selected := ForLog(record)
+
+	key, value, err := selected.SessionID(record)
+	require.NoError(t, err)
+	require.Equal(t, "gen_ai.conversation.id", key)
+	require.Equal(t, "semconv-conversation-id", value)
+
+	key, value, err = selected.ExternalUserEmail(record)
+	require.NoError(t, err)
+	require.Empty(t, key)
+	require.Empty(t, value)
+
+	key, value, err = selected.ExternalUserID(record)
+	require.NoError(t, err)
+	require.Equal(t, "user.id", key)
+	require.Equal(t, "semconv-user-id", value)
+}
+
 func TestCodexLogDoesNotApplyToTraceSafeScope(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/otel/dialect/log_shared.go
+++ b/server/internal/otel/dialect/log_shared.go
@@ -4,8 +4,11 @@ import otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
 
 func getOneLogAttr(record *otelv1.InboundLogRecord, desired string) (string, string) {
 	for _, kv := range record.GetAttributes() {
-		if kv.GetKey() == desired && kv.GetValue().HasStringValue() {
-			return desired, kv.GetValue().GetStringValue()
+		if kv.GetKey() != desired || !kv.GetValue().HasStringValue() {
+			continue
+		}
+		if value := kv.GetValue().GetStringValue(); value != "" {
+			return desired, value
 		}
 	}
 	return "", ""


### PR DESCRIPTION
## Summary

- recognize Codex content-bearing OpenTelemetry logs
- extract user prompts, conversation IDs, and external user identity with semantic-convention fallback
- configure local Codex OTLP log export and a 3 MiB tool-result preview limit

## Testing

- `mise run test:server ./internal/otel/dialect/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Codex log dialect that parses content-bearing OpenTelemetry logs to extract prompts, session, and external user identity. Previously these logs fell back to Semconv; now we parse `codex.user_prompt` when present and non-redacted, with Semconv fallback for missing or empty identifiers and `gen_ai.response.id`.

- Applies only to scope `codex_otel.log_only`; `codex_otel.trace_safe` continues to use Semconv.
- Parses `prompt` from `codex.user_prompt`; skips empty values and `[REDACTED]`.
- Captures `conversation.id`, `user.email`, and `user.account_id`; falls back to Semconv when these are missing or empty, and for `gen_ai.response.id`.
- Registers the dialect in log selection and adds tests for selection, extraction, and empty-value fallback.

<sup>Written for commit abab8d39972890d12bb0a5d17825569e5d802263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

