### PR TITLE
fix: clear dead remote session refresh tokens on non-RFC invalid_grant bodies

### DIFF
--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -80,3 +80,68 @@ func TestRefreshNow_InvalidGrant_ClearsRefreshGrantWhenCacheUnavailable(t *testi
 	require.Equal(t, "expired-access", resolved, "unknown-expiry access remains usable")
 	require.EqualValues(t, 1, refreshAttempts.Load(), "cache failure must not prevent the upstream attempt")
 }
+
+func TestRefreshNow_InvalidGrant_DatadogErrorsArray_ClearsRefreshGrant(t *testing.T) {
+	t.Parallel()
+
+	assertRefreshNowClearsDeadGrant(
+		t,
+		"refreshnow-datadog-errors",
+		http.StatusBadRequest,
+		`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`,
+		"invalid_grant: Invalid or expired refresh token or code verifier.",
+	)
+}
+
+func TestRefreshNow_InvalidGrant_DubUnauthorized_ClearsRefreshGrant(t *testing.T) {
+	t.Parallel()
+
+	assertRefreshNowClearsDeadGrant(
+		t,
+		"refreshnow-dub-unauthorized",
+		http.StatusUnauthorized,
+		`{"error":{"code":"unauthorized","message":"Refresh token not found."}}`,
+		"invalid_grant: Refresh token not found.",
+	)
+}
+
+func assertRefreshNowClearsDeadGrant(t *testing.T, slugSuffix string, status int, body string, wantReason string) {
+	t.Helper()
+
+	ctx, env := newSyntheticExpiryEnv(t, slugSuffix, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") != "refresh_token" {
+			_, _ = w.Write([]byte(`{"access_token":"expired-access","refresh_token":"dead-refresh"}`))
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+
+	session, err := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.NoError(t, err)
+
+	result, err := env.refresher.RefreshNow(ctx, session, "")
+	require.Error(t, err)
+	require.Empty(t, result.Outcome)
+	require.Empty(t, result.AccessToken)
+
+	var tokenErr *remotesessions.TokenRefreshError
+	require.ErrorAs(t, err, &tokenErr)
+	require.Equal(t, wantReason, tokenErr.Reason)
+
+	active, err := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.NoError(t, err)
+	require.False(t, active.RefreshTokenEncrypted.Valid)
+	require.False(t, active.RefreshExpiresAt.Valid)
+}

--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -105,6 +105,18 @@ func TestRefreshNow_InvalidGrant_DubUnauthorized_ClearsRefreshGrant(t *testing.T
 	)
 }
 
+func TestRefreshNow_InvalidGrant_Generic4xxTokenMention_ClearsRefreshGrant(t *testing.T) {
+	t.Parallel()
+
+	assertRefreshNowClearsDeadGrant(
+		t,
+		"refreshnow-generic-4xx",
+		http.StatusBadRequest,
+		`token endpoint rejected refresh: invalid_grant`,
+		"invalid_grant",
+	)
+}
+
 func assertRefreshNowClearsDeadGrant(t *testing.T, slugSuffix string, status int, body string, wantReason string) {
 	t.Helper()
 

--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -105,18 +105,6 @@ func TestRefreshNow_InvalidGrant_DubUnauthorized_ClearsRefreshGrant(t *testing.T
 	)
 }
 
-func TestRefreshNow_InvalidGrant_Generic4xxTokenMention_ClearsRefreshGrant(t *testing.T) {
-	t.Parallel()
-
-	assertRefreshNowClearsDeadGrant(
-		t,
-		"refreshnow-generic-4xx",
-		http.StatusBadRequest,
-		`token endpoint rejected refresh: invalid_grant`,
-		"invalid_grant",
-	)
-}
-
 func assertRefreshNowClearsDeadGrant(t *testing.T, slugSuffix string, status int, body string, wantReason string) {
 	t.Helper()
 

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -16,25 +16,12 @@ const oauthErrInvalidGrant = "invalid_grant"
 
 // tokenErrorResponse is the public-safe view of an upstream token-endpoint
 // error: an OAuth error code plus optional description. RFC 6749 §5.2 members
-// are preferred; well-known provider shapes (an errors[] of invalid_grant
-// messages, a nested error object) are normalized onto the same fields.
+// are preferred; the known provider shapes recognized by the dialect matchers
+// below are normalized onto the same fields.
 type tokenErrorResponse struct {
 	Error            string
 	ErrorDescription string
 	ErrorURI         string
-}
-
-type rawTokenErrorResponse struct {
-	Error            json.RawMessage
-	ErrorDescription string
-	ErrorURI         string
-	Errors           []string
-}
-
-type nestedTokenError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Error   string `json:"error"`
 }
 
 func newTokenError(code, description, uri string) tokenErrorResponse {
@@ -45,66 +32,48 @@ func newTokenError(code, description, uri string) tokenErrorResponse {
 	}
 }
 
