### PR TITLE
fix: resolve directory enrichment for email subaddresses

### DIFF
--- a/server/internal/otel/enrich_log_directory_test.go
+++ b/server/internal/otel/enrich_log_directory_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
@@ -46,4 +47,21 @@ func TestEnrichLogDirectoryIncludesCachedUserEnrichment(t *testing.T) {
 		DirectoryGroupNames([]string{"Developers"}),
 		GramUserRoles([]string{"member"}),
 	}, got)
+}
+
+func TestEnrichLogDirectoryResolvesSubaddress(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDatabase(t)
+	seed := seedUserEnrichment(t, db)
+	enricher := newEnrichLogDirectory(testenv.NewLogger(t), db, cache.NoopCache)
+	record := (&otelv1.InboundLogRecord_builder{
+		Provenance: (&otelv1.InboundLogRecord_Provenance_builder{OrganizationId: new(seed.organizationID)}).Build(),
+		Attributes: []*otelv1.InboundLogRecord_KeyValue{logStringAttribute("user.email", "user+log@example.invalid")},
+	}).Build()
+
+	got, err := enricher.Enrich(t.Context(), record)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, seed.want.attributes(), got)
 }

--- a/server/internal/otel/enrich_log_directory_test.go
+++ b/server/internal/otel/enrich_log_directory_test.go
@@ -65,3 +65,21 @@ func TestEnrichLogDirectoryResolvesSubaddress(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t, seed.want.attributes(), got)
 }
+
+func TestEnrichLogDirectoryPrefersRawSubaddress(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDatabase(t)
+	canonical := seedUserEnrichment(t, db)
+	raw := seedSubaddressUserEnrichment(t, db, canonical.organizationID)
+	enricher := newEnrichLogDirectory(testenv.NewLogger(t), db, cache.NoopCache)
+	record := (&otelv1.InboundLogRecord_builder{
+		Provenance: (&otelv1.InboundLogRecord_Provenance_builder{OrganizationId: new(raw.organizationID)}).Build(),
+		Attributes: []*otelv1.InboundLogRecord_KeyValue{logStringAttribute("user.email", raw.email)},
+	}).Build()
+
+	got, err := enricher.Enrich(t.Context(), record)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, raw.want.attributes(), got)
+}

--- a/server/internal/otel/enrich_span_directory_test.go
+++ b/server/internal/otel/enrich_span_directory_test.go
@@ -34,6 +34,19 @@ func TestEnrichDirectoryResolvesSubaddress(t *testing.T) {
 	require.ElementsMatch(t, seed.want.attributes(), got)
 }
 
