### PR TITLE
chore: require reviewer context in pull request descriptions

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -9,22 +9,31 @@ Create a Pull Request for the current changes and/or branch:
 1. Ask user what the scope of the changes is for context
 2. Use the current branch or create a new branch if on main
 3. **Validate conventional commit prefix**: Ensure PR title and any commits use proper conventional commit prefixes:
-   - `chore:` - for maintenance tasks, configuration changes, tooling updates
-   - `feat:` - for new features or functionality additions
+   - `feat:` - for new **user-facing** features or functionality additions
    - `fix:` - for bug fixes and error corrections
    - `mig:` - for database migrations and schema changes
+   - `chore:` - for maintenance tasks, configuration changes, tooling updates, and generally anything not user-facing
    - Ask user to clarify the change type if unclear, and enforce one of these four prefixes
 4. If there are uncommitted changes, create a single line conventional commit summarizing the changes eg. `feat: add new feature`
 5. **Scrub the branch**: Before pushing, check the branch name and every commit message on the branch against the rules in [Public metadata hygiene](#public-metadata-hygiene) below. Fix anything that fails before continuing — a push publishes both.
 6. Ensure the branch is up-to-date with `origin/main`
 7. Push the branch to `origin`
-8. Create a short but well-structured PR description in a temporary file (with a unique file name) in the /tmp directory for reviewers
+8. Draft the PR description in a uniquely named file under `/tmp`, following [Writing style](#writing-style).
 9. **Scrub the PR metadata**: Check the PR title and the drafted description against the same rules. Fix them in place before opening the PR — once created, they are public.
 10. Create PR with the description file using GitHub CLI, ensuring the title starts with `chore:`, `feat:`, `fix:`, or `mig:` and targets `main`
 11. Add appropriate labels based on change type (enhancement, bug, documentation, etc.). Ensure to query for the available labels beforehand.
 12. Provide a clickable link to the PR in the output
 
 Follow conventional commit standards and keep PR descriptions concise but informative. **IMPORTANT**: All PR titles MUST start with one of the four prefixes: `chore:`, `feat:`, `fix:`, or `mig:`.
+
+## Writing style
+
+Derive the PR description from the diff, commits, and user intent. Do not merely restate the title or list commit subjects. Include:
+
+- `## Summary`: the concrete, reviewer-relevant changes and their scope.
+- `## Motivation`: the problem being solved and why this approach was taken.
+
+Do not add a `Testing` or `Verification` section or enumerate test commands and steps. Keep each included section concise but complete. If a Linear ticket was provided, include it at the top. Otherwise, tell the user after creating the PR; if they then provide one, amend the description.
 
 ## Public metadata hygiene
 


### PR DESCRIPTION
## Summary

Tighten the pull-request skill’s writing contract so descriptions derive concise reviewer context from the diff, commits, and user intent: the concrete change and scope in `Summary`, and the rationale in `Motivation`. The guidance explicitly keeps test commands and procedural steps out of the description, clarifies that `feat:` is reserved for user-facing additions while other maintenance uses `chore:`, and connects the temporary description-file step to the new contract.

## Motivation

The previous “short but well-structured” requirement could be satisfied by restating the title or listing commit subjects, leaving reviewers without enough context to understand the change or why it was made. Requiring the what and why while excluding test steps keeps descriptions concise, durable, and useful for review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the pull-request skill’s description contract to require concise reviewer context and forbid testing steps. This makes PRs easier to review and clarifies when to use `feat:` vs `chore:`.

- Adds a Writing style: require Summary (what changed, scope) and Motivation (why), derive content from diff/commits/user intent, exclude Testing/Verification; include a Linear ticket at the top when provided, otherwise notify the user and amend later.
- Updates step 8 to draft the PR description in a uniquely named file under `/tmp` following the new style.
- Refines conventional commit guidance: `feat:` only for user-facing additions; `chore:` for maintenance and other non-user-facing changes; still enforce one of `chore:`, `feat:`, `fix:`, or `mig:`.

<sup>Written for commit 133b0a2a9f3861514302e7868ac84582280879ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