-// allowsHeuristicInvalidGrant reports whether statusCode may carry a heuristic
-// (non-exact-code) invalid_grant classification. 5xx pages, rate limits (429),
-// and request timeouts (408) mention error codes without meaning them, and a
-// false positive here permanently clears a still-usable refresh grant.
-func allowsHeuristicInvalidGrant(statusCode int) bool {
+// nonRFCErrorDefinitive reports whether statusCode can carry a definitive
+// invalid_grant signal from a non-RFC provider shape. 5xx pages, rate limits
+// (429), and request timeouts (408) are never definitive: a false positive
+// here permanently clears a still-usable refresh grant.
+func nonRFCErrorDefinitive(statusCode int) bool {
 	return statusCode >= 400 && statusCode < 500 &&
 		statusCode != http.StatusRequestTimeout &&
 		statusCode != http.StatusTooManyRequests
 }
 
-// parseTokenErrorResponse decodes an upstream token error body. Each member is
+// parseTokenErrorResponse decodes an upstream token error body. Members are
 // decoded independently, so a provider extension with an unexpected shape
-// cannot discard an RFC 6749 error code sitting next to it. A body that does
-// not decode, or that carries no recognizable error, yields the zero value —
-// whose summary falls back to the HTTP status.
+// cannot discard an RFC 6749 error code sitting next to it. Beyond the RFC
+// members, only explicitly recognized provider dialects (Datadog, Dub) can
+// classify — free text never does. A body that does not decode, or that
+// carries no recognizable error, yields the zero value — whose summary falls
+// back to the HTTP status.
 func parseTokenErrorResponse(statusCode int, body []byte) tokenErrorResponse {
 	var members map[string]json.RawMessage
 	if json.Unmarshal(body, &members) != nil {
 		return newTokenError("", "", "")
 	}
 
-	raw := rawTokenErrorResponse{
-		Error:            members["error"],
-		ErrorDescription: "",
-		ErrorURI:         "",
-		Errors:           nil,
-	}
-	_ = json.Unmarshal(members["error_description"], &raw.ErrorDescription)
-	_ = json.Unmarshal(members["error_uri"], &raw.ErrorURI)
+	var desc, uri string
+	_ = json.Unmarshal(members["error_description"], &desc)
+	_ = json.Unmarshal(members["error_uri"], &uri)
 
-	var entries []json.RawMessage
-	_ = json.Unmarshal(members["errors"], &entries)
-	for _, entry := range entries {
-		var s string
-		if json.Unmarshal(entry, &s) == nil {
-			raw.Errors = append(raw.Errors, s)
+	var code string
+	if json.Unmarshal(members["error"], &code) == nil && strings.TrimSpace(code) != "" {
+		return newTokenError(strings.TrimSpace(code), desc, uri)
+	}
+
+	if nonRFCErrorDefinitive(statusCode) {
+		if e, ok := datadogInvalidGrant(members["errors"]); ok {
+			return e
+		}
+		if e, ok := nestedProviderError(members["error"]); ok {
+			return e
 		}
 	}
 
-	heuristicOK := allowsHeuristicInvalidGrant(statusCode)
-
-	if e, ok := parseErrorMember(raw.Error, heuristicOK); ok {
-		if e.ErrorDescription == "" {
-			e.ErrorDescription = raw.ErrorDescription
-		}
-		if e.ErrorURI == "" {
-			e.ErrorURI = raw.ErrorURI
-		}
-		return e
-	}
-
-	if heuristicOK {
-		for _, msg := range raw.Errors {
-			if e, ok := splitInvalidGrant(msg); ok {
-				return e
-			}
-		}
-	}
-
-	return newTokenError("", raw.ErrorDescription, raw.ErrorURI)
+	return newTokenError("", desc, uri)
 }
 
 // summary renders a short, public-safe description of the error, preferring the
@@ -123,98 +92,29 @@ func (e tokenErrorResponse) summary(status string) string {
 	}
 }
 
-// parseErrorMember normalizes the "error" member, which is an RFC 6749 code
-// string for spec-compliant providers and an object for others. An exact
-// invalid_grant code is honored on any status; looser matches (a code with a
-// trailing description, a dead-grant remap) apply only when heuristicOK.
-func parseErrorMember(raw json.RawMessage, heuristicOK bool) (tokenErrorResponse, bool) {
-	if len(raw) == 0 {
-		return newTokenError("", "", ""), false
-	}
-
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return newTokenError("", "", ""), false
+// datadogInvalidGrant matches Datadog's token error dialect: an errors[] array
+// with an entry of the form "invalid_grant - <description>". Only entries that
+// begin with the code count; a mention elsewhere in a message never does.
+func datadogInvalidGrant(raw json.RawMessage) (tokenErrorResponse, bool) {
+	var entries []json.RawMessage
+	_ = json.Unmarshal(raw, &entries)
+	for _, entry := range entries {
+		var msg string
+		if json.Unmarshal(entry, &msg) != nil {
+			continue
 		}
-		if s == oauthErrInvalidGrant {
-			return newTokenError(oauthErrInvalidGrant, "", ""), true
+		rest, ok := strings.CutPrefix(strings.TrimSpace(msg), oauthErrInvalidGrant)
+		if !ok || (rest != "" && isErrorTokenByte(rest[0])) {
+			continue
 		}
-		if heuristicOK {
-			if e, ok := splitInvalidGrant(s); ok {
-				return e, true
-			}
-		}
-		return newTokenError(s, "", ""), true
-	}
-
-	var nested nestedTokenError
-	if json.Unmarshal(raw, &nested) != nil {
-		return newTokenError("", "", ""), false
-	}
-
-	code := strings.TrimSpace(conv.Default(nested.Code, nested.Error))
-	desc := strings.TrimSpace(nested.Message)
-	if code == "" && desc == "" {
-		return newTokenError("", "", ""), false
-	}
-
-	if code == oauthErrInvalidGrant {
-		return newTokenError(oauthErrInvalidGrant, desc, ""), true
-	}
-	if heuristicOK && isDeadRefreshGrant(code, desc) {
-		return newTokenError(oauthErrInvalidGrant, conv.Default(desc, code), ""), true
-	}
-	if code == "" {
-		return newTokenError("", "", ""), false
-	}
-	return newTokenError(code, desc, ""), true
-}
-
-// splitInvalidGrant reports whether msg is an invalid_grant signal: it starts
-// with that code (optionally followed by a separator and description), or it
-// contains invalid_grant as a standalone token. In the standalone case the
-// surrounding message is dropped — it is arbitrary upstream text and Reason is
-// public, so only the bare code is kept.
-func splitInvalidGrant(msg string) (tokenErrorResponse, bool) {
-	msg = strings.TrimSpace(msg)
-	if msg == "" {
-		return newTokenError("", "", ""), false
-	}
-
-	if rest, ok := strings.CutPrefix(msg, oauthErrInvalidGrant); ok {
-		if rest == "" || !isErrorTokenByte(rest[0]) {
-			rest = strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(rest), "-:."))
-			return newTokenError(oauthErrInvalidGrant, rest, ""), true
-		}
-	}
-	if containsOAuthErrorToken(msg, oauthErrInvalidGrant) {
-		return newTokenError(oauthErrInvalidGrant, "", ""), true
+		rest = strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(rest), "-:."))
+		return newTokenError(oauthErrInvalidGrant, rest, ""), true
 	}
 	return newTokenError("", "", ""), false
 }
 
