### PR TITLE
feat: add org-level Event Feed page

### DIFF
--- a/.changeset/otel-event-feed-ui.md
+++ b/.changeset/otel-event-feed-ui.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+New org-level Data > Event Feed page showing every OTel signal ingested through Gram: search and kind/source/name filters, a stacked logs-vs-spans volume chart, an infinite-scrolling event table, and a detail sheet with Parsed and Raw views.

--- a/client/dashboard/src/components/log-workbench.tsx
+++ b/client/dashboard/src/components/log-workbench.tsx
@@ -14,6 +14,8 @@ export interface LogWorkbenchProps {
   description?: React.ReactNode;
   actions?: React.ReactNode;
   filters?: React.ReactNode;
+  /** Full-width row (e.g. a summary chart) between the filters and the log surface. */
+  summary?: React.ReactNode;
   status?: React.ReactNode;
   header?: React.ReactNode;
   children: React.ReactNode;
@@ -33,6 +35,7 @@ export function LogWorkbench({
   description,
   actions,
   filters,
+  summary,
   status,
   header,
   children,
@@ -73,6 +76,8 @@ export function LogWorkbench({
             <div className="flex flex-wrap items-center gap-4">{filters}</div>
           ) : null}
         </div>
+
+        {summary ? <div className="shrink-0">{summary}</div> : null}
 
         {/* Inset the table in a bordered card so it doesn't run full-bleed to
             the page edges — matching the Tool Logs page layout. */}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -91,6 +91,8 @@ export function OrgSidebar({
     orgRoutes.encryptionKeys,
   ].some((r) => r.active);
 
+  const dataActive = [orgRoutes.data].some((r) => r.active);
+
   const secureActive = [
     orgRoutes.auditLogs,
     orgRoutes.deviceAgent,
@@ -112,15 +114,14 @@ export function OrgSidebar({
     orgRoutes.platformRemoteIdentityProviders,
   ].some((r) => r.active);
 
-  const activeGroup = settingsActive
-    ? "Settings"
-    : secureActive
-      ? "Secure"
-      : identityActive
-        ? "Identity"
-        : platformAdminActive
-          ? "Platform Admin"
-          : undefined;
+  const groupActivations: Array<[string, boolean]> = [
+    ["Settings", settingsActive],
+    ["Data", dataActive],
+    ["Secure", secureActive],
+    ["Identity", identityActive],
+    ["Platform Admin", platformAdminActive],
+  ];
+  const activeGroup = groupActivations.find(([, active]) => active)?.[0];
 
   const allOrgNavRoutes = [
     orgRoutes.home,
@@ -136,6 +137,7 @@ export function OrgSidebar({
     orgRoutes.webhooks,
     orgRoutes.externalServices,
     orgRoutes.encryptionKeys,
+    orgRoutes.data,
     orgRoutes.auditLogs,
     orgRoutes.deviceAgent,
     orgRoutes.access,
@@ -174,7 +176,7 @@ export function OrgSidebar({
         ) : (
           <NavGroupProvider
             activeGroup={activeGroup}
-            defaultOpenGroups={["Settings", "Secure", "Identity"]}
+            defaultOpenGroups={["Settings", "Data", "Secure", "Identity"]}
             activeItem={activeItem}
           >
             <SidebarMenu className="gap-1 px-2">
@@ -230,6 +232,14 @@ export function OrgSidebar({
                   { item: orgRoutes.aiIntegrations, scope: orgReadOrAdmin },
                   { item: orgRoutes.webhooks, scope: orgReadOrAdmin },
                 ]}
+              />
+
+              {/* Data group — org-wide ingested telemetry surfaces. The Event
+                  Feed item carries a Preview badge via its route's `stage`. */}
+              <ScopeGatedNavGroup
+                label="Data"
+                Icon={(p) => <Icon {...p} name="database" />}
+                items={[{ item: orgRoutes.data, scope: orgReadOrAdmin }]}
               />
 
               {/* Secure group */}

--- a/client/dashboard/src/pages/data/EventDetailSheet.tsx
+++ b/client/dashboard/src/pages/data/EventDetailSheet.tsx
@@ -72,7 +72,6 @@ function EventDetailContent({ event }: { event: EventLogEntry }) {
 
         {/* Meta — definition-list rows with eyebrow keys and copyable mono values */}
         <div className="border-border divide-border flex flex-col divide-y border-y">
-          <MetadataRow label="Record ID" value={event.recordId} />
           {event.traceId && (
             <MetadataRow label="Trace ID" value={event.traceId} />
           )}

--- a/client/dashboard/src/pages/data/EventDetailSheet.tsx
+++ b/client/dashboard/src/pages/data/EventDetailSheet.tsx
@@ -29,7 +29,11 @@ export function EventDetailSheet({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         className="h-full max-h-screen overflow-y-auto"
-        style={{ width: "33vw", minWidth: 500, maxWidth: "none" }}
+        style={{
+          width: "33vw",
+          minWidth: "min(500px, 100vw)",
+          maxWidth: "none",
+        }}
       >
         {event && <EventDetailContent event={event} />}
       </SheetContent>
@@ -115,6 +119,12 @@ function EventDetailContent({ event }: { event: EventLogEntry }) {
   );
 }
 
+// The Clipboard API is undefined in insecure contexts, so guard before
+// writing rather than throwing from the click handler.
+function copyToClipboard(value: string) {
+  void navigator.clipboard?.writeText(value);
+}
+
 function CopyButton({
   value,
   label,
@@ -130,7 +140,7 @@ function CopyButton({
       aria-label={label}
       title={label}
       className={cn("hover:bg-muted p-1.5", className)}
-      onClick={() => void navigator.clipboard.writeText(value)}
+      onClick={() => copyToClipboard(value)}
     >
       <Copy aria-hidden="true" className="size-4" />
     </button>
@@ -142,7 +152,7 @@ function MetadataRow({ label, value }: { label: string; value: string }) {
     <button
       type="button"
       className="hover:bg-muted/50 flex items-center justify-between gap-4 py-2 text-left transition-colors"
-      onClick={() => void navigator.clipboard.writeText(value)}
+      onClick={() => copyToClipboard(value)}
       title={`Copy ${label}`}
     >
       <span className="text-eyebrow shrink-0">{label}</span>

--- a/client/dashboard/src/pages/data/EventDetailSheet.tsx
+++ b/client/dashboard/src/pages/data/EventDetailSheet.tsx
@@ -1,0 +1,253 @@
+import { unixNanoToDate } from "@/components/chart/chartUtils";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/Sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
+import { useOrganization } from "@/contexts/Auth";
+import { formatPlatform } from "@/lib/formatPlatform";
+import { cn } from "@/lib/utils";
+import type { EventLogEntry } from "@gram/client/models/components/eventlogentry.js";
+import { Copy } from "lucide-react";
+import { EventKindBadge, EventSourceIcon } from "./event-display";
+
+interface EventDetailSheetProps {
+  event: EventLogEntry | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Detail sheet for a single event-feed entry (an ingested OpenTelemetry log
+ * record or span). Two tabs: Parsed (flattened attribute key/value rows with
+ * per-value copy) and Raw (the pretty-printed full record). Modeled on
+ * `LogDetailSheet`.
+ */
+export function EventDetailSheet({
+  event,
+  open,
+  onOpenChange,
+}: EventDetailSheetProps): JSX.Element {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        className="h-full max-h-screen overflow-y-auto"
+        style={{ width: "33vw", minWidth: 500, maxWidth: "none" }}
+      >
+        {event && <EventDetailContent event={event} />}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function EventDetailContent({ event }: { event: EventLogEntry }) {
+  const organization = useOrganization();
+  const projectLabel =
+    organization.projects.find((p) => p.id === event.projectId)?.name ??
+    event.projectId;
+  const timeLabel = unixNanoToDate(event.timeUnixNano).toLocaleString();
+  const rawJson = JSON.stringify(event, null, 2);
+
+  return (
+    <div className="flex flex-col gap-6 px-5 pt-6 pb-6">
+      {/* Header — kind + source marks over the name, then a meta subtitle */}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <EventKindBadge kind={event.kind} />
+            <EventSourceIcon
+              source={event.source}
+              className="size-4 shrink-0"
+            />
+          </div>
+          <SheetTitle className="font-display text-xl font-light tracking-tight break-words">
+            {event.name || "(unnamed event)"}
+          </SheetTitle>
+          <p className="text-muted-foreground text-sm">
+            {formatPlatform(event.source)} &middot; {projectLabel} &middot;{" "}
+            {timeLabel}
+          </p>
+        </div>
+
+        {/* Meta — definition-list rows with eyebrow keys and copyable mono values */}
+        <div className="border-border divide-border flex flex-col divide-y border-y">
+          <MetadataRow label="Record ID" value={event.recordId} />
+          {event.traceId && (
+            <MetadataRow label="Trace ID" value={event.traceId} />
+          )}
+          {event.spanId && <MetadataRow label="Span ID" value={event.spanId} />}
+        </div>
+      </div>
+
+      {/* Tabs: Parsed / Raw */}
+      <Tabs defaultValue="parsed" className="w-full flex-1">
+        <TabsList className="w-full">
+          <TabsTrigger value="parsed" className="flex-1">
+            Parsed
+          </TabsTrigger>
+          <TabsTrigger value="raw" className="flex-1">
+            Raw
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="parsed" className="mt-5 flex flex-col gap-5">
+          {event.bodyPreview && <BodySection body={event.bodyPreview} />}
+          <AttributeSection
+            title="Attributes"
+            data={asRecord(event.attributes)}
+          />
+          <AttributeSection
+            title="Resource"
+            data={asRecord(event.resourceAttributes)}
+          />
+        </TabsContent>
+
+        <TabsContent value="raw" className="mt-5 flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <div className="text-eyebrow">Full Event Record</div>
+            <CopyButton value={rawJson} label="Copy full event record" />
+          </div>
+          <div className="border-border flex-1 overflow-y-auto border p-4">
+            <pre className="font-mono text-sm break-all whitespace-pre-wrap">
+              {rawJson}
+            </pre>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function CopyButton({
+  value,
+  label,
+  className,
+}: {
+  value: string;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className={cn("hover:bg-muted p-1.5", className)}
+      onClick={() => void navigator.clipboard.writeText(value)}
+    >
+      <Copy aria-hidden="true" className="size-4" />
+    </button>
+  );
+}
+
+function MetadataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <button
+      type="button"
+      className="hover:bg-muted/50 flex items-center justify-between gap-4 py-2 text-left transition-colors"
+      onClick={() => void navigator.clipboard.writeText(value)}
+      title={`Copy ${label}`}
+    >
+      <span className="text-eyebrow shrink-0">{label}</span>
+      <span className="min-w-0 truncate font-mono text-xs">{value}</span>
+    </button>
+  );
+}
+
+function BodySection({ body }: { body: string }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="text-eyebrow">Body</div>
+        <CopyButton value={body} label="Copy body" />
+      </div>
+      <div className="border-border max-h-96 overflow-y-auto border p-4">
+        <pre className="font-mono text-sm break-words whitespace-pre-wrap">
+          {body}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+interface FlatAttribute {
+  key: string;
+  value: string;
+}
+
+// Flatten a nested attribute object into dot-notation key/value rows,
+// e.g. { http: { method: "POST" } } => [{ key: "http.method", value: "POST" }].
+function flattenAttributes(
+  obj: Record<string, unknown>,
+  prefix = "",
+): FlatAttribute[] {
+  const result: FlatAttribute[] = [];
+  for (const [key, raw] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+      const nested = raw as Record<string, unknown>;
+      if (Object.keys(nested).length > 0) {
+        result.push(...flattenAttributes(nested, fullKey));
+      }
+      continue;
+    }
+    result.push({ key: fullKey, value: stringifyAttributeValue(raw) });
+  }
+  return result;
+}
+
+function stringifyAttributeValue(value: unknown): string {
+  if (value === null || value === undefined) return "\u2014";
+  if (typeof value === "string") return value || "\u2014";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function AttributeSection({
+  title,
+  data,
+}: {
+  title: string;
+  data: Record<string, unknown> | null;
+}) {
+  if (!data || Object.keys(data).length === 0) return null;
+  const entries = flattenAttributes(data);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="text-eyebrow">{title}</div>
+        <CopyButton
+          value={JSON.stringify(data, null, 2)}
+          label={`Copy ${title.toLowerCase()}`}
+        />
+      </div>
+      <div className="border-border divide-border divide-y border-y">
+        {entries.map((entry) => (
+          <div
+            key={entry.key}
+            className="group hover:bg-muted/50 relative flex flex-col gap-1 px-2 py-2.5 transition-colors"
+          >
+            <span className="text-muted-foreground pr-8 text-xs break-all">
+              {entry.key}
+            </span>
+            <span className="pr-8 font-mono text-sm break-all">
+              {entry.value}
+            </span>
+            <CopyButton
+              value={entry.value}
+              label={`Copy ${entry.key}`}
+              className="absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/data/EventFeed.tsx
+++ b/client/dashboard/src/pages/data/EventFeed.tsx
@@ -15,9 +15,9 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { getPresetRange } from "@/elements";
 import { formatPlatform } from "@/lib/formatPlatform";
 import { cn } from "@/lib/utils";
-import { telemetryGetEventFacets } from "@gram/client/funcs/telemetryGetEventFacets";
-import { telemetryGetEventVolume } from "@gram/client/funcs/telemetryGetEventVolume";
-import { telemetryListEventLog } from "@gram/client/funcs/telemetryListEventLog";
+import { otelGetEventFacets } from "@gram/client/funcs/otelGetEventFacets";
+import { otelGetEventVolume } from "@gram/client/funcs/otelGetEventVolume";
+import { otelListEventLog } from "@gram/client/funcs/otelListEventLog";
 import {
   EventLogEntryKind,
   type EventLogEntry,
@@ -115,7 +115,7 @@ function EventFeedWorkbench(): JSX.Element {
     queryKey: ["event-feed", "facets", fromIso, toIso, kinds],
     queryFn: () =>
       unwrapAsync(
-        telemetryGetEventFacets(client, {
+        otelGetEventFacets(client, {
           getEventFacetsPayload: {
             from,
             to,
@@ -139,7 +139,7 @@ function EventFeedWorkbench(): JSX.Element {
     ],
     queryFn: () =>
       unwrapAsync(
-        telemetryGetEventVolume(client, {
+        otelGetEventVolume(client, {
           getEventVolumePayload: {
             from,
             to,
@@ -166,7 +166,7 @@ function EventFeedWorkbench(): JSX.Element {
     ],
     queryFn: ({ pageParam }) =>
       unwrapAsync(
-        telemetryListEventLog(client, {
+        otelListEventLog(client, {
           listEventLogPayload: {
             from,
             to,
@@ -424,8 +424,15 @@ function EventFeedRows({
 
   return (
     <>
-      {events.map((event) => (
-        <EventFeedRow key={event.recordId} event={event} onSelect={onSelect} />
+      {events.map((event, i) => (
+        // Events have no server-side identity (at-least-once ingestion can
+        // even surface duplicates), so key by position: the list only ever
+        // appends as pages load, keeping index keys stable.
+        <EventFeedRow
+          key={`${event.timeUnixNano}-${i}`}
+          event={event}
+          onSelect={onSelect}
+        />
       ))}
 
       {isFetchingNextPage && (

--- a/client/dashboard/src/pages/data/EventFeed.tsx
+++ b/client/dashboard/src/pages/data/EventFeed.tsx
@@ -95,13 +95,18 @@ function EventFeedWorkbench(): JSX.Element {
   const names = values.name;
   const searchTerm = search.trim();
 
+  // Bumped on manual refresh so relative presets re-anchor to "now" instead
+  // of serving the window computed when the filter was last touched.
+  const [rangeEpoch, setRangeEpoch] = useState(0);
+
   // The date range always resolves to a concrete window (the API requires
   // from/to): a custom range as picked, otherwise the preset (default 24h).
   const { from, to } = useMemo(() => {
+    void rangeEpoch;
     const d = values.date;
     if (d.customRange) return d.customRange;
     return getPresetRange(d.preset ?? "1d");
-  }, [values.date]);
+  }, [values.date, rangeEpoch]);
   const fromIso = from.toISOString();
   const toIso = to.toISOString();
   const timeRangeMs = to.getTime() - from.getTime();
@@ -222,11 +227,22 @@ function EventFeedWorkbench(): JSX.Element {
     [facetsQuery.data],
   );
 
+  const { refetch: refetchEvents } = eventsQuery;
+  const { refetch: refetchVolume } = volumeQuery;
+  const { refetch: refetchFacets } = facetsQuery;
+  const hasCustomRange = !!values.date.customRange;
   const refetchAll = useCallback(() => {
-    void eventsQuery.refetch();
-    void volumeQuery.refetch();
-    void facetsQuery.refetch();
-  }, [eventsQuery.refetch, volumeQuery.refetch, facetsQuery.refetch]);
+    if (hasCustomRange) {
+      // Custom windows are fixed, so the query keys don't move: refetch them.
+      void refetchEvents();
+      void refetchVolume();
+      void refetchFacets();
+      return;
+    }
+    // Relative presets re-anchor to "now"; the key change refetches all
+    // three queries against the advanced window.
+    setRangeEpoch((epoch) => epoch + 1);
+  }, [hasCustomRange, refetchEvents, refetchVolume, refetchFacets]);
 
   const handleScroll = useCallback(
     (e: React.UIEvent<HTMLDivElement>) => {
@@ -327,6 +343,7 @@ function EventFeedWorkbench(): JSX.Element {
         hasActiveFilters={hasActiveFilters}
         isFetchingNextPage={eventsQuery.isFetchingNextPage}
         onSelect={setSelectedEvent}
+        onRetry={() => void eventsQuery.fetchNextPage()}
       />
     </LogWorkbench>
   );
@@ -356,6 +373,7 @@ function EventFeedRows({
   hasActiveFilters,
   isFetchingNextPage,
   onSelect,
+  onRetry,
 }: {
   error: Error | null;
   isLoading: boolean;
@@ -363,8 +381,12 @@ function EventFeedRows({
   hasActiveFilters: boolean;
   isFetchingNextPage: boolean;
   onSelect: (event: EventLogEntry) => void;
+  onRetry: () => void;
 }) {
-  if (error) {
+  // The full-page error view is reserved for an initial load failure; when a
+  // later page fails, the rows already loaded stay visible and the error
+  // renders as an inline retry strip below them.
+  if (error && events.length === 0) {
     return (
       <div className="flex flex-col items-center gap-3 py-12">
         <div className="bg-destructive/10 flex size-12 items-center justify-center">
@@ -410,6 +432,18 @@ function EventFeedRows({
         <div className="text-muted-foreground flex items-center justify-center gap-2 border-t py-4">
           <Icon name="loader-circle" className="size-4 animate-spin" />
           <span className="text-sm">Loading more events...</span>
+        </div>
+      )}
+
+      {error && !isFetchingNextPage && (
+        <div className="flex items-center justify-center gap-3 border-t py-4">
+          <Icon name="circle-alert" className="text-destructive size-4" />
+          <span className="text-muted-foreground text-sm">
+            Failed to load more events.
+          </span>
+          <Button variant="tertiary" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
         </div>
       )}
     </>

--- a/client/dashboard/src/pages/data/EventFeed.tsx
+++ b/client/dashboard/src/pages/data/EventFeed.tsx
@@ -1,0 +1,508 @@
+import { unixNanoToDate } from "@/components/chart/chartUtils";
+import {
+  defineFilters,
+  useFilterState,
+  type FilterValue,
+  type OptionsById,
+} from "@/components/filters";
+import { InlineEmptyState } from "@/components/inline-empty-state";
+import { LogWorkbench } from "@/components/log-workbench";
+import { Page } from "@/components/page-layout";
+import { WorkbenchPage } from "@/components/page-templates";
+import { Button } from "@/components/ui/Button";
+import { Icon } from "@/components/ui/Icon";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { getPresetRange } from "@/elements";
+import { formatPlatform } from "@/lib/formatPlatform";
+import { cn } from "@/lib/utils";
+import { telemetryGetEventFacets } from "@gram/client/funcs/telemetryGetEventFacets";
+import { telemetryGetEventVolume } from "@gram/client/funcs/telemetryGetEventVolume";
+import { telemetryListEventLog } from "@gram/client/funcs/telemetryListEventLog";
+import {
+  EventLogEntryKind,
+  type EventLogEntry,
+} from "@gram/client/models/components/eventlogentry.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { unwrapAsync } from "@gram/client/types/fp";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EventDetailSheet } from "./EventDetailSheet";
+import { EventKindBadge, EventSourceIcon } from "./event-display";
+import { EventVolumeChart } from "./EventVolumeChart";
+
+// Column tracks shared by the header row and every data row. Body gets the
+// widest track and a min-width-0 cell so it truncates responsively.
+const EVENT_FEED_GRID =
+  "grid grid-cols-[130px_64px_minmax(0,0.9fr)_minmax(0,1fr)_minmax(0,2fr)] gap-3";
+
+const PAGE_SIZE = 50;
+
+// Strongly-typed filter schema for the event feed. Everything is pinned: the
+// feed is read along exactly these axes (time window, signal kind, source,
+// name), so no dimension belongs behind "More filters".
+const EVENT_FEED_FILTERS = defineFilters([
+  {
+    id: "date",
+    label: "Date range",
+    kind: "daterange",
+    pinned: true,
+    defaultPreset: "1d",
+  },
+  {
+    id: "kind",
+    label: "Kind",
+    kind: "multiselect",
+    pinned: true,
+    allLabel: "All kinds",
+  },
+  { id: "source", label: "Source", kind: "multiselect", pinned: true },
+  { id: "name", label: "Name", kind: "multiselect", pinned: true },
+]);
+
+const KIND_OPTIONS = [
+  { label: "Logs", value: EventLogEntryKind.Log },
+  { label: "Spans", value: EventLogEntryKind.Span },
+];
+
+function isEventKind(value: string): value is EventLogEntryKind {
+  return value === EventLogEntryKind.Log || value === EventLogEntryKind.Span;
+}
+
+export default function EventFeed(): JSX.Element {
+  // The scope gate wraps the data-owning component so its queries never fire
+  // for unauthorized users.
+  return (
+    <WorkbenchPage scope="org:read">
+      <EventFeedWorkbench />
+    </WorkbenchPage>
+  );
+}
+
+function EventFeedWorkbench(): JSX.Element {
+  const client = useGramContext();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { values, setValue, clearValue, clearAll } =
+    useFilterState(EVENT_FEED_FILTERS);
+  const [search, setSearch] = useState("");
+  const [selectedEvent, setSelectedEvent] = useState<EventLogEntry | null>(
+    null,
+  );
+
+  const kinds = useMemo(() => values.kind.filter(isEventKind), [values.kind]);
+  const sources = values.source;
+  const names = values.name;
+  const searchTerm = search.trim();
+
+  // The date range always resolves to a concrete window (the API requires
+  // from/to): a custom range as picked, otherwise the preset (default 24h).
+  const { from, to } = useMemo(() => {
+    const d = values.date;
+    if (d.customRange) return d.customRange;
+    return getPresetRange(d.preset ?? "1d");
+  }, [values.date]);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
+  const timeRangeMs = to.getTime() - from.getTime();
+
+  const facetsQuery = useQuery({
+    queryKey: ["event-feed", "facets", fromIso, toIso, kinds],
+    queryFn: () =>
+      unwrapAsync(
+        telemetryGetEventFacets(client, {
+          getEventFacetsPayload: {
+            from,
+            to,
+            kinds: kinds.length > 0 ? kinds : undefined,
+          },
+        }),
+      ),
+    throwOnError: false,
+  });
+
+  const volumeQuery = useQuery({
+    queryKey: [
+      "event-feed",
+      "volume",
+      fromIso,
+      toIso,
+      kinds,
+      sources,
+      names,
+      searchTerm,
+    ],
+    queryFn: () =>
+      unwrapAsync(
+        telemetryGetEventVolume(client, {
+          getEventVolumePayload: {
+            from,
+            to,
+            kinds: kinds.length > 0 ? kinds : undefined,
+            sources: sources.length > 0 ? sources : undefined,
+            names: names.length > 0 ? names : undefined,
+            search: searchTerm || undefined,
+          },
+        }),
+      ),
+    throwOnError: false,
+  });
+
+  const eventsQuery = useInfiniteQuery({
+    queryKey: [
+      "event-feed",
+      "events",
+      fromIso,
+      toIso,
+      kinds,
+      sources,
+      names,
+      searchTerm,
+    ],
+    queryFn: ({ pageParam }) =>
+      unwrapAsync(
+        telemetryListEventLog(client, {
+          listEventLogPayload: {
+            from,
+            to,
+            kinds: kinds.length > 0 ? kinds : undefined,
+            sources: sources.length > 0 ? sources : undefined,
+            names: names.length > 0 ? names : undefined,
+            search: searchTerm || undefined,
+            limit: PAGE_SIZE,
+            cursor: pageParam,
+          },
+        }),
+      ),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    throwOnError: false,
+  });
+
+  const events = useMemo(
+    () => eventsQuery.data?.pages.flatMap((p) => p.events) ?? [],
+    [eventsQuery.data],
+  );
+  const totalCount = eventsQuery.data?.pages[0]?.totalCount;
+  const totalCountCapped =
+    eventsQuery.data?.pages[0]?.totalCountCapped ?? false;
+
+  const hasActiveFilters =
+    kinds.length > 0 ||
+    sources.length > 0 ||
+    names.length > 0 ||
+    searchTerm.length > 0;
+
+  // Reset the list to the top whenever a filter changes, so users don't stay
+  // at a stale scroll offset and miss the newly filtered results.
+  const filterSignature = [
+    fromIso,
+    toIso,
+    kinds.join(","),
+    sources.join(","),
+    names.join(","),
+    searchTerm,
+  ].join("|");
+  useEffect(() => {
+    containerRef.current?.scrollTo({ top: 0 });
+  }, [filterSignature]);
+
+  const optionsById: OptionsById = useMemo(
+    () => ({
+      kind: KIND_OPTIONS,
+      source: (facetsQuery.data?.sources ?? []).map((source) => ({
+        label: formatPlatform(source),
+        value: source,
+      })),
+      name: (facetsQuery.data?.names ?? []).map((name) => ({
+        label: name,
+        value: name,
+      })),
+    }),
+    [facetsQuery.data],
+  );
+
+  const refetchAll = useCallback(() => {
+    void eventsQuery.refetch();
+    void volumeQuery.refetch();
+    void facetsQuery.refetch();
+  }, [eventsQuery.refetch, volumeQuery.refetch, facetsQuery.refetch]);
+
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const container = e.currentTarget;
+      const distanceFromBottom =
+        container.scrollHeight - (container.scrollTop + container.clientHeight);
+
+      if (eventsQuery.isFetchingNextPage || eventsQuery.isFetching) return;
+      if (!eventsQuery.hasNextPage) return;
+
+      if (distanceFromBottom < 200) {
+        void eventsQuery.fetchNextPage();
+      }
+    },
+    [eventsQuery],
+  );
+
+  const countLabel =
+    totalCount !== undefined
+      ? `${events.length.toLocaleString()} of ${totalCountCapped ? "10,000+" : totalCount.toLocaleString()} events`
+      : null;
+
+  return (
+    <LogWorkbench
+      eyebrow="Data"
+      title="Event Feed"
+      stage="preview"
+      description="Every OpenTelemetry log record and span ingested through Gram's /otel/v1 endpoints across this organization."
+      filters={
+        <Page.Toolbar>
+          <Page.Toolbar.Search
+            value={search}
+            onChange={setSearch}
+            debounceMs={300}
+            placeholder="Search events"
+          />
+          <Page.Toolbar.Filters
+            schema={EVENT_FEED_FILTERS}
+            values={values}
+            optionsById={optionsById}
+            onChange={setValue as (id: string, value: FilterValue) => void}
+            onClear={clearValue as (id: string) => void}
+            onClearAll={clearAll}
+          />
+          {countLabel ? (
+            <Page.Toolbar.Actions>
+              <span className="text-eyebrow whitespace-nowrap">
+                {countLabel}
+              </span>
+            </Page.Toolbar.Actions>
+          ) : null}
+          <Page.Toolbar.Refresh
+            onRefresh={refetchAll}
+            isRefreshing={eventsQuery.isFetching}
+          />
+        </Page.Toolbar>
+      }
+      summary={
+        <EventVolumeChart
+          buckets={volumeQuery.data?.buckets ?? []}
+          timeRangeMs={timeRangeMs}
+          isLoading={volumeQuery.isPending}
+          isError={volumeQuery.isError}
+        />
+      }
+      status={
+        eventsQuery.isFetching && events.length > 0 ? (
+          <div className="bg-primary/20 h-1 shrink-0">
+            <div className="bg-primary h-full animate-pulse" />
+          </div>
+        ) : null
+      }
+      header={<EventFeedHeaderRow />}
+      footer={
+        eventsQuery.hasNextPage ? (
+          <EventFeedFooter
+            isFetchingNextPage={eventsQuery.isFetchingNextPage}
+            onLoadMore={() => void eventsQuery.fetchNextPage()}
+          />
+        ) : null
+      }
+      detail={
+        <EventDetailSheet
+          event={selectedEvent}
+          open={!!selectedEvent}
+          onOpenChange={(open) => {
+            if (!open) setSelectedEvent(null);
+          }}
+        />
+      }
+      scrollRef={containerRef}
+      onScroll={handleScroll}
+    >
+      <EventFeedRows
+        error={eventsQuery.error}
+        isLoading={eventsQuery.isPending}
+        events={events}
+        hasActiveFilters={hasActiveFilters}
+        isFetchingNextPage={eventsQuery.isFetchingNextPage}
+        onSelect={setSelectedEvent}
+      />
+    </LogWorkbench>
+  );
+}
+
+function EventFeedHeaderRow() {
+  return (
+    <div
+      className={cn(
+        EVENT_FEED_GRID,
+        "text-eyebrow bg-muted/30 shrink-0 items-center border-b px-5 py-2.5 whitespace-nowrap",
+      )}
+    >
+      <div className="min-w-0">Time</div>
+      <div className="min-w-0">Kind</div>
+      <div className="min-w-0">Source</div>
+      <div className="min-w-0">Name</div>
+      <div className="min-w-0">Body</div>
+    </div>
+  );
+}
+
+function EventFeedRows({
+  error,
+  isLoading,
+  events,
+  hasActiveFilters,
+  isFetchingNextPage,
+  onSelect,
+}: {
+  error: Error | null;
+  isLoading: boolean;
+  events: EventLogEntry[];
+  hasActiveFilters: boolean;
+  isFetchingNextPage: boolean;
+  onSelect: (event: EventLogEntry) => void;
+}) {
+  if (error) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-12">
+        <div className="bg-destructive/10 flex size-12 items-center justify-center">
+          <Icon name="circle-alert" className="text-destructive size-6" />
+        </div>
+        <span className="text-foreground font-medium">
+          Error loading events
+        </span>
+        <span className="text-muted-foreground max-w-sm text-center text-sm">
+          {error.message}
+        </span>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return <EventFeedSkeletonRows />;
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="p-4">
+        <InlineEmptyState
+          icon="inbox"
+          heading={hasActiveFilters ? "No matching events" : "No events yet"}
+          description={
+            hasActiveFilters
+              ? "Try adjusting your filters or time range."
+              : "Events appear here as OpenTelemetry logs and spans are ingested through Gram."
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {events.map((event) => (
+        <EventFeedRow key={event.recordId} event={event} onSelect={onSelect} />
+      ))}
+
+      {isFetchingNextPage && (
+        <div className="text-muted-foreground flex items-center justify-center gap-2 border-t py-4">
+          <Icon name="loader-circle" className="size-4 animate-spin" />
+          <span className="text-sm">Loading more events...</span>
+        </div>
+      )}
+    </>
+  );
+}
+
+function EventFeedSkeletonRows() {
+  return (
+    <div aria-label="Loading events" role="status">
+      {Array.from({ length: 10 }, (_, i) => (
+        <div
+          key={i}
+          className={cn(
+            EVENT_FEED_GRID,
+            "items-center border-b px-5 py-2.5 last:border-b-0",
+          )}
+        >
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-4 w-10" />
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="h-3 w-32" />
+          <Skeleton className="h-3 w-full max-w-md" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EventFeedRow({
+  event,
+  onSelect,
+}: {
+  event: EventLogEntry;
+  onSelect: (event: EventLogEntry) => void;
+}) {
+  const timestamp = unixNanoToDate(event.timeUnixNano);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(event)}
+      className={cn(
+        EVENT_FEED_GRID,
+        "hover:bg-muted/30 w-full cursor-pointer items-center border-b px-5 py-2.5 text-left text-sm transition-colors",
+      )}
+    >
+      <div
+        className="text-muted-foreground min-w-0 font-mono text-xs tabular-nums"
+        title={timestamp.toLocaleString()}
+      >
+        {format(timestamp, "MMM d HH:mm:ss")}
+      </div>
+
+      <div className="min-w-0">
+        <EventKindBadge kind={event.kind} />
+      </div>
+
+      <div className="flex min-w-0 items-center gap-2">
+        <EventSourceIcon source={event.source} className="size-4 shrink-0" />
+        <span className="text-foreground min-w-0 truncate font-mono text-xs">
+          {formatPlatform(event.source)}
+        </span>
+      </div>
+
+      <div className="text-foreground min-w-0 truncate font-mono text-xs font-medium">
+        {event.name || "\u2014"}
+      </div>
+
+      <div className="text-muted-foreground min-w-0 truncate text-xs">
+        {event.bodyPreview || "\u2014"}
+      </div>
+    </button>
+  );
+}
+
+function EventFeedFooter({
+  isFetchingNextPage,
+  onLoadMore,
+}: {
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}) {
+  return (
+    <div className="bg-muted/30 text-muted-foreground flex shrink-0 items-center justify-between gap-4 border-t px-5 py-3 text-sm">
+      <span>Scroll to load more</span>
+      <Button
+        variant="tertiary"
+        size="sm"
+        disabled={isFetchingNextPage}
+        onClick={onLoadMore}
+      >
+        {isFetchingNextPage ? "Loading..." : "Load More"}
+      </Button>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/data/EventVolumeChart.tsx
+++ b/client/dashboard/src/pages/data/EventVolumeChart.tsx
@@ -1,0 +1,157 @@
+import { ChartCard } from "@/components/chart/ChartCard";
+import {
+  formatChartLabel,
+  unixNanoToDate,
+} from "@/components/chart/chartUtils";
+import { AXIS, TOOLTIP, withAlpha } from "@/components/chart/palette";
+import {
+  useIsDarkTheme,
+  useSeriesColors,
+} from "@/components/chart/useSeriesColors";
+import { WidgetEmptyState } from "@/components/chart/WidgetEmptyState";
+import { formatCompact } from "@/lib/format";
+import type { EventVolumeBucket } from "@gram/client/models/components/eventvolumebucket.js";
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Tooltip,
+  type ChartData,
+  type ChartOptions,
+} from "chart.js";
+import { useMemo, useState } from "react";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+const CHART_ID = "event-volume";
+
+export interface EventVolumeChartProps {
+  /** Zero-filled buckets in ascending time order. */
+  buckets: EventVolumeBucket[];
+  /** Span of the selected window in milliseconds, picks the axis label format. */
+  timeRangeMs: number;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * Event volume over time: stacked bars splitting ingested OpenTelemetry log
+ * records vs spans, driven by `telemetry.getEventVolume` buckets. Modeled on
+ * `ToolCallsTimeSeriesChart`.
+ */
+export function EventVolumeChart({
+  buckets,
+  timeRangeMs,
+  isLoading,
+  isError,
+}: EventVolumeChartProps): JSX.Element {
+  const [expandedChart, setExpandedChart] = useState<string | null>(null);
+  const isExpanded = expandedChart === CHART_ID;
+  const height = isExpanded ? 420 : 220;
+  const hasData = buckets.some((b) => b.logCount > 0 || b.spanCount > 0);
+
+  const seriesColors = useSeriesColors();
+  const chartData = useMemo<ChartData<"bar", number[], string>>(() => {
+    const labels = buckets.map((b) =>
+      formatChartLabel(unixNanoToDate(b.bucketTimeUnixNano), timeRangeMs),
+    );
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: "Logs",
+          data: buckets.map((b) => b.logCount),
+          // First two slots of the categorical ramp (ink, brand blue) — two
+          // neutral peers, unlike the success/failure split elsewhere.
+          backgroundColor: withAlpha(seriesColors[0]!, 0.75),
+          stack: "events",
+        },
+        {
+          label: "Spans",
+          data: buckets.map((b) => b.spanCount),
+          backgroundColor: withAlpha(seriesColors[1]!, 0.75),
+          stack: "events",
+        },
+      ],
+    };
+  }, [buckets, timeRangeMs, seriesColors]);
+
+  // Chart.js paints the canvas with static defaults that ignore the CSS
+  // theme, so gridlines and tick labels need explicit dark-mode colors.
+  const isDark = useIsDarkTheme();
+
+  const options = useMemo<ChartOptions<"bar">>(() => {
+    const textColor = isDark ? AXIS.faded : AXIS.label;
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: {
+          position: "bottom",
+          labels: {
+            boxWidth: 12,
+            usePointStyle: true,
+            padding: 16,
+            font: { size: 11 },
+          },
+        },
+        tooltip: {
+          ...TOOLTIP,
+          padding: 12,
+          usePointStyle: true,
+          callbacks: {
+            label: (item) =>
+              ` ${item.dataset.label}: ${formatCompact(Number(item.parsed.y ?? 0))}`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          stacked: true,
+          grid: {
+            display: true,
+            color: isDark ? AXIS.gridDark : AXIS.grid,
+          },
+          ticks: { maxTicksLimit: 8, color: textColor },
+        },
+        y: {
+          stacked: true,
+          beginAtZero: true,
+          grid: { color: isDark ? AXIS.gridDark : AXIS.grid },
+          ticks: {
+            color: textColor,
+            callback: (value) => formatCompact(Number(value)),
+          },
+        },
+      },
+    };
+  }, [isDark]);
+
+  return (
+    <ChartCard
+      title="Event Volume"
+      chartId={CHART_ID}
+      expandedChart={expandedChart}
+      onExpand={setExpandedChart}
+      hasData={hasData}
+      loading={isLoading}
+      error={isError}
+    >
+      {!hasData ? (
+        <WidgetEmptyState
+          message="No events for the selected time range"
+          className="h-[220px]"
+        />
+      ) : (
+        <div style={{ height }}>
+          <Bar data={chartData} options={options} />
+        </div>
+      )}
+    </ChartCard>
+  );
+}

--- a/client/dashboard/src/pages/data/event-display.tsx
+++ b/client/dashboard/src/pages/data/event-display.tsx
@@ -1,0 +1,37 @@
+import speakeasyIcon from "@/assets/speakeasy-icon.svg";
+import { AgentProviderIcon } from "@/components/agent-providers/AgentProviderIcon";
+import type { EventLogEntryKind } from "@gram/client/models/components/eventlogentry.js";
+
+/** Mono uppercase tag for a signal kind — `log` or `span`. */
+export function EventKindBadge({
+  kind,
+}: {
+  kind: EventLogEntryKind;
+}): JSX.Element {
+  return (
+    <span className="border-border text-muted-foreground border px-1.5 py-0.5 font-mono text-[10px] tracking-wide uppercase">
+      {kind}
+    </span>
+  );
+}
+
+// Sources canonicalized from Gram's own services (e.g. gram-server) carry the
+// Speakeasy mark; everything else routes through the shared agent-provider
+// icon set (claude-code, litellm, ...), which falls back to a globe.
+function isGramSource(source: string): boolean {
+  return source.trim().toLowerCase().startsWith("gram");
+}
+
+/** Logo for a canonicalized event source (resource service name). */
+export function EventSourceIcon({
+  source,
+  className,
+}: {
+  source: string;
+  className?: string;
+}): JSX.Element {
+  if (isGramSource(source)) {
+    return <img src={speakeasyIcon} alt="" className={className} />;
+  }
+  return <AgentProviderIcon source={source} className={className} />;
+}

--- a/client/dashboard/src/pages/data/event-display.tsx
+++ b/client/dashboard/src/pages/data/event-display.tsx
@@ -17,9 +17,12 @@ export function EventKindBadge({
 
 // Sources canonicalized from Gram's own services (e.g. gram-server) carry the
 // Speakeasy mark; everything else routes through the shared agent-provider
-// icon set (claude-code, litellm, ...), which falls back to a globe.
+// icon set (claude-code, litellm, ...), which falls back to a globe. The
+// match is exact-or-hyphenated so unrelated services that merely start with
+// "gram" don't pick up the mark.
 function isGramSource(source: string): boolean {
-  return source.trim().toLowerCase().startsWith("gram");
+  const canonical = source.trim().toLowerCase();
+  return canonical === "gram" || canonical.startsWith("gram-");
 }
 
 /** Logo for a canonicalized event source (resource service name). */

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -29,6 +29,7 @@ import SkillVersionHistory from "./pages/skills/SkillVersionHistory";
 import Deployment from "./pages/deployments/deployment/Deployment";
 import Deployments, { DeploymentsRoot } from "./pages/deployments/Deployments";
 import UserSessions from "./pages/org/UserSessions";
+import EventFeed from "./pages/data/EventFeed";
 import DeviceAgent, { DeviceAgentRoot } from "./pages/device-agent/DeviceAgent";
 import MdmIntegrationDetail from "./pages/org/device-integrations/MdmIntegrationDetail";
 import Elements from "./pages/elements/Elements";
@@ -1021,6 +1022,13 @@ const ORG_ROUTE_STRUCTURE = {
     url: "logs",
     icon: "file-text",
     component: OrgLogs,
+  },
+  data: {
+    title: "Event Feed",
+    url: "data",
+    icon: "activity",
+    stage: "preview",
+    component: EventFeed,
   },
   skills: {
     title: "Skills",


### PR DESCRIPTION
## Summary

- New org route `/:orgSlug/data` and a "Data" sidebar group with an Event Feed item carrying a Preview badge.
- `EventFeed` page: toolbar with debounced search, kind/source/name filters and a time-range select, an "n of m events" count, a stacked logs-vs-spans volume chart, and an infinite-scrolling event table with per-source logos and responsive body truncation. Data comes from the otel SDK namespace (`otelListEventLog` and friends).
- `EventDetailSheet`: header with kind badge and source logo, copyable trace/span ids, and Parsed (flattened key/value) and Raw (pretty-printed JSON) tabs.
- `LogWorkbench` gains an optional `summary` slot so the volume chart can sit between the filters and the log surface.

## Motivation

Gives org admins one place to see every OTel signal ingested through Gram's `/otel/v1/*` endpoints, with enough filtering and per-event detail to understand what their agents and tools are emitting. Built on the read endpoints from the previous PR.

**Stack (3 of 3):** #5639 (ingest tee) → #5640 (read endpoints) → this PR. Merges into the read-endpoints branch.