+func TestEnrichDirectoryIncludesDirectoryAndRoleAttributes(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDatabase(t)
+	seed := seedUserEnrichment(t, db)
+	enricher := NewEnrichDirectory(testenv.NewLogger(t), db, cache.NoopCache)
+
+	got, err := enricher.Enrich(t.Context(), directoryEnrichmentTestSpan(seed.organizationID, seed.email))
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, seed.want.attributes(), got)
+}
+
 func TestEnrichDirectoryLookupFailureDoesNotFailSpan(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/otel/enrich_span_directory_test.go
+++ b/server/internal/otel/enrich_span_directory_test.go
@@ -21,14 +21,14 @@ func TestEnrichDirectoryReturnsNoAttributesWithoutMatchingUser(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestEnrichDirectoryIncludesDirectoryAndRoleAttributes(t *testing.T) {
+func TestEnrichDirectoryResolvesSubaddress(t *testing.T) {
 	t.Parallel()
 
 	db := newTestDatabase(t)
 	seed := seedUserEnrichment(t, db)
 	enricher := NewEnrichDirectory(testenv.NewLogger(t), db, cache.NoopCache)
 
-	got, err := enricher.Enrich(t.Context(), directoryEnrichmentTestSpan(seed.organizationID, seed.email))
+	got, err := enricher.Enrich(t.Context(), directoryEnrichmentTestSpan(seed.organizationID, "user+span@example.invalid"))
 
 	require.NoError(t, err)
 	require.ElementsMatch(t, seed.want.attributes(), got)

--- a/server/internal/otel/user_enrichment.go
+++ b/server/internal/otel/user_enrichment.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/singleflight"
 
@@ -108,17 +108,25 @@ func fetchUserEnrichmentWithLookupContext(
 }
 
 func loadUserEnrichment(ctx context.Context, replicaDB database.DBTX, organizationID string, email string) (userEnrichment, error) {
-	user, err := usersrepo.New(replicaDB).GetConnectedUserByEmail(ctx, usersrepo.GetConnectedUserByEmailParams{
-		Email:          email,
+	users, err := usersrepo.New(replicaDB).GetConnectedUsersByEmails(ctx, usersrepo.GetConnectedUsersByEmailsParams{
+		Emails:         userEnrichmentEmailCandidates(email),
 		OrganizationID: organizationID,
 	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		var empty userEnrichment
-		return empty, nil
-	case err != nil:
+	if err != nil {
 		var empty userEnrichment
 		return empty, fmt.Errorf("resolve connected user by email: %w", err)
+	}
+	if len(users) == 0 {
+		var empty userEnrichment
+		return empty, nil
+	}
+
+	user := users[0]
+	for _, candidate := range users {
+		if conv.NormalizeEmail(candidate.Email) == email {
+			user = candidate
+			break
+		}
 	}
 
 	var result userEnrichment
@@ -151,6 +159,21 @@ func loadUserEnrichment(ctx context.Context, replicaDB database.DBTX, organizati
 	}
 
 	return result, profileErr
+}
+
+func userEnrichmentEmailCandidates(email string) []string {
+	emails := []string{email}
+	local, domain, found := strings.Cut(email, "@")
+	if !found || local == "" || domain == "" || strings.Contains(domain, "@") {
+		return emails
+	}
+
+	canonicalLocal, _, found := strings.Cut(local, "+")
+	if !found || canonicalLocal == "" {
+		return emails
+	}
+
+	return append(emails, canonicalLocal+"@"+domain)
 }
 
 type userEnrichment struct {

--- a/server/internal/otel/user_enrichment_test.go
+++ b/server/internal/otel/user_enrichment_test.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -193,16 +194,16 @@ func (blockingUserEnrichmentDB) Exec(context.Context, string, ...any) (pgconn.Co
 	return pgconn.CommandTag{}, errors.New("unexpected exec")
 }
 
-func (blockingUserEnrichmentDB) Query(context.Context, string, ...any) (pgx.Rows, error) {
-	return nil, errors.New("unexpected query")
-}
-
-func (b blockingUserEnrichmentDB) QueryRow(ctx context.Context, _ string, _ ...any) pgx.Row {
+func (b blockingUserEnrichmentDB) Query(ctx context.Context, _ string, _ ...any) (pgx.Rows, error) {
 	if b.started != nil {
 		close(b.started)
 	}
 	<-ctx.Done()
-	return userEnrichmentErrorRow{err: ctx.Err()}
+	return nil, fmt.Errorf("block user enrichment query: %w", ctx.Err())
+}
+
+func (blockingUserEnrichmentDB) QueryRow(context.Context, string, ...any) pgx.Row {
+	return userEnrichmentErrorRow{err: errors.New("unexpected query row")}
 }
 
 type userEnrichmentErrorRow struct {

--- a/server/internal/otel/user_enrichment_test.go
+++ b/server/internal/otel/user_enrichment_test.go
@@ -20,6 +20,7 @@ import (
 	directoryrepo "github.com/speakeasy-api/gram/server/internal/directory/repo"
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
@@ -111,6 +112,21 @@ func TestFetchUserEnrichmentReturnsEmptyWithoutMatchingUser(t *testing.T) {
 	loads := singleflight.Group{}
 
 	got, err := fetchUserEnrichment(t.Context(), db, &enrichmentCache, &loads, "organization-id", "missing@example.invalid")
+
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestFetchUserEnrichmentIgnoresDeletedCanonicalCandidate(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDatabase(t)
+	seed := seedUserEnrichment(t, db)
+	require.NoError(t, testrepo.New(db).ForceSoftDeleteUser(t.Context(), seed.userID))
+	enrichmentCache := cache.NewTypedObjectCache[cachedUserEnrichment](testenv.NewLogger(t), cache.NoopCache, cache.SuffixNone)
+	loads := singleflight.Group{}
+
+	got, err := fetchUserEnrichment(t.Context(), db, &enrichmentCache, &loads, seed.organizationID, "user+deleted@example.invalid")
 
 	require.NoError(t, err)
 	require.Empty(t, got)
@@ -216,6 +232,7 @@ func (r userEnrichmentErrorRow) Scan(...any) error {
 
 type userEnrichmentSeed struct {
 	organizationID string
+	userID         string
 	email          string
 	want           userEnrichment
 }
@@ -311,6 +328,7 @@ func seedUserEnrichment(t *testing.T, db *pgxpool.Pool) userEnrichmentSeed {
 
 	return userEnrichmentSeed{
 		organizationID: organizationID,
+		userID:         userID,
 		email:          email,
 		want: userEnrichment{
 			DirectoryID: directoryUserID,
@@ -322,6 +340,56 @@ func seedUserEnrichment(t *testing.T, db *pgxpool.Pool) userEnrichmentSeed {
 			DirectoryGroupIDs:   []string{directoryGroupID},
 			DirectoryGroupNames: []string{"Developers"},
 			Roles:               []string{role},
+		},
+	}
+}
+
+func seedSubaddressUserEnrichment(t *testing.T, db *pgxpool.Pool, organizationID string) userEnrichmentSeed {
+	t.Helper()
+
+	const userID = "user-enrichment-subaddress"
+	const email = "user+log@example.invalid"
+	const directoryUserID = "directory-user-enrichment-subaddress"
+	syncedAt := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err := usersrepo.New(db).UpsertUser(t.Context(), usersrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: "Subaddress User Enrichment",
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	_, err = organizationsrepo.New(db).UpsertOrganizationUserRelationship(t.Context(), organizationsrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+
+	_, err = directoryrepo.New(db).UpsertDirectoryUser(t.Context(), directoryrepo.UpsertDirectoryUserParams{
+		OrganizationID:        organizationID,
+		UserID:                conv.ToPGText(userID),
+		WorkosDirectoryUserID: directoryUserID,
+		Email:                 conv.ToPGText(email),
+		Attributes:            []byte(`{"department":"Raw"}`),
+		RestoreDeleted:        true,
+		WorkosCreatedAt:       conv.ToPGTimestamptz(syncedAt),
+		WorkosUpdatedAt:       conv.ToPGTimestamptz(syncedAt),
+		WorkosLastEventID:     conv.ToPGText("event-directory-user-enrichment-subaddress"),
+	})
+	require.NoError(t, err)
+
+	return userEnrichmentSeed{
+		organizationID: organizationID,
+		userID:         userID,
+		email:          email,
+		want: userEnrichment{
+			DirectoryID:         directoryUserID,
+			DirectoryAttributes: map[string]any{"department": "Raw"},
+			DirectoryGroupIDs:   nil,
+			DirectoryGroupNames: nil,
+			Roles:               nil,
 		},
 	}
 }

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -79,6 +79,7 @@ LIMIT 1;
 SELECT DISTINCT ON (lower(u.email)) u.* FROM users u
 JOIN organization_user_relationships our ON our.user_id = u.id
 WHERE lower(u.email) = ANY(ARRAY(SELECT lower(e) FROM unnest(@emails::text[]) AS e))
+  AND u.deleted_at IS NULL
   AND our.organization_id = @organization_id
   AND our.deleted_at IS NULL
 ORDER BY lower(u.email), (u.email = lower(u.email)) DESC, u.created_at, u.id;

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -76,6 +76,7 @@ const getConnectedUsersByEmails = `-- name: GetConnectedUsersByEmails :many
 SELECT DISTINCT ON (lower(u.email)) u.id, u.email, u.display_name, u.photo_url, u.admin, u.last_login, u.workos_id, u.workos_created_at, u.workos_updated_at, u.workos_deleted_at, u.deleted_at, u.created_at, u.updated_at FROM users u
 JOIN organization_user_relationships our ON our.user_id = u.id
 WHERE lower(u.email) = ANY(ARRAY(SELECT lower(e) FROM unnest($1::text[]) AS e))
+  AND u.deleted_at IS NULL
   AND our.organization_id = $2
   AND our.deleted_at IS NULL
 ORDER BY lower(u.email), (u.email = lower(u.email)) DESC, u.created_at, u.id


### PR DESCRIPTION
## Summary

- resolve directory enrichment against both raw and plus-stripped email addresses
- prefer an exact raw email identity when both candidates exist
- cover log and span enrichment for subaddressed users

## Testing

- `mise run test:server ./internal/otel/`
- `mise lint:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve directory enrichment for email subaddresses and exclude soft-deleted users. Before: only exact emails matched and deleted users could be returned. Now: we query both the raw and plus-stripped addresses, prefer an exact raw match, and ignore deleted users.

- `loadUserEnrichment` uses `usersrepo.GetConnectedUsersByEmails` with candidates from `userEnrichmentEmailCandidates`, selecting the preferred match; SQL now filters `u.deleted_at IS NULL`.
- Add log/span tests for subaddress resolution and a test that ignores a deleted canonical candidate; update the blocking DB test to block on query.
- No schema, API, or rollout changes.

<sup>Written for commit 2702bf0601d2c583c2eb74bbf65cb5d57b36c2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