-// containsOAuthErrorToken reports whether token appears in s with non-identifier
-// boundaries, so "invalid_grant_extra" does not match "invalid_grant".
-func containsOAuthErrorToken(s, token string) bool {
-	start := 0
-	for {
-		i := strings.Index(s[start:], token)
-		if i < 0 {
-			return false
-		}
-		i += start
-		beforeOK := i == 0 || !isErrorTokenByte(s[i-1])
-		after := i + len(token)
-		afterOK := after == len(s) || !isErrorTokenByte(s[after])
-		if beforeOK && afterOK {
-			return true
-		}
-		start = i + 1
-	}
-}
-
+// isErrorTokenByte reports whether b can be part of an OAuth error code, so
+// "invalid_grant_extra" does not match "invalid_grant".
 func isErrorTokenByte(b byte) bool {
 	return b == '_' ||
 		(b >= 'a' && b <= 'z') ||
@@ -222,47 +122,45 @@ func isErrorTokenByte(b byte) bool {
 		(b >= '0' && b <= '9')
 }
 
-// deadRefreshGrantPhrases are lowercase statements about the refresh token
-// itself being unusable. The dead-verdict word must be anchored to "refresh
-// token" as a phrase: a message where it attaches to something else ("Invalid
-// client credentials for refresh token exchange", "client ID is invalid")
-// describes a recoverable failure, never a dead grant.
-var deadRefreshGrantPhrases = []string{
+// deadGrantMessages are literal (lowercase, period-stripped) provider messages
+// that report the refresh grant itself as permanently unusable under a generic
+// "unauthorized" code. Dub is the only known producer. Add new literals as
+// providers are observed in logs — never patterns: fuzzy matching here has
+// repeatedly misclassified recoverable client-auth failures, and a false
+// positive irreversibly clears live grants.
+var deadGrantMessages = []string{
 	"refresh token not found",
-	"refresh token was not found",
-	"refresh token is invalid",
-	"invalid refresh token",
-	"refresh token is expired",
-	"refresh token has expired",
-	"refresh token expired",
-	"expired refresh token",
-	"refresh token is revoked",
-	"refresh token has been revoked",
-	"refresh token revoked",
-	"revoked refresh token",
-	"refresh token is unknown",
-	"unknown refresh token",
 }
 
-// isDeadRefreshGrant reports whether a nested provider error is a refresh
-// grant that can never succeed again. Dub encodes this as unauthorized plus a
-// "Refresh token not found." message rather than RFC 6749 invalid_grant.
-func isDeadRefreshGrant(code, message string) bool {
-	if !strings.EqualFold(code, "unauthorized") {
-		return false
+// nestedProviderError matches the nested-object dialect used by Dub and
+// similar APIs: {"error": {"code": ..., "message": ...}}. An explicit
+// invalid_grant code counts, as does a known dead-grant literal under
+// "unauthorized"; any other code passes through unclassified.
+func nestedProviderError(raw json.RawMessage) (tokenErrorResponse, bool) {
+	var nested struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Error   string `json:"error"`
 	}
-	m := strings.ToLower(message)
-	// Client-auth wording marks the failure recoverable even alongside a
-	// dead-token phrase; merely naming a client does not.
-	for _, excluded := range []string{"credential", "secret", "client authentication"} {
-		if strings.Contains(m, excluded) {
-			return false
+	if len(raw) == 0 || json.Unmarshal(raw, &nested) != nil {
+		return newTokenError("", "", ""), false
+	}
+
+	code := strings.TrimSpace(conv.Default(nested.Code, nested.Error))
+	msg := strings.TrimSpace(nested.Message)
+	if code == oauthErrInvalidGrant {
+		return newTokenError(oauthErrInvalidGrant, msg, ""), true
+	}
+	if strings.EqualFold(code, "unauthorized") {
+		normalized := strings.TrimRight(strings.ToLower(msg), ".")
+		for _, dead := range deadGrantMessages {
+			if normalized == dead {
+				return newTokenError(oauthErrInvalidGrant, msg, ""), true
+			}
 		}
 	}
-	for _, phrase := range deadRefreshGrantPhrases {
-		if strings.Contains(m, phrase) {
-			return true
-		}
+	if code == "" {
+		return newTokenError("", "", ""), false
 	}
-	return false
+	return newTokenError(code, msg, ""), true
 }

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -2,6 +2,7 @@ package remotesessions
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -24,10 +25,10 @@ type tokenErrorResponse struct {
 }
 
 type rawTokenErrorResponse struct {
-	Error            json.RawMessage `json:"error"`
-	ErrorDescription string          `json:"error_description"`
-	ErrorURI         string          `json:"error_uri"`
-	Errors           []string        `json:"errors"`
+	Error            json.RawMessage
+	ErrorDescription string
+	ErrorURI         string
+	Errors           []string
 }
 
 type nestedTokenError struct {
@@ -44,16 +45,48 @@ func newTokenError(code, description, uri string) tokenErrorResponse {
 	}
 }
 
-// parseTokenErrorResponse decodes an upstream token error body. A body that
-// does not decode, or that carries no recognizable error, yields the zero
-// value — whose summary falls back to the HTTP status.
-func parseTokenErrorResponse(body []byte) tokenErrorResponse {
-	var raw rawTokenErrorResponse
-	if json.Unmarshal(body, &raw) != nil {
+// allowsHeuristicInvalidGrant reports whether statusCode may carry a heuristic
+// (non-exact-code) invalid_grant classification. 5xx pages, rate limits (429),
+// and request timeouts (408) mention error codes without meaning them, and a
+// false positive here permanently clears a still-usable refresh grant.
+func allowsHeuristicInvalidGrant(statusCode int) bool {
+	return statusCode >= 400 && statusCode < 500 &&
+		statusCode != http.StatusRequestTimeout &&
+		statusCode != http.StatusTooManyRequests
+}
+
+// parseTokenErrorResponse decodes an upstream token error body. Each member is
+// decoded independently, so a provider extension with an unexpected shape
+// cannot discard an RFC 6749 error code sitting next to it. A body that does
+// not decode, or that carries no recognizable error, yields the zero value —
+// whose summary falls back to the HTTP status.
+func parseTokenErrorResponse(statusCode int, body []byte) tokenErrorResponse {
+	var members map[string]json.RawMessage
+	if json.Unmarshal(body, &members) != nil {
 		return newTokenError("", "", "")
 	}
 
-	if e, ok := parseErrorMember(raw.Error); ok {
+	raw := rawTokenErrorResponse{
+		Error:            members["error"],
+		ErrorDescription: "",
+		ErrorURI:         "",
+		Errors:           nil,
+	}
+	_ = json.Unmarshal(members["error_description"], &raw.ErrorDescription)
+	_ = json.Unmarshal(members["error_uri"], &raw.ErrorURI)
+
+	var entries []json.RawMessage
+	_ = json.Unmarshal(members["errors"], &entries)
+	for _, entry := range entries {
+		var s string
+		if json.Unmarshal(entry, &s) == nil {
+			raw.Errors = append(raw.Errors, s)
+		}
+	}
+
+	heuristicOK := allowsHeuristicInvalidGrant(statusCode)
+
+	if e, ok := parseErrorMember(raw.Error, heuristicOK); ok {
 		if e.ErrorDescription == "" {
 			e.ErrorDescription = raw.ErrorDescription
 		}
@@ -63,9 +96,11 @@ func parseTokenErrorResponse(body []byte) tokenErrorResponse {
 		return e
 	}
 
-	for _, msg := range raw.Errors {
-		if e, ok := splitInvalidGrant(msg); ok {
-			return e
+	if heuristicOK {
+		for _, msg := range raw.Errors {
+			if e, ok := splitInvalidGrant(msg); ok {
+				return e
+			}
 		}
 	}
 
@@ -88,7 +123,11 @@ func (e tokenErrorResponse) summary(status string) string {
 	}
 }
 
-func parseErrorMember(raw json.RawMessage) (tokenErrorResponse, bool) {
+// parseErrorMember normalizes the "error" member, which is an RFC 6749 code
+// string for spec-compliant providers and an object for others. An exact
+// invalid_grant code is honored on any status; looser matches (a code with a
+// trailing description, a dead-grant remap) apply only when heuristicOK.
+func parseErrorMember(raw json.RawMessage, heuristicOK bool) (tokenErrorResponse, bool) {
 	if len(raw) == 0 {
 		return newTokenError("", "", ""), false
 	}
@@ -99,8 +138,13 @@ func parseErrorMember(raw json.RawMessage) (tokenErrorResponse, bool) {
 		if s == "" {
 			return newTokenError("", "", ""), false
 		}
-		if e, ok := splitInvalidGrant(s); ok {
-			return e, true
+		if s == oauthErrInvalidGrant {
+			return newTokenError(oauthErrInvalidGrant, "", ""), true
+		}
+		if heuristicOK {
+			if e, ok := splitInvalidGrant(s); ok {
+				return e, true
+			}
 		}
 		return newTokenError(s, "", ""), true
 	}
@@ -116,13 +160,10 @@ func parseErrorMember(raw json.RawMessage) (tokenErrorResponse, bool) {
 		return newTokenError("", "", ""), false
 	}
 
-	if e, ok := splitInvalidGrant(code); ok {
-		if e.ErrorDescription == "" {
-			e.ErrorDescription = desc
-		}
-		return e, true
+	if code == oauthErrInvalidGrant {
+		return newTokenError(oauthErrInvalidGrant, desc, ""), true
 	}
-	if isDeadRefreshGrant(code, desc) {
+	if heuristicOK && isDeadRefreshGrant(code, desc) {
 		return newTokenError(oauthErrInvalidGrant, conv.Default(desc, code), ""), true
 	}
 	if code == "" {
@@ -133,7 +174,9 @@ func parseErrorMember(raw json.RawMessage) (tokenErrorResponse, bool) {
 
 // splitInvalidGrant reports whether msg is an invalid_grant signal: it starts
 // with that code (optionally followed by a separator and description), or it
-// contains invalid_grant as a standalone token.
+// contains invalid_grant as a standalone token. In the standalone case the
+// surrounding message is dropped — it is arbitrary upstream text and Reason is
+// public, so only the bare code is kept.
 func splitInvalidGrant(msg string) (tokenErrorResponse, bool) {
 	msg = strings.TrimSpace(msg)
 	if msg == "" {
@@ -147,7 +190,7 @@ func splitInvalidGrant(msg string) (tokenErrorResponse, bool) {
 		}
 	}
 	if containsOAuthErrorToken(msg, oauthErrInvalidGrant) {
-		return newTokenError(oauthErrInvalidGrant, msg, ""), true
+		return newTokenError(oauthErrInvalidGrant, "", ""), true
 	}
 	return newTokenError("", "", ""), false
 }
@@ -182,6 +225,9 @@ func isErrorTokenByte(b byte) bool {
 // isDeadRefreshGrant reports whether a nested provider error is a refresh
 // grant that can never succeed again. Dub encodes this as unauthorized plus a
 // "Refresh token not found." message rather than RFC 6749 invalid_grant.
+// Client-auth failures ("Invalid client credentials for refresh token
+// exchange") are recoverable by fixing the client configuration and must never
+// be remapped, so any mention of the client or its credentials disqualifies.
 func isDeadRefreshGrant(code, message string) bool {
 	if !strings.EqualFold(code, "unauthorized") {
 		return false
@@ -189,6 +235,11 @@ func isDeadRefreshGrant(code, message string) bool {
 	m := strings.ToLower(message)
 	if !strings.Contains(m, "refresh token") {
 		return false
+	}
+	for _, excluded := range []string{"client", "credential", "secret"} {
+		if strings.Contains(m, excluded) {
+			return false
+		}
 	}
 	for _, needle := range []string{"not found", "invalid", "expired", "revoked", "unknown"} {
 		if strings.Contains(m, needle) {

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -2,6 +2,9 @@ package remotesessions
 
 import (
 	"encoding/json"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
 )
 
 // oauthErrInvalidGrant is the RFC 6749 §5.2 error code an OAuth 2.0 token
@@ -10,27 +13,67 @@ import (
 // renew, distinct from transient failures (server_error, temporarily_unavailable).
 const oauthErrInvalidGrant = "invalid_grant"
 
-// tokenErrorResponse is the RFC 6749 §5.2 error response an OAuth 2.0 token
-// endpoint returns on a failed grant (e.g. a rejected refresh_token). Only the
-// three RFC-defined members are modeled; provider-specific extensions are
-// ignored. error_uri is rarely populated in practice but is part of the spec.
+// tokenErrorResponse is the public-safe view of an upstream token-endpoint
+// error: an OAuth error code plus optional description. RFC 6749 §5.2 members
+// are preferred; well-known provider shapes (an errors[] of invalid_grant
+// messages, a nested error object) are normalized onto the same fields.
 type tokenErrorResponse struct {
-	Error            string `json:"error"`
-	ErrorDescription string `json:"error_description"`
-	ErrorURI         string `json:"error_uri"`
+	Error            string
+	ErrorDescription string
+	ErrorURI         string
 }
 
-// parseTokenErrorResponse decodes an RFC 6749 §5.2 token error response body. A
-// body that does not decode, or that omits the required "error" member, yields
-// the zero value — whose summary falls back to the HTTP status.
+type rawTokenErrorResponse struct {
+	Error            json.RawMessage `json:"error"`
+	ErrorDescription string          `json:"error_description"`
+	ErrorURI         string          `json:"error_uri"`
+	Errors           []string        `json:"errors"`
+}
+
+type nestedTokenError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+func newTokenError(code, description, uri string) tokenErrorResponse {
+	return tokenErrorResponse{
+		Error:            code,
+		ErrorDescription: description,
+		ErrorURI:         uri,
+	}
+}
+
+// parseTokenErrorResponse decodes an upstream token error body. A body that
+// does not decode, or that carries no recognizable error, yields the zero
+// value — whose summary falls back to the HTTP status.
 func parseTokenErrorResponse(body []byte) tokenErrorResponse {
-	var e tokenErrorResponse
-	_ = json.Unmarshal(body, &e)
-	return e
+	var raw rawTokenErrorResponse
+	if json.Unmarshal(body, &raw) != nil {
+		return newTokenError("", "", "")
+	}
+
+	if e, ok := parseErrorMember(raw.Error); ok {
+		if e.ErrorDescription == "" {
+			e.ErrorDescription = raw.ErrorDescription
+		}
+		if e.ErrorURI == "" {
+			e.ErrorURI = raw.ErrorURI
+		}
+		return e
+	}
+
+	for _, msg := range raw.Errors {
+		if e, ok := splitInvalidGrant(msg); ok {
+			return e
+		}
+	}
+
+	return newTokenError("", raw.ErrorDescription, raw.ErrorURI)
 }
 
 // summary renders a short, public-safe description of the error, preferring the
-// RFC error / error_description and falling back to the supplied HTTP status
+// OAuth error / error_description and falling back to the supplied HTTP status
 // when the body carried no recognizable error. The raw body is never surfaced.
 func (e tokenErrorResponse) summary(status string) string {
 	switch {
@@ -43,4 +86,114 @@ func (e tokenErrorResponse) summary(status string) string {
 	default:
 		return "HTTP " + status
 	}
+}
+
+func parseErrorMember(raw json.RawMessage) (tokenErrorResponse, bool) {
+	if len(raw) == 0 {
+		return newTokenError("", "", ""), false
+	}
+
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return newTokenError("", "", ""), false
+		}
+		if e, ok := splitInvalidGrant(s); ok {
+			return e, true
+		}
+		return newTokenError(s, "", ""), true
+	}
+
+	var nested nestedTokenError
+	if json.Unmarshal(raw, &nested) != nil {
+		return newTokenError("", "", ""), false
+	}
+
+	code := strings.TrimSpace(conv.Default(nested.Code, nested.Error))
+	desc := strings.TrimSpace(nested.Message)
+	if code == "" && desc == "" {
+		return newTokenError("", "", ""), false
+	}
+
+	if e, ok := splitInvalidGrant(code); ok {
+		if e.ErrorDescription == "" {
+			e.ErrorDescription = desc
+		}
+		return e, true
+	}
+	if isDeadRefreshGrant(code, desc) {
+		return newTokenError(oauthErrInvalidGrant, conv.Default(desc, code), ""), true
+	}
+	if code == "" {
+		return newTokenError("", "", ""), false
+	}
+	return newTokenError(code, desc, ""), true
+}
+
+// splitInvalidGrant reports whether msg is an invalid_grant signal: it starts
+// with that code (optionally followed by a separator and description), or it
+// contains invalid_grant as a standalone token.
+func splitInvalidGrant(msg string) (tokenErrorResponse, bool) {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return newTokenError("", "", ""), false
+	}
+
+	if rest, ok := strings.CutPrefix(msg, oauthErrInvalidGrant); ok {
+		if rest == "" || !isErrorTokenByte(rest[0]) {
+			rest = strings.TrimSpace(strings.TrimLeft(rest, "-:."))
+			return newTokenError(oauthErrInvalidGrant, rest, ""), true
+		}
+	}
+	if containsOAuthErrorToken(msg, oauthErrInvalidGrant) {
+		return newTokenError(oauthErrInvalidGrant, msg, ""), true
+	}
+	return newTokenError("", "", ""), false
+}
+
+// containsOAuthErrorToken reports whether token appears in s with non-identifier
+// boundaries, so "invalid_grant_extra" does not match "invalid_grant".
+func containsOAuthErrorToken(s, token string) bool {
+	start := 0
+	for {
+		i := strings.Index(s[start:], token)
+		if i < 0 {
+			return false
+		}
+		i += start
+		beforeOK := i == 0 || !isErrorTokenByte(s[i-1])
+		after := i + len(token)
+		afterOK := after == len(s) || !isErrorTokenByte(s[after])
+		if beforeOK && afterOK {
+			return true
+		}
+		start = i + 1
+	}
+}
+
+func isErrorTokenByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// isDeadRefreshGrant reports whether a nested provider error is a refresh
+// grant that can never succeed again. Dub encodes this as unauthorized plus a
+// "Refresh token not found." message rather than RFC 6749 invalid_grant.
+func isDeadRefreshGrant(code, message string) bool {
+	if !strings.EqualFold(code, "unauthorized") {
+		return false
+	}
+	m := strings.ToLower(message)
+	if !strings.Contains(m, "refresh token") {
+		return false
+	}
+	for _, needle := range []string{"not found", "invalid", "expired", "revoked", "unknown"} {
+		if strings.Contains(m, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -142,7 +142,7 @@ func splitInvalidGrant(msg string) (tokenErrorResponse, bool) {
 
 	if rest, ok := strings.CutPrefix(msg, oauthErrInvalidGrant); ok {
 		if rest == "" || !isErrorTokenByte(rest[0]) {
-			rest = strings.TrimSpace(strings.TrimLeft(rest, "-:."))
+			rest = strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(rest), "-:."))
 			return newTokenError(oauthErrInvalidGrant, rest, ""), true
 		}
 	}

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -229,6 +229,7 @@ func isErrorTokenByte(b byte) bool {
 // describes a recoverable failure, never a dead grant.
 var deadRefreshGrantPhrases = []string{
 	"refresh token not found",
+	"refresh token was not found",
 	"refresh token is invalid",
 	"invalid refresh token",
 	"refresh token is expired",
@@ -251,6 +252,13 @@ func isDeadRefreshGrant(code, message string) bool {
 		return false
 	}
 	m := strings.ToLower(message)
+	// Client-auth wording marks the failure recoverable even alongside a
+	// dead-token phrase; merely naming a client does not.
+	for _, excluded := range []string{"credential", "secret", "client authentication"} {
+		if strings.Contains(m, excluded) {
+			return false
+		}
+	}
 	for _, phrase := range deadRefreshGrantPhrases {
 		if strings.Contains(m, phrase) {
 			return true

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -227,7 +227,8 @@ func isErrorTokenByte(b byte) bool {
 // "Refresh token not found." message rather than RFC 6749 invalid_grant.
 // Client-auth failures ("Invalid client credentials for refresh token
 // exchange") are recoverable by fixing the client configuration and must never
-// be remapped, so any mention of the client or its credentials disqualifies.
+// be remapped, so client-auth phrasing disqualifies; a message that merely
+// names a client ("Refresh token not found for client abc") does not.
 func isDeadRefreshGrant(code, message string) bool {
 	if !strings.EqualFold(code, "unauthorized") {
 		return false
@@ -236,7 +237,7 @@ func isDeadRefreshGrant(code, message string) bool {
 	if !strings.Contains(m, "refresh token") {
 		return false
 	}
-	for _, excluded := range []string{"client", "credential", "secret"} {
+	for _, excluded := range []string{"credential", "secret", "invalid client", "unknown client", "client authentication"} {
 		if strings.Contains(m, excluded) {
 			return false
 		}

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -65,10 +65,13 @@ func parseTokenErrorResponse(statusCode int, body []byte) tokenErrorResponse {
 	}
 
 	if nonRFCErrorDefinitive(statusCode) {
-		if e, ok := datadogInvalidGrant(members["errors"]); ok {
-			return e
+		e, ok := datadogInvalidGrant(members["errors"])
+		if !ok {
+			e, ok = nestedProviderError(members["error"])
 		}
-		if e, ok := nestedProviderError(members["error"]); ok {
+		if ok {
+			e.ErrorDescription = conv.Default(e.ErrorDescription, desc)
+			e.ErrorURI = conv.Default(e.ErrorURI, uri)
 			return e
 		}
 	}

--- a/server/internal/remotesessions/token_error_response.go
+++ b/server/internal/remotesessions/token_error_response.go
@@ -222,28 +222,37 @@ func isErrorTokenByte(b byte) bool {
 		(b >= '0' && b <= '9')
 }
 
+// deadRefreshGrantPhrases are lowercase statements about the refresh token
+// itself being unusable. The dead-verdict word must be anchored to "refresh
+// token" as a phrase: a message where it attaches to something else ("Invalid
+// client credentials for refresh token exchange", "client ID is invalid")
+// describes a recoverable failure, never a dead grant.
+var deadRefreshGrantPhrases = []string{
+	"refresh token not found",
+	"refresh token is invalid",
+	"invalid refresh token",
+	"refresh token is expired",
+	"refresh token has expired",
+	"refresh token expired",
+	"expired refresh token",
+	"refresh token is revoked",
+	"refresh token has been revoked",
+	"refresh token revoked",
+	"revoked refresh token",
+	"refresh token is unknown",
+	"unknown refresh token",
+}
+
 // isDeadRefreshGrant reports whether a nested provider error is a refresh
 // grant that can never succeed again. Dub encodes this as unauthorized plus a
 // "Refresh token not found." message rather than RFC 6749 invalid_grant.
-// Client-auth failures ("Invalid client credentials for refresh token
-// exchange") are recoverable by fixing the client configuration and must never
-// be remapped, so client-auth phrasing disqualifies; a message that merely
-// names a client ("Refresh token not found for client abc") does not.
 func isDeadRefreshGrant(code, message string) bool {
 	if !strings.EqualFold(code, "unauthorized") {
 		return false
 	}
 	m := strings.ToLower(message)
-	if !strings.Contains(m, "refresh token") {
-		return false
-	}
-	for _, excluded := range []string{"credential", "secret", "invalid client", "unknown client", "client authentication"} {
-		if strings.Contains(m, excluded) {
-			return false
-		}
-	}
-	for _, needle := range []string{"not found", "invalid", "expired", "revoked", "unknown"} {
-		if strings.Contains(m, needle) {
+	for _, phrase := range deadRefreshGrantPhrases {
+		if strings.Contains(m, phrase) {
 			return true
 		}
 	}

--- a/server/internal/remotesessions/token_error_response_test.go
+++ b/server/internal/remotesessions/token_error_response_test.go
@@ -68,6 +68,14 @@ func TestParseTokenErrorResponseDoesNotRemapClientAuthFailureMentioningRefreshTo
 	require.Equal(t, "Invalid client credentials for refresh token exchange.", got.ErrorDescription)
 }
 
+func TestParseTokenErrorResponseRemapsDeadGrantNamingAClient(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Refresh token not found for client abc."}}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Equal(t, "Refresh token not found for client abc.", got.ErrorDescription)
+}
+
 func TestParseTokenErrorResponseDoesNotOverrideOtherRFCCodes(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/token_error_response_test.go
+++ b/server/internal/remotesessions/token_error_response_test.go
@@ -34,6 +34,14 @@ func TestParseTokenErrorResponseDatadogErrorsArray(t *testing.T) {
 	require.Equal(t, "invalid_grant: Invalid or expired refresh token or code verifier.", got.summary("400 Bad Request"))
 }
 
+func TestParseTokenErrorResponseDatadogMentionMidMessageDoesNotClassify(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"errors":["Grant failure: invalid_grant (see docs)"]}`))
+	require.Empty(t, got.Error)
+	require.Equal(t, "HTTP 400 Bad Request", got.summary("400 Bad Request"))
+}
+
 func TestParseTokenErrorResponseDubNestedUnauthorized(t *testing.T) {
 	t.Parallel()
 
@@ -60,44 +68,18 @@ func TestParseTokenErrorResponseDoesNotRemapOtherUnauthorized(t *testing.T) {
 	require.NotEqual(t, oauthErrInvalidGrant, got.Error)
 }
 
-func TestParseTokenErrorResponseDoesNotRemapClientAuthFailureMentioningRefreshToken(t *testing.T) {
+func TestParseTokenErrorResponseDoesNotRemapNonLiteralUnauthorizedMessages(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Invalid client credentials for refresh token exchange."}}`))
-	require.Equal(t, "unauthorized", got.Error)
-	require.Equal(t, "Invalid client credentials for refresh token exchange.", got.ErrorDescription)
-}
-
-func TestParseTokenErrorResponseDoesNotRemapClientSubjectFailures(t *testing.T) {
-	t.Parallel()
-
-	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"client ID is invalid for refresh token exchange"}}`))
-	require.Equal(t, "unauthorized", got.Error)
-
-	got = parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"client is unauthorized"}}`))
-	require.Equal(t, "unauthorized", got.Error)
-}
-
-func TestParseTokenErrorResponseRemapsDeadGrantWasNotFound(t *testing.T) {
-	t.Parallel()
-
-	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Refresh token was not found."}}`))
-	require.Equal(t, oauthErrInvalidGrant, got.Error)
-}
-
-func TestParseTokenErrorResponseDoesNotRemapDeadPhraseWithClientAuthWording(t *testing.T) {
-	t.Parallel()
-
-	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Invalid refresh token: client authentication failed"}}`))
-	require.Equal(t, "unauthorized", got.Error)
-}
-
-func TestParseTokenErrorResponseRemapsDeadGrantNamingAClient(t *testing.T) {
-	t.Parallel()
-
-	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Refresh token not found for client abc."}}`))
-	require.Equal(t, oauthErrInvalidGrant, got.Error)
-	require.Equal(t, "Refresh token not found for client abc.", got.ErrorDescription)
+	for _, msg := range []string{
+		"Invalid client credentials for refresh token exchange.",
+		"client ID is invalid for refresh token exchange",
+		"client is unauthorized",
+		"Refresh token not found for client abc.",
+	} {
+		got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"`+msg+`"}}`))
+		require.Equal(t, "unauthorized", got.Error, "message %q must not be remapped", msg)
+	}
 }
 
 func TestParseTokenErrorResponseDoesNotOverrideOtherRFCCodes(t *testing.T) {
@@ -124,15 +106,6 @@ func TestParseTokenErrorResponseKeepsRFCMembersNextToMalformedExtension(t *testi
 	require.Equal(t, "Token has been revoked.", got.ErrorDescription)
 }
 
-func TestParseTokenErrorResponseStandaloneMentionDropsUpstreamMessage(t *testing.T) {
-	t.Parallel()
-
-	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"errors":["Grant failure: invalid_grant (see docs)"]}`))
-	require.Equal(t, oauthErrInvalidGrant, got.Error)
-	require.Empty(t, got.ErrorDescription)
-	require.Equal(t, oauthErrInvalidGrant, got.summary("400 Bad Request"))
-}
-
 func TestNewTokenRefreshErrorFromHTTPDatadogInvalidGrant(t *testing.T) {
 	t.Parallel()
 
@@ -157,7 +130,7 @@ func TestNewTokenRefreshErrorFromHTTPDubUnauthorizedInvalidGrant(t *testing.T) {
 	require.Equal(t, "invalid_grant: Refresh token not found.", err.Reason)
 }
 
-func TestNewTokenRefreshErrorFromHTTPGeneric4xxInvalidGrantToken(t *testing.T) {
+func TestNewTokenRefreshErrorFromHTTPRawTextMentionDoesNotClearGrant(t *testing.T) {
 	t.Parallel()
 
 	err := newTokenRefreshErrorFromHTTP(
@@ -165,8 +138,8 @@ func TestNewTokenRefreshErrorFromHTTPGeneric4xxInvalidGrantToken(t *testing.T) {
 		"400 Bad Request",
 		[]byte(`token endpoint rejected refresh: invalid_grant`),
 	)
-	require.True(t, err.invalidGrant())
-	require.Equal(t, oauthErrInvalidGrant, err.Reason)
+	require.False(t, err.invalidGrant())
+	require.Equal(t, "HTTP 400 Bad Request", err.Reason)
 }
 
 func TestNewTokenRefreshErrorFromHTTPServerErrorDoesNotTreatInvalidGrantToken(t *testing.T) {
@@ -181,24 +154,24 @@ func TestNewTokenRefreshErrorFromHTTPServerErrorDoesNotTreatInvalidGrantToken(t 
 	require.Equal(t, "HTTP 500 Internal Server Error", err.Reason)
 }
 
-func TestNewTokenRefreshErrorFromHTTPServerErrorJSONMentionDoesNotClearGrant(t *testing.T) {
+func TestNewTokenRefreshErrorFromHTTPServerErrorDialectDoesNotClearGrant(t *testing.T) {
 	t.Parallel()
 
 	err := newTokenRefreshErrorFromHTTP(
 		http.StatusInternalServerError,
 		"500 Internal Server Error",
-		[]byte(`{"error":"token rejected: invalid_grant"}`),
+		[]byte(`{"errors": ["invalid_grant - transient upstream fault"]}`),
 	)
 	require.False(t, err.invalidGrant())
 }
 
-func TestNewTokenRefreshErrorFromHTTPRateLimitMentionDoesNotClearGrant(t *testing.T) {
+func TestNewTokenRefreshErrorFromHTTPRateLimitDialectDoesNotClearGrant(t *testing.T) {
 	t.Parallel()
 
 	err := newTokenRefreshErrorFromHTTP(
 		http.StatusTooManyRequests,
 		"429 Too Many Requests",
-		[]byte(`{"message":"Too many requests; see https://api.example.com/docs/errors#invalid_grant"}`),
+		[]byte(`{"errors": ["invalid_grant - throttled"]}`),
 	)
 	require.False(t, err.invalidGrant())
 	require.True(t, IsTokenRefreshRateLimited(err))

--- a/server/internal/remotesessions/token_error_response_test.go
+++ b/server/internal/remotesessions/token_error_response_test.go
@@ -1,0 +1,125 @@
+package remotesessions
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTokenErrorResponseRFC6749(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse([]byte(`{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Equal(t, "Unknown or invalid refresh token.", got.ErrorDescription)
+	require.Equal(t, "invalid_grant: Unknown or invalid refresh token.", got.summary("400 Bad Request"))
+}
+
+func TestParseTokenErrorResponseRFC6749CodeOnly(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse([]byte(`{"error":"temporarily_unavailable"}`))
+	require.Equal(t, "temporarily_unavailable", got.Error)
+	require.Empty(t, got.ErrorDescription)
+	require.Equal(t, "temporarily_unavailable", got.summary("503 Service Unavailable"))
+}
+
+func TestParseTokenErrorResponseDatadogErrorsArray(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse([]byte(`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Equal(t, "Invalid or expired refresh token or code verifier.", got.ErrorDescription)
+	require.Equal(t, "invalid_grant: Invalid or expired refresh token or code verifier.", got.summary("400 Bad Request"))
+}
+
+func TestParseTokenErrorResponseDubNestedUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse([]byte(`{"error":{"code":"unauthorized","message":"Refresh token not found."}}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Equal(t, "Refresh token not found.", got.ErrorDescription)
+	require.Equal(t, "invalid_grant: Refresh token not found.", got.summary("401 Unauthorized"))
+}
+
+func TestParseTokenErrorResponseDubNestedInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse([]byte(`{"error":{"code":"invalid_grant","message":"The refresh token is expired."}}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Equal(t, "The refresh token is expired.", got.ErrorDescription)
+}
+
+func TestParseTokenErrorResponseDoesNotRemapOtherUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse([]byte(`{"error":{"code":"unauthorized","message":"Invalid client credentials."}}`))
+	require.Equal(t, "unauthorized", got.Error)
+	require.Equal(t, "Invalid client credentials.", got.ErrorDescription)
+	require.NotEqual(t, oauthErrInvalidGrant, got.Error)
+}
+
+func TestParseTokenErrorResponseDoesNotOverrideOtherRFCCodes(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse([]byte(`{"error":"invalid_client","error_description":"do not mention invalid_grant here"}`))
+	require.Equal(t, "invalid_client", got.Error)
+	require.Equal(t, "do not mention invalid_grant here", got.ErrorDescription)
+}
+
+func TestParseTokenErrorResponseEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(nil)
+	require.Empty(t, got.Error)
+	require.Equal(t, "HTTP 400 Bad Request", got.summary("400 Bad Request"))
+}
+
+func TestNewTokenRefreshErrorFromHTTPDatadogInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	err := newTokenRefreshErrorFromHTTP(
+		http.StatusBadRequest,
+		"400 Bad Request",
+		[]byte(`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`),
+	)
+	require.True(t, err.invalidGrant())
+	require.Equal(t, "invalid_grant: Invalid or expired refresh token or code verifier.", err.Reason)
+}
+
+func TestNewTokenRefreshErrorFromHTTPDubUnauthorizedInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	err := newTokenRefreshErrorFromHTTP(
+		http.StatusUnauthorized,
+		"401 Unauthorized",
+		[]byte(`{"error":{"code":"unauthorized","message":"Refresh token not found."}}`),
+	)
+	require.True(t, err.invalidGrant())
+	require.Equal(t, "invalid_grant: Refresh token not found.", err.Reason)
+}
+
+func TestNewTokenRefreshErrorFromHTTPGeneric4xxInvalidGrantToken(t *testing.T) {
+	t.Parallel()
+
+	err := newTokenRefreshErrorFromHTTP(
+		http.StatusBadRequest,
+		"400 Bad Request",
+		[]byte(`token endpoint rejected refresh: invalid_grant`),
+	)
+	require.True(t, err.invalidGrant())
+	require.Equal(t, oauthErrInvalidGrant, err.Reason)
+}
+
+func TestNewTokenRefreshErrorFromHTTPServerErrorDoesNotTreatInvalidGrantToken(t *testing.T) {
+	t.Parallel()
+
+	err := newTokenRefreshErrorFromHTTP(
+		http.StatusInternalServerError,
+		"500 Internal Server Error",
+		[]byte(`upstream mentioned invalid_grant on an error page`),
+	)
+	require.False(t, err.invalidGrant())
+	require.Equal(t, "HTTP 500 Internal Server Error", err.Reason)
+}

--- a/server/internal/remotesessions/token_error_response_test.go
+++ b/server/internal/remotesessions/token_error_response_test.go
@@ -78,6 +78,20 @@ func TestParseTokenErrorResponseDoesNotRemapClientSubjectFailures(t *testing.T) 
 	require.Equal(t, "unauthorized", got.Error)
 }
 
+func TestParseTokenErrorResponseRemapsDeadGrantWasNotFound(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Refresh token was not found."}}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+}
+
+func TestParseTokenErrorResponseDoesNotRemapDeadPhraseWithClientAuthWording(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Invalid refresh token: client authentication failed"}}`))
+	require.Equal(t, "unauthorized", got.Error)
+}
+
 func TestParseTokenErrorResponseRemapsDeadGrantNamingAClient(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/token_error_response_test.go
+++ b/server/internal/remotesessions/token_error_response_test.go
@@ -82,6 +82,14 @@ func TestParseTokenErrorResponseDoesNotRemapNonLiteralUnauthorizedMessages(t *te
 	}
 }
 
+func TestParseTokenErrorResponseDialectInheritsTopLevelDescription(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"errors":["invalid_grant"],"error_description":"Token has been revoked."}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Equal(t, "Token has been revoked.", got.ErrorDescription)
+}
+
 func TestParseTokenErrorResponseDoesNotOverrideOtherRFCCodes(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/token_error_response_test.go
+++ b/server/internal/remotesessions/token_error_response_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseTokenErrorResponseRFC6749(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse([]byte(`{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}`))
+	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}`))
 	require.Equal(t, oauthErrInvalidGrant, got.Error)
 	require.Equal(t, "Unknown or invalid refresh token.", got.ErrorDescription)
 	require.Equal(t, "invalid_grant: Unknown or invalid refresh token.", got.summary("400 Bad Request"))
@@ -19,7 +19,7 @@ func TestParseTokenErrorResponseRFC6749(t *testing.T) {
 func TestParseTokenErrorResponseRFC6749CodeOnly(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse([]byte(`{"error":"temporarily_unavailable"}`))
+	got := parseTokenErrorResponse(http.StatusServiceUnavailable, []byte(`{"error":"temporarily_unavailable"}`))
 	require.Equal(t, "temporarily_unavailable", got.Error)
 	require.Empty(t, got.ErrorDescription)
 	require.Equal(t, "temporarily_unavailable", got.summary("503 Service Unavailable"))
@@ -28,7 +28,7 @@ func TestParseTokenErrorResponseRFC6749CodeOnly(t *testing.T) {
 func TestParseTokenErrorResponseDatadogErrorsArray(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse([]byte(`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`))
+	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`))
 	require.Equal(t, oauthErrInvalidGrant, got.Error)
 	require.Equal(t, "Invalid or expired refresh token or code verifier.", got.ErrorDescription)
 	require.Equal(t, "invalid_grant: Invalid or expired refresh token or code verifier.", got.summary("400 Bad Request"))
@@ -37,7 +37,7 @@ func TestParseTokenErrorResponseDatadogErrorsArray(t *testing.T) {
 func TestParseTokenErrorResponseDubNestedUnauthorized(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse([]byte(`{"error":{"code":"unauthorized","message":"Refresh token not found."}}`))
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Refresh token not found."}}`))
 	require.Equal(t, oauthErrInvalidGrant, got.Error)
 	require.Equal(t, "Refresh token not found.", got.ErrorDescription)
 	require.Equal(t, "invalid_grant: Refresh token not found.", got.summary("401 Unauthorized"))
@@ -46,7 +46,7 @@ func TestParseTokenErrorResponseDubNestedUnauthorized(t *testing.T) {
 func TestParseTokenErrorResponseDubNestedInvalidGrant(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse([]byte(`{"error":{"code":"invalid_grant","message":"The refresh token is expired."}}`))
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"invalid_grant","message":"The refresh token is expired."}}`))
 	require.Equal(t, oauthErrInvalidGrant, got.Error)
 	require.Equal(t, "The refresh token is expired.", got.ErrorDescription)
 }
@@ -54,16 +54,24 @@ func TestParseTokenErrorResponseDubNestedInvalidGrant(t *testing.T) {
 func TestParseTokenErrorResponseDoesNotRemapOtherUnauthorized(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse([]byte(`{"error":{"code":"unauthorized","message":"Invalid client credentials."}}`))
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Invalid client credentials."}}`))
 	require.Equal(t, "unauthorized", got.Error)
 	require.Equal(t, "Invalid client credentials.", got.ErrorDescription)
 	require.NotEqual(t, oauthErrInvalidGrant, got.Error)
 }
 
+func TestParseTokenErrorResponseDoesNotRemapClientAuthFailureMentioningRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"Invalid client credentials for refresh token exchange."}}`))
+	require.Equal(t, "unauthorized", got.Error)
+	require.Equal(t, "Invalid client credentials for refresh token exchange.", got.ErrorDescription)
+}
+
 func TestParseTokenErrorResponseDoesNotOverrideOtherRFCCodes(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse([]byte(`{"error":"invalid_client","error_description":"do not mention invalid_grant here"}`))
+	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"error":"invalid_client","error_description":"do not mention invalid_grant here"}`))
 	require.Equal(t, "invalid_client", got.Error)
 	require.Equal(t, "do not mention invalid_grant here", got.ErrorDescription)
 }
@@ -71,9 +79,26 @@ func TestParseTokenErrorResponseDoesNotOverrideOtherRFCCodes(t *testing.T) {
 func TestParseTokenErrorResponseEmptyBody(t *testing.T) {
 	t.Parallel()
 
-	got := parseTokenErrorResponse(nil)
+	got := parseTokenErrorResponse(http.StatusBadRequest, nil)
 	require.Empty(t, got.Error)
 	require.Equal(t, "HTTP 400 Bad Request", got.summary("400 Bad Request"))
+}
+
+func TestParseTokenErrorResponseKeepsRFCMembersNextToMalformedExtension(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"error":"invalid_grant","error_description":"Token has been revoked.","errors":[{"detail":"x"}]}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Equal(t, "Token has been revoked.", got.ErrorDescription)
+}
+
+func TestParseTokenErrorResponseStandaloneMentionDropsUpstreamMessage(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusBadRequest, []byte(`{"errors":["Grant failure: invalid_grant (see docs)"]}`))
+	require.Equal(t, oauthErrInvalidGrant, got.Error)
+	require.Empty(t, got.ErrorDescription)
+	require.Equal(t, oauthErrInvalidGrant, got.summary("400 Bad Request"))
 }
 
 func TestNewTokenRefreshErrorFromHTTPDatadogInvalidGrant(t *testing.T) {
@@ -122,4 +147,38 @@ func TestNewTokenRefreshErrorFromHTTPServerErrorDoesNotTreatInvalidGrantToken(t 
 	)
 	require.False(t, err.invalidGrant())
 	require.Equal(t, "HTTP 500 Internal Server Error", err.Reason)
+}
+
+func TestNewTokenRefreshErrorFromHTTPServerErrorJSONMentionDoesNotClearGrant(t *testing.T) {
+	t.Parallel()
+
+	err := newTokenRefreshErrorFromHTTP(
+		http.StatusInternalServerError,
+		"500 Internal Server Error",
+		[]byte(`{"error":"token rejected: invalid_grant"}`),
+	)
+	require.False(t, err.invalidGrant())
+}
+
+func TestNewTokenRefreshErrorFromHTTPRateLimitMentionDoesNotClearGrant(t *testing.T) {
+	t.Parallel()
+
+	err := newTokenRefreshErrorFromHTTP(
+		http.StatusTooManyRequests,
+		"429 Too Many Requests",
+		[]byte(`{"message":"Too many requests; see https://api.example.com/docs/errors#invalid_grant"}`),
+	)
+	require.False(t, err.invalidGrant())
+	require.True(t, IsTokenRefreshRateLimited(err))
+}
+
+func TestNewTokenRefreshErrorFromHTTPServerErrorExactRFCCodeStillDefinitive(t *testing.T) {
+	t.Parallel()
+
+	err := newTokenRefreshErrorFromHTTP(
+		http.StatusInternalServerError,
+		"500 Internal Server Error",
+		[]byte(`{"error":"invalid_grant"}`),
+	)
+	require.True(t, err.invalidGrant())
 }

--- a/server/internal/remotesessions/token_error_response_test.go
+++ b/server/internal/remotesessions/token_error_response_test.go
@@ -68,6 +68,16 @@ func TestParseTokenErrorResponseDoesNotRemapClientAuthFailureMentioningRefreshTo
 	require.Equal(t, "Invalid client credentials for refresh token exchange.", got.ErrorDescription)
 }
 
+func TestParseTokenErrorResponseDoesNotRemapClientSubjectFailures(t *testing.T) {
+	t.Parallel()
+
+	got := parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"client ID is invalid for refresh token exchange"}}`))
+	require.Equal(t, "unauthorized", got.Error)
+
+	got = parseTokenErrorResponse(http.StatusUnauthorized, []byte(`{"error":{"code":"unauthorized","message":"client is unauthorized"}}`))
+	require.Equal(t, "unauthorized", got.Error)
+}
+
 func TestParseTokenErrorResponseRemapsDeadGrantNamingAClient(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/token_refresh_error.go
+++ b/server/internal/remotesessions/token_refresh_error.go
@@ -56,15 +56,8 @@ func IsTokenRefreshRateLimited(err error) bool {
 // error body (falling back to the HTTP status); the raw status and body are kept
 // only as the private cause and never surfaced.
 //
-// A 4xx body that contains the invalid_grant token is treated as definitive
-// even when the provider did not emit a spec-shaped "error" string. 5xx pages,
-// rate limits, and request timeouts are not, so a mention of the code on an
-// upstream error page does not clear a still-usable refresh grant.
 func newTokenRefreshErrorFromHTTP(statusCode int, status string, body []byte) *TokenRefreshError {
 	response := parseTokenErrorResponse(statusCode, body)
-	if response.Error == "" && allowsHeuristicInvalidGrant(statusCode) && containsOAuthErrorToken(string(body), oauthErrInvalidGrant) {
-		response.Error = oauthErrInvalidGrant
-	}
 	return &TokenRefreshError{
 		Reason:     response.summary(status),
 		cause:      fmt.Errorf("refresh endpoint %s: %s", status, string(body)),

--- a/server/internal/remotesessions/token_refresh_error.go
+++ b/server/internal/remotesessions/token_refresh_error.go
@@ -52,11 +52,19 @@ func IsTokenRefreshRateLimited(err error) bool {
 }
 
 // newTokenRefreshErrorFromHTTP builds a TokenRefreshError from a non-2xx response
-// from the upstream token endpoint. The public Reason summarizes the RFC 6749
+// from the upstream token endpoint. The public Reason summarizes the parsed
 // error body (falling back to the HTTP status); the raw status and body are kept
 // only as the private cause and never surfaced.
+//
+// A 4xx body that contains the invalid_grant token is treated as definitive
+// even when the provider did not emit a spec-shaped "error" string. 5xx bodies
+// are not, so a mention of the code on an upstream error page does not clear
+// a still-usable refresh grant.
 func newTokenRefreshErrorFromHTTP(statusCode int, status string, body []byte) *TokenRefreshError {
 	response := parseTokenErrorResponse(body)
+	if response.Error == "" && statusCode >= 400 && statusCode < 500 && containsOAuthErrorToken(string(body), oauthErrInvalidGrant) {
+		response.Error = oauthErrInvalidGrant
+	}
 	return &TokenRefreshError{
 		Reason:     response.summary(status),
 		cause:      fmt.Errorf("refresh endpoint %s: %s", status, string(body)),

--- a/server/internal/remotesessions/token_refresh_error.go
+++ b/server/internal/remotesessions/token_refresh_error.go
@@ -55,7 +55,6 @@ func IsTokenRefreshRateLimited(err error) bool {
 // from the upstream token endpoint. The public Reason summarizes the parsed
 // error body (falling back to the HTTP status); the raw status and body are kept
 // only as the private cause and never surfaced.
-//
 func newTokenRefreshErrorFromHTTP(statusCode int, status string, body []byte) *TokenRefreshError {
 	response := parseTokenErrorResponse(statusCode, body)
 	return &TokenRefreshError{

--- a/server/internal/remotesessions/token_refresh_error.go
+++ b/server/internal/remotesessions/token_refresh_error.go
@@ -57,12 +57,12 @@ func IsTokenRefreshRateLimited(err error) bool {
 // only as the private cause and never surfaced.
 //
 // A 4xx body that contains the invalid_grant token is treated as definitive
-// even when the provider did not emit a spec-shaped "error" string. 5xx bodies
-// are not, so a mention of the code on an upstream error page does not clear
-// a still-usable refresh grant.
+// even when the provider did not emit a spec-shaped "error" string. 5xx pages,
+// rate limits, and request timeouts are not, so a mention of the code on an
+// upstream error page does not clear a still-usable refresh grant.
 func newTokenRefreshErrorFromHTTP(statusCode int, status string, body []byte) *TokenRefreshError {
-	response := parseTokenErrorResponse(body)
-	if response.Error == "" && statusCode >= 400 && statusCode < 500 && containsOAuthErrorToken(string(body), oauthErrInvalidGrant) {
+	response := parseTokenErrorResponse(statusCode, body)
+	if response.Error == "" && allowsHeuristicInvalidGrant(statusCode) && containsOAuthErrorToken(string(body), oauthErrInvalidGrant) {
 		response.Error = oauthErrInvalidGrant
 	}
 	return &TokenRefreshError{


### PR DESCRIPTION
AIS-616

## Summary

`parseTokenErrorResponse` now recognizes the two observed non-RFC token-endpoint error dialects, and `RefreshNow` therefore clears the stored refresh grant after a single definitive rejection:

- Datadog: an `errors[]` entry that starts with `invalid_grant` (with an optional trailing description)
- Dub: a nested `error` object with `code: "unauthorized"` and a literal known dead-grant message ("Refresh token not found.")

Classification is deliberately shape-based, not text-based: free-text and phrase heuristics were tried and repeatedly misclassified recoverable failures (rate limits, 5xx error pages, client-auth failures) as dead grants, which irreversibly clears live tokens. An unrecognized provider now degrades to retry-and-rechallenge, and new providers are added as explicit literals when observed in logs (the raw body is preserved in the private error cause). Non-RFC dialects only classify on 4xx excluding 408/429; exact RFC `{"error":"invalid_grant"}` stays definitive on any status. JSON members are decoded independently so a malformed provider extension cannot mask RFC fields.

The public `Reason` for recognized shapes is `invalid_grant: …` instead of the HTTP status fallback.

## Motivation

Two production token endpoints reject a dead refresh token without a string `error` member. The parsed code stayed empty, so `invalidGrant()` was false and the dead grant remained on the `remote_sessions` row. Every later MCP request re-presented the same token, got the same rejection, and the issuer gate returned 401. Clearing the grant once lets subsequent requests short-circuit on `ErrNoValidToken` until the user reconnects.

Linear Issue: [AIS-616](https://linear.app/speakeasy/issue/AIS-616/fix-clear-dead-remote-session-refresh-tokens-when-the-upstream-returns)
