### PR TITLE
feat: add tool-call token consumption to insights

### DIFF
--- a/.changeset/tool-call-consumption-insights.md
+++ b/.changeset/tool-call-consumption-insights.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The MCP & Tools insights page now shows agent-turn token consumption alongside tool-call counts, grouped and filterable by harness, MCP server, and MCP tool.

--- a/.changeset/tool-call-consumption-insights.md
+++ b/.changeset/tool-call-consumption-insights.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-The MCP & Tools insights page now shows agent-turn token consumption alongside tool-call counts, grouped and filterable by harness, MCP server, and MCP tool.
+The MCP & Tools insights page now shows agent-turn token consumption next to tool-call counts, grouped and filterable by harness, MCP server, and MCP tool.

--- a/client/dashboard/src/components/observe/InsightsToolCallConsumption.tsx
+++ b/client/dashboard/src/components/observe/InsightsToolCallConsumption.tsx
@@ -1,0 +1,487 @@
+import { ChartCard } from "@/components/chart/ChartCard";
+import { TOOLTIP } from "@/components/chart/palette";
+import { StatTile, StatTileGroup } from "@/components/chart/stat-tile";
+import { useSeriesColors } from "@/components/chart/useSeriesColors";
+import { type FilterChip } from "@/components/observe/ObserveFilterBar";
+import { HOOK_SOURCE_FILTER_PATH } from "@/components/observe/observeTargetFilters";
+import {
+  type ConsumptionGroupBy,
+  type ConsumptionMeasure,
+  CONSUMPTION_GROUP_OPTIONS,
+  buildConsumptionFilters,
+  consumptionBarRows,
+  consumptionRowLabel,
+  consumptionTimeSeriesStacks,
+  hasConsumptionActivity,
+  rankedConsumptionRows,
+  sortByForMeasure,
+  sumConsumptionRows,
+} from "@/components/observe/toolCallConsumption";
+import { StackedTimeSeriesPanel } from "@/components/stacked-time-series-panel";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { Skeleton, SkeletonTable } from "@/components/ui/Skeleton";
+import { Column, Table } from "@/components/ui/Table";
+import { Text } from "@/components/ui/Text";
+import { useProject } from "@/contexts/Auth";
+import { formatCompact } from "@/lib/format";
+import { formatPlatform } from "@/lib/formatPlatform";
+import { formatCost } from "@/lib/money";
+import { telemetryQuery } from "@gram/client/funcs/telemetryQuery";
+import { Dimension } from "@gram/client/models/components/queryfilter.js";
+import { type GroupBy } from "@gram/client/models/components/querypayload.js";
+import { type QueryResult } from "@gram/client/models/components/queryresult.js";
+import { type QueryRow } from "@gram/client/models/components/queryrow.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { unwrapAsync } from "@gram/client/types/fp";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  BarElement,
+  BarController,
+  CategoryScale,
+  Chart as ChartJS,
+  type ChartOptions,
+  LinearScale,
+  Tooltip,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+import { useMemo, useState } from "react";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  BarController,
+  Tooltip,
+);
+
+const CONSUMPTION_TOP_N = 20;
+
+type ConsumptionTableRow = {
+  key: string;
+  label: string;
+  groupValue: string;
+  toolCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+  tokens: number;
+  cost: number;
+};
+
+function formatCount(value: number): string {
+  return value.toLocaleString();
+}
+
+export function InsightsToolCallConsumption({
+  from,
+  to,
+  hookSources,
+  accountType,
+  addFilter,
+  onRangeSelect,
+}: {
+  from: Date;
+  to: Date;
+  hookSources: string[];
+  accountType: string;
+  addFilter: (chip: FilterChip) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+}): JSX.Element | null {
+  const project = useProject();
+  const client = useGramContext();
+  const seriesColors = useSeriesColors();
+  const [groupBy, setGroupBy] = useState<ConsumptionGroupBy>(
+    Dimension.HookSource,
+  );
+  const [measure, setMeasure] = useState<ConsumptionMeasure>("tokens");
+  const [expandedChart, setExpandedChart] = useState<string | null>(null);
+
+  const filters = useMemo(
+    () => buildConsumptionFilters(project.id, hookSources, accountType),
+    [project.id, hookSources, accountType],
+  );
+
+  const query = useQuery({
+    queryKey: [
+      "tool-call-consumption",
+      project.id,
+      from.toISOString(),
+      to.toISOString(),
+      hookSources,
+      accountType,
+      groupBy,
+      measure,
+    ],
+    queryFn: () =>
+      unwrapAsync(
+        telemetryQuery(client, {
+          queryPayload: {
+            from,
+            to,
+            groupBy: groupBy as GroupBy,
+            sortBy: sortByForMeasure(measure),
+            topN: CONSUMPTION_TOP_N,
+            filters,
+          },
+        }),
+      ),
+    enabled: !!project.id,
+    placeholderData: keepPreviousData,
+    throwOnError: false,
+  });
+
+  const data = query.data;
+  const totals = useMemo(
+    () => sumConsumptionRows(data?.table ?? []),
+    [data?.table],
+  );
+  const hasActivity = hasConsumptionActivity(data?.table ?? []);
+  const groupLabel =
+    CONSUMPTION_GROUP_OPTIONS.find((option) => option.value === groupBy)
+      ?.label ?? "Group";
+
+  const barRows = useMemo(
+    () => consumptionBarRows(data?.table ?? [], groupBy, measure),
+    [data?.table, groupBy, measure],
+  );
+  const tableRows = useMemo(
+    () => toTableRows(data?.table ?? [], groupBy),
+    [data?.table, groupBy],
+  );
+  const { bucketsMs, stacks } = useMemo(
+    () =>
+      consumptionTimeSeriesStacks(
+        data?.timeseries ?? [],
+        groupBy,
+        measure,
+        rollupGroupValue(data),
+      ),
+    [data, groupBy, measure],
+  );
+
+  const columns = useMemo<Column<ConsumptionTableRow>[]>(
+    () => [
+      {
+        key: "label",
+        header: groupLabel,
+        sortable: true,
+        sortValue: (row) => row.label,
+        render: (row) => (
+          <Text as="span" className="font-medium">
+            {row.label}
+          </Text>
+        ),
+      },
+      {
+        key: "toolCalls",
+        header: "Calls",
+        width: "90px",
+        sortable: true,
+        sortValue: (row) => row.toolCalls,
+        render: (row) => <Text as="span">{formatCount(row.toolCalls)}</Text>,
+      },
+      {
+        key: "inputTokens",
+        header: "Input",
+        width: "100px",
+        sortable: true,
+        sortValue: (row) => row.inputTokens,
+        render: (row) => <Text as="span">{formatCount(row.inputTokens)}</Text>,
+      },
+      {
+        key: "outputTokens",
+        header: "Output",
+        width: "100px",
+        sortable: true,
+        sortValue: (row) => row.outputTokens,
+        render: (row) => <Text as="span">{formatCount(row.outputTokens)}</Text>,
+      },
+      {
+        key: "tokens",
+        header: "Tokens",
+        width: "100px",
+        sortable: true,
+        sortValue: (row) => row.tokens,
+        render: (row) => <Text as="span">{formatCount(row.tokens)}</Text>,
+      },
+      {
+        key: "cost",
+        header: "Cost",
+        width: "100px",
+        sortable: true,
+        sortValue: (row) => row.cost,
+        render: (row) => <Text as="span">{formatCost(row.cost)}</Text>,
+      },
+    ],
+    [groupLabel],
+  );
+
+  const handleBarClick = (groupValue: string) => {
+    if (
+      groupBy !== Dimension.HookSource ||
+      !groupValue ||
+      groupValue === "Other"
+    ) {
+      return;
+    }
+    addFilter({
+      display: formatPlatform(groupValue),
+      filters: [groupValue],
+      path: HOOK_SOURCE_FILTER_PATH,
+    });
+  };
+
+  if (query.isError && !data) {
+    return null;
+  }
+
+  if (!query.isPending && !hasActivity) {
+    return null;
+  }
+
+  const measureNoun = measure === "calls" ? "tool calls" : "tokens";
+  const barTitle = `${measure === "calls" ? "Tool calls" : "Tokens"} by ${groupLabel}`;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-col gap-1">
+          <p className="text-eyebrow">Token consumption</p>
+          <Text muted small>
+            Agent-turn tokens attributed to the tool that ran on that turn —
+            grouped by agent harness, MCP server, or MCP tool.
+          </Text>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <SegmentedControl
+            value={groupBy}
+            onChange={setGroupBy}
+            options={CONSUMPTION_GROUP_OPTIONS.map((option) => ({
+              value: option.value,
+              label: option.label,
+            }))}
+          />
+          <SegmentedControl
+            value={measure}
+            onChange={setMeasure}
+            options={[
+              {
+                value: "calls",
+                label: "Calls",
+                tooltip: "Rank by completed tool calls",
+              },
+              {
+                value: "tokens",
+                label: "Tokens",
+                tooltip: "Rank by attributed token consumption",
+              },
+            ]}
+          />
+        </div>
+      </div>
+
+      <StatTileGroup>
+        {query.isPending && !data ? (
+          Array.from({ length: 5 }).map((_, index) => (
+            <Skeleton key={index} className="h-[104px] flex-1" />
+          ))
+        ) : (
+          <>
+            <StatTile
+              title="Tool Calls"
+              value={totals.toolCalls}
+              tone="information"
+              icon="wrench"
+            />
+            <StatTile
+              title="Input Tokens"
+              value={totals.inputTokens}
+              tone="information"
+              icon="log-in"
+            />
+            <StatTile
+              title="Output Tokens"
+              value={totals.outputTokens}
+              tone="information"
+              icon="log-out"
+            />
+            <StatTile
+              title="Total Tokens"
+              value={totals.tokens}
+              tone="information"
+              icon="coins"
+            />
+            <StatTile
+              title="Cost"
+              value={totals.cost}
+              format="currency"
+              tone="neutral"
+              icon="credit-card"
+            />
+          </>
+        )}
+      </StatTileGroup>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <ChartCard
+          title={barTitle}
+          chartId="tool-call-consumption-bar"
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+          loading={query.isPending && !data}
+          error={query.isError}
+          hasData={barRows.length > 0}
+        >
+          {barRows.length === 0 ? (
+            <div className="text-muted-foreground flex h-24 items-center justify-center text-sm">
+              No {measureNoun} in this period
+            </div>
+          ) : (
+            <ConsumptionBarChart
+              rows={barRows}
+              color={seriesColors[0]!}
+              measure={measure}
+              onSelect={handleBarClick}
+            />
+          )}
+        </ChartCard>
+
+        <div className="border-border bg-card min-h-0 border">
+          {query.isPending && !data ? (
+            <div className="p-4">
+              <SkeletonTable />
+            </div>
+          ) : (
+            <Table
+              columns={columns}
+              data={tableRows}
+              rowKey={(row) => row.key}
+              className="max-h-[360px] overflow-y-auto"
+              noResultsMessage={<Text muted>No matching groups</Text>}
+            />
+          )}
+        </div>
+      </div>
+
+      <StackedTimeSeriesPanel
+        title={`${measure === "calls" ? "Tool calls" : "Tokens"} over time`}
+        headerHint={`Attributed ${measureNoun} over time, stacked by ${groupLabel.toLowerCase()}. Click or drag on the chart to zoom to a period.`}
+        bucketsMs={bucketsMs}
+        stacks={query.isError ? [] : stacks}
+        formatValue={
+          measure === "calls"
+            ? (value) => `${formatCount(value)} calls`
+            : (value) => `${formatCount(value)} tokens`
+        }
+        formatAxisValue={formatCompact}
+        emptyMessage={
+          query.isError
+            ? "Failed to load token consumption."
+            : `No ${measureNoun} in this range.`
+        }
+        loading={query.isPending && !data}
+        onSelectRange={onRangeSelect}
+      />
+    </section>
+  );
+}
+
+function toTableRows(
+  rows: QueryRow[],
+  groupBy: ConsumptionGroupBy,
+): ConsumptionTableRow[] {
+  return rankedConsumptionRows(rows, groupBy, "tokens").map((row) => ({
+    key: row.groupValue || "(unset)",
+    label: consumptionRowLabel(groupBy, row.groupValue),
+    groupValue: row.groupValue,
+    toolCalls: row.measures.totalToolCalls ?? 0,
+    inputTokens: row.measures.totalInputTokens ?? 0,
+    outputTokens: row.measures.totalOutputTokens ?? 0,
+    tokens: row.measures.totalTokens ?? 0,
+    cost: row.measures.totalCost ?? 0,
+  }));
+}
+
+function rollupGroupValue(data: QueryResult | undefined): string | undefined {
+  const rows = data?.table ?? [];
+  return rows.length >= CONSUMPTION_TOP_N
+    ? rows[rows.length - 1]?.groupValue
+    : undefined;
+}
+
+function ConsumptionBarChart({
+  rows,
+  color,
+  measure,
+  onSelect,
+}: {
+  rows: { label: string; value: number; groupValue: string }[];
+  color: string;
+  measure: ConsumptionMeasure;
+  onSelect: (groupValue: string) => void;
+}): JSX.Element {
+  const height = Math.max(120, rows.length * 32 + 40);
+  const options = useMemo<ChartOptions<"bar">>(
+    () => ({
+      indexAxis: "y",
+      responsive: true,
+      maintainAspectRatio: false,
+      onClick(_, elements) {
+        if (!elements.length) return;
+        const index = elements[0]!.index;
+        const groupValue = rows[index]?.groupValue;
+        if (groupValue) onSelect(groupValue);
+      },
+      onHover(event, elements) {
+        const el = event.native?.target as HTMLElement | null;
+        if (el) el.style.cursor = elements.length ? "pointer" : "default";
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          ...TOOLTIP,
+          cornerRadius: 0,
+          callbacks: {
+            label: (item) =>
+              measure === "calls"
+                ? ` ${formatCount(item.parsed.x ?? 0)} calls`
+                : ` ${formatCount(item.parsed.x ?? 0)} tokens`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          grid: { color: "#e5e5e5" },
+          ticks: {
+            color: "#A3A3A3",
+            callback: (value) => formatCompact(Number(value)),
+          },
+        },
+        y: {
+          grid: { display: false },
+          ticks: { color: "#A3A3A3", font: { size: 12 } },
+        },
+      },
+    }),
+    [measure, onSelect, rows],
+  );
+
+  return (
+    <div style={{ height }}>
+      <Bar
+        data={{
+          labels: rows.map((row) => row.label),
+          datasets: [
+            {
+              data: rows.map((row) => row.value),
+              backgroundColor: color,
+              barThickness: 18,
+              borderRadius: 0,
+              borderSkipped: false,
+            },
+          ],
+        }}
+        options={options}
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -11,6 +11,8 @@ import {
   ObserveFilterBar,
   type ObserveTypeFilterValue,
 } from "@/components/observe/ObserveFilterBar";
+import { InsightsToolCallConsumption } from "@/components/observe/InsightsToolCallConsumption";
+import { useToolCallConsumptionTotals } from "@/components/observe/useToolCallConsumption";
 import {
   SERVER_FILTER_PATH,
   TOOL_USAGE_DEFAULT_TYPES,
@@ -31,6 +33,7 @@ import { useLogsEnabledErrorCheck } from "@/hooks/useLogsEnabled";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { useServerNameMappings } from "@/hooks/useServerNameMappings";
 import { cn } from "@/lib/utils";
+import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
 import { useOrgRoutes } from "@/routes";
 import { getPresetRange, type DateRangePreset } from "@/elements";
 import { telemetryGetToolUsageFilterOptions } from "@gram/client/funcs/telemetryGetToolUsageFilterOptions";
@@ -583,8 +586,10 @@ export function InsightsToolsContent(): JSX.Element {
       <InsightsConfig
         mcpConfig={mcpConfig}
         title="Explore MCP Servers & Tools"
-        subtitle="Ask me about your MCP servers and tools! Powered by Elements + platform MCP"
+        subtitle="Ask me about your MCP servers, tools, agent harnesses, and token consumption."
         hideTrigger={isLogsDisabled}
+        suggestions={INSIGHTS_SUGGESTIONS.insights}
+        contextInfo="MCP & Tools insights: tool-call event counts by target and user, plus agent-turn token consumption grouped by harness, MCP server, and MCP tool."
       />
       {isLogsDisabled ? (
         <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto p-8 pb-24">
@@ -594,8 +599,8 @@ export function InsightsToolsContent(): JSX.Element {
               MCP Servers & Tool Insights
             </h1>
             <p className="text-muted-foreground text-sm">
-              Monitor MCP servers and tool events across all users and agents in
-              your project
+              Monitor MCP servers, tool events, and token consumption across
+              agents in your project
             </p>
           </div>
           <div className="relative flex-1">
@@ -736,6 +741,19 @@ function HooksInnerContent({
     [onCustomRangeChange],
   );
   const hasSummaryData = (summaryData?.totals.eventCount ?? 0) > 0;
+  const hookSources = useMemo(
+    () => selectedHookSources(activeFilters),
+    [activeFilters],
+  );
+  const consumption = useToolCallConsumptionTotals({
+    from,
+    to,
+    hookSources,
+    accountType,
+  });
+  const hasConsumptionData = consumption.hasActivity;
+  const hasAnyData =
+    hasSummaryData || hasConsumptionData || consumption.pending;
 
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col">
@@ -747,8 +765,8 @@ function HooksInnerContent({
               MCP Servers & Tool Insights
             </h1>
             <p className="text-muted-foreground text-sm">
-              Monitor MCP servers and tool events across all users and agents in
-              your project
+              Monitor MCP servers, tool events, and token consumption across
+              agents in your project
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -804,14 +822,14 @@ function HooksInnerContent({
                 <Spinner className="mr-0 size-5" />
                 <span>Loading tool usage...</span>
               </div>
-            ) : !hasSummaryData &&
+            ) : !hasAnyData &&
               activeFilters.length === 0 &&
               selectedRoleIds.length === 0 ? (
               <HooksEmptyState
                 title="No Insights Generated"
                 subtitle="Install Observability plugin in your AI agent to start generating tool insights"
               />
-            ) : !hasSummaryData ? (
+            ) : !hasAnyData ? (
               <div className="py-12 text-center">
                 <div className="flex flex-col items-center gap-3">
                   <div className="bg-muted flex size-12 items-center justify-center rounded-full">
@@ -829,23 +847,35 @@ function HooksInnerContent({
                 </div>
               </div>
             ) : (
-              <HooksAnalytics
-                serverNameMappings={serverNameMappings}
-                from={from}
-                to={to}
-                compact={false}
-                addFilter={addFilter}
-                onHookTypesChange={onHookTypesChange}
-                summaryData={summaryData}
-                summaryPending={summaryPending}
-                summaryIsError={summaryIsError}
-                sectionStatus={sectionStatus}
-                expandedChart={expandedChart}
-                onExpandedChartChange={setExpandedChart}
-                onRangeSelect={handleChartRangeSelect}
-                isZoomed={customRange !== null}
-                onResetZoom={onClearCustomRange}
-              />
+              <div className="space-y-8">
+                <InsightsToolCallConsumption
+                  from={from}
+                  to={to}
+                  hookSources={hookSources}
+                  accountType={accountType}
+                  addFilter={addFilter}
+                  onRangeSelect={handleChartRangeSelect}
+                />
+                {hasSummaryData ? (
+                  <HooksAnalytics
+                    serverNameMappings={serverNameMappings}
+                    from={from}
+                    to={to}
+                    compact={false}
+                    addFilter={addFilter}
+                    onHookTypesChange={onHookTypesChange}
+                    summaryData={summaryData}
+                    summaryPending={summaryPending}
+                    summaryIsError={summaryIsError}
+                    sectionStatus={sectionStatus}
+                    expandedChart={expandedChart}
+                    onExpandedChartChange={setExpandedChart}
+                    onRangeSelect={handleChartRangeSelect}
+                    isZoomed={customRange !== null}
+                    onResetZoom={onClearCustomRange}
+                  />
+                ) : null}
+              </div>
             )}
           </div>
         </div>

--- a/client/dashboard/src/components/observe/observeTargetFilters.ts
+++ b/client/dashboard/src/components/observe/observeTargetFilters.ts
@@ -13,7 +13,7 @@ import { normalizeUserEmailFilter } from "./observeUserFilters";
 
 export const SERVER_FILTER_PATH = "gram.tool_call.source";
 export const USER_EMAIL_FILTER_PATH = "user.email";
-const HOOK_SOURCE_FILTER_PATH = "gram.hook.source";
+export const HOOK_SOURCE_FILTER_PATH = "gram.hook.source";
 
 const HOSTED_SERVER_PREFIX = "hosted:";
 const SHADOW_SERVER_PREFIX = "shadow:";

--- a/client/dashboard/src/components/observe/toolCallConsumption.test.ts
+++ b/client/dashboard/src/components/observe/toolCallConsumption.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { Dimension } from "@gram/client/models/components/queryfilter.js";
+import { type QueryMeasures } from "@gram/client/models/components/querymeasures.js";
+import { type QueryRow } from "@gram/client/models/components/queryrow.js";
+import { type QuerySeries } from "@gram/client/models/components/queryseries.js";
+import {
+  buildConsumptionFilters,
+  consumptionBarRows,
+  consumptionRowLabel,
+  consumptionTimeSeriesStacks,
+  hasConsumptionActivity,
+  rankedConsumptionRows,
+  sortByForMeasure,
+  sumConsumptionRows,
+  visibleConsumptionRows,
+} from "./toolCallConsumption";
+
+function measures(overrides: Partial<QueryMeasures> = {}): QueryMeasures {
+  return {
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    scoredCost: 0,
+    scoredTokens: 0,
+    totalChats: 0,
+    totalCost: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalTokens: 0,
+    totalToolCalls: 0,
+    totalWorkUnits: 0,
+    ...overrides,
+  };
+}
+
+function row(
+  groupValue: string,
+  overrides: Partial<QueryMeasures> = {},
+): QueryRow {
+  return {
+    groupValue,
+    measures: measures(overrides),
+    dimensionValues: {},
+  };
+}
+
+function series(
+  groupValue: string,
+  values: number[],
+  measure: "calls" | "tokens" = "tokens",
+): QuerySeries {
+  return {
+    groupValue,
+    points: values.map((value, index) => ({
+      bucketTimeUnixNano: String(
+        (1_700_000_000 + index * 3600) * 1_000_000_000,
+      ),
+      measures: measures(
+        measure === "calls"
+          ? { totalToolCalls: value }
+          : { totalTokens: value },
+      ),
+    })),
+  };
+}
+
+describe("buildConsumptionFilters", () => {
+  it("always scopes to the project and adds optional filters", () => {
+    expect(buildConsumptionFilters("proj-1", [], "")).toEqual([
+      { dimension: Dimension.ProjectId, values: ["proj-1"] },
+    ]);
+    expect(
+      buildConsumptionFilters("proj-1", ["claude-code", "cursor"], "team"),
+    ).toEqual([
+      { dimension: Dimension.ProjectId, values: ["proj-1"] },
+      { dimension: Dimension.HookSource, values: ["claude-code", "cursor"] },
+      { dimension: Dimension.AccountType, values: ["team"] },
+    ]);
+  });
+});
+
+describe("sortByForMeasure", () => {
+  it("ranks by tool calls or tokens", () => {
+    expect(sortByForMeasure("calls")).toBe("total_tool_calls");
+    expect(sortByForMeasure("tokens")).toBe("total_tokens");
+  });
+});
+
+describe("sumConsumptionRows", () => {
+  it("adds every additive measure across groups", () => {
+    expect(
+      sumConsumptionRows([
+        row("claude-code", {
+          totalToolCalls: 10,
+          totalInputTokens: 100,
+          totalOutputTokens: 20,
+          totalTokens: 120,
+          totalCost: 1.5,
+        }),
+        row("cursor", {
+          totalToolCalls: 4,
+          totalInputTokens: 50,
+          totalOutputTokens: 10,
+          totalTokens: 60,
+          totalCost: 0.25,
+        }),
+      ]),
+    ).toEqual({
+      toolCalls: 14,
+      inputTokens: 150,
+      outputTokens: 30,
+      tokens: 180,
+      cost: 1.75,
+    });
+  });
+});
+
+describe("hasConsumptionActivity", () => {
+  it("is false when every measure is zero", () => {
+    expect(hasConsumptionActivity([row(""), row("Other")])).toBe(false);
+  });
+
+  it("is true when any group has calls, tokens, or cost", () => {
+    expect(hasConsumptionActivity([row("cursor", { totalToolCalls: 1 })])).toBe(
+      true,
+    );
+    expect(hasConsumptionActivity([row("cursor", { totalTokens: 9 })])).toBe(
+      true,
+    );
+    expect(hasConsumptionActivity([row("cursor", { totalCost: 0.01 })])).toBe(
+      true,
+    );
+  });
+});
+
+describe("visibleConsumptionRows", () => {
+  it("keeps empty hook_source groups and drops empty MCP attribution", () => {
+    const rows = [row(""), row("linear")];
+    expect(
+      visibleConsumptionRows(rows, Dimension.HookSource).map(
+        (r) => r.groupValue,
+      ),
+    ).toEqual(["", "linear"]);
+    expect(
+      visibleConsumptionRows(rows, Dimension.McpServerName).map(
+        (r) => r.groupValue,
+      ),
+    ).toEqual(["linear"]);
+    expect(
+      visibleConsumptionRows(rows, Dimension.McpToolName).map(
+        (r) => r.groupValue,
+      ),
+    ).toEqual(["linear"]);
+  });
+});
+
+describe("consumptionRowLabel", () => {
+  it("uses product-surface labels for agents", () => {
+    expect(consumptionRowLabel(Dimension.HookSource, "claude-code")).toBe(
+      "Claude Code",
+    );
+    expect(consumptionRowLabel(Dimension.HookSource, "cursor")).toBe("Cursor");
+  });
+
+  it("keeps MCP names and the Other rollup as-is", () => {
+    expect(consumptionRowLabel(Dimension.McpToolName, "get_issue")).toBe(
+      "get_issue",
+    );
+    expect(consumptionRowLabel(Dimension.McpServerName, "Other")).toBe("Other");
+  });
+});
+
+describe("rankedConsumptionRows", () => {
+  it("orders by the active measure and hides empty MCP groups", () => {
+    const ranked = rankedConsumptionRows(
+      [
+        row("", { totalTokens: 999, totalToolCalls: 99 }),
+        row("linear", { totalTokens: 10, totalToolCalls: 2 }),
+        row("github", { totalTokens: 40, totalToolCalls: 1 }),
+      ],
+      Dimension.McpServerName,
+      "tokens",
+    );
+    expect(ranked.map((r) => r.groupValue)).toEqual(["github", "linear"]);
+  });
+});
+
+describe("consumptionBarRows", () => {
+  it("returns labeled values for the ranked chart", () => {
+    expect(
+      consumptionBarRows(
+        [
+          row("claude-code", { totalToolCalls: 12 }),
+          row("cursor", { totalToolCalls: 3 }),
+          row("codex", { totalToolCalls: 0 }),
+        ],
+        Dimension.HookSource,
+        "calls",
+      ),
+    ).toEqual([
+      { label: "Claude Code", value: 12, groupValue: "claude-code" },
+      { label: "Cursor", value: 3, groupValue: "cursor" },
+    ]);
+  });
+});
+
+describe("consumptionTimeSeriesStacks", () => {
+  it("merges same-label series and ranks stacks by volume", () => {
+    const { stacks } = consumptionTimeSeriesStacks(
+      [series("claude-code", [10, 0]), series("cursor", [1, 2])],
+      Dimension.HookSource,
+      "tokens",
+    );
+    expect(stacks.map((s) => s.label)).toEqual(["Claude Code", "Cursor"]);
+    expect(stacks[0]?.series).toEqual([10, 0]);
+  });
+
+  it("drops empty MCP attribution series", () => {
+    const { stacks } = consumptionTimeSeriesStacks(
+      [series("", [100, 100]), series("linear", [4, 1])],
+      Dimension.McpServerName,
+      "tokens",
+    );
+    expect(stacks.map((s) => s.label)).toEqual(["linear"]);
+  });
+});

--- a/client/dashboard/src/components/observe/toolCallConsumption.ts
+++ b/client/dashboard/src/components/observe/toolCallConsumption.ts
@@ -37,7 +37,7 @@ export type ConsumptionTotals = {
   cost: number;
 };
 
-export const EMPTY_CONSUMPTION_TOTALS: ConsumptionTotals = {
+const EMPTY_CONSUMPTION_TOTALS: ConsumptionTotals = {
   toolCalls: 0,
   inputTokens: 0,
   outputTokens: 0,
@@ -68,7 +68,7 @@ export function sortByForMeasure(
   return measure === "calls" ? "total_tool_calls" : "total_tokens";
 }
 
-export function measureValue(
+function measureValue(
   measures: QueryMeasures,
   measure: ConsumptionMeasure,
 ): number {

--- a/client/dashboard/src/components/observe/toolCallConsumption.ts
+++ b/client/dashboard/src/components/observe/toolCallConsumption.ts
@@ -1,0 +1,218 @@
+import {
+  Dimension,
+  type QueryFilter,
+} from "@gram/client/models/components/queryfilter.js";
+import { type QueryPayloadSortBy } from "@gram/client/models/components/querypayload.js";
+import { type QueryMeasures } from "@gram/client/models/components/querymeasures.js";
+import { type QueryRow } from "@gram/client/models/components/queryrow.js";
+import { type QuerySeries } from "@gram/client/models/components/queryseries.js";
+import { unixNanoToMs } from "@/components/chart/chartUtils";
+import {
+  OTHER_STACK_LABEL,
+  type TimeSeriesStack,
+} from "@/components/stacked-time-series";
+import { displayName, isAttributionDim } from "@/pages/costs/taxonomy";
+
+export type ConsumptionMeasure = "calls" | "tokens";
+
+export type ConsumptionGroupBy =
+  | typeof Dimension.HookSource
+  | typeof Dimension.McpServerName
+  | typeof Dimension.McpToolName;
+
+export const CONSUMPTION_GROUP_OPTIONS: {
+  value: ConsumptionGroupBy;
+  label: string;
+}[] = [
+  { value: Dimension.HookSource, label: "Agent" },
+  { value: Dimension.McpServerName, label: "MCP Server" },
+  { value: Dimension.McpToolName, label: "MCP Tool" },
+];
+
+export type ConsumptionTotals = {
+  toolCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+  tokens: number;
+  cost: number;
+};
+
+export const EMPTY_CONSUMPTION_TOTALS: ConsumptionTotals = {
+  toolCalls: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  tokens: 0,
+  cost: 0,
+};
+
+export function buildConsumptionFilters(
+  projectId: string,
+  hookSources: string[],
+  accountType: string,
+): QueryFilter[] {
+  const filters: QueryFilter[] = [
+    { dimension: Dimension.ProjectId, values: [projectId] },
+  ];
+  if (hookSources.length > 0) {
+    filters.push({ dimension: Dimension.HookSource, values: hookSources });
+  }
+  if (accountType) {
+    filters.push({ dimension: Dimension.AccountType, values: [accountType] });
+  }
+  return filters;
+}
+
+export function sortByForMeasure(
+  measure: ConsumptionMeasure,
+): QueryPayloadSortBy {
+  return measure === "calls" ? "total_tool_calls" : "total_tokens";
+}
+
+export function measureValue(
+  measures: QueryMeasures,
+  measure: ConsumptionMeasure,
+): number {
+  return measure === "calls" ? measures.totalToolCalls : measures.totalTokens;
+}
+
+export function sumConsumptionRows(rows: QueryRow[]): ConsumptionTotals {
+  return rows.reduce<ConsumptionTotals>(
+    (acc, row) => ({
+      toolCalls: acc.toolCalls + (row.measures.totalToolCalls ?? 0),
+      inputTokens: acc.inputTokens + (row.measures.totalInputTokens ?? 0),
+      outputTokens: acc.outputTokens + (row.measures.totalOutputTokens ?? 0),
+      tokens: acc.tokens + (row.measures.totalTokens ?? 0),
+      cost: acc.cost + (row.measures.totalCost ?? 0),
+    }),
+    { ...EMPTY_CONSUMPTION_TOTALS },
+  );
+}
+
+export function hasConsumptionActivity(rows: QueryRow[]): boolean {
+  return rows.some(
+    (row) =>
+      (row.measures.totalToolCalls ?? 0) > 0 ||
+      (row.measures.totalTokens ?? 0) > 0 ||
+      (row.measures.totalCost ?? 0) > 0,
+  );
+}
+
+// Attribution cuts use "" for "not applicable" (the turn had no MCP tool),
+// not an unset identity. Hide those from ranked charts/tables so they don't
+// read as a real server or tool.
+export function visibleConsumptionRows(
+  rows: QueryRow[],
+  groupBy: ConsumptionGroupBy,
+): QueryRow[] {
+  return rows.filter(
+    (row) => !(isAttributionDim(groupBy) && row.groupValue === ""),
+  );
+}
+
+export function consumptionRowLabel(
+  groupBy: ConsumptionGroupBy,
+  groupValue: string,
+): string {
+  if (groupValue === "Other") return "Other";
+  return displayName(groupBy, groupValue);
+}
+
+const MAX_BAR_ROWS = 12;
+const MAX_CHART_STACKS = 7;
+
+export function rankedConsumptionRows(
+  rows: QueryRow[],
+  groupBy: ConsumptionGroupBy,
+  measure: ConsumptionMeasure,
+): QueryRow[] {
+  return [...visibleConsumptionRows(rows, groupBy)].sort(
+    (a, b) =>
+      measureValue(b.measures, measure) - measureValue(a.measures, measure),
+  );
+}
+
+export function consumptionBarRows(
+  rows: QueryRow[],
+  groupBy: ConsumptionGroupBy,
+  measure: ConsumptionMeasure,
+): { label: string; value: number; groupValue: string }[] {
+  return rankedConsumptionRows(rows, groupBy, measure)
+    .filter((row) => measureValue(row.measures, measure) > 0)
+    .slice(0, MAX_BAR_ROWS)
+    .map((row) => ({
+      label: consumptionRowLabel(groupBy, row.groupValue),
+      value: measureValue(row.measures, measure),
+      groupValue: row.groupValue,
+    }));
+}
+
+export function consumptionTimeSeriesStacks(
+  series: QuerySeries[],
+  groupBy: ConsumptionGroupBy,
+  measure: ConsumptionMeasure,
+  serverRollupValue?: string,
+): { bucketsMs: number[]; stacks: TimeSeriesStack[] } {
+  const bucketsMs = (series[0]?.points ?? []).map((point) =>
+    unixNanoToMs(point.bucketTimeUnixNano),
+  );
+
+  const visible = series.filter(
+    (item) => !(isAttributionDim(groupBy) && item.groupValue === ""),
+  );
+
+  const byLabel = new Map<string, number[]>();
+  let rollupSeed: number[] | null = null;
+  for (const item of visible) {
+    const values = item.points.map((point) =>
+      measureValue(point.measures, measure),
+    );
+    if (item.groupValue === serverRollupValue) {
+      rollupSeed = values;
+      continue;
+    }
+    const label = consumptionRowLabel(groupBy, item.groupValue);
+    const merged = byLabel.get(label);
+    if (merged) {
+      values.forEach((value, index) => {
+        merged[index] = (merged[index] ?? 0) + value;
+      });
+    } else {
+      byLabel.set(label, values);
+    }
+  }
+
+  const all = [...byLabel.entries()]
+    .map(([label, values]) => ({
+      label,
+      series: values,
+      total: values.reduce((sum, value) => sum + value, 0),
+    }))
+    .filter((item) => item.total > 0)
+    .sort((a, b) => b.total - a.total)
+    .map(({ label, series: values }) => ({ label, series: values }));
+
+  if (rollupSeed === null && all.length <= MAX_CHART_STACKS + 1) {
+    return { bucketsMs, stacks: all };
+  }
+
+  const kept = all.slice(0, MAX_CHART_STACKS);
+  const rest = all.slice(MAX_CHART_STACKS);
+  let rollupLabel = OTHER_STACK_LABEL;
+  while (byLabel.has(rollupLabel)) rollupLabel += " (other)";
+
+  return {
+    bucketsMs,
+    stacks: [
+      ...kept,
+      {
+        label: rollupLabel,
+        rollup: true,
+        series: bucketsMs.map(
+          (_, index) =>
+            (rollupSeed?.[index] ?? 0) +
+            rest.reduce((sum, item) => sum + (item.series[index] ?? 0), 0),
+        ),
+      },
+    ],
+  };
+}

--- a/client/dashboard/src/components/observe/useToolCallConsumption.ts
+++ b/client/dashboard/src/components/observe/useToolCallConsumption.ts
@@ -1,0 +1,62 @@
+import {
+  buildConsumptionFilters,
+  hasConsumptionActivity,
+} from "@/components/observe/toolCallConsumption";
+import { useProject } from "@/contexts/Auth";
+import { telemetryQuery } from "@gram/client/funcs/telemetryQuery";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { unwrapAsync } from "@gram/client/types/fp";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+export function useToolCallConsumptionTotals(args: {
+  from: Date;
+  to: Date;
+  hookSources: string[];
+  accountType: string;
+  enabled?: boolean;
+}): {
+  pending: boolean;
+  error: boolean;
+  hasActivity: boolean;
+} {
+  const project = useProject();
+  const client = useGramContext();
+  const filters = useMemo(
+    () =>
+      buildConsumptionFilters(project.id, args.hookSources, args.accountType),
+    [project.id, args.hookSources, args.accountType],
+  );
+
+  const query = useQuery({
+    queryKey: [
+      "tool-call-consumption-totals",
+      project.id,
+      args.from.toISOString(),
+      args.to.toISOString(),
+      args.hookSources,
+      args.accountType,
+    ],
+    queryFn: () =>
+      unwrapAsync(
+        telemetryQuery(client, {
+          queryPayload: {
+            from: args.from,
+            to: args.to,
+            filters,
+            sortBy: "total_tokens",
+            topN: 1,
+          },
+        }),
+      ),
+    enabled: args.enabled !== false && !!project.id,
+    placeholderData: keepPreviousData,
+    throwOnError: false,
+  });
+
+  return {
+    pending: query.isPending,
+    error: query.isError,
+    hasActivity: hasConsumptionActivity(query.data?.table ?? []),
+  };
+}

--- a/client/dashboard/src/lib/insights-suggestions.ts
+++ b/client/dashboard/src/lib/insights-suggestions.ts
@@ -637,6 +637,30 @@ export const INSIGHTS_SUGGESTIONS = {
     },
   ],
 
+  insights: [
+    {
+      title: "How is usage trending?",
+      label: "Top tools & users",
+      icon: "trend",
+      prompt:
+        "Summarize tool usage for this period: top tools, top users, and how the volume is trending.",
+    },
+    {
+      title: "Which harness is busiest?",
+      label: "Agent harness usage",
+      icon: "terminal",
+      prompt:
+        "Which CLI or agent harness is used most in this period — Claude Code, Cursor, or others — and how do their tool-call counts and token consumption compare?",
+    },
+    {
+      title: "Which tools cost tokens?",
+      label: "Token consumption",
+      icon: "coins",
+      prompt:
+        "Which MCP servers and tools consume the most tokens in this period? Break it down by input vs output tokens and call out any outliers.",
+    },
+  ],
+
   "insights/tools": [
     {
       title: "How is usage trending?",
@@ -646,17 +670,18 @@ export const INSIGHTS_SUGGESTIONS = {
         "Summarize tool usage for this period: top tools, top users, and how the volume is trending.",
     },
     {
-      title: "Which tools fail most?",
-      label: "Highest failure rates",
-      icon: "alert",
+      title: "Which harness is busiest?",
+      label: "Agent harness usage",
+      icon: "terminal",
       prompt:
-        "Which tools have the highest failure rates right now, and what do the errors look like?",
+        "Which CLI or agent harness is used most in this period — Claude Code, Cursor, or others — and how do their tool-call counts and token consumption compare?",
     },
     {
-      title: "Slowest tools?",
-      label: "Slowest tools",
-      icon: "gauge",
-      prompt: "Find tools with the slowest p95 latency in this period.",
+      title: "Which tools cost tokens?",
+      label: "Token consumption",
+      icon: "coins",
+      prompt:
+        "Which MCP servers and tools consume the most tokens in this period? Break it down by input vs output tokens and call out any outliers.",
     },
   ],
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Linear: [DNO-949](https://linear.app/speakeasy/issue/DNO-949/tool-call-telemetry-usage-token-consumption-analytics)

## Summary

The MCP & Tools insights page now has a **Token consumption** section so operators can see, for one project, which agent harness, MCP server, and MCP tool drive calls, tokens, and cost — with a ranked table and a stacked time series.

Event counts stay on `getToolUsage*` / `trace_summaries`. Token consumption reuses the existing org-scoped `telemetry.query` aggregate (`attribute_metrics_summaries`), scoped to the current project. No new ClickHouse columns or management API.

The section groups by Agent (`hook_source`), MCP Server, or MCP Tool, ranks by Calls or Tokens, and clicking an Agent bar adds a hook-source filter. Empty MCP groups (turns with no MCP tool) are hidden, matching Costs. The page empty-state treats token activity as first-class so an agent-only project still shows insights.

![Token consumption grouped by agent](https://cursor.com/artifacts/c/art-59e79994-9e16-47c5-8207-a59ac90f3b43)
![Token consumption grouped by MCP server](https://cursor.com/artifacts/c/art-0ab720eb-d93a-4903-9d8e-91c5f330adce)
<a href="https://cursor.com/agents/bc-921eab6c-19c1-450e-bee4-1eb098925f93/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoken_consumption_groupby.webm"><img src="https://cursor.com/artifacts/c/art-6f0f5d5f-7f2a-4afb-973b-46393b69630d" alt="token_consumption_groupby.webm" /></a>

## Motivation

DNO-949 asked for an Insights-style view of tool-call usage and token consumption. The counts were already on this page; tokens and cost already lived in `telemetry.query` (used by Costs) but were not surfaced here.

Tokens are **agent-turn tokens** attributed to the MCP tool that ran on that turn (Claude `api_request` + MCP attribution, plus harness usage rows) — not per-call payload sizes. Per-call token columns on `trace_summaries` and a `message_type` dimension are still out of scope: most hook tool-call rows do not carry `gen_ai.usage.*`, and AGE-2749 lives in the risk/chat layer.

Cross-harness tool-name parsing (`toolref`, AGE-2782) already runs at ingest, so the same logical tool aggregates instead of fragmenting by harness-specific names.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-949](https://linear.app/speakeasy/issue/DNO-949/tool-call-telemetry-usage-token-consumption-analytics)

<div><a href="https://cursor.com/agents/bc-921eab6c-19c1-450e-bee4-1eb098925f93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-921eab6c-19c1-450e-bee4-1eb098925f93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds token-consumption insights to the MCP & Tools page so operators can see which agents, MCP servers, and tools drive calls, tokens, and cost with trends. Previously the page showed only tool-call events; now it attributes agent-turn tokens to the MCP tool used on that turn and surfaces rankings and time series.

- Implements Linear DNO-949: group/filter by agent harness (`hook_source`), MCP server, and MCP tool; rank by calls or tokens; show KPIs (calls, input/output/total tokens, cost), a ranked bar + table, and a stacked time series with “Other” rollup. Clicking an Agent bar adds a `hook_source` filter. Query topN=20; bar shows top 12; time-series keeps top 7 stacks.
- Data: event counts remain from `getToolUsage*`/`trace_summaries`. Tokens and cost come from `telemetry.query` over `attribute_metrics_summaries`, scoped to the current project. Hide empty MCP-attribution groups (blank server/tool).
- UI/UX: new `InsightsToolCallConsumption` and `useToolCallConsumptionTotals`. `InsightsTools.tsx` renders the section and treats token activity as first-class in the empty state. Updates `INSIGHTS_SUGGESTIONS`. Exports `HOOK_SOURCE_FILTER_PATH`.
- Review focus: `InsightsToolCallConsumption.tsx`, `toolCallConsumption.ts`, `useToolCallConsumption.ts`, tests in `toolCallConsumption.test.ts`. Minor helper visibility tweak to satisfy Knip; no behavior changes. No backend or schema changes; no migrations.

<sup>Written for commit 8116990ab3f9d04eea841c3dd94aac2caaac6b4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

